### PR TITLE
fix: percent-encode credentials when building DATABASE_URL (#126)

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -52,8 +52,17 @@ check_writable_current_user() {
   fi
 }
 
+# Percent-encode a single URL component so credentials containing reserved
+# characters (#, /, ?, @, :, spaces, ...) don't corrupt the DATABASE_URL.
+urlencode() {
+  node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$1"
+}
+
 if [ -z "$DATABASE_URL" ]; then
-  export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB}"
+  encoded_user="$(urlencode "$POSTGRES_USER")"
+  encoded_password="$(urlencode "$POSTGRES_PASSWORD")"
+  encoded_db="$(urlencode "$POSTGRES_DB")"
+  export DATABASE_URL="postgres://${encoded_user}:${encoded_password}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${encoded_db}"
 fi
 
 export APP_DATA_PATH="${APP_DATA_PATH:-/data}"


### PR DESCRIPTION
## Before you submit

> **New feature?** Please open an issue first and get approval from the maintainers before writing any code.
> PRs that introduce features without a prior discussion will be closed.
>
> **Used AI assistance?** That's fine - but make sure you've read and understood every line of the diff
> before submitting. PRs that show no sign of self-review will be closed without detailed feedback.
>
> **Keep it focused.** One thing per PR. Don't bundle a bug fix with a refactor or unrelated cleanup.
> If it's not ready, open it as a draft instead.

---

## What does this PR do?

When `DATABASE_URL` is not explicitly set, `server/entrypoint.sh` builds
it by interpolating `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`
raw into a `postgres://` URL. Any reserved URL character in the password
(`#`, `/`, `?`, `@`, `:`, space) corrupts the string — a `#` in particular
turns everything after it into a URL fragment — so `pg-connection-string`'s
`new URL()` throws `ERR_INVALID_URL` and the container crashes during
`runMigrations` before it can boot.

This adds a small `urlencode()` helper that pipes each credential component
through `node -e 'encodeURIComponent(...)'` before assembling the URL. Host
and port are intentionally left unencoded.

Fixes #126

## How did you test this?

Reproduced the failure with node directly: building the URL the old way with
a password containing `#` and calling `new URL()` throws `ERR_INVALID_URL`.
With the encoded form it parses cleanly, the host/port/db fields are intact,
and `decodeURIComponent` returns the original plaintext — so Postgres receives
the correct password. Also ran `sh -n server/entrypoint.sh` to confirm no
syntax errors, and verified the helper handles empty values correctly
(encoding to empty, preserving the existing default-fallback behaviour).

## Screenshots

N/A — no UI changes.

## Anything non-obvious in the diff?

`urlencode()` shells out to `node -e 'encodeURIComponent(...)'` rather than
a pure-shell loop. This is intentional: node is always available here (the
runtime is `node:alpine` and the very next lines run `node dist/scripts/migrate.js`
and `node dist/main.js`), and `encodeURIComponent` gives a fully-correct
RFC 3986 encoder with no edge cases to hand-roll.

## Checklist

- [x] I've read through my own diff
- [x] This PR was discussed in an issue and has maintainer approval (for new features) — N/A, this is a bug fix on a tracked issue
- [x] Lint and tests pass locally (`sh -n` clean; repo has no shell test suite)
- [x] No unintended files included (build artifacts, `.env`, personal configs)