### PR TITLE
fix(auth): allow https in csp img-src for oidc provider icons

### DIFF
--- a/server/src/common/utils/bootstrap.utils.test.ts
+++ b/server/src/common/utils/bootstrap.utils.test.ts
@@ -191,9 +191,15 @@ describe('buildCspDirectives', () => {
   });
 
   describe('static directives', () => {
-    it('imgSrc allows self, data, and blob', () => {
+    it('imgSrc allows self, data, blob, and https (for admin-configured OIDC provider icons)', () => {
       const { imgSrc } = buildCspDirectives();
-      expect(imgSrc).toEqual(["'self'", 'data:', 'blob:']);
+      expect(imgSrc).toEqual(["'self'", 'data:', 'blob:', 'https:']);
+    });
+
+    it('imgSrc does not allow plain http to keep mixed-content protection', () => {
+      const { imgSrc } = buildCspDirectives();
+      expect(imgSrc).not.toContain('http:');
+      expect(imgSrc).not.toContain('*');
     });
 
     it('mediaSrc allows self, data, and blob', () => {

--- a/server/src/common/utils/bootstrap.utils.ts
+++ b/server/src/common/utils/bootstrap.utils.ts
@@ -41,7 +41,7 @@ export function buildCspDirectives(options: CspOptions = {}) {
     defaultSrc: ["'self'"],
     scriptSrc,
     styleSrc: ["'self'", "'unsafe-inline'", 'blob:', 'https://fonts.googleapis.com'],
-    imgSrc: ["'self'", 'data:', 'blob:'],
+    imgSrc: ["'self'", 'data:', 'blob:', 'https:'],
     connectSrc,
     mediaSrc: ["'self'", 'data:', 'blob:'],
     fontSrc: ["'self'", 'data:', 'blob:', 'https://fonts.gstatic.com'],


### PR DESCRIPTION
The Content Security Policy was previously blocking external images, preventing admin-configured OIDC provider icons from loading. This allows https: images to be loaded while continuing to block plain http: to maintain mixed-content protection.

Closes #131
