### PR TITLE
feat(metadata): add bulk metadata edit dialog

### DIFF
--- a/client/src/features/book/components/BulkEditMetadataDialog.vue
+++ b/client/src/features/book/components/BulkEditMetadataDialog.vue
@@ -1,0 +1,345 @@
+<script setup lang="ts">
+import { reactive, computed, watch } from 'vue'
+import { X } from 'lucide-vue-next'
+import ChipInput from '@/components/ui/ChipInput.vue'
+import InputWithSuggestions from '@/components/ui/InputWithSuggestions.vue'
+import { useAuthorSearch } from '@/features/book/composables/useAuthorSearch'
+import { useGenreSearch, useTagSearch } from '@/features/book/composables/useTagSearch'
+import { useNarratorSearch } from '@/features/book/composables/useNarratorSearch'
+import { usePublisherSearch, useSeriesNameSearch, useLanguageSearch } from '@/features/book/composables/useMetadataFieldSearch'
+import type { BulkEditFields, ArrayMode } from '@/features/book/composables/useBulkEditMetadata'
+
+type UIArrayMode = ArrayMode | 'clear'
+
+const props = defineProps<{
+  open: boolean
+  bookCount: number
+  submitting: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  confirm: [fields: BulkEditFields]
+}>()
+
+const ARRAY_FIELDS = ['authors', 'genres', 'tags', 'narrators'] as const
+const SCALAR_FIELDS = ['seriesName', 'publisher', 'language', 'publishedYear'] as const
+
+type ArrayFieldKey = (typeof ARRAY_FIELDS)[number]
+type ScalarFieldKey = (typeof SCALAR_FIELDS)[number]
+type FieldKey = ArrayFieldKey | ScalarFieldKey
+
+const FIELD_LABELS: Record<FieldKey, string> = {
+  authors: 'Authors',
+  genres: 'Genres',
+  tags: 'Tags',
+  narrators: 'Narrators',
+  seriesName: 'Series',
+  publisher: 'Publisher',
+  language: 'Language',
+  publishedYear: 'Year',
+}
+
+const MODE_LABELS: Record<UIArrayMode, string> = {
+  add: 'Add',
+  remove: 'Remove',
+  replace: 'Replace',
+  clear: 'Clear',
+}
+
+const { search: searchAuthors } = useAuthorSearch()
+const { search: searchGenres } = useGenreSearch()
+const { search: searchTags } = useTagSearch()
+const { search: searchNarrators } = useNarratorSearch()
+const { search: searchPublishers } = usePublisherSearch()
+const { search: searchSeries } = useSeriesNameSearch()
+const { search: searchLanguages } = useLanguageSearch()
+
+const SEARCH_FNS: Record<ArrayFieldKey, (q: string) => Promise<string[]>> = {
+  authors: searchAuthors,
+  genres: searchGenres,
+  tags: searchTags,
+  narrators: searchNarrators,
+}
+
+const SUGGESTION_FNS: Partial<Record<ScalarFieldKey, (q: string) => Promise<string[]>>> = {
+  seriesName: searchSeries,
+  publisher: searchPublishers,
+  language: searchLanguages,
+}
+
+const enabledFields = reactive<Record<FieldKey, boolean>>({
+  authors: false,
+  genres: false,
+  tags: false,
+  narrators: false,
+  seriesName: false,
+  publisher: false,
+  language: false,
+  publishedYear: false,
+})
+
+const arrayModes = reactive<Record<ArrayFieldKey, UIArrayMode>>({
+  authors: 'add',
+  genres: 'add',
+  tags: 'add',
+  narrators: 'add',
+})
+
+const arrayValues = reactive<Record<ArrayFieldKey, string[]>>({
+  authors: [],
+  genres: [],
+  tags: [],
+  narrators: [],
+})
+
+const scalarValues = reactive<Record<ScalarFieldKey, string>>({
+  seriesName: '',
+  publisher: '',
+  language: '',
+  publishedYear: '',
+})
+
+const hasAnyEnabledField = computed(() => Object.values(enabledFields).some(Boolean))
+
+const yearError = computed(() => {
+  if (!enabledFields.publishedYear) return null
+  const raw = scalarValues.publishedYear.trim()
+  if (!raw) return null
+  if (!/^\d+$/.test(raw)) return 'Enter a valid year (numbers only)'
+  return null
+})
+
+const canConfirm = computed(() => {
+  if (!hasAnyEnabledField.value) return false
+  if (yearError.value) return false
+
+  for (const key of ARRAY_FIELDS) {
+    if (!enabledFields[key]) continue
+    if (arrayModes[key] === 'clear') continue
+    if (arrayValues[key].length === 0) return false
+  }
+
+  return true
+})
+
+function buildFields(): BulkEditFields {
+  const fields: BulkEditFields = {}
+
+  for (const key of ARRAY_FIELDS) {
+    if (!enabledFields[key]) continue
+    if (arrayModes[key] === 'clear') {
+      fields[key] = { mode: 'replace', values: [] }
+    } else {
+      fields[key] = { mode: arrayModes[key], values: arrayValues[key] }
+    }
+  }
+
+  for (const key of SCALAR_FIELDS) {
+    if (!enabledFields[key]) continue
+    if (key === 'publishedYear') {
+      const num = scalarValues[key].trim() ? parseInt(scalarValues[key], 10) : null
+      fields[key] = { value: num !== null && Number.isNaN(num) ? null : num }
+    } else {
+      fields[key] = { value: scalarValues[key].trim() || null }
+    }
+  }
+
+  return fields
+}
+
+function handleConfirm() {
+  if (!canConfirm.value || props.submitting) return
+  emit('confirm', buildFields())
+}
+
+function resetForm() {
+  for (const key of [...ARRAY_FIELDS, ...SCALAR_FIELDS]) {
+    enabledFields[key] = false
+  }
+  for (const key of ARRAY_FIELDS) {
+    arrayModes[key] = 'add'
+    arrayValues[key] = []
+  }
+  for (const key of SCALAR_FIELDS) {
+    scalarValues[key] = ''
+  }
+}
+
+function handleClose() {
+  if (props.submitting) return
+  emit('update:open', false)
+}
+
+function toggleField(key: FieldKey) {
+  enabledFields[key] = !enabledFields[key]
+}
+
+function setArrayMode(key: ArrayFieldKey, mode: UIArrayMode) {
+  arrayModes[key] = mode
+}
+
+watch(
+  () => props.open,
+  (open) => {
+    if (!open) resetForm()
+  },
+)
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="fixed inset-0 z-50 flex items-center justify-center">
+      <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="handleClose" />
+      <div class="relative z-10 w-full max-w-lg mx-4 max-h-[90vh] bg-card border border-border rounded-lg shadow-2xl flex flex-col">
+        <!-- Header -->
+        <div class="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
+          <h2 class="text-base font-semibold text-foreground">Edit metadata - {{ bookCount }} book{{ bookCount === 1 ? '' : 's' }}</h2>
+          <button
+            type="button"
+            class="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            :disabled="submitting"
+            @click="handleClose"
+          >
+            <X :size="18" />
+          </button>
+        </div>
+
+        <!-- Scrollable body -->
+        <div class="overflow-y-auto px-6 py-4 space-y-4 min-h-0">
+          <p class="text-sm text-muted-foreground">Toggle fields to edit, then configure values. Only toggled fields will be changed.</p>
+
+          <!-- Array fields -->
+          <div v-for="key in ARRAY_FIELDS" :key="key" class="space-y-2">
+            <button type="button" class="flex items-center gap-2 w-full text-left" @click="toggleField(key)">
+              <div
+                :class="[
+                  'w-4 h-4 rounded border transition-colors flex items-center justify-center shrink-0',
+                  enabledFields[key] ? 'bg-primary border-primary' : 'border-muted-foreground/40 hover:border-foreground/60',
+                ]"
+              >
+                <svg
+                  v-if="enabledFields[key]"
+                  viewBox="0 0 16 16"
+                  class="w-3 h-3 text-primary-foreground"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polyline points="3.5 8 6.5 11 12.5 5" />
+                </svg>
+              </div>
+              <span class="text-sm font-medium text-foreground">{{ FIELD_LABELS[key] }}</span>
+            </button>
+
+            <div v-if="enabledFields[key]" class="pl-6 space-y-2">
+              <div class="flex gap-1.5">
+                <button
+                  v-for="m in ['add', 'remove', 'replace', 'clear'] as UIArrayMode[]"
+                  :key="m"
+                  type="button"
+                  :class="[
+                    'px-2.5 py-1 rounded text-xs font-medium transition-colors',
+                    arrayModes[key] === m
+                      ? m === 'clear'
+                        ? 'bg-destructive text-destructive-foreground'
+                        : 'bg-primary text-primary-foreground'
+                      : 'bg-muted text-muted-foreground hover:text-foreground',
+                  ]"
+                  @click="setArrayMode(key, m)"
+                >
+                  {{ MODE_LABELS[m] }}
+                </button>
+              </div>
+
+              <p v-if="arrayModes[key] === 'clear'" class="text-xs text-destructive">
+                This will remove all {{ FIELD_LABELS[key].toLowerCase() }} from the selected books.
+              </p>
+              <ChipInput
+                v-else
+                v-model="arrayValues[key]"
+                :search-fn="SEARCH_FNS[key]"
+                :placeholder="`Search ${FIELD_LABELS[key].toLowerCase()}...`"
+              />
+            </div>
+          </div>
+
+          <!-- Scalar fields -->
+          <div v-for="key in SCALAR_FIELDS" :key="key" class="space-y-2">
+            <button type="button" class="flex items-center gap-2 w-full text-left" @click="toggleField(key)">
+              <div
+                :class="[
+                  'w-4 h-4 rounded border transition-colors flex items-center justify-center shrink-0',
+                  enabledFields[key] ? 'bg-primary border-primary' : 'border-muted-foreground/40 hover:border-foreground/60',
+                ]"
+              >
+                <svg
+                  v-if="enabledFields[key]"
+                  viewBox="0 0 16 16"
+                  class="w-3 h-3 text-primary-foreground"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polyline points="3.5 8 6.5 11 12.5 5" />
+                </svg>
+              </div>
+              <span class="text-sm font-medium text-foreground">{{ FIELD_LABELS[key] }}</span>
+            </button>
+
+            <div v-if="enabledFields[key]" class="pl-6">
+              <InputWithSuggestions
+                v-if="SUGGESTION_FNS[key]"
+                :model-value="scalarValues[key] || null"
+                :search-fn="SUGGESTION_FNS[key]!"
+                :placeholder="`Enter ${FIELD_LABELS[key].toLowerCase()}`"
+                class="w-full h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                @update:model-value="scalarValues[key] = $event ?? ''"
+              />
+              <input
+                v-else
+                v-model="scalarValues[key]"
+                type="text"
+                :inputmode="key === 'publishedYear' ? 'numeric' : undefined"
+                :placeholder="key === 'publishedYear' ? 'e.g. 2024' : `Enter ${FIELD_LABELS[key].toLowerCase()}`"
+                class="w-full h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              />
+              <p v-if="key === 'publishedYear' && yearError" class="text-xs text-destructive mt-1">
+                {{ yearError }}
+              </p>
+              <p v-else class="text-xs text-muted-foreground mt-1">Leave empty to clear this field on all selected books.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="flex justify-end gap-2 px-6 py-4 border-t border-border shrink-0">
+          <button
+            type="button"
+            class="h-9 px-4 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            :disabled="submitting"
+            @click="handleClose"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            :disabled="!canConfirm || submitting"
+            class="h-9 px-4 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-2"
+            @click="handleConfirm"
+          >
+            <svg v-if="submitting" class="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            {{ submitting ? 'Applying...' : 'Apply' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/client/src/features/book/components/__tests__/BulkEditMetadataDialog.spec.ts
+++ b/client/src/features/book/components/__tests__/BulkEditMetadataDialog.spec.ts
@@ -1,0 +1,549 @@
+import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick, defineComponent, h } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import BulkEditMetadataDialog from '../BulkEditMetadataDialog.vue'
+
+const searchMock = vi.fn<(q: string) => Promise<string[]>>().mockResolvedValue([])
+
+vi.mock('@/features/book/composables/useAuthorSearch', () => ({
+  useAuthorSearch: () => ({ search: searchMock }),
+}))
+vi.mock('@/features/book/composables/useTagSearch', () => ({
+  useGenreSearch: () => ({ search: searchMock }),
+  useTagSearch: () => ({ search: searchMock }),
+}))
+vi.mock('@/features/book/composables/useNarratorSearch', () => ({
+  useNarratorSearch: () => ({ search: searchMock }),
+}))
+vi.mock('@/features/book/composables/useMetadataFieldSearch', () => ({
+  usePublisherSearch: () => ({ search: searchMock }),
+  useSeriesNameSearch: () => ({ search: searchMock }),
+  useLanguageSearch: () => ({ search: searchMock }),
+}))
+
+const ChipInputStub = defineComponent({
+  name: 'ChipInput',
+  props: ['modelValue', 'searchFn', 'placeholder'],
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('div', { 'data-testid': 'chip-input' }, [
+        h('input', {
+          value: (props.modelValue as string[]).join(','),
+          onInput: (e: Event) => {
+            const val = (e.target as HTMLInputElement).value
+            emit('update:modelValue', val ? val.split(',').map((s) => s.trim()) : [])
+          },
+        }),
+      ])
+  },
+})
+
+const InputWithSuggestionsStub = defineComponent({
+  name: 'InputWithSuggestions',
+  props: ['modelValue', 'searchFn', 'placeholder', 'disabled', 'class'],
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h('input', {
+        'data-testid': 'suggestions-input',
+        value: props.modelValue ?? '',
+        placeholder: props.placeholder,
+        onInput: (e: Event) => emit('update:modelValue', (e.target as HTMLInputElement).value || null),
+      })
+  },
+})
+
+function mountDialog(props: { open?: boolean; bookCount?: number; submitting?: boolean } = {}) {
+  return mount(BulkEditMetadataDialog, {
+    props: {
+      open: true,
+      bookCount: 3,
+      submitting: false,
+      ...props,
+    },
+    global: {
+      stubs: {
+        Teleport: true,
+        ChipInput: ChipInputStub,
+        InputWithSuggestions: InputWithSuggestionsStub,
+      },
+    },
+  })
+}
+
+describe('BulkEditMetadataDialog', () => {
+  beforeEach(() => {
+    searchMock.mockReset()
+    searchMock.mockResolvedValue([])
+  })
+
+  describe('initial state', () => {
+    it('renders the dialog when open', () => {
+      const wrapper = mountDialog()
+      expect(wrapper.find('h2').text()).toContain('Edit metadata - 3 books')
+    })
+
+    it('shows singular "book" for bookCount=1', () => {
+      const wrapper = mountDialog({ bookCount: 1 })
+      expect(wrapper.find('h2').text()).toContain('1 book')
+      expect(wrapper.find('h2').text()).not.toContain('books')
+    })
+
+    it('renders all expected field labels', () => {
+      const wrapper = mountDialog()
+      const labels = ['Authors', 'Genres', 'Tags', 'Narrators', 'Series', 'Publisher', 'Language', 'Year']
+      for (const label of labels) {
+        expect(wrapper.text()).toContain(label)
+      }
+    })
+
+    it('Apply button is disabled when no fields are enabled', () => {
+      const wrapper = mountDialog()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeDefined()
+    })
+  })
+
+  describe('field toggling', () => {
+    it('enables Publisher input when Publisher toggle is clicked', async () => {
+      const wrapper = mountDialog()
+      const publisherToggle = wrapper.findAll('button').find((b) => b.text() === 'Publisher')
+      await publisherToggle!.trigger('click')
+      await nextTick()
+      expect(wrapper.findAll('[data-testid="suggestions-input"]').length).toBeGreaterThan(0)
+    })
+
+    it('enables Year input when Year toggle is clicked', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      expect(wrapper.find('input[placeholder="e.g. 2024"]').exists()).toBe(true)
+    })
+
+    it('enables ChipInput when Authors toggle is clicked', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      expect(wrapper.find('[data-testid="chip-input"]').exists()).toBe(true)
+    })
+
+    it('shows mode buttons (Add/Remove/Replace/Clear) when array field is enabled', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      expect(wrapper.text()).toContain('Add')
+      expect(wrapper.text()).toContain('Remove')
+      expect(wrapper.text()).toContain('Replace')
+      expect(wrapper.text()).toContain('Clear')
+    })
+
+    it('hides input when field is toggled off', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      expect(wrapper.find('input[placeholder="e.g. 2024"]').exists()).toBe(true)
+      await yearToggle!.trigger('click')
+      await nextTick()
+      expect(wrapper.find('input[placeholder="e.g. 2024"]').exists()).toBe(false)
+    })
+  })
+
+  describe('canConfirm logic', () => {
+    it('enables Apply when a scalar field is toggled on', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeUndefined()
+    })
+
+    it('disables Apply when array field is in Replace mode with no values', async () => {
+      const wrapper = mountDialog()
+      const genresToggle = wrapper.findAll('button').find((b) => b.text() === 'Genres')
+      await genresToggle!.trigger('click')
+      await nextTick()
+      const replaceBtn = wrapper.findAll('button').find((b) => b.text() === 'Replace')
+      await replaceBtn!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeDefined()
+    })
+
+    it('enables Apply when Clear mode is selected (no values needed)', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      const clearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear')
+      await clearBtn!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeUndefined()
+    })
+
+    it('disables Apply when one field is Clear (valid) and another is Add with no values', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      const clearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear')
+      await clearBtn!.trigger('click')
+      await nextTick()
+      const tagsToggle = wrapper.findAll('button').find((b) => b.text() === 'Tags')
+      await tagsToggle!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeDefined()
+    })
+
+    it('disables Apply when array field is in Add mode with no values', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeDefined()
+    })
+
+    it('disables Apply when array field is in Remove mode with no values', async () => {
+      const wrapper = mountDialog()
+      const tagsToggle = wrapper.findAll('button').find((b) => b.text() === 'Tags')
+      await tagsToggle!.trigger('click')
+      await nextTick()
+      const removeBtn = wrapper.findAll('button').find((b) => b.text() === 'Remove')
+      await removeBtn!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeDefined()
+    })
+
+    it('enables Apply when array field has values in Add mode', async () => {
+      const wrapper = mountDialog()
+      const tagsToggle = wrapper.findAll('button').find((b) => b.text() === 'Tags')
+      await tagsToggle!.trigger('click')
+      await nextTick()
+      const chipInput = wrapper.find('[data-testid="chip-input"] input')
+      await chipInput.setValue('fantasy')
+      await chipInput.trigger('input')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeUndefined()
+    })
+
+    it('disables Apply when year contains letters', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      const yearInput = wrapper.find('input[placeholder="e.g. 2024"]')
+      await yearInput.setValue('abc')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeDefined()
+    })
+
+    it('disables Apply when year is partial numeric like "2024abc"', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      const yearInput = wrapper.find('input[placeholder="e.g. 2024"]')
+      await yearInput.setValue('2024abc')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeDefined()
+    })
+
+    it('shows year validation error message for invalid input', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      const yearInput = wrapper.find('input[placeholder="e.g. 2024"]')
+      await yearInput.setValue('abc')
+      await nextTick()
+      expect(wrapper.text()).toContain('Enter a valid year (numbers only)')
+    })
+
+    it('hides year error message when year is valid', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      const yearInput = wrapper.find('input[placeholder="e.g. 2024"]')
+      await yearInput.setValue('2024')
+      await nextTick()
+      expect(wrapper.text()).not.toContain('Enter a valid year')
+    })
+
+    it('enables Apply and does not show error when year is empty (clear)', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      expect(applyBtn?.attributes('disabled')).toBeUndefined()
+      expect(wrapper.text()).not.toContain('Enter a valid year')
+    })
+  })
+
+  describe('emits', () => {
+    it('emits confirm with correct scalar field when Apply is clicked', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      const yearInput = wrapper.find('input[placeholder="e.g. 2024"]')
+      await yearInput.setValue('2024')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      await applyBtn!.trigger('click')
+      await nextTick()
+      const emitted = wrapper.emitted('confirm')
+      expect(emitted).toHaveLength(1)
+      const fields = (emitted![0] as [Record<string, unknown>])[0]
+      expect(fields.publishedYear).toEqual({ value: 2024 })
+    })
+
+    it('emits confirm with null when scalar field is empty', async () => {
+      const wrapper = mountDialog()
+      const publisherToggle = wrapper.findAll('button').find((b) => b.text() === 'Publisher')
+      await publisherToggle!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      await applyBtn!.trigger('click')
+      await nextTick()
+      const emitted = wrapper.emitted('confirm')
+      const fields = (emitted![0] as [Record<string, unknown>])[0]
+      expect(fields.publisher).toEqual({ value: null })
+    })
+
+    it('emits confirm with correct array field in replace mode', async () => {
+      const wrapper = mountDialog()
+      const genresToggle = wrapper.findAll('button').find((b) => b.text() === 'Genres')
+      await genresToggle!.trigger('click')
+      await nextTick()
+      const replaceBtn = wrapper.findAll('button').find((b) => b.text() === 'Replace')
+      await replaceBtn!.trigger('click')
+      await nextTick()
+      const chipInput = wrapper.find('[data-testid="chip-input"] input')
+      await chipInput.setValue('Fantasy,Sci-Fi')
+      await chipInput.trigger('input')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      await applyBtn!.trigger('click')
+      await nextTick()
+      const emitted = wrapper.emitted('confirm')
+      const fields = (emitted![0] as [Record<string, unknown>])[0]
+      expect(fields.genres).toEqual({ mode: 'replace', values: ['Fantasy', 'Sci-Fi'] })
+    })
+
+    it('emits confirm with { mode: replace, values: [] } when Clear mode Apply is clicked', async () => {
+      const wrapper = mountDialog()
+      const tagsToggle = wrapper.findAll('button').find((b) => b.text() === 'Tags')
+      await tagsToggle!.trigger('click')
+      await nextTick()
+      const clearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear')
+      await clearBtn!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Apply'))
+      await applyBtn!.trigger('click')
+      await nextTick()
+      const emitted = wrapper.emitted('confirm')
+      expect(emitted).toHaveLength(1)
+      const fields = (emitted![0] as [Record<string, unknown>])[0]
+      expect(fields.tags).toEqual({ mode: 'replace', values: [] })
+    })
+
+    it('does not emit confirm when Apply is clicked while submitting', async () => {
+      const wrapper = mountDialog({ submitting: true })
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Applying'))
+      await applyBtn?.trigger('click')
+      await nextTick()
+      expect(wrapper.emitted('confirm')).toBeUndefined()
+    })
+
+    it('emits update:open false when Cancel is clicked', async () => {
+      const wrapper = mountDialog()
+      const cancelBtn = wrapper.findAll('button').find((b) => b.text() === 'Cancel')
+      await cancelBtn!.trigger('click')
+      expect(wrapper.emitted('update:open')).toEqual([[false]])
+    })
+
+    it('emits update:open false when backdrop is clicked', async () => {
+      const wrapper = mountDialog()
+      const backdrop = wrapper.find('.absolute.inset-0')
+      await backdrop.trigger('click')
+      expect(wrapper.emitted('update:open')).toEqual([[false]])
+    })
+
+    it('does not emit update:open false when backdrop is clicked while submitting', async () => {
+      const wrapper = mountDialog({ submitting: true })
+      const backdrop = wrapper.find('.absolute.inset-0')
+      await backdrop.trigger('click')
+      expect(wrapper.emitted('update:open')).toBeUndefined()
+    })
+  })
+
+  describe('submitting state', () => {
+    it('shows Applying... text when submitting', () => {
+      const wrapper = mountDialog({ submitting: true })
+      const applyBtn = wrapper.findAll('button').find((b) => b.text().includes('Applying'))
+      expect(applyBtn).toBeDefined()
+    })
+
+    it('disables Cancel button when submitting', () => {
+      const wrapper = mountDialog({ submitting: true })
+      const cancelBtn = wrapper.findAll('button').find((b) => b.text() === 'Cancel')
+      expect(cancelBtn?.attributes('disabled')).toBeDefined()
+    })
+  })
+
+  describe('form reset', () => {
+    it('resets field state when dialog closes then reopens', async () => {
+      const wrapper = mountDialog()
+      const yearToggle = wrapper.findAll('button').find((b) => b.text() === 'Year')
+      await yearToggle!.trigger('click')
+      await nextTick()
+      expect(wrapper.find('input[placeholder="e.g. 2024"]').exists()).toBe(true)
+      await wrapper.setProps({ open: false })
+      await nextTick()
+      await wrapper.setProps({ open: true })
+      await nextTick()
+      expect(wrapper.find('input[placeholder="e.g. 2024"]').exists()).toBe(false)
+    })
+
+    it('resets array field values when dialog closes', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      const replaceBtn = wrapper.findAll('button').find((b) => b.text() === 'Replace')
+      await replaceBtn!.trigger('click')
+      await nextTick()
+      const chipInput = wrapper.find('[data-testid="chip-input"] input')
+      await chipInput.setValue('Author One')
+      await chipInput.trigger('input')
+      await nextTick()
+      await wrapper.setProps({ open: false })
+      await nextTick()
+      await wrapper.setProps({ open: true })
+      await nextTick()
+      await flushPromises()
+      expect(wrapper.find('[data-testid="chip-input"]').exists()).toBe(false)
+    })
+  })
+
+  describe('array mode switching', () => {
+    it('switches array field mode to Remove when Remove is clicked', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      const removeBtn = wrapper.findAll('button').find((b) => b.text() === 'Remove')
+      await removeBtn!.trigger('click')
+      await nextTick()
+      const updatedRemoveBtn = wrapper.findAll('button').find((b) => b.text() === 'Remove')
+      expect(updatedRemoveBtn?.classes()).toContain('bg-primary')
+    })
+
+    it('switches to Clear mode and highlights Clear pill with destructive style', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      const clearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear')
+      await clearBtn!.trigger('click')
+      await nextTick()
+      const updatedClearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear')
+      expect(updatedClearBtn?.classes()).toContain('bg-destructive')
+    })
+
+    it('hides ChipInput and shows warning when Clear mode is selected', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      const clearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear')
+      await clearBtn!.trigger('click')
+      await nextTick()
+      expect(wrapper.find('[data-testid="chip-input"]').exists()).toBe(false)
+      expect(wrapper.text()).toContain('This will remove all authors from the selected books.')
+    })
+
+    it('shows ChipInput again when switching from Clear back to Add', async () => {
+      const wrapper = mountDialog()
+      const tagsToggle = wrapper.findAll('button').find((b) => b.text() === 'Tags')
+      await tagsToggle!.trigger('click')
+      await nextTick()
+      const clearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear')
+      await clearBtn!.trigger('click')
+      await nextTick()
+      expect(wrapper.find('[data-testid="chip-input"]').exists()).toBe(false)
+      const addBtn = wrapper.findAll('button').find((b) => b.text() === 'Add')
+      await addBtn!.trigger('click')
+      await nextTick()
+      expect(wrapper.find('[data-testid="chip-input"]').exists()).toBe(true)
+    })
+
+    it('preserves chip values when switching to Clear and back to Replace', async () => {
+      const wrapper = mountDialog()
+      const genresToggle = wrapper.findAll('button').find((b) => b.text() === 'Genres')
+      await genresToggle!.trigger('click')
+      await nextTick()
+      const replaceBtn = wrapper.findAll('button').find((b) => b.text() === 'Replace')
+      await replaceBtn!.trigger('click')
+      await nextTick()
+      const chipInput = wrapper.find('[data-testid="chip-input"] input')
+      await chipInput.setValue('Fantasy')
+      await chipInput.trigger('input')
+      await nextTick()
+      const clearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear')
+      await clearBtn!.trigger('click')
+      await nextTick()
+      const replaceBtn2 = wrapper.findAll('button').find((b) => b.text() === 'Replace')
+      await replaceBtn2!.trigger('click')
+      await nextTick()
+      const chipInput2 = wrapper.find('[data-testid="chip-input"] input')
+      expect((chipInput2.element as HTMLInputElement).value).toBe('Fantasy')
+    })
+
+    it('resets Clear mode to Add when dialog closes and reopens', async () => {
+      const wrapper = mountDialog()
+      const authorsToggle = wrapper.findAll('button').find((b) => b.text() === 'Authors')
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      const clearBtn = wrapper.findAll('button').find((b) => b.text() === 'Clear')
+      await clearBtn!.trigger('click')
+      await nextTick()
+      await wrapper.setProps({ open: false })
+      await nextTick()
+      await wrapper.setProps({ open: true })
+      await nextTick()
+      await authorsToggle!.trigger('click')
+      await nextTick()
+      const updatedAddBtn = wrapper.findAll('button').find((b) => b.text() === 'Add')
+      expect(updatedAddBtn?.classes()).toContain('bg-primary')
+    })
+
+    it('does not show the old empty-replace clear hint', async () => {
+      const wrapper = mountDialog()
+      const genresToggle = wrapper.findAll('button').find((b) => b.text() === 'Genres')
+      await genresToggle!.trigger('click')
+      await nextTick()
+      const replaceBtn = wrapper.findAll('button').find((b) => b.text() === 'Replace')
+      await replaceBtn!.trigger('click')
+      await nextTick()
+      expect(wrapper.text()).not.toContain('Apply with no values to clear all')
+    })
+  })
+})

--- a/client/src/features/book/composables/__tests__/useBulkEditMetadata.test.ts
+++ b/client/src/features/book/composables/__tests__/useBulkEditMetadata.test.ts
@@ -1,0 +1,512 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { BookCard } from '@bookorbit/types'
+import { useBulkEditMetadata } from '../useBulkEditMetadata'
+import type { BulkEditFields } from '../useBulkEditMetadata'
+
+const mocks = vi.hoisted(() => ({
+  api: vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<{ ok: boolean; json: () => Promise<unknown> }>>(),
+  toastSuccess: vi.fn<(message: string) => void>(),
+  toastError: vi.fn<(message: string) => void>(),
+  toastWarning: vi.fn<(message: string) => void>(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: mocks.api,
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError,
+    warning: mocks.toastWarning,
+  },
+}))
+
+function makeBook(overrides: Partial<BookCard> = {}): BookCard {
+  return {
+    id: 1,
+    status: 'present',
+    title: 'Test Book',
+    authors: ['Author One'],
+    seriesName: null,
+    seriesIndex: null,
+    files: [],
+    publishedYear: null,
+    language: null,
+    genres: [],
+    rating: null,
+    readingProgress: null,
+    readStatus: null,
+    addedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: null,
+    metadataScore: null,
+    hasCover: false,
+    hasMetadataLocks: false,
+    lockedFields: [],
+    subtitle: null,
+    publisher: null,
+    pageCount: null,
+    isbn13: null,
+    narrators: [],
+    tags: [],
+    ...overrides,
+  }
+}
+
+function makeBulkResult(overrides = {}) {
+  return {
+    updatedBooks: 2,
+    fields: {
+      publisher: { updated: 2, skippedLocked: 0 },
+    },
+    ...overrides,
+  }
+}
+
+describe('useBulkEditMetadata', () => {
+  beforeEach(() => {
+    mocks.api.mockReset()
+    mocks.toastSuccess.mockClear()
+    mocks.toastError.mockClear()
+    mocks.toastWarning.mockClear()
+  })
+
+  describe('selectedCount', () => {
+    it('returns size of selectedIds when no querySelection', () => {
+      const ids = ref(new Set([1, 2, 3]))
+      const { selectedCount } = useBulkEditMetadata(ids)
+      expect(selectedCount.value).toBe(3)
+    })
+
+    it('returns querySelection.total when querySelection is provided', () => {
+      const ids = ref(new Set([1, 2]))
+      const query = ref({ libraryId: 1, total: 100 })
+      const { selectedCount } = useBulkEditMetadata(ids, undefined, query)
+      expect(selectedCount.value).toBe(100)
+    })
+
+    it('returns size of selectedIds when querySelection is null', () => {
+      const ids = ref(new Set([1, 2]))
+      const query = ref<{ libraryId?: number; total: number } | null>(null)
+      const { selectedCount } = useBulkEditMetadata(ids, undefined, query)
+      expect(selectedCount.value).toBe(2)
+    })
+  })
+
+  describe('submit - selection payload', () => {
+    it('sends bookIds payload when no querySelection', async () => {
+      const ids = ref(new Set([10, 20]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({ ok: true, json: async () => makeBulkResult() })
+
+      const fields: BulkEditFields = { publisher: { value: 'Penguin' } }
+      await submit(fields)
+
+      const [, init] = mocks.api.mock.calls[0] as [string, RequestInit]
+      const body = JSON.parse(init.body as string) as { bookIds: number[]; fields: BulkEditFields }
+      expect(body.bookIds).toEqual([10, 20])
+      expect(body.fields).toEqual(fields)
+    })
+
+    it('sends query payload when querySelection is active', async () => {
+      const ids = ref(new Set<number>())
+      const query = ref({ libraryId: 5, q: 'fantasy', sort: [{ field: 'title' as const, dir: 'asc' as const }], total: 50 })
+      const { submit } = useBulkEditMetadata(ids, undefined, query)
+      mocks.api.mockResolvedValue({ ok: true, json: async () => makeBulkResult() })
+
+      const fields: BulkEditFields = { publisher: { value: 'Penguin' } }
+      await submit(fields)
+
+      const [, init] = mocks.api.mock.calls[0] as [string, RequestInit]
+      const body = JSON.parse(init.body as string) as { query: Record<string, unknown>; fields: BulkEditFields }
+      expect(body.query).toEqual({ libraryId: 5, q: 'fantasy', sort: [{ field: 'title', dir: 'asc' }] })
+      expect(body.fields).toEqual(fields)
+      expect((body as Record<string, unknown>).bookIds).toBeUndefined()
+    })
+  })
+
+  describe('submit - success responses', () => {
+    it('shows success toast with count when all books updated', async () => {
+      const ids = ref(new Set([1, 2]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 2, fields: { publisher: { updated: 2, skippedLocked: 0 } } }),
+      })
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('Updated metadata for 2 books')
+    })
+
+    it('shows singular book in toast when only 1 book updated', async () => {
+      const ids = ref(new Set([1]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { publisher: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('Updated metadata for 1 book')
+    })
+
+    it('shows warning toast when all books had locked fields', async () => {
+      const ids = ref(new Set([1, 2]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => ({ updatedBooks: 0, fields: { publisher: { updated: 0, skippedLocked: 2 } } }),
+      })
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(mocks.toastWarning).toHaveBeenCalledWith('All selected books had locked fields - no changes applied')
+    })
+
+    it('shows partial success toast when some books had locked fields', async () => {
+      const ids = ref(new Set([1, 2, 3]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => ({ updatedBooks: 2, fields: { publisher: { updated: 2, skippedLocked: 1 } } }),
+      })
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('Updated 2 books (some fields skipped due to locks)')
+    })
+
+    it('returns the result object on success', async () => {
+      const ids = ref(new Set([1]))
+      const { submit } = useBulkEditMetadata(ids)
+      const result = makeBulkResult()
+      mocks.api.mockResolvedValue({ ok: true, json: async () => result })
+
+      const returned = await submit({ publisher: { value: 'Test' } })
+
+      expect(returned).toEqual(result)
+    })
+  })
+
+  describe('submit - failure responses', () => {
+    it('shows error toast on non-ok API response', async () => {
+      const ids = ref(new Set([1]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({ ok: false, json: async () => ({ message: 'Not authorized' }) })
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(mocks.toastError).toHaveBeenCalledWith('Not authorized')
+    })
+
+    it('shows array message first element on validation errors', async () => {
+      const ids = ref(new Set([1]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({ ok: false, json: async () => ({ message: ['Error 1', 'Error 2'] }) })
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(mocks.toastError).toHaveBeenCalledWith('Error 1')
+    })
+
+    it('returns null on non-ok API response', async () => {
+      const ids = ref(new Set([1]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({ ok: false, json: async () => null })
+
+      const result = await submit({ publisher: { value: 'Test' } })
+
+      expect(result).toBeNull()
+    })
+
+    it('shows generic error toast when api() throws', async () => {
+      const ids = ref(new Set([1]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockRejectedValue(new Error('Network error'))
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(mocks.toastError).toHaveBeenCalledWith('An unexpected error occurred while saving changes')
+    })
+
+    it('returns null when api() throws', async () => {
+      const ids = ref(new Set([1]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockRejectedValue(new Error('Session expired'))
+
+      const result = await submit({ publisher: { value: 'Test' } })
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('submit - submitting flag', () => {
+    it('sets submitting to true during API call', async () => {
+      const ids = ref(new Set([1]))
+      const { submit, submitting } = useBulkEditMetadata(ids)
+      let duringSubmit = false
+      mocks.api.mockImplementation(async () => {
+        duringSubmit = submitting.value
+        return { ok: true, json: async () => makeBulkResult() }
+      })
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(duringSubmit).toBe(true)
+    })
+
+    it('resets submitting to false after success', async () => {
+      const ids = ref(new Set([1]))
+      const { submit, submitting } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({ ok: true, json: async () => makeBulkResult() })
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(submitting.value).toBe(false)
+    })
+
+    it('resets submitting to false after non-ok response', async () => {
+      const ids = ref(new Set([1]))
+      const { submit, submitting } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({ ok: false, json: async () => null })
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(submitting.value).toBe(false)
+    })
+
+    it('resets submitting to false when api() throws', async () => {
+      const ids = ref(new Set([1]))
+      const { submit, submitting } = useBulkEditMetadata(ids)
+      mocks.api.mockRejectedValue(new Error('Network error'))
+
+      await submit({ publisher: { value: 'Test' } })
+
+      expect(submitting.value).toBe(false)
+    })
+  })
+
+  describe('optimistic updates', () => {
+    function makeBookList(count = 3) {
+      return ref(
+        Array.from({ length: count }, (_, i) =>
+          makeBook({
+            id: i + 1,
+            seriesName: 'Old Series',
+            publisher: 'Old Publisher',
+            language: 'en',
+            publishedYear: 2000,
+            authors: ['Author One'],
+            genres: ['Drama'],
+            tags: ['unread'],
+            narrators: ['Narrator One'],
+          }),
+        ),
+      )
+    }
+
+    it('applies scalar field updates optimistically when no reload needed', async () => {
+      const ids = ref(new Set([1, 2, 3]))
+      const books = makeBookList(3)
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({ ok: true, json: async () => makeBulkResult({ updatedBooks: 3 }) })
+
+      await submit({
+        seriesName: { value: 'New Series' },
+        publisher: { value: 'New Publisher' },
+        language: { value: 'fr' },
+        publishedYear: { value: 2025 },
+      })
+
+      for (const book of books.value) {
+        expect(book.seriesName).toBe('New Series')
+        expect(book.publisher).toBe('New Publisher')
+        expect(book.language).toBe('fr')
+        expect(book.publishedYear).toBe(2025)
+      }
+    })
+
+    it('applies null scalar value to clear fields optimistically', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, publisher: 'Old Publisher' })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { publisher: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ publisher: { value: null } })
+
+      expect(books.value[0]!.publisher).toBeNull()
+    })
+
+    it('applies replace mode authors update optimistically', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, authors: ['Old Author'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { authors: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ authors: { mode: 'replace', values: ['New Author A', 'New Author B'] } })
+
+      expect(books.value[0]!.authors).toEqual(['New Author A', 'New Author B'])
+    })
+
+    it('applies replace mode genres update optimistically', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, genres: ['Drama'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { genres: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ genres: { mode: 'replace', values: ['Fantasy'] } })
+
+      expect(books.value[0]!.genres).toEqual(['Fantasy'])
+    })
+
+    it('applies replace mode tags update optimistically', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, tags: ['unread'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { tags: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ tags: { mode: 'replace', values: ['read', 'favorite'] } })
+
+      expect(books.value[0]!.tags).toEqual(['read', 'favorite'])
+    })
+
+    it('applies replace mode narrators update optimistically', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, narrators: ['Old Narrator'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { narrators: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ narrators: { mode: 'replace', values: ['New Narrator'] } })
+
+      expect(books.value[0]!.narrators).toEqual(['New Narrator'])
+    })
+
+    it('replaces genres with empty array to clear all', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, genres: ['Drama', 'Sci-Fi'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { genres: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ genres: { mode: 'replace', values: [] } })
+
+      expect(books.value[0]!.genres).toEqual([])
+    })
+
+    it('clears authors optimistically when replace with empty values (clear mode payload)', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, authors: ['Author One', 'Author Two'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { authors: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ authors: { mode: 'replace', values: [] } })
+
+      expect(books.value[0]!.authors).toEqual([])
+    })
+
+    it('clears tags optimistically when replace with empty values (clear mode payload)', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, tags: ['read', 'favorite'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { tags: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ tags: { mode: 'replace', values: [] } })
+
+      expect(books.value[0]!.tags).toEqual([])
+    })
+
+    it('clears narrators optimistically when replace with empty values (clear mode payload)', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, narrators: ['Narrator A'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({
+        ok: true,
+        json: async () => makeBulkResult({ updatedBooks: 1, fields: { narrators: { updated: 1, skippedLocked: 0 } } }),
+      })
+
+      await submit({ narrators: { mode: 'replace', values: [] } })
+
+      expect(books.value[0]!.narrators).toEqual([])
+    })
+
+    it('only updates books in selectedIds', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, publisher: 'Old' }), makeBook({ id: 2, publisher: 'Old' })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({ ok: true, json: async () => makeBulkResult({ updatedBooks: 1 }) })
+
+      await submit({ publisher: { value: 'New' } })
+
+      expect(books.value[0]!.publisher).toBe('New')
+      expect(books.value[1]!.publisher).toBe('Old')
+    })
+
+    it('does not apply optimistic update when add mode is used (triggers reload)', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, authors: ['Author One'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({ ok: true, json: async () => makeBulkResult() })
+
+      await submit({ authors: { mode: 'add', values: ['Author Two'] } })
+
+      expect(books.value[0]!.authors).toEqual(['Author One'])
+    })
+
+    it('does not apply optimistic update when remove mode is used (triggers reload)', async () => {
+      const ids = ref(new Set([1]))
+      const books = ref([makeBook({ id: 1, tags: ['tag1', 'tag2'] })])
+      const { submit } = useBulkEditMetadata(ids, books)
+      mocks.api.mockResolvedValue({ ok: true, json: async () => makeBulkResult() })
+
+      await submit({ tags: { mode: 'remove', values: ['tag1'] } })
+
+      expect(books.value[0]!.tags).toEqual(['tag1', 'tag2'])
+    })
+
+    it('does not apply optimistic update when querySelection is active', async () => {
+      const ids = ref(new Set<number>())
+      const books = ref([makeBook({ id: 1, publisher: 'Old' })])
+      const query = ref({ libraryId: 1, total: 100 })
+      const { submit } = useBulkEditMetadata(ids, books, query)
+      mocks.api.mockResolvedValue({ ok: true, json: async () => makeBulkResult() })
+
+      await submit({ publisher: { value: 'New' } })
+
+      expect(books.value[0]!.publisher).toBe('Old')
+    })
+
+    it('does not apply optimistic update when books ref is not provided', async () => {
+      const ids = ref(new Set([1]))
+      const { submit } = useBulkEditMetadata(ids)
+      mocks.api.mockResolvedValue({ ok: true, json: async () => makeBulkResult() })
+
+      await expect(submit({ publisher: { value: 'Test' } })).resolves.not.toThrow()
+    })
+  })
+})

--- a/client/src/features/book/composables/useBookTableShell.ts
+++ b/client/src/features/book/composables/useBookTableShell.ts
@@ -45,6 +45,7 @@ export function useBookTableShell({ books, querySelection }: BookTableShellOptio
 
   const addToCollectionOpen = ref(false)
   const bulkTagsOpen = ref(false)
+  const bulkEditOpen = ref(false)
   const sendBookOpen = ref(false)
   const quickViewBookId = ref<number | null>(null)
   const quickViewOpen = ref(false)
@@ -88,6 +89,7 @@ export function useBookTableShell({ books, querySelection }: BookTableShellOptio
     ...bulk,
     addToCollectionOpen,
     bulkTagsOpen,
+    bulkEditOpen,
     sendBookOpen,
     quickViewBookId,
     quickViewOpen,

--- a/client/src/features/book/composables/useBulkEditMetadata.ts
+++ b/client/src/features/book/composables/useBulkEditMetadata.ts
@@ -1,0 +1,157 @@
+import { ref, computed } from 'vue'
+import { api } from '@/lib/api'
+import { toast } from 'vue-sonner'
+import type { Ref } from 'vue'
+import type { BookCard, SortSpec, GroupRule } from '@bookorbit/types'
+
+export type ArrayMode = 'add' | 'remove' | 'replace'
+
+export type BulkEditArrayField = {
+  mode: ArrayMode
+  values: string[]
+}
+
+export type BulkEditScalarStringField = {
+  value: string | null
+}
+
+export type BulkEditScalarNumberField = {
+  value: number | null
+}
+
+export type BulkEditFields = {
+  authors?: BulkEditArrayField
+  genres?: BulkEditArrayField
+  tags?: BulkEditArrayField
+  narrators?: BulkEditArrayField
+  seriesName?: BulkEditScalarStringField
+  publisher?: BulkEditScalarStringField
+  language?: BulkEditScalarStringField
+  publishedYear?: BulkEditScalarNumberField
+}
+
+type FieldResult = { updated: number; skippedLocked: number }
+
+export type BulkEditResult = {
+  updatedBooks: number
+  fields: Record<string, FieldResult>
+}
+
+type QueryPayload = {
+  query: {
+    libraryId?: number
+    filter?: GroupRule
+    q?: string
+    sort?: SortSpec[]
+  }
+}
+
+type IdsPayload = { bookIds: number[] }
+
+type SelectionPayload = QueryPayload | IdsPayload
+
+export function useBulkEditMetadata(
+  selectedIds: Ref<Set<number>>,
+  books?: Ref<BookCard[]>,
+  querySelection?: Ref<{ libraryId?: number; filter?: GroupRule; q?: string; sort?: SortSpec[]; total: number } | null>,
+) {
+  const submitting = ref(false)
+
+  function getSelectionPayload(): SelectionPayload {
+    if (querySelection?.value) {
+      const { libraryId, filter, q, sort } = querySelection.value
+      return { query: { libraryId, filter, q, sort } }
+    }
+    return { bookIds: [...selectedIds.value] }
+  }
+
+  const selectedCount = computed(() => {
+    if (querySelection?.value) return querySelection.value.total
+    return selectedIds.value.size
+  })
+
+  async function submit(fields: BulkEditFields): Promise<BulkEditResult | null> {
+    submitting.value = true
+    try {
+      const res = await api('/api/v1/books/bulk-edit-metadata', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...getSelectionPayload(), fields }),
+      })
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null)
+        const message = body?.message ?? 'Failed to update metadata'
+        toast.error(Array.isArray(message) ? message[0] : message)
+        return null
+      }
+
+      const result: BulkEditResult = await res.json()
+
+      const totalUpdated = result.updatedBooks
+      const totalSkipped = Object.values(result.fields).reduce((sum, f) => sum + f.skippedLocked, 0)
+
+      if (totalUpdated === 0 && totalSkipped > 0) {
+        toast.warning('All selected books had locked fields - no changes applied')
+      } else if (totalSkipped > 0) {
+        toast.success(`Updated ${totalUpdated} book${totalUpdated === 1 ? '' : 's'} (some fields skipped due to locks)`)
+      } else {
+        toast.success(`Updated metadata for ${totalUpdated} book${totalUpdated === 1 ? '' : 's'}`)
+      }
+
+      const needsReload = hasAddOrRemoveMode(fields) || !!querySelection?.value
+      if (!needsReload && books) {
+        applyOptimisticUpdates(fields, [...selectedIds.value], books)
+      }
+
+      return result
+    } catch {
+      toast.error('An unexpected error occurred while saving changes')
+      return null
+    } finally {
+      submitting.value = false
+    }
+  }
+
+  return { submit, submitting, selectedCount }
+}
+
+function hasAddOrRemoveMode(fields: BulkEditFields): boolean {
+  const arrayFields = [fields.authors, fields.genres, fields.tags, fields.narrators]
+  return arrayFields.some((f) => f && f.mode !== 'replace')
+}
+
+function applyOptimisticUpdates(fields: BulkEditFields, ids: number[], books: Ref<BookCard[]>) {
+  const idSet = new Set(ids)
+  books.value = books.value.map((book) => {
+    if (!idSet.has(book.id)) return book
+    const updated = { ...book }
+
+    if (fields.seriesName !== undefined) {
+      updated.seriesName = fields.seriesName.value
+    }
+    if (fields.publisher !== undefined) {
+      updated.publisher = fields.publisher.value
+    }
+    if (fields.language !== undefined) {
+      updated.language = fields.language.value
+    }
+    if (fields.publishedYear !== undefined) {
+      updated.publishedYear = fields.publishedYear.value
+    }
+    if (fields.authors?.mode === 'replace') {
+      updated.authors = fields.authors.values
+    }
+    if (fields.genres?.mode === 'replace') {
+      updated.genres = fields.genres.values
+    }
+    if (fields.tags?.mode === 'replace') {
+      updated.tags = fields.tags.values
+    }
+    if (fields.narrators?.mode === 'replace') {
+      updated.narrators = fields.narrators.values
+    }
+
+    return updated
+  })
+}

--- a/client/src/views/CollectionView.vue
+++ b/client/src/views/CollectionView.vue
@@ -13,6 +13,7 @@ import ViewHeader from '@/components/ViewHeader.vue'
 import SelectionActionBar from '@/components/SelectionActionBar.vue'
 import AddToCollectionSheet from '@/features/collection/components/AddToCollectionSheet.vue'
 import BulkUpdateTagsDialog from '@/features/book/components/BulkUpdateTagsDialog.vue'
+import BulkEditMetadataDialog from '@/features/book/components/BulkEditMetadataDialog.vue'
 import MetadataExportDialog from '@/features/book/components/MetadataExportDialog.vue'
 import EditCollectionDialog from '@/features/collection/components/EditCollectionDialog.vue'
 import SendBookDialog from '@/features/email/components/SendBookDialog.vue'
@@ -34,6 +35,8 @@ import { useBookViewContext } from '@/features/book/composables/useBookViewConte
 import { useBookTableShell } from '@/features/book/composables/useBookTableShell'
 import { useInfiniteScrollSentinel } from '@/features/book/composables/useInfiniteScrollSentinel'
 import { useSavedViews, type SavedView } from '@/features/book/composables/useSavedViews'
+import { useBulkEditMetadata } from '@/features/book/composables/useBulkEditMetadata'
+import type { BulkEditFields } from '@/features/book/composables/useBulkEditMetadata'
 import type { BookCard, SortSpec } from '@bookorbit/types'
 import EntityNotFound from '@/components/EntityNotFound.vue'
 
@@ -176,6 +179,7 @@ const {
   handleDeleteSelected,
   addToCollectionOpen,
   bulkTagsOpen,
+  bulkEditOpen,
   sendBookOpen,
   quickViewBookId,
   quickViewOpen,
@@ -243,12 +247,27 @@ function openMetadataExport() {
   collapseMobileControlsIfNeeded()
 }
 
+const { submit: submitBulkEdit, submitting: bulkEditSubmitting, selectedCount: bulkEditCount } = useBulkEditMetadata(selectedIds, books)
+
 function handleEditSelected() {
+  const count = selectedIds.value.size
+  if (count === 0) return
+  if (count >= 2) {
+    bulkEditOpen.value = true
+    return
+  }
   const ids = [...selectedIds.value]
-  if (ids.length === 0) return
   setBookContext(ids, ids.length)
   router.push({ name: 'book-detail', params: { bookId: ids[0] }, query: { tab: 'edit' } })
   exitSelectionMode()
+}
+
+async function handleBulkEditConfirm(fields: BulkEditFields) {
+  const result = await submitBulkEdit(fields)
+  if (result) {
+    bulkEditOpen.value = false
+    load(true)
+  }
 }
 
 async function handleToggleCollapse() {
@@ -340,6 +359,14 @@ watch(debouncedQuery, () => {
     @done="exitSelectionMode"
   />
   <BulkUpdateTagsDialog :open="bulkTagsOpen" :book-count="selectedCount" @update:open="bulkTagsOpen = $event" @confirm="handleBulkUpdateTags" />
+
+  <BulkEditMetadataDialog
+    :open="bulkEditOpen"
+    :book-count="bulkEditCount"
+    :submitting="bulkEditSubmitting"
+    @update:open="bulkEditOpen = $event"
+    @confirm="handleBulkEditConfirm"
+  />
 
   <EditCollectionDialog
     v-if="collection"

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -29,6 +29,9 @@ import ViewHeader from '@/components/ViewHeader.vue'
 import SelectionActionBar from '@/components/SelectionActionBar.vue'
 import AddToCollectionSheet from '@/features/collection/components/AddToCollectionSheet.vue'
 import BulkUpdateTagsDialog from '@/features/book/components/BulkUpdateTagsDialog.vue'
+import BulkEditMetadataDialog from '@/features/book/components/BulkEditMetadataDialog.vue'
+import { useBulkEditMetadata } from '@/features/book/composables/useBulkEditMetadata'
+import type { BulkEditFields } from '@/features/book/composables/useBulkEditMetadata'
 import MetadataExportDialog from '@/features/book/components/MetadataExportDialog.vue'
 import SendBookDialog from '@/features/email/components/SendBookDialog.vue'
 import SaveAsSmartScopeDialog from '@/features/smart-scope/components/SaveAsSmartScopeDialog.vue'
@@ -399,6 +402,7 @@ const {
   handleDeleteSelected,
   addToCollectionOpen,
   bulkTagsOpen,
+  bulkEditOpen,
   sendBookOpen,
   quickViewBookId,
   quickViewOpen,
@@ -439,12 +443,37 @@ watch(selectionMode, (active) => {
   }
 })
 
+const {
+  submit: submitBulkEdit,
+  submitting: bulkEditSubmitting,
+  selectedCount: bulkEditCount,
+} = useBulkEditMetadata(selectedIds, books, querySelection)
+
 function handleEditSelected() {
+  const count = querySelection.value ? querySelection.value.total : selectedIds.value.size
+  if (count === 0) return
+  if (count >= 2 || querySelection.value) {
+    bulkEditOpen.value = true
+    return
+  }
   const ids = [...selectedIds.value]
-  if (ids.length === 0) return
   setBookContext(ids, ids.length)
   router.push({ name: 'book-detail', params: { bookId: ids[0] }, query: { tab: 'edit' } })
   exitSelectionMode()
+}
+
+async function handleBulkEditConfirm(fields: BulkEditFields) {
+  const result = await submitBulkEdit(fields)
+  if (result) {
+    bulkEditOpen.value = false
+    if (querySelection.value || hasAddOrRemoveFields(fields)) {
+      load(true)
+    }
+  }
+}
+
+function hasAddOrRemoveFields(fields: BulkEditFields): boolean {
+  return [fields.authors, fields.genres, fields.tags, fields.narrators].some((f) => f && f.mode !== 'replace')
 }
 
 async function handleToggleCollapse() {
@@ -918,6 +947,14 @@ async function handleToggleCollapse() {
   />
 
   <BulkUpdateTagsDialog :open="bulkTagsOpen" :book-count="selectedCount" @update:open="bulkTagsOpen = $event" @confirm="handleBulkUpdateTags" />
+
+  <BulkEditMetadataDialog
+    :open="bulkEditOpen"
+    :book-count="bulkEditCount"
+    :submitting="bulkEditSubmitting"
+    @update:open="bulkEditOpen = $event"
+    @confirm="handleBulkEditConfirm"
+  />
 
   <SendBookDialog :open="sendBookOpen" :book-ids="[...selectedIds]" @update:open="sendBookOpen = $event" @sent="exitSelectionMode" />
 

--- a/client/src/views/SmartScopeView.vue
+++ b/client/src/views/SmartScopeView.vue
@@ -24,6 +24,7 @@ import SmartScopeEditorPanel from '@/features/smart-scope/components/SmartScopeE
 import SelectionActionBar from '@/components/SelectionActionBar.vue'
 import AddToCollectionSheet from '@/features/collection/components/AddToCollectionSheet.vue'
 import BulkUpdateTagsDialog from '@/features/book/components/BulkUpdateTagsDialog.vue'
+import BulkEditMetadataDialog from '@/features/book/components/BulkEditMetadataDialog.vue'
 import MetadataExportDialog from '@/features/book/components/MetadataExportDialog.vue'
 import SendBookDialog from '@/features/email/components/SendBookDialog.vue'
 import DeleteBookDialog from '@/features/book/components/DeleteBookDialog.vue'
@@ -44,6 +45,8 @@ import { useBookTableShell } from '@/features/book/composables/useBookTableShell
 import { useInfiniteScrollSentinel } from '@/features/book/composables/useInfiniteScrollSentinel'
 import { useSavedViews, type SavedView } from '@/features/book/composables/useSavedViews'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
+import { useBulkEditMetadata } from '@/features/book/composables/useBulkEditMetadata'
+import type { BulkEditFields } from '@/features/book/composables/useBulkEditMetadata'
 import type { BookCard, GroupRule, SortField, SortSpec } from '@bookorbit/types'
 import EntityNotFound from '@/components/EntityNotFound.vue'
 
@@ -184,6 +187,7 @@ const {
   handleDeleteSelected,
   addToCollectionOpen,
   bulkTagsOpen,
+  bulkEditOpen,
   sendBookOpen,
   quickViewBookId,
   quickViewOpen,
@@ -199,12 +203,27 @@ const visibleExportColumns = computed(() => {
   return tableRef.value.allColumns.filter((column) => column.visible).map((column) => column.id)
 })
 
+const { submit: submitBulkEdit, submitting: bulkEditSubmitting, selectedCount: bulkEditCount } = useBulkEditMetadata(selectedIds, books)
+
 function handleEditSelected() {
+  const count = selectedIds.value.size
+  if (count === 0) return
+  if (count >= 2) {
+    bulkEditOpen.value = true
+    return
+  }
   const ids = [...selectedIds.value]
-  if (ids.length === 0) return
   setBookContext(ids, ids.length)
   router.push({ name: 'book-detail', params: { bookId: ids[0] }, query: { tab: 'edit' } })
   exitSelectionMode()
+}
+
+async function handleBulkEditConfirm(fields: BulkEditFields) {
+  const result = await submitBulkEdit(fields)
+  if (result) {
+    bulkEditOpen.value = false
+    load(true)
+  }
 }
 
 watch(
@@ -359,6 +378,14 @@ watch(debouncedQuery, () => {
     @done="exitSelectionMode"
   />
   <BulkUpdateTagsDialog :open="bulkTagsOpen" :book-count="selectedCount" @update:open="bulkTagsOpen = $event" @confirm="handleBulkUpdateTags" />
+
+  <BulkEditMetadataDialog
+    :open="bulkEditOpen"
+    :book-count="bulkEditCount"
+    :submitting="bulkEditSubmitting"
+    @update:open="bulkEditOpen = $event"
+    @confirm="handleBulkEditConfirm"
+  />
   <SendBookDialog :open="sendBookOpen" :book-ids="[...selectedIds]" @update:open="sendBookOpen = $event" @sent="exitSelectionMode" />
 
   <DeleteBookDialog :open="deleteBookId !== null" :deleting="deletingBook" @confirm="confirmDelete" @cancel="cancelDelete" />

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -52,6 +52,7 @@ export enum AuditAction {
   BookBulkSetMetadata = "book.bulk.set_metadata",
   BookBulkUpdateTags = "book.bulk.update_tags",
   BookBulkSetMetadataLock = "book.bulk.set_metadata_lock",
+  BookBulkEditMetadata = "book.bulk.edit_metadata",
 
   CollectionCreate = "collection.create",
   CollectionUpdate = "collection.update",

--- a/server/src/modules/book-metadata-lock/book-metadata-lock.service.ts
+++ b/server/src/modules/book-metadata-lock/book-metadata-lock.service.ts
@@ -92,6 +92,10 @@ export class BookMetadataLockService {
     return locked;
   }
 
+  async getLockedFieldsMap(bookIds: number[]): Promise<Map<number, string[]>> {
+    return this.lockRepo.findLockedFieldsByBookIds(bookIds);
+  }
+
   async assertFieldsUnlocked(bookId: number, fields: readonly BookMetadataLockField[]): Promise<void> {
     const lockedFields = await this.getLockedFields(bookId);
     const lockedSet = new Set(lockedFields);

--- a/server/src/modules/book/book.controller.test.ts
+++ b/server/src/modules/book/book.controller.test.ts
@@ -123,6 +123,8 @@ function makeController() {
     bulkRefreshMetadata: vi.fn(),
     bulkReExtractCover: vi.fn(),
     bulkSetMetadata: vi.fn(),
+    bulkEditMetadata: vi.fn(),
+    bulkUpdateTags: vi.fn(),
     getExportFiles: vi.fn(),
     getMetadataExportPreflight: vi.fn(),
     buildMetadataExport: vi.fn(),
@@ -844,6 +846,7 @@ describe('BookController', () => {
       BookController.prototype.bulkSetMetadata,
       BookController.prototype.bulkUpdateTags,
       BookController.prototype.bulkSetMetadataLock,
+      BookController.prototype.bulkEditMetadata,
     ];
 
     for (const method of bulkMethods) {
@@ -883,5 +886,40 @@ describe('BookController', () => {
     await controller.downloadFile(1, makeUser(), reply);
 
     expect(headers['Content-Disposition']).toBe(`attachment; filename="ok-__-_.epub"; filename*=UTF-8''ok-%F0%9F%98%80-.epub`);
+  });
+
+  describe('bulkEditMetadata', () => {
+    it('resolves selection and delegates to service', async () => {
+      const { controller, bookService } = makeController();
+      const user = makeUser();
+      const fields = { publisher: { value: 'Penguin' } };
+      const expectedResult = {
+        updatedBooks: 2,
+        fields: { publisher: { updated: 2, skippedLocked: 0 } },
+      };
+      bookService.resolveSelectionToIds.mockResolvedValue([7, 9]);
+      bookService.bulkEditMetadata.mockResolvedValue(expectedResult);
+
+      const result = await controller.bulkEditMetadata({ bookIds: [7, 9], fields } as never, user);
+
+      expect(bookService.resolveSelectionToIds).toHaveBeenCalledWith({ bookIds: [7, 9], fields }, user);
+      expect(bookService.bulkEditMetadata).toHaveBeenCalledWith([7, 9], fields, user);
+      expect(result).toEqual(expectedResult);
+    });
+
+    it('has the correct permission and audit decorators', () => {
+      const permission = Reflect.getMetadata('permission', BookController.prototype.bulkEditMetadata);
+      expect(permission).toBe(Permission.LibraryEditMetadata);
+
+      const forbidden = Reflect.getMetadata(FORBIDDEN_PERMISSION_KEY, BookController.prototype.bulkEditMetadata);
+      expect(forbidden).toEqual({
+        permission: Permission.DemoRestricted,
+        message: 'Demo-restricted account cannot perform bulk edits',
+      });
+
+      const audit = Reflect.getMetadata(AUDITABLE_KEY, BookController.prototype.bulkEditMetadata);
+      expect(audit).toBeDefined();
+      expect(audit.action).toBe('book.bulk.edit_metadata');
+    });
   });
 });

--- a/server/src/modules/book/book.controller.ts
+++ b/server/src/modules/book/book.controller.ts
@@ -37,6 +37,7 @@ import { BulkSetRatingDto } from './dto/bulk-set-rating.dto';
 import { BulkSetMetadataDto } from './dto/bulk-set-metadata.dto';
 import { BulkUpdateTagsDto } from './dto/bulk-update-tags.dto';
 import { BulkSetMetadataLockDto } from './dto/bulk-set-metadata-lock.dto';
+import { BulkEditMetadataDto } from './dto/bulk-edit-metadata.dto';
 import { DeleteBooksDto } from './dto/delete-books.dto';
 import { ExportBooksDto } from './dto/export-books.dto';
 import { MetadataExportDto } from './dto/metadata-export.dto';
@@ -648,6 +649,24 @@ export class BookController {
   async bulkSetMetadataLock(@Body() dto: BulkSetMetadataLockDto, @CurrentUser() user: RequestUser) {
     const ids = await this.bookService.resolveSelectionToIds(dto, user);
     return this.bookService.bulkSetMetadataLock(ids, dto.locked, user);
+  }
+
+  @Post('bulk-edit-metadata')
+  @RequirePermission(Permission.LibraryEditMetadata)
+  @ForbidPermission(Permission.DemoRestricted, 'Demo-restricted account cannot perform bulk edits')
+  @Auditable({
+    action: AuditAction.BookBulkEditMetadata,
+    resource: AuditResource.Book,
+    description: (req) => {
+      const body = req.body as { bookIds?: number[]; query?: unknown };
+      const count = body?.bookIds?.length ?? 0;
+      const via = body?.query ? 'query' : `${count} id${count !== 1 ? 's' : ''}`;
+      return `Bulk edit metadata for ${via}`;
+    },
+  })
+  async bulkEditMetadata(@Body() dto: BulkEditMetadataDto, @CurrentUser() user: RequestUser) {
+    const ids = await this.bookService.resolveSelectionToIds(dto, user);
+    return this.bookService.bulkEditMetadata(ids, dto.fields, user);
   }
 
   @Get(':id')

--- a/server/src/modules/book/book.repository.ts
+++ b/server/src/modules/book/book.repository.ts
@@ -872,6 +872,56 @@ export class BookRepository {
     return result;
   }
 
+  async findAuthorsByBookIds(bookIds: number[], executor: MetadataReadExecutor = this.db): Promise<Map<number, string[]>> {
+    if (bookIds.length === 0) return new Map();
+    const rows = await executor
+      .select({ bookId: bookAuthors.bookId, name: authors.name })
+      .from(bookAuthors)
+      .innerJoin(authors, eq(bookAuthors.authorId, authors.id))
+      .where(inArray(bookAuthors.bookId, bookIds))
+      .orderBy(asc(bookAuthors.bookId), asc(bookAuthors.displayOrder));
+    const result = new Map<number, string[]>();
+    for (const row of rows) {
+      const existing = result.get(row.bookId) ?? [];
+      existing.push(row.name);
+      result.set(row.bookId, existing);
+    }
+    return result;
+  }
+
+  async findGenresByBookIds(bookIds: number[], executor: MetadataReadExecutor = this.db): Promise<Map<number, string[]>> {
+    if (bookIds.length === 0) return new Map();
+    const rows = await executor
+      .select({ bookId: bookGenres.bookId, name: genres.name })
+      .from(bookGenres)
+      .innerJoin(genres, eq(bookGenres.genreId, genres.id))
+      .where(inArray(bookGenres.bookId, bookIds));
+    const result = new Map<number, string[]>();
+    for (const row of rows) {
+      const existing = result.get(row.bookId) ?? [];
+      existing.push(row.name);
+      result.set(row.bookId, existing);
+    }
+    return result;
+  }
+
+  async findNarratorsByBookIds(bookIds: number[], executor: MetadataReadExecutor = this.db): Promise<Map<number, string[]>> {
+    if (bookIds.length === 0) return new Map();
+    const rows = await executor
+      .select({ bookId: bookNarrators.bookId, name: narrators.name })
+      .from(bookNarrators)
+      .innerJoin(narrators, eq(bookNarrators.narratorId, narrators.id))
+      .where(inArray(bookNarrators.bookId, bookIds))
+      .orderBy(asc(bookNarrators.bookId), asc(bookNarrators.displayOrder));
+    const result = new Map<number, string[]>();
+    for (const row of rows) {
+      const existing = result.get(row.bookId) ?? [];
+      existing.push(row.name);
+      result.set(row.bookId, existing);
+    }
+    return result;
+  }
+
   async updateMetadataFields(
     bookId: number,
     fields: Partial<typeof bookMetadata.$inferInsert>,

--- a/server/src/modules/book/book.service.test.ts
+++ b/server/src/modules/book/book.service.test.ts
@@ -11,6 +11,7 @@ import { parseMobiFile } from '../metadata/lib/mobi-parser';
 import { parsePdfFile } from '../metadata/lib/pdf-parser';
 import { ACHIEVEMENT_EVENT_BOOK_RATING_CHANGED } from '../achievement/achievement-events.service';
 import { UpdateBookMetadataDto } from './dto/update-book-metadata.dto';
+import { BulkEditFieldsDto } from './dto/bulk-edit-metadata.dto';
 import { BookQueryBuilder } from './book-query-builder.service';
 import { BookService } from './book.service';
 import { EMPTY_CONTENT_FILTER_RULES } from '@bookorbit/types';
@@ -89,6 +90,9 @@ function makeService() {
     findPrimaryFilesByBookIds: vi.fn(),
     findAllFilesByBookIds: vi.fn(),
     findTagsByBookIds: vi.fn(),
+    findAuthorsByBookIds: vi.fn(),
+    findGenresByBookIds: vi.fn(),
+    findNarratorsByBookIds: vi.fn(),
     findPrimaryFile: vi.fn(),
     findById: vi.fn(),
     findRatingByBookAndUser: vi.fn().mockResolvedValue(null),
@@ -176,6 +180,7 @@ function makeService() {
     assertFieldsUnlocked: vi.fn().mockResolvedValue(undefined),
     getCoverLockedBookIds: vi.fn().mockResolvedValue(new Set()),
     getBookIdsWithLockedField: vi.fn().mockResolvedValue(new Set()),
+    getLockedFieldsMap: vi.fn().mockResolvedValue(new Map()),
     replaceLockedFields: vi.fn().mockResolvedValue([]),
   };
   const userBookStatusService = {
@@ -2383,6 +2388,319 @@ describe('BookService', () => {
 
       expect(bookRepo.findTagsByBookIds).not.toHaveBeenCalled();
       expect(metadataService.replaceTags).toHaveBeenCalledWith(9, ['fresh'], { executor: tx });
+    });
+  });
+
+  describe('bulkEditMetadata', () => {
+    function makeFields(overrides: Record<string, unknown> = {}): BulkEditFieldsDto {
+      const dto = new BulkEditFieldsDto();
+      Object.assign(dto, overrides);
+      return dto;
+    }
+
+    it('updates scalar fields and triggers post-metadata effects', async () => {
+      const { service, bookRepo, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+      const triggerSpy = vi.spyOn(service, 'triggerPostMetadataUpdateEffects' as never).mockReturnValue(undefined as never);
+
+      const fields = makeFields({
+        publisher: { value: 'Bloomsbury' },
+        language: { value: 'en' },
+      });
+
+      const result = await service.bulkEditMetadata([7, 9], fields, user);
+
+      expect(bookRepo.bulkUpdateMetadataFields).toHaveBeenCalled();
+      expect(result.updatedBooks).toBe(2);
+      expect(result.fields.publisher).toEqual({ updated: 2, skippedLocked: 0 });
+      expect(result.fields.language).toEqual({ updated: 2, skippedLocked: 0 });
+      expect(triggerSpy).toHaveBeenCalledWith([7, 9], user.id);
+    });
+
+    it('updates publishedYear as integer', async () => {
+      const { service, bookRepo, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        publishedYear: { value: 2001 },
+      });
+
+      const result = await service.bulkEditMetadata([7], fields, user);
+
+      expect(result.fields.publishedYear).toEqual({ updated: 1, skippedLocked: 0 });
+    });
+
+    it('replaces authors in replace mode', async () => {
+      const { service, bookRepo, metadataService, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        authors: { mode: 'replace', values: ['Author A', 'Author B'] },
+      });
+
+      await service.bulkEditMetadata([7, 9], fields, user);
+
+      expect(metadataService.replaceAuthors).toHaveBeenCalledTimes(2);
+      expect(metadataService.replaceAuthors).toHaveBeenCalledWith(
+        7,
+        [
+          { name: 'Author A', sortName: null },
+          { name: 'Author B', sortName: null },
+        ],
+        { executor: tx },
+      );
+    });
+
+    it('adds authors in add mode by merging with existing', async () => {
+      const { service, bookRepo, metadataService, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+      bookRepo.findAuthorsByBookIds.mockResolvedValue(new Map([[7, ['Existing Author']]]));
+
+      const fields = makeFields({
+        authors: { mode: 'add', values: ['New Author'] },
+      });
+
+      await service.bulkEditMetadata([7], fields, user);
+
+      expect(bookRepo.findAuthorsByBookIds).toHaveBeenCalledWith([7], tx);
+      expect(metadataService.replaceAuthors).toHaveBeenCalledWith(
+        7,
+        [
+          { name: 'Existing Author', sortName: null },
+          { name: 'New Author', sortName: null },
+        ],
+        { executor: tx },
+      );
+    });
+
+    it('removes authors in remove mode', async () => {
+      const { service, bookRepo, metadataService, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+      bookRepo.findAuthorsByBookIds.mockResolvedValue(new Map([[7, ['Author A', 'Author B']]]));
+
+      const fields = makeFields({
+        authors: { mode: 'remove', values: ['Author A'] },
+      });
+
+      await service.bulkEditMetadata([7], fields, user);
+
+      expect(metadataService.replaceAuthors).toHaveBeenCalledWith(7, [{ name: 'Author B', sortName: null }], { executor: tx });
+    });
+
+    it('replaces tags in replace mode', async () => {
+      const { service, bookRepo, metadataService, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        tags: { mode: 'replace', values: ['favorite', 'reading'] },
+      });
+
+      await service.bulkEditMetadata([7, 9], fields, user);
+
+      expect(metadataService.replaceTags).toHaveBeenCalledTimes(2);
+      expect(metadataService.replaceTags).toHaveBeenCalledWith(7, ['favorite', 'reading'], { executor: tx });
+      expect(metadataService.replaceTags).toHaveBeenCalledWith(9, ['favorite', 'reading'], { executor: tx });
+    });
+
+    it('adds tags in add mode by merging with existing', async () => {
+      const { service, bookRepo, metadataService, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+      bookRepo.findTagsByBookIds.mockResolvedValue(new Map([[7, ['existing']]]));
+
+      const fields = makeFields({
+        tags: { mode: 'add', values: ['new'] },
+      });
+
+      await service.bulkEditMetadata([7], fields, user);
+
+      expect(metadataService.replaceTags).toHaveBeenCalledWith(7, ['existing', 'new'], { executor: tx });
+    });
+
+    it('replaces genres in replace mode', async () => {
+      const { service, bookRepo, metadataService, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        genres: { mode: 'replace', values: ['Fantasy'] },
+      });
+
+      await service.bulkEditMetadata([7], fields, user);
+
+      expect(metadataService.replaceGenres).toHaveBeenCalledWith(7, ['Fantasy'], { executor: tx });
+    });
+
+    it('replaces narrators in replace mode', async () => {
+      const { service, bookRepo, narratorService, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        narrators: { mode: 'replace', values: ['Stephen Fry'] },
+      });
+
+      await service.bulkEditMetadata([7], fields, user);
+
+      expect(narratorService.replaceForBook).toHaveBeenCalledWith(7, ['Stephen Fry'], { executor: tx });
+    });
+
+    it('skips locked fields per-field and reports correctly', async () => {
+      const { service, bookRepo, metadataService, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(
+        new Map([
+          [7, ['authors']],
+          [9, []],
+        ]),
+      );
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        authors: { mode: 'replace', values: ['New Author'] },
+        genres: { mode: 'replace', values: ['Fantasy'] },
+      });
+
+      const result = await service.bulkEditMetadata([7, 9], fields, user);
+
+      expect(result.fields.authors).toEqual({ updated: 1, skippedLocked: 1 });
+      expect(result.fields.genres).toEqual({ updated: 2, skippedLocked: 0 });
+      expect(metadataService.replaceAuthors).toHaveBeenCalledTimes(1);
+      expect(metadataService.replaceAuthors).toHaveBeenCalledWith(9, [{ name: 'New Author', sortName: null }], { executor: tx });
+      expect(metadataService.replaceGenres).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles mixed scalar and array fields in one call', async () => {
+      const { service, bookRepo, metadataService, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        publisher: { value: 'Penguin' },
+        tags: { mode: 'replace', values: ['classic'] },
+      });
+
+      const result = await service.bulkEditMetadata([7], fields, user);
+
+      expect(result.updatedBooks).toBe(1);
+      expect(result.fields.publisher).toEqual({ updated: 1, skippedLocked: 0 });
+      expect(result.fields.tags).toEqual({ updated: 1, skippedLocked: 0 });
+      expect(bookRepo.bulkUpdateMetadataFields).toHaveBeenCalled();
+      expect(metadataService.replaceTags).toHaveBeenCalledWith(7, ['classic'], { executor: tx });
+    });
+
+    it('throws BadRequestException when no fields are provided', async () => {
+      const { service } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+
+      const fields = makeFields({});
+
+      await expect(service.bulkEditMetadata([7], fields, user)).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when add mode has empty values', async () => {
+      const { service } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+
+      const fields = makeFields({
+        authors: { mode: 'add', values: [] },
+      });
+
+      await expect(service.bulkEditMetadata([7], fields, user)).rejects.toThrow(BadRequestException);
+    });
+
+    it('returns zero updatedBooks when all books have all fields locked', async () => {
+      const { service, bookRepo, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map([[7, ['publisher']]]));
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        publisher: { value: 'Test' },
+      });
+
+      const result = await service.bulkEditMetadata([7], fields, user);
+
+      expect(result.updatedBooks).toBe(0);
+      expect(result.fields.publisher).toEqual({ updated: 0, skippedLocked: 1 });
+      expect(bookRepo.bulkUpdateMetadataFields).not.toHaveBeenCalled();
+    });
+
+    it('clears a scalar field when value is null', async () => {
+      const { service, bookRepo, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        seriesName: { value: null },
+      });
+
+      const result = await service.bulkEditMetadata([7], fields, user);
+
+      expect(result.fields.seriesName).toEqual({ updated: 1, skippedLocked: 0 });
+      expect(bookRepo.bulkUpdateMetadataFields).toHaveBeenCalledWith([7], expect.objectContaining({ seriesName: null }), tx);
+    });
+
+    it('verifies library access for all book IDs', async () => {
+      const { service, bookRepo, bookMetadataLockService } = makeService();
+      const user = makeUser();
+      const verifySpy = vi.spyOn(service, 'verifyLibraryAccessForBookIds').mockResolvedValue(undefined);
+      bookMetadataLockService.getLockedFieldsMap.mockResolvedValue(new Map());
+      const tx = {};
+      bookRepo.withTransaction.mockImplementation(async (cb: (value: unknown) => Promise<unknown>) => cb(tx));
+
+      const fields = makeFields({
+        publisher: { value: 'Test' },
+      });
+
+      await service.bulkEditMetadata([7, 8, 9], fields, user);
+
+      expect(verifySpy).toHaveBeenCalledWith([7, 8, 9], user);
     });
   });
 

--- a/server/src/modules/book/book.service.ts
+++ b/server/src/modules/book/book.service.ts
@@ -64,6 +64,7 @@ import { BookRepository } from './book.repository';
 import { ComicMetadataRepository } from '../metadata/comic-metadata.repository';
 import { BookDetailDto } from './dto/book-detail.dto';
 import type { BulkMetadataField } from './dto/bulk-set-metadata.dto';
+import type { BulkEditFieldsDto } from './dto/bulk-edit-metadata.dto';
 import type { BulkSelectionDto } from './dto/bulk-selection.dto';
 import type { MetadataExportDto, MetadataExportFormat, MetadataExportViewType } from './dto/metadata-export.dto';
 import type { MetadataExportColumnMode } from './dto/metadata-export-options.dto';
@@ -85,6 +86,12 @@ const METADATA_UPDATE_FAILPOINTS = [
 
 export type MetadataUpdateFailpoint = (typeof METADATA_UPDATE_FAILPOINTS)[number];
 export type ExportScope = 'primary' | 'all' | 'audio';
+
+export type BulkEditFieldResult = { updated: number; skippedLocked: number };
+export type BulkEditMetadataResult = {
+  updatedBooks: number;
+  fields: Record<string, BulkEditFieldResult>;
+};
 const BULK_METADATA_LOCK_FIELD_BY_FIELD: Record<BulkMetadataField, BookMetadataLockField> = {
   seriesName: 'seriesName',
   publisher: 'publisher',
@@ -1590,6 +1597,180 @@ export class BookService {
     this.logger.log(
       `[${event}] [end] userId=${user.id} count=${bookIds.length} locked=${locked} durationMs=${Date.now() - startedAt} - bulk set metadata lock completed`,
     );
+  }
+
+  async bulkEditMetadata(bookIds: number[], fields: BulkEditFieldsDto, user: RequestUser): Promise<BulkEditMetadataResult> {
+    const event = 'book.bulk.edit_metadata';
+    const startedAt = Date.now();
+    const fieldNames = Object.keys(fields).filter((k) => (fields as unknown as Record<string, unknown>)[k] !== undefined);
+    this.logger.log(`[${event}] [start] userId=${user.id} count=${bookIds.length} fields=${fieldNames.join(',')} - bulk edit metadata started`);
+
+    if (!fields.hasAtLeastOneField()) {
+      throw new BadRequestException('fields must contain at least one editable field');
+    }
+    if (!fields.hasValidArrayValues()) {
+      throw new BadRequestException('array fields with add or remove mode must have a non-empty values array');
+    }
+
+    await this.verifyLibraryAccessForBookIds(bookIds, user);
+
+    const locksMap = await this.bookMetadataLockService.getLockedFieldsMap(bookIds);
+    const fieldResults: Record<string, BulkEditFieldResult> = {};
+    const allUpdatedBookIds = new Set<number>();
+
+    const getUpdatableIds = (lockField: BookMetadataLockField): number[] => {
+      return bookIds.filter((id) => {
+        const locked = locksMap.get(id) ?? [];
+        return !locked.includes(lockField);
+      });
+    };
+
+    const recordResult = (fieldName: string, updatableIds: number[]) => {
+      const skippedLocked = bookIds.length - updatableIds.length;
+      fieldResults[fieldName] = { updated: updatableIds.length, skippedLocked };
+      for (const id of updatableIds) allUpdatedBookIds.add(id);
+    };
+
+    try {
+      await this.bookRepo.withTransaction(async (tx) => {
+        for (const fieldName of ['seriesName', 'publisher', 'language'] as const) {
+          if (!fields[fieldName]) continue;
+          const ids = getUpdatableIds(BULK_METADATA_LOCK_FIELD_BY_FIELD[fieldName]);
+          recordResult(fieldName, ids);
+          if (ids.length === 0) continue;
+          const val = fields[fieldName].value;
+          const textValue = val === null ? null : String(val).trim() || null;
+          await this.bookRepo.bulkUpdateMetadataFields(ids, { [fieldName]: textValue, updatedAt: new Date() }, tx);
+        }
+
+        if (fields.publishedYear) {
+          const ids = getUpdatableIds('publishedYear');
+          recordResult('publishedYear', ids);
+          if (ids.length > 0) {
+            const val = fields.publishedYear.value;
+            if (val !== null && (!Number.isFinite(val) || !Number.isInteger(val))) {
+              throw new BadRequestException('Invalid publishedYear value');
+            }
+            await this.bookRepo.bulkUpdateMetadataFields(ids, { publishedYear: val, updatedAt: new Date() }, tx);
+          }
+        }
+
+        if (fields.authors) {
+          const ids = getUpdatableIds('authors');
+          recordResult('authors', ids);
+          if (ids.length > 0) {
+            const names = this.normalizeListValues(fields.authors.values);
+            if (fields.authors.mode === 'replace') {
+              for (const bookId of ids) {
+                await this.metadataService.replaceAuthors(
+                  bookId,
+                  names.map((name) => ({ name, sortName: null })),
+                  { executor: tx },
+                );
+              }
+            } else {
+              const currentMap = await this.bookRepo.findAuthorsByBookIds(ids, tx);
+              for (const bookId of ids) {
+                const current = currentMap.get(bookId) ?? [];
+                const merged = fields.authors!.mode === 'add' ? [...new Set([...current, ...names])] : current.filter((n) => !names.includes(n));
+                await this.metadataService.replaceAuthors(
+                  bookId,
+                  merged.map((name) => ({ name, sortName: null })),
+                  { executor: tx },
+                );
+              }
+            }
+          }
+        }
+
+        if (fields.genres) {
+          const ids = getUpdatableIds('genres');
+          recordResult('genres', ids);
+          if (ids.length > 0) {
+            const names = this.normalizeListValues(fields.genres.values);
+            if (fields.genres.mode === 'replace') {
+              for (const bookId of ids) {
+                await this.metadataService.replaceGenres(bookId, names, { executor: tx });
+              }
+            } else {
+              const currentMap = await this.bookRepo.findGenresByBookIds(ids, tx);
+              for (const bookId of ids) {
+                const current = currentMap.get(bookId) ?? [];
+                const merged = fields.genres!.mode === 'add' ? [...new Set([...current, ...names])] : current.filter((n) => !names.includes(n));
+                await this.metadataService.replaceGenres(bookId, merged, { executor: tx });
+              }
+            }
+          }
+        }
+
+        if (fields.tags) {
+          const ids = getUpdatableIds('tags');
+          recordResult('tags', ids);
+          if (ids.length > 0) {
+            const names = this.normalizeListValues(fields.tags.values);
+            if (fields.tags.mode === 'replace') {
+              for (const bookId of ids) {
+                await this.metadataService.replaceTags(bookId, names, { executor: tx });
+              }
+            } else {
+              const currentMap = await this.bookRepo.findTagsByBookIds(ids, tx);
+              for (const bookId of ids) {
+                const current = currentMap.get(bookId) ?? [];
+                const merged = fields.tags!.mode === 'add' ? [...new Set([...current, ...names])] : current.filter((n) => !names.includes(n));
+                await this.metadataService.replaceTags(bookId, merged, { executor: tx });
+              }
+            }
+          }
+        }
+
+        if (fields.narrators) {
+          const ids = getUpdatableIds('narrators');
+          recordResult('narrators', ids);
+          if (ids.length > 0) {
+            const names = this.normalizeListValues(fields.narrators.values);
+            if (fields.narrators.mode === 'replace') {
+              for (const bookId of ids) {
+                await this.narratorService.replaceForBook(bookId, names, { executor: tx });
+              }
+            } else {
+              const currentMap = await this.bookRepo.findNarratorsByBookIds(ids, tx);
+              for (const bookId of ids) {
+                const current = currentMap.get(bookId) ?? [];
+                const merged = fields.narrators!.mode === 'add' ? [...new Set([...current, ...names])] : current.filter((n) => !names.includes(n));
+                await this.narratorService.replaceForBook(bookId, merged, { executor: tx });
+              }
+            }
+          }
+        }
+      });
+    } catch (error) {
+      const durationMs = Date.now() - startedAt;
+      const errorClass = error instanceof Error ? error.constructor.name : 'UnknownError';
+      const errorMessage = error instanceof Error ? sanitizeLogValue(error.message) : 'unknown';
+      this.logger.error(
+        `[${event}] [fail] userId=${user.id} count=${bookIds.length} durationMs=${durationMs} errorClass=${errorClass} error="${errorMessage}" - bulk edit metadata failed`,
+      );
+      throw error;
+    }
+
+    if (allUpdatedBookIds.size > 0) {
+      this.triggerPostMetadataUpdateEffects([...allUpdatedBookIds], user.id);
+    }
+
+    const result: BulkEditMetadataResult = {
+      updatedBooks: allUpdatedBookIds.size,
+      fields: fieldResults,
+    };
+
+    this.logger.log(
+      `[${event}] [end] userId=${user.id} count=${bookIds.length} updatedBooks=${allUpdatedBookIds.size} fieldCount=${fieldNames.length} durationMs=${Date.now() - startedAt} - bulk edit metadata completed`,
+    );
+
+    return result;
+  }
+
+  private normalizeListValues(values: string[]): string[] {
+    return [...new Set(values.map((v) => v.trim()).filter((v) => v.length > 0))];
   }
 
   async getKoboState(id: number, user: RequestUser): Promise<BookKoboState> {

--- a/server/src/modules/book/dto/bulk-edit-metadata.dto.test.ts
+++ b/server/src/modules/book/dto/bulk-edit-metadata.dto.test.ts
@@ -1,0 +1,215 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { BulkEditMetadataDto, BulkEditFieldsDto } from './bulk-edit-metadata.dto';
+
+async function errorsFor(value: Record<string, unknown>) {
+  const dto = plainToInstance(BulkEditMetadataDto, value);
+  return validate(dto);
+}
+
+describe('BulkEditMetadataDto', () => {
+  describe('valid payloads', () => {
+    it('accepts a single scalar field with bookIds', async () => {
+      const errors = await errorsFor({
+        bookIds: [1, 2],
+        fields: { publisher: { value: 'Bloomsbury' } },
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts a single array field in add mode', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { authors: { mode: 'add', values: ['Author A'] } },
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts a single array field in remove mode', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { tags: { mode: 'remove', values: ['unread'] } },
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts a single array field in replace mode with empty values (clear all)', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { genres: { mode: 'replace', values: [] } },
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts multiple fields at once', async () => {
+      const errors = await errorsFor({
+        bookIds: [1, 2, 3],
+        fields: {
+          authors: { mode: 'add', values: ['Author X'] },
+          seriesName: { value: 'Harry Potter' },
+          genres: { mode: 'replace', values: ['Fantasy', 'Adventure'] },
+          publisher: { value: 'Bloomsbury' },
+          language: { value: 'en' },
+          publishedYear: { value: 2001 },
+          narrators: { mode: 'add', values: ['Stephen Fry'] },
+        },
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts query selection instead of bookIds', async () => {
+      const errors = await errorsFor({
+        query: { libraryId: 5 },
+        fields: { publisher: { value: 'Penguin' } },
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts null scalar value (clearing a field)', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { publisher: { value: null } },
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts null publishedYear value (clearing)', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { publishedYear: { value: null } },
+      });
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('invalid payloads', () => {
+    it('rejects missing fields', async () => {
+      const errors = await errorsFor({ bookIds: [1] });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects invalid array mode', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { authors: { mode: 'invalid', values: ['x'] } },
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects missing bookIds and query', async () => {
+      const errors = await errorsFor({
+        fields: { publisher: { value: 'Test' } },
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects non-integer publishedYear', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { publishedYear: { value: 20.5 } },
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects non-string values in array field', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { authors: { mode: 'add', values: [123] } },
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects missing mode in array field', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { authors: { values: ['Author A'] } },
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects missing values in array field', async () => {
+      const errors = await errorsFor({
+        bookIds: [1],
+        fields: { authors: { mode: 'add' } },
+      });
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('BulkEditFieldsDto helper methods', () => {
+    it('hasAtLeastOneField returns true when a field is set', () => {
+      const fields = plainToInstance(BulkEditFieldsDto, {
+        publisher: { value: 'Test' },
+      });
+      expect(fields.hasAtLeastOneField()).toBe(true);
+    });
+
+    it('hasAtLeastOneField returns false for empty object', () => {
+      const fields = plainToInstance(BulkEditFieldsDto, {});
+      expect(fields.hasAtLeastOneField()).toBe(false);
+    });
+
+    it('hasOnlyAllowedKeys returns false for unknown keys', () => {
+      const fields = plainToInstance(BulkEditFieldsDto, {});
+      expect(fields.hasOnlyAllowedKeys({ unknownField: { value: 'x' } })).toBe(false);
+    });
+
+    it('hasOnlyAllowedKeys returns true for known keys only', () => {
+      const fields = plainToInstance(BulkEditFieldsDto, {});
+      expect(fields.hasOnlyAllowedKeys({ authors: {}, publisher: {} })).toBe(true);
+    });
+
+    it('hasValidArrayValues returns false for add mode with empty values', () => {
+      const fields = plainToInstance(BulkEditFieldsDto, {
+        authors: { mode: 'add', values: [] },
+      });
+      expect(fields.hasValidArrayValues()).toBe(false);
+    });
+
+    it('hasValidArrayValues returns false for remove mode with empty values', () => {
+      const fields = plainToInstance(BulkEditFieldsDto, {
+        tags: { mode: 'remove', values: [] },
+      });
+      expect(fields.hasValidArrayValues()).toBe(false);
+    });
+
+    it('hasValidArrayValues returns true for replace mode with empty values', () => {
+      const fields = plainToInstance(BulkEditFieldsDto, {
+        genres: { mode: 'replace', values: [] },
+      });
+      expect(fields.hasValidArrayValues()).toBe(true);
+    });
+
+    it('hasValidArrayValues returns true when all array fields have values', () => {
+      const fields = plainToInstance(BulkEditFieldsDto, {
+        authors: { mode: 'add', values: ['A'] },
+        tags: { mode: 'remove', values: ['x'] },
+      });
+      expect(fields.hasValidArrayValues()).toBe(true);
+    });
+
+    it('provides typed access to all field types', () => {
+      const fields = plainToInstance(BulkEditFieldsDto, {
+        authors: { mode: 'add', values: ['A'] },
+        seriesName: { value: 'S' },
+        genres: { mode: 'replace', values: [] },
+        tags: { mode: 'remove', values: ['x'] },
+        publisher: { value: 'P' },
+        language: { value: 'en' },
+        publishedYear: { value: 2024 },
+        narrators: { mode: 'add', values: ['N'] },
+      });
+      expect(fields.authors?.mode).toBe('add');
+      expect(fields.seriesName?.value).toBe('S');
+      expect(fields.genres?.values).toEqual([]);
+      expect(fields.tags?.mode).toBe('remove');
+      expect(fields.publisher?.value).toBe('P');
+      expect(fields.language?.value).toBe('en');
+      expect(fields.publishedYear?.value).toBe(2024);
+      expect(fields.narrators?.values).toEqual(['N']);
+    });
+  });
+});

--- a/server/src/modules/book/dto/bulk-edit-metadata.dto.ts
+++ b/server/src/modules/book/dto/bulk-edit-metadata.dto.ts
@@ -1,0 +1,99 @@
+import { IsArray, IsIn, IsInt, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { BulkSelectionDto } from './bulk-selection.dto';
+
+const ARRAY_MODES = ['add', 'remove', 'replace'] as const;
+export type BulkArrayMode = (typeof ARRAY_MODES)[number];
+
+export class BulkArrayFieldDto {
+  @IsIn(ARRAY_MODES)
+  mode!: BulkArrayMode;
+
+  @IsArray()
+  @IsString({ each: true })
+  values!: string[];
+}
+
+export class BulkScalarStringFieldDto {
+  @IsOptional()
+  @IsString()
+  value!: string | null;
+}
+
+export class BulkScalarNumberFieldDto {
+  @IsOptional()
+  @IsInt()
+  value!: number | null;
+}
+
+const ALLOWED_FIELD_KEYS = new Set<string>(['authors', 'seriesName', 'genres', 'tags', 'publisher', 'language', 'publishedYear', 'narrators']);
+
+export class BulkEditFieldsDto {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BulkArrayFieldDto)
+  authors?: BulkArrayFieldDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BulkScalarStringFieldDto)
+  seriesName?: BulkScalarStringFieldDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BulkArrayFieldDto)
+  genres?: BulkArrayFieldDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BulkArrayFieldDto)
+  tags?: BulkArrayFieldDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BulkScalarStringFieldDto)
+  publisher?: BulkScalarStringFieldDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BulkScalarStringFieldDto)
+  language?: BulkScalarStringFieldDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BulkScalarNumberFieldDto)
+  publishedYear?: BulkScalarNumberFieldDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => BulkArrayFieldDto)
+  narrators?: BulkArrayFieldDto;
+
+  hasAtLeastOneField(): boolean {
+    return Object.keys(this).some((k) => ALLOWED_FIELD_KEYS.has(k) && (this as Record<string, unknown>)[k] !== undefined);
+  }
+
+  hasOnlyAllowedKeys(rawInput: Record<string, unknown>): boolean {
+    return Object.keys(rawInput).every((k) => ALLOWED_FIELD_KEYS.has(k));
+  }
+
+  hasValidArrayValues(): boolean {
+    for (const key of ['authors', 'genres', 'tags', 'narrators'] as const) {
+      const field = this[key];
+      if (!field) continue;
+      if ((field.mode === 'add' || field.mode === 'remove') && (!field.values || field.values.length === 0)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
+export { ALLOWED_FIELD_KEYS as BULK_EDIT_ALLOWED_FIELD_KEYS };
+
+export class BulkEditMetadataDto extends BulkSelectionDto {
+  @IsObject()
+  @ValidateNested()
+  @Type(() => BulkEditFieldsDto)
+  fields!: BulkEditFieldsDto;
+}


### PR DESCRIPTION
## What does this PR do?

Adds a bulk metadata edit workflow for multi-selected books across Home, Collection, and Smart Scope views.

Closes #150

## How did you test this?

- Set of unit tests and maual tests

## Screenshots

<img width="506" height="725" alt="Screenshot 2026-05-30 at 10 07 08 AM" src="https://github.com/user-attachments/assets/ea33769a-9487-4a94-8079-d6775d194fdc" />


## Anything non-obvious in the diff?

- `clear` is intentionally a UI-only mode and is submitted as `replace` with an empty list to keep backend API modes explicit.
- Optimistic updates are only applied for safe cases (replace-only edits on loaded selection); query-scope edits or add/remove list edits trigger reload paths.
- A follow-up port-resolution commit removes unrelated `writeAndRename` test carryover introduced by cross-branch conflict context, without changing feature behavior.

## Checklist

- [x] I've read through my own diff
- [x] This PR was discussed in an issue and has maintainer approval (for new features)
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)
