### PR TITLE
fix(Kobo): fix kobo device removed re sync

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -32,6 +32,10 @@ async function bootstrap() {
     const isJson = ct.startsWith('application/json');
     const isEmpty = request.headers['content-length'] === '0' || request.headers['content-length'] === undefined;
     if (isJson && isEmpty) {
+      // Kobo sends Content-Length: 0 with application/json on DELETE; align header with injected body.
+      if (request.method === 'DELETE' && request.headers['content-length'] === '0') {
+        request.headers['content-length'] = '2';
+      }
       const fake = new Readable();
       fake.push('{}');
       fake.push(null);

--- a/server/src/modules/kobo/services/kobo-sync.service.test.ts
+++ b/server/src/modules/kobo/services/kobo-sync.service.test.ts
@@ -350,15 +350,15 @@ describe('KoboSyncService', () => {
       return [];
     }
 
-    it('issues only CREATE TEMP and 5 maintenance queries when eligibleBooks is empty', async () => {
+    it('issues only CREATE TEMP and 6 maintenance queries when eligibleBooks is empty', async () => {
       const { fn: txExecute } = makeTxExecute();
       const db = makeReconcileDb(txExecute);
       const service = new KoboSyncService(db as never, {} as never, {} as never);
 
       await (service as any).reconcileSnapshot(42, []);
 
-      // CREATE TEMP + 5 maintenance queries (no batch insert when list is empty)
-      expect(txExecute).toHaveBeenCalledTimes(6);
+      // CREATE TEMP + 6 maintenance queries (no batch insert when list is empty)
+      expect(txExecute).toHaveBeenCalledTimes(7);
     });
 
     it('issues one batch INSERT when eligibleBooks fits in a single batch', async () => {
@@ -371,8 +371,8 @@ describe('KoboSyncService', () => {
         { bookId: 2, fileHash: null, metadataHash: 'm2' },
       ]);
 
-      // CREATE TEMP + 1 batch INSERT + 5 maintenance queries
-      expect(txExecute).toHaveBeenCalledTimes(7);
+      // CREATE TEMP + 1 batch INSERT + 6 maintenance queries
+      expect(txExecute).toHaveBeenCalledTimes(8);
 
       const batchInsert = captured[1];
       const sqlStrings = extractSqlStrings(batchInsert);
@@ -419,8 +419,8 @@ describe('KoboSyncService', () => {
       }));
       await (service as any).reconcileSnapshot(99, eligible);
 
-      // CREATE TEMP + 2 batch INSERTs + 5 maintenance queries
-      expect(txExecute).toHaveBeenCalledTimes(8);
+      // CREATE TEMP + 2 batch INSERTs + 6 maintenance queries
+      expect(txExecute).toHaveBeenCalledTimes(9);
     });
 
     it('includes snapshotId as a param in all maintenance queries', async () => {
@@ -431,8 +431,8 @@ describe('KoboSyncService', () => {
       const snapshotId = 77;
       await (service as any).reconcileSnapshot(snapshotId, [{ bookId: 1, fileHash: 'f', metadataHash: 'm' }]);
 
-      // Statements at index 2-6 are the 5 maintenance queries
-      const maintenanceStmts = captured.slice(2);
+      // Statements at index 2-7 are the 6 maintenance queries
+      const maintenanceStmts = captured.slice(2, 8);
       for (const stmt of maintenanceStmts) {
         const params = extractSqlParams(stmt);
         expect(params).toContain(snapshotId);
@@ -462,6 +462,24 @@ describe('KoboSyncService', () => {
       expect(batch2Params).toContain(5001);
       expect(batch2Params).toContain(5002);
       expect(batch2Params).not.toContain(1);
+    });
+
+    it('resets device-removed rows that remain eligible for re-delivery', async () => {
+      const { fn: txExecute, captured } = makeTxExecute();
+      const db = makeReconcileDb(txExecute);
+      const service = new KoboSyncService(db as never, {} as never, {} as never);
+
+      await (service as any).reconcileSnapshot(5, [{ bookId: 7, fileHash: 'abc', metadataHash: 'xyz' }]);
+
+      const resetStmt = captured.find((stmt) => {
+        const sql = extractSqlStrings(stmt).join(' ');
+        return sql.includes('removed_by_device = false') && sql.includes('removed_by_device = true');
+      });
+
+      expect(resetStmt).toBeDefined();
+      const sql = extractSqlStrings(resetStmt).join(' ');
+      expect(sql).toContain('synced = false');
+      expect(sql).toContain('is_new = true');
     });
   });
 

--- a/server/src/modules/kobo/services/kobo-sync.service.ts
+++ b/server/src/modules/kobo/services/kobo-sync.service.ts
@@ -203,6 +203,21 @@ export class KoboSyncService {
 
       await tx.execute(sql`
         UPDATE ${schema.koboSnapshotBooks} AS sb
+        SET removed_by_device = false,
+            synced = false,
+            is_new = true,
+            file_hash = e.file_hash,
+            metadata_hash = e.metadata_hash
+        FROM kobo_eligible_books_tmp e
+        WHERE sb.snapshot_id = ${snapshotId}
+          AND sb.book_id = e.book_id
+          AND sb.removed_by_device = true
+          AND sb.synced = true
+          AND sb.pending_delete = false
+      `);
+
+      await tx.execute(sql`
+        UPDATE ${schema.koboSnapshotBooks} AS sb
         SET synced = false,
             is_new = false,
             file_hash = e.file_hash,


### PR DESCRIPTION
## Before you submit

> **New feature?** Please open an issue first and get approval from the maintainers before writing any code.
> PRs that introduce features without a prior discussion will be closed.
>
> **Used AI assistance?** That's fine - but make sure you've read and understood every line of the diff
> before submitting. PRs that show no sign of self-review will be closed without detailed feedback.
>
> **Keep it focused.** One thing per PR. Don't bundle a bug fix with a refactor or unrelated cleanup.
> If it's not ready, open it as a draft instead.

---

## What does this PR do?

Closes #180 — books removed on the Kobo were never re-delivered on later syncs while still in a Sync-to-Kobo collection.
Two server-side fixes (both required):
1. kobo-sync.service.ts:
 the wedged snapshot row
When a book is device-removed but stays eligible (removed_by_device=true, synced=true), reconcileSnapshot() had no branch to reset it, so it was never re-queued. It now resets such rows to synced=false, is_new=true on the next sync, sending a full NewEntitlement (re-download). This mirrors the existing pending_delete re-add branch.
3. main.ts:
The Kobo sends DELETE with Content-Type: application/json and Content-Length: 0. The preParsing hook injected {} as a body but left Content-Length at 0, so Fastify rejected the request with 400 before removeBookFromSync() ran. Device removal was therefore never recorded — which means fix (1) had nothing to react to. The hook now sets Content-Length to match the injected body.



## How did you test this?

**Automated**
- [x] `pnpm --filter server exec vitest run src/modules/kobo` — 113 passed (includes a new regression test for the wedged-row reset: removed_by_device=true, synced=true + eligible → synced=false, is_new=true)
- [x] `pnpm verify:fast` (lint + typecheck)
- [x] `pnpm run test:server` : 463 files / 5622 tests passed
- [x] Kobo regression test + manual device verification

**Manual (Kobo Libra Colour, firmware 4.45.x):**
- [x] Sync book from Sync-to-Kobo collection -> downloads to device
- [x] Remove on device (remove from my books, not remove download)-> server logs `DELETE .../v1/library/{id}` **200** (was 400 before `main.ts` fix)
- [x] Sync again without changing collection -> book re-downloads; `NewEntitlement` in library sync response

## Screenshots

<!-- If this touches the UI, please include a before/after screenshot or a short screen recording.
     You can drag and drop images directly here. -->
Delete 400 errors (Current behavior, blocks deleteFromLibrary from triggering)
<img width="940" height="291" alt="image" src="https://github.com/user-attachments/assets/b89e61f1-104a-4464-b45e-641bcaaac421" />

### Post-Fix

Fresh Factory Install Kobo, synced to BookOrbit test instance. Server has a collection with a book and Sync to Kobo enabled
<img width="3072" height="4096" alt="IMG_20260601_233912226" src="https://github.com/user-attachments/assets/67e8acd1-6eae-49c2-a3a2-9b919a7f719f" />

Initial Sync to load test book
<img width="3072" height="4096" alt="IMG_20260601_234138006" src="https://github.com/user-attachments/assets/3c5d9579-91c8-426b-8a4a-12151ded6178" />

Manually remove book
<img width="3072" height="4096" alt="IMG_20260601_234149075" src="https://github.com/user-attachments/assets/f715efa0-ff71-4efc-a825-faafe314364c" />

Book appears on next sync (Book still in sync to Kobo collection)
<img width="3072" height="4096" alt="IMG_20260601_234208003" src="https://github.com/user-attachments/assets/49fffbfe-c3cc-413f-909d-475fad04361f" />


## Anything non-obvious in the diff?

- The reconcile fix alone is insufficient without the DELETE fix. Without recording `removed_by_device`, the new reconcile branch never runs.
- `Content-Length` is set to the byte length of the injected `{}` body (`2`), and the hook change is scoped to the Kobo DELETE path so it doesn't affect other request handling.
- `POST .../v1/library/tags/col-N/items/delete` 400s during sync are pre-existing (proxied to Kobo store; BookOrbit virtual tags don't exist there). Out of scope; does not block re-delivery.

## AI tools used
Cursor used to parse and understand the code base, helped with tracing and debugging the main.ts bug. I've reviewed every line of the diff and understand each change.

## Checklist

- [X] I've read through my own diff
- [X] This PR was discussed in an issue and has maintainer approval (for new features)
- [X] Lint and tests pass locally
- [X] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header handling for DELETE requests with empty JSON bodies to ensure correct payload alignment.
  * Improved synchronization so items previously marked as removed are correctly re-synced when eligible.

* **Tests**
  * Updated reconciliation tests to reflect revised maintenance query behavior and added a test verifying reset of removed-but-eligible items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->