### PR TITLE
feat(client): add configurable spine and shadow effects for book covers

### DIFF
--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -7,6 +7,7 @@
 @import './theme/accents.css';
 @import './theme/radius.css';
 @import './theme/bridge.css';
+@import './theme/cover-effects.css';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/client/src/assets/theme/cover-effects.css
+++ b/client/src/assets/theme/cover-effects.css
@@ -1,0 +1,91 @@
+.book-cover-surface {
+  --book-cover-shadow: var(--elevation-md);
+  --book-cover-shadow-hover: var(--elevation-xl);
+  --book-cover-mini-shadow: var(--elevation-sm);
+  --book-cover-spine-opacity: 0;
+  --book-cover-spine-width: 6%;
+  position: relative;
+  isolation: isolate;
+  background-color: white;
+  background-size: cover;
+  box-shadow: var(--book-cover-shadow);
+}
+
+.book-cover-surface[data-cover-shadow='strong'] {
+  --book-cover-shadow: 0 10px 18px oklch(0 0 0 / 0.28), 0 5px 8px oklch(0 0 0 / 0.2);
+  --book-cover-shadow-hover: 0 20px 34px oklch(0 0 0 / 0.3), 0 10px 16px oklch(0 0 0 / 0.22);
+  --book-cover-mini-shadow: 0 5px 8px oklch(0 0 0 / 0.24), 0 2px 4px oklch(0 0 0 / 0.2);
+}
+
+.book-cover-surface[data-cover-spine='subtle'] {
+  --book-cover-spine-opacity: 0.7;
+  --book-cover-spine-width: 6%;
+}
+
+.book-cover-surface[data-cover-spine='strong'] {
+  --book-cover-spine-opacity: 1;
+  --book-cover-spine-width: 8%;
+}
+
+.book-cover-surface--mini {
+  box-shadow: var(--book-cover-mini-shadow);
+}
+
+.book-cover-surface--interactive {
+  transition: box-shadow 180ms ease;
+}
+
+.group:hover .book-cover-surface--interactive {
+  box-shadow: var(--book-cover-shadow-hover);
+}
+
+.book-cover-spine-layer {
+  pointer-events: none;
+  border-radius: inherit;
+  overflow: hidden;
+}
+
+.book-cover-surface::before,
+.book-cover-surface::after,
+.book-cover-spine-layer::before,
+.book-cover-spine-layer::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
+  pointer-events: none;
+  transition: opacity 180ms ease;
+}
+
+.book-cover-surface::before,
+.book-cover-spine-layer::before {
+  background: linear-gradient(to bottom, oklch(1 0 0 / 0.11), oklch(0 0 0 / 0.2));
+  opacity: var(--book-cover-spine-opacity);
+}
+
+.book-cover-surface::after,
+.book-cover-spine-layer::after {
+  background-image: linear-gradient(
+    to right,
+    oklch(0 0 0 / 0.28) 0%,
+    oklch(0 0 0 / 0) calc(var(--book-cover-spine-width) * 0.2),
+    oklch(0 0 0 / 0.24) calc(var(--book-cover-spine-width) * 0.36),
+    oklch(0 0 0 / 0) calc(var(--book-cover-spine-width) * 0.48),
+    oklch(1 0 0 / 0.42) calc(var(--book-cover-spine-width) * 0.56),
+    oklch(1 0 0 / 0.22) calc(var(--book-cover-spine-width) * 0.74),
+    oklch(0 0 0 / 0.18) calc(var(--book-cover-spine-width) * 0.9),
+    oklch(0 0 0 / 0) calc(var(--book-cover-spine-width) * 1.1),
+    oklch(1 0 0 / 0.2) calc(var(--book-cover-spine-width) * 1.2),
+    oklch(1 0 0 / 0) calc(var(--book-cover-spine-width) * 1.45)
+  );
+  box-shadow:
+    inset -0.5px -1px 2px oklch(0 0 0 / 0.2),
+    inset -0.5px -0.5px 1px oklch(0 0 0 / 0.2);
+  opacity: var(--book-cover-spine-opacity);
+}
+
+.book-cover-surface.book-cover-surface--spine-fitted::before,
+.book-cover-surface.book-cover-surface--spine-fitted::after {
+  opacity: 0;
+}

--- a/client/src/composables/useDisplaySettings.ts
+++ b/client/src/composables/useDisplaySettings.ts
@@ -5,12 +5,30 @@ export type CardOverlayKey = 'progress-bar' | 'format' | 'rating' | 'read-status
 export type AuthorCoverShape = 'square' | 'circle'
 export type CoverSizeScope = 'per-view' | 'synced'
 export type TableDensity = 'compact' | 'comfortable' | 'roomy'
+export type BookSpineOverlay = 'off' | 'subtle' | 'strong'
+export type BookShadowStrength = 'default' | 'strong'
 
 const DEFAULT_PORTRAIT_COVER_SIZE = 130
 const DEFAULT_SQUARE_COVER_SIZE = 150
 const DEFAULT_GRID_GAP = 28
+const DEFAULT_BOOK_SPINE_OVERLAY: BookSpineOverlay = 'off'
+const DEFAULT_BOOK_SHADOW_STRENGTH: BookShadowStrength = 'default'
 const CARD_OVERLAY_KEYS: CardOverlayKey[] = ['progress-bar', 'format', 'rating', 'read-status', 'lock-status', 'series-position']
 const DEFAULT_CARD_OVERLAYS: CardOverlayKey[] = ['progress-bar', 'format', 'rating', 'read-status', 'series-position']
+const BOOK_SPINE_OVERLAYS: BookSpineOverlay[] = ['off', 'subtle', 'strong']
+const BOOK_SHADOW_STRENGTHS: BookShadowStrength[] = ['default', 'strong']
+
+function normalizeBookSpineOverlay(value: unknown): BookSpineOverlay {
+  return typeof value === 'string' && BOOK_SPINE_OVERLAYS.includes(value as BookSpineOverlay)
+    ? (value as BookSpineOverlay)
+    : DEFAULT_BOOK_SPINE_OVERLAY
+}
+
+function normalizeBookShadowStrength(value: unknown): BookShadowStrength {
+  return typeof value === 'string' && BOOK_SHADOW_STRENGTHS.includes(value as BookShadowStrength)
+    ? (value as BookShadowStrength)
+    : DEFAULT_BOOK_SHADOW_STRENGTH
+}
 
 function normalizeCardOverlays(value: unknown): CardOverlayKey[] {
   if (!Array.isArray(value)) return [...DEFAULT_CARD_OVERLAYS]
@@ -48,6 +66,8 @@ const authorCoverSize = ref(Math.max(storage.get('authorCoverSize', 120), 100))
 const authorCoverShape = ref<AuthorCoverShape>(storage.get('authorCoverShape', 'circle'))
 const tableZebraStriping = ref(storage.get('tableZebraStriping', false))
 const tableDensity = ref<TableDensity>(storage.get('tableDensity', 'comfortable'))
+const bookSpineOverlay = ref<BookSpineOverlay>(normalizeBookSpineOverlay(storage.get('bookSpineOverlay', DEFAULT_BOOK_SPINE_OVERLAY)))
+const bookShadowStrength = ref<BookShadowStrength>(normalizeBookShadowStrength(storage.get('bookShadowStrength', DEFAULT_BOOK_SHADOW_STRENGTH)))
 
 watch(portraitCoverSize, (v) => storage.set('portraitCoverSize', v))
 watch(squareCoverSize, (v) => storage.set('squareCoverSize', v))
@@ -62,6 +82,8 @@ watch(authorCoverSize, (v) => storage.set('authorCoverSize', v))
 watch(authorCoverShape, (v) => storage.set('authorCoverShape', v))
 watch(tableZebraStriping, (v) => storage.set('tableZebraStriping', v))
 watch(tableDensity, (v) => storage.set('tableDensity', v))
+watch(bookSpineOverlay, (value) => storage.set('bookSpineOverlay', normalizeBookSpineOverlay(value)))
+watch(bookShadowStrength, (value) => storage.set('bookShadowStrength', normalizeBookShadowStrength(value)))
 
 export function useDisplaySettings() {
   return {
@@ -78,5 +100,7 @@ export function useDisplaySettings() {
     authorCoverShape,
     tableZebraStriping,
     tableDensity,
+    bookSpineOverlay,
+    bookShadowStrength,
   }
 }

--- a/client/src/features/book/components/BookCoverCard.vue
+++ b/client/src/features/book/components/BookCoverCard.vue
@@ -43,11 +43,12 @@ import { useRefreshingBooks } from '../composables/useRefreshingBooks'
 import { mergeBookCardWithDetail } from '../lib/book-card-mapper'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 import { useDisplaySettings } from '@/composables/useDisplaySettings'
-import { COVER_ASPECT_RATIO_KEY, DEFAULT_COVER_ASPECT_RATIO } from '../lib/cover-aspect-ratio'
+import { coverAspectRatioValue, COVER_ASPECT_RATIO_KEY, DEFAULT_COVER_ASPECT_RATIO, fittedCoverFrameStyle } from '../lib/cover-aspect-ratio'
 import { useBookDownload } from '@/features/book/composables/useBookDownload'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import SendBookDialog from '@/features/email/components/SendBookDialog.vue'
 import BookCoverPlaceholder from './BookCoverPlaceholder.vue'
+import BookCoverSurface from './BookCoverSurface.vue'
 
 const router = useRouter()
 
@@ -147,6 +148,7 @@ const ratingColor = computed(() => {
 
 const coverLoaded = ref(false)
 const coverFailed = ref(false)
+const coverImageRatio = ref<number | null>(null)
 const isMissing = computed(() => props.book.status === 'missing')
 const showMobileOverlay = ref(false)
 const root = ref<HTMLElement | null>(null)
@@ -156,11 +158,29 @@ const isTouch = computed(() => typeof window !== 'undefined' && window.matchMedi
 watch(coverSrc, () => {
   coverLoaded.value = false
   coverFailed.value = false
+  coverImageRatio.value = null
 })
+
+const slotAspectRatio = computed(() => coverAspectRatioValue(String(coverAspectRatio.value)))
+const fittedCoverSpineStyle = computed(() => fittedCoverFrameStyle(coverImageRatio.value, slotAspectRatio.value))
+
+function updateCoverImageRatio(img: HTMLImageElement | null) {
+  if (!img || img.naturalWidth <= 0 || img.naturalHeight <= 0) return
+  coverImageRatio.value = img.naturalWidth / img.naturalHeight
+}
 
 function onMainImgRef(el: Element | ComponentPublicInstance | null) {
   const img = el as HTMLImageElement | null
-  if (img?.complete && img.naturalWidth > 0) coverLoaded.value = true
+  if (img?.complete && img.naturalWidth > 0) {
+    coverLoaded.value = true
+    updateCoverImageRatio(img)
+  }
+}
+
+function handleMainImageLoad(event: Event) {
+  const target = event.target as HTMLImageElement | null
+  updateCoverImageRatio(target)
+  coverLoaded.value = true
 }
 
 function openFile(file: BookFileRef) {
@@ -257,9 +277,10 @@ async function handleSetStatus(status: ReadStatus) {
     @contextmenu.prevent
   >
     <!-- Cover -->
-    <div
-      class="relative w-full rounded-sm overflow-hidden shadow-md transition-[box-shadow,transform,ring] duration-150 will-change-transform"
-      :class="[isMissing ? '' : selectionMode ? '' : 'group-hover:shadow-xl group-hover:scale-[1.02]']"
+    <BookCoverSurface
+      class="book-cover-surface--spine-fitted relative w-full rounded-sm overflow-hidden transition-[box-shadow,transform,ring] duration-150 will-change-transform"
+      :class="isMissing || selectionMode ? '' : 'group-hover:scale-[1.02]'"
+      :interactive="!isMissing && !selectionMode"
       :style="[{ aspectRatio: coverAspectRatio }, !book.hasCover || !coverLoaded || coverFailed ? coverStyle : {}]"
     >
       <!-- Missing border overlay: mirror selected overlay pattern so border is never clipped/hidden -->
@@ -283,9 +304,11 @@ async function handleSetStatus(status: ReadStatus) {
         loading="lazy"
         decoding="async"
         :alt="book.title ?? ''"
-        @load="coverLoaded = true"
+        @load="handleMainImageLoad"
         @error="coverFailed = true"
       />
+
+      <div v-if="book.hasCover && coverLoaded && !coverFailed" class="book-cover-spine-layer absolute z-[3]" :style="fittedCoverSpineStyle" />
 
       <!-- Skeleton shimmer while a known-cover loads -->
       <div v-if="book.hasCover && !coverLoaded && !coverFailed" class="absolute inset-0 animate-pulse bg-white/10" />
@@ -547,7 +570,7 @@ async function handleSetStatus(status: ReadStatus) {
           </DropdownMenu>
         </div>
       </div>
-    </div>
+    </BookCoverSurface>
   </div>
 
   <SendBookDialog

--- a/client/src/features/book/components/BookCoverSurface.vue
+++ b/client/src/features/book/components/BookCoverSurface.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useDisplaySettings } from '@/composables/useDisplaySettings'
+
+const props = withDefaults(
+  defineProps<{
+    size?: 'default' | 'mini'
+    interactive?: boolean
+    tag?: string
+  }>(),
+  {
+    size: 'default',
+    interactive: false,
+    tag: 'div',
+  },
+)
+
+const { bookSpineOverlay, bookShadowStrength } = useDisplaySettings()
+
+const classes = computed(() => [
+  'book-cover-surface',
+  props.size === 'mini' ? 'book-cover-surface--mini' : '',
+  props.interactive ? 'book-cover-surface--interactive' : '',
+])
+</script>
+
+<template>
+  <component
+    :is="tag"
+    :class="classes"
+    :data-cover-size="size"
+    :data-cover-shadow="bookShadowStrength"
+    :data-cover-spine="bookSpineOverlay"
+    :data-cover-interactive="interactive ? 'true' : 'false'"
+  >
+    <slot />
+  </component>
+</template>

--- a/client/src/features/book/components/BookListRow.vue
+++ b/client/src/features/book/components/BookListRow.vue
@@ -3,6 +3,7 @@ import type { BookCard, BookFileRef } from '@bookorbit/types'
 import { FORMAT_TO_GROUP } from '@bookorbit/types'
 import { bookCoverStyle } from '../lib/book-cover'
 import BookCoverPlaceholder from './BookCoverPlaceholder.vue'
+import BookCoverSurface from './BookCoverSurface.vue'
 import { api } from '@/lib/api'
 import { computed, inject, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
@@ -24,7 +25,7 @@ import {
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useCoverVersions } from '../composables/useCoverVersions'
-import { COVER_ASPECT_RATIO_KEY, DEFAULT_COVER_ASPECT_RATIO } from '../lib/cover-aspect-ratio'
+import { coverAspectRatioValue, COVER_ASPECT_RATIO_KEY, DEFAULT_COVER_ASPECT_RATIO, fittedCoverFrameStyle } from '../lib/cover-aspect-ratio'
 import { useRefreshMetadata } from '../composables/useRefreshMetadata'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 import SendBookDialog from '@/features/email/components/SendBookDialog.vue'
@@ -73,6 +74,7 @@ const visibleTags = computed(() => props.book.genres.slice(0, 2))
 
 const coverLoaded = ref(false)
 const coverFailed = ref(false)
+const coverImageRatio = ref<number | null>(null)
 
 const localRating = ref<number | null>(props.book.rating)
 const hoverRating = ref<number | null>(null)
@@ -102,10 +104,21 @@ const coverSrc = computed(() => coverUrl(props.book.id))
 watch(coverSrc, () => {
   coverLoaded.value = false
   coverFailed.value = false
+  coverImageRatio.value = null
 })
 
 const { refreshing, refreshWithFeedback } = useRefreshMetadata()
 const coverAspectRatio = inject(COVER_ASPECT_RATIO_KEY, ref(DEFAULT_COVER_ASPECT_RATIO))
+const slotAspectRatio = computed(() => coverAspectRatioValue(String(coverAspectRatio.value)))
+const fittedCoverSpineStyle = computed(() => fittedCoverFrameStyle(coverImageRatio.value, slotAspectRatio.value))
+
+function handleCoverLoad(event: Event) {
+  const target = event.target as HTMLImageElement | null
+  if (target && target.naturalWidth > 0 && target.naturalHeight > 0) {
+    coverImageRatio.value = target.naturalWidth / target.naturalHeight
+  }
+  coverLoaded.value = true
+}
 
 function openFile(file: BookFileRef) {
   router.push({
@@ -141,8 +154,9 @@ function openAuthorBrowse() {
     </div>
 
     <!-- Cover -->
-    <div
-      class="w-16 rounded shrink-0 overflow-hidden relative"
+    <BookCoverSurface
+      size="mini"
+      class="book-cover-surface--spine-fitted w-16 rounded shrink-0 overflow-hidden relative"
       :class="isMissing ? 'opacity-50 grayscale' : ''"
       :style="[{ aspectRatio: coverAspectRatio }, !book.hasCover || !coverLoaded || coverFailed ? coverStyle : {}]"
     >
@@ -161,9 +175,10 @@ function openAuthorBrowse() {
         loading="lazy"
         decoding="async"
         :alt="book.title ?? ''"
-        @load="coverLoaded = true"
+        @load="handleCoverLoad"
         @error="coverFailed = true"
       />
+      <div v-if="book.hasCover && coverLoaded && !coverFailed" class="book-cover-spine-layer absolute z-[3]" :style="fittedCoverSpineStyle" />
       <BookCoverPlaceholder
         v-if="!book.hasCover || coverFailed"
         :title="book.title"
@@ -171,7 +186,7 @@ function openAuthorBrowse() {
         :is-audio="isAudiobook"
         :seed="book.title ?? String(book.id)"
       />
-    </div>
+    </BookCoverSurface>
 
     <!-- Main info -->
     <div class="flex flex-col min-w-0 flex-1 gap-0.5">

--- a/client/src/features/book/components/CollapsedSeriesCard.vue
+++ b/client/src/features/book/components/CollapsedSeriesCard.vue
@@ -3,6 +3,7 @@ import { computed, inject, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import type { BookCard } from '@bookorbit/types'
 import BookCoverPlaceholder from './BookCoverPlaceholder.vue'
+import BookCoverSurface from './BookCoverSurface.vue'
 import { COVER_ASPECT_RATIO_KEY, DEFAULT_COVER_ASPECT_RATIO } from '../lib/cover-aspect-ratio'
 import { useCoverVersions } from '../composables/useCoverVersions'
 
@@ -44,8 +45,9 @@ function tileClass(index: number): string {
 <template>
   <div class="group flex flex-col @container cursor-pointer" @click="handleClick">
     <!-- Cover -->
-    <div
-      class="relative w-full rounded-sm overflow-hidden shadow-md transition-[box-shadow,transform] duration-150 will-change-transform group-hover:shadow-xl group-hover:scale-[1.02]"
+    <BookCoverSurface
+      class="relative w-full rounded-sm overflow-hidden transition-[box-shadow,transform] duration-150 will-change-transform group-hover:scale-[1.02]"
+      interactive
       :style="{ aspectRatio: coverAspectRatio }"
     >
       <!-- Adaptive cover mosaic -->
@@ -90,6 +92,6 @@ function tileClass(index: number): string {
           </p>
         </div>
       </div>
-    </div>
+    </BookCoverSurface>
   </div>
 </template>

--- a/client/src/features/book/components/__tests__/BookCoverCard.spec.ts
+++ b/client/src/features/book/components/__tests__/BookCoverCard.spec.ts
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import BookCoverCard from '../BookCoverCard.vue'
 import type { BookCard } from '@bookorbit/types'
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 import { COVER_ASPECT_RATIO_KEY } from '@/features/book/lib/cover-aspect-ratio'
 import { useDisplaySettings } from '@/composables/useDisplaySettings'
 
@@ -58,10 +58,12 @@ function mountCard(book: BookCard, coverAspectRatio: '2/3' | '1/1' = '2/3') {
   })
 }
 
-const { cardOverlays } = useDisplaySettings()
+const { cardOverlays, bookSpineOverlay, bookShadowStrength } = useDisplaySettings()
 
 afterEach(() => {
   cardOverlays.value = ['progress-bar', 'format', 'rating', 'read-status']
+  bookSpineOverlay.value = 'off'
+  bookShadowStrength.value = 'default'
 })
 
 const missingBook: BookCard = {
@@ -220,6 +222,30 @@ describe('BookCoverCard — present state', () => {
 
     expect(wrapper.find('.text-emerald-400').exists()).toBe(true)
     expect(wrapper.find('.text-amber-400').exists()).toBe(false)
+  })
+})
+
+describe('BookCoverCard — cover style preferences', () => {
+  it('applies the reusable cover surface class to the main cover container', () => {
+    const wrapper = mountCard(presentBook)
+    const coverDiv = wrapper.find('[style*="aspect-ratio"]')
+    expect(coverDiv.classes()).toContain('book-cover-surface')
+  })
+
+  it('applies the selected spine overlay mode to the cover surface', async () => {
+    const wrapper = mountCard(presentBook)
+    bookSpineOverlay.value = 'strong'
+    await nextTick()
+    const coverDiv = wrapper.find('[style*="aspect-ratio"]')
+    expect(coverDiv.attributes('data-cover-spine')).toBe('strong')
+  })
+
+  it('applies the selected shadow strength mode to the cover surface', async () => {
+    const wrapper = mountCard(presentBook)
+    bookShadowStrength.value = 'strong'
+    await nextTick()
+    const coverDiv = wrapper.find('[style*="aspect-ratio"]')
+    expect(coverDiv.attributes('data-cover-shadow')).toBe('strong')
   })
 })
 

--- a/client/src/features/book/components/__tests__/BookCoverSurface.spec.ts
+++ b/client/src/features/book/components/__tests__/BookCoverSurface.spec.ts
@@ -1,0 +1,47 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import BookCoverSurface from '../BookCoverSurface.vue'
+import { useDisplaySettings } from '@/composables/useDisplaySettings'
+
+const { bookSpineOverlay, bookShadowStrength } = useDisplaySettings()
+
+afterEach(() => {
+  bookSpineOverlay.value = 'off'
+  bookShadowStrength.value = 'default'
+})
+
+describe('BookCoverSurface', () => {
+  it('applies base, size, and interactive classes', () => {
+    const wrapper = mount(BookCoverSurface, {
+      props: { size: 'mini', interactive: true },
+      slots: { default: '<div class="content" />' },
+    })
+
+    expect(wrapper.classes()).toContain('book-cover-surface')
+    expect(wrapper.classes()).toContain('book-cover-surface--mini')
+    expect(wrapper.classes()).toContain('book-cover-surface--interactive')
+    expect(wrapper.find('.content').exists()).toBe(true)
+  })
+
+  it('applies style mode data attributes from display settings', () => {
+    bookSpineOverlay.value = 'strong'
+    bookShadowStrength.value = 'strong'
+
+    const wrapper = mount(BookCoverSurface)
+    expect(wrapper.attributes('data-cover-spine')).toBe('strong')
+    expect(wrapper.attributes('data-cover-shadow')).toBe('strong')
+    expect(wrapper.attributes('data-cover-size')).toBe('default')
+    expect(wrapper.attributes('data-cover-interactive')).toBe('false')
+  })
+
+  it('renders dynamic tag and forwards native attrs', () => {
+    const wrapper = mount(BookCoverSurface, {
+      props: { tag: 'button', interactive: true },
+      attrs: { type: 'button', 'aria-label': 'cover' },
+    })
+
+    expect(wrapper.element.tagName).toBe('BUTTON')
+    expect(wrapper.attributes('type')).toBe('button')
+    expect(wrapper.attributes('aria-label')).toBe('cover')
+  })
+})

--- a/client/src/features/book/components/table/BookTableCollapsedSeriesRow.vue
+++ b/client/src/features/book/components/table/BookTableCollapsedSeriesRow.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { ChevronRight } from 'lucide-vue-next'
 import type { BookCard } from '@bookorbit/types'
+import BookCoverSurface from '../BookCoverSurface.vue'
 
 const props = defineProps<{
   book: BookCard
@@ -33,10 +34,12 @@ function thumbnailUrl(bookId: number): string {
     <div class="flex items-center gap-3 min-w-0">
       <!-- Cover row: up to 4 thumbnails -->
       <div class="flex shrink-0 gap-0.5">
-        <img v-for="coverId in coverIds" :key="coverId" :src="thumbnailUrl(coverId)" class="h-8 w-6 rounded-sm object-cover" loading="lazy" alt="" />
-        <div v-if="coverIds.length === 0" class="h-8 w-6 rounded-sm bg-muted flex items-center justify-center">
+        <BookCoverSurface v-for="coverId in coverIds" :key="coverId" size="mini" class="h-8 w-6 rounded-sm overflow-hidden">
+          <img :src="thumbnailUrl(coverId)" class="h-full w-full object-cover" loading="lazy" alt="" />
+        </BookCoverSurface>
+        <BookCoverSurface v-if="coverIds.length === 0" size="mini" class="h-8 w-6 rounded-sm bg-muted flex items-center justify-center">
           <span class="text-[8px] text-muted-foreground">?</span>
-        </div>
+        </BookCoverSurface>
       </div>
 
       <!-- Series info -->

--- a/client/src/features/book/components/table/BookTableCoverCell.vue
+++ b/client/src/features/book/components/table/BookTableCoverCell.vue
@@ -3,6 +3,7 @@ import { computed, ref, onUnmounted } from 'vue'
 import { Loader2 } from 'lucide-vue-next'
 import BookCoverImage from '../BookCoverImage.vue'
 import BookCoverPlaceholder from '../BookCoverPlaceholder.vue'
+import BookCoverSurface from '../BookCoverSurface.vue'
 import { useRefreshingBooks } from '@/features/book/composables/useRefreshingBooks'
 
 const props = defineProps<{
@@ -64,7 +65,8 @@ const adjustedTop = computed(() => {
 
 <template>
   <div class="relative" @mouseenter="handleMouseEnter" @mouseleave="handleMouseLeave">
-    <div
+    <BookCoverSurface
+      size="mini"
       tabindex="0"
       role="button"
       aria-label="View cover"
@@ -77,7 +79,7 @@ const adjustedTop = computed(() => {
       <div v-if="isRefreshingBook" class="absolute inset-0 flex items-center justify-center bg-black/50">
         <Loader2 :size="12" class="animate-spin text-white" />
       </div>
-    </div>
+    </BookCoverSurface>
 
     <Teleport to="body">
       <div

--- a/client/src/features/book/components/table/__tests__/BookTableCollapsedSeriesRow.spec.ts
+++ b/client/src/features/book/components/table/__tests__/BookTableCollapsedSeriesRow.spec.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BookCard } from '@bookorbit/types'
 import BookTableCollapsedSeriesRow from '../BookTableCollapsedSeriesRow.vue'
@@ -52,7 +52,7 @@ describe('BookTableCollapsedSeriesRow', () => {
   })
 
   it('renders the series name and book count', () => {
-    const wrapper = shallowMount(BookTableCollapsedSeriesRow, {
+    const wrapper = mount(BookTableCollapsedSeriesRow, {
       props: { book: makeBook(), colspan: 6 },
     })
 
@@ -61,7 +61,7 @@ describe('BookTableCollapsedSeriesRow', () => {
   })
 
   it('renders the read count when some books are read', () => {
-    const wrapper = shallowMount(BookTableCollapsedSeriesRow, {
+    const wrapper = mount(BookTableCollapsedSeriesRow, {
       props: { book: makeBook(), colspan: 6 },
     })
 
@@ -69,7 +69,7 @@ describe('BookTableCollapsedSeriesRow', () => {
   })
 
   it('does not render the read count when no books are read', () => {
-    const wrapper = shallowMount(BookTableCollapsedSeriesRow, {
+    const wrapper = mount(BookTableCollapsedSeriesRow, {
       props: {
         book: makeBook({
           collapsedSeries: { bookCount: 5, readCount: 0, coverBookIds: [10, 20], seriesLatestAddedAt: null },
@@ -82,7 +82,7 @@ describe('BookTableCollapsedSeriesRow', () => {
   })
 
   it('renders up to four cover thumbnails', () => {
-    const wrapper = shallowMount(BookTableCollapsedSeriesRow, {
+    const wrapper = mount(BookTableCollapsedSeriesRow, {
       props: { book: makeBook(), colspan: 6 },
     })
 
@@ -97,7 +97,7 @@ describe('BookTableCollapsedSeriesRow', () => {
   })
 
   it('renders a placeholder when no cover ids are available', () => {
-    const wrapper = shallowMount(BookTableCollapsedSeriesRow, {
+    const wrapper = mount(BookTableCollapsedSeriesRow, {
       props: {
         book: makeBook({
           collapsedSeries: { bookCount: 5, readCount: 0, coverBookIds: [], seriesLatestAddedAt: null },
@@ -111,7 +111,7 @@ describe('BookTableCollapsedSeriesRow', () => {
   })
 
   it('navigates to the series detail route on click', async () => {
-    const wrapper = shallowMount(BookTableCollapsedSeriesRow, {
+    const wrapper = mount(BookTableCollapsedSeriesRow, {
       props: { book: makeBook(), colspan: 6 },
     })
 
@@ -124,7 +124,7 @@ describe('BookTableCollapsedSeriesRow', () => {
   })
 
   it('renders no more than four thumbnails even when more cover ids are provided', () => {
-    const wrapper = shallowMount(BookTableCollapsedSeriesRow, {
+    const wrapper = mount(BookTableCollapsedSeriesRow, {
       props: {
         book: makeBook({
           collapsedSeries: { bookCount: 6, readCount: 1, coverBookIds: [10, 20, 30, 40, 50, 60], seriesLatestAddedAt: null },
@@ -137,7 +137,7 @@ describe('BookTableCollapsedSeriesRow', () => {
   })
 
   it('sets the expected colspan on the table cell', () => {
-    const wrapper = shallowMount(BookTableCollapsedSeriesRow, {
+    const wrapper = mount(BookTableCollapsedSeriesRow, {
       props: { book: makeBook(), colspan: 9 },
     })
 
@@ -145,7 +145,7 @@ describe('BookTableCollapsedSeriesRow', () => {
   })
 
   it('does not navigate when selectionMode is true', async () => {
-    const wrapper = shallowMount(BookTableCollapsedSeriesRow, {
+    const wrapper = mount(BookTableCollapsedSeriesRow, {
       props: { book: makeBook(), colspan: 6, selectionMode: true },
     })
 

--- a/client/src/features/book/lib/cover-aspect-ratio.test.ts
+++ b/client/src/features/book/lib/cover-aspect-ratio.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { coverAspectRatioValue, fittedCoverFrameStyle } from './cover-aspect-ratio'
+
+describe('coverAspectRatioValue', () => {
+  it('parses a valid ratio string', () => {
+    expect(coverAspectRatioValue('1/1')).toBe(1)
+    expect(coverAspectRatioValue('2/3')).toBeCloseTo(2 / 3, 5)
+  })
+
+  it('falls back to default when input is invalid', () => {
+    expect(coverAspectRatioValue('bad')).toBeCloseTo(2 / 3, 5)
+    expect(coverAspectRatioValue('2/0')).toBeCloseTo(2 / 3, 5)
+    expect(coverAspectRatioValue('2/')).toBeCloseTo(2 / 3, 5)
+  })
+})
+
+describe('fittedCoverFrameStyle', () => {
+  it('returns full inset when image ratio or slot ratio is invalid', () => {
+    expect(fittedCoverFrameStyle(null, 2 / 3)).toEqual({ inset: '0' })
+    expect(fittedCoverFrameStyle(1, 0)).toEqual({ inset: '0' })
+  })
+
+  it('returns full inset when ratios match', () => {
+    expect(fittedCoverFrameStyle(2 / 3, 2 / 3)).toEqual({ inset: '0' })
+  })
+
+  it('fits by height when image is wider than slot', () => {
+    const style = fittedCoverFrameStyle(1, 2 / 3)
+    expect(style.width).toBe('100%')
+    expect(style.top).toBe('50%')
+    expect(style.left).toBe('0')
+    expect(style.transform).toBe('translateY(-50%)')
+    expect(parseFloat(style.height ?? '0')).toBeCloseTo(66.6667, 2)
+  })
+
+  it('fits by width when image is narrower than slot', () => {
+    const style = fittedCoverFrameStyle(0.5, 2 / 3)
+    expect(style.height).toBe('100%')
+    expect(style.top).toBe('0')
+    expect(style.left).toBe('50%')
+    expect(style.transform).toBe('translateX(-50%)')
+    expect(parseFloat(style.width ?? '0')).toBeCloseTo(75, 2)
+  })
+})

--- a/client/src/features/book/lib/cover-aspect-ratio.ts
+++ b/client/src/features/book/lib/cover-aspect-ratio.ts
@@ -3,3 +3,44 @@ import type { CoverAspectRatio } from '@bookorbit/types'
 
 export const COVER_ASPECT_RATIO_KEY: InjectionKey<Readonly<Ref<CoverAspectRatio>>> = Symbol('coverAspectRatio')
 export const DEFAULT_COVER_ASPECT_RATIO: CoverAspectRatio = '2/3'
+
+export function coverAspectRatioValue(value: string): number {
+  const parts = value.split('/')
+  if (parts.length !== 2) return 2 / 3
+  const width = Number(parts[0])
+  const height = Number(parts[1])
+  if (Number.isFinite(width) && Number.isFinite(height) && height > 0) {
+    return width / height
+  }
+  return 2 / 3
+}
+
+export function fittedCoverFrameStyle(imageRatio: number | null, slotRatio: number): Record<string, string> {
+  if (!imageRatio || imageRatio <= 0 || !slotRatio || slotRatio <= 0) {
+    return { inset: '0' }
+  }
+
+  if (Math.abs(imageRatio - slotRatio) < 0.0001) {
+    return { inset: '0' }
+  }
+
+  if (imageRatio > slotRatio) {
+    const heightPercent = (slotRatio / imageRatio) * 100
+    return {
+      width: '100%',
+      height: `${heightPercent}%`,
+      top: '50%',
+      left: '0',
+      transform: 'translateY(-50%)',
+    }
+  }
+
+  const widthPercent = (imageRatio / slotRatio) * 100
+  return {
+    width: `${widthPercent}%`,
+    height: '100%',
+    top: '0',
+    left: '50%',
+    transform: 'translateX(-50%)',
+  }
+}

--- a/client/src/features/dashboard/components/widgets/CurrentlyReadingWidget.vue
+++ b/client/src/features/dashboard/components/widgets/CurrentlyReadingWidget.vue
@@ -3,6 +3,7 @@ import { BookOpen, Play } from 'lucide-vue-next'
 import { useRouter } from 'vue-router'
 
 import { useCoverVersions } from '@/features/book/composables/useCoverVersions'
+import BookCoverSurface from '@/features/book/components/BookCoverSurface.vue'
 import { useCurrentlyReadingWidget } from '../../composables/useCurrentlyReadingWidget'
 
 const { data, loading, error } = useCurrentlyReadingWidget()
@@ -62,12 +63,12 @@ function continueReading(bookId: number, fileId: number | null, fileFormat: stri
           @click="goToBook(book.bookId)"
         >
           <!-- Cover thumbnail -->
-          <div class="h-14 w-9 shrink-0 overflow-hidden rounded shadow-sm">
+          <BookCoverSurface size="mini" class="h-14 w-9 shrink-0 overflow-hidden rounded">
             <img v-if="book.hasCover" :src="coverUrl(book.bookId)" :alt="book.title ?? 'Book cover'" class="h-full w-full object-cover" />
             <div v-else class="flex h-full w-full items-center justify-center bg-muted text-muted-foreground">
               <BookOpen :size="12" />
             </div>
-          </div>
+          </BookCoverSurface>
 
           <!-- Info -->
           <div class="flex min-w-0 flex-1 flex-col justify-center">

--- a/client/src/features/dashboard/components/widgets/HighlightOfTheDayWidget.vue
+++ b/client/src/features/dashboard/components/widgets/HighlightOfTheDayWidget.vue
@@ -3,6 +3,7 @@ import { Highlighter, BookOpen, ExternalLink } from 'lucide-vue-next'
 import { useRouter } from 'vue-router'
 
 import { useCoverVersions } from '@/features/book/composables/useCoverVersions'
+import BookCoverSurface from '@/features/book/components/BookCoverSurface.vue'
 import { useHighlightOfTheDayWidget } from '../../composables/useHighlightOfTheDayWidget'
 
 const { data, loading, error } = useHighlightOfTheDayWidget()
@@ -47,9 +48,9 @@ function goToBook() {
         "{{ data.text.length > 200 ? data.text.slice(0, 200) + '...' : data.text }}"
       </blockquote>
       <button class="flex cursor-pointer items-center gap-2 rounded-lg pb-1 pl-1 text-left transition-colors hover:bg-muted/40" @click="goToBook">
-        <div v-if="data.hasCover" class="h-9 w-6 shrink-0 overflow-hidden rounded shadow-sm">
+        <BookCoverSurface v-if="data.hasCover" size="mini" class="h-9 w-6 shrink-0 overflow-hidden rounded">
           <img :src="coverUrl(data.bookId)" :alt="data.bookTitle ?? 'Cover'" class="h-full w-full object-cover" />
-        </div>
+        </BookCoverSurface>
         <div v-else class="flex h-8 w-5 shrink-0 items-center justify-center rounded bg-muted">
           <BookOpen :size="10" class="text-muted-foreground" />
         </div>

--- a/client/src/features/dashboard/components/widgets/LongWaitWidget.vue
+++ b/client/src/features/dashboard/components/widgets/LongWaitWidget.vue
@@ -3,6 +3,7 @@ import { Clock, BookOpen, Play } from 'lucide-vue-next'
 import { useRouter } from 'vue-router'
 
 import { useCoverVersions } from '@/features/book/composables/useCoverVersions'
+import BookCoverSurface from '@/features/book/components/BookCoverSurface.vue'
 import { useLongWaitWidget } from '../../composables/useLongWaitWidget'
 
 const { data, loading, error } = useLongWaitWidget()
@@ -55,12 +56,18 @@ function startReading() {
     <!-- Long wait book -->
     <div v-else class="flex flex-1 flex-col">
       <div class="flex flex-1 items-center justify-center gap-4">
-        <button class="h-24 w-18 shrink-0 cursor-pointer overflow-hidden rounded shadow-sm transition-opacity hover:opacity-80" @click="goToBook">
+        <BookCoverSurface
+          tag="button"
+          type="button"
+          size="mini"
+          class="h-24 w-18 shrink-0 cursor-pointer overflow-hidden rounded transition-opacity hover:opacity-80"
+          @click="goToBook"
+        >
           <img v-if="data.hasCover" :src="coverUrl(data.bookId)" :alt="data.title ?? 'Cover'" class="h-full w-full object-cover" />
           <div v-else class="flex h-full w-full items-center justify-center bg-muted">
             <BookOpen :size="14" class="text-muted-foreground" />
           </div>
-        </button>
+        </BookCoverSurface>
 
         <div class="min-w-0 text-left">
           <button class="block cursor-pointer truncate text-xs font-semibold leading-tight hover:underline" @click="goToBook">

--- a/client/src/features/dashboard/components/widgets/NeglectedGemsWidget.vue
+++ b/client/src/features/dashboard/components/widgets/NeglectedGemsWidget.vue
@@ -4,6 +4,7 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { useCoverVersions } from '@/features/book/composables/useCoverVersions'
+import BookCoverSurface from '@/features/book/components/BookCoverSurface.vue'
 import { useBookStatus } from '@/features/book/composables/useBookStatus'
 import { useNeglectedGemsWidget } from '../../composables/useNeglectedGemsWidget'
 
@@ -60,12 +61,18 @@ async function addToQueue() {
 
     <!-- Gem -->
     <div v-else-if="currentGem" class="flex flex-1 flex-col items-center justify-center gap-2">
-      <button class="h-19 w-13 cursor-pointer overflow-hidden rounded shadow-sm transition-opacity hover:opacity-80" @click="goToBook">
+      <BookCoverSurface
+        tag="button"
+        type="button"
+        size="mini"
+        class="h-19 w-13 cursor-pointer overflow-hidden rounded transition-opacity hover:opacity-80"
+        @click="goToBook"
+      >
         <img v-if="currentGem.hasCover" :src="coverUrl(currentGem.bookId)" :alt="currentGem.title ?? 'Cover'" class="h-full w-full object-cover" />
         <div v-else class="flex h-full w-full items-center justify-center bg-muted">
           <BookOpen :size="14" class="text-muted-foreground" />
         </div>
-      </button>
+      </BookCoverSurface>
       <button class="max-w-full cursor-pointer truncate text-center text-xs font-semibold hover:underline" @click="goToBook">
         {{ currentGem.title ?? 'Untitled' }}
       </button>

--- a/client/src/features/settings/AppearanceSettings.vue
+++ b/client/src/features/settings/AppearanceSettings.vue
@@ -2,7 +2,13 @@
 import { computed } from 'vue'
 import { ACCENT_VIVID, ACCENT_PASTEL, BACKGROUND_OPTIONS, RADIUS_OPTIONS, useThemeStore } from '@/stores/theme'
 import { Circle, Moon, Square, Sun } from 'lucide-vue-next'
-import { useDisplaySettings, type CardOverlayKey, type CoverSizeScope } from '@/composables/useDisplaySettings'
+import {
+  useDisplaySettings,
+  type BookShadowStrength,
+  type BookSpineOverlay,
+  type CardOverlayKey,
+  type CoverSizeScope,
+} from '@/composables/useDisplaySettings'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import SettingsPageHeader from './SettingsPageHeader.vue'
@@ -20,6 +26,8 @@ const {
   authorCoverSize,
   authorCoverShape,
   tableZebraStriping,
+  bookSpineOverlay,
+  bookShadowStrength,
 } = useDisplaySettings()
 
 const { prefs, setPreference } = useSeriesCollapsePreference()
@@ -36,6 +44,17 @@ const OVERLAY_OPTIONS: { key: CardOverlayKey; label: string; hint: string }[] = 
   { key: 'read-status', label: 'Read status', hint: 'Color icon showing the current reading status at top-left' },
   { key: 'series-position', label: 'Series number', hint: 'Badge showing the book position in its series at top-right (e.g. #3, #1.5)' },
   { key: 'lock-status', label: 'Lock status', hint: 'Metadata lock icon at top-right - orange when locked, green when unlocked' },
+]
+
+const BOOK_SPINE_OPTIONS: { id: BookSpineOverlay; label: string; hint: string }[] = [
+  { id: 'off', label: 'Off', hint: 'No spine/gloss effect on covers' },
+  { id: 'subtle', label: 'Subtle', hint: 'Light spine and sheen, closer to the default look' },
+  { id: 'strong', label: 'Strong', hint: 'More pronounced spine and gloss treatment' },
+]
+
+const BOOK_SHADOW_OPTIONS: { id: BookShadowStrength; label: string; hint: string }[] = [
+  { id: 'default', label: 'Default', hint: 'Current elevation and depth' },
+  { id: 'strong', label: 'Strong', hint: 'Heavier shelf-like drop shadow under covers' },
 ]
 
 const BACKGROUND_GROUPS: { label: string; ids: string[] }[] = [
@@ -56,6 +75,14 @@ function toggleOverlay(key: CardOverlayKey) {
 
 function setCoverSizeScope(mode: CoverSizeScope) {
   coverSizeScope.value = mode
+}
+
+function setBookSpineOverlay(mode: BookSpineOverlay) {
+  bookSpineOverlay.value = mode
+}
+
+function setBookShadowStrength(mode: BookShadowStrength) {
+  bookShadowStrength.value = mode
 }
 
 const syncModeEnabled = computed(() => coverSizeScope.value === 'synced')
@@ -202,6 +229,49 @@ const syncModeEnabled = computed(() => coverSizeScope.value === 'synced')
   <!-- Library view -->
   <div>
     <p class="settings-group-label">Library View</p>
+
+    <!-- Cover styling -->
+    <div class="border border-border rounded-lg overflow-hidden divide-y divide-border mb-4 shadow-xs">
+      <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
+        <div>
+          <p class="settings-label">Book spine overlay</p>
+          <p class="settings-hint">Adds a stylized spine and gloss effect to cover cards</p>
+        </div>
+        <div class="mt-3 grid gap-2 sm:grid-cols-3">
+          <button
+            v-for="opt in BOOK_SPINE_OPTIONS"
+            :key="opt.id"
+            class="rounded-md border px-3 py-2 text-left transition-colors"
+            :class="
+              bookSpineOverlay === opt.id
+                ? 'border-primary bg-primary/8 text-primary'
+                : 'border-border text-muted-foreground hover:border-muted-foreground/40 hover:text-foreground'
+            "
+            @click="setBookSpineOverlay(opt.id)"
+          >
+            <p class="text-xs font-semibold">{{ opt.label }}</p>
+            <p class="mt-0.5 text-[11px] leading-snug opacity-80">{{ opt.hint }}</p>
+          </button>
+        </div>
+      </div>
+      <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
+        <div>
+          <p class="settings-label">Cover shadow strength</p>
+          <p class="settings-hint">Controls depth under covers across grid, list, table, and dashboard thumbnails</p>
+        </div>
+        <div class="mt-3 flex items-center gap-1 p-1 rounded-lg border border-border bg-muted/50 self-start">
+          <button
+            v-for="opt in BOOK_SHADOW_OPTIONS"
+            :key="opt.id"
+            class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
+            :class="bookShadowStrength === opt.id ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
+            @click="setBookShadowStrength(opt.id)"
+          >
+            {{ opt.label }}
+          </button>
+        </div>
+      </div>
+    </div>
 
     <!-- Background pattern -->
     <div class="border border-border rounded-lg overflow-hidden divide-y divide-border mb-4 shadow-xs">


### PR DESCRIPTION
Unify cover rendering with a reusable surface wrapper so cover styling stays consistent across grid, list, table, and dashboard views. Expose spine overlay and shadow strength controls in appearance settings and fit spine overlays to cropped cover frames to avoid visual bleed. Add tests for the cover surface component and aspect-ratio fitting helpers.

closes #62
