### PR TITLE
fix(series): prevent 404 for long series titles

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -19,7 +19,7 @@ const MAX_COVER_BYTES = 20 * 1024 * 1024;
 async function bootstrap() {
   const allowCloudflareInsights = parseBooleanEnv(process.env.CSP_ALLOW_CLOUDFLARE_INSIGHTS, false);
 
-  const adapter = new FastifyAdapter({ logger: false, trustProxy: parseTrustProxy(process.env.TRUST_PROXY) });
+  const adapter = new FastifyAdapter({ logger: false, trustProxy: parseTrustProxy(process.env.TRUST_PROXY), maxParamLength: 1000 });
   const app = await NestFactory.create<NestFastifyApplication>(AppModule, adapter, { bufferLogs: true });
   app.useLogger(app.get(Logger));
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes the bug described in issue #198 by increasing the maxParamLength



## Screenshots
<img width="1751" height="849" alt="image" src="https://github.com/user-attachments/assets/e0d4d56a-2167-4472-8441-d28fb093d6cf" />


## Checklist

- [X] I've read through my own diff
- [ ] This PR was discussed in an issue and has maintainer approval (for new features)
- [X] Lint and tests pass locally
- [X] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the maximum URL parameter length limit to accommodate longer request parameters in server requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->