### PR TITLE
fix(email): fix recipient loading when send dialog opens

### DIFF
--- a/client/src/features/email/components/SendBookDialog.vue
+++ b/client/src/features/email/components/SendBookDialog.vue
@@ -56,6 +56,7 @@ watch(
       fetchTemplates().catch(() => {})
     }
   },
+  { immediate: true },
 )
 
 function toggleRecipient(id: number) {

--- a/client/src/features/email/components/__tests__/SendBookDialog.spec.ts
+++ b/client/src/features/email/components/__tests__/SendBookDialog.spec.ts
@@ -1,0 +1,213 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SendBookDialog from '../SendBookDialog.vue'
+
+const mockState = vi.hoisted(() => ({
+  providers: [] as Array<{ id: number; name: string }>,
+  recipients: [] as Array<{ id: number; name: string; email: string; isDefault: boolean }>,
+  groups: [] as Array<{ id: number; name: string; members: Array<{ id: number }> }>,
+  templates: [] as Array<{ id: number; name: string }>,
+  fetchProviders: vi.fn<() => Promise<void>>(),
+  fetchRecipients: vi.fn<() => Promise<void>>(),
+  fetchGroups: vi.fn<() => Promise<void>>(),
+  fetchTemplates: vi.fn<() => Promise<void>>(),
+  sendBook: vi.fn<(payload: unknown) => Promise<{ queued: number }>>(),
+  toastSuccess: vi.fn<(message: string) => void>(),
+  toastError: vi.fn<(message: string) => void>(),
+}))
+
+vi.mock('../../composables/useEmailProviders', () => ({
+  useEmailProviders: () => ({
+    providers: mockState.providers,
+    fetchProviders: mockState.fetchProviders,
+  }),
+}))
+
+vi.mock('../../composables/useEmailRecipients', () => ({
+  useEmailRecipients: () => ({
+    recipients: mockState.recipients,
+    fetchRecipients: mockState.fetchRecipients,
+  }),
+}))
+
+vi.mock('../../composables/useEmailGroups', () => ({
+  useEmailGroups: () => ({
+    groups: mockState.groups,
+    fetchGroups: mockState.fetchGroups,
+  }),
+}))
+
+vi.mock('../../composables/useEmailTemplates', () => ({
+  useEmailTemplates: () => ({
+    templates: mockState.templates,
+    fetchTemplates: mockState.fetchTemplates,
+  }),
+}))
+
+vi.mock('../../composables/useEmailSend', () => ({
+  useEmailSend: () => ({
+    sendBook: mockState.sendBook,
+  }),
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    success: mockState.toastSuccess,
+    error: mockState.toastError,
+  },
+}))
+
+function mountDialog(
+  overrides: Partial<{ open: boolean; bookIds: number[]; bookFiles: Array<{ id: number; format: string | null; role: string }> }> = {},
+) {
+  return mount(SendBookDialog, {
+    props: {
+      open: true,
+      bookIds: [12],
+      ...overrides,
+    },
+    global: {
+      stubs: {
+        Teleport: true,
+      },
+    },
+  })
+}
+
+describe('SendBookDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockState.providers.splice(0, mockState.providers.length, { id: 3, name: 'SMTP Default' })
+    mockState.recipients.splice(0, mockState.recipients.length, { id: 10, name: 'Kindle', email: 'reader@example.com', isDefault: true })
+    mockState.groups.splice(0, mockState.groups.length, { id: 99, name: 'Devices', members: [{ id: 10 }] })
+    mockState.templates.splice(0, mockState.templates.length, { id: 7, name: 'Default Template' })
+
+    mockState.fetchProviders.mockResolvedValue(undefined)
+    mockState.fetchRecipients.mockResolvedValue(undefined)
+    mockState.fetchGroups.mockResolvedValue(undefined)
+    mockState.fetchTemplates.mockResolvedValue(undefined)
+    mockState.sendBook.mockResolvedValue({ queued: 2 })
+  })
+
+  it('fetches dialog data immediately when mounted with open=true', () => {
+    mountDialog({ open: true })
+
+    expect(mockState.fetchRecipients).toHaveBeenCalledTimes(1)
+    expect(mockState.fetchGroups).toHaveBeenCalledTimes(1)
+    expect(mockState.fetchProviders).toHaveBeenCalledTimes(1)
+    expect(mockState.fetchTemplates).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fetch while closed, then fetches once when opened', async () => {
+    const wrapper = mountDialog({ open: false })
+
+    expect(mockState.fetchRecipients).not.toHaveBeenCalled()
+    expect(mockState.fetchGroups).not.toHaveBeenCalled()
+    expect(mockState.fetchProviders).not.toHaveBeenCalled()
+    expect(mockState.fetchTemplates).not.toHaveBeenCalled()
+
+    await wrapper.setProps({ open: true })
+
+    expect(mockState.fetchRecipients).toHaveBeenCalledTimes(1)
+    expect(mockState.fetchGroups).toHaveBeenCalledTimes(1)
+    expect(mockState.fetchProviders).toHaveBeenCalledTimes(1)
+    expect(mockState.fetchTemplates).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends selected recipients and groups, then emits close and sent', async () => {
+    const wrapper = mountDialog({
+      open: true,
+      bookIds: [12, 13],
+      bookFiles: [
+        { id: 101, format: 'epub', role: 'primary' },
+        { id: 102, format: 'pdf', role: 'secondary' },
+      ],
+    })
+
+    const checkboxes = wrapper.findAll('input[type="checkbox"]')
+    expect(checkboxes).toHaveLength(2)
+
+    await checkboxes[0]!.trigger('change')
+    await checkboxes[1]!.trigger('change')
+
+    await wrapper.findAll('select')[0]!.setValue('102')
+    await wrapper.findAll('select')[1]!.setValue('3')
+    await wrapper.findAll('select')[2]!.setValue('7')
+
+    const sendButton = wrapper.findAll('button').find((button) => button.text().trim() === 'Send')
+    await sendButton!.trigger('click')
+
+    expect(mockState.sendBook).toHaveBeenCalledWith({
+      bookIds: [12, 13],
+      recipientIds: [10],
+      groupIds: [99],
+      providerId: 3,
+      templateId: 7,
+      fileId: 102,
+    })
+    expect(mockState.toastSuccess).toHaveBeenCalledWith('2 emails queued')
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+    expect(wrapper.emitted('sent')).toEqual([[]])
+  })
+
+  it('can deselect recipient and group after selecting them', async () => {
+    const wrapper = mountDialog({ open: true })
+
+    const checkboxes = wrapper.findAll('input[type="checkbox"]')
+    await checkboxes[0]!.trigger('change')
+    await checkboxes[1]!.trigger('change')
+    await checkboxes[0]!.trigger('change')
+    await checkboxes[1]!.trigger('change')
+    await checkboxes[0]!.trigger('change')
+
+    const sendButton = wrapper.findAll('button').find((button) => button.text().trim() === 'Send')
+    await sendButton!.trigger('click')
+
+    expect(mockState.sendBook).toHaveBeenCalledWith({
+      bookIds: [12],
+      recipientIds: [10],
+      groupIds: undefined,
+      providerId: undefined,
+      templateId: undefined,
+      fileId: undefined,
+    })
+  })
+
+  it('shows a toast error when send fails', async () => {
+    mockState.sendBook.mockRejectedValueOnce(new Error('Failed to send'))
+
+    const wrapper = mountDialog()
+
+    const recipientCheckbox = wrapper.find('input[type="checkbox"]')
+    await recipientCheckbox.trigger('change')
+
+    const sendButton = wrapper.findAll('button').find((button) => button.text().trim() === 'Send')
+    await sendButton!.trigger('click')
+
+    expect(mockState.toastError).toHaveBeenCalledWith('Failed to send')
+    expect(wrapper.emitted('update:open')).toBeUndefined()
+    expect(wrapper.emitted('sent')).toBeUndefined()
+  })
+
+  it('emits close when cancel is clicked', async () => {
+    const wrapper = mountDialog()
+
+    const cancelButton = wrapper.findAll('button').find((button) => button.text().trim() === 'Cancel')
+    await cancelButton!.trigger('click')
+
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+  })
+
+  it('emits close when the backdrop is clicked', async () => {
+    const wrapper = mountDialog()
+    await wrapper.find('.absolute.inset-0.bg-black\\/50').trigger('click')
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+  })
+
+  it('emits close when the header close button is clicked', async () => {
+    const wrapper = mountDialog()
+    await wrapper.find('button.text-muted-foreground').trigger('click')
+    expect(wrapper.emitted('update:open')).toEqual([[false]])
+  })
+})

--- a/client/src/features/email/composables/__tests__/useEmailRecipients.spec.ts
+++ b/client/src/features/email/composables/__tests__/useEmailRecipients.spec.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMock = vi.hoisted(() => vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>())
+
+vi.mock('@/lib/api', () => ({
+  api: apiMock,
+}))
+
+function makeResponse(data?: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => data,
+  } as Response
+}
+
+function makeRecipient(id: number, overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id,
+    userId: 42,
+    name: `Recipient ${id}`,
+    email: `recipient${id}@example.com`,
+    isDefault: false,
+    deviceType: null,
+    preferredFormat: null,
+    defaultTemplateId: null,
+    createdAt: '2026-05-22T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('useEmailRecipients', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    apiMock.mockReset()
+  })
+
+  it('fetches recipients and stores them', async () => {
+    const rows = [makeRecipient(1), makeRecipient(2)]
+    apiMock.mockResolvedValueOnce(makeResponse(rows))
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { recipients, fetchRecipients } = useEmailRecipients()
+
+    await fetchRecipients()
+
+    expect(apiMock).toHaveBeenCalledWith('/api/v1/email/recipients')
+    expect(recipients.value).toEqual(rows)
+  })
+
+  it('deduplicates concurrent fetches using the in-flight promise', async () => {
+    let resolveFetch: ((value: Response) => void) | null = null
+    apiMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFetch = resolve
+      }),
+    )
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { fetchRecipients } = useEmailRecipients()
+
+    const first = fetchRecipients()
+    const second = fetchRecipients()
+
+    expect(apiMock).toHaveBeenCalledTimes(1)
+    resolveFetch!(makeResponse([makeRecipient(1)]))
+    await Promise.all([first, second])
+  })
+
+  it('allows retry after a failed fetch', async () => {
+    apiMock.mockResolvedValueOnce(makeResponse({}, false)).mockResolvedValueOnce(makeResponse([makeRecipient(3)]))
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { recipients, fetchRecipients } = useEmailRecipients()
+
+    await expect(fetchRecipients()).rejects.toThrow('Failed to load recipients')
+    await fetchRecipients()
+
+    expect(apiMock).toHaveBeenCalledTimes(2)
+    expect(recipients.value).toEqual([makeRecipient(3)])
+  })
+
+  it('creates a recipient and appends it to local state', async () => {
+    const existing = makeRecipient(1)
+    const created = makeRecipient(2)
+    apiMock.mockResolvedValueOnce(makeResponse(created))
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { recipients, createRecipient } = useEmailRecipients()
+    recipients.value = [existing]
+
+    await createRecipient({
+      name: created.name,
+      email: created.email,
+      deviceType: null,
+      preferredFormat: null,
+      defaultTemplateId: null,
+    })
+
+    const [, request] = apiMock.mock.calls[0] as [string, RequestInit]
+    expect(request.method).toBe('POST')
+    expect(JSON.parse(String(request.body))).toEqual({
+      name: created.name,
+      email: created.email,
+      deviceType: null,
+      preferredFormat: null,
+      defaultTemplateId: null,
+    })
+    expect(recipients.value).toEqual([existing, created])
+  })
+
+  it('surfaces backend message on create failure', async () => {
+    apiMock.mockResolvedValueOnce(makeResponse({ message: 'duplicate recipient' }, false))
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { createRecipient } = useEmailRecipients()
+
+    await expect(
+      createRecipient({
+        name: 'Kindle',
+        email: 'kindle@example.com',
+        deviceType: null,
+        preferredFormat: null,
+        defaultTemplateId: null,
+      }),
+    ).rejects.toThrow('duplicate recipient')
+  })
+
+  it('updates a recipient in local state', async () => {
+    const first = makeRecipient(1)
+    const second = makeRecipient(2)
+    const updated = makeRecipient(1, { name: 'Updated name', preferredFormat: 'epub' })
+    apiMock.mockResolvedValueOnce(makeResponse(updated))
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { recipients, updateRecipient } = useEmailRecipients()
+    recipients.value = [first, second]
+
+    await updateRecipient(1, { name: 'Updated name', preferredFormat: 'epub' })
+
+    expect(recipients.value).toEqual([updated, second])
+  })
+
+  it('surfaces backend message on update failure', async () => {
+    apiMock.mockResolvedValueOnce(makeResponse({ message: 'email already exists' }, false))
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { updateRecipient } = useEmailRecipients()
+
+    await expect(updateRecipient(7, { email: 'duplicate@example.com' })).rejects.toThrow('email already exists')
+  })
+
+  it('deletes a recipient from local state', async () => {
+    apiMock.mockResolvedValueOnce(makeResponse())
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { recipients, deleteRecipient } = useEmailRecipients()
+    recipients.value = [makeRecipient(1), makeRecipient(2)]
+
+    await deleteRecipient(1)
+
+    expect(apiMock).toHaveBeenCalledWith('/api/v1/email/recipients/1', { method: 'DELETE' })
+    expect(recipients.value).toEqual([makeRecipient(2)])
+  })
+
+  it('throws when delete recipient request fails', async () => {
+    apiMock.mockResolvedValueOnce(makeResponse({}, false))
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { deleteRecipient } = useEmailRecipients()
+
+    await expect(deleteRecipient(11)).rejects.toThrow('Failed to delete recipient')
+  })
+
+  it('sets default recipient and clears default from others', async () => {
+    const first = makeRecipient(1, { isDefault: false })
+    const second = makeRecipient(2, { isDefault: true })
+    const updated = makeRecipient(1, { isDefault: true })
+    apiMock.mockResolvedValueOnce(makeResponse(updated))
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { recipients, setDefaultRecipient } = useEmailRecipients()
+    recipients.value = [first, second]
+
+    await setDefaultRecipient(1)
+
+    expect(apiMock).toHaveBeenCalledWith('/api/v1/email/recipients/1/default', { method: 'PATCH' })
+    expect(recipients.value).toEqual([
+      { ...first, isDefault: true },
+      { ...second, isDefault: false },
+    ])
+  })
+
+  it('throws when set default request fails', async () => {
+    apiMock.mockResolvedValueOnce(makeResponse({}, false))
+
+    const { useEmailRecipients } = await import('../useEmailRecipients')
+    const { setDefaultRecipient } = useEmailRecipients()
+
+    await expect(setDefaultRecipient(3)).rejects.toThrow('Failed to set default')
+  })
+})


### PR DESCRIPTION
Run recipient fetch on initial open state so dialogs mounted with open=true load data immediately. Add dialog and recipient composable unit tests to lock in the regression behavior and error paths.

Closes #89
