### PR TITLE
feat(stats): ingest KOReader plugin reading stats

### DIFF
--- a/client/src/features/book/components/detail/BookDetailTabs.vue
+++ b/client/src/features/book/components/detail/BookDetailTabs.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject } from 'vue'
+import type { ComputedRef } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { normalizeBookDetailTab, type BookDetailTab } from '@/features/book/lib/book-detail-tabs'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
@@ -9,16 +10,21 @@ const route = useRoute()
 const router = useRouter()
 const { hasPermission } = usePermissions()
 
+const showKoreaderTab = inject<ComputedRef<boolean>>('showKoreaderTab')
+
 const activeTab = computed(() => normalizeBookDetailTab(route.query.tab))
 
 const tabs = computed<{ label: string; tab: BookDetailTab }[]>(() => {
-  const result: { label: string; tab: BookDetailTab }[] = [{ label: 'Details', tab: 'details' }]
+  const result: { label: string; tab: BookDetailTab }[] = [{ label: 'Book Details', tab: 'details' }]
   if (hasPermission('library_edit_metadata')) {
     result.push({ label: 'Edit Metadata', tab: 'edit' })
   }
-  result.push({ label: 'Files', tab: 'files' })
   result.push({ label: 'Reading Log', tab: 'reading-log' })
+  if (showKoreaderTab?.value) {
+    result.push({ label: 'KOReader Log', tab: 'koreader' })
+  }
   result.push({ label: 'Highlights', tab: 'highlights' })
+  result.push({ label: 'Files', tab: 'files' })
   return result
 })
 

--- a/client/src/features/book/components/detail/tabs/KoreaderActivityChart.vue
+++ b/client/src/features/book/components/detail/tabs/KoreaderActivityChart.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed, onMounted, shallowRef, watchEffect } from 'vue'
+import VChart from 'vue-echarts'
+import { useThemeStore } from '@/stores/theme'
+import { getBookorbitThemeName, initChartThemes } from '@/lib/echarts'
+
+const props = defineProps<{
+  dailySummary: { day: string; durationSeconds: number }[]
+  loading: boolean
+}>()
+
+const themeStore = useThemeStore()
+const chartTheme = computed(() => getBookorbitThemeName(themeStore.theme, themeStore.accent))
+const hasData = computed(() => props.dailySummary.length > 0)
+const option = shallowRef({})
+
+onMounted(() => initChartThemes())
+
+watchEffect(() => {
+  if (!hasData.value) return
+
+  option.value = {
+    tooltip: {
+      trigger: 'axis',
+      formatter: (params: { name: string; value: number }[]) => {
+        const p = params[0]
+        if (!p) return ''
+        const minutes = Math.round(p.value / 60)
+        return `${p.name}: <strong>${minutes} min</strong>`
+      },
+    },
+    grid: { left: '2%', right: '2%', top: '6%', bottom: '12%', containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: props.dailySummary.map((d) => d.day),
+      axisTick: { show: false },
+      axisLabel: {
+        fontSize: 10,
+        interval: Math.max(0, Math.floor(props.dailySummary.length / 6) - 1),
+        formatter: (val: string) => val.slice(5),
+      },
+    },
+    yAxis: {
+      type: 'value',
+      minInterval: 60,
+      axisLabel: { fontSize: 10, formatter: (v: number) => `${Math.round(v / 60)}m` },
+    },
+    series: [
+      {
+        type: 'bar',
+        data: props.dailySummary.map((d) => d.durationSeconds),
+        barMaxWidth: 12,
+        itemStyle: { borderRadius: [2, 2, 0, 0] },
+      },
+    ],
+  }
+})
+</script>
+
+<template>
+  <div>
+    <div v-if="loading && !hasData" class="h-36 rounded-lg bg-muted animate-shimmer sm:h-40" />
+    <div v-else-if="hasData" class="h-36 w-full sm:h-40">
+      <VChart :option="option" :theme="chartTheme" autoresize class="h-full w-full" />
+    </div>
+  </div>
+</template>

--- a/client/src/features/book/components/detail/tabs/KoreaderSessionTable.vue
+++ b/client/src/features/book/components/detail/tabs/KoreaderSessionTable.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { KoreaderReadingSession } from '@bookorbit/types'
+
+const props = defineProps<{
+  sessions: KoreaderReadingSession[]
+  total: number
+  page: number
+  pageSize: number
+  loading: boolean
+}>()
+
+const emit = defineEmits<{
+  pageChange: [page: number]
+}>()
+
+const totalPages = computed(() => Math.ceil(props.total / props.pageSize))
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = Math.floor(seconds % 60)
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m`
+  return `${s}s`
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function handlePrev() {
+  emit('pageChange', props.page - 1)
+}
+
+function handleNext() {
+  emit('pageChange', props.page + 1)
+}
+</script>
+
+<template>
+  <div>
+    <div class="overflow-x-auto rounded-lg border border-border">
+      <table class="w-full text-xs sm:text-sm">
+        <thead>
+          <tr class="border-b border-border bg-muted/50">
+            <th class="px-3 py-2 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:px-4 sm:py-2.5 sm:text-xs">
+              Date
+            </th>
+            <th class="px-3 py-2 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:px-4 sm:py-2.5 sm:text-xs">
+              Page
+            </th>
+            <th class="px-3 py-2 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:px-4 sm:py-2.5 sm:text-xs">
+              Duration
+            </th>
+            <th class="px-3 py-2 text-right text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:px-4 sm:py-2.5 sm:text-xs">
+              Progress
+            </th>
+          </tr>
+        </thead>
+        <tbody :class="{ 'opacity-50': loading }">
+          <template v-if="sessions.length === 0 && !loading">
+            <tr>
+              <td colspan="4" class="px-4 py-6 text-center text-muted-foreground text-sm">No sessions recorded yet</td>
+            </tr>
+          </template>
+          <tr v-for="session in sessions" :key="session.id" class="border-b border-border last:border-0 hover:bg-muted/30 transition-colors">
+            <td class="px-3 py-2 text-foreground sm:px-4 sm:py-2.5">{{ formatDate(session.startedAt) }}</td>
+            <td class="px-3 py-2 text-right tabular-nums text-foreground sm:px-4 sm:py-2.5">{{ session.page }}</td>
+            <td class="px-3 py-2 text-right tabular-nums text-foreground sm:px-4 sm:py-2.5">{{ formatDuration(session.durationSeconds) }}</td>
+            <td class="px-3 py-2 text-right text-[11px] tabular-nums text-muted-foreground sm:px-4 sm:py-2.5 sm:text-xs">
+              {{ Math.round((session.page / session.totalPages) * 100) }}%
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div v-if="totalPages > 1" class="mt-3 flex items-center justify-between text-xs sm:text-sm">
+      <span class="text-muted-foreground">{{ total }} sessions total</span>
+      <div class="flex items-center gap-1.5 sm:gap-2">
+        <button
+          class="rounded-md border border-border px-2.5 py-1 text-xs transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-40 sm:px-3 sm:py-1.5 sm:text-sm"
+          :disabled="page <= 1"
+          @click="handlePrev"
+        >
+          Previous
+        </button>
+        <span class="text-muted-foreground">{{ page }} / {{ totalPages }}</span>
+        <button
+          class="rounded-md border border-border px-2.5 py-1 text-xs transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-40 sm:px-3 sm:py-1.5 sm:text-sm"
+          :disabled="page >= totalPages"
+          @click="handleNext"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/client/src/features/book/components/detail/tabs/KoreaderStatsStrip.vue
+++ b/client/src/features/book/components/detail/tabs/KoreaderStatsStrip.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { KoreaderBookStats } from '@bookorbit/types'
+
+const props = defineProps<{
+  stats: KoreaderBookStats | null
+  total: number
+  loading: boolean
+}>()
+
+const CARD_CLASS = 'rounded-md border border-border bg-card px-2.5 py-2 sm:px-3 sm:py-2.5'
+const CARD_COUNT = 6
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (h > 0) return `${h}h ${m}m`
+  if (m > 0) return `${m}m`
+  return `${seconds}s`
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return '-'
+  const diff = Date.now() - new Date(iso).getTime()
+  const s = Math.floor(diff / 1000)
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  if (d < 30) return `${d}d ago`
+  const mo = Math.floor(d / 30)
+  if (mo < 12) return `${mo} month${mo === 1 ? '' : 's'} ago`
+  const yr = Math.floor(mo / 12)
+  return `${yr} year${yr === 1 ? '' : 's'} ago`
+}
+
+const statCards = computed(() => [
+  {
+    label: 'Reading Time',
+    value: props.stats ? formatDuration(props.stats.totalReadSecs) : '0s',
+  },
+  {
+    label: 'Pages Read',
+    value: String(props.stats?.totalReadPages ?? 0),
+  },
+  {
+    label: 'Sessions',
+    value: String(props.total),
+  },
+  {
+    label: 'Highlights',
+    value: String(props.stats?.highlightsCount ?? 0),
+  },
+  {
+    label: 'Notes',
+    value: String(props.stats?.notesCount ?? 0),
+  },
+  {
+    label: 'Last Opened',
+    value: props.stats ? formatRelative(props.stats.lastOpenAt) : '-',
+  },
+])
+</script>
+
+<template>
+  <div
+    class="grid grid-cols-2 gap-1.5 transition-opacity sm:gap-2 md:grid-cols-6"
+    :class="{ 'opacity-50 pointer-events-none': loading && stats !== null }"
+  >
+    <template v-if="stats === null && loading">
+      <div v-for="i in CARD_COUNT" :key="i" :class="CARD_CLASS">
+        <div class="h-3 w-16 rounded bg-muted animate-shimmer mb-2" />
+        <div class="h-6 w-12 rounded bg-muted animate-shimmer" />
+      </div>
+    </template>
+    <template v-else>
+      <div v-for="card in statCards" :key="card.label" data-testid="stat-card" :class="CARD_CLASS">
+        <p class="mb-0.5 text-[10px] text-muted-foreground sm:text-[11px]">{{ card.label }}</p>
+        <p class="text-base font-semibold text-foreground sm:text-lg">{{ card.value }}</p>
+      </div>
+    </template>
+  </div>
+</template>

--- a/client/src/features/book/components/detail/tabs/KoreaderTab.vue
+++ b/client/src/features/book/components/detail/tabs/KoreaderTab.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { computed, inject } from 'vue'
+import { KOREADER_BOOK_STATS_KEY } from '@/features/koreader/composables/useKoreaderBookStats'
+import KoreaderStatsStrip from './KoreaderStatsStrip.vue'
+import KoreaderActivityChart from './KoreaderActivityChart.vue'
+import KoreaderSessionTable from './KoreaderSessionTable.vue'
+
+const { tabData, loading, page, pageSize, setPage } = inject(KOREADER_BOOK_STATS_KEY)!
+
+const stats = computed(() => tabData.value?.stats ?? null)
+const sessions = computed(() => tabData.value?.sessions ?? [])
+const total = computed(() => tabData.value?.total ?? 0)
+const dailySummary = computed(() => tabData.value?.dailySummary ?? [])
+
+function handlePageChange(p: number) {
+  setPage(p)
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <KoreaderStatsStrip :stats="stats" :total="total" :loading="loading" />
+    <KoreaderActivityChart v-if="dailySummary.length > 0 || loading" :daily-summary="dailySummary" :loading="loading" />
+    <KoreaderSessionTable :sessions="sessions" :total="total" :page="page" :page-size="pageSize" :loading="loading" @page-change="handlePageChange" />
+  </div>
+</template>

--- a/client/src/features/book/components/detail/tabs/ReadingLogStatsStrip.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogStatsStrip.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const CARD_COUNT = 8
-const CARD_CLASS = 'rounded-lg border border-border bg-card px-3 py-2.5 sm:px-4 sm:py-3'
+const CARD_CLASS = 'rounded-md border border-border bg-card px-2.5 py-2 sm:px-3 sm:py-2.5'
 
 function toUtcDayStart(date: Date): number {
   return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
@@ -163,7 +163,7 @@ const statCards = computed(() => [
 
 <template>
   <div
-    class="grid grid-cols-2 gap-2 sm:gap-3 transition-opacity md:grid-cols-8"
+    class="grid grid-cols-2 gap-1.5 transition-opacity sm:gap-2 md:grid-cols-8"
     :class="{ 'opacity-50 pointer-events-none': loading && stats !== null }"
   >
     <template v-if="stats === null && loading">
@@ -173,9 +173,9 @@ const statCards = computed(() => [
       </div>
     </template>
     <template v-else>
-      <div v-for="card in statCards" :key="card.label" :class="CARD_CLASS">
-        <p class="mb-0.5 text-[11px] text-muted-foreground sm:mb-1 sm:text-xs">{{ card.label }}</p>
-        <p class="text-lg font-semibold sm:text-xl" :class="card.tone">{{ card.value }}</p>
+      <div v-for="card in statCards" :key="card.label" data-testid="stat-card" :class="CARD_CLASS">
+        <p class="mb-0.5 text-[10px] text-muted-foreground sm:text-[11px]">{{ card.label }}</p>
+        <p class="text-base font-semibold sm:text-lg" :class="card.tone">{{ card.value }}</p>
       </div>
     </template>
   </div>

--- a/client/src/features/book/components/detail/tabs/ReadingLogTab.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogTab.vue
@@ -63,16 +63,16 @@ const quickFilters: { label: string; value: QuickFilter }[] = [
 </script>
 
 <template>
-  <div class="space-y-5">
+  <div class="space-y-4">
     <div v-if="error" class="rounded-md border border-destructive bg-destructive/10 px-4 py-3 text-sm text-destructive">
       {{ error }}
     </div>
 
-    <div class="flex flex-wrap items-center gap-2">
+    <div class="flex flex-wrap items-center gap-1.5">
       <button
         v-for="qf in quickFilters"
         :key="qf.value"
-        class="px-3 py-1.5 rounded-md text-sm font-medium border transition-colors"
+        class="rounded-md border px-2.5 py-1 text-xs font-medium transition-colors sm:px-3 sm:py-1.5 sm:text-sm"
         :class="
           activeQuick === qf.value
             ? 'bg-primary text-primary-foreground border-primary'
@@ -85,7 +85,7 @@ const quickFilters: { label: string; value: QuickFilter }[] = [
 
       <select
         v-if="hasMultipleFormats"
-        class="ml-auto px-3 py-1.5 rounded-md text-sm border border-border bg-card text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        class="ml-auto rounded-md border border-border bg-card px-2.5 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-primary sm:px-3 sm:py-1.5 sm:text-sm"
         :value="selectedFormat ?? ''"
         @change="handleFormatChange"
       >

--- a/client/src/features/book/components/detail/tabs/ReadingLogTable.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogTable.vue
@@ -100,7 +100,7 @@ const SORTABLE_COLS = [
 
 <template>
   <div @click.self="clearConfirmDelete">
-    <div v-if="sessions.length === 0 && !loading" class="flex items-center justify-center py-16 text-muted-foreground text-sm">
+    <div v-if="sessions.length === 0 && !loading" class="flex items-center justify-center py-10 text-muted-foreground text-sm">
       No reading sessions recorded yet.
     </div>
 
@@ -111,7 +111,7 @@ const SORTABLE_COLS = [
             <th
               v-for="col in SORTABLE_COLS"
               :key="col.id"
-              class="px-2 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:px-4 sm:py-3 sm:text-xs"
+              class="px-2 py-2 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:px-3 sm:py-2.5 sm:text-xs"
             >
               <button class="flex items-center gap-1 whitespace-nowrap hover:text-foreground transition-colors" @click="() => handleSort(col.id)">
                 <span class="sm:hidden">{{ col.mobileLabel }}</span>
@@ -123,12 +123,12 @@ const SORTABLE_COLS = [
             </th>
             <th
               v-if="hasMultipleFormats"
-              class="px-2 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:px-4 sm:py-3 sm:text-xs"
+              class="px-2 py-2 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:px-3 sm:py-2.5 sm:text-xs"
             >
               <span class="sm:hidden">Fmt</span>
               <span class="hidden sm:inline">Format</span>
             </th>
-            <th class="w-28 px-2 py-2.5 sm:px-4 sm:py-3" />
+            <th class="w-24 px-2 py-2 sm:px-3 sm:py-2.5" />
           </tr>
         </thead>
         <tbody>
@@ -137,34 +137,34 @@ const SORTABLE_COLS = [
             :key="session.id"
             class="border-b border-border odd:bg-muted/20 last:border-0 hover:bg-muted/30 transition-colors"
           >
-            <td class="px-2 py-2.5 text-foreground whitespace-nowrap sm:px-4 sm:py-3">
+            <td class="px-2 py-2 text-foreground whitespace-nowrap sm:px-3 sm:py-2.5">
               <span class="sm:hidden">{{ formatDateCompact(session.startedAt) }}</span>
               <span class="hidden sm:inline">{{ formatDate(session.startedAt) }}</span>
             </td>
-            <td class="px-2 py-2.5 text-foreground whitespace-nowrap sm:px-4 sm:py-3">{{ formatDuration(session.durationSeconds) }}</td>
+            <td class="px-2 py-2 text-foreground whitespace-nowrap sm:px-3 sm:py-2.5">{{ formatDuration(session.durationSeconds) }}</td>
             <td
-              class="px-2 py-2.5 whitespace-nowrap sm:px-4 sm:py-3"
+              class="px-2 py-2 whitespace-nowrap sm:px-3 sm:py-2.5"
               :class="session.progressDelta != null && session.progressDelta > 0 ? 'text-green-600' : 'text-muted-foreground'"
             >
               {{ session.progressDelta != null ? `+${session.progressDelta.toFixed(1)}%` : '-' }}
             </td>
-            <td class="px-2 py-2.5 text-foreground whitespace-nowrap sm:px-4 sm:py-3">
+            <td class="px-2 py-2 text-foreground whitespace-nowrap sm:px-3 sm:py-2.5">
               {{ session.endProgress != null ? `${session.endProgress.toFixed(1)}%` : '-' }}
             </td>
-            <td v-if="hasMultipleFormats" class="px-2 py-2.5 text-foreground whitespace-nowrap sm:px-4 sm:py-3">{{ session.format ?? '-' }}</td>
-            <td class="w-28 px-2 py-2.5 sm:px-4 sm:py-3">
-              <div class="ml-auto flex h-7 w-[5.75rem] items-center justify-end gap-1">
+            <td v-if="hasMultipleFormats" class="px-2 py-2 text-foreground whitespace-nowrap sm:px-3 sm:py-2.5">{{ session.format ?? '-' }}</td>
+            <td class="w-24 px-2 py-2 sm:px-3 sm:py-2.5">
+              <div class="ml-auto flex h-6 w-[5.25rem] items-center justify-end gap-1">
                 <template v-if="confirmDeleteId === session.id">
                   <button
-                    class="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    class="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                     title="Cancel delete"
                     aria-label="Cancel delete session"
                     @click="clearConfirmDelete"
                   >
-                    <X :size="14" />
+                    <X :size="12" />
                   </button>
                   <button
-                    class="inline-flex h-7 items-center justify-center rounded px-2 text-xs font-medium uppercase tracking-wide transition-colors bg-destructive/15 text-destructive ring-1 ring-destructive/40"
+                    class="inline-flex h-6 items-center justify-center rounded px-2 text-[10px] font-medium uppercase tracking-wide transition-colors bg-destructive/15 text-destructive ring-1 ring-destructive/40"
                     title="Click again to confirm delete"
                     aria-label="Confirm delete session"
                     @click="() => handleDeleteClick(session.id)"
@@ -174,12 +174,12 @@ const SORTABLE_COLS = [
                 </template>
                 <button
                   v-else
-                  class="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
+                  class="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
                   title="Delete"
                   aria-label="Delete session"
                   @click="() => handleDeleteClick(session.id)"
                 >
-                  <Trash2 :size="14" />
+                  <Trash2 :size="12" />
                 </button>
               </div>
             </td>
@@ -188,11 +188,11 @@ const SORTABLE_COLS = [
       </table>
     </div>
 
-    <div v-if="total > 0" class="flex items-center justify-between mt-4 text-sm text-muted-foreground">
+    <div v-if="total > 0" class="mt-3 flex items-center justify-between text-xs text-muted-foreground sm:text-sm">
       <span>Showing {{ startItem }}-{{ endItem }} of {{ total }} sessions</span>
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-1.5 sm:gap-2">
         <button
-          class="px-3 py-1.5 rounded border border-border bg-card hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed text-foreground text-sm"
+          class="rounded border border-border bg-card px-2.5 py-1 text-xs text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 sm:px-3 sm:py-1.5 sm:text-sm"
           :disabled="page <= 1"
           @click="handlePrevPage"
         >
@@ -200,7 +200,7 @@ const SORTABLE_COLS = [
         </button>
         <span class="text-xs">{{ page }} / {{ totalPages }}</span>
         <button
-          class="px-3 py-1.5 rounded border border-border bg-card hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed text-foreground text-sm"
+          class="rounded border border-border bg-card px-2.5 py-1 text-xs text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 sm:px-3 sm:py-1.5 sm:text-sm"
           :disabled="page >= totalPages"
           @click="handleNextPage"
         >

--- a/client/src/features/book/components/detail/tabs/__tests__/ReadingLogStatsStrip.spec.ts
+++ b/client/src/features/book/components/detail/tabs/__tests__/ReadingLogStatsStrip.spec.ts
@@ -43,14 +43,14 @@ describe('ReadingLogStatsStrip', () => {
     const wrapper = mount(ReadingLogStatsStrip, {
       props: makeProps(),
     })
-    expect(wrapper.findAll('.rounded-lg.border').length).toBe(8)
+    expect(wrapper.findAll('[data-testid="stat-card"]').length).toBe(8)
   })
 
   it('renders 8 stat cards when stats loaded even while re-fetching', () => {
     const wrapper = mount(ReadingLogStatsStrip, {
       props: makeProps({ loading: true }),
     })
-    expect(wrapper.findAll('.rounded-lg.border').length).toBe(8)
+    expect(wrapper.findAll('[data-testid="stat-card"]').length).toBe(8)
   })
 
   it('formats 3780 seconds as "1h 3m"', () => {

--- a/client/src/features/book/lib/book-detail-tabs.ts
+++ b/client/src/features/book/lib/book-detail-tabs.ts
@@ -1,4 +1,4 @@
-export const BOOK_DETAIL_TABS = ['details', 'edit', 'files', 'reading-log', 'highlights'] as const
+export const BOOK_DETAIL_TABS = ['details', 'edit', 'reading-log', 'koreader', 'highlights', 'files'] as const
 
 export type BookDetailTab = (typeof BOOK_DETAIL_TABS)[number]
 

--- a/client/src/features/koreader/composables/__tests__/useKoreaderSync.spec.ts
+++ b/client/src/features/koreader/composables/__tests__/useKoreaderSync.spec.ts
@@ -29,6 +29,8 @@ function makeSyncStatus(overrides: Partial<KoreaderSyncStatus> = {}): KoreaderSy
     ],
     totalSyncedBooks: 14,
     lastSyncAt: '2026-01-02T00:00:00.000Z',
+    booksWithStats: 9,
+    totalReadingSeconds: 18_000,
     ...overrides,
   }
 }

--- a/client/src/features/koreader/composables/useKoreaderBookStats.ts
+++ b/client/src/features/koreader/composables/useKoreaderBookStats.ts
@@ -1,0 +1,52 @@
+import { computed, ref, watch } from 'vue'
+import type { InjectionKey, Ref } from 'vue'
+import { api } from '@/lib/api'
+import type { KoreaderTabData } from '@bookorbit/types'
+
+export type KoreaderBookStatsComposable = ReturnType<typeof useKoreaderBookStats>
+export const KOREADER_BOOK_STATS_KEY = Symbol('koreaderBookStats') as InjectionKey<KoreaderBookStatsComposable>
+
+const PAGE_SIZE = 20
+
+export function useKoreaderBookStats(bookIdRef: Ref<number>) {
+  const tabData = ref<KoreaderTabData | null>(null)
+  const loading = ref(false)
+  const page = ref(1)
+  const pageSize = PAGE_SIZE
+
+  const hasData = computed(() => tabData.value !== null)
+
+  async function fetchTabData(targetPage = 1): Promise<void> {
+    loading.value = true
+    try {
+      const res = await api(`/api/v1/koreader/books/${bookIdRef.value}/stats?page=${targetPage}&pageSize=${pageSize}`)
+      if (!res.ok) {
+        tabData.value = null
+        return
+      }
+      const data = await res.json()
+      tabData.value = data ?? null
+    } catch {
+      tabData.value = null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function setPage(p: number) {
+    page.value = p
+    fetchTabData(p)
+  }
+
+  watch(
+    bookIdRef,
+    () => {
+      page.value = 1
+      tabData.value = null
+      fetchTabData(1)
+    },
+    { immediate: true },
+  )
+
+  return { tabData, loading, page, pageSize, hasData, fetchTabData, setPage }
+}

--- a/client/src/features/settings/KoreaderSettings.vue
+++ b/client/src/features/settings/KoreaderSettings.vue
@@ -30,6 +30,17 @@ const syncUrl = computed(() => getSyncUrl())
 const hasCredentials = computed(() => !!credentials.value)
 const deviceCount = computed(() => syncStatus.value?.devices.length ?? 0)
 const totalSyncedBooks = computed(() => syncStatus.value?.totalSyncedBooks ?? 0)
+const booksWithStats = computed(() => syncStatus.value?.booksWithStats ?? 0)
+const totalReadingSeconds = computed(() => syncStatus.value?.totalReadingSeconds ?? 0)
+
+function formatReadingTime(seconds: number): string {
+  if (seconds === 0) return '0m'
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (h === 0) return `${m}m`
+  if (m === 0) return `${h}h`
+  return `${h}h ${m}m`
+}
 
 function formatLastSync(dateStr: string | null): string {
   if (!dateStr) return 'Never'
@@ -286,6 +297,18 @@ async function handleRefresh() {
             <div>
               <p class="settings-label">Synced Books</p>
               <p class="settings-hint">{{ totalSyncedBooks }} {{ totalSyncedBooks === 1 ? 'book' : 'books' }}</p>
+            </div>
+          </div>
+          <div class="flex items-center justify-between px-4 py-3.5 bg-card md:px-5">
+            <div>
+              <p class="settings-label">Books with Stats</p>
+              <p class="settings-hint">{{ booksWithStats }} {{ booksWithStats === 1 ? 'book' : 'books' }}</p>
+            </div>
+          </div>
+          <div class="flex items-center justify-between px-4 py-3.5 bg-card md:px-5">
+            <div>
+              <p class="settings-label">Total Reading Time</p>
+              <p class="settings-hint">{{ formatReadingTime(totalReadingSeconds) }}</p>
             </div>
           </div>
           <div class="flex items-center justify-between px-4 py-3.5 bg-card md:px-5">

--- a/client/src/features/statistics/api/koreader-statistics.api.ts
+++ b/client/src/features/statistics/api/koreader-statistics.api.ts
@@ -1,0 +1,62 @@
+import { api } from '@/lib/api'
+import type {
+  KoreaderStatsSummary,
+  KoreaderHeatmapPoint,
+  KoreaderMonthlyPoint,
+  KoreaderHourPoint,
+  KoreaderSessionLengthBin,
+  KoreaderTopBookItem,
+  KoreaderTopAnnotatedItem,
+  KoreaderWeekdayPoint,
+  KoreaderDevicePoint,
+} from '@bookorbit/types'
+
+async function parseJson<T>(res: Response): Promise<T> {
+  if (!res.ok) throw new Error(`KOReader stats request failed: ${res.status}`)
+  return res.json() as Promise<T>
+}
+
+export async function fetchKoreaderStatsSummary(): Promise<KoreaderStatsSummary> {
+  const res = await api('/api/v1/koreader/statistics/summary')
+  return parseJson<KoreaderStatsSummary>(res)
+}
+
+export async function fetchKoreaderActivityHeatmap(): Promise<KoreaderHeatmapPoint[]> {
+  const res = await api('/api/v1/koreader/statistics/heatmap')
+  return parseJson<KoreaderHeatmapPoint[]>(res)
+}
+
+export async function fetchKoreaderMonthlyReading(): Promise<KoreaderMonthlyPoint[]> {
+  const res = await api('/api/v1/koreader/statistics/monthly')
+  return parseJson<KoreaderMonthlyPoint[]>(res)
+}
+
+export async function fetchKoreaderTimeOfDay(): Promise<KoreaderHourPoint[]> {
+  const res = await api('/api/v1/koreader/statistics/time-of-day')
+  return parseJson<KoreaderHourPoint[]>(res)
+}
+
+export async function fetchKoreaderSessionLengths(): Promise<KoreaderSessionLengthBin[]> {
+  const res = await api('/api/v1/koreader/statistics/session-lengths')
+  return parseJson<KoreaderSessionLengthBin[]>(res)
+}
+
+export async function fetchKoreaderTopBooks(): Promise<KoreaderTopBookItem[]> {
+  const res = await api('/api/v1/koreader/statistics/top-books')
+  return parseJson<KoreaderTopBookItem[]>(res)
+}
+
+export async function fetchKoreaderTopAnnotated(): Promise<KoreaderTopAnnotatedItem[]> {
+  const res = await api('/api/v1/koreader/statistics/top-annotated')
+  return parseJson<KoreaderTopAnnotatedItem[]>(res)
+}
+
+export async function fetchKoreaderWeeklyRhythm(): Promise<KoreaderWeekdayPoint[]> {
+  const res = await api('/api/v1/koreader/statistics/weekly-rhythm')
+  return parseJson<KoreaderWeekdayPoint[]>(res)
+}
+
+export async function fetchKoreaderDevices(): Promise<KoreaderDevicePoint[]> {
+  const res = await api('/api/v1/koreader/statistics/devices')
+  return parseJson<KoreaderDevicePoint[]>(res)
+}

--- a/client/src/features/statistics/components/StatisticsGrid.vue
+++ b/client/src/features/statistics/components/StatisticsGrid.vue
@@ -41,6 +41,14 @@ const CHART_COMPONENTS: Record<StatisticsChartId, Component> = {
   'reading-clock': defineAsyncComponent(() => import('./user/ReadingClockChart.vue')),
   'reading-session-timeline': defineAsyncComponent(() => import('./user/ReadingSessionTimelineChart.vue')),
   'session-archetypes': defineAsyncComponent(() => import('./user/SessionArchetypesChart.vue')),
+  'ko-activity-heatmap': defineAsyncComponent(() => import('./koreader/KoreaderActivityHeatmapChart.vue')),
+  'ko-monthly-reading': defineAsyncComponent(() => import('./koreader/KoreaderMonthlyReadingChart.vue')),
+  'ko-time-of-day': defineAsyncComponent(() => import('./koreader/KoreaderTimeOfDayChart.vue')),
+  'ko-session-lengths': defineAsyncComponent(() => import('./koreader/KoreaderSessionLengthsChart.vue')),
+  'ko-top-books': defineAsyncComponent(() => import('./koreader/KoreaderTopBooksChart.vue')),
+  'ko-top-annotated': defineAsyncComponent(() => import('./koreader/KoreaderTopAnnotatedChart.vue')),
+  'ko-weekly-rhythm': defineAsyncComponent(() => import('./koreader/KoreaderWeeklyRhythmChart.vue')),
+  'ko-devices': defineAsyncComponent(() => import('./koreader/KoreaderDevicesChart.vue')),
 }
 
 const { reorder } = useStatisticsConfig()

--- a/client/src/features/statistics/components/StatisticsPage.vue
+++ b/client/src/features/statistics/components/StatisticsPage.vue
@@ -8,21 +8,27 @@ import type { ChartConfigEntry, StatisticsChartId } from '@bookorbit/types'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
+import { usePermissions } from '@/features/auth/composables/usePermissions'
 import { useLibraries } from '@/features/library/composables/useLibraries'
 import { STATISTICS_CHART_META } from '../statistics-chart-meta'
 import { useStatisticsConfig } from '../composables/useStatisticsConfig'
+import KoreaderSummaryStrip from './koreader/KoreaderSummaryStrip.vue'
 import StatisticsGrid from './StatisticsGrid.vue'
 import StatisticsSummaryCard from './StatisticsSummaryCard.vue'
 
 const {
   orderedLibraryCharts,
   orderedUserCharts,
+  orderedKoreaderCharts,
   visibleLibraryCharts,
   visibleUserCharts,
+  visibleKoreaderCharts,
   libraryChartCount,
   userChartCount,
+  koreaderChartCount,
   visibleLibraryChartCount,
   visibleUserChartCount,
+  visibleKoreaderChartCount,
   filters,
   init,
   toggleVisibility,
@@ -34,16 +40,19 @@ const {
 const route = useRoute()
 const router = useRouter()
 const { libraries, fetchLibraries } = useLibraries()
+const { hasPermission } = usePermissions()
 const configOpen = ref(false)
+const canViewKoreaderStats = computed(() => hasPermission('koreader_sync'))
 
-type StatisticsTab = 'library' | 'user'
+type StatisticsTab = 'library' | 'user' | 'koreader'
 
-function resolveStatisticsTab(tabQuery: unknown): StatisticsTab {
+function resolveStatisticsTab(tabQuery: unknown, allowKoreader: boolean): StatisticsTab {
   const tab = Array.isArray(tabQuery) ? tabQuery[0] : tabQuery
+  if (tab === 'koreader' && allowKoreader) return 'koreader'
   return tab === 'user' ? 'user' : 'library'
 }
 
-const initialTab = resolveStatisticsTab(route.query.tab)
+const initialTab = resolveStatisticsTab(route.query.tab, canViewKoreaderStats.value)
 const activeTab = ref<StatisticsTab>(initialTab)
 const loaded = ref<Set<StatisticsTab>>(new Set([initialTab]))
 
@@ -54,12 +63,31 @@ onMounted(fetchLibraries)
 watch(
   () => route.query.tab,
   (tabQuery) => {
-    const tab = resolveStatisticsTab(tabQuery)
+    const rawTab = Array.isArray(tabQuery) ? tabQuery[0] : tabQuery
+    if (rawTab === 'koreader' && !canViewKoreaderStats.value) {
+      void router.replace({ query: { ...route.query, tab: 'library' } })
+      return
+    }
+    const tab = resolveStatisticsTab(tabQuery, canViewKoreaderStats.value)
     if (tab === activeTab.value) return
     activeTab.value = tab
     loaded.value.add(tab)
   },
+  { immediate: true },
 )
+
+watch(canViewKoreaderStats, (canView) => {
+  if (!canView) {
+    if (activeTab.value !== 'koreader') return
+    setTab('library')
+    return
+  }
+
+  const tab = resolveStatisticsTab(route.query.tab, true)
+  if (tab === activeTab.value) return
+  activeTab.value = tab
+  loaded.value.add(tab)
+})
 
 watch(
   libraries,
@@ -76,9 +104,23 @@ watch(
   { immediate: true },
 )
 
-const activeVisibleCount = computed(() => (activeTab.value === 'library' ? visibleLibraryChartCount.value : visibleUserChartCount.value))
-const activeTotalCount = computed(() => (activeTab.value === 'library' ? libraryChartCount.value : userChartCount.value))
-const activeOrderedCharts = computed(() => (activeTab.value === 'library' ? orderedLibraryCharts.value : orderedUserCharts.value))
+const activeVisibleCount = computed(() => {
+  if (activeTab.value === 'library') return visibleLibraryChartCount.value
+  if (activeTab.value === 'user') return visibleUserChartCount.value
+  return visibleKoreaderChartCount.value
+})
+
+const activeTotalCount = computed(() => {
+  if (activeTab.value === 'library') return libraryChartCount.value
+  if (activeTab.value === 'user') return userChartCount.value
+  return koreaderChartCount.value
+})
+
+const activeOrderedCharts = computed(() => {
+  if (activeTab.value === 'library') return orderedLibraryCharts.value
+  if (activeTab.value === 'user') return orderedUserCharts.value
+  return orderedKoreaderCharts.value
+})
 
 const libraryLabel = computed(() => {
   const count = filters.value.libraryIds.length
@@ -130,6 +172,7 @@ function chartMeta(id: StatisticsChartId) {
 }
 
 function setTab(tab: StatisticsTab) {
+  if (tab === 'koreader' && !canViewKoreaderStats.value) return
   activeTab.value = tab
   loaded.value.add(tab)
   void router.replace({ query: { ...route.query, tab } })
@@ -158,10 +201,20 @@ function setTab(tab: StatisticsTab) {
         >
           My Reading
         </button>
+        <button
+          v-if="canViewKoreaderStats"
+          :class="[
+            'flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-colors sm:flex-none',
+            activeTab === 'koreader' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
+          ]"
+          @click="setTab('koreader')"
+        >
+          KOReader Stats
+        </button>
       </div>
 
       <div class="flex w-full min-w-0 items-center gap-2 sm:w-auto sm:justify-end">
-        <Popover v-if="libraries.length > 1">
+        <Popover v-if="libraries.length > 1 && activeTab !== 'koreader'">
           <PopoverTrigger as-child>
             <button
               :class="[
@@ -213,7 +266,8 @@ function setTab(tab: StatisticsTab) {
       </div>
     </div>
 
-    <StatisticsSummaryCard />
+    <StatisticsSummaryCard v-if="activeTab !== 'koreader'" />
+    <KoreaderSummaryStrip v-else />
 
     <Sheet v-model:open="configOpen">
       <SheetContent side="right" class="w-[90dvw] max-w-[90dvw] sm:w-[420px] sm:max-w-[420px]">
@@ -269,6 +323,9 @@ function setTab(tab: StatisticsTab) {
     </div>
     <div v-if="loaded.has('user')" v-show="activeTab === 'user'">
       <StatisticsGrid :charts="visibleUserCharts" />
+    </div>
+    <div v-if="canViewKoreaderStats && loaded.has('koreader')" v-show="activeTab === 'koreader'">
+      <StatisticsGrid :charts="visibleKoreaderCharts" />
     </div>
   </div>
 </template>

--- a/client/src/features/statistics/components/koreader/KoreaderActivityHeatmapChart.vue
+++ b/client/src/features/statistics/components/koreader/KoreaderActivityHeatmapChart.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { computed, shallowRef, watchEffect } from 'vue'
+import VChart from 'vue-echarts'
+import { Calendar } from 'lucide-vue-next'
+import { useThemeStore } from '@/stores/theme'
+
+import { buildHeatmapPalette } from '../../heatmap-palette'
+import { useKoreaderActivityHeatmap } from '../../composables/useKoreaderActivityHeatmap'
+import ChartCard from '../ChartCard.vue'
+import ChartEmptyState from '../ChartEmptyState.vue'
+
+const MIN_ACTIVE_DAYS = 5
+const HEATMAP_DAYS = 364
+
+const themeStore = useThemeStore()
+const { data, loading, error } = useKoreaderActivityHeatmap()
+const option = shallowRef({})
+
+const activeDays = computed(() => data.value.length)
+const isEmpty = computed(() => activeDays.value === 0)
+const lowConfidence = computed(() => activeDays.value > 0 && activeDays.value < MIN_ACTIVE_DAYS)
+
+const paletteState = computed(() => ({
+  accent: themeStore.accent,
+  palette: buildHeatmapPalette({ theme: themeStore.theme, profile: 'github' }),
+}))
+
+function buildPieces(scale: string[]) {
+  return [
+    { value: 0, label: '0m', color: scale[0] },
+    { gt: 0, lte: 15, label: '1-15m', color: scale[1] },
+    { gt: 15, lte: 30, label: '16-30m', color: scale[2] },
+    { gt: 30, lte: 60, label: '31-60m', color: scale[3] },
+    { gt: 60, label: '60m+', color: scale[4] },
+  ]
+}
+
+watchEffect(() => {
+  option.value = {}
+  if (isEmpty.value || lowConfidence.value || !data.value.length) return
+
+  const endDay = new Date()
+  endDay.setUTCHours(0, 0, 0, 0)
+  const startDay = new Date(endDay)
+  startDay.setUTCDate(startDay.getUTCDate() - HEATMAP_DAYS)
+  const startDayKey = startDay.toISOString().slice(0, 10)
+  const endDayKey = endDay.toISOString().slice(0, 10)
+
+  const palette = paletteState.value.palette
+  const byDay = new Map(data.value.map((d) => [d.date, d.durationSeconds]))
+
+  const values: Array<[string, number]> = []
+  for (const cursor = new Date(startDay); cursor <= endDay; cursor.setUTCDate(cursor.getUTCDate() + 1)) {
+    const day = cursor.toISOString().slice(0, 10)
+    const minutes = Math.round((byDay.get(day) ?? 0) / 60)
+    values.push([day, minutes])
+  }
+
+  option.value = {
+    tooltip: {
+      appendToBody: true,
+      backgroundColor: palette.tooltipBackground,
+      borderColor: palette.tooltipBorder,
+      borderWidth: 1,
+      textStyle: { color: palette.tooltipText, fontSize: 12 },
+      formatter: (params: { value: [string, number] }) => {
+        const [day, minutes] = params.value
+        return `${day}<br/><strong>${minutes}</strong> min read`
+      },
+    },
+    visualMap: {
+      type: 'piecewise',
+      show: true,
+      dimension: 1,
+      pieces: buildPieces(palette.scale),
+      orient: 'horizontal',
+      left: 'center',
+      top: 10,
+      itemWidth: 10,
+      itemHeight: 10,
+      itemGap: 8,
+      textStyle: { color: palette.axisColor, fontSize: 12 },
+    },
+    calendar: {
+      top: 100,
+      left: 25,
+      right: 0,
+      bottom: 20,
+      cellSize: ['auto', 13],
+      range: [startDayKey, endDayKey],
+      yearLabel: { show: false },
+      splitLine: { show: false },
+      monthLabel: {
+        show: true,
+        fontSize: 11,
+        color: palette.axisColor,
+        margin: 10,
+        nameMap: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+      },
+      dayLabel: {
+        show: true,
+        firstDay: 1,
+        fontSize: 10,
+        color: palette.axisColor,
+        margin: 8,
+        nameMap: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+      },
+      itemStyle: {
+        color: 'transparent',
+        borderWidth: 0.5,
+        borderColor: palette.borderColor,
+        borderRadius: 1,
+      },
+    },
+    series: [{ type: 'heatmap', coordinateSystem: 'calendar', data: values, emphasis: { disabled: true } }],
+  }
+})
+</script>
+
+<template>
+  <ChartCard title="Reading Activity Heatmap" :icon="Calendar" :color-index="1" :loading :error :empty="isEmpty">
+    <ChartEmptyState
+      v-if="lowConfidence"
+      :icon="Calendar"
+      title="Not enough data yet"
+      :description="`Need activity on at least ${MIN_ACTIVE_DAYS} days.`"
+    />
+    <div v-else class="h-full min-h-0 rounded-md px-2 py-2">
+      <VChart :option autoresize class="h-full w-full" />
+    </div>
+  </ChartCard>
+</template>

--- a/client/src/features/statistics/components/koreader/KoreaderDevicesChart.vue
+++ b/client/src/features/statistics/components/koreader/KoreaderDevicesChart.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { computed, shallowRef, watchEffect } from 'vue'
+import VChart from 'vue-echarts'
+import { Tablet } from 'lucide-vue-next'
+
+import { useKoreaderDevices } from '../../composables/useKoreaderDevices'
+import ChartCard from '../ChartCard.vue'
+
+const { data, loading, error } = useKoreaderDevices()
+const option = shallowRef({})
+
+const isEmpty = computed(() => data.value.length === 0)
+
+watchEffect(() => {
+  option.value = {}
+  if (isEmpty.value || !data.value.length) return
+
+  option.value = {
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: { name: string; value: number; percent: number }) => {
+        const label = params.value === 1 ? 'book' : 'books'
+        return `${params.name}<br/><strong>${params.value}</strong> ${label} synced (${params.percent}%)`
+      },
+    },
+    legend: { bottom: 0, left: 'center', textStyle: { fontSize: 11 } },
+    series: [
+      {
+        type: 'pie',
+        radius: ['44%', '70%'],
+        center: ['50%', '46%'],
+        minAngle: 3,
+        label: { formatter: '{b}', fontSize: 10 },
+        data: data.value.map((item) => ({
+          name: item.device,
+          value: item.booksTracked,
+        })),
+      },
+    ],
+  }
+})
+</script>
+
+<template>
+  <ChartCard title="Synced Books by Device" :icon="Tablet" :color-index="8" :loading :error :empty="isEmpty">
+    <VChart :option autoresize style="height: 100%" />
+  </ChartCard>
+</template>

--- a/client/src/features/statistics/components/koreader/KoreaderMonthlyReadingChart.vue
+++ b/client/src/features/statistics/components/koreader/KoreaderMonthlyReadingChart.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed, shallowRef, watchEffect } from 'vue'
+import VChart from 'vue-echarts'
+import { BarChart2 } from 'lucide-vue-next'
+
+import { useKoreaderMonthlyReading } from '../../composables/useKoreaderMonthlyReading'
+import ChartCard from '../ChartCard.vue'
+
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+const { data, loading, error } = useKoreaderMonthlyReading()
+const option = shallowRef({})
+
+const isEmpty = computed(() => data.value.every((p) => p.durationSeconds === 0))
+
+watchEffect(() => {
+  option.value = {}
+  if (isEmpty.value || !data.value.length) return
+
+  const labels = data.value.map((p) => `${MONTH_NAMES[p.month - 1]} ${String(p.year).slice(-2)}`)
+  const values = data.value.map((p) => Math.round(p.durationSeconds / 60))
+
+  option.value = {
+    tooltip: {
+      trigger: 'axis',
+      formatter: (params: Array<{ axisValue: string; data: number }>) => {
+        const p = params[0]
+        if (!p) return ''
+        const h = Math.floor(p.data / 60)
+        const m = p.data % 60
+        const label = h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`
+        return `${p.axisValue}<br/><strong>${label}</strong> read`
+      },
+    },
+    grid: { left: '3%', right: '3%', bottom: '12%', top: '6%', containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: labels,
+      axisTick: { show: false },
+      axisLabel: { fontSize: 10, rotate: 40, interval: 0 },
+    },
+    yAxis: {
+      type: 'value',
+      min: 0,
+      minInterval: 1,
+      axisLabel: {
+        fontSize: 11,
+        formatter: (v: number) => (v >= 60 ? `${Math.round(v / 60)}h` : `${v}m`),
+      },
+    },
+    series: [{ type: 'bar', data: values, barMaxWidth: 28 }],
+  }
+})
+</script>
+
+<template>
+  <ChartCard title="Monthly Reading Time" :icon="BarChart2" :color-index="2" :loading :error :empty="isEmpty">
+    <VChart :option autoresize style="height: 100%" />
+  </ChartCard>
+</template>

--- a/client/src/features/statistics/components/koreader/KoreaderSessionLengthsChart.vue
+++ b/client/src/features/statistics/components/koreader/KoreaderSessionLengthsChart.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { computed, shallowRef, watchEffect } from 'vue'
+import VChart from 'vue-echarts'
+import { Timer } from 'lucide-vue-next'
+
+import { useKoreaderSessionLengths } from '../../composables/useKoreaderSessionLengths'
+import ChartCard from '../ChartCard.vue'
+
+const { data, loading, error } = useKoreaderSessionLengths()
+const option = shallowRef({})
+
+const isEmpty = computed(() => data.value.every((b) => b.count === 0))
+
+watchEffect(() => {
+  option.value = {}
+  if (isEmpty.value || !data.value.length) return
+
+  const labels = data.value.map((b) => b.label)
+  const values = data.value.map((b) => b.count)
+
+  option.value = {
+    tooltip: {
+      trigger: 'axis',
+      formatter: (params: Array<{ axisValue: string; data: number }>) => {
+        const p = params[0]
+        if (!p) return ''
+        const label = p.data === 1 ? 'session' : 'sessions'
+        return `${p.axisValue}<br/><strong>${p.data}</strong> ${label}`
+      },
+    },
+    grid: { left: '3%', right: '3%', bottom: '8%', top: '6%', containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: labels,
+      axisTick: { show: false },
+      axisLabel: { fontSize: 11 },
+    },
+    yAxis: {
+      type: 'value',
+      min: 0,
+      minInterval: 1,
+      axisLabel: { fontSize: 11 },
+    },
+    series: [{ type: 'bar', data: values, barMaxWidth: 40 }],
+  }
+})
+</script>
+
+<template>
+  <ChartCard title="Session Lengths" :icon="Timer" :color-index="4" :loading :error :empty="isEmpty">
+    <VChart :option autoresize style="height: 100%" />
+  </ChartCard>
+</template>

--- a/client/src/features/statistics/components/koreader/KoreaderSummaryStrip.spec.ts
+++ b/client/src/features/statistics/components/koreader/KoreaderSummaryStrip.spec.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import KoreaderSummaryStrip from './KoreaderSummaryStrip.vue'
+
+const apiMock = vi.hoisted(() => vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>())
+
+vi.mock('@/lib/api', () => ({
+  api: apiMock,
+}))
+
+function makeResponse(data: unknown, options: { ok?: boolean; status?: number } = {}): Response {
+  const { ok = true, status = ok ? 200 : 500 } = options
+  return {
+    ok,
+    status,
+    json: async () => data,
+  } as Response
+}
+
+describe('KoreaderSummaryStrip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders onboarding empty state when summary is all zeros', async () => {
+    apiMock.mockResolvedValueOnce(
+      makeResponse({
+        totalReadSecs: 0,
+        totalSessions: 0,
+        totalHighlights: 0,
+        totalNotes: 0,
+        booksWithStats: 0,
+        currentStreak: 0,
+        longestStreak: 0,
+      }),
+    )
+
+    const wrapper = mount(KoreaderSummaryStrip)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No KOReader data yet')
+    expect(wrapper.text()).toContain('Sync reading progress from KOReader')
+  })
+
+  it('renders KPI values when summary has data', async () => {
+    apiMock.mockResolvedValueOnce(
+      makeResponse({
+        totalReadSecs: 7260,
+        totalSessions: 42,
+        totalHighlights: 17,
+        totalNotes: 5,
+        booksWithStats: 9,
+        currentStreak: 4,
+        longestStreak: 11,
+      }),
+    )
+
+    const wrapper = mount(KoreaderSummaryStrip)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Total Reading Time')
+    expect(wrapper.text()).toContain('2h 1m')
+    expect(wrapper.text()).toContain('42')
+    expect(wrapper.text()).toContain('4d')
+    expect(wrapper.text()).toContain('17')
+    expect(wrapper.text()).not.toContain('No KOReader data yet')
+  })
+
+  it('does not show empty state when booksWithStats is non-zero', async () => {
+    apiMock.mockResolvedValueOnce(
+      makeResponse({
+        totalReadSecs: 0,
+        totalSessions: 0,
+        totalHighlights: 0,
+        totalNotes: 0,
+        booksWithStats: 3,
+        currentStreak: 0,
+        longestStreak: 0,
+      }),
+    )
+
+    const wrapper = mount(KoreaderSummaryStrip)
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('No KOReader data yet')
+    expect(wrapper.text()).toContain('Sessions')
+  })
+})

--- a/client/src/features/statistics/components/koreader/KoreaderSummaryStrip.vue
+++ b/client/src/features/statistics/components/koreader/KoreaderSummaryStrip.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { Clock, BookOpen, Flame, Highlighter } from 'lucide-vue-next'
+import { Skeleton } from '@/components/ui/skeleton'
+import { useKoreaderStatsSummary } from '../../composables/useKoreaderStatsSummary'
+import ChartEmptyState from '../ChartEmptyState.vue'
+
+function formatReadingTime(seconds: number): string {
+  if (seconds === 0) return '0m'
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  if (h === 0) return `${m}m`
+  if (m === 0) return `${h}h`
+  return `${h}h ${m}m`
+}
+
+const { data, loading } = useKoreaderStatsSummary()
+const hasAnyData = computed(
+  () =>
+    data.value.totalSessions > 0 ||
+    data.value.totalReadSecs > 0 ||
+    data.value.totalHighlights > 0 ||
+    data.value.totalNotes > 0 ||
+    data.value.booksWithStats > 0 ||
+    data.value.currentStreak > 0 ||
+    data.value.longestStreak > 0,
+)
+
+const kpis = computed(() => [
+  { label: 'Total Reading Time', value: formatReadingTime(data.value.totalReadSecs), icon: Clock, colorIndex: 1 },
+  { label: 'Sessions', value: data.value.totalSessions.toLocaleString(), icon: BookOpen, colorIndex: 2 },
+  { label: 'Current Streak', value: `${data.value.currentStreak}d`, icon: Flame, colorIndex: 3 },
+  { label: 'Highlights', value: data.value.totalHighlights.toLocaleString(), icon: Highlighter, colorIndex: 4 },
+])
+
+const ICON_HUE_OFFSETS = [0, 45, 90, 135, 180, 225, 270, 315, 337]
+
+function iconStyle(colorIndex: number) {
+  const offset = ICON_HUE_OFFSETS[(colorIndex - 1) % ICON_HUE_OFFSETS.length] ?? 0
+  const color = `oklch(from var(--primary) l c calc(h + ${offset}))`
+  return { backgroundColor: `color-mix(in oklch, ${color} 15%, transparent)`, color }
+}
+</script>
+
+<template>
+  <div v-if="!loading && !hasAnyData" class="bg-card rounded-lg border p-4 sm:p-6">
+    <ChartEmptyState :icon="BookOpen" title="No KOReader data yet" description="Sync reading progress from KOReader to populate these statistics." />
+  </div>
+  <div v-else class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+    <div v-for="kpi in kpis" :key="kpi.label" class="bg-card text-card-foreground flex items-center gap-3 rounded-lg border p-4 shadow-sm">
+      <div class="shrink-0 rounded-md p-2" :style="iconStyle(kpi.colorIndex)">
+        <component :is="kpi.icon" class="size-5" />
+      </div>
+      <div class="min-w-0">
+        <p class="text-muted-foreground text-xs">{{ kpi.label }}</p>
+        <Skeleton v-if="loading" class="mt-1 h-5 w-16" />
+        <p v-else class="text-foreground text-lg font-bold leading-tight">{{ kpi.value }}</p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/client/src/features/statistics/components/koreader/KoreaderTimeOfDayChart.vue
+++ b/client/src/features/statistics/components/koreader/KoreaderTimeOfDayChart.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed, shallowRef, watchEffect } from 'vue'
+import VChart from 'vue-echarts'
+import { Sun } from 'lucide-vue-next'
+
+import { useKoreaderTimeOfDay } from '../../composables/useKoreaderTimeOfDay'
+import ChartCard from '../ChartCard.vue'
+
+const { data, loading, error } = useKoreaderTimeOfDay()
+const option = shallowRef({})
+
+const isEmpty = computed(() => data.value.every((p) => p.durationSeconds === 0))
+
+function hourLabel(h: number): string {
+  if (h === 0) return '12am'
+  if (h === 12) return '12pm'
+  return h < 12 ? `${h}am` : `${h - 12}pm`
+}
+
+watchEffect(() => {
+  option.value = {}
+  if (isEmpty.value || !data.value.length) return
+
+  const labels = data.value.map((p) => hourLabel(p.hour))
+  const values = data.value.map((p) => Math.round(p.durationSeconds / 60))
+
+  option.value = {
+    tooltip: {
+      trigger: 'axis',
+      formatter: (params: Array<{ axisValue: string; data: number }>) => {
+        const p = params[0]
+        if (!p) return ''
+        return `${p.axisValue}<br/><strong>${p.data}m</strong> read`
+      },
+    },
+    grid: { left: '3%', right: '3%', bottom: '12%', top: '6%', containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: labels,
+      axisTick: { show: false },
+      axisLabel: { fontSize: 10, rotate: 45, interval: 2 },
+    },
+    yAxis: {
+      type: 'value',
+      min: 0,
+      axisLabel: {
+        fontSize: 11,
+        formatter: (v: number) => (v >= 60 ? `${Math.round(v / 60)}h` : `${v}m`),
+      },
+    },
+    series: [{ type: 'bar', data: values, barMaxWidth: 20 }],
+  }
+})
+</script>
+
+<template>
+  <ChartCard title="Time of Day" :icon="Sun" :color-index="3" :loading :error :empty="isEmpty">
+    <VChart :option autoresize style="height: 100%" />
+  </ChartCard>
+</template>

--- a/client/src/features/statistics/components/koreader/KoreaderTopAnnotatedChart.vue
+++ b/client/src/features/statistics/components/koreader/KoreaderTopAnnotatedChart.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed, shallowRef, watchEffect } from 'vue'
+import VChart from 'vue-echarts'
+import { Highlighter } from 'lucide-vue-next'
+
+import { useKoreaderTopAnnotated } from '../../composables/useKoreaderTopAnnotated'
+import ChartCard from '../ChartCard.vue'
+
+const TOP_LIMIT = 20
+
+const { data, loading, error } = useKoreaderTopAnnotated()
+const option = shallowRef({})
+
+const isEmpty = computed(() => data.value.length === 0)
+
+watchEffect(() => {
+  option.value = {}
+  if (isEmpty.value || !data.value.length) return
+
+  const top = data.value.slice(0, TOP_LIMIT)
+  const labels = top.map((b) => (b.title.length > 30 ? `${b.title.slice(0, 30)}...` : b.title))
+  const highlights = top.map((b) => b.highlightsCount)
+  const notes = top.map((b) => b.notesCount)
+  const fullTitles = top.map((b) => b.title)
+
+  option.value = {
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'none' },
+      formatter: (params: Array<{ seriesName: string; dataIndex: number; data: number }>) => {
+        const i = params[0]?.dataIndex ?? 0
+        return `${fullTitles[i]}<br/>${highlights[i]} highlights, ${notes[i]} notes`
+      },
+    },
+    legend: { data: ['Highlights', 'Notes'], top: 0, textStyle: { fontSize: 11 } },
+    grid: { left: '3%', right: '8%', bottom: '3%', top: '28px', containLabel: true },
+    xAxis: { type: 'value', axisLabel: { fontSize: 11 }, minInterval: 1 },
+    yAxis: { type: 'category', data: labels, axisLabel: { fontSize: 11 }, inverse: true },
+    series: [
+      { name: 'Highlights', type: 'bar', stack: 'total', data: highlights },
+      { name: 'Notes', type: 'bar', stack: 'total', data: notes },
+    ],
+  }
+})
+</script>
+
+<template>
+  <ChartCard title="Most Annotated Books" :icon="Highlighter" :color-index="6" :loading :error :empty="isEmpty">
+    <VChart :option autoresize style="height: 100%" />
+  </ChartCard>
+</template>

--- a/client/src/features/statistics/components/koreader/KoreaderTopBooksChart.vue
+++ b/client/src/features/statistics/components/koreader/KoreaderTopBooksChart.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed, shallowRef, watchEffect } from 'vue'
+import VChart from 'vue-echarts'
+import { BookOpen } from 'lucide-vue-next'
+
+import { useKoreaderTopBooks } from '../../composables/useKoreaderTopBooks'
+import ChartCard from '../ChartCard.vue'
+
+const TOP_LIMIT = 20
+
+const { data, loading, error } = useKoreaderTopBooks()
+const option = shallowRef({})
+
+const isEmpty = computed(() => data.value.length === 0)
+
+function formatTime(secs: number): string {
+  const h = Math.floor(secs / 3600)
+  const m = Math.floor((secs % 3600) / 60)
+  if (h === 0) return `${m}m`
+  if (m === 0) return `${h}h`
+  return `${h}h ${m}m`
+}
+
+watchEffect(() => {
+  option.value = {}
+  if (isEmpty.value || !data.value.length) return
+
+  const top = data.value.slice(0, TOP_LIMIT)
+  const labels = top.map((b) => (b.title.length > 30 ? `${b.title.slice(0, 30)}...` : b.title))
+  const values = top.map((b) => Math.round(b.totalReadSecs / 60))
+  const fullTitles = top.map((b) => b.title)
+
+  option.value = {
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'none' },
+      formatter: (params: Array<{ dataIndex: number; data: number }>) => {
+        const p = params[0]
+        if (!p) return ''
+        return `${fullTitles[p.dataIndex]}<br/><strong>${formatTime(top[p.dataIndex]!.totalReadSecs)}</strong>`
+      },
+    },
+    grid: { left: '3%', right: '8%', bottom: '3%', top: '4%', containLabel: true },
+    xAxis: { type: 'value', axisLabel: { fontSize: 11, formatter: (v: number) => (v >= 60 ? `${Math.round(v / 60)}h` : `${v}m`) } },
+    yAxis: { type: 'category', data: labels, axisLabel: { fontSize: 11 }, inverse: true },
+    series: [
+      {
+        type: 'bar',
+        data: values,
+        label: { show: true, position: 'right', fontSize: 10, formatter: (p: { dataIndex: number }) => formatTime(top[p.dataIndex]!.totalReadSecs) },
+      },
+    ],
+  }
+})
+</script>
+
+<template>
+  <ChartCard title="Top Books by Reading Time" :icon="BookOpen" :color-index="5" :loading :error :empty="isEmpty">
+    <VChart :option autoresize style="height: 100%" />
+  </ChartCard>
+</template>

--- a/client/src/features/statistics/components/koreader/KoreaderWeeklyRhythmChart.vue
+++ b/client/src/features/statistics/components/koreader/KoreaderWeeklyRhythmChart.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { computed, shallowRef, watchEffect } from 'vue'
+import VChart from 'vue-echarts'
+import { Repeat } from 'lucide-vue-next'
+
+import { useKoreaderWeeklyRhythm } from '../../composables/useKoreaderWeeklyRhythm'
+import ChartCard from '../ChartCard.vue'
+
+const { data, loading, error } = useKoreaderWeeklyRhythm()
+const option = shallowRef({})
+
+const isEmpty = computed(() => data.value.every((p) => p.durationSeconds === 0))
+
+watchEffect(() => {
+  option.value = {}
+  if (isEmpty.value || !data.value.length) return
+
+  const labels = data.value.map((p) => p.label)
+  const values = data.value.map((p) => Math.round(p.durationSeconds / 60))
+
+  option.value = {
+    tooltip: {
+      trigger: 'axis',
+      formatter: (params: Array<{ axisValue: string; data: number }>) => {
+        const p = params[0]
+        if (!p) return ''
+        const h = Math.floor(p.data / 60)
+        const m = p.data % 60
+        const label = h > 0 ? (m > 0 ? `${h}h ${m}m` : `${h}h`) : `${m}m`
+        return `${p.axisValue}<br/><strong>${label}</strong> total`
+      },
+    },
+    grid: { left: '3%', right: '3%', bottom: '8%', top: '6%', containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: labels,
+      axisTick: { show: false },
+      axisLabel: { fontSize: 12 },
+    },
+    yAxis: {
+      type: 'value',
+      min: 0,
+      axisLabel: {
+        fontSize: 11,
+        formatter: (v: number) => (v >= 60 ? `${Math.round(v / 60)}h` : `${v}m`),
+      },
+    },
+    series: [{ type: 'bar', data: values, barMaxWidth: 40 }],
+  }
+})
+</script>
+
+<template>
+  <ChartCard title="Weekly Reading Rhythm" :icon="Repeat" :color-index="7" :loading :error :empty="isEmpty">
+    <VChart :option autoresize style="height: 100%" />
+  </ChartCard>
+</template>

--- a/client/src/features/statistics/composables/__tests__/useStatisticsConfig.spec.ts
+++ b/client/src/features/statistics/composables/__tests__/useStatisticsConfig.spec.ts
@@ -1,0 +1,164 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_KOREADER_CHART_ORDER } from '@bookorbit/types'
+
+const state = vi.hoisted(() => ({
+  user: null as Record<string, unknown> | null,
+  apiMock: vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(),
+  toastError: vi.fn<(message: string) => void>(),
+}))
+
+vi.mock('@/features/auth/composables/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      get value() {
+        return state.user
+      },
+      set value(next) {
+        state.user = next
+      },
+    },
+  }),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: state.apiMock,
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    error: state.toastError,
+  },
+}))
+
+describe('useStatisticsConfig', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    state.apiMock.mockReset().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response)
+    state.toastError.mockReset()
+    state.user = null
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('initializes and exposes KOReader charts from defaults', async () => {
+    const { useStatisticsConfig } = await import('../useStatisticsConfig')
+    const config = useStatisticsConfig()
+    config.init()
+
+    expect(config.koreaderChartCount.value).toBe(DEFAULT_KOREADER_CHART_ORDER.length)
+    expect(config.visibleKoreaderChartCount.value).toBe(DEFAULT_KOREADER_CHART_ORDER.length)
+    expect(config.orderedKoreaderCharts.value.map((chart) => chart.id)).toEqual(DEFAULT_KOREADER_CHART_ORDER)
+  })
+
+  it('normalizes legacy/saved chart config and appends missing KOReader charts', async () => {
+    state.user = {
+      settings: {
+        statisticsConfig: {
+          charts: [{ id: 'ko-devices', visible: false, order: 0 }],
+          filters: {
+            libraryIds: [12],
+            booksOverTimeGranularity: 'yearly',
+            booksOverTimeRange: 'all-time',
+          },
+        },
+      },
+    }
+
+    const { useStatisticsConfig } = await import('../useStatisticsConfig')
+    const config = useStatisticsConfig()
+    config.init()
+
+    expect(config.orderedKoreaderCharts.value.map((chart) => chart.id)).toContain('ko-devices')
+    expect(config.orderedKoreaderCharts.value.some((chart) => chart.visible)).toBe(true)
+    expect(config.orderedKoreaderCharts.value.find((chart) => chart.id === 'ko-devices')?.visible).toBe(false)
+    expect(config.filters.value.libraryIds).toEqual([12])
+    expect(config.filters.value.booksOverTimeGranularity).toBe('yearly')
+    expect(config.filters.value.booksOverTimeRange).toBe('all-time')
+  })
+
+  it('reorders KOReader charts without dropping charts from other categories', async () => {
+    const { useStatisticsConfig } = await import('../useStatisticsConfig')
+    const config = useStatisticsConfig()
+    config.init()
+
+    const beforeTotal = config.orderedCharts.value.length
+    const reversedKoreader = [...config.orderedKoreaderCharts.value].reverse()
+    config.reorder(reversedKoreader)
+
+    expect(config.orderedCharts.value.length).toBe(beforeTotal)
+    expect(config.orderedKoreaderCharts.value.map((chart) => chart.id)).toEqual(reversedKoreader.map((chart) => chart.id))
+  })
+
+  it('resetToDefaults restores KOReader chart visibility and order', async () => {
+    const { useStatisticsConfig } = await import('../useStatisticsConfig')
+    const config = useStatisticsConfig()
+    config.init()
+
+    config.toggleVisibility('ko-devices')
+    expect(config.orderedKoreaderCharts.value.find((chart) => chart.id === 'ko-devices')?.visible).toBe(false)
+
+    config.resetToDefaults()
+    vi.runAllTimers()
+
+    expect(config.orderedKoreaderCharts.value.map((chart) => chart.id)).toEqual(DEFAULT_KOREADER_CHART_ORDER)
+    expect(config.orderedKoreaderCharts.value.every((chart) => chart.visible)).toBe(true)
+  })
+
+  it('updates filter helpers and exposes chart category metadata', async () => {
+    const { useStatisticsConfig } = await import('../useStatisticsConfig')
+    const config = useStatisticsConfig()
+    config.init()
+
+    config.setLibraryFilter([3, 5])
+    config.setGranularity('yearly')
+    config.setDateRange('all-time')
+
+    expect(config.filters.value.libraryIds).toEqual([3, 5])
+    expect(config.filters.value.booksOverTimeGranularity).toBe('yearly')
+    expect(config.filters.value.booksOverTimeRange).toBe('all-time')
+    expect(config.chartCategory('ko-top-books')).toBe('koreader')
+  })
+
+  it('shows a toast when persisting configuration fails', async () => {
+    state.apiMock.mockRejectedValueOnce(new Error('network error'))
+
+    const { useStatisticsConfig } = await import('../useStatisticsConfig')
+    const config = useStatisticsConfig()
+    config.init()
+    config.setLibraryFilter([9])
+
+    await vi.runAllTimersAsync()
+
+    expect(state.toastError).toHaveBeenCalledWith('Failed to save chart configuration')
+  })
+
+  it('evaluates all chart-group computed refs and no-op toggle path', async () => {
+    const { useStatisticsConfig } = await import('../useStatisticsConfig')
+    const config = useStatisticsConfig()
+    config.init()
+
+    expect(config.orderedCharts.value.length).toBeGreaterThan(0)
+    expect(config.visibleCharts.value.length).toBeGreaterThan(0)
+    expect(config.orderedLibraryCharts.value.length).toBeGreaterThan(0)
+    expect(config.orderedUserCharts.value.length).toBeGreaterThan(0)
+    expect(config.orderedKoreaderCharts.value.length).toBeGreaterThan(0)
+    expect(config.visibleLibraryCharts.value.length).toBeGreaterThan(0)
+    expect(config.visibleUserCharts.value.length).toBeGreaterThan(0)
+    expect(config.visibleKoreaderCharts.value.length).toBeGreaterThan(0)
+    expect(config.libraryChartCount.value).toBeGreaterThan(0)
+    expect(config.userChartCount.value).toBeGreaterThan(0)
+    expect(config.koreaderChartCount.value).toBeGreaterThan(0)
+    expect(config.visibleLibraryChartCount.value).toBeGreaterThan(0)
+    expect(config.visibleUserChartCount.value).toBeGreaterThan(0)
+    expect(config.visibleKoreaderChartCount.value).toBeGreaterThan(0)
+
+    config.toggleVisibility('not-a-real-chart-id' as never)
+    expect(config.orderedCharts.value.length).toBeGreaterThan(0)
+  })
+})

--- a/client/src/features/statistics/composables/useKoreaderActivityHeatmap.ts
+++ b/client/src/features/statistics/composables/useKoreaderActivityHeatmap.ts
@@ -1,0 +1,9 @@
+import type { KoreaderHeatmapPoint } from '@bookorbit/types'
+import { fetchKoreaderActivityHeatmap } from '../api/koreader-statistics.api'
+import { useKoreaderStatisticsQuery } from './useKoreaderStatisticsQuery'
+
+const EMPTY: KoreaderHeatmapPoint[] = []
+
+export function useKoreaderActivityHeatmap() {
+  return useKoreaderStatisticsQuery(EMPTY, fetchKoreaderActivityHeatmap)
+}

--- a/client/src/features/statistics/composables/useKoreaderDevices.ts
+++ b/client/src/features/statistics/composables/useKoreaderDevices.ts
@@ -1,0 +1,9 @@
+import type { KoreaderDevicePoint } from '@bookorbit/types'
+import { fetchKoreaderDevices } from '../api/koreader-statistics.api'
+import { useKoreaderStatisticsQuery } from './useKoreaderStatisticsQuery'
+
+const EMPTY: KoreaderDevicePoint[] = []
+
+export function useKoreaderDevices() {
+  return useKoreaderStatisticsQuery(EMPTY, fetchKoreaderDevices)
+}

--- a/client/src/features/statistics/composables/useKoreaderMonthlyReading.ts
+++ b/client/src/features/statistics/composables/useKoreaderMonthlyReading.ts
@@ -1,0 +1,9 @@
+import type { KoreaderMonthlyPoint } from '@bookorbit/types'
+import { fetchKoreaderMonthlyReading } from '../api/koreader-statistics.api'
+import { useKoreaderStatisticsQuery } from './useKoreaderStatisticsQuery'
+
+const EMPTY: KoreaderMonthlyPoint[] = []
+
+export function useKoreaderMonthlyReading() {
+  return useKoreaderStatisticsQuery(EMPTY, fetchKoreaderMonthlyReading)
+}

--- a/client/src/features/statistics/composables/useKoreaderSessionLengths.ts
+++ b/client/src/features/statistics/composables/useKoreaderSessionLengths.ts
@@ -1,0 +1,9 @@
+import type { KoreaderSessionLengthBin } from '@bookorbit/types'
+import { fetchKoreaderSessionLengths } from '../api/koreader-statistics.api'
+import { useKoreaderStatisticsQuery } from './useKoreaderStatisticsQuery'
+
+const EMPTY: KoreaderSessionLengthBin[] = []
+
+export function useKoreaderSessionLengths() {
+  return useKoreaderStatisticsQuery(EMPTY, fetchKoreaderSessionLengths)
+}

--- a/client/src/features/statistics/composables/useKoreaderStatisticsQuery.ts
+++ b/client/src/features/statistics/composables/useKoreaderStatisticsQuery.ts
@@ -1,0 +1,23 @@
+import { onMounted, ref } from 'vue'
+
+export function useKoreaderStatisticsQuery<T>(initialData: T, fetcher: () => Promise<T>) {
+  const data = ref<T>(initialData) as { value: T }
+  const loading = ref(true)
+  const error = ref(false)
+
+  async function load() {
+    loading.value = true
+    error.value = false
+    try {
+      data.value = await fetcher()
+    } catch {
+      error.value = true
+    } finally {
+      loading.value = false
+    }
+  }
+
+  onMounted(load)
+
+  return { data, loading, error }
+}

--- a/client/src/features/statistics/composables/useKoreaderStatsSummary.ts
+++ b/client/src/features/statistics/composables/useKoreaderStatsSummary.ts
@@ -1,0 +1,17 @@
+import type { KoreaderStatsSummary } from '@bookorbit/types'
+import { fetchKoreaderStatsSummary } from '../api/koreader-statistics.api'
+import { useKoreaderStatisticsQuery } from './useKoreaderStatisticsQuery'
+
+const EMPTY: KoreaderStatsSummary = {
+  totalReadSecs: 0,
+  totalSessions: 0,
+  totalHighlights: 0,
+  totalNotes: 0,
+  booksWithStats: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+}
+
+export function useKoreaderStatsSummary() {
+  return useKoreaderStatisticsQuery(EMPTY, fetchKoreaderStatsSummary)
+}

--- a/client/src/features/statistics/composables/useKoreaderTimeOfDay.ts
+++ b/client/src/features/statistics/composables/useKoreaderTimeOfDay.ts
@@ -1,0 +1,9 @@
+import type { KoreaderHourPoint } from '@bookorbit/types'
+import { fetchKoreaderTimeOfDay } from '../api/koreader-statistics.api'
+import { useKoreaderStatisticsQuery } from './useKoreaderStatisticsQuery'
+
+const EMPTY: KoreaderHourPoint[] = []
+
+export function useKoreaderTimeOfDay() {
+  return useKoreaderStatisticsQuery(EMPTY, fetchKoreaderTimeOfDay)
+}

--- a/client/src/features/statistics/composables/useKoreaderTopAnnotated.ts
+++ b/client/src/features/statistics/composables/useKoreaderTopAnnotated.ts
@@ -1,0 +1,9 @@
+import type { KoreaderTopAnnotatedItem } from '@bookorbit/types'
+import { fetchKoreaderTopAnnotated } from '../api/koreader-statistics.api'
+import { useKoreaderStatisticsQuery } from './useKoreaderStatisticsQuery'
+
+const EMPTY: KoreaderTopAnnotatedItem[] = []
+
+export function useKoreaderTopAnnotated() {
+  return useKoreaderStatisticsQuery(EMPTY, fetchKoreaderTopAnnotated)
+}

--- a/client/src/features/statistics/composables/useKoreaderTopBooks.ts
+++ b/client/src/features/statistics/composables/useKoreaderTopBooks.ts
@@ -1,0 +1,9 @@
+import type { KoreaderTopBookItem } from '@bookorbit/types'
+import { fetchKoreaderTopBooks } from '../api/koreader-statistics.api'
+import { useKoreaderStatisticsQuery } from './useKoreaderStatisticsQuery'
+
+const EMPTY: KoreaderTopBookItem[] = []
+
+export function useKoreaderTopBooks() {
+  return useKoreaderStatisticsQuery(EMPTY, fetchKoreaderTopBooks)
+}

--- a/client/src/features/statistics/composables/useKoreaderWeeklyRhythm.ts
+++ b/client/src/features/statistics/composables/useKoreaderWeeklyRhythm.ts
@@ -1,0 +1,9 @@
+import type { KoreaderWeekdayPoint } from '@bookorbit/types'
+import { fetchKoreaderWeeklyRhythm } from '../api/koreader-statistics.api'
+import { useKoreaderStatisticsQuery } from './useKoreaderStatisticsQuery'
+
+const EMPTY: KoreaderWeekdayPoint[] = []
+
+export function useKoreaderWeeklyRhythm() {
+  return useKoreaderStatisticsQuery(EMPTY, fetchKoreaderWeeklyRhythm)
+}

--- a/client/src/features/statistics/composables/useStatisticsConfig.ts
+++ b/client/src/features/statistics/composables/useStatisticsConfig.ts
@@ -12,7 +12,7 @@ import {
 } from '@bookorbit/types'
 import { api } from '@/lib/api'
 import { useAuth } from '@/features/auth/composables/useAuth'
-import { LIBRARY_CHART_IDS, STATISTICS_CHART_IDS, STATISTICS_CHART_META, USER_CHART_IDS } from '../statistics-chart-meta'
+import { KOREADER_CHART_IDS, LIBRARY_CHART_IDS, STATISTICS_CHART_IDS, STATISTICS_CHART_META, USER_CHART_IDS } from '../statistics-chart-meta'
 
 const KNOWN_CHART_IDS: StatisticsChartId[] = [...STATISTICS_CHART_IDS]
 
@@ -39,6 +39,7 @@ function normalizeCharts(saved: ChartConfigEntry[] | undefined): ChartConfigEntr
 
 const libraryChartIdSet = new Set<StatisticsChartId>(LIBRARY_CHART_IDS)
 const userChartIdSet = new Set<StatisticsChartId>(USER_CHART_IDS)
+const koreaderChartIdSet = new Set<StatisticsChartId>(KOREADER_CHART_IDS)
 
 function normalizeFilters(saved: StatisticsFilterConfig | undefined): StatisticsFilterConfig {
   return {
@@ -81,13 +82,17 @@ export function useStatisticsConfig() {
 
   const orderedLibraryCharts = computed(() => orderedCharts.value.filter((c) => libraryChartIdSet.has(c.id)))
   const orderedUserCharts = computed(() => orderedCharts.value.filter((c) => userChartIdSet.has(c.id)))
+  const orderedKoreaderCharts = computed(() => orderedCharts.value.filter((c) => koreaderChartIdSet.has(c.id)))
   const visibleLibraryCharts = computed(() => orderedLibraryCharts.value.filter((c) => c.visible))
   const visibleUserCharts = computed(() => orderedUserCharts.value.filter((c) => c.visible))
+  const visibleKoreaderCharts = computed(() => orderedKoreaderCharts.value.filter((c) => c.visible))
 
   const libraryChartCount = computed(() => orderedLibraryCharts.value.length)
   const userChartCount = computed(() => orderedUserCharts.value.length)
+  const koreaderChartCount = computed(() => orderedKoreaderCharts.value.length)
   const visibleLibraryChartCount = computed(() => visibleLibraryCharts.value.length)
   const visibleUserChartCount = computed(() => visibleUserCharts.value.length)
+  const visibleKoreaderChartCount = computed(() => visibleKoreaderCharts.value.length)
 
   function toggleVisibility(id: StatisticsChartId) {
     const entry = config.value.find((c) => c.id === id)
@@ -151,12 +156,16 @@ export function useStatisticsConfig() {
     visibleCharts,
     orderedLibraryCharts,
     orderedUserCharts,
+    orderedKoreaderCharts,
     visibleLibraryCharts,
     visibleUserCharts,
+    visibleKoreaderCharts,
     libraryChartCount,
     userChartCount,
+    koreaderChartCount,
     visibleLibraryChartCount,
     visibleUserChartCount,
+    visibleKoreaderChartCount,
     filters,
     init,
     toggleVisibility,

--- a/client/src/features/statistics/statistics-chart-meta.ts
+++ b/client/src/features/statistics/statistics-chart-meta.ts
@@ -1,34 +1,40 @@
 import type { Component } from 'vue'
 import {
+  BarChart2,
   BarChart3,
   BookCheck,
+  BookOpen,
   Calendar,
   CalendarDays,
   CalendarRange,
   Clock,
   Clock3,
-  BookOpen,
   GitMerge,
   Goal,
   Globe,
   Gauge,
   HardDrive,
+  Highlighter,
   Layers,
   ListChecks,
   PieChart,
   Rabbit,
+  Repeat,
   ShieldCheck,
+  Sun,
+  Tablet,
   Tag,
+  Timer,
   TrendingUp,
   Users,
   Waypoints,
   Zap,
 } from 'lucide-vue-next'
 
-import { DEFAULT_LIBRARY_CHART_ORDER, DEFAULT_USER_CHART_ORDER, type StatisticsChartId } from '@bookorbit/types'
+import { DEFAULT_KOREADER_CHART_ORDER, DEFAULT_LIBRARY_CHART_ORDER, DEFAULT_USER_CHART_ORDER, type StatisticsChartId } from '@bookorbit/types'
 
 export type StatisticsChartSize = '1x1' | '2x1' | '2x2' | '1x2' | '3x1' | '4x1'
-export type StatisticsChartCategory = 'library' | 'user'
+export type StatisticsChartCategory = 'library' | 'user' | 'koreader'
 
 export interface StatisticsChartMetaEntry {
   label: string
@@ -230,10 +236,62 @@ export const STATISTICS_CHART_META: Record<StatisticsChartId, StatisticsChartMet
     size: '2x1',
     category: 'user',
   },
+  'ko-activity-heatmap': {
+    label: 'Activity Heatmap',
+    icon: Calendar,
+    size: '2x1',
+    category: 'koreader',
+  },
+  'ko-monthly-reading': {
+    label: 'Monthly Reading Time',
+    icon: BarChart2,
+    size: '2x1',
+    category: 'koreader',
+  },
+  'ko-time-of-day': {
+    label: 'Time of Day',
+    icon: Sun,
+    size: '1x1',
+    category: 'koreader',
+  },
+  'ko-session-lengths': {
+    label: 'Session Length Distribution',
+    icon: Timer,
+    size: '1x1',
+    category: 'koreader',
+  },
+  'ko-top-books': {
+    label: 'Top Books by Reading Time',
+    icon: BookOpen,
+    size: '2x1',
+    category: 'koreader',
+  },
+  'ko-top-annotated': {
+    label: 'Most Annotated Books',
+    icon: Highlighter,
+    size: '2x1',
+    category: 'koreader',
+  },
+  'ko-weekly-rhythm': {
+    label: 'Weekly Reading Rhythm',
+    icon: Repeat,
+    size: '1x1',
+    category: 'koreader',
+  },
+  'ko-devices': {
+    label: 'Reading by Device',
+    icon: Tablet,
+    size: '1x1',
+    category: 'koreader',
+  },
 }
 
 export const LIBRARY_CHART_IDS: StatisticsChartId[] = DEFAULT_LIBRARY_CHART_ORDER.filter((id): id is StatisticsChartId => id in STATISTICS_CHART_META)
 
 export const USER_CHART_IDS: StatisticsChartId[] = DEFAULT_USER_CHART_ORDER.filter((id): id is StatisticsChartId => id in STATISTICS_CHART_META)
 
-export const STATISTICS_CHART_IDS: StatisticsChartId[] = [...LIBRARY_CHART_IDS, ...USER_CHART_IDS]
+export const KOREADER_CHART_IDS: StatisticsChartId[] = DEFAULT_KOREADER_CHART_ORDER.filter(
+  (id): id is StatisticsChartId => id in STATISTICS_CHART_META,
+)
+
+export const STATISTICS_CHART_IDS: StatisticsChartId[] = [...LIBRARY_CHART_IDS, ...USER_CHART_IDS, ...KOREADER_CHART_IDS]

--- a/client/src/views/BookDetailView.vue
+++ b/client/src/views/BookDetailView.vue
@@ -15,9 +15,11 @@ import { usePermissions } from '@/features/auth/composables/usePermissions'
 import { useLibraries } from '@/features/library/composables/useLibraries'
 import { COVER_ASPECT_RATIO_KEY, DEFAULT_COVER_ASPECT_RATIO } from '@/features/book/lib/cover-aspect-ratio'
 import EntityNotFound from '@/components/EntityNotFound.vue'
+import { useKoreaderBookStats, KOREADER_BOOK_STATS_KEY } from '@/features/koreader/composables/useKoreaderBookStats'
 
 const ReadingLogTab = defineAsyncComponent(() => import('@/features/book/components/detail/tabs/ReadingLogTab.vue'))
 const HighlightsTab = defineAsyncComponent(() => import('@/features/book/components/detail/tabs/HighlightsTab.vue'))
+const KoreaderTab = defineAsyncComponent(() => import('@/features/book/components/detail/tabs/KoreaderTab.vue'))
 
 const route = useRoute()
 const { hasPermission } = usePermissions()
@@ -43,6 +45,7 @@ const pageTitle = computed(() => {
   if (tab.value === 'files') return `Files · ${base}`
   if (tab.value === 'reading-log') return `Reading Log · ${base}`
   if (tab.value === 'highlights') return `Highlights · ${base}`
+  if (tab.value === 'koreader') return `KOReader Log · ${base}`
   return `Book · ${base}`
 })
 usePageTitle(pageTitle)
@@ -54,6 +57,13 @@ watch(
     if (id !== undefined) subscribeLibrary(id)
   },
 )
+
+const koreaderStats = useKoreaderBookStats(bookId)
+provide(KOREADER_BOOK_STATS_KEY, koreaderStats)
+
+const showKoreaderTab = computed(() => hasPermission('koreader_sync') && koreaderStats.hasData.value)
+
+provide('showKoreaderTab', showKoreaderTab)
 
 const { onBookMissing, onBookRestored, onBookMoved } = useBookEvents()
 onBookMissing((bookIds) => {
@@ -98,6 +108,7 @@ function onCoverChanged(source: 'extracted' | 'custom' | null) {
         <FilesTab v-else-if="tab === 'files'" :book="detail" />
         <ReadingLogTab v-else-if="tab === 'reading-log'" :book="detail" />
         <HighlightsTab v-else-if="tab === 'highlights'" :book="detail" />
+        <KoreaderTab v-else-if="tab === 'koreader' && showKoreaderTab" />
       </div>
 
       <div v-else-if="loading" key="loading">
@@ -148,6 +159,15 @@ function onCoverChanged(source: 'extracted' | 'custom' | null) {
           </div>
           <div class="space-y-3">
             <div v-for="i in 3" :key="i" class="h-24 rounded-lg bg-muted animate-shimmer" />
+          </div>
+        </div>
+        <div v-else-if="tab === 'koreader'" class="space-y-4">
+          <div class="grid grid-cols-2 sm:grid-cols-6 gap-3">
+            <div v-for="i in 6" :key="i" class="h-16 rounded-lg bg-muted animate-shimmer" />
+          </div>
+          <div class="h-48 rounded-lg bg-muted animate-shimmer" />
+          <div class="space-y-2">
+            <div v-for="i in 5" :key="i" class="h-12 rounded-md bg-muted animate-shimmer" />
           </div>
         </div>
       </div>

--- a/packages/types/src/koreader.ts
+++ b/packages/types/src/koreader.ts
@@ -25,6 +25,8 @@ export interface KoreaderSyncStatus {
   devices: KoreaderDeviceInfo[];
   totalSyncedBooks: number;
   lastSyncAt: string | null;
+  booksWithStats: number;
+  totalReadingSeconds: number;
 }
 
 export interface KoreaderBookSyncInfo {
@@ -54,4 +56,36 @@ export interface TestKoreaderConnectionResult {
   success: boolean;
   username: string;
   serverUrl: string;
+}
+
+export interface KoreaderReadingSession {
+  id: number;
+  page: number;
+  startedAt: string;
+  durationSeconds: number;
+  totalPages: number;
+}
+
+export interface KoreaderBookStats {
+  bookFileId: number;
+  totalReadSecs: number;
+  totalReadPages: number;
+  highlightsCount: number;
+  notesCount: number;
+  lastOpenAt: string | null;
+  updatedAt: string;
+}
+
+export interface KoreaderTabData {
+  stats: KoreaderBookStats;
+  sessions: KoreaderReadingSession[];
+  dailySummary: { day: string; durationSeconds: number }[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface KoreaderStatsResponse {
+  processed: number;
+  unmatched: number;
 }

--- a/packages/types/src/statistics.ts
+++ b/packages/types/src/statistics.ts
@@ -30,7 +30,15 @@ export type StatisticsChartId =
   | "acquisition-lag-scatter"
   | "largest-books"
   | "top-series"
-  | "publication-year-timeline";
+  | "publication-year-timeline"
+  | "ko-activity-heatmap"
+  | "ko-monthly-reading"
+  | "ko-time-of-day"
+  | "ko-session-lengths"
+  | "ko-top-books"
+  | "ko-top-annotated"
+  | "ko-weekly-rhythm"
+  | "ko-devices";
 
 export type StatisticsGranularity = "monthly" | "yearly";
 export type StatisticsDateRange = "last-year" | "last-5-years" | "all-time";
@@ -92,7 +100,18 @@ export const DEFAULT_USER_CHART_ORDER: StatisticsChartId[] = [
   "session-archetypes",
 ];
 
-export const DEFAULT_STATISTICS_CHART_ORDER: StatisticsChartId[] = [...DEFAULT_LIBRARY_CHART_ORDER, ...DEFAULT_USER_CHART_ORDER];
+export const DEFAULT_KOREADER_CHART_ORDER: StatisticsChartId[] = [
+  "ko-activity-heatmap",
+  "ko-monthly-reading",
+  "ko-time-of-day",
+  "ko-session-lengths",
+  "ko-top-books",
+  "ko-top-annotated",
+  "ko-weekly-rhythm",
+  "ko-devices",
+];
+
+export const DEFAULT_STATISTICS_CHART_ORDER: StatisticsChartId[] = [...DEFAULT_LIBRARY_CHART_ORDER, ...DEFAULT_USER_CHART_ORDER, ...DEFAULT_KOREADER_CHART_ORDER];
 
 export const DEFAULT_STATISTICS_FILTERS: StatisticsFilterConfig = {
   libraryIds: [],
@@ -271,4 +290,63 @@ export interface StatisticsSummary {
   publicationYearMin: number | null;
   publicationYearMax: number | null;
   booksAddedThisYear: number;
+}
+
+// KOReader Statistics types
+
+export interface KoreaderStatsSummary {
+  totalReadSecs: number;
+  totalSessions: number;
+  totalHighlights: number;
+  totalNotes: number;
+  booksWithStats: number;
+  currentStreak: number;
+  longestStreak: number;
+}
+
+export interface KoreaderHeatmapPoint {
+  date: string;
+  durationSeconds: number;
+}
+
+export interface KoreaderMonthlyPoint {
+  year: number;
+  month: number;
+  durationSeconds: number;
+}
+
+export interface KoreaderHourPoint {
+  hour: number;
+  durationSeconds: number;
+}
+
+export interface KoreaderSessionLengthBin {
+  label: string;
+  minSecs: number;
+  maxSecs: number | null;
+  count: number;
+}
+
+export interface KoreaderTopBookItem {
+  bookId: number;
+  title: string;
+  totalReadSecs: number;
+}
+
+export interface KoreaderTopAnnotatedItem {
+  bookId: number;
+  title: string;
+  highlightsCount: number;
+  notesCount: number;
+}
+
+export interface KoreaderWeekdayPoint {
+  dow: number;
+  label: string;
+  durationSeconds: number;
+}
+
+export interface KoreaderDevicePoint {
+  device: string;
+  booksTracked: number;
 }

--- a/server/src/db/migrations/0011_koreader-stats-ingestion.sql
+++ b/server/src/db/migrations/0011_koreader-stats-ingestion.sql
@@ -1,0 +1,33 @@
+CREATE TABLE "koreader_book_stats" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"book_file_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"total_read_secs" integer DEFAULT 0 NOT NULL,
+	"total_read_pages" integer DEFAULT 0 NOT NULL,
+	"highlights_count" integer DEFAULT 0 NOT NULL,
+	"notes_count" integer DEFAULT 0 NOT NULL,
+	"last_open_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "koreader_reading_sessions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"book_file_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"session_hash" varchar(64) NOT NULL,
+	"page" integer NOT NULL,
+	"started_at" timestamp with time zone NOT NULL,
+	"duration_seconds" integer NOT NULL,
+	"total_pages" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "koreader_book_stats" ADD CONSTRAINT "koreader_book_stats_book_file_id_book_files_id_fk" FOREIGN KEY ("book_file_id") REFERENCES "public"."book_files"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "koreader_book_stats" ADD CONSTRAINT "koreader_book_stats_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "koreader_reading_sessions" ADD CONSTRAINT "koreader_reading_sessions_book_file_id_book_files_id_fk" FOREIGN KEY ("book_file_id") REFERENCES "public"."book_files"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "koreader_reading_sessions" ADD CONSTRAINT "koreader_reading_sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "koreader_book_stats_user_book_file_uidx" ON "koreader_book_stats" USING btree ("user_id","book_file_id");--> statement-breakpoint
+CREATE INDEX "koreader_book_stats_user_idx" ON "koreader_book_stats" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "koreader_reading_sessions_session_hash_uidx" ON "koreader_reading_sessions" USING btree ("session_hash");--> statement-breakpoint
+CREATE INDEX "koreader_reading_sessions_book_user_started_idx" ON "koreader_reading_sessions" USING btree ("book_file_id","user_id","started_at");--> statement-breakpoint
+CREATE INDEX "koreader_reading_sessions_user_idx" ON "koreader_reading_sessions" USING btree ("user_id");

--- a/server/src/db/migrations/meta/0011_snapshot.json
+++ b/server/src/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,11246 @@
+{
+  "id": "f2e0fabf-a271-4099-bd5f-abc826051adf",
+  "prevId": "83f0250b-9d64-484b-93d7-e2fa62c523e1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_user_id": {
+          "name": "idx_audit_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource": {
+          "name": "idx_audit_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_action": {
+          "name": "idx_audit_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_ip": {
+          "name": "idx_audit_ip",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_created_at": {
+          "name": "idx_audit_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.magic_access_tokens": {
+      "name": "magic_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_token": {
+          "name": "raw_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "magic_access_tokens_user_id_idx": {
+          "name": "magic_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_access_tokens_user_id_users_id_fk": {
+          "name": "magic_access_tokens_user_id_users_id_fk",
+          "tableFrom": "magic_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "magic_access_tokens_created_by_users_id_fk": {
+          "name": "magic_access_tokens_created_by_users_id_fk",
+          "tableFrom": "magic_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "magic_access_tokens_token_hash_unique": {
+          "name": "magic_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "magic_access_tokens_use_count_nonneg_chk": {
+          "name": "magic_access_tokens_use_count_nonneg_chk",
+          "value": "\"magic_access_tokens\".\"use_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_user_id_idx": {
+          "name": "password_reset_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_expires_at_idx": {
+          "name": "password_reset_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "password_reset_tokens_expires_after_created_chk": {
+          "name": "password_reset_tokens_expires_after_created_chk",
+          "value": "\"password_reset_tokens\".\"expires_at\" > \"password_reset_tokens\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_token_hash": {
+          "name": "replaced_by_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "refresh_tokens_expires_after_created_chk": {
+          "name": "refresh_tokens_expires_after_created_chk",
+          "value": "\"refresh_tokens\".\"expires_at\" > \"refresh_tokens\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_content_filter_genres": {
+      "name": "user_content_filter_genres",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "content_filter_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_content_filter_genres_genre_id_idx": {
+          "name": "user_content_filter_genres_genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_content_filter_genres_user_id_users_id_fk": {
+          "name": "user_content_filter_genres_user_id_users_id_fk",
+          "tableFrom": "user_content_filter_genres",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_content_filter_genres_genre_id_genres_id_fk": {
+          "name": "user_content_filter_genres_genre_id_genres_id_fk",
+          "tableFrom": "user_content_filter_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_content_filter_genres_user_id_filter_type_genre_id_pk": {
+          "name": "user_content_filter_genres_user_id_filter_type_genre_id_pk",
+          "columns": [
+            "user_id",
+            "filter_type",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_content_filter_tags": {
+      "name": "user_content_filter_tags",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "content_filter_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_content_filter_tags_tag_id_idx": {
+          "name": "user_content_filter_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_content_filter_tags_user_id_users_id_fk": {
+          "name": "user_content_filter_tags_user_id_users_id_fk",
+          "tableFrom": "user_content_filter_tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_content_filter_tags_tag_id_tags_id_fk": {
+          "name": "user_content_filter_tags_tag_id_tags_id_fk",
+          "tableFrom": "user_content_filter_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_content_filter_tags_user_id_filter_type_tag_id_pk": {
+          "name": "user_content_filter_tags_user_id_filter_type_tag_id_pk",
+          "columns": [
+            "user_id",
+            "filter_type",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_library_access": {
+      "name": "user_library_access",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "library_access_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        }
+      },
+      "indexes": {
+        "user_library_access_library_user_idx": {
+          "name": "user_library_access_library_user_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_library_access_user_id_users_id_fk": {
+          "name": "user_library_access_user_id_users_id_fk",
+          "tableFrom": "user_library_access",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_access_library_id_libraries_id_fk": {
+          "name": "user_library_access_library_id_libraries_id_fk",
+          "tableFrom": "user_library_access",
+          "tableTo": "libraries",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_library_access_user_id_library_id_pk": {
+          "name": "user_library_access_user_id_library_id_pk",
+          "columns": [
+            "user_id",
+            "library_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permissions": {
+      "name": "user_permissions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_name": {
+          "name": "permission_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_permissions_user_id_users_id_fk": {
+          "name": "user_permissions_user_id_users_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_permissions_user_id_permission_name_pk": {
+          "name": "user_permissions_user_id_permission_name_pk",
+          "columns": [
+            "user_id",
+            "permission_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_superuser": {
+          "name": "is_superuser",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_password": {
+          "name": "is_default_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_source": {
+          "name": "avatar_source",
+          "type": "user_avatar_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "avatar_version": {
+          "name": "avatar_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "provisioning_method": {
+          "name": "provisioning_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_username_lower_uidx": {
+          "name": "users_username_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_lower_uidx": {
+          "name": "users_email_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"email\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_oidc_subject_issuer_uidx": {
+          "name": "users_oidc_subject_issuer_uidx",
+          "columns": [
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"oidc_subject\" is not null and \"users\".\"oidc_issuer\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_provisioning_method_chk": {
+          "name": "users_provisioning_method_chk",
+          "value": "\"users\".\"provisioning_method\" in ('local', 'manual', 'oidc', 'shared')"
+        },
+        "users_token_version_nonnegative_chk": {
+          "name": "users_token_version_nonnegative_chk",
+          "value": "\"users\".\"token_version\" >= 0"
+        },
+        "users_failed_login_attempts_nonnegative_chk": {
+          "name": "users_failed_login_attempts_nonnegative_chk",
+          "value": "\"users\".\"failed_login_attempts\" >= 0"
+        },
+        "users_avatar_version_nonnegative_chk": {
+          "name": "users_avatar_version_nonnegative_chk",
+          "value": "\"users\".\"avatar_version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comic_metadata": {
+      "name": "comic_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_name": {
+          "name": "volume_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pencillers": {
+          "name": "pencillers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inkers": {
+          "name": "inkers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colorists": {
+          "name": "colorists",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "letterers": {
+          "name": "letterers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_artists": {
+          "name": "cover_artists",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "characters": {
+          "name": "characters",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams": {
+          "name": "teams",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locations": {
+          "name": "locations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "story_arcs": {
+          "name": "story_arcs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comic_metadata_book_id_books_id_fk": {
+          "name": "comic_metadata_book_id_books_id_fk",
+          "tableFrom": "comic_metadata",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comic_metadata_book_id_unique": {
+          "name": "comic_metadata_book_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "book_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_plan_artifacts": {
+      "name": "migration_plan_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot_hash": {
+          "name": "source_snapshot_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_hash": {
+          "name": "profile_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_hash": {
+          "name": "plan_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_data": {
+          "name": "source_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_plan_artifacts_plan_hash_uidx": {
+          "name": "migration_plan_artifacts_plan_hash_uidx",
+          "columns": [
+            {
+              "expression": "plan_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_plan_artifacts_source_id_idx": {
+          "name": "migration_plan_artifacts_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_plan_artifacts_profile_id_idx": {
+          "name": "migration_plan_artifacts_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_plan_artifacts_source_id_migration_sources_id_fk": {
+          "name": "migration_plan_artifacts_source_id_migration_sources_id_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "migration_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_plan_artifacts_profile_id_migration_profiles_id_fk": {
+          "name": "migration_plan_artifacts_profile_id_migration_profiles_id_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "migration_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_plan_artifacts_created_by_user_id_users_id_fk": {
+          "name": "migration_plan_artifacts_created_by_user_id_users_id_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "migration_plan_artifacts_profile_source_fk": {
+          "name": "migration_plan_artifacts_profile_source_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "migration_profiles",
+          "columnsFrom": [
+            "profile_id",
+            "source_id"
+          ],
+          "columnsTo": [
+            "id",
+            "source_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "migration_plan_artifacts_id_source_profile_unique": {
+          "name": "migration_plan_artifacts_id_source_profile_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "source_id",
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_profiles": {
+      "name": "migration_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_mappings": {
+          "name": "user_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_mappings": {
+          "name": "path_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_profiles_source_name_version_uidx": {
+          "name": "migration_profiles_source_name_version_uidx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_profiles_source_id_idx": {
+          "name": "migration_profiles_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_profiles_source_id_migration_sources_id_fk": {
+          "name": "migration_profiles_source_id_migration_sources_id_fk",
+          "tableFrom": "migration_profiles",
+          "tableTo": "migration_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_profiles_created_by_user_id_users_id_fk": {
+          "name": "migration_profiles_created_by_user_id_users_id_fk",
+          "tableFrom": "migration_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "migration_profiles_id_source_id_unique": {
+          "name": "migration_profiles_id_source_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "migration_profiles_version_positive_chk": {
+          "name": "migration_profiles_version_positive_chk",
+          "value": "\"migration_profiles\".\"version\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_run_metrics": {
+      "name": "migration_run_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported": {
+          "name": "imported",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unresolved": {
+          "name": "unresolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_run_metrics_run_stage_entity_uidx": {
+          "name": "migration_run_metrics_run_stage_entity_uidx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_run_metrics_run_id_idx": {
+          "name": "migration_run_metrics_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_run_metrics_run_id_migration_runs_id_fk": {
+          "name": "migration_run_metrics_run_id_migration_runs_id_fk",
+          "tableFrom": "migration_run_metrics",
+          "tableTo": "migration_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_run_metrics_processed_nonnegative_chk": {
+          "name": "migration_run_metrics_processed_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"processed\" >= 0"
+        },
+        "migration_run_metrics_imported_nonnegative_chk": {
+          "name": "migration_run_metrics_imported_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"imported\" >= 0"
+        },
+        "migration_run_metrics_skipped_nonnegative_chk": {
+          "name": "migration_run_metrics_skipped_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"skipped\" >= 0"
+        },
+        "migration_run_metrics_unresolved_nonnegative_chk": {
+          "name": "migration_run_metrics_unresolved_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"unresolved\" >= 0"
+        },
+        "migration_run_metrics_failed_nonnegative_chk": {
+          "name": "migration_run_metrics_failed_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"failed\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_artifact_id": {
+          "name": "plan_artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bookorbit'"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_runs_source_target_state_idx": {
+          "name": "migration_runs_source_target_state_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_state_idx": {
+          "name": "migration_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_source_id_migration_sources_id_fk": {
+          "name": "migration_runs_source_id_migration_sources_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_profile_id_migration_profiles_id_fk": {
+          "name": "migration_runs_profile_id_migration_profiles_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_plan_artifact_id_migration_plan_artifacts_id_fk": {
+          "name": "migration_runs_plan_artifact_id_migration_plan_artifacts_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_plan_artifacts",
+          "columnsFrom": [
+            "plan_artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "migration_runs_triggered_by_user_id_users_id_fk": {
+          "name": "migration_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "migration_runs_profile_source_fk": {
+          "name": "migration_runs_profile_source_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_profiles",
+          "columnsFrom": [
+            "profile_id",
+            "source_id"
+          ],
+          "columnsTo": [
+            "id",
+            "source_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_plan_artifact_source_profile_fk": {
+          "name": "migration_runs_plan_artifact_source_profile_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_plan_artifacts",
+          "columnsFrom": [
+            "plan_artifact_id",
+            "source_id",
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id",
+            "source_id",
+            "profile_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_state_chk": {
+          "name": "migration_runs_state_chk",
+          "value": "\"state\" IN ('draft', 'preflight_failed', 'dry_run_ready', 'running', 'failed', 'completed')"
+        },
+        "migration_runs_started_before_ended_chk": {
+          "name": "migration_runs_started_before_ended_chk",
+          "value": "\"migration_runs\".\"ended_at\" is null or \"migration_runs\".\"started_at\" is null or \"migration_runs\".\"ended_at\" >= \"migration_runs\".\"started_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_sources": {
+      "name": "migration_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_config": {
+          "name": "connection_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_sources_type_name_uidx": {
+          "name": "migration_sources_type_name_uidx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_sources_created_by_user_id_idx": {
+          "name": "migration_sources_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_sources_created_by_user_id_users_id_fk": {
+          "name": "migration_sources_created_by_user_id_users_id_fk",
+          "tableFrom": "migration_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.libraries": {
+      "name": "libraries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cover_aspect_ratio": {
+          "name": "cover_aspect_ratio",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2/3'"
+        },
+        "watch": {
+          "name": "watch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_scan_cron_expression": {
+          "name": "auto_scan_cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_precedence": {
+          "name": "metadata_precedence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"folderStructure\",\"embedded\",\"nfoFile\",\"opfFile\",\"sidecar\"]'::jsonb"
+        },
+        "format_priority": {
+          "name": "format_priority",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"epub\",\"pdf\",\"cbz\",\"cbr\",\"cb7\",\"mobi\",\"azw3\",\"azw\",\"fb2\",\"m4b\",\"mp3\",\"m4a\",\"opus\",\"ogg\",\"flac\"]'::jsonb"
+        },
+        "allowed_formats": {
+          "name": "allowed_formats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "organization_mode": {
+          "name": "organization_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'book_per_folder'"
+        },
+        "exclude_patterns": {
+          "name": "exclude_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reading_threshold": {
+          "name": "reading_threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.25
+        },
+        "mark_as_finished_percent_complete": {
+          "name": "mark_as_finished_percent_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 98
+        },
+        "file_write_enabled": {
+          "name": "file_write_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_write_write_cover": {
+          "name": "file_write_write_cover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "file_write_epub_enabled": {
+          "name": "file_write_epub_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "file_write_epub_max_file_size_mb": {
+          "name": "file_write_epub_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "file_write_pdf_enabled": {
+          "name": "file_write_pdf_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "file_write_pdf_max_file_size_mb": {
+          "name": "file_write_pdf_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "file_write_cbx_enabled": {
+          "name": "file_write_cbx_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_write_cbx_max_file_size_mb": {
+          "name": "file_write_cbx_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "file_rename_enabled": {
+          "name": "file_rename_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_naming_pattern": {
+          "name": "file_naming_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_fetch_preferences": {
+          "name": "metadata_fetch_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_metadata_fetch_config": {
+          "name": "book_metadata_fetch_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_metadata_fetch_last_run_at": {
+          "name": "book_metadata_fetch_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_metadata_fetch_last_queued_count": {
+          "name": "book_metadata_fetch_last_queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_mode": {
+          "name": "scan_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 300
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "libraries_name_lower_uidx": {
+          "name": "libraries_name_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "libraries_display_order_nonnegative_chk": {
+          "name": "libraries_display_order_nonnegative_chk",
+          "value": "\"libraries\".\"display_order\" >= 0"
+        },
+        "libraries_organization_mode_chk": {
+          "name": "libraries_organization_mode_chk",
+          "value": "\"libraries\".\"organization_mode\" in ('book_per_folder', 'book_per_file')"
+        },
+        "libraries_reading_threshold_range_chk": {
+          "name": "libraries_reading_threshold_range_chk",
+          "value": "\"libraries\".\"reading_threshold\" >= 0 and \"libraries\".\"reading_threshold\" <= 100"
+        },
+        "libraries_mark_finished_percent_range_chk": {
+          "name": "libraries_mark_finished_percent_range_chk",
+          "value": "\"libraries\".\"mark_as_finished_percent_complete\" >= 0 and \"libraries\".\"mark_as_finished_percent_complete\" <= 100"
+        },
+        "libraries_scan_mode_chk": {
+          "name": "libraries_scan_mode_chk",
+          "value": "\"libraries\".\"scan_mode\" in ('auto', 'manual')"
+        },
+        "libraries_poll_interval_nonnegative_chk": {
+          "name": "libraries_poll_interval_nonnegative_chk",
+          "value": "\"libraries\".\"poll_interval_seconds\" is null or \"libraries\".\"poll_interval_seconds\" >= 0"
+        },
+        "libraries_file_write_epub_max_size_chk": {
+          "name": "libraries_file_write_epub_max_size_chk",
+          "value": "\"libraries\".\"file_write_epub_max_file_size_mb\" >= 1"
+        },
+        "libraries_file_write_pdf_max_size_chk": {
+          "name": "libraries_file_write_pdf_max_size_chk",
+          "value": "\"libraries\".\"file_write_pdf_max_file_size_mb\" >= 1"
+        },
+        "libraries_file_write_cbx_max_size_chk": {
+          "name": "libraries_file_write_cbx_max_size_chk",
+          "value": "\"libraries\".\"file_write_cbx_max_file_size_mb\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.library_folders": {
+      "name": "library_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_folders_library_id_idx": {
+          "name": "library_folders_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_folders_library_path_uidx": {
+          "name": "library_folders_library_path_uidx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_folders_library_id_libraries_id_fk": {
+          "name": "library_folders_library_id_libraries_id_fk",
+          "tableFrom": "library_folders",
+          "tableTo": "libraries",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "library_folders_id_library_id_unique": {
+          "name": "library_folders_id_library_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "library_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_files": {
+      "name": "book_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_folder_id": {
+          "name": "library_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_path": {
+          "name": "absolute_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rel_path": {
+          "name": "rel_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ino": {
+          "name": "ino",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'content'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_files_absolute_path_uidx": {
+          "name": "book_files_absolute_path_uidx",
+          "columns": [
+            {
+              "expression": "absolute_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_book_id_idx": {
+          "name": "book_files_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_library_folder_id_idx": {
+          "name": "book_files_library_folder_id_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_file_hash_idx": {
+          "name": "book_files_file_hash_idx",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_ino_idx": {
+          "name": "book_files_ino_idx",
+          "columns": [
+            {
+              "expression": "ino",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_format_idx": {
+          "name": "book_files_format_idx",
+          "columns": [
+            {
+              "expression": "format",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_library_folder_file_hash_idx": {
+          "name": "book_files_library_folder_file_hash_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_library_folder_ino_idx": {
+          "name": "book_files_library_folder_ino_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ino",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_files_book_id_books_id_fk": {
+          "name": "book_files_book_id_books_id_fk",
+          "tableFrom": "book_files",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_files_library_folder_id_library_folders_id_fk": {
+          "name": "book_files_library_folder_id_library_folders_id_fk",
+          "tableFrom": "book_files",
+          "tableTo": "library_folders",
+          "columnsFrom": [
+            "library_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_files_book_folder_consistency_fk": {
+          "name": "book_files_book_folder_consistency_fk",
+          "tableFrom": "book_files",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id",
+            "library_folder_id"
+          ],
+          "columnsTo": [
+            "id",
+            "library_folder_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_files_role_chk": {
+          "name": "book_files_role_chk",
+          "value": "\"book_files\".\"role\" in ('content', 'cover', 'metadata', 'supplement')"
+        },
+        "book_files_size_bytes_nonnegative_chk": {
+          "name": "book_files_size_bytes_nonnegative_chk",
+          "value": "\"book_files\".\"size_bytes\" is null or \"book_files\".\"size_bytes\" >= 0"
+        },
+        "book_files_duration_seconds_nonnegative_chk": {
+          "name": "book_files_duration_seconds_nonnegative_chk",
+          "value": "\"book_files\".\"duration_seconds\" is null or \"book_files\".\"duration_seconds\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_folder_id": {
+          "name": "library_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_file_id": {
+          "name": "primary_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_path": {
+          "name": "folder_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'present'"
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "books_library_id_folder_path_idx": {
+          "name": "books_library_id_folder_path_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folder_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_primary_file_id_idx": {
+          "name": "books_primary_file_id_idx",
+          "columns": [
+            {
+              "expression": "primary_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_status_idx": {
+          "name": "books_library_status_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_added_at_idx": {
+          "name": "books_library_added_at_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"added_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_library_id_libraries_id_fk": {
+          "name": "books_library_id_libraries_id_fk",
+          "tableFrom": "books",
+          "tableTo": "libraries",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "books_library_folder_id_library_folders_id_fk": {
+          "name": "books_library_folder_id_library_folders_id_fk",
+          "tableFrom": "books",
+          "tableTo": "library_folders",
+          "columnsFrom": [
+            "library_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "books_primary_file_id_book_files_id_fk": {
+          "name": "books_primary_file_id_book_files_id_fk",
+          "tableFrom": "books",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "primary_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "books_library_folder_library_fk": {
+          "name": "books_library_folder_library_fk",
+          "tableFrom": "books",
+          "tableTo": "library_folders",
+          "columnsFrom": [
+            "library_folder_id",
+            "library_id"
+          ],
+          "columnsTo": [
+            "id",
+            "library_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "books_id_library_folder_id_unique": {
+          "name": "books_id_library_folder_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "library_folder_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "books_status_chk": {
+          "name": "books_status_chk",
+          "value": "\"books\".\"status\" in ('present', 'missing', 'processing')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collection_books": {
+      "name": "collection_books",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_books_book_id_idx": {
+          "name": "collection_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_books_collection_id_collections_id_fk": {
+          "name": "collection_books_collection_id_collections_id_fk",
+          "tableFrom": "collection_books",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_books_book_id_books_id_fk": {
+          "name": "collection_books_book_id_books_id_fk",
+          "tableFrom": "collection_books",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_books_collection_id_book_id_pk": {
+          "name": "collection_books_collection_id_book_id_pk",
+          "columns": [
+            "collection_id",
+            "book_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_to_kobo": {
+          "name": "sync_to_kobo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_name_uidx": {
+          "name": "collections_user_name_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_user_display_name_idx": {
+          "name": "collections_user_display_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.smart_scopes": {
+      "name": "smart_scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_sort": {
+          "name": "default_sort",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "smart_scopes_user_id_users_id_fk": {
+          "name": "smart_scopes_user_id_users_id_fk",
+          "tableFrom": "smart_scopes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "smart_scopes_user_id_name_unique": {
+          "name": "smart_scopes_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.author_enrichment_queue": {
+      "name": "author_enrichment_queue",
+      "schema": "",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "author_enrichment_queue_status_next_attempt_idx": {
+          "name": "author_enrichment_queue_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "author_enrichment_queue_next_attempt_idx": {
+          "name": "author_enrichment_queue_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "author_enrichment_queue_single_processing_idx": {
+          "name": "author_enrichment_queue_single_processing_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"author_enrichment_queue\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "author_enrichment_queue_author_id_authors_id_fk": {
+          "name": "author_enrichment_queue_author_id_authors_id_fk",
+          "tableFrom": "author_enrichment_queue",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "author_enrichment_queue_status_chk": {
+          "name": "author_enrichment_queue_status_chk",
+          "value": "\"author_enrichment_queue\".\"status\" in ('queued', 'processing', 'rate_limited', 'failed', 'done')"
+        },
+        "author_enrichment_queue_reason_chk": {
+          "name": "author_enrichment_queue_reason_chk",
+          "value": "\"author_enrichment_queue\".\"reason\" in ('unknown', 'metadata_replace', 'manual_backfill', 'manual_backfill_all', 'author_rename', 'author_merge_target')"
+        },
+        "author_enrichment_queue_attempt_count_nonnegative_chk": {
+          "name": "author_enrichment_queue_attempt_count_nonnegative_chk",
+          "value": "\"author_enrichment_queue\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_photo": {
+          "name": "has_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_enriched_at": {
+          "name": "last_enriched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "authors_name_trgm_idx": {
+          "name": "authors_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authors_name_unique": {
+          "name": "authors_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_authors": {
+      "name": "book_authors",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "book_authors_author_id_idx": {
+          "name": "book_authors_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_authors_book_display_idx": {
+          "name": "book_authors_book_display_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_authors_book_id_books_id_fk": {
+          "name": "book_authors_book_id_books_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_authors_author_id_authors_id_fk": {
+          "name": "book_authors_author_id_authors_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_authors_book_id_author_id_pk": {
+          "name": "book_authors_book_id_author_id_pk",
+          "columns": [
+            "book_id",
+            "author_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_genres": {
+      "name": "book_genres",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_genres_genre_id_idx": {
+          "name": "book_genres_genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_genres_book_id_books_id_fk": {
+          "name": "book_genres_book_id_books_id_fk",
+          "tableFrom": "book_genres",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_genres_genre_id_genres_id_fk": {
+          "name": "book_genres_genre_id_genres_id_fk",
+          "tableFrom": "book_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genre_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_genres_book_id_genre_id_pk": {
+          "name": "book_genres_book_id_genre_id_pk",
+          "columns": [
+            "book_id",
+            "genre_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_metadata": {
+      "name": "book_metadata",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn10": {
+          "name": "isbn10",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn13": {
+          "name": "isbn13",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_name": {
+          "name": "series_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_index": {
+          "name": "series_index",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_source": {
+          "name": "cover_source",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_id": {
+          "name": "google_books_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goodreads_id": {
+          "name": "goodreads_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amazon_id": {
+          "name": "amazon_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_id": {
+          "name": "hardcover_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_library_id": {
+          "name": "open_library_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itunes_id": {
+          "name": "itunes_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_score": {
+          "name": "metadata_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_metadata_fetch_at": {
+          "name": "last_metadata_fetch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_written_at": {
+          "name": "last_written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abridged": {
+          "name": "abridged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audible_id": {
+          "name": "audible_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comicvine_id": {
+          "name": "comicvine_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_fields": {
+          "name": "locked_fields",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bm_title_trgm_idx": {
+          "name": "bm_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_title_lower_idx": {
+          "name": "bm_title_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"title\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_trgm_idx": {
+          "name": "bm_series_trgm_idx",
+          "columns": [
+            {
+              "expression": "series_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_publisher_trgm_idx": {
+          "name": "bm_publisher_trgm_idx",
+          "columns": [
+            {
+              "expression": "publisher",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_language_idx": {
+          "name": "bm_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_language_trgm_idx": {
+          "name": "bm_language_trgm_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_published_year_idx": {
+          "name": "bm_published_year_idx",
+          "columns": [
+            {
+              "expression": "published_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_name_index_idx": {
+          "name": "bm_series_name_index_idx",
+          "columns": [
+            {
+              "expression": "series_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "series_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_isbn10_idx": {
+          "name": "bm_isbn10_idx",
+          "columns": [
+            {
+              "expression": "isbn10",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_isbn13_idx": {
+          "name": "bm_isbn13_idx",
+          "columns": [
+            {
+              "expression": "isbn13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_embedding_hnsw_cosine_idx": {
+          "name": "bm_embedding_hnsw_cosine_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_metadata_book_id_books_id_fk": {
+          "name": "book_metadata_book_id_books_id_fk",
+          "tableFrom": "book_metadata",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_metadata_rating_range_chk": {
+          "name": "book_metadata_rating_range_chk",
+          "value": "\"book_metadata\".\"rating\" is null or (\"book_metadata\".\"rating\" >= 1 and \"book_metadata\".\"rating\" <= 10)"
+        },
+        "book_metadata_published_year_range_chk": {
+          "name": "book_metadata_published_year_range_chk",
+          "value": "\"book_metadata\".\"published_year\" is null or (\"book_metadata\".\"published_year\" >= 1000 and \"book_metadata\".\"published_year\" <= 2200)"
+        },
+        "book_metadata_page_count_nonnegative_chk": {
+          "name": "book_metadata_page_count_nonnegative_chk",
+          "value": "\"book_metadata\".\"page_count\" is null or \"book_metadata\".\"page_count\" >= 0"
+        },
+        "book_metadata_duration_seconds_nonnegative_chk": {
+          "name": "book_metadata_duration_seconds_nonnegative_chk",
+          "value": "\"book_metadata\".\"duration_seconds\" is null or \"book_metadata\".\"duration_seconds\" >= 0"
+        },
+        "book_metadata_cover_source_chk": {
+          "name": "book_metadata_cover_source_chk",
+          "value": "\"book_metadata\".\"cover_source\" is null or \"book_metadata\".\"cover_source\" in ('extracted', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_metadata_fetch_queue": {
+      "name": "book_metadata_fetch_queue",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual_trigger'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bmfq_status_idx": {
+          "name": "bmfq_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bmfq_created_at_idx": {
+          "name": "bmfq_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bmfq_status_created_book_idx": {
+          "name": "bmfq_status_created_book_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_metadata_fetch_queue_book_id_books_id_fk": {
+          "name": "book_metadata_fetch_queue_book_id_books_id_fk",
+          "tableFrom": "book_metadata_fetch_queue",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_metadata_fetch_queue_status_chk": {
+          "name": "book_metadata_fetch_queue_status_chk",
+          "value": "\"book_metadata_fetch_queue\".\"status\" in ('queued', 'processing', 'failed')"
+        },
+        "book_metadata_fetch_queue_reason_chk": {
+          "name": "book_metadata_fetch_queue_reason_chk",
+          "value": "\"book_metadata_fetch_queue\".\"reason\" in ('event_import', 'manual_trigger', 'manual_retry')"
+        },
+        "book_metadata_fetch_queue_attempt_count_nonnegative_chk": {
+          "name": "book_metadata_fetch_queue_attempt_count_nonnegative_chk",
+          "value": "\"book_metadata_fetch_queue\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_id_idx": {
+          "name": "book_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_books_id_fk": {
+          "name": "book_tags_book_id_books_id_fk",
+          "tableFrom": "book_tags",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_tag_id_tags_id_fk": {
+          "name": "book_tags_tag_id_tags_id_fk",
+          "tableFrom": "book_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_book_id_tag_id_pk": {
+          "name": "book_tags_book_id_tag_id_pk",
+          "columns": [
+            "book_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "genres_name_trgm_idx": {
+          "name": "genres_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_trgm_idx": {
+          "name": "tags_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_narrators": {
+      "name": "book_narrators",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrator_id": {
+          "name": "narrator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "book_narrators_narrator_id_idx": {
+          "name": "book_narrators_narrator_id_idx",
+          "columns": [
+            {
+              "expression": "narrator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_narrators_book_id_books_id_fk": {
+          "name": "book_narrators_book_id_books_id_fk",
+          "tableFrom": "book_narrators",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_narrators_narrator_id_narrators_id_fk": {
+          "name": "book_narrators_narrator_id_narrators_id_fk",
+          "tableFrom": "book_narrators",
+          "tableTo": "narrators",
+          "columnsFrom": [
+            "narrator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_narrators_book_id_narrator_id_pk": {
+          "name": "book_narrators_book_id_narrator_id_pk",
+          "columns": [
+            "book_id",
+            "narrator_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.narrators": {
+      "name": "narrators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "narrators_name_trgm_idx": {
+          "name": "narrators_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "narrators_name_unique": {
+          "name": "narrators_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_dir_scan_state": {
+      "name": "library_dir_scan_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_folder_id": {
+          "name": "library_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dir_path": {
+          "name": "dir_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_mtime_ms": {
+          "name": "last_seen_mtime_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_dir_scan_state_folder_dir_uidx": {
+          "name": "library_dir_scan_state_folder_dir_uidx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dir_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_dir_scan_state_folder_idx": {
+          "name": "library_dir_scan_state_folder_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_dir_scan_state_library_folder_id_library_folders_id_fk": {
+          "name": "library_dir_scan_state_library_folder_id_library_folders_id_fk",
+          "tableFrom": "library_dir_scan_state",
+          "tableTo": "library_folders",
+          "columnsFrom": [
+            "library_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_jobs": {
+      "name": "scan_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_count": {
+          "name": "added_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "missing_count": {
+          "name": "missing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scan_jobs_library_status_idx": {
+          "name": "scan_jobs_library_status_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_jobs_library_id_libraries_id_fk": {
+          "name": "scan_jobs_library_id_libraries_id_fk",
+          "tableFrom": "scan_jobs",
+          "tableTo": "libraries",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scan_jobs_status_chk": {
+          "name": "scan_jobs_status_chk",
+          "value": "\"scan_jobs\".\"status\" in ('running', 'completed', 'failed')"
+        },
+        "scan_jobs_triggered_by_chk": {
+          "name": "scan_jobs_triggered_by_chk",
+          "value": "\"scan_jobs\".\"triggered_by\" in ('manual', 'watcher', 'schedule')"
+        },
+        "scan_jobs_added_count_nonnegative_chk": {
+          "name": "scan_jobs_added_count_nonnegative_chk",
+          "value": "\"scan_jobs\".\"added_count\" >= 0"
+        },
+        "scan_jobs_updated_count_nonnegative_chk": {
+          "name": "scan_jobs_updated_count_nonnegative_chk",
+          "value": "\"scan_jobs\".\"updated_count\" >= 0"
+        },
+        "scan_jobs_missing_count_nonnegative_chk": {
+          "name": "scan_jobs_missing_count_nonnegative_chk",
+          "value": "\"scan_jobs\".\"missing_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.annotations": {
+      "name": "annotations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cfi": {
+          "name": "cfi",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yellow'"
+        },
+        "style": {
+          "name": "style",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'highlight'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_title": {
+          "name": "chapter_title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annotations_user_id_idx": {
+          "name": "annotations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotations_user_book_idx": {
+          "name": "annotations_user_book_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "annotations_user_id_users_id_fk": {
+          "name": "annotations_user_id_users_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "annotations_book_id_books_id_fk": {
+          "name": "annotations_book_id_books_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "annotations_style_chk": {
+          "name": "annotations_style_chk",
+          "value": "\"annotations\".\"style\" in ('highlight', 'underline', 'strikethrough', 'squiggly')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audiobook_progress": {
+      "name": "audiobook_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_file_id": {
+          "name": "current_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "abp_user_id_idx": {
+          "name": "abp_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audiobook_progress_user_id_users_id_fk": {
+          "name": "audiobook_progress_user_id_users_id_fk",
+          "tableFrom": "audiobook_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audiobook_progress_book_id_books_id_fk": {
+          "name": "audiobook_progress_book_id_books_id_fk",
+          "tableFrom": "audiobook_progress",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audiobook_progress_current_file_id_book_files_id_fk": {
+          "name": "audiobook_progress_current_file_id_book_files_id_fk",
+          "tableFrom": "audiobook_progress",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "current_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audiobook_progress_user_id_book_id_pk": {
+          "name": "audiobook_progress_user_id_book_id_pk",
+          "columns": [
+            "user_id",
+            "book_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audiobook_progress_percentage_range_chk": {
+          "name": "audiobook_progress_percentage_range_chk",
+          "value": "\"audiobook_progress\".\"percentage\" >= 0 and \"audiobook_progress\".\"percentage\" <= 100"
+        },
+        "audiobook_progress_position_seconds_nonnegative_chk": {
+          "name": "audiobook_progress_position_seconds_nonnegative_chk",
+          "value": "\"audiobook_progress\".\"position_seconds\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cfi": {
+          "name": "cfi",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_book_idx": {
+          "name": "bookmarks_user_book_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_user_book_cfi_uidx": {
+          "name": "bookmarks_user_book_cfi_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cfi",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bookmarks\".\"cfi\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_user_book_pos_uidx": {
+          "name": "bookmarks_user_book_pos_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position_seconds",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bookmarks\".\"position_seconds\" is not null and \"bookmarks\".\"cfi\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_book_id_books_id_fk": {
+          "name": "bookmarks_book_id_books_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reader_default_preferences": {
+      "name": "reader_default_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_group": {
+          "name": "format_group",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rdp_user_format_idx": {
+          "name": "rdp_user_format_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "format_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reader_default_preferences_user_id_users_id_fk": {
+          "name": "reader_default_preferences_user_id_users_id_fk",
+          "tableFrom": "reader_default_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reader_default_preferences_format_group_chk": {
+          "name": "reader_default_preferences_format_group_chk",
+          "value": "\"reader_default_preferences\".\"format_group\" in ('epub', 'pdf', 'cbx', 'audio')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reader_preferences": {
+      "name": "reader_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rp_user_file_idx": {
+          "name": "rp_user_file_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reader_preferences_user_id_users_id_fk": {
+          "name": "reader_preferences_user_id_users_id_fk",
+          "tableFrom": "reader_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reader_preferences_book_file_id_book_files_id_fk": {
+          "name": "reader_preferences_book_file_id_book_files_id_fk",
+          "tableFrom": "reader_preferences",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_progress": {
+      "name": "reading_progress",
+      "schema": "",
+      "columns": {
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cfi": {
+          "name": "cfi",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_number": {
+          "name": "page_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_progress_user_id_idx": {
+          "name": "reading_progress_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reading_progress_user_updated_at_idx": {
+          "name": "reading_progress_user_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reading_progress_book_file_id_book_files_id_fk": {
+          "name": "reading_progress_book_file_id_book_files_id_fk",
+          "tableFrom": "reading_progress",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_progress_user_id_users_id_fk": {
+          "name": "reading_progress_user_id_users_id_fk",
+          "tableFrom": "reading_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reading_progress_book_file_id_user_id_pk": {
+          "name": "reading_progress_book_file_id_user_id_pk",
+          "columns": [
+            "book_file_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reading_progress_percentage_range_chk": {
+          "name": "reading_progress_percentage_range_chk",
+          "value": "\"reading_progress\".\"percentage\" >= 0 and \"reading_progress\".\"percentage\" <= 100"
+        },
+        "reading_progress_page_number_nonnegative_chk": {
+          "name": "reading_progress_page_number_nonnegative_chk",
+          "value": "\"reading_progress\".\"page_number\" is null or \"reading_progress\".\"page_number\" >= 0"
+        },
+        "reading_progress_position_seconds_nonnegative_chk": {
+          "name": "reading_progress_position_seconds_nonnegative_chk",
+          "value": "\"reading_progress\".\"position_seconds\" is null or \"reading_progress\".\"position_seconds\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reading_sessions": {
+      "name": "reading_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress_delta": {
+          "name": "progress_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_progress": {
+          "name": "end_progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rs_user_session_id_uidx": {
+          "name": "rs_user_session_id_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_user_started_at_idx": {
+          "name": "rs_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_book_file_started_at_idx": {
+          "name": "rs_book_file_started_at_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_user_book_file_idx": {
+          "name": "rs_user_book_file_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reading_sessions_user_id_users_id_fk": {
+          "name": "reading_sessions_user_id_users_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_sessions_book_file_id_book_files_id_fk": {
+          "name": "reading_sessions_book_file_id_book_files_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reading_sessions_duration_seconds_nonnegative_chk": {
+          "name": "reading_sessions_duration_seconds_nonnegative_chk",
+          "value": "\"reading_sessions\".\"duration_seconds\" >= 0"
+        },
+        "reading_sessions_end_progress_range_chk": {
+          "name": "reading_sessions_end_progress_range_chk",
+          "value": "\"reading_sessions\".\"end_progress\" is null or (\"reading_sessions\".\"end_progress\" >= 0 and \"reading_sessions\".\"end_progress\" <= 100)"
+        },
+        "reading_sessions_ended_after_started_chk": {
+          "name": "reading_sessions_ended_after_started_chk",
+          "value": "\"reading_sessions\".\"ended_at\" >= \"reading_sessions\".\"started_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_book_ratings": {
+      "name": "user_book_ratings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ubr_user_id_idx": {
+          "name": "ubr_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubr_book_id_idx": {
+          "name": "ubr_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubr_book_user_rating_idx": {
+          "name": "ubr_book_user_rating_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_book_ratings_user_id_users_id_fk": {
+          "name": "user_book_ratings_user_id_users_id_fk",
+          "tableFrom": "user_book_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_book_ratings_book_id_books_id_fk": {
+          "name": "user_book_ratings_book_id_books_id_fk",
+          "tableFrom": "user_book_ratings",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_book_ratings_user_id_book_id_pk": {
+          "name": "user_book_ratings_user_id_book_id_pk",
+          "columns": [
+            "user_id",
+            "book_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_book_ratings_rating_range_chk": {
+          "name": "user_book_ratings_rating_range_chk",
+          "value": "\"user_book_ratings\".\"rating\" >= 1 and \"user_book_ratings\".\"rating\" <= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_book_status": {
+      "name": "user_book_status",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unread'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ubs_user_id_idx": {
+          "name": "ubs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubs_user_status_idx": {
+          "name": "ubs_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubs_book_user_idx": {
+          "name": "ubs_book_user_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_book_status_user_id_users_id_fk": {
+          "name": "user_book_status_user_id_users_id_fk",
+          "tableFrom": "user_book_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_book_status_book_id_books_id_fk": {
+          "name": "user_book_status_book_id_books_id_fk",
+          "tableFrom": "user_book_status",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_book_status_user_id_book_id_pk": {
+          "name": "user_book_status_user_id_book_id_pk",
+          "columns": [
+            "user_id",
+            "book_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_book_status_status_chk": {
+          "name": "user_book_status_status_chk",
+          "value": "\"user_book_status\".\"status\" in ('unread', 'want_to_read', 'reading', 'on_hold', 'rereading', 'read', 'skimmed', 'abandoned')"
+        },
+        "user_book_status_source_chk": {
+          "name": "user_book_status_source_chk",
+          "value": "\"user_book_status\".\"source\" in ('auto', 'manual')"
+        },
+        "user_book_status_finished_after_started_chk": {
+          "name": "user_book_status_finished_after_started_chk",
+          "value": "\"user_book_status\".\"finished_at\" is null or \"user_book_status\".\"started_at\" is null or \"user_book_status\".\"finished_at\" >= \"user_book_status\".\"started_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_reading_daily_stats": {
+      "name": "user_reading_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reading_seconds": {
+          "name": "reading_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_delta": {
+          "name": "progress_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sessions_count": {
+          "name": "sessions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "urds_user_day_idx": {
+          "name": "urds_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_reading_daily_stats_user_id_users_id_fk": {
+          "name": "user_reading_daily_stats_user_id_users_id_fk",
+          "tableFrom": "user_reading_daily_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_reading_daily_stats_library_id_libraries_id_fk": {
+          "name": "user_reading_daily_stats_library_id_libraries_id_fk",
+          "tableFrom": "user_reading_daily_stats",
+          "tableTo": "libraries",
+          "columnsFrom": [
+            "library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_reading_daily_stats_user_id_library_id_day_pk": {
+          "name": "user_reading_daily_stats_user_id_library_id_day_pk",
+          "columns": [
+            "user_id",
+            "library_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_reading_daily_stats_reading_seconds_nonnegative_chk": {
+          "name": "user_reading_daily_stats_reading_seconds_nonnegative_chk",
+          "value": "\"user_reading_daily_stats\".\"reading_seconds\" >= 0"
+        },
+        "user_reading_daily_stats_sessions_count_nonnegative_chk": {
+          "name": "user_reading_daily_stats_sessions_count_nonnegative_chk",
+          "value": "\"user_reading_daily_stats\".\"sessions_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oidc_group_mappings": {
+      "name": "oidc_group_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_group_claim": {
+          "name": "oidc_group_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_name": {
+          "name": "permission_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_group_mappings_provider_claim_uidx": {
+          "name": "oidc_group_mappings_provider_claim_uidx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_group_claim",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_group_mappings_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_group_mappings_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_group_mappings",
+          "tableTo": "oidc_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_identities": {
+      "name": "oidc_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_identities_provider_subject_uidx": {
+          "name": "oidc_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_identities_user_provider_uidx": {
+          "name": "oidc_identities_user_provider_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_identities_issuer_subject_uidx": {
+          "name": "oidc_identities_issuer_subject_uidx",
+          "columns": [
+            {
+              "expression": "oidc_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_identities_user_id_idx": {
+          "name": "oidc_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_identities_user_id_users_id_fk": {
+          "name": "oidc_identities_user_id_users_id_fk",
+          "tableFrom": "oidc_identities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_identities_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_identities_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_identities",
+          "tableTo": "oidc_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_permission_grants": {
+      "name": "oidc_permission_grants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_name": {
+          "name": "permission_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oidc_permission_grants_user_id_users_id_fk": {
+          "name": "oidc_permission_grants_user_id_users_id_fk",
+          "tableFrom": "oidc_permission_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_permission_grants_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_permission_grants_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_permission_grants",
+          "tableTo": "oidc_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oidc_permission_grants_user_id_provider_id_permission_name_pk": {
+          "name": "oidc_permission_grants_user_id_provider_id_permission_name_pk",
+          "columns": [
+            "user_id",
+            "provider_id",
+            "permission_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issuer_uri": {
+          "name": "issuer_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openid profile email'"
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_mapping": {
+          "name": "claim_mapping",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"username\":\"preferred_username\",\"name\":\"name\",\"email\":\"email\",\"groups\":\"groups\"}'::jsonb"
+        },
+        "auto_provision": {
+          "name": "auto_provision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"enabled\":false,\"allowLocalLinking\":false,\"defaultPermissionNames\":[]}'::jsonb"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_providers_enabled_order_idx": {
+          "name": "oidc_providers_enabled_order_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oidc_providers_slug_unique": {
+          "name": "oidc_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "oidc_providers_issuer_uri_unique": {
+          "name": "oidc_providers_issuer_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "issuer_uri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_sessions": {
+      "name": "oidc_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_session_id": {
+          "name": "oidc_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token_hint": {
+          "name": "id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_refresh_token": {
+          "name": "idp_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oidc_sessions_user_active_idx": {
+          "name": "oidc_sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"oidc_sessions\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_subject_issuer_idx": {
+          "name": "oidc_sessions_subject_issuer_idx",
+          "columns": [
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_sid_idx": {
+          "name": "oidc_sessions_sid_idx",
+          "columns": [
+            {
+              "expression": "oidc_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_expires_at_idx": {
+          "name": "oidc_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_provider_id_idx": {
+          "name": "oidc_sessions_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_sessions_user_id_users_id_fk": {
+          "name": "oidc_sessions_user_id_users_id_fk",
+          "tableFrom": "oidc_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_sessions_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_sessions_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_sessions",
+          "tableTo": "oidc_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_states": {
+      "name": "oidc_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_states_expires_at_idx": {
+          "name": "oidc_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_states_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_states_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_states",
+          "tableTo": "oidc_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_used_jtis": {
+      "name": "oidc_used_jtis",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oidc_used_jtis_expires_at_idx": {
+          "name": "oidc_used_jtis_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opds_users": {
+      "name": "opds_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "opds_sort_order",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recent'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opds_users_username_lower_uidx": {
+          "name": "opds_users_username_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opds_users_user_id_users_id_fk": {
+          "name": "opds_users_user_id_users_id_fk",
+          "tableFrom": "opds_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opds_users_username_unique": {
+          "name": "opds_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_devices": {
+      "name": "kobo_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kobo_devices_user_id_idx": {
+          "name": "kobo_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_devices_user_id_users_id_fk": {
+          "name": "kobo_devices_user_id_users_id_fk",
+          "tableFrom": "kobo_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_devices_token_unique": {
+          "name": "kobo_devices_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_library_snapshots": {
+      "name": "kobo_library_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kobo_library_snapshots_user_id_users_id_fk": {
+          "name": "kobo_library_snapshots_user_id_users_id_fk",
+          "tableFrom": "kobo_library_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_library_snapshots_user_id_unique": {
+          "name": "kobo_library_snapshots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_reading_states": {
+      "name": "kobo_reading_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_kobo": {
+          "name": "created_at_kobo",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_kobo": {
+          "name": "last_modified_kobo",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_timestamp": {
+          "name": "priority_timestamp",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bookmark": {
+          "name": "current_bookmark",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_info": {
+          "name": "status_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kobo_reading_states_user_id_users_id_fk": {
+          "name": "kobo_reading_states_user_id_users_id_fk",
+          "tableFrom": "kobo_reading_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_reading_states_book_id_books_id_fk": {
+          "name": "kobo_reading_states_book_id_books_id_fk",
+          "tableFrom": "kobo_reading_states",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_reading_states_user_id_book_id_unique": {
+          "name": "kobo_reading_states_user_id_book_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "book_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_snapshot_books": {
+      "name": "kobo_snapshot_books",
+      "schema": "",
+      "columns": {
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_delete": {
+          "name": "pending_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_by_device": {
+          "name": "removed_by_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_hash": {
+          "name": "metadata_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kobo_snapshot_books_snapshot_synced_book_idx": {
+          "name": "kobo_snapshot_books_snapshot_synced_book_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "synced",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_snapshot_books_snapshot_id_kobo_library_snapshots_id_fk": {
+          "name": "kobo_snapshot_books_snapshot_id_kobo_library_snapshots_id_fk",
+          "tableFrom": "kobo_snapshot_books",
+          "tableTo": "kobo_library_snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_snapshot_books_book_id_books_id_fk": {
+          "name": "kobo_snapshot_books_book_id_books_id_fk",
+          "tableFrom": "kobo_snapshot_books",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kobo_snapshot_books_snapshot_id_book_id_pk": {
+          "name": "kobo_snapshot_books_snapshot_id_book_id_pk",
+          "columns": [
+            "snapshot_id",
+            "book_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_sync_settings": {
+      "name": "kobo_sync_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reading_threshold": {
+          "name": "reading_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finished_threshold": {
+          "name": "finished_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 99
+        },
+        "convert_to_kepub": {
+          "name": "convert_to_kepub",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "force_enable_hyphenation": {
+          "name": "force_enable_hyphenation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "kepub_conversion_limit_mb": {
+          "name": "kepub_conversion_limit_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kobo_sync_settings_user_id_users_id_fk": {
+          "name": "kobo_sync_settings_user_id_users_id_fk",
+          "tableFrom": "kobo_sync_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_sync_settings_user_id_unique": {
+          "name": "kobo_sync_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kobo_sync_settings_reading_threshold_range_chk": {
+          "name": "kobo_sync_settings_reading_threshold_range_chk",
+          "value": "\"kobo_sync_settings\".\"reading_threshold\" >= 0 and \"kobo_sync_settings\".\"reading_threshold\" <= 100"
+        },
+        "kobo_sync_settings_finished_threshold_range_chk": {
+          "name": "kobo_sync_settings_finished_threshold_range_chk",
+          "value": "\"kobo_sync_settings\".\"finished_threshold\" >= 0 and \"kobo_sync_settings\".\"finished_threshold\" <= 100"
+        },
+        "kobo_sync_settings_conversion_limit_nonnegative_chk": {
+          "name": "kobo_sync_settings_conversion_limit_nonnegative_chk",
+          "value": "\"kobo_sync_settings\".\"kepub_conversion_limit_mb\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_dock_files": {
+      "name": "book_dock_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_path": {
+          "name": "absolute_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "embedded_metadata": {
+          "name": "embedded_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_metadata": {
+          "name": "selected_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_metadata": {
+          "name": "fetched_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_path": {
+          "name": "cover_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_library_id": {
+          "name": "target_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_folder_id": {
+          "name": "target_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_metadata_sources": {
+          "name": "fetched_metadata_sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_edited_at": {
+          "name": "metadata_edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_dock_files_status_idx": {
+          "name": "book_dock_files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_dock_files_uploaded_by_idx": {
+          "name": "book_dock_files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_dock_files_target_library_id_libraries_id_fk": {
+          "name": "book_dock_files_target_library_id_libraries_id_fk",
+          "tableFrom": "book_dock_files",
+          "tableTo": "libraries",
+          "columnsFrom": [
+            "target_library_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_dock_files_target_folder_id_library_folders_id_fk": {
+          "name": "book_dock_files_target_folder_id_library_folders_id_fk",
+          "tableFrom": "book_dock_files",
+          "tableTo": "library_folders",
+          "columnsFrom": [
+            "target_folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_dock_files_uploaded_by_users_id_fk": {
+          "name": "book_dock_files_uploaded_by_users_id_fk",
+          "tableFrom": "book_dock_files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "book_dock_files_absolute_path_unique": {
+          "name": "book_dock_files_absolute_path_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "absolute_path"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "book_dock_files_status_chk": {
+          "name": "book_dock_files_status_chk",
+          "value": "\"book_dock_files\".\"status\" in ('pending', 'extracting', 'fetching', 'ready', 'error')"
+        },
+        "book_dock_files_confidence_range_chk": {
+          "name": "book_dock_files_confidence_range_chk",
+          "value": "\"book_dock_files\".\"confidence\" is null or (\"book_dock_files\".\"confidence\" >= 0 and \"book_dock_files\".\"confidence\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.file_write_log": {
+      "name": "file_write_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fields_written": {
+          "name": "fields_written",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fwl_book_id_written_at_idx": {
+          "name": "fwl_book_id_written_at_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "written_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_write_log_book_id_books_id_fk": {
+          "name": "file_write_log_book_id_books_id_fk",
+          "tableFrom": "file_write_log",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_write_log_book_file_id_book_files_id_fk": {
+          "name": "file_write_log_book_file_id_book_files_id_fk",
+          "tableFrom": "file_write_log",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "file_write_log_user_id_users_id_fk": {
+          "name": "file_write_log_user_id_users_id_fk",
+          "tableFrom": "file_write_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_write_log_status_chk": {
+          "name": "file_write_log_status_chk",
+          "value": "\"file_write_log\".\"status\" in ('success', 'skipped', 'failed')"
+        },
+        "file_write_log_triggered_by_chk": {
+          "name": "file_write_log_triggered_by_chk",
+          "value": "\"file_write_log\".\"triggered_by\" in ('auto', 'sync')"
+        },
+        "file_write_log_duration_ms_nonnegative_chk": {
+          "name": "file_write_log_duration_ms_nonnegative_chk",
+          "value": "\"file_write_log\".\"duration_ms\" is null or \"file_write_log\".\"duration_ms\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_templates_one_default_per_user_uidx": {
+          "name": "email_templates_one_default_per_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"is_default\" = true and \"email_templates\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_templates_system_name_unique": {
+          "name": "email_templates_system_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"user_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_user_id_users_id_fk": {
+          "name": "email_templates_user_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_templates_user_id_name_unique": {
+          "name": "email_templates_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_providers": {
+      "name": "email_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_enc": {
+          "name": "password_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl": {
+          "name": "ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "start_tls": {
+          "name": "start_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_system_provider": {
+          "name": "is_system_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls_reject_unauthorized": {
+          "name": "tls_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_providers_one_default_per_user_uidx": {
+          "name": "email_providers_one_default_per_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_providers\".\"is_default\" = true and \"email_providers\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_providers_one_system_provider_uidx": {
+          "name": "email_providers_one_system_provider_uidx",
+          "columns": [
+            {
+              "expression": "is_system_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_providers\".\"is_system_provider\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_providers_user_id_users_id_fk": {
+          "name": "email_providers_user_id_users_id_fk",
+          "tableFrom": "email_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_providers_user_id_name_unique": {
+          "name": "email_providers_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        },
+        "email_providers_id_user_id_unique": {
+          "name": "email_providers_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_providers_port_range_chk": {
+          "name": "email_providers_port_range_chk",
+          "value": "\"email_providers\".\"port\" >= 1 and \"email_providers\".\"port\" <= 65535"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_recipient_group_members": {
+      "name": "email_recipient_group_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_recipient_group_members_user_id_users_id_fk": {
+          "name": "email_recipient_group_members_user_id_users_id_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_group_id_email_recipient_groups_id_fk": {
+          "name": "email_recipient_group_members_group_id_email_recipient_groups_id_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipient_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_recipient_id_email_recipients_id_fk": {
+          "name": "email_recipient_group_members_recipient_id_email_recipients_id_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipients",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_group_user_fk": {
+          "name": "email_recipient_group_members_group_user_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipient_groups",
+          "columnsFrom": [
+            "group_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_recipient_user_fk": {
+          "name": "email_recipient_group_members_recipient_user_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipients",
+          "columnsFrom": [
+            "recipient_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_recipient_group_members_group_id_recipient_id_pk": {
+          "name": "email_recipient_group_members_group_id_recipient_id_pk",
+          "columns": [
+            "group_id",
+            "recipient_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_recipient_groups": {
+      "name": "email_recipient_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_template_id": {
+          "name": "default_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_recipient_groups_user_id_users_id_fk": {
+          "name": "email_recipient_groups_user_id_users_id_fk",
+          "tableFrom": "email_recipient_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_groups_default_template_id_email_templates_id_fk": {
+          "name": "email_recipient_groups_default_template_id_email_templates_id_fk",
+          "tableFrom": "email_recipient_groups",
+          "tableTo": "email_templates",
+          "columnsFrom": [
+            "default_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_recipient_groups_user_id_name_unique": {
+          "name": "email_recipient_groups_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        },
+        "email_recipient_groups_id_user_id_unique": {
+          "name": "email_recipient_groups_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_recipients": {
+      "name": "email_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_format": {
+          "name": "preferred_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_template_id": {
+          "name": "default_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_recipients_user_email_lower_uidx": {
+          "name": "email_recipients_user_email_lower_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_recipients_one_default_per_user_uidx": {
+          "name": "email_recipients_one_default_per_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_recipients\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_recipients_user_id_users_id_fk": {
+          "name": "email_recipients_user_id_users_id_fk",
+          "tableFrom": "email_recipients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipients_default_template_id_email_templates_id_fk": {
+          "name": "email_recipients_default_template_id_email_templates_id_fk",
+          "tableFrom": "email_recipients",
+          "tableTo": "email_templates",
+          "columnsFrom": [
+            "default_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_recipients_user_id_email_unique": {
+          "name": "email_recipients_user_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "email"
+          ]
+        },
+        "email_recipients_id_user_id_unique": {
+          "name": "email_recipients_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_recipients_device_type_chk": {
+          "name": "email_recipients_device_type_chk",
+          "value": "\"email_recipients\".\"device_type\" is null or \"email_recipients\".\"device_type\" in ('kindle', 'kobo', 'other')"
+        },
+        "email_recipients_preferred_format_chk": {
+          "name": "email_recipients_preferred_format_chk",
+          "value": "\"email_recipients\".\"preferred_format\" is null or \"email_recipients\".\"preferred_format\" in ('epub', 'pdf', 'mobi', 'azw3', 'cbz', 'cbr')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_preferences": {
+      "name": "email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_provider_id": {
+          "name": "default_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_recipient_id": {
+          "name": "default_recipient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_template_id": {
+          "name": "default_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_preferences_user_id_users_id_fk": {
+          "name": "email_preferences_user_id_users_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_provider_id_email_providers_id_fk": {
+          "name": "email_preferences_default_provider_id_email_providers_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_providers",
+          "columnsFrom": [
+            "default_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_recipient_id_email_recipients_id_fk": {
+          "name": "email_preferences_default_recipient_id_email_recipients_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_recipients",
+          "columnsFrom": [
+            "default_recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_template_id_email_templates_id_fk": {
+          "name": "email_preferences_default_template_id_email_templates_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_templates",
+          "columnsFrom": [
+            "default_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_recipient_owner_fk": {
+          "name": "email_preferences_default_recipient_owner_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_recipients",
+          "columnsFrom": [
+            "default_recipient_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_preferences_user_id_unique": {
+          "name": "email_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_send_log": {
+      "name": "email_send_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_email": {
+          "name": "to_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_name": {
+          "name": "to_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_send_log_user_created_at_idx": {
+          "name": "email_send_log_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_send_log_created_at_idx": {
+          "name": "email_send_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_send_log_status_next_retry_idx": {
+          "name": "email_send_log_status_next_retry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_send_log_user_id_users_id_fk": {
+          "name": "email_send_log_user_id_users_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_send_log_book_id_books_id_fk": {
+          "name": "email_send_log_book_id_books_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_send_log_book_file_id_book_files_id_fk": {
+          "name": "email_send_log_book_file_id_book_files_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_send_log_provider_id_email_providers_id_fk": {
+          "name": "email_send_log_provider_id_email_providers_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "email_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_send_log_template_id_email_templates_id_fk": {
+          "name": "email_send_log_template_id_email_templates_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "email_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_send_log_status_chk": {
+          "name": "email_send_log_status_chk",
+          "value": "\"email_send_log\".\"status\" in ('pending', 'sent', 'failed')"
+        },
+        "email_send_log_attempt_count_nonnegative_chk": {
+          "name": "email_send_log_attempt_count_nonnegative_chk",
+          "value": "\"email_send_log\".\"attempt_count\" >= 0"
+        },
+        "email_send_log_sent_after_created_chk": {
+          "name": "email_send_log_sent_after_created_chk",
+          "value": "\"email_send_log\".\"sent_at\" is null or \"email_send_log\".\"sent_at\" >= \"email_send_log\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dismissed_duplicate_pairs": {
+      "name": "dismissed_duplicate_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_a": {
+          "name": "entity_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_b": {
+          "name": "entity_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by": {
+          "name": "dismissed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dismissed_duplicate_pairs_entity_a_idx": {
+          "name": "dismissed_duplicate_pairs_entity_a_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dismissed_duplicate_pairs_entity_b_idx": {
+          "name": "dismissed_duplicate_pairs_entity_b_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dismissed_duplicate_pairs_dismissed_by_users_id_fk": {
+          "name": "dismissed_duplicate_pairs_dismissed_by_users_id_fk",
+          "tableFrom": "dismissed_duplicate_pairs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "dismissed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dismissed_duplicate_pairs_unique": {
+          "name": "dismissed_duplicate_pairs_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "entity_id_a",
+            "entity_id_b"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dismissed_inline_duplicate_pairs": {
+      "name": "dismissed_inline_duplicate_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_a": {
+          "name": "value_a",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_b": {
+          "name": "value_b",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by": {
+          "name": "dismissed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dismissed_inline_pairs_entity_a_idx": {
+          "name": "dismissed_inline_pairs_entity_a_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dismissed_inline_pairs_entity_b_idx": {
+          "name": "dismissed_inline_pairs_entity_b_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dismissed_inline_duplicate_pairs_dismissed_by_users_id_fk": {
+          "name": "dismissed_inline_duplicate_pairs_dismissed_by_users_id_fk",
+          "tableFrom": "dismissed_inline_duplicate_pairs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "dismissed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dismissed_inline_duplicate_pairs_unique": {
+          "name": "dismissed_inline_duplicate_pairs_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "value_a",
+            "value_b"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_duplicate_candidates": {
+      "name": "entity_duplicate_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_a": {
+          "name": "entity_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_b": {
+          "name": "entity_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sim_score": {
+          "name": "sim_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_dup_candidates_type_sim_idx": {
+          "name": "entity_dup_candidates_type_sim_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sim_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_dup_candidates_entity_a_idx": {
+          "name": "entity_dup_candidates_entity_a_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_dup_candidates_entity_b_idx": {
+          "name": "entity_dup_candidates_entity_b_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_duplicate_candidates_unique": {
+          "name": "entity_duplicate_candidates_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "entity_id_a",
+            "entity_id_b"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_duplicate_scan_status": {
+      "name": "entity_duplicate_scan_status",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_computing": {
+          "name": "is_computing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pairs": {
+          "name": "total_pairs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_count": {
+          "name": "processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fonts": {
+      "name": "user_fonts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_name": {
+          "name": "stored_file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 400
+        },
+        "style": {
+          "name": "style",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uf_user_hash_uidx": {
+          "name": "uf_user_hash_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uf_user_family_weight_style_uidx": {
+          "name": "uf_user_family_weight_style_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "family_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "style",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fonts_user_id_users_id_fk": {
+          "name": "user_fonts_user_id_users_id_fk",
+          "tableFrom": "user_fonts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_fonts_format_chk": {
+          "name": "user_fonts_format_chk",
+          "value": "\"user_fonts\".\"format\" in ('ttf', 'otf', 'woff', 'woff2')"
+        },
+        "user_fonts_weight_chk": {
+          "name": "user_fonts_weight_chk",
+          "value": "\"user_fonts\".\"weight\" >= 100 and \"user_fonts\".\"weight\" <= 900 and \"user_fonts\".\"weight\" % 100 = 0"
+        },
+        "user_fonts_style_chk": {
+          "name": "user_fonts_style_chk",
+          "value": "\"user_fonts\".\"style\" in ('normal', 'italic')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_file_chapters": {
+      "name": "book_file_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_index": {
+          "name": "chapter_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spine_index": {
+          "name": "spine_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "book_file_chapters_book_file_id_chapter_index_uidx": {
+          "name": "book_file_chapters_book_file_id_chapter_index_uidx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_file_chapters_book_file_id_idx": {
+          "name": "book_file_chapters_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_file_chapters_book_file_id_book_files_id_fk": {
+          "name": "book_file_chapters_book_file_id_book_files_id_fk",
+          "tableFrom": "book_file_chapters",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_file_hash_history": {
+      "name": "book_file_hash_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_file_hash_history_book_file_id_file_hash_idx": {
+          "name": "book_file_hash_history_book_file_id_file_hash_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_file_hash_history_file_hash_idx": {
+          "name": "book_file_hash_history_file_hash_idx",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_file_hash_history_book_file_id_book_files_id_fk": {
+          "name": "book_file_hash_history_book_file_id_book_files_id_fk",
+          "tableFrom": "book_file_hash_history",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_file_hash_history_reason_chk": {
+          "name": "book_file_hash_history_reason_chk",
+          "value": "\"book_file_hash_history\".\"reason\" in ('file_write', 'external_change', 'rescan')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_book_stats": {
+      "name": "koreader_book_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_read_secs": {
+          "name": "total_read_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_read_pages": {
+          "name": "total_read_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "highlights_count": {
+          "name": "highlights_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes_count": {
+          "name": "notes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_open_at": {
+          "name": "last_open_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_book_stats_user_book_file_uidx": {
+          "name": "koreader_book_stats_user_book_file_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_book_stats_user_idx": {
+          "name": "koreader_book_stats_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_book_stats_book_file_id_book_files_id_fk": {
+          "name": "koreader_book_stats_book_file_id_book_files_id_fk",
+          "tableFrom": "koreader_book_stats",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "koreader_book_stats_user_id_users_id_fk": {
+          "name": "koreader_book_stats_user_id_users_id_fk",
+          "tableFrom": "koreader_book_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.koreader_device_progress": {
+      "name": "koreader_device_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'KOReader'"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_index": {
+          "name": "chapter_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_timestamp": {
+          "name": "sync_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned": {
+          "name": "orphaned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "orphaned_hash": {
+          "name": "orphaned_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_device_progress_book_user_device_uidx": {
+          "name": "koreader_device_progress_book_user_device_uidx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"koreader_device_progress\".\"orphaned\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_device_progress_orphaned_hash_idx": {
+          "name": "koreader_device_progress_orphaned_hash_idx",
+          "columns": [
+            {
+              "expression": "orphaned_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"koreader_device_progress\".\"orphaned\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_device_progress_user_updated_at_idx": {
+          "name": "koreader_device_progress_user_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_device_progress_book_file_id_idx": {
+          "name": "koreader_device_progress_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"koreader_device_progress\".\"book_file_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_device_progress_book_file_id_book_files_id_fk": {
+          "name": "koreader_device_progress_book_file_id_book_files_id_fk",
+          "tableFrom": "koreader_device_progress",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "koreader_device_progress_user_id_users_id_fk": {
+          "name": "koreader_device_progress_user_id_users_id_fk",
+          "tableFrom": "koreader_device_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_device_progress_percentage_range_chk": {
+          "name": "koreader_device_progress_percentage_range_chk",
+          "value": "\"koreader_device_progress\".\"percentage\" is null or (\"koreader_device_progress\".\"percentage\" >= 0 and \"koreader_device_progress\".\"percentage\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_reading_sessions": {
+      "name": "koreader_reading_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_hash": {
+          "name": "session_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_pages": {
+          "name": "total_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_reading_sessions_session_hash_uidx": {
+          "name": "koreader_reading_sessions_session_hash_uidx",
+          "columns": [
+            {
+              "expression": "session_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_reading_sessions_book_user_started_idx": {
+          "name": "koreader_reading_sessions_book_user_started_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_reading_sessions_user_idx": {
+          "name": "koreader_reading_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_reading_sessions_book_file_id_book_files_id_fk": {
+          "name": "koreader_reading_sessions_book_file_id_book_files_id_fk",
+          "tableFrom": "koreader_reading_sessions",
+          "tableTo": "book_files",
+          "columnsFrom": [
+            "book_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "koreader_reading_sessions_user_id_users_id_fk": {
+          "name": "koreader_reading_sessions_user_id_users_id_fk",
+          "tableFrom": "koreader_reading_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.koreader_users": {
+      "name": "koreader_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_md5": {
+          "name": "password_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_enabled": {
+          "name": "sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_users_user_id_uidx": {
+          "name": "koreader_users_user_id_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_users_username_uidx": {
+          "name": "koreader_users_username_uidx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_users_user_id_users_id_fk": {
+          "name": "koreader_users_user_id_users_id_fk",
+          "tableFrom": "koreader_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "achievements_category_sort_idx": {
+          "name": "achievements_category_sort_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "achievements_group_key_idx": {
+          "name": "achievements_group_key_idx",
+          "columns": [
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "achievements_category_chk": {
+          "name": "achievements_category_chk",
+          "value": "\"achievements\".\"category\" in ('reading', 'library', 'exploration', 'dedication')"
+        },
+        "achievements_rarity_chk": {
+          "name": "achievements_rarity_chk",
+          "value": "\"achievements\".\"rarity\" in ('common', 'rare', 'epic', 'legendary')"
+        },
+        "achievements_tier_chk": {
+          "name": "achievements_tier_chk",
+          "value": "\"achievements\".\"tier\" is null or (\"achievements\".\"tier\" >= 1 and \"achievements\".\"tier\" <= 4)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_key": {
+          "name": "achievement_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "context_json": {
+          "name": "context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_achievements_user_key_uidx": {
+          "name": "user_achievements_user_key_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "achievement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_user_id_idx": {
+          "name": "user_achievements_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_user_awarded_at_idx": {
+          "name": "user_achievements_user_awarded_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "awarded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_key_achievements_key_fk": {
+          "name": "user_achievements_achievement_key_achievements_key_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hardcover_book_state": {
+      "name": "hardcover_book_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hardcover_book_id": {
+          "name": "hardcover_book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_edition_id": {
+          "name": "hardcover_edition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_user_book_id": {
+          "name": "hardcover_user_book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_read_id": {
+          "name": "hardcover_read_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_error": {
+          "name": "match_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_status": {
+          "name": "last_synced_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_progress": {
+          "name": "last_synced_progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_rating": {
+          "name": "last_synced_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_started_at": {
+          "name": "last_synced_started_at",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_finished_at": {
+          "name": "last_synced_finished_at",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hardcover_book_state_user_id_users_id_fk": {
+          "name": "hardcover_book_state_user_id_users_id_fk",
+          "tableFrom": "hardcover_book_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hardcover_book_state_book_id_books_id_fk": {
+          "name": "hardcover_book_state_book_id_books_id_fk",
+          "tableFrom": "hardcover_book_state",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hardcover_book_state_user_book_uidx": {
+          "name": "hardcover_book_state_user_book_uidx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "book_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hardcover_user_settings": {
+      "name": "hardcover_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_sync_on_status_change": {
+          "name": "auto_sync_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_sync_on_progress_update": {
+          "name": "auto_sync_on_progress_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_sync_on_rating_change": {
+          "name": "auto_sync_on_rating_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_setting_id": {
+          "name": "privacy_setting_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hardcover_user_settings_user_id_users_id_fk": {
+          "name": "hardcover_user_settings_user_id_users_id_fk",
+          "tableFrom": "hardcover_user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hardcover_user_settings_user_id_unique": {
+          "name": "hardcover_user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "up_user_category_idx": {
+          "name": "up_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.content_filter_type": {
+      "name": "content_filter_type",
+      "schema": "public",
+      "values": [
+        "include",
+        "exclude"
+      ]
+    },
+    "public.library_access_level": {
+      "name": "library_access_level",
+      "schema": "public",
+      "values": [
+        "viewer",
+        "editor",
+        "owner"
+      ]
+    },
+    "public.user_avatar_source": {
+      "name": "user_avatar_source",
+      "schema": "public",
+      "values": [
+        "none",
+        "external",
+        "uploaded"
+      ]
+    },
+    "public.opds_sort_order": {
+      "name": "opds_sort_order",
+      "schema": "public",
+      "values": [
+        "recent",
+        "title_asc",
+        "title_desc",
+        "author_asc",
+        "author_desc",
+        "series_asc",
+        "series_desc"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1780190394625,
       "tag": "0010_fix_reading_threshold",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1780284270418,
+      "tag": "0011_koreader-stats-ingestion",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema/koreader.ts
+++ b/server/src/db/schema/koreader.ts
@@ -108,3 +108,56 @@ export const bookFileChapters = pgTable(
 
 export type BookFileChapter = typeof bookFileChapters.$inferSelect;
 export type NewBookFileChapter = typeof bookFileChapters.$inferInsert;
+
+export const koreaderReadingSessions = pgTable(
+  'koreader_reading_sessions',
+  {
+    id: serial('id').primaryKey(),
+    bookFileId: integer('book_file_id')
+      .notNull()
+      .references(() => bookFiles.id, { onDelete: 'cascade' }),
+    userId: integer('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    sessionHash: varchar('session_hash', { length: 64 }).notNull(),
+    page: integer('page').notNull(),
+    startedAt: timestamp('started_at', { withTimezone: true }).notNull(),
+    durationSeconds: integer('duration_seconds').notNull(),
+    totalPages: integer('total_pages').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (t) => [
+    uniqueIndex('koreader_reading_sessions_session_hash_uidx').on(t.sessionHash),
+    index('koreader_reading_sessions_book_user_started_idx').on(t.bookFileId, t.userId, t.startedAt),
+    index('koreader_reading_sessions_user_idx').on(t.userId),
+  ],
+);
+
+export type KoreaderReadingSessionRow = typeof koreaderReadingSessions.$inferSelect;
+export type NewKoreaderReadingSession = typeof koreaderReadingSessions.$inferInsert;
+
+export const koreaderBookStats = pgTable(
+  'koreader_book_stats',
+  {
+    id: serial('id').primaryKey(),
+    bookFileId: integer('book_file_id')
+      .notNull()
+      .references(() => bookFiles.id, { onDelete: 'cascade' }),
+    userId: integer('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    totalReadSecs: integer('total_read_secs').notNull().default(0),
+    totalReadPages: integer('total_read_pages').notNull().default(0),
+    highlightsCount: integer('highlights_count').notNull().default(0),
+    notesCount: integer('notes_count').notNull().default(0),
+    lastOpenAt: timestamp('last_open_at', { withTimezone: true }),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdateFn(() => new Date()),
+  },
+  (t) => [uniqueIndex('koreader_book_stats_user_book_file_uidx').on(t.userId, t.bookFileId), index('koreader_book_stats_user_idx').on(t.userId)],
+);
+
+export type KoreaderBookStatsRow = typeof koreaderBookStats.$inferSelect;
+export type NewKoreaderBookStats = typeof koreaderBookStats.$inferInsert;

--- a/server/src/modules/koreader/dto/index.ts
+++ b/server/src/modules/koreader/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './koreader-progress.dto';
 export * from './koreader-user.dto';
+export * from './save-stats.dto';

--- a/server/src/modules/koreader/dto/save-stats.dto.ts
+++ b/server/src/modules/koreader/dto/save-stats.dto.ts
@@ -1,0 +1,108 @@
+import { Type } from 'class-transformer';
+import { IsArray, IsInt, IsNumber, IsOptional, IsString, Min, ValidateNested } from 'class-validator';
+
+export class PageSessionDto {
+  @IsInt()
+  @Min(1)
+  page!: number;
+
+  @IsInt()
+  @Min(0)
+  start_time!: number;
+
+  @IsInt()
+  @Min(1)
+  duration!: number;
+
+  @IsInt()
+  @Min(1)
+  total_pages!: number;
+}
+
+export class BookStatsDto {
+  @IsString()
+  document!: string;
+
+  @IsString()
+  @IsOptional()
+  md5?: string;
+
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  authors?: string;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  pages?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  id_book?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  total_read_secs?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  total_read_mins?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  total_read_pages?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  highlights?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  notes?: number;
+
+  @IsNumber()
+  @Min(0)
+  @IsOptional()
+  last_open?: number;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PageSessionDto)
+  @IsOptional()
+  page_sessions?: PageSessionDto[];
+}
+
+export class SaveStatsDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => BookStatsDto)
+  books!: BookStatsDto[];
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  since?: number;
+
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  timestamp?: number;
+
+  @IsString()
+  @IsOptional()
+  device?: string;
+
+  @IsString()
+  @IsOptional()
+  device_id?: string;
+}

--- a/server/src/modules/koreader/koreader.controller.ts
+++ b/server/src/modules/koreader/koreader.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, ForbiddenException, Get, Headers, Param, ParseIntPipe, Patch, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, ForbiddenException, Get, Headers, Param, ParseIntPipe, Patch, Post, Put, Query, UseGuards } from '@nestjs/common';
 
 import { Permission } from '@bookorbit/types';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
@@ -7,7 +7,7 @@ import { RequirePermission } from '../../common/decorators/require-permission.de
 import type { RequestUser } from '../../common/types/request-user';
 import { KoreaderAuthGuard } from './koreader-auth.guard';
 import { KoreaderService } from './koreader.service';
-import { CreateKoreaderUserDto, SaveProgressDto, TestConnectionDto, UpdateKoreaderUserDto } from './dto';
+import { CreateKoreaderUserDto, SaveProgressDto, SaveStatsDto, TestConnectionDto, UpdateKoreaderUserDto } from './dto';
 
 @Controller('koreader')
 export class KoreaderController {
@@ -33,6 +33,20 @@ export class KoreaderController {
   @Put('syncs/progress')
   async saveProgress(@CurrentUser() user: RequestUser, @Body() dto: SaveProgressDto) {
     return this.koreaderService.saveProgress(user.id, dto);
+  }
+
+  @Public()
+  @UseGuards(KoreaderAuthGuard)
+  @Put('progress')
+  async saveProgressAlias(@CurrentUser() user: RequestUser, @Body() dto: SaveProgressDto) {
+    return this.koreaderService.saveProgress(user.id, dto);
+  }
+
+  @Public()
+  @UseGuards(KoreaderAuthGuard)
+  @Post('stats')
+  async saveStats(@CurrentUser() user: RequestUser, @Body() dto: SaveStatsDto) {
+    return this.koreaderService.saveStats(user.id, dto);
   }
 
   @Public()
@@ -91,9 +105,80 @@ export class KoreaderController {
   }
 
   @RequirePermission(Permission.KoreaderSync)
+  @Get('books/:bookId/stats')
+  async getBookStats(
+    @CurrentUser() user: RequestUser,
+    @Param('bookId', ParseIntPipe) bookId: number,
+    @Query('page', new ParseIntPipe({ optional: true })) page = 1,
+    @Query('pageSize', new ParseIntPipe({ optional: true })) pageSize = 20,
+  ) {
+    return this.koreaderService.getKoreaderTabData(user.id, bookId, page, pageSize);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('aggregate-stats')
+  async getAggregateStats(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderAggregateSyncStats(user.id);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
   @Post('test-connection')
   async testConnection(@CurrentUser() user: RequestUser, @Body() dto: TestConnectionDto) {
     const success = await this.koreaderService.testConnection(user.id, dto.username, dto.password);
     return { success, username: dto.username, serverUrl: '/api/koreader' };
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('statistics/summary')
+  getStatsSummary(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderStatsSummary(user.id);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('statistics/heatmap')
+  getActivityHeatmap(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderActivityHeatmap(user.id);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('statistics/monthly')
+  getMonthlyReading(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderMonthlyReading(user.id);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('statistics/time-of-day')
+  getTimeOfDay(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderTimeOfDay(user.id);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('statistics/session-lengths')
+  getSessionLengths(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderSessionLengths(user.id);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('statistics/top-books')
+  getTopBooks(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderTopBooks(user.id);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('statistics/top-annotated')
+  getTopAnnotated(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderTopAnnotated(user.id);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('statistics/weekly-rhythm')
+  getKoreaderWeeklyRhythm(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderWeeklyRhythm(user.id);
+  }
+
+  @RequirePermission(Permission.KoreaderSync)
+  @Get('statistics/devices')
+  getKoreaderStatDevices(@CurrentUser() user: RequestUser) {
+    return this.koreaderService.getKoreaderDevices(user.id);
   }
 }

--- a/server/src/modules/koreader/koreader.repository.test.ts
+++ b/server/src/modules/koreader/koreader.repository.test.ts
@@ -40,6 +40,23 @@ function makeDb() {
   };
 }
 
+function getSqlTextFromExecuteCall(arg: unknown): string {
+  if (!arg || typeof arg !== 'object' || !('queryChunks' in arg)) return '';
+  const queryChunks = (arg as { queryChunks?: unknown }).queryChunks;
+  if (!Array.isArray(queryChunks)) return '';
+
+  return queryChunks
+    .map((chunk) => {
+      if (chunk && typeof chunk === 'object' && 'value' in chunk) {
+        const value = (chunk as { value?: unknown }).value;
+        return Array.isArray(value) ? value.join('') : '';
+      }
+
+      return '?';
+    })
+    .join('');
+}
+
 describe('KoreaderRepository', () => {
   let db: ReturnType<typeof makeDb>;
   let repo: KoreaderRepository;
@@ -565,8 +582,14 @@ describe('KoreaderRepository', () => {
       });
 
       const result = await repo.getKoreaderTopBooks(7);
+      const sqlText = getSqlTextFromExecuteCall(db.execute.mock.calls[0]?.[0]);
 
       expect(result).toEqual([{ bookId: 11, title: 'Book A', totalReadSecs: 5400 }]);
+      expect(sqlText).toContain('LEFT JOIN book_metadata bm ON bm.book_id = b.id');
+      expect(sqlText).toContain("coalesce(nullif(bm.title, ''), 'Unknown Book') AS title");
+      expect(sqlText).toContain('GROUP BY b.id, bm.title');
+      expect(sqlText).not.toContain('coalesce(b.title');
+      expect(sqlText).not.toContain('GROUP BY b.id, b.title');
     });
 
     it('getKoreaderTopAnnotated maps annotation aggregates', async () => {
@@ -575,8 +598,14 @@ describe('KoreaderRepository', () => {
       });
 
       const result = await repo.getKoreaderTopAnnotated(7);
+      const sqlText = getSqlTextFromExecuteCall(db.execute.mock.calls[0]?.[0]);
 
       expect(result).toEqual([{ bookId: 11, title: 'Book A', highlightsCount: 12, notesCount: 2 }]);
+      expect(sqlText).toContain('LEFT JOIN book_metadata bm ON bm.book_id = b.id');
+      expect(sqlText).toContain("coalesce(nullif(bm.title, ''), 'Unknown Book') AS title");
+      expect(sqlText).toContain('GROUP BY b.id, bm.title');
+      expect(sqlText).not.toContain('coalesce(b.title');
+      expect(sqlText).not.toContain('GROUP BY b.id, b.title');
     });
 
     it('getKoreaderWeeklyRhythm maps weekday aggregates', async () => {

--- a/server/src/modules/koreader/koreader.repository.test.ts
+++ b/server/src/modules/koreader/koreader.repository.test.ts
@@ -12,7 +12,17 @@ function makeQueryChain(result: unknown) {
   chain.leftJoin = vi.fn().mockReturnValue(chain);
   chain.where = vi.fn().mockReturnValue(chain);
   chain.orderBy = vi.fn().mockReturnValue(chain);
-  chain.limit = vi.fn().mockResolvedValue(result);
+  chain.limit = vi.fn().mockReturnValue(chain);
+  chain.offset = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+
+function makeInsertChain() {
+  const chain: Record<string, unknown> = {};
+  chain.returning = vi.fn().mockResolvedValue([]);
+  chain.onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  chain.onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+  chain.values = vi.fn().mockReturnValue(chain);
   return chain;
 }
 
@@ -116,6 +126,180 @@ describe('KoreaderRepository', () => {
     });
   });
 
+  describe('credential CRUD helpers', () => {
+    it('findKoreaderUser delegates to query.koreaderUsers', async () => {
+      const row = { userId: 7, username: 'reader' };
+      db.query.koreaderUsers.findFirst.mockResolvedValue(row);
+
+      const result = await repo.findKoreaderUser(7);
+
+      expect(db.query.koreaderUsers.findFirst).toHaveBeenCalledTimes(1);
+      expect(result).toBe(row);
+    });
+
+    it('findKoreaderUserByUsername delegates to query.koreaderUsers', async () => {
+      const row = { userId: 7, username: 'reader' };
+      db.query.koreaderUsers.findFirst.mockResolvedValue(row);
+
+      const result = await repo.findKoreaderUserByUsername('reader');
+
+      expect(db.query.koreaderUsers.findFirst).toHaveBeenCalledTimes(1);
+      expect(result).toBe(row);
+    });
+
+    it('createKoreaderUser returns first inserted row', async () => {
+      const row = { userId: 7, username: 'reader' };
+      const insertChain = makeInsertChain();
+      insertChain.returning = vi.fn().mockResolvedValue([row]);
+      db.insert.mockReturnValue(insertChain);
+
+      const result = await repo.createKoreaderUser({
+        userId: 7,
+        username: 'reader',
+        passwordHash: 'hash',
+        passwordMd5: 'md5',
+      });
+
+      expect(insertChain.values).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(row);
+    });
+
+    it('updateKoreaderUser issues update with where clause', async () => {
+      const where = vi.fn().mockResolvedValue(undefined);
+      const set = vi.fn().mockReturnValue({ where });
+      db.update.mockReturnValue({ set });
+
+      await repo.updateKoreaderUser(7, { syncEnabled: false });
+
+      expect(set).toHaveBeenCalledWith({ syncEnabled: false });
+      expect(where).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('progress helpers', () => {
+    it('upsertDeviceProgress writes row and conflict update clause', async () => {
+      const insertChain = makeInsertChain();
+      db.insert.mockReturnValue(insertChain);
+
+      await repo.upsertDeviceProgress({
+        bookFileId: 44,
+        userId: 12,
+        device: 'Kobo',
+        deviceId: 'device-1',
+        percentage: 55.5,
+        progress: '/body/DocFragment[1]/body',
+        chapterIndex: 0,
+        syncTimestamp: 1_700_000_000,
+      });
+
+      expect(insertChain.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bookFileId: 44,
+          userId: 12,
+          orphaned: false,
+          orphanedHash: null,
+        }),
+      );
+      expect(insertChain.onConflictDoUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    it('getLatestDeviceProgress returns first row or null', async () => {
+      db.select.mockReturnValueOnce(makeQueryChain([{ id: 9 }])).mockReturnValueOnce(makeQueryChain([]));
+
+      await expect(repo.getLatestDeviceProgress(44, 12)).resolves.toEqual({ id: 9 });
+      await expect(repo.getLatestDeviceProgress(44, 12)).resolves.toBeNull();
+    });
+
+    it('getReadingProgress returns first row or null', async () => {
+      db.select.mockReturnValueOnce(makeQueryChain([{ id: 3 }])).mockReturnValueOnce(makeQueryChain([]));
+
+      await expect(repo.getReadingProgress(44, 12)).resolves.toEqual({ id: 3 });
+      await expect(repo.getReadingProgress(44, 12)).resolves.toBeNull();
+    });
+
+    it('getAllDeviceProgress returns ordered rows', async () => {
+      const rows = [{ id: 2 }, { id: 1 }];
+      db.select.mockReturnValue(makeQueryChain(rows));
+
+      const result = await repo.getAllDeviceProgress(44, 12);
+
+      expect(result).toEqual(rows);
+    });
+
+    it('getBookProgressForDashboard combines device and reading progress lookups', async () => {
+      db.select.mockReturnValueOnce(makeQueryChain([{ id: 2 }])).mockReturnValueOnce(makeQueryChain([{ id: 1 }]));
+
+      const result = await repo.getBookProgressForDashboard(44, 12);
+
+      expect(result).toEqual({
+        deviceProgress: [{ id: 2 }],
+        readingProgress: { id: 1 },
+      });
+    });
+  });
+
+  describe('device/list aggregation helpers', () => {
+    it('getDevicesList maps raw rows into API shape', async () => {
+      db.execute.mockResolvedValue({
+        rows: [
+          {
+            device: 'Kobo Libra',
+            device_id: 'device-1',
+            last_sync_at: new Date('2026-01-01T00:00:00.000Z'),
+            last_book_title: 'Project Hail Mary',
+          },
+        ],
+      });
+
+      const result = await repo.getDevicesList(7);
+
+      expect(result).toEqual([
+        {
+          device: 'Kobo Libra',
+          deviceId: 'device-1',
+          lastSyncAt: new Date('2026-01-01T00:00:00.000Z'),
+          lastBookTitle: 'Project Hail Mary',
+        },
+      ]);
+    });
+
+    it('getTotalSyncedBooks returns numeric distinct count', async () => {
+      db.select.mockReturnValue(makeQueryChain([{ count: '8' }]));
+
+      const result = await repo.getTotalSyncedBooks(7);
+
+      expect(result).toBe(8);
+    });
+  });
+
+  describe('chapter/session utility queries', () => {
+    it('getChapters returns ordered chapter rows', async () => {
+      const rows = [{ chapterIndex: 0, title: 'Chapter 1' }];
+      db.select.mockReturnValue(makeQueryChain(rows));
+
+      const result = await repo.getChapters(44);
+
+      expect(result).toEqual(rows);
+    });
+
+    it('hasKoreaderBookStats returns true when row exists', async () => {
+      db.select.mockReturnValueOnce(makeQueryChain([{ id: 1 }])).mockReturnValueOnce(makeQueryChain([]));
+
+      await expect(repo.hasKoreaderBookStats(44, 12)).resolves.toBe(true);
+      await expect(repo.hasKoreaderBookStats(44, 12)).resolves.toBe(false);
+    });
+
+    it('getKoreaderSessionsDailySummary maps day aggregates', async () => {
+      db.execute.mockResolvedValue({
+        rows: [{ day: '2026-01-01', duration_seconds: '900' }],
+      });
+
+      const result = await repo.getKoreaderSessionsDailySummary(44, 12);
+
+      expect(result).toEqual([{ day: '2026-01-01', durationSeconds: 900 }]);
+    });
+  });
+
   describe('findBookFileIdByBookId', () => {
     it('returns the book file id when found', async () => {
       db.select.mockReturnValue(makeQueryChain([{ id: 5 }]));
@@ -153,6 +337,110 @@ describe('KoreaderRepository', () => {
     });
   });
 
+  describe('upsertKoreaderBookStats', () => {
+    it('inserts and configures conflict handling', async () => {
+      const insertChain = makeInsertChain();
+      db.insert.mockReturnValue(insertChain);
+
+      await repo.upsertKoreaderBookStats({
+        bookFileId: 44,
+        userId: 12,
+        totalReadSecs: 3600,
+        totalReadPages: 100,
+        highlightsCount: 3,
+        notesCount: 1,
+        lastOpenAt: new Date('2026-01-01T00:00:00.000Z'),
+      });
+
+      expect(db.insert).toHaveBeenCalledTimes(1);
+      expect(insertChain.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bookFileId: 44,
+          userId: 12,
+          totalReadSecs: 3600,
+        }),
+      );
+      expect(insertChain.onConflictDoUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('bulkInsertKoreaderReadingSessions', () => {
+    it('skips inserts for empty arrays', async () => {
+      await repo.bulkInsertKoreaderReadingSessions([]);
+
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('inserts non-empty session arrays', async () => {
+      const insertChain = makeInsertChain();
+      db.insert.mockReturnValue(insertChain);
+      const sessions = [
+        {
+          bookFileId: 44,
+          userId: 12,
+          sessionHash: 'hash',
+          page: 5,
+          startedAt: new Date('2026-01-01T00:00:00.000Z'),
+          durationSeconds: 120,
+          totalPages: 300,
+        },
+      ];
+
+      await repo.bulkInsertKoreaderReadingSessions(sessions);
+
+      expect(db.insert).toHaveBeenCalledTimes(1);
+      expect(insertChain.values).toHaveBeenCalledWith(sessions);
+      expect(insertChain.onConflictDoNothing).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getKoreaderBookStats', () => {
+    it('returns null when no row exists', async () => {
+      db.select.mockReturnValue(makeQueryChain([]));
+
+      const result = await repo.getKoreaderBookStats(44, 12);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns the row when found', async () => {
+      const row = { id: 1, bookFileId: 44, userId: 12, totalReadSecs: 3600 };
+      db.select.mockReturnValue(makeQueryChain([row]));
+
+      const result = await repo.getKoreaderBookStats(44, 12);
+
+      expect(result).toBe(row);
+    });
+  });
+
+  describe('getKoreaderReadingSessions', () => {
+    it('returns paginated rows and total count', async () => {
+      const countChain = makeQueryChain([{ count: '2' }]);
+      const rowsChain = makeQueryChain([
+        { id: 2, page: 7, startedAt: new Date('2026-01-02T00:00:00.000Z') },
+        { id: 1, page: 5, startedAt: new Date('2026-01-01T00:00:00.000Z') },
+      ]);
+      db.select.mockReturnValueOnce(countChain).mockReturnValueOnce(rowsChain);
+
+      const result = await repo.getKoreaderReadingSessions(44, 12, 2, 5);
+
+      expect(result.total).toBe(2);
+      expect(result.rows).toHaveLength(2);
+      expect(rowsChain.limit).toHaveBeenCalledWith(5);
+      expect(rowsChain.offset).toHaveBeenCalledWith(5);
+    });
+  });
+
+  describe('getKoreaderAggregateStats', () => {
+    it('converts aggregate results to numbers', async () => {
+      db.select.mockReturnValue(makeQueryChain([{ booksWithStats: '3', totalReadingSeconds: '7200' }]));
+
+      const result = await repo.getKoreaderAggregateStats(12);
+
+      expect(result).toEqual({ booksWithStats: 3, totalReadingSeconds: 7200 });
+    });
+  });
+
   describe('upsertReadingProgress', () => {
     it('upserts percentage and clears stale web locator fields on conflict', async () => {
       const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
@@ -183,6 +471,132 @@ describe('KoreaderRepository', () => {
 
       const conflictArg = onConflictDoUpdate.mock.calls[0]?.[0] as { set?: Record<string, unknown> } | undefined;
       expect(conflictArg?.set?.['updatedAt']).toBeDefined();
+    });
+  });
+
+  describe('KOReader statistics queries', () => {
+    it('getKoreaderStatsActiveDates returns ordered day strings', async () => {
+      db.execute.mockResolvedValue({
+        rows: [{ day: '2026-01-01' }, { day: '2026-01-03' }],
+      });
+
+      const result = await repo.getKoreaderStatsActiveDates(7);
+
+      expect(db.execute).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(['2026-01-01', '2026-01-03']);
+    });
+
+    it('getKoreaderStatsTotals normalizes numeric aggregates', async () => {
+      db.execute
+        .mockResolvedValueOnce({
+          rows: [{ total_sessions: '5', total_duration_secs: '3600' }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ total_highlights: '7', total_notes: '3', books_with_stats: '2' }],
+        });
+
+      const result = await repo.getKoreaderStatsTotals(7);
+
+      expect(db.execute).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({
+        totalSessions: 5,
+        totalDurationSecs: 3600,
+        totalHighlights: 7,
+        totalNotes: 3,
+        booksWithStats: 2,
+      });
+    });
+
+    it('getKoreaderActivityHeatmap maps rows to typed points', async () => {
+      db.execute.mockResolvedValue({
+        rows: [{ date: '2026-02-01', duration_seconds: '1800' }],
+      });
+
+      const result = await repo.getKoreaderActivityHeatmap(7);
+
+      expect(result).toEqual([{ date: '2026-02-01', durationSeconds: 1800 }]);
+    });
+
+    it('getKoreaderMonthlyReading maps month aggregates', async () => {
+      db.execute.mockResolvedValue({
+        rows: [
+          { year: '2026', month: '1', duration_seconds: '1200' },
+          { year: '2026', month: '2', duration_seconds: '0' },
+        ],
+      });
+
+      const result = await repo.getKoreaderMonthlyReading(7);
+
+      expect(result).toEqual([
+        { year: 2026, month: 1, durationSeconds: 1200 },
+        { year: 2026, month: 2, durationSeconds: 0 },
+      ]);
+    });
+
+    it('getKoreaderTimeOfDay maps hour aggregates', async () => {
+      db.execute.mockResolvedValue({
+        rows: [{ hour: '9', duration_seconds: '600' }],
+      });
+
+      const result = await repo.getKoreaderTimeOfDay(7);
+
+      expect(result).toEqual([{ hour: 9, durationSeconds: 600 }]);
+    });
+
+    it('getKoreaderSessionLengths maps bins and preserves open-ended max', async () => {
+      db.execute.mockResolvedValue({
+        rows: [
+          { label: '0-5m', min_secs: '0', max_secs: '300', count: '4' },
+          { label: '2h+', min_secs: '7200', max_secs: null, count: '1' },
+        ],
+      });
+
+      const result = await repo.getKoreaderSessionLengths(7);
+
+      expect(result).toEqual([
+        { label: '0-5m', minSecs: 0, maxSecs: 300, count: 4 },
+        { label: '2h+', minSecs: 7200, maxSecs: null, count: 1 },
+      ]);
+    });
+
+    it('getKoreaderTopBooks maps top-book rows', async () => {
+      db.execute.mockResolvedValue({
+        rows: [{ book_id: '11', title: 'Book A', total_read_secs: '5400' }],
+      });
+
+      const result = await repo.getKoreaderTopBooks(7);
+
+      expect(result).toEqual([{ bookId: 11, title: 'Book A', totalReadSecs: 5400 }]);
+    });
+
+    it('getKoreaderTopAnnotated maps annotation aggregates', async () => {
+      db.execute.mockResolvedValue({
+        rows: [{ book_id: '11', title: 'Book A', highlights_count: '12', notes_count: '2' }],
+      });
+
+      const result = await repo.getKoreaderTopAnnotated(7);
+
+      expect(result).toEqual([{ bookId: 11, title: 'Book A', highlightsCount: 12, notesCount: 2 }]);
+    });
+
+    it('getKoreaderWeeklyRhythm maps weekday aggregates', async () => {
+      db.execute.mockResolvedValue({
+        rows: [{ dow: '1', duration_seconds: '900' }],
+      });
+
+      const result = await repo.getKoreaderWeeklyRhythm(7);
+
+      expect(result).toEqual([{ dow: 1, durationSeconds: 900 }]);
+    });
+
+    it('getKoreaderDevices maps device aggregation rows', async () => {
+      db.execute.mockResolvedValue({
+        rows: [{ device: 'Kobo Libra', books_tracked: '3' }],
+      });
+
+      const result = await repo.getKoreaderDevices(7);
+
+      expect(result).toEqual([{ device: 'Kobo Libra', booksTracked: 3 }]);
     });
   });
 });

--- a/server/src/modules/koreader/koreader.repository.ts
+++ b/server/src/modules/koreader/koreader.repository.ts
@@ -517,13 +517,14 @@ export class KoreaderRepository {
     const result = await this.db.execute<{ book_id: number; title: string; total_read_secs: number }>(sql`
       SELECT
         b.id AS book_id,
-        coalesce(b.title, 'Unknown Book') AS title,
+        coalesce(nullif(bm.title, ''), 'Unknown Book') AS title,
         sum(ks.total_read_secs)::integer AS total_read_secs
       FROM koreader_book_stats ks
       INNER JOIN book_files bf ON bf.id = ks.book_file_id
       INNER JOIN books b ON b.id = bf.book_id
+      LEFT JOIN book_metadata bm ON bm.book_id = b.id
       WHERE ks.user_id = ${userId} AND ks.total_read_secs > 0
-      GROUP BY b.id, b.title
+      GROUP BY b.id, bm.title
       ORDER BY total_read_secs DESC
       LIMIT ${limit}
     `);
@@ -537,15 +538,16 @@ export class KoreaderRepository {
     const result = await this.db.execute<{ book_id: number; title: string; highlights_count: number; notes_count: number }>(sql`
       SELECT
         b.id AS book_id,
-        coalesce(b.title, 'Unknown Book') AS title,
+        coalesce(nullif(bm.title, ''), 'Unknown Book') AS title,
         sum(ks.highlights_count)::integer AS highlights_count,
         sum(ks.notes_count)::integer AS notes_count
       FROM koreader_book_stats ks
       INNER JOIN book_files bf ON bf.id = ks.book_file_id
       INNER JOIN books b ON b.id = bf.book_id
+      LEFT JOIN book_metadata bm ON bm.book_id = b.id
       WHERE ks.user_id = ${userId}
         AND (ks.highlights_count > 0 OR ks.notes_count > 0)
-      GROUP BY b.id, b.title
+      GROUP BY b.id, bm.title
       HAVING sum(ks.highlights_count) + sum(ks.notes_count) > 0
       ORDER BY sum(ks.highlights_count) + sum(ks.notes_count) DESC
       LIMIT ${limit}

--- a/server/src/modules/koreader/koreader.repository.ts
+++ b/server/src/modules/koreader/koreader.repository.ts
@@ -249,4 +249,346 @@ export class KoreaderRepository {
       .limit(1);
     return row?.id ?? null;
   }
+
+  async upsertKoreaderBookStats(data: {
+    bookFileId: number;
+    userId: number;
+    totalReadSecs: number;
+    totalReadPages: number;
+    highlightsCount: number;
+    notesCount: number;
+    lastOpenAt: Date | null;
+  }): Promise<void> {
+    await this.db
+      .insert(schema.koreaderBookStats)
+      .values({
+        bookFileId: data.bookFileId,
+        userId: data.userId,
+        totalReadSecs: data.totalReadSecs,
+        totalReadPages: data.totalReadPages,
+        highlightsCount: data.highlightsCount,
+        notesCount: data.notesCount,
+        lastOpenAt: data.lastOpenAt,
+      })
+      .onConflictDoUpdate({
+        target: [schema.koreaderBookStats.userId, schema.koreaderBookStats.bookFileId],
+        set: {
+          totalReadSecs: sql`GREATEST(${schema.koreaderBookStats.totalReadSecs}, EXCLUDED.total_read_secs)`,
+          totalReadPages: sql`GREATEST(${schema.koreaderBookStats.totalReadPages}, EXCLUDED.total_read_pages)`,
+          highlightsCount: data.highlightsCount,
+          notesCount: data.notesCount,
+          lastOpenAt: sql`GREATEST(${schema.koreaderBookStats.lastOpenAt}, EXCLUDED.last_open_at)`,
+          updatedAt: new Date(),
+        },
+      });
+  }
+
+  async bulkInsertKoreaderReadingSessions(
+    sessions: Array<{
+      bookFileId: number;
+      userId: number;
+      sessionHash: string;
+      page: number;
+      startedAt: Date;
+      durationSeconds: number;
+      totalPages: number;
+    }>,
+  ): Promise<void> {
+    if (sessions.length === 0) return;
+    await this.db.insert(schema.koreaderReadingSessions).values(sessions).onConflictDoNothing();
+  }
+
+  async getKoreaderBookStats(bookFileId: number, userId: number): Promise<typeof schema.koreaderBookStats.$inferSelect | null> {
+    const [row] = await this.db
+      .select()
+      .from(schema.koreaderBookStats)
+      .where(and(eq(schema.koreaderBookStats.bookFileId, bookFileId), eq(schema.koreaderBookStats.userId, userId)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async getKoreaderReadingSessions(
+    bookFileId: number,
+    userId: number,
+    page: number,
+    pageSize: number,
+  ): Promise<{ rows: (typeof schema.koreaderReadingSessions.$inferSelect)[]; total: number }> {
+    const offset = (page - 1) * pageSize;
+
+    const [countResult] = await this.db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.koreaderReadingSessions)
+      .where(and(eq(schema.koreaderReadingSessions.bookFileId, bookFileId), eq(schema.koreaderReadingSessions.userId, userId)));
+
+    const total = Number(countResult?.count ?? 0);
+
+    const rows = await this.db
+      .select()
+      .from(schema.koreaderReadingSessions)
+      .where(and(eq(schema.koreaderReadingSessions.bookFileId, bookFileId), eq(schema.koreaderReadingSessions.userId, userId)))
+      .orderBy(desc(schema.koreaderReadingSessions.startedAt))
+      .limit(pageSize)
+      .offset(offset);
+
+    return { rows, total };
+  }
+
+  async getKoreaderAggregateStats(userId: number): Promise<{ booksWithStats: number; totalReadingSeconds: number }> {
+    const [result] = await this.db
+      .select({
+        booksWithStats: sql<number>`count(distinct ${schema.bookFiles.bookId})`,
+        totalReadingSeconds: sql<number>`coalesce(sum(${schema.koreaderBookStats.totalReadSecs}), 0)`,
+      })
+      .from(schema.koreaderBookStats)
+      .innerJoin(schema.bookFiles, eq(schema.bookFiles.id, schema.koreaderBookStats.bookFileId))
+      .where(eq(schema.koreaderBookStats.userId, userId));
+
+    return {
+      booksWithStats: Number(result?.booksWithStats ?? 0),
+      totalReadingSeconds: Number(result?.totalReadingSeconds ?? 0),
+    };
+  }
+
+  async hasKoreaderBookStats(bookFileId: number, userId: number): Promise<boolean> {
+    const [row] = await this.db
+      .select({ id: schema.koreaderBookStats.id })
+      .from(schema.koreaderBookStats)
+      .where(and(eq(schema.koreaderBookStats.bookFileId, bookFileId), eq(schema.koreaderBookStats.userId, userId)))
+      .limit(1);
+    return row != null;
+  }
+
+  async getKoreaderSessionsDailySummary(bookFileId: number, userId: number): Promise<{ day: string; durationSeconds: number }[]> {
+    const result = await this.db.execute<{ day: string; duration_seconds: number }>(sql`
+      SELECT
+        to_char(date_trunc('day', started_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS day,
+        sum(duration_seconds)::integer AS duration_seconds
+      FROM koreader_reading_sessions
+      WHERE book_file_id = ${bookFileId} AND user_id = ${userId}
+      GROUP BY date_trunc('day', started_at AT TIME ZONE 'UTC')
+      ORDER BY day ASC
+    `);
+    return result.rows.map((r) => ({ day: r.day, durationSeconds: Number(r.duration_seconds) }));
+  }
+
+  async getKoreaderStatsActiveDates(userId: number): Promise<string[]> {
+    const result = await this.db.execute<{ day: string }>(sql`
+      SELECT DISTINCT to_char(date_trunc('day', started_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS day
+      FROM koreader_reading_sessions
+      WHERE user_id = ${userId} AND duration_seconds > 0
+      ORDER BY day ASC
+    `);
+    return result.rows.map((r) => r.day);
+  }
+
+  async getKoreaderStatsTotals(userId: number): Promise<{
+    totalSessions: number;
+    totalDurationSecs: number;
+    totalHighlights: number;
+    totalNotes: number;
+    booksWithStats: number;
+  }> {
+    const sessionsResult = await this.db.execute<{ total_sessions: number; total_duration_secs: number }>(sql`
+      SELECT count(*)::integer AS total_sessions,
+             coalesce(sum(duration_seconds), 0)::integer AS total_duration_secs
+      FROM koreader_reading_sessions
+      WHERE user_id = ${userId} AND duration_seconds > 0
+    `);
+    const bookStatsResult = await this.db.execute<{ total_highlights: number; total_notes: number; books_with_stats: number }>(sql`
+      SELECT coalesce(sum(highlights_count), 0)::integer AS total_highlights,
+             coalesce(sum(notes_count), 0)::integer AS total_notes,
+             count(distinct ${schema.bookFiles.bookId})::integer AS books_with_stats
+      FROM koreader_book_stats
+      INNER JOIN book_files ON book_files.id = koreader_book_stats.book_file_id
+      WHERE koreader_book_stats.user_id = ${userId}
+    `);
+    const sessions = sessionsResult.rows[0];
+    const bookStats = bookStatsResult.rows[0];
+    return {
+      totalSessions: Number(sessions?.total_sessions ?? 0),
+      totalDurationSecs: Number(sessions?.total_duration_secs ?? 0),
+      totalHighlights: Number(bookStats?.total_highlights ?? 0),
+      totalNotes: Number(bookStats?.total_notes ?? 0),
+      booksWithStats: Number(bookStats?.books_with_stats ?? 0),
+    };
+  }
+
+  async getKoreaderActivityHeatmap(userId: number): Promise<{ date: string; durationSeconds: number }[]> {
+    const result = await this.db.execute<{ date: string; duration_seconds: number }>(sql`
+      SELECT
+        to_char(date_trunc('day', started_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS date,
+        sum(duration_seconds)::integer AS duration_seconds
+      FROM koreader_reading_sessions
+      WHERE user_id = ${userId} AND duration_seconds > 0
+      GROUP BY date_trunc('day', started_at AT TIME ZONE 'UTC')
+      ORDER BY date ASC
+    `);
+    return result.rows.map((r) => ({ date: r.date, durationSeconds: Number(r.duration_seconds) }));
+  }
+
+  async getKoreaderMonthlyReading(userId: number): Promise<{ year: number; month: number; durationSeconds: number }[]> {
+    const result = await this.db.execute<{ year: number; month: number; duration_seconds: number }>(sql`
+      WITH months AS (
+        SELECT
+          EXTRACT(YEAR FROM m)::integer AS year,
+          EXTRACT(MONTH FROM m)::integer AS month
+        FROM generate_series(
+          date_trunc('month', (now() AT TIME ZONE 'UTC') - interval '23 months'),
+          date_trunc('month', now() AT TIME ZONE 'UTC'),
+          interval '1 month'
+        ) AS m
+      ),
+      session_sums AS (
+        SELECT
+          EXTRACT(YEAR FROM started_at AT TIME ZONE 'UTC')::integer AS year,
+          EXTRACT(MONTH FROM started_at AT TIME ZONE 'UTC')::integer AS month,
+          sum(duration_seconds)::integer AS duration_seconds
+        FROM koreader_reading_sessions
+        WHERE user_id = ${userId} AND duration_seconds > 0
+        GROUP BY 1, 2
+      )
+      SELECT m.year, m.month, coalesce(s.duration_seconds, 0) AS duration_seconds
+      FROM months m
+      LEFT JOIN session_sums s USING (year, month)
+      ORDER BY m.year, m.month
+    `);
+    return result.rows.map((r) => ({ year: Number(r.year), month: Number(r.month), durationSeconds: Number(r.duration_seconds) }));
+  }
+
+  async getKoreaderTimeOfDay(userId: number): Promise<{ hour: number; durationSeconds: number }[]> {
+    const result = await this.db.execute<{ hour: number; duration_seconds: number }>(sql`
+      WITH hours AS (
+        SELECT generate_series(0, 23) AS hour
+      ),
+      session_sums AS (
+        SELECT
+          EXTRACT(HOUR FROM started_at AT TIME ZONE 'UTC')::integer AS hour,
+          sum(duration_seconds)::integer AS duration_seconds
+        FROM koreader_reading_sessions
+        WHERE user_id = ${userId} AND duration_seconds > 0
+        GROUP BY 1
+      )
+      SELECT h.hour, coalesce(s.duration_seconds, 0) AS duration_seconds
+      FROM hours h
+      LEFT JOIN session_sums s USING (hour)
+      ORDER BY h.hour
+    `);
+    return result.rows.map((r) => ({ hour: Number(r.hour), durationSeconds: Number(r.duration_seconds) }));
+  }
+
+  async getKoreaderSessionLengths(userId: number): Promise<{ label: string; minSecs: number; maxSecs: number | null; count: number }[]> {
+    const result = await this.db.execute<{ label: string; min_secs: number; max_secs: number | null; count: number }>(sql`
+      WITH bins(label, min_secs, max_secs) AS (VALUES
+        ('0-5m',  0,    300),
+        ('5-10m', 300,  600),
+        ('10-20m',600,  1200),
+        ('20-30m',1200, 1800),
+        ('30-60m',1800, 3600),
+        ('1-2h',  3600, 7200),
+        ('2h+',   7200, null)
+      ),
+      session_counts AS (
+        SELECT
+          b.label,
+          b.min_secs,
+          b.max_secs,
+          count(s.id)::integer AS count
+        FROM bins b
+        LEFT JOIN koreader_reading_sessions s
+          ON s.user_id = ${userId}
+          AND s.duration_seconds > 0
+          AND s.duration_seconds >= b.min_secs
+          AND (b.max_secs IS NULL OR s.duration_seconds < b.max_secs)
+        GROUP BY b.label, b.min_secs, b.max_secs
+      )
+      SELECT label, min_secs, max_secs, count
+      FROM session_counts
+      ORDER BY min_secs
+    `);
+    return result.rows.map((r) => ({
+      label: r.label,
+      minSecs: Number(r.min_secs),
+      maxSecs: r.max_secs != null ? Number(r.max_secs) : null,
+      count: Number(r.count),
+    }));
+  }
+
+  async getKoreaderTopBooks(userId: number, limit = 20): Promise<{ bookId: number; title: string; totalReadSecs: number }[]> {
+    const result = await this.db.execute<{ book_id: number; title: string; total_read_secs: number }>(sql`
+      SELECT
+        b.id AS book_id,
+        coalesce(b.title, 'Unknown Book') AS title,
+        sum(ks.total_read_secs)::integer AS total_read_secs
+      FROM koreader_book_stats ks
+      INNER JOIN book_files bf ON bf.id = ks.book_file_id
+      INNER JOIN books b ON b.id = bf.book_id
+      WHERE ks.user_id = ${userId} AND ks.total_read_secs > 0
+      GROUP BY b.id, b.title
+      ORDER BY total_read_secs DESC
+      LIMIT ${limit}
+    `);
+    return result.rows.map((r) => ({ bookId: Number(r.book_id), title: r.title, totalReadSecs: Number(r.total_read_secs) }));
+  }
+
+  async getKoreaderTopAnnotated(
+    userId: number,
+    limit = 20,
+  ): Promise<{ bookId: number; title: string; highlightsCount: number; notesCount: number }[]> {
+    const result = await this.db.execute<{ book_id: number; title: string; highlights_count: number; notes_count: number }>(sql`
+      SELECT
+        b.id AS book_id,
+        coalesce(b.title, 'Unknown Book') AS title,
+        sum(ks.highlights_count)::integer AS highlights_count,
+        sum(ks.notes_count)::integer AS notes_count
+      FROM koreader_book_stats ks
+      INNER JOIN book_files bf ON bf.id = ks.book_file_id
+      INNER JOIN books b ON b.id = bf.book_id
+      WHERE ks.user_id = ${userId}
+        AND (ks.highlights_count > 0 OR ks.notes_count > 0)
+      GROUP BY b.id, b.title
+      HAVING sum(ks.highlights_count) + sum(ks.notes_count) > 0
+      ORDER BY sum(ks.highlights_count) + sum(ks.notes_count) DESC
+      LIMIT ${limit}
+    `);
+    return result.rows.map((r) => ({
+      bookId: Number(r.book_id),
+      title: r.title,
+      highlightsCount: Number(r.highlights_count),
+      notesCount: Number(r.notes_count),
+    }));
+  }
+
+  async getKoreaderWeeklyRhythm(userId: number): Promise<{ dow: number; durationSeconds: number }[]> {
+    const result = await this.db.execute<{ dow: number; duration_seconds: number }>(sql`
+      WITH days AS (
+        SELECT generate_series(1, 7) AS dow
+      ),
+      session_sums AS (
+        SELECT
+          EXTRACT(ISODOW FROM started_at AT TIME ZONE 'UTC')::integer AS dow,
+          sum(duration_seconds)::integer AS duration_seconds
+        FROM koreader_reading_sessions
+        WHERE user_id = ${userId} AND duration_seconds > 0
+        GROUP BY 1
+      )
+      SELECT d.dow, coalesce(s.duration_seconds, 0) AS duration_seconds
+      FROM days d
+      LEFT JOIN session_sums s USING (dow)
+      ORDER BY d.dow
+    `);
+    return result.rows.map((r) => ({ dow: Number(r.dow), durationSeconds: Number(r.duration_seconds) }));
+  }
+
+  async getKoreaderDevices(userId: number): Promise<{ device: string; booksTracked: number }[]> {
+    const result = await this.db.execute<{ device: string; books_tracked: number }>(sql`
+      SELECT
+        coalesce(device, 'Unknown Device') AS device,
+        count(distinct book_file_id)::integer AS books_tracked
+      FROM koreader_device_progress
+      WHERE user_id = ${userId} AND orphaned = false AND book_file_id IS NOT NULL
+      GROUP BY coalesce(device, 'Unknown Device')
+      ORDER BY books_tracked DESC
+    `);
+    return result.rows.map((r) => ({ device: r.device, booksTracked: Number(r.books_tracked) }));
+  }
 }

--- a/server/src/modules/koreader/koreader.service.test.ts
+++ b/server/src/modules/koreader/koreader.service.test.ts
@@ -62,6 +62,23 @@ describe('KoreaderService', () => {
     getBookProgressForDashboard: ReturnType<typeof vi.fn>;
     getChapters: ReturnType<typeof vi.fn>;
     getLastFileWriteTime: ReturnType<typeof vi.fn>;
+    upsertKoreaderBookStats: ReturnType<typeof vi.fn>;
+    bulkInsertKoreaderReadingSessions: ReturnType<typeof vi.fn>;
+    getKoreaderBookStats: ReturnType<typeof vi.fn>;
+    getKoreaderReadingSessions: ReturnType<typeof vi.fn>;
+    getKoreaderAggregateStats: ReturnType<typeof vi.fn>;
+    hasKoreaderBookStats: ReturnType<typeof vi.fn>;
+    getKoreaderSessionsDailySummary: ReturnType<typeof vi.fn>;
+    getKoreaderStatsActiveDates: ReturnType<typeof vi.fn>;
+    getKoreaderStatsTotals: ReturnType<typeof vi.fn>;
+    getKoreaderActivityHeatmap: ReturnType<typeof vi.fn>;
+    getKoreaderMonthlyReading: ReturnType<typeof vi.fn>;
+    getKoreaderTimeOfDay: ReturnType<typeof vi.fn>;
+    getKoreaderSessionLengths: ReturnType<typeof vi.fn>;
+    getKoreaderTopBooks: ReturnType<typeof vi.fn>;
+    getKoreaderTopAnnotated: ReturnType<typeof vi.fn>;
+    getKoreaderWeeklyRhythm: ReturnType<typeof vi.fn>;
+    getKoreaderDevices: ReturnType<typeof vi.fn>;
   };
   let mockChapterService: {
     parseChapterIndexFromProgress: ReturnType<typeof vi.fn>;
@@ -72,6 +89,7 @@ describe('KoreaderService', () => {
   };
   let mockUserBookStatusService: {
     autoUpdate: ReturnType<typeof vi.fn>;
+    setStartedAtIfNull: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -110,6 +128,23 @@ describe('KoreaderService', () => {
       getBookProgressForDashboard: vi.fn(),
       getChapters: vi.fn(),
       getLastFileWriteTime: vi.fn(),
+      upsertKoreaderBookStats: vi.fn(),
+      bulkInsertKoreaderReadingSessions: vi.fn(),
+      getKoreaderBookStats: vi.fn(),
+      getKoreaderReadingSessions: vi.fn(),
+      getKoreaderAggregateStats: vi.fn(),
+      hasKoreaderBookStats: vi.fn(),
+      getKoreaderSessionsDailySummary: vi.fn(),
+      getKoreaderStatsActiveDates: vi.fn(),
+      getKoreaderStatsTotals: vi.fn(),
+      getKoreaderActivityHeatmap: vi.fn(),
+      getKoreaderMonthlyReading: vi.fn(),
+      getKoreaderTimeOfDay: vi.fn(),
+      getKoreaderSessionLengths: vi.fn(),
+      getKoreaderTopBooks: vi.fn(),
+      getKoreaderTopAnnotated: vi.fn(),
+      getKoreaderWeeklyRhythm: vi.fn(),
+      getKoreaderDevices: vi.fn(),
     };
 
     mockChapterService = {
@@ -123,16 +158,38 @@ describe('KoreaderService', () => {
 
     mockUserBookStatusService = {
       autoUpdate: vi.fn(),
+      setStartedAtIfNull: vi.fn(),
     };
 
     mockRepo.deleteKoreaderUser.mockResolvedValue(undefined);
     mockRepo.updateKoreaderUser.mockResolvedValue(undefined);
     mockRepo.upsertDeviceProgress.mockResolvedValue(undefined);
     mockRepo.upsertReadingProgress.mockResolvedValue(undefined);
+    mockRepo.upsertKoreaderBookStats.mockResolvedValue(undefined);
+    mockRepo.bulkInsertKoreaderReadingSessions.mockResolvedValue(undefined);
     mockRepo.getAccessibleLibraryIds.mockResolvedValue([1, 2]);
+    mockRepo.getKoreaderAggregateStats.mockResolvedValue({ booksWithStats: 0, totalReadingSeconds: 0 });
+    mockRepo.getKoreaderSessionsDailySummary.mockResolvedValue([]);
+    mockRepo.getKoreaderStatsActiveDates.mockResolvedValue([]);
+    mockRepo.getKoreaderStatsTotals.mockResolvedValue({
+      totalSessions: 0,
+      totalDurationSecs: 0,
+      totalHighlights: 0,
+      totalNotes: 0,
+      booksWithStats: 0,
+    });
+    mockRepo.getKoreaderActivityHeatmap.mockResolvedValue([]);
+    mockRepo.getKoreaderMonthlyReading.mockResolvedValue([]);
+    mockRepo.getKoreaderTimeOfDay.mockResolvedValue([]);
+    mockRepo.getKoreaderSessionLengths.mockResolvedValue([]);
+    mockRepo.getKoreaderTopBooks.mockResolvedValue([]);
+    mockRepo.getKoreaderTopAnnotated.mockResolvedValue([]);
+    mockRepo.getKoreaderWeeklyRhythm.mockResolvedValue([]);
+    mockRepo.getKoreaderDevices.mockResolvedValue([]);
     mockChapterService.parseChapterIndexFromProgress.mockReturnValue(null);
     mockChapterExtractor.extractAndStoreChapters.mockResolvedValue([]);
     mockUserBookStatusService.autoUpdate.mockResolvedValue(undefined);
+    mockUserBookStatusService.setStartedAtIfNull.mockResolvedValue(undefined);
 
     vi.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
     vi.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
@@ -287,6 +344,108 @@ describe('KoreaderService', () => {
       bcryptCompareMock.mockResolvedValue(false);
 
       await expect(service.testConnection(7, 'reader', 'legacy-secret')).resolves.toBe(true);
+    });
+  });
+
+  describe('saveStats', () => {
+    it('returns processed=0 unmatched=0 for empty book list', async () => {
+      const result = await service.saveStats(7, { books: [], device: 'KOReader', device_id: 'abc' });
+      expect(result).toEqual({ processed: 0, unmatched: 0 });
+      expect(mockRepo.resolveBookFileByHash).not.toHaveBeenCalled();
+    });
+
+    it('counts unmatched books that cannot be resolved', async () => {
+      mockRepo.resolveBookFileByHash.mockResolvedValue(null);
+
+      const result = await service.saveStats(7, {
+        books: [{ document: 'unknownhash', page_sessions: [] }],
+      });
+
+      expect(result.unmatched).toBe(1);
+      expect(result.processed).toBe(0);
+    });
+
+    it('processes a matched book and upserts stats and sessions', async () => {
+      mockRepo.resolveBookFileByHash.mockResolvedValue({ id: 10, bookId: 20 });
+
+      const result = await service.saveStats(7, {
+        books: [
+          {
+            document: 'abc123',
+            md5: 'abc123',
+            total_read_secs: 3600,
+            total_read_pages: 100,
+            highlights: 3,
+            notes: 1,
+            last_open: 1700000000,
+            page_sessions: [{ page: 5, start_time: 1700000000, duration: 120, total_pages: 300 }],
+          },
+        ],
+      });
+
+      expect(result).toEqual({ processed: 1, unmatched: 0 });
+      expect(mockRepo.upsertKoreaderBookStats).toHaveBeenCalledWith(expect.objectContaining({ bookFileId: 10, userId: 7, totalReadSecs: 3600 }));
+      expect(mockRepo.bulkInsertKoreaderReadingSessions).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ bookFileId: 10, userId: 7, page: 5, durationSeconds: 120 })]),
+      );
+      expect(mockUserBookStatusService.setStartedAtIfNull).toHaveBeenCalledWith(7, 20, expect.any(Date));
+    });
+
+    it('filters out zero-duration sessions', async () => {
+      mockRepo.resolveBookFileByHash.mockResolvedValue({ id: 10, bookId: 20 });
+
+      await service.saveStats(7, {
+        books: [
+          {
+            document: 'abc',
+            page_sessions: [
+              { page: 1, start_time: 1700000000, duration: 0, total_pages: 300 },
+              { page: 2, start_time: 1700000001, duration: 60, total_pages: 300 },
+            ],
+          },
+        ],
+      });
+
+      const sessions = mockRepo.bulkInsertKoreaderReadingSessions.mock.calls[0][0];
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].page).toBe(2);
+    });
+
+    it('does not call setStartedAtIfNull when last_open is 0', async () => {
+      mockRepo.resolveBookFileByHash.mockResolvedValue({ id: 10, bookId: 20 });
+
+      await service.saveStats(7, {
+        books: [{ document: 'abc', last_open: 0, page_sessions: [] }],
+      });
+
+      expect(mockUserBookStatusService.setStartedAtIfNull).not.toHaveBeenCalled();
+    });
+
+    it('uses md5 field over document for hash lookup when md5 is non-empty', async () => {
+      mockRepo.resolveBookFileByHash.mockResolvedValue({ id: 10, bookId: 20 });
+
+      await service.saveStats(7, {
+        books: [{ document: '/path/to/book.epub', md5: 'actualmd5', page_sessions: [] }],
+      });
+
+      expect(mockRepo.resolveBookFileByHash).toHaveBeenCalledWith('actualmd5', expect.anything());
+    });
+
+    it('processes multiple books independently', async () => {
+      mockRepo.resolveBookFileByHash
+        .mockResolvedValueOnce({ id: 10, bookId: 20 })
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: 11, bookId: 21 });
+
+      const result = await service.saveStats(7, {
+        books: [
+          { document: 'hash1', page_sessions: [] },
+          { document: 'hash2', page_sessions: [] },
+          { document: 'hash3', page_sessions: [] },
+        ],
+      });
+
+      expect(result).toEqual({ processed: 2, unmatched: 1 });
     });
   });
 
@@ -483,6 +642,65 @@ describe('KoreaderService', () => {
     });
   });
 
+  describe('getKoreaderTabData', () => {
+    it('returns null when no book file found', async () => {
+      mockRepo.findBookFileIdByBookId.mockResolvedValue(null);
+
+      const result = await service.getKoreaderTabData(7, 99, 1, 20);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when no stats exist for the book', async () => {
+      mockRepo.findBookFileIdByBookId.mockResolvedValue(10);
+      mockRepo.getKoreaderBookStats.mockResolvedValue(null);
+
+      const result = await service.getKoreaderTabData(7, 99, 1, 20);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns tab data when stats exist', async () => {
+      mockRepo.findBookFileIdByBookId.mockResolvedValue(10);
+      mockRepo.getKoreaderBookStats.mockResolvedValue({
+        id: 1,
+        bookFileId: 10,
+        userId: 7,
+        totalReadSecs: 3600,
+        totalReadPages: 100,
+        highlightsCount: 3,
+        notesCount: 1,
+        lastOpenAt: new Date('2024-01-15T10:00:00Z'),
+        updatedAt: new Date('2024-01-15T10:00:00Z'),
+      });
+      mockRepo.getKoreaderReadingSessions.mockResolvedValue({
+        rows: [
+          {
+            id: 1,
+            bookFileId: 10,
+            userId: 7,
+            sessionHash: 'abc',
+            page: 5,
+            startedAt: new Date('2024-01-15T09:00:00Z'),
+            durationSeconds: 120,
+            totalPages: 300,
+            createdAt: new Date('2024-01-15T10:00:00Z'),
+          },
+        ],
+        total: 1,
+      });
+      mockRepo.getKoreaderSessionsDailySummary.mockResolvedValue([{ day: '2024-01-15', durationSeconds: 120 }]);
+
+      const result = await service.getKoreaderTabData(7, 99, 1, 20);
+
+      expect(result).not.toBeNull();
+      expect(result!.stats.totalReadSecs).toBe(3600);
+      expect(result!.sessions).toHaveLength(1);
+      expect(result!.total).toBe(1);
+      expect(result!.dailySummary).toEqual([{ day: '2024-01-15', durationSeconds: 120 }]);
+    });
+  });
+
   describe('getSyncStatus', () => {
     it('aggregates credentials, devices, totals, and last sync time', async () => {
       const credentials = {
@@ -507,11 +725,25 @@ describe('KoreaderService', () => {
         devices,
         totalSyncedBooks: 14,
         lastSyncAt: '2026-02-01T10:00:00.000Z',
+        booksWithStats: 0,
+        totalReadingSeconds: 0,
       });
 
       expect(getCredentialsSpy).toHaveBeenCalledWith(7);
       expect(getDevicesSpy).toHaveBeenCalledWith(7);
       expect(mockRepo.getTotalSyncedBooks).toHaveBeenCalledWith(7);
+    });
+
+    it('includes booksWithStats and totalReadingSeconds from aggregate stats', async () => {
+      mockRepo.findKoreaderUser.mockResolvedValue(makeKoreaderUserRow());
+      mockRepo.getDevicesList.mockResolvedValue([]);
+      mockRepo.getTotalSyncedBooks.mockResolvedValue(5);
+      mockRepo.getKoreaderAggregateStats.mockResolvedValue({ booksWithStats: 3, totalReadingSeconds: 7200 });
+
+      const result = await service.getSyncStatus(7);
+
+      expect(result.booksWithStats).toBe(3);
+      expect(result.totalReadingSeconds).toBe(7200);
     });
   });
 
@@ -739,6 +971,224 @@ describe('KoreaderService', () => {
 
       expect(result?.canonicalSource).toBe('koreader');
       expect(result?.fileModifiedSinceLastSync).toBe(false);
+    });
+  });
+
+  describe('getKoreaderStatsSummary', () => {
+    it('returns zeros and 0 streaks when no data', async () => {
+      mockRepo.getKoreaderStatsActiveDates.mockResolvedValue([]);
+      mockRepo.getKoreaderStatsTotals.mockResolvedValue({
+        totalSessions: 0,
+        totalDurationSecs: 0,
+        totalHighlights: 0,
+        totalNotes: 0,
+        booksWithStats: 0,
+      });
+
+      const result = await service.getKoreaderStatsSummary(7);
+
+      expect(result.totalReadSecs).toBe(0);
+      expect(result.totalSessions).toBe(0);
+      expect(result.currentStreak).toBe(0);
+      expect(result.longestStreak).toBe(0);
+    });
+
+    it('computes correct streak for consecutive days ending today', async () => {
+      const today = new Date().toISOString().slice(0, 10);
+      const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+      const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+      mockRepo.getKoreaderStatsActiveDates.mockResolvedValue([twoDaysAgo, yesterday, today]);
+      mockRepo.getKoreaderStatsTotals.mockResolvedValue({
+        totalSessions: 5,
+        totalDurationSecs: 3600,
+        totalHighlights: 2,
+        totalNotes: 1,
+        booksWithStats: 1,
+      });
+
+      const result = await service.getKoreaderStatsSummary(7);
+
+      expect(result.currentStreak).toBe(3);
+      expect(result.longestStreak).toBe(3);
+      expect(result.totalReadSecs).toBe(3600);
+      expect(result.totalSessions).toBe(5);
+    });
+
+    it('normalizes unsorted and duplicate streak dates before computing streaks', async () => {
+      const today = new Date().toISOString().slice(0, 10);
+      const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+      const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+      mockRepo.getKoreaderStatsActiveDates.mockResolvedValue([today, yesterday, today, twoDaysAgo]);
+      mockRepo.getKoreaderStatsTotals.mockResolvedValue({
+        totalSessions: 3,
+        totalDurationSecs: 1800,
+        totalHighlights: 0,
+        totalNotes: 0,
+        booksWithStats: 1,
+      });
+
+      const result = await service.getKoreaderStatsSummary(7);
+
+      expect(result.currentStreak).toBe(3);
+      expect(result.longestStreak).toBe(3);
+    });
+
+    it('returns 0 current streak when last session was 2+ days ago', async () => {
+      const threeDaysAgo = new Date(Date.now() - 3 * 86_400_000).toISOString().slice(0, 10);
+      const fourDaysAgo = new Date(Date.now() - 4 * 86_400_000).toISOString().slice(0, 10);
+      mockRepo.getKoreaderStatsActiveDates.mockResolvedValue([fourDaysAgo, threeDaysAgo]);
+      mockRepo.getKoreaderStatsTotals.mockResolvedValue({
+        totalSessions: 2,
+        totalDurationSecs: 7200,
+        totalHighlights: 0,
+        totalNotes: 0,
+        booksWithStats: 1,
+      });
+
+      const result = await service.getKoreaderStatsSummary(7);
+
+      expect(result.currentStreak).toBe(0);
+      expect(result.longestStreak).toBe(2);
+    });
+
+    it('counts longest streak correctly across a gap', async () => {
+      mockRepo.getKoreaderStatsActiveDates.mockResolvedValue(['2026-01-01', '2026-01-02', '2026-01-03', '2026-01-10', '2026-01-11']);
+      mockRepo.getKoreaderStatsTotals.mockResolvedValue({
+        totalSessions: 5,
+        totalDurationSecs: 0,
+        totalHighlights: 0,
+        totalNotes: 0,
+        booksWithStats: 0,
+      });
+
+      const result = await service.getKoreaderStatsSummary(7);
+
+      expect(result.longestStreak).toBe(3);
+    });
+
+    it('returns highlights and notes from totals', async () => {
+      mockRepo.getKoreaderStatsActiveDates.mockResolvedValue([]);
+      mockRepo.getKoreaderStatsTotals.mockResolvedValue({
+        totalSessions: 0,
+        totalDurationSecs: 0,
+        totalHighlights: 42,
+        totalNotes: 7,
+        booksWithStats: 3,
+      });
+
+      const result = await service.getKoreaderStatsSummary(7);
+
+      expect(result.totalHighlights).toBe(42);
+      expect(result.totalNotes).toBe(7);
+      expect(result.booksWithStats).toBe(3);
+    });
+  });
+
+  describe('getKoreaderWeeklyRhythm', () => {
+    it('maps DOW to labels and fills missing weekdays', async () => {
+      mockRepo.getKoreaderWeeklyRhythm.mockResolvedValue([
+        { dow: 1, durationSeconds: 600 },
+        { dow: 7, durationSeconds: 1200 },
+      ]);
+
+      const result = await service.getKoreaderWeeklyRhythm(7);
+
+      expect(result[0]).toEqual({ dow: 1, label: 'Mon', durationSeconds: 600 });
+      expect(result[1]).toEqual({ dow: 2, label: 'Tue', durationSeconds: 0 });
+      expect(result[6]).toEqual({ dow: 7, label: 'Sun', durationSeconds: 1200 });
+      expect(result).toHaveLength(7);
+    });
+
+    it('returns seven zero-filled weekday entries when no data', async () => {
+      mockRepo.getKoreaderWeeklyRhythm.mockResolvedValue([]);
+      const result = await service.getKoreaderWeeklyRhythm(7);
+      expect(result).toHaveLength(7);
+      expect(result.every((item) => item.durationSeconds === 0)).toBe(true);
+      expect(result[0]?.label).toBe('Mon');
+      expect(result[6]?.label).toBe('Sun');
+    });
+  });
+
+  describe('getKoreaderActivityHeatmap', () => {
+    it('delegates to repository', async () => {
+      const heatmap = [{ date: '2026-01-01', durationSeconds: 3600 }];
+      mockRepo.getKoreaderActivityHeatmap.mockResolvedValue(heatmap);
+
+      const result = await service.getKoreaderActivityHeatmap(7);
+
+      expect(result).toEqual(heatmap);
+      expect(mockRepo.getKoreaderActivityHeatmap).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('getKoreaderMonthlyReading', () => {
+    it('delegates to repository', async () => {
+      const monthly = [{ year: 2026, month: 1, durationSeconds: 7200 }];
+      mockRepo.getKoreaderMonthlyReading.mockResolvedValue(monthly);
+
+      const result = await service.getKoreaderMonthlyReading(7);
+
+      expect(result).toEqual(monthly);
+    });
+  });
+
+  describe('getKoreaderSessionLengths', () => {
+    it('delegates to repository', async () => {
+      const bins = [{ label: '0-5m', minSecs: 0, maxSecs: 300, count: 5 }];
+      mockRepo.getKoreaderSessionLengths.mockResolvedValue(bins);
+
+      const result = await service.getKoreaderSessionLengths(7);
+
+      expect(result).toEqual(bins);
+    });
+  });
+
+  describe('getKoreaderTopBooks', () => {
+    it('delegates to repository', async () => {
+      const books = [{ bookId: 1, title: 'Test Book', totalReadSecs: 3600 }];
+      mockRepo.getKoreaderTopBooks.mockResolvedValue(books);
+
+      const result = await service.getKoreaderTopBooks(7);
+
+      expect(result).toEqual(books);
+      expect(mockRepo.getKoreaderTopBooks).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('getKoreaderTopAnnotated', () => {
+    it('delegates to repository', async () => {
+      const annotated = [{ bookId: 1, title: 'Annotated Book', highlightsCount: 10, notesCount: 2 }];
+      mockRepo.getKoreaderTopAnnotated.mockResolvedValue(annotated);
+
+      const result = await service.getKoreaderTopAnnotated(7);
+
+      expect(result).toEqual(annotated);
+    });
+  });
+
+  describe('getKoreaderDevices', () => {
+    it('delegates to repository', async () => {
+      const devices = [{ device: 'Kobo Libra', booksTracked: 5 }];
+      mockRepo.getKoreaderDevices.mockResolvedValue(devices);
+
+      const result = await service.getKoreaderDevices(7);
+
+      expect(result).toEqual(devices);
+      expect(mockRepo.getKoreaderDevices).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('getKoreaderTimeOfDay', () => {
+    it('fills all 24 hours when repository returns partial data', async () => {
+      const hours = [{ hour: 9, durationSeconds: 1800 }];
+      mockRepo.getKoreaderTimeOfDay.mockResolvedValue(hours);
+
+      const result = await service.getKoreaderTimeOfDay(7);
+
+      expect(result).toHaveLength(24);
+      expect(result[9]).toEqual({ hour: 9, durationSeconds: 1800 });
+      expect(result[8]).toEqual({ hour: 8, durationSeconds: 0 });
+      expect(result[23]).toEqual({ hour: 23, durationSeconds: 0 });
     });
   });
 });

--- a/server/src/modules/koreader/koreader.service.ts
+++ b/server/src/modules/koreader/koreader.service.ts
@@ -2,16 +2,36 @@ import { ConflictException, Injectable, Logger, NotFoundException } from '@nestj
 import { hash as bcryptHash } from 'bcryptjs';
 import { createHash } from 'crypto';
 
-import type { KoreaderBookSyncInfo, KoreaderDeviceInfo, KoreaderSyncStatus } from '@bookorbit/types';
+import type {
+  KoreaderBookSyncInfo,
+  KoreaderDeviceInfo,
+  KoreaderDevicePoint,
+  KoreaderHeatmapPoint,
+  KoreaderHourPoint,
+  KoreaderMonthlyPoint,
+  KoreaderSessionLengthBin,
+  KoreaderStatsResponse,
+  KoreaderStatsSummary,
+  KoreaderSyncStatus,
+  KoreaderTabData,
+  KoreaderTopAnnotatedItem,
+  KoreaderTopBookItem,
+  KoreaderWeekdayPoint,
+} from '@bookorbit/types';
 import { KoreaderRepository } from './koreader.repository';
 import { KoreaderChapterService } from './koreader-chapter.service';
 import { KoreaderChapterExtractorService } from './koreader-chapter-extractor.service';
 import { UserBookStatusService } from '../user-book-status/user-book-status.service';
+import type { SaveStatsDto } from './dto';
 
 const BCRYPT_ROUNDS = 12;
 const SYNC_EVENT = 'koreader.sync';
 const CREDENTIALS_EVENT = 'koreader.credentials';
+const STATS_EVENT = 'koreader.stats';
 const DEFAULT_DEVICE = 'KOReader';
+const DAY_MS = 86_400_000;
+const HOURS_PER_DAY = 24;
+const WEEKDAY_LABELS: readonly string[] = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 @Injectable()
 export class KoreaderService {
@@ -197,12 +217,22 @@ export class KoreaderService {
   }
 
   async getSyncStatus(userId: number): Promise<KoreaderSyncStatus> {
-    const credentials = await this.getCredentials(userId);
-    const devices = await this.getDevices(userId);
-    const totalSyncedBooks = await this.repo.getTotalSyncedBooks(userId);
+    const [credentials, devices, totalSyncedBooks, aggregateStats] = await Promise.all([
+      this.getCredentials(userId),
+      this.getDevices(userId),
+      this.repo.getTotalSyncedBooks(userId),
+      this.repo.getKoreaderAggregateStats(userId),
+    ]);
     const lastSyncAt = devices.length > 0 ? devices[0]!.lastSyncAt : null;
 
-    return { credentials, devices, totalSyncedBooks, lastSyncAt };
+    return {
+      credentials,
+      devices,
+      totalSyncedBooks,
+      lastSyncAt,
+      booksWithStats: aggregateStats.booksWithStats,
+      totalReadingSeconds: aggregateStats.totalReadingSeconds,
+    };
   }
 
   async getDevices(userId: number): Promise<KoreaderDeviceInfo[]> {
@@ -258,6 +288,164 @@ export class KoreaderService {
       fileModifiedSinceLastSync,
     };
   }
+
+  async saveStats(userId: number, dto: SaveStatsDto): Promise<KoreaderStatsResponse> {
+    const startedAt = Date.now();
+    this.logger.log(`[${STATS_EVENT}] [start] userId=${userId} bookCount=${dto.books.length} - stats sync started`);
+
+    const accessibleLibraryIds = await this.repo.getAccessibleLibraryIds(userId);
+    let processed = 0;
+    let unmatched = 0;
+
+    for (const bookDto of dto.books) {
+      const docKey = bookDto.md5 && bookDto.md5.length > 0 ? bookDto.md5 : bookDto.document;
+      const bookFile = await this.repo.resolveBookFileByHash(docKey, accessibleLibraryIds);
+
+      if (!bookFile) {
+        unmatched++;
+        continue;
+      }
+
+      const lastOpenAt = bookDto.last_open && bookDto.last_open > 0 ? new Date(bookDto.last_open * 1000) : null;
+
+      await this.repo.upsertKoreaderBookStats({
+        bookFileId: bookFile.id,
+        userId,
+        totalReadSecs: bookDto.total_read_secs ?? 0,
+        totalReadPages: bookDto.total_read_pages ?? 0,
+        highlightsCount: bookDto.highlights ?? 0,
+        notesCount: bookDto.notes ?? 0,
+        lastOpenAt,
+      });
+
+      const validSessions = (bookDto.page_sessions ?? [])
+        .filter((s) => s.duration > 0 && s.total_pages > 0)
+        .map((s) => ({
+          bookFileId: bookFile.id,
+          userId,
+          sessionHash: createHash('sha256').update(`${userId}:${bookFile.id}:${s.page}:${s.start_time}`).digest('hex'),
+          page: s.page,
+          startedAt: new Date(s.start_time * 1000),
+          durationSeconds: s.duration,
+          totalPages: s.total_pages,
+        }));
+
+      await this.repo.bulkInsertKoreaderReadingSessions(validSessions);
+
+      if (lastOpenAt) {
+        await this.userBookStatusService.setStartedAtIfNull(userId, bookFile.bookId, lastOpenAt);
+      }
+
+      processed++;
+    }
+
+    this.logger.log(
+      `[${STATS_EVENT}] [end] userId=${userId} bookCount=${dto.books.length} processed=${processed} unmatched=${unmatched} durationMs=${Date.now() - startedAt} - stats sync completed`,
+    );
+
+    return { processed, unmatched };
+  }
+
+  async getKoreaderTabData(userId: number, bookId: number, page: number, pageSize: number): Promise<KoreaderTabData | null> {
+    const bookFileId = await this.repo.findBookFileIdByBookId(bookId);
+    if (!bookFileId) return null;
+
+    const statsRow = await this.repo.getKoreaderBookStats(bookFileId, userId);
+    if (!statsRow) return null;
+
+    const safePage = Math.max(1, page);
+    const safePageSize = Math.min(Math.max(1, pageSize), 100);
+
+    const [{ rows, total }, dailySummary] = await Promise.all([
+      this.repo.getKoreaderReadingSessions(bookFileId, userId, safePage, safePageSize),
+      this.repo.getKoreaderSessionsDailySummary(bookFileId, userId),
+    ]);
+
+    return {
+      stats: {
+        bookFileId,
+        totalReadSecs: statsRow.totalReadSecs,
+        totalReadPages: statsRow.totalReadPages,
+        highlightsCount: statsRow.highlightsCount,
+        notesCount: statsRow.notesCount,
+        lastOpenAt: statsRow.lastOpenAt?.toISOString() ?? null,
+        updatedAt: statsRow.updatedAt.toISOString(),
+      },
+      sessions: rows.map((r) => ({
+        id: r.id,
+        page: r.page,
+        startedAt: r.startedAt.toISOString(),
+        durationSeconds: r.durationSeconds,
+        totalPages: r.totalPages,
+      })),
+      dailySummary,
+      total,
+      page: safePage,
+      pageSize: safePageSize,
+    };
+  }
+
+  async getKoreaderAggregateSyncStats(userId: number): Promise<{ booksWithStats: number; totalReadingSeconds: number }> {
+    return this.repo.getKoreaderAggregateStats(userId);
+  }
+
+  async getKoreaderStatsSummary(userId: number): Promise<KoreaderStatsSummary> {
+    const [activeDates, totals] = await Promise.all([this.repo.getKoreaderStatsActiveDates(userId), this.repo.getKoreaderStatsTotals(userId)]);
+
+    const { currentStreak, longestStreak } = computeStreaks(normalizeStreakDates(activeDates));
+
+    return {
+      totalReadSecs: totals.totalDurationSecs,
+      totalSessions: totals.totalSessions,
+      totalHighlights: totals.totalHighlights,
+      totalNotes: totals.totalNotes,
+      booksWithStats: totals.booksWithStats,
+      currentStreak,
+      longestStreak,
+    };
+  }
+
+  async getKoreaderActivityHeatmap(userId: number): Promise<KoreaderHeatmapPoint[]> {
+    return this.repo.getKoreaderActivityHeatmap(userId);
+  }
+
+  async getKoreaderMonthlyReading(userId: number): Promise<KoreaderMonthlyPoint[]> {
+    return this.repo.getKoreaderMonthlyReading(userId);
+  }
+
+  async getKoreaderTimeOfDay(userId: number): Promise<KoreaderHourPoint[]> {
+    const rows = await this.repo.getKoreaderTimeOfDay(userId);
+    const durationsByHour = new Map(rows.map((row) => [row.hour, row.durationSeconds]));
+    return Array.from({ length: HOURS_PER_DAY }, (_, hour) => ({
+      hour,
+      durationSeconds: durationsByHour.get(hour) ?? 0,
+    }));
+  }
+
+  async getKoreaderSessionLengths(userId: number): Promise<KoreaderSessionLengthBin[]> {
+    return this.repo.getKoreaderSessionLengths(userId);
+  }
+
+  async getKoreaderTopBooks(userId: number): Promise<KoreaderTopBookItem[]> {
+    return this.repo.getKoreaderTopBooks(userId);
+  }
+
+  async getKoreaderTopAnnotated(userId: number): Promise<KoreaderTopAnnotatedItem[]> {
+    return this.repo.getKoreaderTopAnnotated(userId);
+  }
+
+  async getKoreaderWeeklyRhythm(userId: number): Promise<KoreaderWeekdayPoint[]> {
+    const rows = await this.repo.getKoreaderWeeklyRhythm(userId);
+    const durationsByDow = new Map(rows.map((row) => [row.dow, row.durationSeconds]));
+    return WEEKDAY_LABELS.map((label, index) => {
+      const dow = index + 1;
+      return { dow, label, durationSeconds: durationsByDow.get(dow) ?? 0 };
+    });
+  }
+
+  async getKoreaderDevices(userId: number): Promise<KoreaderDevicePoint[]> {
+    return this.repo.getKoreaderDevices(userId);
+  }
 }
 
 function toBookorbitPercentage(koreaderPct: number): number {
@@ -266,4 +454,49 @@ function toBookorbitPercentage(koreaderPct: number): number {
 
 function toKoreaderPercentage(bookorbitPct: number): number {
   return Math.round(bookorbitPct * 100) / 10000;
+}
+
+function computeStreaks(sortedDates: string[]): { currentStreak: number; longestStreak: number } {
+  if (sortedDates.length === 0) return { currentStreak: 0, longestStreak: 0 };
+
+  let longestStreak = 1;
+  let currentRun = 1;
+
+  for (let i = 1; i < sortedDates.length; i++) {
+    const prev = new Date(sortedDates[i - 1]!);
+    const curr = new Date(sortedDates[i]!);
+    const diffDays = Math.round((curr.getTime() - prev.getTime()) / DAY_MS);
+    if (diffDays === 1) {
+      currentRun++;
+      if (currentRun > longestStreak) longestStreak = currentRun;
+    } else if (diffDays > 1) {
+      currentRun = 1;
+    }
+  }
+
+  const todayUtc = new Date().toISOString().slice(0, 10);
+  const yesterdayUtc = new Date(Date.now() - DAY_MS).toISOString().slice(0, 10);
+  const lastDate = sortedDates[sortedDates.length - 1]!;
+  const isActive = lastDate === todayUtc || lastDate === yesterdayUtc;
+
+  if (!isActive) return { currentStreak: 0, longestStreak };
+
+  let streak = 1;
+  for (let i = sortedDates.length - 2; i >= 0; i--) {
+    const curr = new Date(sortedDates[i + 1]!);
+    const prev = new Date(sortedDates[i]!);
+    const diffDays = Math.round((curr.getTime() - prev.getTime()) / DAY_MS);
+    if (diffDays === 1) streak++;
+    else break;
+  }
+
+  return { currentStreak: streak, longestStreak };
+}
+
+function normalizeStreakDates(dates: string[]): string[] {
+  const unique = new Set<string>();
+  for (const day of dates) {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(day)) unique.add(day);
+  }
+  return [...unique].sort();
 }

--- a/server/src/modules/user-book-status/user-book-status.repository.ts
+++ b/server/src/modules/user-book-status/user-book-status.repository.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
 import { DB } from '../../db';
@@ -92,5 +92,12 @@ export class UserBookStatusRepository {
           updatedAt: state.updatedAt,
         },
       });
+  }
+
+  async setStartedAtIfNull(userId: number, bookId: number, startedAt: Date): Promise<void> {
+    await this.db
+      .update(userBookStatus)
+      .set({ startedAt, updatedAt: new Date() })
+      .where(and(eq(userBookStatus.userId, userId), eq(userBookStatus.bookId, bookId), isNull(userBookStatus.startedAt)));
   }
 }

--- a/server/src/modules/user-book-status/user-book-status.service.test.ts
+++ b/server/src/modules/user-book-status/user-book-status.service.test.ts
@@ -29,6 +29,7 @@ const mockRepo = {
         ...args: [number, number, { status: ReadStatus; source: ReadStatusSource; startedAt: Date | null; finishedAt: Date | null; updatedAt: Date }]
       ) => Promise<void>
     >(),
+  setStartedAtIfNull: vi.fn<(...args: [number, number, Date]) => Promise<void>>(),
 };
 const mockAchievementEvents = {
   emit: vi.fn(),
@@ -42,6 +43,7 @@ beforeEach(() => {
   mockRepo.findByBookIds.mockResolvedValue([]);
   mockRepo.upsert.mockResolvedValue(undefined);
   mockRepo.upsertState.mockResolvedValue(undefined);
+  mockRepo.setStartedAtIfNull.mockResolvedValue(undefined);
   service = new UserBookStatusService(mockRepo as unknown as UserBookStatusRepository, mockAchievementEvents as never);
 });
 
@@ -307,6 +309,33 @@ describe('autoUpdate normalization and guard behavior', () => {
 
     expect(mockRepo.upsert).toHaveBeenCalledOnce();
     expect(mockRepo.upsert.mock.calls[0][2]).toBe('unread');
+  });
+});
+
+describe('setStartedAtIfNull', () => {
+  it('returns early when no row exists', async () => {
+    mockRepo.findOne.mockResolvedValue(null);
+
+    await service.setStartedAtIfNull(1, 10, new Date('2026-04-01T00:00:00.000Z'));
+
+    expect(mockRepo.setStartedAtIfNull).not.toHaveBeenCalled();
+  });
+
+  it('returns early for manual rows', async () => {
+    mockRepo.findOne.mockResolvedValue(makeRow({ source: 'manual' }));
+
+    await service.setStartedAtIfNull(1, 10, new Date('2026-04-01T00:00:00.000Z'));
+
+    expect(mockRepo.setStartedAtIfNull).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the repository for auto rows', async () => {
+    const startedAt = new Date('2026-04-01T00:00:00.000Z');
+    mockRepo.findOne.mockResolvedValue(makeRow({ source: 'auto' }));
+
+    await service.setStartedAtIfNull(1, 10, startedAt);
+
+    expect(mockRepo.setStartedAtIfNull).toHaveBeenCalledWith(1, 10, startedAt);
   });
 });
 

--- a/server/src/modules/user-book-status/user-book-status.service.ts
+++ b/server/src/modules/user-book-status/user-book-status.service.ts
@@ -132,6 +132,13 @@ export class UserBookStatusService {
     return row ? this.toDto(row) : null;
   }
 
+  async setStartedAtIfNull(userId: number, bookId: number, startedAt: Date): Promise<void> {
+    const existing = await this.repo.findOne(userId, bookId);
+    if (!existing) return;
+    if (existing.source === 'manual') return;
+    await this.repo.setStartedAtIfNull(userId, bookId, startedAt);
+  }
+
   async findByBookIds(userId: number, bookIds: number[]): Promise<Map<number, UserBookStatus>> {
     const rows = await this.repo.findByBookIds(userId, bookIds);
     const map = new Map<number, UserBookStatus>();


### PR DESCRIPTION
Add full support for the bookorbit-koplugin stats sync payload to ingest, store, and display per-book stats and page-level reading sessions.

Closes #28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KOReader analytics dashboard with charts: activity heatmap, monthly reading, time-of-day, session lengths, top books, annotated items, weekly rhythm, and device breakdown
  * KOReader tab on book pages showing stats, activity chart, paginated session list, and per-book KPIs
  * Account metrics: Books with Stats and Total Reading Time

* **Style**
  * Tighter spacing and compact card/table layouts in reading logs and stats

* **Tests**
  * Expanded test coverage for KOReader stats and statistics configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->