### PR TITLE
fix(collections): restore add-to-collection from quick view

### DIFF
--- a/client/src/features/book/components/BookQuickView.vue
+++ b/client/src/features/book/components/BookQuickView.vue
@@ -40,6 +40,9 @@ const { detail, loading, fetch } = useBookDetail()
 const coverLoaded = ref(false)
 const coverFailed = ref(false)
 const providerIconErrors = ref<Record<string, boolean>>({})
+const descriptionExpanded = ref(false)
+const genresExpanded = ref(false)
+const coverLightboxOpen = ref(false)
 
 watch(
   () => props.bookId,
@@ -133,9 +136,6 @@ const providerLinks = computed<ProviderLink[]>(() => {
   return out
 })
 
-const descriptionExpanded = ref(false)
-const genresExpanded = ref(false)
-const coverLightboxOpen = ref(false)
 const safeDescription = useSafeHtml(() => detail.value?.description)
 
 const coverAspectRatio = inject(COVER_ASPECT_RATIO_KEY, ref(DEFAULT_COVER_ASPECT_RATIO))
@@ -187,6 +187,16 @@ function openDetails() {
 
 function toggleGenres() {
   genresExpanded.value = !genresExpanded.value
+}
+
+function handleAddToCollection() {
+  emit('update:open', false)
+  emit('action', 'add-to-collection')
+}
+
+function handleDelete() {
+  emit('update:open', false)
+  emit('action', 'delete')
 }
 </script>
 
@@ -435,8 +445,9 @@ function toggleGenres() {
             <Tooltip>
               <TooltipTrigger as-child>
                 <button
+                  data-testid="quick-view-action-add-to-collection"
                   class="flex items-center justify-center gap-1.5 h-9 px-3 rounded-md border border-input bg-background text-sm hover:bg-muted transition-colors"
-                  @click="emit('action', 'add-to-collection')"
+                  @click="handleAddToCollection"
                 >
                   <FolderPlus class="size-3.5" />
                 </button>
@@ -446,8 +457,9 @@ function toggleGenres() {
             <Tooltip v-if="hasPermission('library_delete_books')">
               <TooltipTrigger as-child>
                 <button
+                  data-testid="quick-view-action-delete"
                   class="flex items-center justify-center h-9 px-3 rounded-md text-sm text-destructive hover:bg-destructive/10 transition-colors"
-                  @click="emit('action', 'delete')"
+                  @click="handleDelete"
                 >
                   <Trash2 class="size-3.5" />
                 </button>

--- a/client/src/features/book/components/__tests__/BookQuickView.spec.ts
+++ b/client/src/features/book/components/__tests__/BookQuickView.spec.ts
@@ -1,0 +1,192 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { BookDetail } from '@bookorbit/types'
+import BookQuickView from '../BookQuickView.vue'
+
+const permissionState = {
+  canDelete: true,
+  canEditMetadata: true,
+}
+
+const fetchMock = vi.fn<(bookId: number) => void>()
+const pushMock = vi.fn<(...args: unknown[]) => unknown>()
+
+const detailRef = ref<BookDetail | null>(null)
+const loadingRef = ref(false)
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: pushMock,
+    }),
+  }
+})
+
+vi.mock('@/features/auth/composables/usePermissions', () => ({
+  usePermissions: () => ({
+    hasPermission: (name: string) => {
+      if (name === 'library_delete_books') return permissionState.canDelete
+      if (name === 'library_edit_metadata') return permissionState.canEditMetadata
+      return true
+    },
+  }),
+}))
+
+vi.mock('@/features/book/composables/useBookDetail', () => ({
+  useBookDetail: () => ({
+    detail: detailRef,
+    loading: loadingRef,
+    fetch: fetchMock,
+  }),
+}))
+
+vi.mock('@/features/book/composables/useCoverVersions', () => ({
+  useCoverVersions: () => ({
+    coverUrl: () => '/cover.jpg',
+  }),
+}))
+
+vi.mock('@/features/book/composables/useSafeHtml', () => ({
+  useSafeHtml: () => '',
+}))
+
+function makeDetail(overrides: Partial<BookDetail> = {}): BookDetail {
+  return {
+    id: 42,
+    libraryId: 1,
+    libraryName: 'Library',
+    status: 'present',
+    folderPath: '/books',
+    addedAt: '2026-01-01T00:00:00.000Z',
+    title: 'Quick View Book',
+    subtitle: null,
+    description: null,
+    isbn10: null,
+    isbn13: null,
+    publisher: null,
+    publishedYear: null,
+    language: null,
+    pageCount: null,
+    seriesName: null,
+    seriesIndex: null,
+    rating: null,
+    coverSource: null,
+    providerIds: {},
+    authors: [],
+    genres: [],
+    tags: [],
+    files: [
+      {
+        id: 11,
+        role: 'primary',
+        format: 'EPUB',
+        filename: 'book.epub',
+        sizeBytes: 1024,
+        absolutePath: '/books/book.epub',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        durationSeconds: null,
+      },
+    ],
+    lastWrittenAt: null,
+    metadataScore: null,
+    readStatus: null,
+    audioMetadata: null,
+    formatPriority: [],
+    comicMetadata: null,
+    lockedFields: [],
+    collections: [],
+    ...overrides,
+  }
+}
+
+const globalStubs = {
+  stubs: {
+    Sheet: { template: '<div><slot /></div>' },
+    SheetContent: { template: '<div><slot /></div>' },
+    SheetTitle: { template: '<div><slot /></div>' },
+    SheetDescription: { template: '<div><slot /></div>' },
+    TooltipProvider: { template: '<div><slot /></div>' },
+    Tooltip: { template: '<div><slot /></div>' },
+    TooltipTrigger: { template: '<div><slot /></div>' },
+    TooltipContent: { template: '<div><slot /></div>' },
+    DialogRoot: { template: '<div><slot /></div>' },
+    DialogPortal: { template: '<div><slot /></div>' },
+    DialogOverlay: { template: '<div />' },
+    DialogContent: { template: '<div><slot /></div>' },
+    DialogTitle: { template: '<div><slot /></div>' },
+    DialogDescription: { template: '<div><slot /></div>' },
+    DialogClose: { template: '<button><slot /></button>' },
+    BookCoverPlaceholder: { template: '<div />' },
+    Skeleton: { template: '<div />' },
+  },
+}
+
+describe('BookQuickView', () => {
+  beforeEach(() => {
+    permissionState.canDelete = true
+    permissionState.canEditMetadata = true
+    fetchMock.mockReset()
+    pushMock.mockReset()
+    loadingRef.value = false
+    detailRef.value = makeDetail()
+  })
+
+  it('fetches detail when mounted with a book id', () => {
+    mount(BookQuickView, {
+      props: {
+        open: true,
+        bookId: 42,
+      },
+      global: globalStubs,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(42)
+  })
+
+  it('emits close and add-to-collection action from the add button', async () => {
+    const wrapper = mount(BookQuickView, {
+      props: {
+        open: true,
+        bookId: 42,
+      },
+      global: globalStubs,
+    })
+
+    await wrapper.get('[data-testid="quick-view-action-add-to-collection"]').trigger('click')
+
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+    expect(wrapper.emitted('action')).toEqual([['add-to-collection']])
+  })
+
+  it('emits close and delete action from the delete button', async () => {
+    const wrapper = mount(BookQuickView, {
+      props: {
+        open: true,
+        bookId: 42,
+      },
+      global: globalStubs,
+    })
+
+    await wrapper.get('[data-testid="quick-view-action-delete"]').trigger('click')
+
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+    expect(wrapper.emitted('action')).toEqual([['delete']])
+  })
+
+  it('hides delete action when delete permission is missing', () => {
+    permissionState.canDelete = false
+
+    const wrapper = mount(BookQuickView, {
+      props: {
+        open: true,
+        bookId: 42,
+      },
+      global: globalStubs,
+    })
+
+    expect(wrapper.find('[data-testid="quick-view-action-delete"]').exists()).toBe(false)
+  })
+})

--- a/client/src/features/book/composables/__tests__/useBookTableShell.spec.ts
+++ b/client/src/features/book/composables/__tests__/useBookTableShell.spec.ts
@@ -149,33 +149,39 @@ describe('useBookTableShell', () => {
     it('enters selection mode and toggles the book for add-to-collection when not in selection mode', () => {
       mockSelectionMode.value = false
       const books = ref([makeBook({ id: 3 })])
-      const { handleBookAction, addToCollectionOpen } = useBookTableShell({ books })
+      const { handleBookAction, addToCollectionOpen, quickViewOpen } = useBookTableShell({ books })
+      quickViewOpen.value = true
 
       handleBookAction(makeBook({ id: 3 }), 'add-to-collection')
 
       expect(mocks.enterSelectionMode).toHaveBeenCalledOnce()
       expect(mocks.toggleBook).toHaveBeenCalledWith(3)
+      expect(quickViewOpen.value).toBe(false)
       expect(addToCollectionOpen.value).toBe(true)
     })
 
     it('skips enterSelectionMode for add-to-collection when already in selection mode', () => {
       mockSelectionMode.value = true
       const books = ref([makeBook({ id: 3 })])
-      const { handleBookAction, addToCollectionOpen } = useBookTableShell({ books })
+      const { handleBookAction, addToCollectionOpen, quickViewOpen } = useBookTableShell({ books })
+      quickViewOpen.value = true
 
       handleBookAction(makeBook({ id: 3 }), 'add-to-collection')
 
       expect(mocks.enterSelectionMode).not.toHaveBeenCalled()
       expect(mocks.toggleBook).not.toHaveBeenCalled()
+      expect(quickViewOpen.value).toBe(false)
       expect(addToCollectionOpen.value).toBe(true)
     })
 
     it('calls promptDelete for the delete action', () => {
       const books = ref([makeBook({ id: 5 })])
-      const { handleBookAction } = useBookTableShell({ books })
+      const { handleBookAction, quickViewOpen } = useBookTableShell({ books })
+      quickViewOpen.value = true
 
       handleBookAction(makeBook({ id: 5 }), 'delete')
 
+      expect(quickViewOpen.value).toBe(false)
       expect(mocks.promptDelete).toHaveBeenCalledWith(5)
     })
   })

--- a/client/src/features/book/composables/useBookTableShell.ts
+++ b/client/src/features/book/composables/useBookTableShell.ts
@@ -56,6 +56,8 @@ export function useBookTableShell({ books, querySelection }: BookTableShellOptio
       return
     }
 
+    quickViewOpen.value = false
+
     if (action === 'add-to-collection') {
       if (!selection.selectionMode.value) {
         selection.enterSelectionMode()

--- a/server/src/modules/collection/collection.controller.test.ts
+++ b/server/src/modules/collection/collection.controller.test.ts
@@ -74,6 +74,7 @@ describe('CollectionController', () => {
       await expectBadRequest(() => controller.findAll(USER, '1,two'));
       await expectBadRequest(() => controller.findAll(USER, '-1,2'));
       await expectBadRequest(() => controller.findAll(USER, '0,2'));
+      await expectBadRequest(() => controller.findAll(USER, '   '));
     });
   });
 
@@ -101,6 +102,24 @@ describe('CollectionController', () => {
 
       await expectBadRequest(() => controller.getBooks(10, USER, 2_000_000, 100));
       expect(service.getBooks).not.toHaveBeenCalled();
+    });
+
+    it('accepts pagination at the maximum offset boundary', async () => {
+      const { controller, service } = makeController();
+      service.getBooks.mockResolvedValue({ items: [], total: 0, page: 500, size: 100 });
+
+      await controller.getBooks(10, USER, 500, 100);
+
+      expect(service.getBooks).toHaveBeenCalledWith(10, USER, 500, 100, undefined, undefined);
+    });
+
+    it('forwards collapseSeries and search query when present', async () => {
+      const { controller, service } = makeController();
+      service.getBooks.mockResolvedValue({ items: [], total: 0, page: 0, size: 50 });
+
+      await controller.getBooks(10, USER, 0, 50, true, 'dune');
+
+      expect(service.getBooks).toHaveBeenCalledWith(10, USER, 0, 50, true, 'dune');
     });
   });
 

--- a/server/src/modules/collection/collection.service.test.ts
+++ b/server/src/modules/collection/collection.service.test.ts
@@ -114,6 +114,17 @@ describe('CollectionService', () => {
       expect(collectionRepo.findAllForUserWithMembership).toHaveBeenCalledWith(user.id, [4, 5]);
       expect(result[0]).toEqual(expect.objectContaining({ memberCount: 2 }));
     });
+
+    it('falls back to the non-membership query when book ids are empty', async () => {
+      const { service, collectionRepo } = makeService();
+      const user = makeUser();
+      collectionRepo.findAllForUser.mockResolvedValue([makeCollection()]);
+
+      await service.findAll(user, []);
+
+      expect(collectionRepo.findAllForUser).toHaveBeenCalledWith(user.id);
+      expect(collectionRepo.findAllForUserWithMembership).not.toHaveBeenCalled();
+    });
   });
 
   describe('findOne', () => {
@@ -181,6 +192,22 @@ describe('CollectionService', () => {
       await expect(service.update(10, { name: 'Favorites' }, makeUser())).rejects.toThrow('A collection with this name already exists');
     });
 
+    it('maps wrapped unique constraint errors to ConflictException semantics', async () => {
+      const { service, collectionRepo } = makeService();
+      collectionRepo.findById.mockResolvedValue([makeCollection()]);
+      collectionRepo.update.mockRejectedValue(new Error('duplicate key', { cause: { code: '23505' } }));
+
+      await expect(service.update(10, { name: 'Favorites' }, makeUser())).rejects.toThrow('A collection with this name already exists');
+    });
+
+    it('rethrows non-unique update errors', async () => {
+      const { service, collectionRepo } = makeService();
+      collectionRepo.findById.mockResolvedValue([makeCollection()]);
+      collectionRepo.update.mockRejectedValue(new Error('db write failed'));
+
+      await expect(service.update(10, { name: 'Favorites' }, makeUser())).rejects.toThrow('db write failed');
+    });
+
     it('rejects changes that would leave a collection without an icon', async () => {
       const { service, collectionRepo } = makeService();
       collectionRepo.findById.mockResolvedValue([makeCollection({ icon: null })]);
@@ -207,6 +234,29 @@ describe('CollectionService', () => {
         }),
       );
       expect(result).toEqual(expect.objectContaining({ id: 25, name: 'New Collection' }));
+    });
+
+    it('rejects create when icon is empty after trimming', async () => {
+      const { service, collectionRepo } = makeService();
+
+      await expect(service.create({ name: 'No Icon', icon: '   ' } as any, makeUser({ id: 9 }))).rejects.toThrow(BadRequestException);
+      expect(collectionRepo.insert).not.toHaveBeenCalled();
+    });
+
+    it('maps unique violations from wrapped database errors during create', async () => {
+      const { service, collectionRepo } = makeService();
+      collectionRepo.insert.mockRejectedValue(new Error('constraint fail', { cause: { code: '23505' } }));
+
+      await expect(service.create({ name: 'Favorites', icon: '⭐' } as any, makeUser({ id: 9 }))).rejects.toThrow(
+        'A collection with this name already exists',
+      );
+    });
+
+    it('rethrows non-unique create errors', async () => {
+      const { service, collectionRepo } = makeService();
+      collectionRepo.insert.mockRejectedValue(new Error('insert timeout'));
+
+      await expect(service.create({ name: 'Favorites', icon: '⭐' } as any, makeUser({ id: 9 }))).rejects.toThrow('insert timeout');
     });
 
     it('propagates ownership checks on remove and deletes using owner id', async () => {
@@ -400,6 +450,14 @@ describe('CollectionService', () => {
 
       expect(collectionRepo.removeBooks).toHaveBeenCalledWith(10, [7]);
       expect(result).toEqual(expect.objectContaining({ bookCount: 1 }));
+    });
+
+    it('rethrows repository errors while removing books', async () => {
+      const { service, collectionRepo } = makeService();
+      collectionRepo.findById.mockResolvedValue([makeCollection()]);
+      collectionRepo.removeBooks.mockRejectedValue(new Error('remove failed'));
+
+      await expect(service.removeBooks(10, { bookIds: [7] }, makeUser())).rejects.toThrow('remove failed');
     });
   });
 });


### PR DESCRIPTION
Close the quick-view sheet before dispatching add or delete actions so the collection sheet can open reliably from the side panel.

Add regression tests for quick-view and table-shell action flow, and expand collection controller/service edge-case coverage for this path.

Fixes #36