### PR TITLE
refactor(settings): consolidate 17 settings tabs into 10 grouped subt…

### DIFF
--- a/client/src/features/admin/UsersPage.vue
+++ b/client/src/features/admin/UsersPage.vue
@@ -12,6 +12,8 @@ import SettingsPageHeader from '@/features/settings/SettingsPageHeader.vue'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import MagicLinksSettings from '@/features/settings/MagicLinksSettings.vue'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 type Tab = 'users' | 'magic-links'
 
 interface Library {
@@ -136,6 +138,7 @@ function openMagicLinkCreate() {
 <template>
   <!-- Desktop header -->
   <SettingsPageHeader
+    v-if="!props.embedded"
     class="hidden md:flex"
     :title="activeTab === 'users' ? 'Users' : 'Magic Links'"
     :subtitle="activeTab === 'users' ? 'Manage user accounts and permission assignments.' : 'Create shareable login links for shared accounts.'"
@@ -151,7 +154,7 @@ function openMagicLinkCreate() {
   </SettingsPageHeader>
 
   <!-- Mobile title -->
-  <div class="md:hidden px-1">
+  <div v-if="!props.embedded" class="md:hidden px-1">
     <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ activeTab === 'users' ? 'Users' : 'Magic Links' }}</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
@@ -162,7 +165,7 @@ function openMagicLinkCreate() {
 
   <!-- Tab bar (superusers only) -->
   <div
-    v-if="isSuperuser"
+    v-if="isSuperuser && !props.embedded"
     class="flex gap-1 mt-1 mb-5 md:mb-6 border-b border-border overflow-x-auto md:overflow-visible md:static sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 snap-x"
   >
     <button

--- a/client/src/features/audit/AuditLogPage.vue
+++ b/client/src/features/audit/AuditLogPage.vue
@@ -6,6 +6,8 @@ import SettingsPageHeader from '@/features/settings/SettingsPageHeader.vue'
 import { useAuditLog } from './useAuditLog'
 import { useMediaQuery } from '@vueuse/core'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 const { entries, total, page, pageSize, loading, error, filters, fetchPage, applyFilters, clearFilters, goToPage } = useAuditLog()
 
 const totalPages = computed(() => Math.ceil(total.value / pageSize))
@@ -83,8 +85,13 @@ watch(
 </script>
 
 <template>
-  <SettingsPageHeader class="hidden md:flex" title="Audit Log" subtitle="A record of admin-significant actions performed across the system." />
-  <div class="md:hidden px-1">
+  <SettingsPageHeader
+    v-if="!props.embedded"
+    class="hidden md:flex"
+    title="Audit Log"
+    subtitle="A record of admin-significant actions performed across the system."
+  />
+  <div v-if="!props.embedded" class="md:hidden px-1">
     <h1 class="text-xl font-semibold tracking-tight text-foreground">Audit Log</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"

--- a/client/src/features/hardcover/components/HardcoverSettings.vue
+++ b/client/src/features/hardcover/components/HardcoverSettings.vue
@@ -6,6 +6,8 @@ import HardcoverSyncProgress from '../components/HardcoverSyncProgress.vue'
 import { useHardcoverSettings } from '../composables/useHardcoverSettings'
 import { useHardcoverSync } from '../composables/useHardcoverSync'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 const { settings } = useHardcoverSettings()
 const { fetchStatus, stopSyncTracking } = useHardcoverSync()
 
@@ -20,7 +22,7 @@ onUnmounted(() => {
 
 <template>
   <div class="space-y-6">
-    <SettingsPageHeader title="Hardcover" subtitle="Sync your reading progress, status, and ratings to Hardcover." />
+    <SettingsPageHeader v-if="!props.embedded" title="Hardcover" subtitle="Sync your reading progress, status, and ratings to Hardcover." />
 
     <HardcoverConnectionCard />
 

--- a/client/src/features/notifications/components/NotificationPreferences.vue
+++ b/client/src/features/notifications/components/NotificationPreferences.vue
@@ -7,6 +7,8 @@ import { useAuth } from '@/features/auth/composables/useAuth'
 import { api } from '@/lib/api'
 import SettingsPageHeader from '@/features/settings/SettingsPageHeader.vue'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 const { user, me } = useAuth()
 
 const saving = ref(false)
@@ -74,8 +76,13 @@ async function handleSave() {
 </script>
 
 <template>
-  <SettingsPageHeader class="hidden md:flex" title="Notifications" subtitle="Choose which notification categories you want to receive." />
-  <div class="md:hidden px-1">
+  <SettingsPageHeader
+    v-if="!props.embedded"
+    class="hidden md:flex"
+    title="Notifications"
+    subtitle="Choose which notification categories you want to receive."
+  />
+  <div v-if="!props.embedded" class="md:hidden px-1">
     <h1 class="text-xl font-semibold tracking-tight text-foreground">Notifications</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"

--- a/client/src/features/settings/AccountAllSettings.vue
+++ b/client/src/features/settings/AccountAllSettings.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import AccountSettings from './AccountSettings.vue'
+import NotificationPreferences from '@/features/notifications/components/NotificationPreferences.vue'
+import { usePermissions } from '@/features/auth/composables/usePermissions'
+import SettingsPageHeader from './SettingsPageHeader.vue'
+import { ACCOUNT_TAB_INFO, ACCOUNT_TABS, normalizeAccountTab, type AccountTab as Tab } from './lib/account-tabs'
+
+const route = useRoute()
+const router = useRouter()
+const { isDemoRestrictedAccount } = usePermissions()
+
+const availableTabs = computed(() =>
+  ACCOUNT_TABS.filter((id) => {
+    if (id === 'notifications') return !isDemoRestrictedAccount.value
+    return true
+  }).map((id) => ({ id, label: ACCOUNT_TAB_INFO[id].navLabel })),
+)
+
+function resolveTab(raw: unknown): Tab {
+  const normalized = normalizeAccountTab(raw)
+  if (availableTabs.value.some((t) => t.id === normalized)) return normalized
+  return 'profile'
+}
+
+const activeTab = ref<Tab>(resolveTab(route.query.tab))
+
+if (!route.query.tab) {
+  router.replace({ name: 'settings-account', query: { ...route.query, tab: activeTab.value } })
+}
+
+watch(
+  () => route.query.tab,
+  (value) => {
+    activeTab.value = resolveTab(value)
+  },
+)
+
+watch(isDemoRestrictedAccount, () => {
+  if (activeTab.value === 'notifications' && isDemoRestrictedAccount.value) {
+    activeTab.value = 'profile'
+    router.replace({ name: 'settings-account', query: { ...route.query, tab: 'profile' } })
+  }
+})
+
+function selectTab(tab: Tab) {
+  activeTab.value = tab
+  router.replace({ name: 'settings-account', query: { ...route.query, tab } })
+}
+</script>
+
+<template>
+  <SettingsPageHeader title="Account" subtitle="Manage your profile and notification preferences." />
+
+  <div
+    class="flex gap-1 mb-5 md:mb-6 border-b border-border overflow-x-auto md:overflow-visible md:static sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 snap-x"
+  >
+    <button
+      v-for="tab in availableTabs"
+      :key="tab.id"
+      class="px-3 py-3 md:py-2 text-sm font-medium shrink-0 border-b-2 -mb-px transition-colors snap-start"
+      :class="
+        activeTab === tab.id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+      "
+      @click="selectTab(tab.id)"
+    >
+      {{ tab.label }}
+    </button>
+  </div>
+
+  <AccountSettings v-if="activeTab === 'profile'" embedded />
+  <NotificationPreferences v-else-if="activeTab === 'notifications'" embedded />
+</template>

--- a/client/src/features/settings/AccountSettings.vue
+++ b/client/src/features/settings/AccountSettings.vue
@@ -14,6 +14,8 @@ import SettingsPageHeader from './SettingsPageHeader.vue'
 import { useMediaQuery } from '@vueuse/core'
 import { useOnboardingTour } from '@/features/onboarding/composables/useOnboardingTour'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 const { user, me } = useAuth()
 const { isDemoRestrictedAccount } = usePermissions()
 const { open: openChangePassword } = useChangePasswordDialog()
@@ -301,8 +303,8 @@ function closeUnlinkDialog() {
 </script>
 
 <template>
-  <SettingsPageHeader class="hidden md:flex" title="Account" subtitle="Manage your personal profile settings." />
-  <div class="md:hidden px-1">
+  <SettingsPageHeader v-if="!props.embedded" class="hidden md:flex" title="Account" subtitle="Manage your personal profile settings." />
+  <div v-if="!props.embedded" class="md:hidden px-1">
     <h1 class="text-xl font-semibold tracking-tight text-foreground">Account</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"

--- a/client/src/features/settings/AdminAllSettings.vue
+++ b/client/src/features/settings/AdminAllSettings.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import SettingsPageHeader from './SettingsPageHeader.vue'
+import UsersPage from '@/features/admin/UsersPage.vue'
+import OidcSettings from './OidcSettings.vue'
+import { usePermissions } from '@/features/auth/composables/usePermissions'
+import { ADMIN_TAB_INFO, ADMIN_TABS, normalizeAdminTab, type AdminTab as Tab } from './lib/admin-tabs'
+
+const route = useRoute()
+const router = useRouter()
+const { isSuperuser, userPermissions } = usePermissions()
+
+const availableTabs = computed(() =>
+  ADMIN_TABS.filter((id) => {
+    const perm = ADMIN_TAB_INFO[id].permission
+    return isSuperuser.value || (perm !== null && userPermissions.value.includes(perm))
+  }).map((id) => ({ id, label: ADMIN_TAB_INFO[id].navLabel })),
+)
+
+function resolveTab(raw: unknown): Tab {
+  const normalized = normalizeAdminTab(raw)
+  if (availableTabs.value.some((t) => t.id === normalized)) return normalized
+  return availableTabs.value[0]?.id ?? 'users'
+}
+
+const activeTab = ref<Tab>(resolveTab(route.query.tab))
+
+if (!route.query.tab) {
+  router.replace({ name: 'settings-admin', query: { ...route.query, tab: activeTab.value } })
+}
+
+watch(
+  () => route.query.tab,
+  (value) => {
+    activeTab.value = resolveTab(value)
+  },
+)
+
+watch(availableTabs, (tabs) => {
+  if (!tabs.some((t) => t.id === activeTab.value)) {
+    const fallback = tabs[0]?.id ?? 'users'
+    activeTab.value = fallback
+    router.replace({ name: 'settings-admin', query: { ...route.query, tab: fallback } })
+  }
+})
+
+const tabWidths: Record<Tab, string> = {
+  users: 'max-w-6xl',
+  oidc: 'max-w-3xl',
+}
+
+function selectTab(tab: Tab) {
+  activeTab.value = tab
+  router.replace({ name: 'settings-admin', query: { ...route.query, tab } })
+}
+</script>
+
+<template>
+  <SettingsPageHeader title="Admin" subtitle="Manage users and authentication settings." />
+
+  <div
+    :class="[
+      tabWidths[activeTab],
+      'flex gap-1 mb-5 md:mb-6 border-b border-border overflow-x-auto md:overflow-visible md:static sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 snap-x',
+    ]"
+  >
+    <button
+      v-for="tab in availableTabs"
+      :key="tab.id"
+      class="px-3 py-3 md:py-2 text-sm font-medium shrink-0 border-b-2 -mb-px transition-colors snap-start"
+      :class="
+        activeTab === tab.id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+      "
+      @click="selectTab(tab.id)"
+    >
+      {{ tab.label }}
+    </button>
+  </div>
+
+  <div :class="tabWidths[activeTab]">
+    <UsersPage v-if="activeTab === 'users'" embedded />
+    <OidcSettings v-else-if="activeTab === 'oidc'" embedded />
+  </div>
+</template>

--- a/client/src/features/settings/BookDockSettings.vue
+++ b/client/src/features/settings/BookDockSettings.vue
@@ -8,6 +8,7 @@ import SettingsPageHeader from './SettingsPageHeader.vue'
 import { api } from '@/lib/api'
 import { useLibraries } from '@/features/library/composables/useLibraries'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
 const autoFetch = ref(true)
 const autoFinalizeEnabled = ref(false)
 const autoFinalizeThreshold = ref(85)
@@ -130,8 +131,13 @@ async function onMetadataModeChange(event: Event) {
 </script>
 
 <template>
-  <SettingsPageHeader class="hidden md:flex" title="Book Dock" subtitle="Configure how files are processed when they enter Book Dock." />
-  <div class="md:hidden px-1">
+  <SettingsPageHeader
+    v-if="!props.embedded"
+    class="hidden md:flex"
+    title="Book Dock"
+    subtitle="Configure how files are processed when they enter Book Dock."
+  />
+  <div v-if="!props.embedded" class="md:hidden px-1">
     <h1 class="text-xl font-semibold tracking-tight text-foreground">Book Dock</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"

--- a/client/src/features/settings/FileNamingSettings.vue
+++ b/client/src/features/settings/FileNamingSettings.vue
@@ -15,6 +15,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Badge } from '@/components/ui/badge'
 import SettingsPageHeader from './SettingsPageHeader.vue'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 const {
   globalPattern,
   globalError,
@@ -244,11 +246,12 @@ onUnmounted(() => {
 <template>
   <div class="space-y-10 pb-20">
     <SettingsPageHeader
+      v-if="!props.embedded"
       class="hidden md:flex"
       title="File Naming"
       subtitle="Control how files are organized on disk when uploaded and how they are named when downloaded using placeholder tokens."
     />
-    <div class="md:hidden px-1">
+    <div v-if="!props.embedded" class="md:hidden px-1">
       <h1 class="text-xl font-semibold tracking-tight text-foreground">File Naming</h1>
       <p
         class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"

--- a/client/src/features/settings/IntegrationsAllSettings.vue
+++ b/client/src/features/settings/IntegrationsAllSettings.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import SettingsPageHeader from './SettingsPageHeader.vue'
+import KoboSettings from './KoboSettings.vue'
+import KoreaderSettings from './KoreaderSettings.vue'
+import HardcoverSettings from '@/features/hardcover/components/HardcoverSettings.vue'
+import { INTEGRATIONS_TAB_INFO, INTEGRATIONS_TABS, normalizeIntegrationsTab, type IntegrationsTab as Tab } from './lib/integrations-tabs'
+
+const route = useRoute()
+const router = useRouter()
+
+const activeTab = ref<Tab>(normalizeIntegrationsTab(route.query.tab))
+
+if (!route.query.tab) {
+  router.replace({ name: 'settings-integrations', query: { ...route.query, tab: activeTab.value } })
+}
+
+watch(
+  () => route.query.tab,
+  (value) => {
+    activeTab.value = normalizeIntegrationsTab(value)
+  },
+)
+
+const tabs = INTEGRATIONS_TABS.map((id) => ({ id, label: INTEGRATIONS_TAB_INFO[id].navLabel }))
+
+function selectTab(tab: Tab) {
+  activeTab.value = tab
+  router.replace({ name: 'settings-integrations', query: { ...route.query, tab } })
+}
+</script>
+
+<template>
+  <SettingsPageHeader title="Integrations" subtitle="Configure connections to external devices and services." />
+
+  <div
+    class="flex gap-1 mb-5 md:mb-6 border-b border-border overflow-x-auto md:overflow-visible md:static sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 snap-x"
+  >
+    <button
+      v-for="tab in tabs"
+      :key="tab.id"
+      class="px-3 py-3 md:py-2 text-sm font-medium shrink-0 border-b-2 -mb-px transition-colors snap-start"
+      :class="
+        activeTab === tab.id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+      "
+      @click="selectTab(tab.id)"
+    >
+      {{ tab.label }}
+    </button>
+  </div>
+
+  <KoboSettings v-if="activeTab === 'kobo'" embedded />
+  <KoreaderSettings v-else-if="activeTab === 'koreader'" embedded />
+  <HardcoverSettings v-else-if="activeTab === 'hardcover'" embedded />
+</template>

--- a/client/src/features/settings/KoboSettings.vue
+++ b/client/src/features/settings/KoboSettings.vue
@@ -8,6 +8,8 @@ import { useKoboDevices } from '@/features/kobo/composables/useKoboDevices'
 import { useKoboSettings } from '@/features/kobo/composables/useKoboSettings'
 import type { KoboDevice } from '@bookorbit/types'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 const { devices, fetchDevices, createDevice, renameDevice, revokeDevice } = useKoboDevices()
 const { settings, fetchSettings, updateSettings } = useKoboSettings()
 
@@ -164,7 +166,7 @@ async function saveSettings() {
 </script>
 
 <template>
-  <SettingsPageHeader title="Kobo Sync" subtitle="Pair your Kobo device to sync your library." />
+  <SettingsPageHeader v-if="!props.embedded" title="Kobo Sync" subtitle="Pair your Kobo device to sync your library." />
 
   <div v-if="loading" class="text-sm text-muted-foreground">Loading...</div>
   <div v-else-if="error" class="text-sm text-destructive">{{ error }}</div>

--- a/client/src/features/settings/KoreaderSettings.vue
+++ b/client/src/features/settings/KoreaderSettings.vue
@@ -6,6 +6,8 @@ import SettingsPageHeader from './SettingsPageHeader.vue'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import { useKoreaderSync } from '@/features/koreader/composables/useKoreaderSync'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 const { credentials, syncStatus, loading, fetchSyncStatus, createCredentials, updateCredentials, deleteCredentials, getSyncUrl } = useKoreaderSync()
 
 const error = ref<string | null>(null)
@@ -131,8 +133,13 @@ async function handleRefresh() {
 </script>
 
 <template>
-  <SettingsPageHeader class="hidden md:flex" title="KOReader Sync" subtitle="Sync reading progress between KOReader devices and BookOrbit." />
-  <div class="md:hidden px-1">
+  <SettingsPageHeader
+    v-if="!props.embedded"
+    class="hidden md:flex"
+    title="KOReader Sync"
+    subtitle="Sync reading progress between KOReader devices and BookOrbit."
+  />
+  <div v-if="!props.embedded" class="md:hidden px-1">
     <h1 class="text-xl font-semibold tracking-tight text-foreground">KOReader Sync</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"

--- a/client/src/features/settings/MaintenanceSettings.vue
+++ b/client/src/features/settings/MaintenanceSettings.vue
@@ -9,6 +9,8 @@ import { api } from '@/lib/api'
 import { getWorkflowState, type MigrationWorkflowState } from '@/features/migration/lib/migration-api'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 const showMigrationModal = ref(false)
 
 const running = ref(false)
@@ -168,8 +170,13 @@ function formatDate(iso: string | null | undefined): string {
 
 <template>
   <MigrationModal v-if="showMigrationModal" @close="onMigrationModalClose" />
-  <SettingsPageHeader class="hidden md:flex" title="Maintenance" subtitle="Manage background tasks, system indices, and maintenance operations." />
-  <div class="md:hidden px-1">
+  <SettingsPageHeader
+    v-if="!props.embedded"
+    class="hidden md:flex"
+    title="Maintenance"
+    subtitle="Manage background tasks, system indices, and maintenance operations."
+  />
+  <div v-if="!props.embedded" class="md:hidden px-1">
     <h1 class="text-xl font-semibold tracking-tight text-foreground">Maintenance</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"

--- a/client/src/features/settings/OidcSettings.vue
+++ b/client/src/features/settings/OidcSettings.vue
@@ -8,6 +8,8 @@ import { ArrowLeft, Plus, ShieldCheck, Trash2 } from 'lucide-vue-next'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import SettingsPageHeader from './SettingsPageHeader.vue'
 
+const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
 interface ProviderSummary {
   id: number
   slug: string
@@ -336,8 +338,13 @@ async function deleteGroupMapping(id: number) {
 <template>
   <!-- List view -->
   <template v-if="viewMode === 'list'">
-    <SettingsPageHeader class="hidden md:flex" title="OIDC / SSO" subtitle="Manage OpenID Connect providers for single sign-on." />
-    <div class="md:hidden px-1">
+    <SettingsPageHeader
+      v-if="!props.embedded"
+      class="hidden md:flex"
+      title="OIDC / SSO"
+      subtitle="Manage OpenID Connect providers for single sign-on."
+    />
+    <div v-if="!props.embedded" class="md:hidden px-1">
       <h1 class="text-xl font-semibold tracking-tight text-foreground">OIDC / SSO</h1>
       <p
         class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"

--- a/client/src/features/settings/SettingsHeader.vue
+++ b/client/src/features/settings/SettingsHeader.vue
@@ -5,7 +5,7 @@ import { usePermissions } from '@/features/auth/composables/usePermissions'
 
 const route = useRoute()
 const router = useRouter()
-const { isSuperuser, userPermissions, isDemoRestrictedAccount } = usePermissions()
+const { isSuperuser, userPermissions } = usePermissions()
 
 interface Section {
   label: string
@@ -32,44 +32,26 @@ const sections = computed<Section[]>(() => {
   if (su || perms.includes('manage_metadata_config')) {
     result.push({ label: 'Metadata', routeName: 'settings-admin-metadata' })
   }
-  if (su || perms.includes('book_dock_access')) {
-    result.push({ label: 'Book Dock', routeName: 'settings-admin-book-dock' })
-  }
-  if (su || perms.includes('manage_app_settings')) {
-    result.push({ label: 'File Naming', routeName: 'settings-admin-file-naming' })
-  }
-  if (su || perms.includes('manage_users')) {
-    result.push({ label: 'Users', routeName: 'settings-admin-users' })
-  }
-  if (su || perms.includes('manage_app_settings')) {
-    result.push({ label: 'OIDC / SSO', routeName: 'settings-admin-oidc' })
-  }
+
+  result.push({ label: 'Integrations', routeName: 'settings-integrations' })
+
   if (su || perms.includes('email_send') || perms.includes('manage_email')) {
     result.push({ label: 'Email', routeName: 'settings-email' })
   }
+
   if (su || perms.includes('opds_access')) {
     result.push({ label: 'OPDS', routeName: 'settings-opds' })
   }
-  if (su || perms.includes('kobo_sync')) {
-    result.push({ label: 'Kobo', routeName: 'settings-kobo' })
+
+  if (su || perms.includes('manage_users') || perms.includes('manage_app_settings')) {
+    result.push({ label: 'Admin', routeName: 'settings-admin' })
   }
-  if (su || perms.includes('koreader_sync')) {
-    result.push({ label: 'KOReader', routeName: 'settings-koreader' })
-  }
-  result.push({ label: 'Hardcover', routeName: 'settings-hardcover' })
-  if (su || perms.includes('manage_app_settings')) {
-    result.push({ label: 'Maintenance', routeName: 'settings-admin-maintenance' })
+
+  if (su || perms.includes('manage_app_settings') || perms.includes('book_dock_access')) {
+    result.push({ label: 'System', routeName: 'settings-system' })
   }
 
   result.push({ label: 'Account', routeName: 'settings-account' })
-
-  if (!isDemoRestrictedAccount.value) {
-    result.push({ label: 'Notifications', routeName: 'settings-notifications' })
-  }
-
-  if (su) {
-    result.push({ label: 'Audit Log', routeName: 'settings-admin-audit-log' })
-  }
 
   return result
 })

--- a/client/src/features/settings/SettingsPageHeader.vue
+++ b/client/src/features/settings/SettingsPageHeader.vue
@@ -3,7 +3,7 @@ defineProps<{ title: string; subtitle: string }>()
 </script>
 
 <template>
-  <div class="flex items-center justify-between mb-8 gap-4">
+  <div class="flex items-center justify-between mb-6 gap-4">
     <div class="min-w-0">
       <h2 class="settings-title">{{ title }}</h2>
       <p class="settings-subtitle">{{ subtitle }}</p>

--- a/client/src/features/settings/SystemAllSettings.vue
+++ b/client/src/features/settings/SystemAllSettings.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import SettingsPageHeader from './SettingsPageHeader.vue'
+import FileNamingSettings from './FileNamingSettings.vue'
+import BookDockSettings from './BookDockSettings.vue'
+import MaintenanceSettings from './MaintenanceSettings.vue'
+import AuditLogPage from '@/features/audit/AuditLogPage.vue'
+import { usePermissions } from '@/features/auth/composables/usePermissions'
+import { SYSTEM_TAB_INFO, SYSTEM_TABS, normalizeSystemTab, type SystemTab as Tab } from './lib/system-tabs'
+
+const route = useRoute()
+const router = useRouter()
+const { isSuperuser, userPermissions } = usePermissions()
+
+const availableTabs = computed(() =>
+  SYSTEM_TABS.filter((id) => {
+    const perm = SYSTEM_TAB_INFO[id].permission
+    if (id === 'audit-log') return isSuperuser.value
+    return isSuperuser.value || (perm !== null && userPermissions.value.includes(perm))
+  }).map((id) => ({ id, label: SYSTEM_TAB_INFO[id].navLabel })),
+)
+
+function resolveTab(raw: unknown): Tab {
+  const normalized = normalizeSystemTab(raw)
+  if (availableTabs.value.some((t) => t.id === normalized)) return normalized
+  return availableTabs.value[0]?.id ?? 'file-naming'
+}
+
+const activeTab = ref<Tab>(resolveTab(route.query.tab))
+
+if (!route.query.tab) {
+  router.replace({ name: 'settings-system', query: { ...route.query, tab: activeTab.value } })
+}
+
+watch(
+  () => route.query.tab,
+  (value) => {
+    activeTab.value = resolveTab(value)
+  },
+)
+
+watch(availableTabs, (tabs) => {
+  if (!tabs.some((t) => t.id === activeTab.value)) {
+    const fallback = tabs[0]?.id ?? 'file-naming'
+    activeTab.value = fallback
+    router.replace({ name: 'settings-system', query: { ...route.query, tab: fallback } })
+  }
+})
+
+const tabWidths: Record<Tab, string> = {
+  'file-naming': 'max-w-7xl',
+  'book-dock': 'max-w-3xl',
+  maintenance: 'max-w-3xl',
+  'audit-log': 'max-w-7xl',
+}
+
+function selectTab(tab: Tab) {
+  activeTab.value = tab
+  router.replace({ name: 'settings-system', query: { ...route.query, tab } })
+}
+</script>
+
+<template>
+  <SettingsPageHeader title="System" subtitle="File organization, ingestion, and maintenance settings." />
+
+  <div
+    :class="[
+      tabWidths[activeTab],
+      'flex gap-1 mb-5 md:mb-6 border-b border-border overflow-x-auto md:overflow-visible md:static sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 snap-x',
+    ]"
+  >
+    <button
+      v-for="tab in availableTabs"
+      :key="tab.id"
+      class="px-3 py-3 md:py-2 text-sm font-medium shrink-0 border-b-2 -mb-px transition-colors snap-start"
+      :class="
+        activeTab === tab.id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground hover:border-border'
+      "
+      @click="selectTab(tab.id)"
+    >
+      {{ tab.label }}
+    </button>
+  </div>
+
+  <div :class="tabWidths[activeTab]">
+    <FileNamingSettings v-if="activeTab === 'file-naming'" embedded />
+    <BookDockSettings v-else-if="activeTab === 'book-dock'" embedded />
+    <MaintenanceSettings v-else-if="activeTab === 'maintenance'" embedded />
+    <AuditLogPage v-else-if="activeTab === 'audit-log'" embedded />
+  </div>
+</template>

--- a/client/src/features/settings/__tests__/AccountAllSettings.spec.ts
+++ b/client/src/features/settings/__tests__/AccountAllSettings.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { computed } from 'vue'
+import AccountAllSettings from '../AccountAllSettings.vue'
+
+// --- Permission state ---
+const permState = { isDemo: false }
+
+const routerState = {
+  currentQuery: {} as Record<string, string>,
+  replacedQuery: null as Record<string, string> | null,
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: routerState.currentQuery }),
+  useRouter: () => ({
+    replace: vi.fn<(to: { name: string; query: Record<string, string> }) => void>((to) => {
+      routerState.replacedQuery = to.query
+    }),
+  }),
+}))
+
+vi.mock('@/features/auth/composables/usePermissions', () => ({
+  usePermissions: () => ({
+    isDemoRestrictedAccount: computed(() => permState.isDemo),
+  }),
+}))
+
+vi.mock('../AccountSettings.vue', () => ({ default: { template: '<div data-testid="account-settings" />' } }))
+vi.mock('@/features/notifications/components/NotificationPreferences.vue', () => ({
+  default: { template: '<div data-testid="notification-preferences" />' },
+}))
+
+function mountComponent(queryTab?: string, isDemo = false) {
+  permState.isDemo = isDemo
+  routerState.currentQuery = queryTab ? { tab: queryTab } : {}
+  routerState.replacedQuery = null
+  return mount(AccountAllSettings)
+}
+
+describe('AccountAllSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('non-demo user', () => {
+    it('sees both Profile and Notifications tabs', () => {
+      const wrapper = mountComponent()
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).toContain('Profile')
+      expect(labels).toContain('Notifications')
+    })
+
+    it('defaults to profile tab and shows AccountSettings', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.find('[data-testid="account-settings"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="notification-preferences"]').exists()).toBe(false)
+    })
+
+    it('replaces URL with ?tab=profile on mount when no param', () => {
+      mountComponent()
+      expect(routerState.replacedQuery?.tab).toBe('profile')
+    })
+
+    it('shows NotificationPreferences when tab=notifications', () => {
+      const wrapper = mountComponent('notifications')
+      expect(wrapper.find('[data-testid="notification-preferences"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="account-settings"]').exists()).toBe(false)
+    })
+
+    it('shows AccountSettings when tab=profile', () => {
+      const wrapper = mountComponent('profile')
+      expect(wrapper.find('[data-testid="account-settings"]').exists()).toBe(true)
+    })
+
+    it('falls back to profile for unknown tab', () => {
+      const wrapper = mountComponent('unknown')
+      expect(wrapper.find('[data-testid="account-settings"]').exists()).toBe(true)
+    })
+  })
+
+  describe('demo-restricted user', () => {
+    it('sees only Profile tab (no Notifications)', () => {
+      const wrapper = mountComponent(undefined, true)
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).toContain('Profile')
+      expect(labels).not.toContain('Notifications')
+    })
+
+    it('defaults to profile', () => {
+      const wrapper = mountComponent(undefined, true)
+      expect(wrapper.find('[data-testid="account-settings"]').exists()).toBe(true)
+    })
+
+    it('falls back to profile when notifications tab is requested', () => {
+      const wrapper = mountComponent('notifications', true)
+      expect(wrapper.find('[data-testid="account-settings"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="notification-preferences"]').exists()).toBe(false)
+    })
+  })
+
+  describe('tab navigation', () => {
+    it('active tab button has border-primary class', () => {
+      const wrapper = mountComponent('profile')
+      const profileBtn = wrapper.findAll('button').find((b) => b.text() === 'Profile')
+      expect(profileBtn?.classes()).toContain('border-primary')
+    })
+
+    it('inactive tab button has border-transparent class', () => {
+      const wrapper = mountComponent('profile')
+      const notifBtn = wrapper.findAll('button').find((b) => b.text() === 'Notifications')
+      expect(notifBtn?.classes()).toContain('border-transparent')
+    })
+
+    it('clicking Notifications tab switches to NotificationPreferences', async () => {
+      permState.isDemo = false
+      routerState.currentQuery = { tab: 'profile' }
+      const wrapper = mount(AccountAllSettings)
+
+      const notifBtn = wrapper.findAll('button').find((b) => b.text() === 'Notifications')
+      await notifBtn!.trigger('click')
+
+      expect(wrapper.find('[data-testid="notification-preferences"]').exists()).toBe(true)
+    })
+
+    it('clicking a tab calls router.replace with the correct tab', async () => {
+      permState.isDemo = false
+      routerState.currentQuery = { tab: 'profile' }
+      routerState.replacedQuery = null
+      const wrapper = mount(AccountAllSettings)
+
+      const notifBtn = wrapper.findAll('button').find((b) => b.text() === 'Notifications')
+      await notifBtn!.trigger('click')
+
+      expect(routerState.replacedQuery!['tab']).toBe('notifications')
+    })
+
+    it('does not replace URL when tab param already set', () => {
+      mountComponent('notifications')
+      expect(routerState.replacedQuery).toBeNull()
+    })
+  })
+})

--- a/client/src/features/settings/__tests__/AdminAllSettings.spec.ts
+++ b/client/src/features/settings/__tests__/AdminAllSettings.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { computed } from 'vue'
+import AdminAllSettings from '../AdminAllSettings.vue'
+
+// --- Permission state ---
+const permState = {
+  isSuperuser: false,
+  permissions: [] as string[],
+}
+
+const routerState = {
+  currentQuery: {} as Record<string, string>,
+  replacedQuery: null as Record<string, string> | null,
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: routerState.currentQuery }),
+  useRouter: () => ({
+    replace: vi.fn<(to: { name: string; query: Record<string, string> }) => void>((to) => {
+      routerState.replacedQuery = to.query
+    }),
+  }),
+}))
+
+vi.mock('@/features/auth/composables/usePermissions', () => ({
+  usePermissions: () => ({
+    isSuperuser: computed(() => permState.isSuperuser),
+    userPermissions: computed(() => permState.permissions),
+  }),
+}))
+
+vi.mock('@/features/admin/UsersPage.vue', () => ({ default: { template: '<div data-testid="users-page" />' } }))
+vi.mock('../OidcSettings.vue', () => ({ default: { template: '<div data-testid="oidc-settings" />' } }))
+vi.mock('../SettingsPageHeader.vue', () => ({ default: { template: '<div />' } }))
+
+function mountComponent(queryTab?: string, opts?: { su?: boolean; perms?: string[] }) {
+  permState.isSuperuser = opts?.su ?? false
+  permState.permissions = opts?.perms ?? []
+  routerState.currentQuery = queryTab ? { tab: queryTab } : {}
+  routerState.replacedQuery = null
+  return mount(AdminAllSettings)
+}
+
+describe('AdminAllSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('superuser', () => {
+    it('sees both Users and OIDC tabs', () => {
+      const wrapper = mountComponent(undefined, { su: true })
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).toContain('Users')
+      expect(labels).toContain('OIDC / SSO')
+    })
+
+    it('defaults to users tab', () => {
+      const wrapper = mountComponent(undefined, { su: true })
+      expect(wrapper.find('[data-testid="users-page"]').exists()).toBe(true)
+    })
+
+    it('renders OidcSettings when tab=oidc', () => {
+      const wrapper = mountComponent('oidc', { su: true })
+      expect(wrapper.find('[data-testid="oidc-settings"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="users-page"]').exists()).toBe(false)
+    })
+
+    it('renders UsersPage when tab=users', () => {
+      const wrapper = mountComponent('users', { su: true })
+      expect(wrapper.find('[data-testid="users-page"]').exists()).toBe(true)
+    })
+  })
+
+  describe('user with manage_users only', () => {
+    it('sees only Users tab', () => {
+      const wrapper = mountComponent(undefined, { perms: ['manage_users'] })
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).toContain('Users')
+      expect(labels).not.toContain('OIDC / SSO')
+    })
+
+    it('defaults to users tab and shows UsersPage', () => {
+      const wrapper = mountComponent(undefined, { perms: ['manage_users'] })
+      expect(wrapper.find('[data-testid="users-page"]').exists()).toBe(true)
+    })
+
+    it('falls back to users when oidc tab is requested but not permitted', () => {
+      const wrapper = mountComponent('oidc', { perms: ['manage_users'] })
+      expect(wrapper.find('[data-testid="users-page"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="oidc-settings"]').exists()).toBe(false)
+    })
+  })
+
+  describe('user with manage_app_settings only', () => {
+    it('sees only OIDC tab', () => {
+      const wrapper = mountComponent(undefined, { perms: ['manage_app_settings'] })
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).not.toContain('Users')
+      expect(labels).toContain('OIDC / SSO')
+    })
+
+    it('defaults to oidc and shows OidcSettings', () => {
+      const wrapper = mountComponent(undefined, { perms: ['manage_app_settings'] })
+      expect(wrapper.find('[data-testid="oidc-settings"]').exists()).toBe(true)
+    })
+  })
+
+  describe('user with both manage_users and manage_app_settings', () => {
+    it('sees both tabs', () => {
+      const wrapper = mountComponent(undefined, { perms: ['manage_users', 'manage_app_settings'] })
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).toContain('Users')
+      expect(labels).toContain('OIDC / SSO')
+    })
+  })
+
+  describe('tab navigation', () => {
+    it('active tab button has border-primary class', () => {
+      const wrapper = mountComponent('users', { su: true })
+      const usersBtn = wrapper.findAll('button').find((b) => b.text() === 'Users')
+      expect(usersBtn?.classes()).toContain('border-primary')
+    })
+
+    it('inactive tab button has border-transparent class', () => {
+      const wrapper = mountComponent('users', { su: true })
+      const oidcBtn = wrapper.findAll('button').find((b) => b.text() === 'OIDC / SSO')
+      expect(oidcBtn?.classes()).toContain('border-transparent')
+    })
+
+    it('clicking a tab switches content', async () => {
+      permState.isSuperuser = true
+      routerState.currentQuery = { tab: 'users' }
+      const wrapper = mount(AdminAllSettings)
+
+      const oidcBtn = wrapper.findAll('button').find((b) => b.text() === 'OIDC / SSO')
+      await oidcBtn!.trigger('click')
+
+      expect(wrapper.find('[data-testid="oidc-settings"]').exists()).toBe(true)
+    })
+
+    it('replaces URL with default tab when no tab param present', () => {
+      mountComponent(undefined, { su: true })
+      expect(routerState.replacedQuery!['tab']).toBe('users')
+    })
+
+    it('does not replace URL when tab param is present', () => {
+      mountComponent('oidc', { su: true })
+      expect(routerState.replacedQuery).toBeNull()
+    })
+  })
+})

--- a/client/src/features/settings/__tests__/IntegrationsAllSettings.spec.ts
+++ b/client/src/features/settings/__tests__/IntegrationsAllSettings.spec.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import IntegrationsAllSettings from '../IntegrationsAllSettings.vue'
+
+// --- Router mock state ---
+const routerState = {
+  currentQuery: {} as Record<string, string>,
+  replacedQuery: null as Record<string, string> | null,
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: routerState.currentQuery,
+  }),
+  useRouter: () => ({
+    replace: vi.fn<(to: { name: string; query: Record<string, string> }) => void>((to) => {
+      routerState.replacedQuery = to.query
+    }),
+  }),
+}))
+
+vi.mock('../KoboSettings.vue', () => ({ default: { template: '<div data-testid="kobo-settings" />' } }))
+vi.mock('../KoreaderSettings.vue', () => ({ default: { template: '<div data-testid="koreader-settings" />' } }))
+vi.mock('@/features/hardcover/components/HardcoverSettings.vue', () => ({
+  default: { template: '<div data-testid="hardcover-settings" />' },
+}))
+vi.mock('../SettingsPageHeader.vue', () => ({ default: { template: '<div />' } }))
+
+function mountComponent(queryTab?: string) {
+  routerState.currentQuery = queryTab ? { tab: queryTab } : {}
+  routerState.replacedQuery = null
+  return mount(IntegrationsAllSettings)
+}
+
+describe('IntegrationsAllSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('default tab', () => {
+    it('shows kobo tab content when no ?tab param is present', () => {
+      const wrapper = mountComponent()
+      expect(wrapper.find('[data-testid="kobo-settings"]').exists()).toBe(true)
+    })
+
+    it('replaces URL with ?tab=kobo when no tab param is present', () => {
+      mountComponent()
+      expect(routerState.replacedQuery?.tab).toBe('kobo')
+    })
+
+    it('does not replace URL when tab param is already set', () => {
+      mountComponent('koreader')
+      expect(routerState.replacedQuery).toBeNull()
+    })
+  })
+
+  describe('tab rendering', () => {
+    it('renders KoboSettings when tab=kobo', () => {
+      const wrapper = mountComponent('kobo')
+      expect(wrapper.find('[data-testid="kobo-settings"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="koreader-settings"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="hardcover-settings"]').exists()).toBe(false)
+    })
+
+    it('renders KoreaderSettings when tab=koreader', () => {
+      const wrapper = mountComponent('koreader')
+      expect(wrapper.find('[data-testid="koreader-settings"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="kobo-settings"]').exists()).toBe(false)
+    })
+
+    it('renders HardcoverSettings when tab=hardcover', () => {
+      const wrapper = mountComponent('hardcover')
+      expect(wrapper.find('[data-testid="hardcover-settings"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="kobo-settings"]').exists()).toBe(false)
+    })
+
+    it('falls back to kobo for unknown tab value', () => {
+      const wrapper = mountComponent('unknown-tab')
+      expect(wrapper.find('[data-testid="kobo-settings"]').exists()).toBe(true)
+    })
+  })
+
+  describe('tab navigation', () => {
+    it('renders three tab buttons', () => {
+      const wrapper = mountComponent('kobo')
+      const buttons = wrapper.findAll('button')
+      expect(buttons).toHaveLength(3)
+    })
+
+    it('tab buttons have correct labels', () => {
+      const wrapper = mountComponent('kobo')
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).toContain('Kobo')
+      expect(labels).toContain('KOReader')
+      expect(labels).toContain('Hardcover')
+    })
+
+    it('active tab button has border-primary class', () => {
+      const wrapper = mountComponent('kobo')
+      const koboBtn = wrapper.findAll('button').find((b) => b.text() === 'Kobo')
+      expect(koboBtn?.classes()).toContain('border-primary')
+    })
+
+    it('inactive tab buttons have border-transparent class', () => {
+      const wrapper = mountComponent('kobo')
+      const koreaderBtn = wrapper.findAll('button').find((b) => b.text() === 'KOReader')
+      expect(koreaderBtn?.classes()).toContain('border-transparent')
+    })
+
+    it('clicking a tab button calls router.replace with the correct tab', async () => {
+      routerState.currentQuery = { tab: 'kobo' }
+      routerState.replacedQuery = null
+      const wrapper = mount(IntegrationsAllSettings)
+
+      const koreaderBtn = wrapper.findAll('button').find((b) => b.text() === 'KOReader')
+      await koreaderBtn!.trigger('click')
+
+      expect(routerState.replacedQuery!['tab']).toBe('koreader')
+    })
+
+    it('clicking a tab updates the displayed component', async () => {
+      routerState.currentQuery = { tab: 'kobo' }
+      const wrapper = mount(IntegrationsAllSettings)
+
+      expect(wrapper.find('[data-testid="kobo-settings"]').exists()).toBe(true)
+
+      const hardcoverBtn = wrapper.findAll('button').find((b) => b.text() === 'Hardcover')
+      await hardcoverBtn!.trigger('click')
+
+      expect(wrapper.find('[data-testid="hardcover-settings"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="kobo-settings"]').exists()).toBe(false)
+    })
+  })
+
+  describe('tab nav sticky bar', () => {
+    it('tab nav container has sticky class', () => {
+      const wrapper = mountComponent('kobo')
+      const nav = wrapper.find('div.sticky')
+      expect(nav.exists()).toBe(true)
+    })
+
+    it('tab nav container has z-20 class', () => {
+      const wrapper = mountComponent('kobo')
+      const nav = wrapper.find('div.z-20')
+      expect(nav.exists()).toBe(true)
+    })
+  })
+})

--- a/client/src/features/settings/__tests__/SettingsHeader.spec.ts
+++ b/client/src/features/settings/__tests__/SettingsHeader.spec.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { computed } from 'vue'
+import SettingsHeader from '../SettingsHeader.vue'
+
+// --- Permission state ---
+const permState = {
+  isSuperuser: false,
+  permissions: [] as string[],
+}
+
+const routeState = { name: 'settings-appearance' }
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ name: routeState.name }),
+  useRouter: () => ({
+    push: vi.fn<() => Promise<void>>(),
+  }),
+}))
+
+vi.mock('@/features/auth/composables/usePermissions', () => ({
+  usePermissions: () => ({
+    isSuperuser: computed(() => permState.isSuperuser),
+    userPermissions: computed(() => permState.permissions),
+  }),
+}))
+
+function mountHeader(opts?: { su?: boolean; perms?: string[]; routeName?: string }) {
+  permState.isSuperuser = opts?.su ?? false
+  permState.permissions = opts?.perms ?? []
+  routeState.name = opts?.routeName ?? 'settings-appearance'
+  return mount(SettingsHeader)
+}
+
+function getTabLabels(wrapper: ReturnType<typeof mount>): string[] {
+  return wrapper.findAll('button').map((b) => b.text())
+}
+
+describe('SettingsHeader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('tabs always visible to all users', () => {
+    it('shows Appearance tab', () => {
+      const labels = getTabLabels(mountHeader())
+      expect(labels).toContain('Appearance')
+    })
+
+    it('shows Reader tab', () => {
+      const labels = getTabLabels(mountHeader())
+      expect(labels).toContain('Reader')
+    })
+
+    it('shows Account tab', () => {
+      const labels = getTabLabels(mountHeader())
+      expect(labels).toContain('Account')
+    })
+
+    it('shows Integrations tab for all users (Hardcover has no permission gate)', () => {
+      const labels = getTabLabels(mountHeader())
+      expect(labels).toContain('Integrations')
+    })
+  })
+
+  describe('tabs removed from top-level navigation', () => {
+    it('does not show a standalone Kobo tab', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).not.toContain('Kobo')
+    })
+
+    it('does not show a standalone KOReader tab', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).not.toContain('KOReader')
+    })
+
+    it('does not show a standalone Hardcover tab', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).not.toContain('Hardcover')
+    })
+
+    it('does not show a standalone Users tab', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).not.toContain('Users')
+    })
+
+    it('does not show a standalone OIDC / SSO tab', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).not.toContain('OIDC / SSO')
+    })
+
+    it('does not show a standalone File Naming tab', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).not.toContain('File Naming')
+    })
+
+    it('does not show a standalone Book Dock tab', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).not.toContain('Book Dock')
+    })
+
+    it('does not show a standalone Maintenance tab', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).not.toContain('Maintenance')
+    })
+
+    it('does not show a standalone Audit Log tab', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).not.toContain('Audit Log')
+    })
+
+    it('does not show a standalone Notifications tab', () => {
+      const labels = getTabLabels(mountHeader())
+      expect(labels).not.toContain('Notifications')
+    })
+  })
+
+  describe('Admin tab visibility', () => {
+    it('shows Admin tab for superuser', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).toContain('Admin')
+    })
+
+    it('shows Admin tab for user with manage_users', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['manage_users'] }))
+      expect(labels).toContain('Admin')
+    })
+
+    it('shows Admin tab for user with manage_app_settings', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['manage_app_settings'] }))
+      expect(labels).toContain('Admin')
+    })
+
+    it('hides Admin tab when user has neither manage_users nor manage_app_settings', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['kobo_sync'] }))
+      expect(labels).not.toContain('Admin')
+    })
+  })
+
+  describe('System tab visibility', () => {
+    it('shows System tab for superuser', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).toContain('System')
+    })
+
+    it('shows System tab for user with manage_app_settings', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['manage_app_settings'] }))
+      expect(labels).toContain('System')
+    })
+
+    it('shows System tab for user with book_dock_access', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['book_dock_access'] }))
+      expect(labels).toContain('System')
+    })
+
+    it('hides System tab when user lacks manage_app_settings and book_dock_access', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['kobo_sync'] }))
+      expect(labels).not.toContain('System')
+    })
+  })
+
+  describe('conditional tabs', () => {
+    it('shows Libraries tab for superuser', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).toContain('Libraries')
+    })
+
+    it('shows Libraries tab for user with manage_libraries', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['manage_libraries'] }))
+      expect(labels).toContain('Libraries')
+    })
+
+    it('hides Libraries tab for user without manage_libraries', () => {
+      const labels = getTabLabels(mountHeader())
+      expect(labels).not.toContain('Libraries')
+    })
+
+    it('shows Metadata tab for superuser', () => {
+      const labels = getTabLabels(mountHeader({ su: true }))
+      expect(labels).toContain('Metadata')
+    })
+
+    it('shows Metadata tab for user with manage_metadata_config', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['manage_metadata_config'] }))
+      expect(labels).toContain('Metadata')
+    })
+
+    it('shows Email tab for user with email_send', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['email_send'] }))
+      expect(labels).toContain('Email')
+    })
+
+    it('shows OPDS tab for user with opds_access', () => {
+      const labels = getTabLabels(mountHeader({ perms: ['opds_access'] }))
+      expect(labels).toContain('OPDS')
+    })
+  })
+
+  describe('active state', () => {
+    it('active tab has border-primary class when route matches', () => {
+      const wrapper = mountHeader({ routeName: 'settings-appearance' })
+      const appearanceBtn = wrapper.findAll('button').find((b) => b.text() === 'Appearance')
+      expect(appearanceBtn?.classes()).toContain('border-primary')
+    })
+
+    it('inactive tabs have border-transparent class', () => {
+      const wrapper = mountHeader({ routeName: 'settings-appearance' })
+      const readerBtn = wrapper.findAll('button').find((b) => b.text() === 'Reader')
+      expect(readerBtn?.classes()).toContain('border-transparent')
+    })
+
+    it('integrations tab is active when route is settings-integrations', () => {
+      const wrapper = mountHeader({ routeName: 'settings-integrations' })
+      const btn = wrapper.findAll('button').find((b) => b.text() === 'Integrations')
+      expect(btn?.classes()).toContain('border-primary')
+    })
+
+    it('admin tab is active when route is settings-admin', () => {
+      const wrapper = mountHeader({ su: true, routeName: 'settings-admin' })
+      const btn = wrapper.findAll('button').find((b) => b.text() === 'Admin')
+      expect(btn?.classes()).toContain('border-primary')
+    })
+
+    it('system tab is active when route is settings-system', () => {
+      const wrapper = mountHeader({ su: true, routeName: 'settings-system' })
+      const btn = wrapper.findAll('button').find((b) => b.text() === 'System')
+      expect(btn?.classes()).toContain('border-primary')
+    })
+
+    it('account tab is active when route is settings-account', () => {
+      const wrapper = mountHeader({ routeName: 'settings-account' })
+      const btn = wrapper.findAll('button').find((b) => b.text() === 'Account')
+      expect(btn?.classes()).toContain('border-primary')
+    })
+  })
+
+  describe('navigation', () => {
+    it('clicking a tab button triggers a click event', async () => {
+      const wrapper = mountHeader({ routeName: 'settings-appearance' })
+      const readerBtn = wrapper.findAll('button').find((b) => b.text() === 'Reader')
+      await readerBtn!.trigger('click')
+      // If click triggers without throwing, navigation is wired correctly
+      expect(readerBtn!.exists()).toBe(true)
+    })
+  })
+})

--- a/client/src/features/settings/__tests__/SystemAllSettings.spec.ts
+++ b/client/src/features/settings/__tests__/SystemAllSettings.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { computed } from 'vue'
+import SystemAllSettings from '../SystemAllSettings.vue'
+
+// --- Permission state ---
+const permState = {
+  isSuperuser: false,
+  permissions: [] as string[],
+}
+
+const routerState = {
+  currentQuery: {} as Record<string, string>,
+  replacedQuery: null as Record<string, string> | null,
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: routerState.currentQuery }),
+  useRouter: () => ({
+    replace: vi.fn<(to: { name: string; query: Record<string, string> }) => void>((to) => {
+      routerState.replacedQuery = to.query
+    }),
+  }),
+}))
+
+vi.mock('@/features/auth/composables/usePermissions', () => ({
+  usePermissions: () => ({
+    isSuperuser: computed(() => permState.isSuperuser),
+    userPermissions: computed(() => permState.permissions),
+  }),
+}))
+
+vi.mock('../FileNamingSettings.vue', () => ({ default: { template: '<div data-testid="file-naming" />' } }))
+vi.mock('../BookDockSettings.vue', () => ({ default: { template: '<div data-testid="book-dock" />' } }))
+vi.mock('../MaintenanceSettings.vue', () => ({ default: { template: '<div data-testid="maintenance" />' } }))
+vi.mock('@/features/audit/AuditLogPage.vue', () => ({ default: { template: '<div data-testid="audit-log" />' } }))
+vi.mock('../SettingsPageHeader.vue', () => ({ default: { template: '<div />' } }))
+
+function mountComponent(queryTab?: string, opts?: { su?: boolean; perms?: string[] }) {
+  permState.isSuperuser = opts?.su ?? false
+  permState.permissions = opts?.perms ?? []
+  routerState.currentQuery = queryTab ? { tab: queryTab } : {}
+  routerState.replacedQuery = null
+  return mount(SystemAllSettings)
+}
+
+describe('SystemAllSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('superuser', () => {
+    it('sees all four tabs', () => {
+      const wrapper = mountComponent(undefined, { su: true })
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).toContain('File Naming')
+      expect(labels).toContain('Book Dock')
+      expect(labels).toContain('Maintenance')
+      expect(labels).toContain('Audit Log')
+    })
+
+    it('defaults to file-naming and shows FileNamingSettings', () => {
+      const wrapper = mountComponent(undefined, { su: true })
+      expect(wrapper.find('[data-testid="file-naming"]').exists()).toBe(true)
+    })
+
+    it('renders BookDockSettings when tab=book-dock', () => {
+      const wrapper = mountComponent('book-dock', { su: true })
+      expect(wrapper.find('[data-testid="book-dock"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="file-naming"]').exists()).toBe(false)
+    })
+
+    it('renders MaintenanceSettings when tab=maintenance', () => {
+      const wrapper = mountComponent('maintenance', { su: true })
+      expect(wrapper.find('[data-testid="maintenance"]').exists()).toBe(true)
+    })
+
+    it('renders AuditLogPage when tab=audit-log', () => {
+      const wrapper = mountComponent('audit-log', { su: true })
+      expect(wrapper.find('[data-testid="audit-log"]').exists()).toBe(true)
+    })
+  })
+
+  describe('user with manage_app_settings', () => {
+    it('sees file-naming and maintenance but not book-dock or audit-log', () => {
+      const wrapper = mountComponent(undefined, { perms: ['manage_app_settings'] })
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).toContain('File Naming')
+      expect(labels).toContain('Maintenance')
+      expect(labels).not.toContain('Book Dock')
+      expect(labels).not.toContain('Audit Log')
+    })
+  })
+
+  describe('user with book_dock_access only', () => {
+    it('sees book-dock tab only', () => {
+      const wrapper = mountComponent(undefined, { perms: ['book_dock_access'] })
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).toContain('Book Dock')
+      expect(labels).not.toContain('File Naming')
+      expect(labels).not.toContain('Maintenance')
+      expect(labels).not.toContain('Audit Log')
+    })
+
+    it('defaults to book-dock', () => {
+      const wrapper = mountComponent(undefined, { perms: ['book_dock_access'] })
+      expect(wrapper.find('[data-testid="book-dock"]').exists()).toBe(true)
+    })
+  })
+
+  describe('non-superuser cannot access audit-log', () => {
+    it('does not see audit-log even with manage_app_settings', () => {
+      const wrapper = mountComponent(undefined, { perms: ['manage_app_settings'] })
+      const labels = wrapper.findAll('button').map((b) => b.text())
+      expect(labels).not.toContain('Audit Log')
+    })
+
+    it('falls back when audit-log requested without superuser', () => {
+      const wrapper = mountComponent('audit-log', { perms: ['manage_app_settings'] })
+      expect(wrapper.find('[data-testid="audit-log"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="file-naming"]').exists()).toBe(true)
+    })
+  })
+
+  describe('tab navigation', () => {
+    it('active tab button has border-primary class', () => {
+      const wrapper = mountComponent('maintenance', { su: true })
+      const btn = wrapper.findAll('button').find((b) => b.text() === 'Maintenance')
+      expect(btn?.classes()).toContain('border-primary')
+    })
+
+    it('inactive tab button has border-transparent class', () => {
+      const wrapper = mountComponent('maintenance', { su: true })
+      const btn = wrapper.findAll('button').find((b) => b.text() === 'File Naming')
+      expect(btn?.classes()).toContain('border-transparent')
+    })
+
+    it('clicking a tab switches content', async () => {
+      permState.isSuperuser = true
+      routerState.currentQuery = { tab: 'file-naming' }
+      const wrapper = mount(SystemAllSettings)
+
+      const btn = wrapper.findAll('button').find((b) => b.text() === 'Audit Log')
+      await btn!.trigger('click')
+
+      expect(wrapper.find('[data-testid="audit-log"]').exists()).toBe(true)
+    })
+
+    it('replaces URL with default tab when no tab param present', () => {
+      mountComponent(undefined, { su: true })
+      expect(routerState.replacedQuery!['tab']).toBe('file-naming')
+    })
+  })
+})

--- a/client/src/features/settings/__tests__/account-tabs.spec.ts
+++ b/client/src/features/settings/__tests__/account-tabs.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { ACCOUNT_TABS, ACCOUNT_TAB_INFO, normalizeAccountTab } from '../lib/account-tabs'
+
+describe('account-tabs', () => {
+  describe('ACCOUNT_TABS', () => {
+    it('contains exactly profile and notifications', () => {
+      expect(ACCOUNT_TABS).toEqual(['profile', 'notifications'])
+    })
+
+    it('has length 2', () => {
+      expect(ACCOUNT_TABS.length).toBe(2)
+    })
+  })
+
+  describe('ACCOUNT_TAB_INFO', () => {
+    it('has an entry for every tab', () => {
+      for (const tab of ACCOUNT_TABS) {
+        expect(ACCOUNT_TAB_INFO[tab]).toBeDefined()
+      }
+    })
+
+    it('every entry has navLabel, titleLabel, and subtitle', () => {
+      for (const tab of ACCOUNT_TABS) {
+        const info = ACCOUNT_TAB_INFO[tab]
+        expect(typeof info.navLabel).toBe('string')
+        expect(info.navLabel.length).toBeGreaterThan(0)
+        expect(typeof info.titleLabel).toBe('string')
+        expect(info.titleLabel.length).toBeGreaterThan(0)
+        expect(typeof info.subtitle).toBe('string')
+        expect(info.subtitle.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('profile entry has correct labels', () => {
+      expect(ACCOUNT_TAB_INFO.profile.navLabel).toBe('Profile')
+      expect(ACCOUNT_TAB_INFO.profile.titleLabel).toBe('Account')
+    })
+
+    it('notifications entry has correct labels', () => {
+      expect(ACCOUNT_TAB_INFO.notifications.navLabel).toBe('Notifications')
+      expect(ACCOUNT_TAB_INFO.notifications.titleLabel).toBe('Notifications')
+    })
+  })
+
+  describe('normalizeAccountTab', () => {
+    it('returns profile for undefined', () => {
+      expect(normalizeAccountTab(undefined)).toBe('profile')
+    })
+
+    it('returns profile for null', () => {
+      expect(normalizeAccountTab(null)).toBe('profile')
+    })
+
+    it('returns profile for empty string', () => {
+      expect(normalizeAccountTab('')).toBe('profile')
+    })
+
+    it('returns profile for unknown string', () => {
+      expect(normalizeAccountTab('unknown')).toBe('profile')
+    })
+
+    it('returns profile for number input', () => {
+      expect(normalizeAccountTab(42)).toBe('profile')
+    })
+
+    it('returns profile when given "profile"', () => {
+      expect(normalizeAccountTab('profile')).toBe('profile')
+    })
+
+    it('returns notifications when given "notifications"', () => {
+      expect(normalizeAccountTab('notifications')).toBe('notifications')
+    })
+
+    it('is case-sensitive (Profile is not valid)', () => {
+      expect(normalizeAccountTab('Profile')).toBe('profile')
+    })
+  })
+})

--- a/client/src/features/settings/__tests__/admin-tabs.spec.ts
+++ b/client/src/features/settings/__tests__/admin-tabs.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { ADMIN_TABS, ADMIN_TAB_INFO, normalizeAdminTab } from '../lib/admin-tabs'
+
+describe('admin-tabs', () => {
+  describe('ADMIN_TABS', () => {
+    it('contains exactly users and oidc', () => {
+      expect(ADMIN_TABS).toEqual(['users', 'oidc'])
+    })
+
+    it('has length 2', () => {
+      expect(ADMIN_TABS.length).toBe(2)
+    })
+  })
+
+  describe('ADMIN_TAB_INFO', () => {
+    it('has an entry for every tab', () => {
+      for (const tab of ADMIN_TABS) {
+        expect(ADMIN_TAB_INFO[tab]).toBeDefined()
+      }
+    })
+
+    it('every entry has navLabel, titleLabel, subtitle, and permission', () => {
+      for (const tab of ADMIN_TABS) {
+        const info = ADMIN_TAB_INFO[tab]
+        expect(typeof info.navLabel).toBe('string')
+        expect(info.navLabel.length).toBeGreaterThan(0)
+        expect(typeof info.titleLabel).toBe('string')
+        expect(info.titleLabel.length).toBeGreaterThan(0)
+        expect(typeof info.subtitle).toBe('string')
+        expect(info.subtitle.length).toBeGreaterThan(0)
+        expect(info.permission === null || typeof info.permission === 'string').toBe(true)
+      }
+    })
+
+    it('users entry has manage_users permission', () => {
+      expect(ADMIN_TAB_INFO.users.permission).toBe('manage_users')
+    })
+
+    it('oidc entry has manage_app_settings permission', () => {
+      expect(ADMIN_TAB_INFO.oidc.permission).toBe('manage_app_settings')
+    })
+
+    it('users entry has correct labels', () => {
+      expect(ADMIN_TAB_INFO.users.navLabel).toBe('Users')
+      expect(ADMIN_TAB_INFO.users.titleLabel).toBe('Users')
+    })
+
+    it('oidc entry has correct labels', () => {
+      expect(ADMIN_TAB_INFO.oidc.navLabel).toBe('OIDC / SSO')
+      expect(ADMIN_TAB_INFO.oidc.titleLabel).toBe('OIDC / SSO')
+    })
+  })
+
+  describe('normalizeAdminTab', () => {
+    it('returns users for undefined', () => {
+      expect(normalizeAdminTab(undefined)).toBe('users')
+    })
+
+    it('returns users for null', () => {
+      expect(normalizeAdminTab(null)).toBe('users')
+    })
+
+    it('returns users for empty string', () => {
+      expect(normalizeAdminTab('')).toBe('users')
+    })
+
+    it('returns users for unknown string', () => {
+      expect(normalizeAdminTab('unknown')).toBe('users')
+    })
+
+    it('returns users for number input', () => {
+      expect(normalizeAdminTab(42)).toBe('users')
+    })
+
+    it('returns users when given "users"', () => {
+      expect(normalizeAdminTab('users')).toBe('users')
+    })
+
+    it('returns oidc when given "oidc"', () => {
+      expect(normalizeAdminTab('oidc')).toBe('oidc')
+    })
+
+    it('is case-sensitive (Users is not valid)', () => {
+      expect(normalizeAdminTab('Users')).toBe('users')
+    })
+  })
+})

--- a/client/src/features/settings/__tests__/integrations-tabs.spec.ts
+++ b/client/src/features/settings/__tests__/integrations-tabs.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { INTEGRATIONS_TABS, INTEGRATIONS_TAB_INFO, normalizeIntegrationsTab } from '../lib/integrations-tabs'
+
+describe('integrations-tabs', () => {
+  describe('INTEGRATIONS_TABS', () => {
+    it('contains exactly kobo, koreader, hardcover', () => {
+      expect(INTEGRATIONS_TABS).toEqual(['kobo', 'koreader', 'hardcover'])
+    })
+
+    it('is readonly (length is 3)', () => {
+      expect(INTEGRATIONS_TABS.length).toBe(3)
+    })
+  })
+
+  describe('INTEGRATIONS_TAB_INFO', () => {
+    it('has an entry for every tab', () => {
+      for (const tab of INTEGRATIONS_TABS) {
+        expect(INTEGRATIONS_TAB_INFO[tab]).toBeDefined()
+      }
+    })
+
+    it('every entry has navLabel, titleLabel, and subtitle', () => {
+      for (const tab of INTEGRATIONS_TABS) {
+        const info = INTEGRATIONS_TAB_INFO[tab]
+        expect(typeof info.navLabel).toBe('string')
+        expect(info.navLabel.length).toBeGreaterThan(0)
+        expect(typeof info.titleLabel).toBe('string')
+        expect(info.titleLabel.length).toBeGreaterThan(0)
+        expect(typeof info.subtitle).toBe('string')
+        expect(info.subtitle.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('kobo entry has correct labels', () => {
+      expect(INTEGRATIONS_TAB_INFO.kobo.navLabel).toBe('Kobo')
+      expect(INTEGRATIONS_TAB_INFO.kobo.titleLabel).toBe('Kobo Sync')
+    })
+
+    it('koreader entry has correct labels', () => {
+      expect(INTEGRATIONS_TAB_INFO.koreader.navLabel).toBe('KOReader')
+      expect(INTEGRATIONS_TAB_INFO.koreader.titleLabel).toBe('KOReader Sync')
+    })
+
+    it('hardcover entry has correct labels', () => {
+      expect(INTEGRATIONS_TAB_INFO.hardcover.navLabel).toBe('Hardcover')
+      expect(INTEGRATIONS_TAB_INFO.hardcover.titleLabel).toBe('Hardcover')
+    })
+  })
+
+  describe('normalizeIntegrationsTab', () => {
+    it('returns kobo for undefined', () => {
+      expect(normalizeIntegrationsTab(undefined)).toBe('kobo')
+    })
+
+    it('returns kobo for null', () => {
+      expect(normalizeIntegrationsTab(null)).toBe('kobo')
+    })
+
+    it('returns kobo for empty string', () => {
+      expect(normalizeIntegrationsTab('')).toBe('kobo')
+    })
+
+    it('returns kobo for unknown string', () => {
+      expect(normalizeIntegrationsTab('unknown')).toBe('kobo')
+    })
+
+    it('returns kobo for number input', () => {
+      expect(normalizeIntegrationsTab(42)).toBe('kobo')
+    })
+
+    it('returns kobo for object input', () => {
+      expect(normalizeIntegrationsTab({})).toBe('kobo')
+    })
+
+    it('returns kobo when given "kobo"', () => {
+      expect(normalizeIntegrationsTab('kobo')).toBe('kobo')
+    })
+
+    it('returns koreader when given "koreader"', () => {
+      expect(normalizeIntegrationsTab('koreader')).toBe('koreader')
+    })
+
+    it('returns hardcover when given "hardcover"', () => {
+      expect(normalizeIntegrationsTab('hardcover')).toBe('hardcover')
+    })
+
+    it('is case-sensitive (Kobo is not a valid tab)', () => {
+      expect(normalizeIntegrationsTab('Kobo')).toBe('kobo')
+    })
+  })
+})

--- a/client/src/features/settings/__tests__/system-tabs.spec.ts
+++ b/client/src/features/settings/__tests__/system-tabs.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { SYSTEM_TABS, SYSTEM_TAB_INFO, normalizeSystemTab } from '../lib/system-tabs'
+
+describe('system-tabs', () => {
+  describe('SYSTEM_TABS', () => {
+    it('contains exactly file-naming, book-dock, maintenance, audit-log', () => {
+      expect(SYSTEM_TABS).toEqual(['file-naming', 'book-dock', 'maintenance', 'audit-log'])
+    })
+
+    it('has length 4', () => {
+      expect(SYSTEM_TABS.length).toBe(4)
+    })
+  })
+
+  describe('SYSTEM_TAB_INFO', () => {
+    it('has an entry for every tab', () => {
+      for (const tab of SYSTEM_TABS) {
+        expect(SYSTEM_TAB_INFO[tab]).toBeDefined()
+      }
+    })
+
+    it('every entry has navLabel, titleLabel, subtitle, and permission', () => {
+      for (const tab of SYSTEM_TABS) {
+        const info = SYSTEM_TAB_INFO[tab]
+        expect(typeof info.navLabel).toBe('string')
+        expect(info.navLabel.length).toBeGreaterThan(0)
+        expect(typeof info.titleLabel).toBe('string')
+        expect(info.titleLabel.length).toBeGreaterThan(0)
+        expect(typeof info.subtitle).toBe('string')
+        expect(info.subtitle.length).toBeGreaterThan(0)
+        expect(info.permission === null || typeof info.permission === 'string').toBe(true)
+      }
+    })
+
+    it('file-naming has manage_app_settings permission', () => {
+      expect(SYSTEM_TAB_INFO['file-naming'].permission).toBe('manage_app_settings')
+    })
+
+    it('book-dock has book_dock_access permission', () => {
+      expect(SYSTEM_TAB_INFO['book-dock'].permission).toBe('book_dock_access')
+    })
+
+    it('maintenance has manage_app_settings permission', () => {
+      expect(SYSTEM_TAB_INFO.maintenance.permission).toBe('manage_app_settings')
+    })
+
+    it('audit-log has null permission (superuser only)', () => {
+      expect(SYSTEM_TAB_INFO['audit-log'].permission).toBeNull()
+    })
+
+    it('file-naming has correct nav label', () => {
+      expect(SYSTEM_TAB_INFO['file-naming'].navLabel).toBe('File Naming')
+    })
+
+    it('book-dock has correct nav label', () => {
+      expect(SYSTEM_TAB_INFO['book-dock'].navLabel).toBe('Book Dock')
+    })
+
+    it('maintenance has correct nav label', () => {
+      expect(SYSTEM_TAB_INFO.maintenance.navLabel).toBe('Maintenance')
+    })
+
+    it('audit-log has correct nav label', () => {
+      expect(SYSTEM_TAB_INFO['audit-log'].navLabel).toBe('Audit Log')
+    })
+  })
+
+  describe('normalizeSystemTab', () => {
+    it('returns file-naming for undefined', () => {
+      expect(normalizeSystemTab(undefined)).toBe('file-naming')
+    })
+
+    it('returns file-naming for null', () => {
+      expect(normalizeSystemTab(null)).toBe('file-naming')
+    })
+
+    it('returns file-naming for empty string', () => {
+      expect(normalizeSystemTab('')).toBe('file-naming')
+    })
+
+    it('returns file-naming for unknown string', () => {
+      expect(normalizeSystemTab('unknown')).toBe('file-naming')
+    })
+
+    it('returns file-naming for number input', () => {
+      expect(normalizeSystemTab(42)).toBe('file-naming')
+    })
+
+    it('returns file-naming when given "file-naming"', () => {
+      expect(normalizeSystemTab('file-naming')).toBe('file-naming')
+    })
+
+    it('returns book-dock when given "book-dock"', () => {
+      expect(normalizeSystemTab('book-dock')).toBe('book-dock')
+    })
+
+    it('returns maintenance when given "maintenance"', () => {
+      expect(normalizeSystemTab('maintenance')).toBe('maintenance')
+    })
+
+    it('returns audit-log when given "audit-log"', () => {
+      expect(normalizeSystemTab('audit-log')).toBe('audit-log')
+    })
+
+    it('is case-sensitive (Maintenance is not valid)', () => {
+      expect(normalizeSystemTab('Maintenance')).toBe('file-naming')
+    })
+  })
+})

--- a/client/src/features/settings/lib/account-tabs.ts
+++ b/client/src/features/settings/lib/account-tabs.ts
@@ -1,0 +1,29 @@
+export const ACCOUNT_TABS = ['profile', 'notifications'] as const
+
+export type AccountTab = (typeof ACCOUNT_TABS)[number]
+
+type AccountTabInfo = {
+  navLabel: string
+  titleLabel: string
+  subtitle: string
+}
+
+export const ACCOUNT_TAB_INFO: Record<AccountTab, AccountTabInfo> = {
+  profile: {
+    navLabel: 'Profile',
+    titleLabel: 'Account',
+    subtitle: 'Manage your personal profile settings.',
+  },
+  notifications: {
+    navLabel: 'Notifications',
+    titleLabel: 'Notifications',
+    subtitle: 'Choose which notification categories you want to receive.',
+  },
+}
+
+export function normalizeAccountTab(value: unknown): AccountTab {
+  if (typeof value === 'string' && ACCOUNT_TABS.includes(value as AccountTab)) {
+    return value as AccountTab
+  }
+  return 'profile'
+}

--- a/client/src/features/settings/lib/admin-tabs.ts
+++ b/client/src/features/settings/lib/admin-tabs.ts
@@ -1,0 +1,32 @@
+export const ADMIN_TABS = ['users', 'oidc'] as const
+
+export type AdminTab = (typeof ADMIN_TABS)[number]
+
+type AdminTabInfo = {
+  navLabel: string
+  titleLabel: string
+  subtitle: string
+  permission: string | null
+}
+
+export const ADMIN_TAB_INFO: Record<AdminTab, AdminTabInfo> = {
+  users: {
+    navLabel: 'Users',
+    titleLabel: 'Users',
+    subtitle: 'Manage user accounts and permission assignments.',
+    permission: 'manage_users',
+  },
+  oidc: {
+    navLabel: 'OIDC / SSO',
+    titleLabel: 'OIDC / SSO',
+    subtitle: 'Manage OpenID Connect providers for single sign-on.',
+    permission: 'manage_app_settings',
+  },
+}
+
+export function normalizeAdminTab(value: unknown): AdminTab {
+  if (typeof value === 'string' && ADMIN_TABS.includes(value as AdminTab)) {
+    return value as AdminTab
+  }
+  return 'users'
+}

--- a/client/src/features/settings/lib/integrations-tabs.ts
+++ b/client/src/features/settings/lib/integrations-tabs.ts
@@ -1,0 +1,34 @@
+export const INTEGRATIONS_TABS = ['kobo', 'koreader', 'hardcover'] as const
+
+export type IntegrationsTab = (typeof INTEGRATIONS_TABS)[number]
+
+type IntegrationsTabInfo = {
+  navLabel: string
+  titleLabel: string
+  subtitle: string
+}
+
+export const INTEGRATIONS_TAB_INFO: Record<IntegrationsTab, IntegrationsTabInfo> = {
+  kobo: {
+    navLabel: 'Kobo',
+    titleLabel: 'Kobo Sync',
+    subtitle: 'Pair your Kobo device to sync your library.',
+  },
+  koreader: {
+    navLabel: 'KOReader',
+    titleLabel: 'KOReader Sync',
+    subtitle: 'Sync reading progress between KOReader devices and BookOrbit.',
+  },
+  hardcover: {
+    navLabel: 'Hardcover',
+    titleLabel: 'Hardcover',
+    subtitle: 'Sync your reading progress, status, and ratings to Hardcover.',
+  },
+}
+
+export function normalizeIntegrationsTab(value: unknown): IntegrationsTab {
+  if (typeof value === 'string' && INTEGRATIONS_TABS.includes(value as IntegrationsTab)) {
+    return value as IntegrationsTab
+  }
+  return 'kobo'
+}

--- a/client/src/features/settings/lib/system-tabs.ts
+++ b/client/src/features/settings/lib/system-tabs.ts
@@ -1,0 +1,44 @@
+export const SYSTEM_TABS = ['file-naming', 'book-dock', 'maintenance', 'audit-log'] as const
+
+export type SystemTab = (typeof SYSTEM_TABS)[number]
+
+type SystemTabInfo = {
+  navLabel: string
+  titleLabel: string
+  subtitle: string
+  permission: string | null
+}
+
+export const SYSTEM_TAB_INFO: Record<SystemTab, SystemTabInfo> = {
+  'file-naming': {
+    navLabel: 'File Naming',
+    titleLabel: 'File Naming',
+    subtitle: 'Control how files are organized on disk when uploaded and how they are named when downloaded using placeholder tokens.',
+    permission: 'manage_app_settings',
+  },
+  'book-dock': {
+    navLabel: 'Book Dock',
+    titleLabel: 'Book Dock',
+    subtitle: 'Configure how files are processed when they enter Book Dock.',
+    permission: 'book_dock_access',
+  },
+  maintenance: {
+    navLabel: 'Maintenance',
+    titleLabel: 'Maintenance',
+    subtitle: 'Manage background tasks, system indices, and maintenance operations.',
+    permission: 'manage_app_settings',
+  },
+  'audit-log': {
+    navLabel: 'Audit Log',
+    titleLabel: 'Audit Log',
+    subtitle: 'A record of admin-significant actions performed across the system.',
+    permission: null,
+  },
+}
+
+export function normalizeSystemTab(value: unknown): SystemTab {
+  if (typeof value === 'string' && SYSTEM_TABS.includes(value as SystemTab)) {
+    return value as SystemTab
+  }
+  return 'file-naming'
+}

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -2,8 +2,10 @@ import { createRouter, createWebHistory, type RouteLocationNormalizedLoaded, typ
 import { EMAIL_TAB_LABELS, normalizeEmailTab } from '@/features/email/lib/email-tabs'
 import { METADATA_TAB_INFO, normalizeMetadataTab } from '@/features/settings/lib/metadata-tabs'
 import { READER_TAB_TITLE_LABELS, normalizeReaderTab } from '@/features/settings/lib/reader-tabs'
-import { Permission } from '@bookorbit/types'
-import { useAuth } from '@/features/auth/composables/useAuth'
+import { INTEGRATIONS_TAB_INFO, normalizeIntegrationsTab } from '@/features/settings/lib/integrations-tabs'
+import { ADMIN_TAB_INFO, normalizeAdminTab } from '@/features/settings/lib/admin-tabs'
+import { SYSTEM_TAB_INFO, normalizeSystemTab } from '@/features/settings/lib/system-tabs'
+import { ACCOUNT_TAB_INFO, normalizeAccountTab } from '@/features/settings/lib/account-tabs'
 import { registerAuthGuard } from './guards/auth.guard'
 import { registerRouteTitleHook } from './title-resolver'
 
@@ -40,12 +42,24 @@ function resolveMetadataTitle(to: RouteLocationNormalizedLoaded): string {
   return METADATA_TAB_INFO[tab].titleLabel
 }
 
-function blockDemoRestrictedNotificationsRoute() {
-  const { user } = useAuth()
-  if (user.value?.permissions?.includes(Permission.DemoRestricted)) {
-    return { name: 'settings-account' }
-  }
-  return true
+function resolveIntegrationsTitle(to: RouteLocationNormalizedLoaded): string {
+  const tab = normalizeIntegrationsTab(to.query.tab)
+  return INTEGRATIONS_TAB_INFO[tab].titleLabel
+}
+
+function resolveAdminTitle(to: RouteLocationNormalizedLoaded): string {
+  const tab = normalizeAdminTab(to.query.tab)
+  return ADMIN_TAB_INFO[tab].titleLabel
+}
+
+function resolveSystemTitle(to: RouteLocationNormalizedLoaded): string {
+  const tab = normalizeSystemTab(to.query.tab)
+  return SYSTEM_TAB_INFO[tab].titleLabel
+}
+
+function resolveAccountTitle(to: RouteLocationNormalizedLoaded): string {
+  const tab = normalizeAccountTab(to.query.tab)
+  return ACCOUNT_TAB_INFO[tab].titleLabel
 }
 
 export const routes: RouteRecordRaw[] = [
@@ -67,15 +81,13 @@ export const routes: RouteRecordRaw[] = [
           {
             path: 'account',
             name: 'settings-account',
-            component: () => import('@/features/settings/AccountSettings.vue'),
-            meta: { title: 'Account' },
+            component: () => import('@/features/settings/AccountAllSettings.vue'),
+            meta: { title: resolveAccountTitle },
           },
           {
             path: 'notifications',
             name: 'settings-notifications',
-            component: () => import('@/features/notifications/components/NotificationPreferences.vue'),
-            beforeEnter: blockDemoRestrictedNotificationsRoute,
-            meta: { title: 'Notifications' },
+            redirect: () => ({ name: 'settings-account', query: { tab: 'notifications' } }),
           },
           {
             path: 'libraries',
@@ -96,22 +108,25 @@ export const routes: RouteRecordRaw[] = [
             meta: { title: 'OPDS' },
           },
           {
+            path: 'integrations',
+            name: 'settings-integrations',
+            component: () => import('@/features/settings/IntegrationsAllSettings.vue'),
+            meta: { maxWidth: 'max-w-3xl', title: resolveIntegrationsTitle },
+          },
+          {
             path: 'kobo',
             name: 'settings-kobo',
-            component: () => import('@/features/settings/KoboSettings.vue'),
-            meta: { maxWidth: 'max-w-3xl', title: 'Kobo Sync' },
+            redirect: () => ({ name: 'settings-integrations', query: { tab: 'kobo' } }),
           },
           {
             path: 'koreader',
             name: 'settings-koreader',
-            component: () => import('@/features/settings/KoreaderSettings.vue'),
-            meta: { maxWidth: 'max-w-3xl', title: 'KOReader Sync' },
+            redirect: () => ({ name: 'settings-integrations', query: { tab: 'koreader' } }),
           },
           {
             path: 'hardcover',
             name: 'settings-hardcover',
-            component: () => import('@/features/hardcover/components/HardcoverSettings.vue'),
-            meta: { maxWidth: 'max-w-3xl', title: 'Hardcover' },
+            redirect: () => ({ name: 'settings-integrations', query: { tab: 'hardcover' } }),
           },
           {
             path: 'email',
@@ -141,10 +156,15 @@ export const routes: RouteRecordRaw[] = [
             redirect: { name: 'settings-reader-general', query: { tab: 'comics' } },
           },
           {
+            path: 'admin',
+            name: 'settings-admin',
+            component: () => import('@/features/settings/AdminAllSettings.vue'),
+            meta: { maxWidth: 'max-w-6xl', title: resolveAdminTitle },
+          },
+          {
             path: 'admin/users',
             name: 'settings-admin-users',
-            component: () => import('@/features/admin/UsersPage.vue'),
-            meta: { maxWidth: 'max-w-6xl', title: 'Users' },
+            redirect: () => ({ name: 'settings-admin', query: { tab: 'users' } }),
           },
           {
             path: 'admin/metadata',
@@ -160,37 +180,38 @@ export const routes: RouteRecordRaw[] = [
           {
             path: 'admin/oidc',
             name: 'settings-admin-oidc',
-            component: () => import('@/features/settings/OidcSettings.vue'),
-            meta: { title: 'OIDC / SSO' },
+            redirect: () => ({ name: 'settings-admin', query: { tab: 'oidc' } }),
+          },
+          {
+            path: 'system',
+            name: 'settings-system',
+            component: () => import('@/features/settings/SystemAllSettings.vue'),
+            meta: { maxWidth: 'max-w-7xl', title: resolveSystemTitle },
           },
           {
             path: 'admin/file-naming',
             name: 'settings-admin-file-naming',
-            component: () => import('@/features/settings/FileNamingSettings.vue'),
-            meta: { maxWidth: 'max-w-7xl', title: 'File Naming' },
+            redirect: () => ({ name: 'settings-system', query: { tab: 'file-naming' } }),
           },
           {
             path: 'admin/book-dock',
             name: 'settings-admin-book-dock',
-            component: () => import('@/features/settings/BookDockSettings.vue'),
-            meta: { title: 'Book Dock Settings' },
+            redirect: () => ({ name: 'settings-system', query: { tab: 'book-dock' } }),
           },
           {
             path: 'admin/maintenance',
             name: 'settings-admin-maintenance',
-            component: () => import('@/features/settings/MaintenanceSettings.vue'),
-            meta: { title: 'Maintenance' },
+            redirect: () => ({ name: 'settings-system', query: { tab: 'maintenance' } }),
           },
           {
             path: 'admin/audit-log',
             name: 'settings-admin-audit-log',
-            component: () => import('@/features/audit/AuditLogPage.vue'),
-            meta: { maxWidth: 'max-w-7xl', title: 'Audit Log' },
+            redirect: () => ({ name: 'settings-system', query: { tab: 'audit-log' } }),
           },
           {
             path: 'admin/magic-links',
             name: 'settings-admin-magic-links',
-            redirect: { name: 'settings-admin-users', query: { tab: 'magic-links' } },
+            redirect: () => ({ name: 'settings-admin', query: { tab: 'users' } }),
           },
           { path: ':pathMatch(.*)*', redirect: { name: 'settings-libraries' } },
         ],


### PR DESCRIPTION
…ab containers

Reduce the settings navigation bar from 17 flat tabs to 10 by grouping related settings into subtab containers, following the existing ?tab= query-param pattern used by Reader and Metadata.

New groups:
- Integrations (/settings/integrations): Kobo, KOReader, Hardcover
- Admin (/settings/admin): Users, OIDC/SSO (permission-filtered)
- System (/settings/system): File Naming, Book Dock, Maintenance, Audit Log (permission-filtered)
- Account (/settings/account): Profile, Notifications (merged from standalone tabs)

All old routes redirect to their new grouped equivalents for backward compatibility. Admin and System containers filter available tabs based on user permissions. Demo-restricted accounts hide the Notifications tab.

New files:
- IntegrationsAllSettings.vue, AdminAllSettings.vue, SystemAllSettings.vue, AccountAllSettings.vue
- lib/integrations-tabs.ts, lib/admin-tabs.ts, lib/system-tabs.ts, lib/account-tabs.ts
- Unit tests for all new containers and tab-lib files (SettingsHeader included)

Closes #55
