### PR TITLE
ci: upload server and client coverage reports to codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,6 +392,8 @@ jobs:
     permissions:
       contents: read
       checks: write
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Check for package changes
         id: has-changes
@@ -435,8 +437,18 @@ jobs:
           if [[ "$PACKAGE" == "server" ]]; then
             pnpm --filter server exec vitest --run --coverage --reporter=default --reporter=github-actions --reporter=junit --outputFile.junit="$JUNIT_OUTPUT"
           else
-            pnpm --filter client exec vitest --run --reporter=default --reporter=junit --outputFile="$JUNIT_OUTPUT"
+            pnpm --filter client exec vitest --run --coverage --reporter=default --reporter=junit --outputFile="$JUNIT_OUTPUT"
           fi
+
+      - name: Upload coverage reports to Codecov
+        if: steps.has-changes.outputs.run == 'true' && env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+          files: ${{ matrix.package == 'server' && 'server/coverage/lcov.info' || 'client/coverage/lcov.info' }}
+          flags: ${{ matrix.package }}
+          name: ${{ matrix.package }}-coverage
+          verbose: true
 
       - name: Publish test report annotations
         if: >

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A self-hosted library management and reading platform for ebooks, PDFs, audioboo
 [![Stars](https://img.shields.io/github/stars/bookorbit/bookorbit?style=flat)](https://github.com/bookorbit/bookorbit/stargazers)
 [![CI](https://github.com/bookorbit/bookorbit/actions/workflows/ci.yml/badge.svg)](https://github.com/bookorbit/bookorbit/actions/workflows/ci.yml)
 [![Release](https://github.com/bookorbit/bookorbit/actions/workflows/release.yml/badge.svg)](https://github.com/bookorbit/bookorbit/actions/workflows/release.yml)
+[![codecov](https://codecov.io/gh/bookorbit/bookorbit/graph/badge.svg?token=F6TADEFCUV)](https://codecov.io/gh/bookorbit/bookorbit)
 [![Latest release](https://img.shields.io/github/v/release/bookorbit/bookorbit?label=latest)](https://github.com/bookorbit/bookorbit/releases)
 [![Commits/month](https://img.shields.io/github/commit-activity/m/bookorbit/bookorbit?label=commits%2Fmonth)](https://github.com/bookorbit/bookorbit/commits/main)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
@@ -26,6 +27,13 @@ A self-hosted library management and reading platform for ebooks, PDFs, audioboo
 ---
 
 ![BookOrbit dashboard showing reading stats, widgets, and book shelves](https://bookorbit.app/images/home/dashboard-overview.webp)
+
+<details>
+<summary>Coverage Map (Codecov Grid)</summary>
+
+![Codecov Grid](https://codecov.io/gh/bookorbit/bookorbit/graphs/tree.svg?token=F6TADEFCUV)
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ A self-hosted library management and reading platform for ebooks, PDFs, audioboo
 <details>
 <summary>Coverage Map (Codecov Grid)</summary>
 
+[![Server coverage](https://codecov.io/gh/bookorbit/bookorbit/graph/badge.svg?token=F6TADEFCUV&flag=server)](https://codecov.io/gh/bookorbit/bookorbit?flags%5B0%5D=server) Server &nbsp; [![Client coverage](https://codecov.io/gh/bookorbit/bookorbit/graph/badge.svg?token=F6TADEFCUV&flag=client)](https://codecov.io/gh/bookorbit/bookorbit?flags%5B0%5D=client) Client
+
 ![Codecov Grid](https://codecov.io/gh/bookorbit/bookorbit/graphs/tree.svg?token=F6TADEFCUV)
 
 </details>

--- a/README.md
+++ b/README.md
@@ -28,17 +28,6 @@ A self-hosted library management and reading platform for ebooks, PDFs, audioboo
 
 ![BookOrbit dashboard showing reading stats, widgets, and book shelves](https://bookorbit.app/images/home/dashboard-overview.webp)
 
-<details>
-<summary>Coverage Map (Codecov Grid)</summary>
-
-[![Server coverage](https://codecov.io/gh/bookorbit/bookorbit/graph/badge.svg?token=F6TADEFCUV&flag=server)](https://codecov.io/gh/bookorbit/bookorbit?flags%5B0%5D=server) Server &nbsp; [![Client coverage](https://codecov.io/gh/bookorbit/bookorbit/graph/badge.svg?token=F6TADEFCUV&flag=client)](https://codecov.io/gh/bookorbit/bookorbit?flags%5B0%5D=client) Client
-
-![Codecov Grid](https://codecov.io/gh/bookorbit/bookorbit/graphs/tree.svg?token=F6TADEFCUV)
-
-</details>
-
----
-
 ## What is BookOrbit?
 
 BookOrbit is a self-hosted digital library and reading platform. Organize and read your books, sync seamlessly with Kobo and KOReader devices, enrich your collection with metadata from multiple providers, and support multiple users with OIDC/SSO authentication and detailed reading statistics. Built-in features include OPDS support, customizable dashboard widgets, Send-to-Kindle delivery, and Smart Scopes for dynamic rule-based shelves and filters - all running on infrastructure you control.
@@ -131,6 +120,12 @@ For the full installation guide including reverse proxy setup, file permissions 
 Full documentation is at **[bookorbit.app](https://bookorbit.app)** - covering libraries, metadata, readers, Kobo sync, OPDS, users and permissions, OIDC setup, and more.
 
 For local development, see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md). To contribute, see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for the full workflow: branch naming, test expectations, PR checklist, and commit format.
+
+---
+
+## Code Coverage Map
+
+![Codecov Grid](https://codecov.io/gh/bookorbit/bookorbit/graphs/tree.svg?token=F6TADEFCUV)
 
 ---
 

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -11,7 +11,7 @@ export default mergeConfig(
       root: fileURLToPath(new URL('./', import.meta.url)),
       coverage: {
         provider: 'v8',
-        reporter: ['text', 'html'],
+        reporter: ['text', 'html', 'lcov'],
         reportsDirectory: './coverage',
         thresholds: {
           lines: 1,

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -13,6 +13,8 @@ export default mergeConfig(
         provider: 'v8',
         reporter: ['text', 'html', 'lcov'],
         reportsDirectory: './coverage',
+        include: ['src/**/*.{ts,vue}'],
+        exclude: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/**/__tests__/**', 'src/main.ts', 'src/**/*.d.ts', 'src/**/*.types.ts'],
         thresholds: {
           lines: 1,
           statements: 1,

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+        base: auto
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,21 @@ coverage:
         target: auto
         threshold: 0%
         base: auto
+        flags:
+          - server
+          - client
+      server:
+        target: auto
+        threshold: 0%
+        base: auto
+        flags:
+          - server
+      client:
+        target: auto
+        threshold: 0%
+        base: auto
+        flags:
+          - client
 
 comment:
   layout: "diff, flags, files"
@@ -13,3 +28,14 @@ comment:
   require_base: false
   require_head: true
   hide_project_coverage: false
+  show_carryforward_flags: true
+
+flags:
+  server:
+    paths:
+      - server/**
+    carryforward: true
+  client:
+    paths:
+      - client/**
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,6 +20,26 @@ coverage:
         base: auto
         flags:
           - client
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+        base: auto
+        flags:
+          - server
+          - client
+      server:
+        target: auto
+        threshold: 0%
+        base: auto
+        flags:
+          - server
+      client:
+        target: auto
+        threshold: 0%
+        base: auto
+        flags:
+          - client
 
 comment:
   layout: "diff, flags, files"


### PR DESCRIPTION
Closes #184

Generate client lcov output and publish per-package coverage from CI so Codecov checks and README coverage artifacts stay up to date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Codecov coverage badge and an embedded coverage map to the README.

* **Chores**
  * CI now collects and uploads test coverage to Codecov when available.
  * Test tooling updated to produce lcov coverage output.
  * Added Codecov configuration to track and report project and patch coverage for server and client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->