### PR TITLE
fix(opds): search catalog by author, series, and ISBN

### DIFF
--- a/server/src/modules/opds/__tests__/opds-book.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds-book.service.test.ts
@@ -37,6 +37,19 @@ function makeService(selectQueue: unknown[] = [], queryBuilderOverrides: Record<
   return { service, db, queryBuilder };
 }
 
+function collectValues(value: unknown, seen = new WeakSet<object>()): unknown[] {
+  if (value === null || typeof value !== 'object') return [value];
+  if (seen.has(value)) return [];
+  seen.add(value);
+
+  const values: unknown[] = [];
+  if ('value' in value) values.push((value as { value: unknown }).value);
+  for (const key of Object.getOwnPropertyNames(value)) {
+    values.push(...collectValues((value as Record<string, unknown>)[key], seen));
+  }
+  return values;
+}
+
 describe('OpdsBookService', () => {
   it('returns accessible library ids for superusers and regular users', async () => {
     const superDb = makeDb([[{ id: 1 }, { id: 4 }]]);
@@ -70,6 +83,7 @@ describe('OpdsBookService', () => {
 
     accessSpy.mockResolvedValueOnce([1, 2]);
     paginatedSpy.mockResolvedValueOnce({ entries: [{ id: 9 }], total: 1 });
+    const searchSpy = vi.spyOn(service as never, 'buildCatalogSearchClause');
     await expect(
       service.getBooksPage(7, 'title_asc', 2, 20, {
         libraryId: 1,
@@ -80,6 +94,27 @@ describe('OpdsBookService', () => {
       }),
     ).resolves.toEqual({ entries: [{ id: 9 }], total: 1 });
     expect(paginatedSpy).toHaveBeenCalledTimes(1);
+    expect(searchSpy).toHaveBeenCalledWith('arrakis');
+  });
+
+  it('builds catalog search across title, author, series, and normalized ISBN', () => {
+    const { service, db } = makeService();
+
+    const clause = (service as unknown as { buildCatalogSearchClause(q: string): unknown }).buildCatalogSearchClause('978-0 141187761');
+    const values = collectValues(clause);
+
+    expect(db.select).toHaveBeenCalledWith({ one: expect.anything() });
+    expect(values).toContain('%978-0 141187761%');
+    expect(values).toContain('9780141187761');
+  });
+
+  it('escapes catalog search LIKE patterns', () => {
+    const { service } = makeService();
+
+    const clause = (service as unknown as { buildCatalogSearchClause(q: string): unknown }).buildCatalogSearchClause('100%_\\');
+    const values = collectValues(clause);
+
+    expect(values).toContain('%100\\%\\_\\\\%');
   });
 
   it('handles getRecentBooksPage empty-access and delegated paths', async () => {

--- a/server/src/modules/opds/opds-book.service.ts
+++ b/server/src/modules/opds/opds-book.service.ts
@@ -1,5 +1,5 @@
 import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
-import { SQL, and, count, eq, gte, inArray, lt, sql } from 'drizzle-orm';
+import { SQL, and, count, eq, gte, ilike, inArray, lt, or, sql } from 'drizzle-orm';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
 import { DB } from '../../db';
@@ -32,6 +32,8 @@ const OPDS_SORT_MAP: Record<OpdsSortOrder, SQL[]> = {
   series_asc: [sql`${bookMetadata.seriesName} ASC NULLS LAST`, sql`${bookMetadata.seriesIndex} ASC NULLS LAST`],
   series_desc: [sql`${bookMetadata.seriesName} DESC NULLS LAST`, sql`${bookMetadata.seriesIndex} DESC NULLS LAST`],
 };
+
+const LIKE_SPECIAL_CHARS = /[%_\\]/g;
 
 export interface OpdsBookEntry {
   id: number;
@@ -143,10 +145,34 @@ export class OpdsBookService {
     }
 
     if (filters?.q) {
-      clauses.push(sql`${bookMetadata.title} ILIKE ${'%' + filters.q + '%'}`);
+      const searchClause = this.buildCatalogSearchClause(filters.q);
+      if (searchClause) clauses.push(searchClause);
     }
 
     return this.paginatedBookQuery(and(...clauses)!, sortOrder, page, size);
+  }
+
+  private buildCatalogSearchClause(q: string): SQL | undefined {
+    const term = q.trim();
+    if (!term) return undefined;
+
+    const pattern = `%${term.replace(LIKE_SPECIAL_CHARS, '\\$&')}%`;
+    const existsAuthor = (() => {
+      const sq = this.db
+        .select({ one: sql`1` })
+        .from(bookAuthors)
+        .innerJoin(authors, eq(bookAuthors.authorId, authors.id))
+        .where(and(eq(bookAuthors.bookId, books.id), ilike(authors.name, pattern))!);
+      return sql`exists (${sq})`;
+    })();
+
+    const clauses: SQL[] = [ilike(bookMetadata.title, pattern), existsAuthor, ilike(bookMetadata.seriesName, pattern)];
+    const normalizedIsbn = normalizeIsbnSearchTerm(term);
+    if (normalizedIsbn) {
+      clauses.push(or(eq(bookMetadata.isbn13, normalizedIsbn), eq(bookMetadata.isbn10, normalizedIsbn))!);
+    }
+
+    return or(...clauses)!;
   }
 
   async getRecentBooksPage(userId: number, page: number, size: number, isSuperuser = false): Promise<{ entries: OpdsBookEntry[]; total: number }> {
@@ -432,4 +458,8 @@ export class OpdsBookService {
       }))
       .sort((a, b) => (idOrder.get(a.id) ?? 0) - (idOrder.get(b.id) ?? 0));
   }
+}
+
+function normalizeIsbnSearchTerm(value: string): string {
+  return value.replace(/[^0-9Xx]/g, '').toUpperCase();
 }

--- a/server/test/opds-auth-catalog.e2e-spec.ts
+++ b/server/test/opds-auth-catalog.e2e-spec.ts
@@ -120,9 +120,9 @@ describe('OPDS auth and catalog (e2e)', { timeout: 120_000 }, () => {
     visibleSeriesName = `Visible Series ${randomUUID().slice(0, 8)}`;
     hiddenSeriesName = `Hidden Series ${randomUUID().slice(0, 8)}`;
 
-    await seedBookMetadata(visibleBookAlpha.bookId, 'Visible Alpha', visibleSeriesName, 1);
+    await seedBookMetadata(visibleBookAlpha.bookId, 'Visible Alpha', visibleSeriesName, 1, '9780141187761');
     await seedBookMetadata(visibleBookBeta.bookId, 'Visible Beta', visibleSeriesName, 2);
-    await seedBookMetadata(hiddenBook.bookId, 'Hidden Gamma', hiddenSeriesName, 1);
+    await seedBookMetadata(hiddenBook.bookId, 'Hidden Gamma', hiddenSeriesName, 1, '9780300000000');
 
     await linkBookAuthor(visibleBookAlpha.bookId, visibleAuthorName);
     await linkBookAuthor(visibleBookBeta.bookId, visibleAuthorName);
@@ -471,6 +471,24 @@ describe('OPDS auth and catalog (e2e)', { timeout: 120_000 }, () => {
       expect(searchResponse.statusCode).toBe(200);
       expect(searchResponse.body).toContain('Visible Alpha');
       expect(searchResponse.body).not.toContain('Visible Beta');
+
+      const authorSearchResponse = await opdsGet(`/api/v1/opds/catalog?q=${encodeURIComponent(visibleAuthorName)}`, ownerCredentials);
+      expect(authorSearchResponse.statusCode).toBe(200);
+      expect(authorSearchResponse.body).toContain('Visible Alpha');
+      expect(authorSearchResponse.body).toContain('Visible Beta');
+      expect(authorSearchResponse.body).not.toContain('Hidden Gamma');
+
+      const seriesSearchResponse = await opdsGet(`/api/v1/opds/catalog?q=${encodeURIComponent(visibleSeriesName)}`, ownerCredentials);
+      expect(seriesSearchResponse.statusCode).toBe(200);
+      expect(seriesSearchResponse.body).toContain('Visible Alpha');
+      expect(seriesSearchResponse.body).toContain('Visible Beta');
+      expect(seriesSearchResponse.body).not.toContain('Hidden Gamma');
+
+      const isbnSearchResponse = await opdsGet('/api/v1/opds/catalog?q=978-0%20141187761', ownerCredentials);
+      expect(isbnSearchResponse.statusCode).toBe(200);
+      expect(isbnSearchResponse.body).toContain('Visible Alpha');
+      expect(isbnSearchResponse.body).not.toContain('Visible Beta');
+      expect(isbnSearchResponse.body).not.toContain('Hidden Gamma');
     });
   });
 
@@ -537,10 +555,13 @@ describe('OPDS auth and catalog (e2e)', { timeout: 120_000 }, () => {
     });
   });
 
-  async function seedBookMetadata(bookId: number, title: string, seriesName: string, seriesIndex: number): Promise<void> {
-    await ctx.db.insert(schema.bookMetadata).values({ bookId, title, seriesName, seriesIndex }).onConflictDoUpdate({
+  async function seedBookMetadata(bookId: number, title: string, seriesName: string, seriesIndex: number, isbn13?: string): Promise<void> {
+    const values = { bookId, title, seriesName, seriesIndex, ...(isbn13 !== undefined ? { isbn13 } : {}) };
+    const set = { title, seriesName, seriesIndex, ...(isbn13 !== undefined ? { isbn13 } : {}) };
+
+    await ctx.db.insert(schema.bookMetadata).values(values).onConflictDoUpdate({
       target: schema.bookMetadata.bookId,
-      set: { title, seriesName, seriesIndex },
+      set,
     });
   }
 


### PR DESCRIPTION

## What does this PR do?

This updates OPDS catalog search so `/api/v1/opds/catalog?q=...` matches title, author, series, and ISBN.

The OPDS catalog search mirrors the dashboard quick-search strategy while keeping the change scoped to OPDS. The main catalog query does not join authors directly; author matching is handled with a correlated `EXISTS` subquery to avoid multiplying rows on large libraries. Title, series, and author matches continue to rely on the existing trigram indexes, while ISBN matches use normalized equality checks against the existing `isbn10` and `isbn13` indexes.

Closes #60.

## How did you test this?

- Extended and ran the OPDS unit tests:
  - `pnpm --filter server test src/modules/opds/__tests__/opds-book.service.test.ts`
- Prepared and migrated the dedicated e2e database:
  - `pnpm run e2e:db:prepare && pnpm run e2e:db:migrate`
- Extended and ran the OPDS e2e suite:
  - `pnpm --filter server exec vitest run --config vitest.config.e2e.ts test/opds-auth-catalog.e2e-spec.ts`
- Ran server checks:
  - `pnpm --filter server type-check`
  - `pnpm --filter server lint:check`
  - `pnpm --filter server format:check`
- Manually verified OPDS search from KOReader, including searching by series name.

## Checklist

- [X] I've read through my own diff
- [X] This PR was discussed in an issue and has maintainer approval (for new features)
- [X] Lint and tests pass locally
- [X] No unintended files included (build artifacts, `.env`, personal configs)
