### PR TITLE
feat(kobo): sync star ratings from ratebook analytics events

### DIFF
--- a/server/src/modules/kobo/kobo.module.test.ts
+++ b/server/src/modules/kobo/kobo.module.test.ts
@@ -21,6 +21,7 @@ import { KoboSyncService } from './services/kobo-sync.service';
 import { KoboThumbnailService } from './services/kobo-thumbnail.service';
 import { KoboAnalyticsResolverService } from './services/kobo-analytics-resolver.service';
 import { KoboAnalyticsService } from './services/kobo-analytics.service';
+import { BookModule } from '../book/book.module';
 import { ReadingSessionModule } from '../reading-session/reading-session.module';
 
 describe('KoboModule', () => {
@@ -29,6 +30,7 @@ describe('KoboModule', () => {
     const providers = Reflect.getMetadata(MODULE_METADATA.PROVIDERS, KoboModule) as unknown[];
     const imports = Reflect.getMetadata(MODULE_METADATA.IMPORTS, KoboModule) as unknown[];
 
+    expect(imports).toContain(BookModule);
     expect(imports).toContain(ReadingSessionModule);
     expect(controllers).toEqual([KoboUserController, KoboAuthController, KoboSyncController, KoboDeviceController]);
     expect(providers).toEqual([

--- a/server/src/modules/kobo/kobo.module.ts
+++ b/server/src/modules/kobo/kobo.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { CommonModule } from '../../common/common.module';
+import { BookModule } from '../book/book.module';
 import { ReadingSessionModule } from '../reading-session/reading-session.module';
 import { UserModule } from '../user/user.module';
 import { UserBookStatusModule } from '../user-book-status/user-book-status.module';
@@ -24,7 +25,7 @@ import { KoboAnalyticsResolverService } from './services/kobo-analytics-resolver
 import { KoboAnalyticsService } from './services/kobo-analytics.service';
 
 @Module({
-  imports: [CommonModule, UserModule, UserBookStatusModule, ReadingSessionModule],
+  imports: [CommonModule, BookModule, UserModule, UserBookStatusModule, ReadingSessionModule],
   controllers: [KoboUserController, KoboAuthController, KoboSyncController, KoboDeviceController],
   providers: [
     KoboTokenGuard,

--- a/server/src/modules/kobo/services/kobo-analytics.service.test.ts
+++ b/server/src/modules/kobo/services/kobo-analytics.service.test.ts
@@ -459,12 +459,43 @@ describe('KoboAnalyticsService', () => {
             Metrics: { stars: 6 },
             Attributes: { volumeid: '1' },
           },
+          {
+            Id: 'fractional-stars',
+            EventType: 'RateBook',
+            Timestamp: '2026-06-01T00:40:50Z',
+            Metrics: { stars: 3.5 },
+            Attributes: { volumeid: '1' },
+          },
         ],
       },
       user,
       device,
     );
 
+    expect(bookService.bulkSetRating).not.toHaveBeenCalled();
+    expect(bookIdentityService.resolveBookIdByEntitlementId).not.toHaveBeenCalled();
+  });
+
+  it('ignores RateBook when volumeid does not resolve to a book', async () => {
+    bookIdentityService.resolveBookIdByEntitlementId.mockResolvedValue(null);
+
+    await makeService().ingest(
+      {
+        Events: [
+          {
+            Id: 'bad-volume',
+            EventType: 'RateBook',
+            Timestamp: '2026-06-01T00:40:50Z',
+            Metrics: { stars: 4 },
+            Attributes: { volumeid: 'unknown-entitlement' },
+          },
+        ],
+      },
+      user,
+      device,
+    );
+
+    expect(bookIdentityService.resolveBookIdByEntitlementId).toHaveBeenCalledWith(7, 'unknown-entitlement');
     expect(bookService.bulkSetRating).not.toHaveBeenCalled();
   });
 

--- a/server/src/modules/kobo/services/kobo-analytics.service.test.ts
+++ b/server/src/modules/kobo/services/kobo-analytics.service.test.ts
@@ -7,11 +7,12 @@ describe('KoboAnalyticsService', () => {
   const bookIdentityService = { resolveBookIdByEntitlementId: vi.fn() };
   const resolver = { resolveBookFileId: vi.fn() };
   const readingSessionService = { save: vi.fn() };
+  const bookService = { bulkSetRating: vi.fn() };
   const user = { id: 7 } as never;
   const device = { deviceId: 2, deviceToken: 'tok', userId: 7 } as never;
 
   function makeService() {
-    return new KoboAnalyticsService(bookIdentityService as never, resolver as never, readingSessionService as never);
+    return new KoboAnalyticsService(bookIdentityService as never, resolver as never, readingSessionService as never, bookService as never);
   }
 
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('KoboAnalyticsService', () => {
     );
     resolver.resolveBookFileId.mockResolvedValue({ kind: 'resolved', bookFileId: 100 });
     readingSessionService.save.mockResolvedValue(undefined);
+    bookService.bulkSetRating.mockResolvedValue(undefined);
   });
 
   it('maps LeaveContent to reading sessions (duration minimum enforced in ReadingSessionService.save)', async () => {
@@ -390,6 +392,152 @@ describe('KoboAnalyticsService', () => {
     );
 
     expect(resolver.resolveBookFileId).not.toHaveBeenCalled();
+    expect(bookService.bulkSetRating).not.toHaveBeenCalled();
+  });
+
+  it('maps RateBook to user ratings via bulkSetRating', async () => {
+    await makeService().ingest(
+      {
+        Events: [
+          {
+            Id: '74db9ad6-152a-4a97-91d1-129308e4b591',
+            EventType: 'RateBook',
+            Timestamp: '2026-06-01T00:40:50Z',
+            Metrics: { stars: 4 },
+            Attributes: { volumeid: '1', title: 'Promise of Blood', progress: '7' },
+          },
+        ],
+      },
+      user,
+      device,
+    );
+
+    expect(bookIdentityService.resolveBookIdByEntitlementId).toHaveBeenCalledWith(7, '1');
+    expect(bookService.bulkSetRating).toHaveBeenCalledWith([1], 4, user);
+    expect(readingSessionService.save).not.toHaveBeenCalled();
+  });
+
+  it('resolves UUID entitlement volumeid values for RateBook', async () => {
+    const entitlementId = '11111111-1111-4111-8111-111111111111';
+    bookIdentityService.resolveBookIdByEntitlementId.mockResolvedValue(9);
+
+    await makeService().ingest(
+      {
+        Events: [
+          {
+            Id: 'rate-uuid',
+            EventType: 'RateBook',
+            Timestamp: '2026-06-01T00:40:50Z',
+            Metrics: { stars: 5 },
+            Attributes: { volumeid: entitlementId },
+          },
+        ],
+      },
+      user,
+      device,
+    );
+
+    expect(bookService.bulkSetRating).toHaveBeenCalledWith([9], 5, user);
+  });
+
+  it('ignores malformed RateBook events', async () => {
+    await makeService().ingest(
+      {
+        Events: [
+          { Id: 'no-stars', EventType: 'RateBook', Timestamp: '2026-06-01T00:40:50Z', Attributes: { volumeid: '1' } },
+          {
+            Id: 'no-volume',
+            EventType: 'RateBook',
+            Timestamp: '2026-06-01T00:40:50Z',
+            Metrics: { stars: 4 },
+            Attributes: {},
+          },
+          {
+            Id: 'too-high',
+            EventType: 'RateBook',
+            Timestamp: '2026-06-01T00:40:50Z',
+            Metrics: { stars: 6 },
+            Attributes: { volumeid: '1' },
+          },
+        ],
+      },
+      user,
+      device,
+    );
+
+    expect(bookService.bulkSetRating).not.toHaveBeenCalled();
+  });
+
+  it('clears the user rating when Kobo sends stars: 0', async () => {
+    await makeService().ingest(
+      {
+        Events: [
+          {
+            Id: 'clear-rating',
+            EventType: 'RateBook',
+            Timestamp: '2026-06-01T00:40:50Z',
+            Metrics: { stars: 0 },
+            Attributes: { volumeid: '1' },
+          },
+        ],
+      },
+      user,
+      device,
+    );
+
+    expect(bookService.bulkSetRating).toHaveBeenCalledWith([1], null, user);
+  });
+
+  it('processes RateBook and LeaveContent in the same batch', async () => {
+    await makeService().ingest(
+      {
+        Events: [
+          {
+            Id: 'rate',
+            EventType: 'RateBook',
+            Timestamp: '2026-06-01T00:40:50Z',
+            Metrics: { stars: 3 },
+            Attributes: { volumeid: '1' },
+          },
+          {
+            Id: 'leave',
+            EventType: 'LeaveContent',
+            Timestamp: '2026-06-01T00:41:00Z',
+            Metrics: { SecondsRead: 20 },
+            Attributes: { volumeid: '1', progress: '8' },
+          },
+        ],
+      },
+      user,
+      device,
+    );
+
+    expect(bookService.bulkSetRating).toHaveBeenCalledWith([1], 3, user);
+    expect(readingSessionService.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a warning when bulkSetRating throws', async () => {
+    const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    bookService.bulkSetRating.mockRejectedValueOnce(new Error('forbidden'));
+
+    await makeService().ingest(
+      {
+        Events: [
+          {
+            Id: 'rate-fail',
+            EventType: 'RateBook',
+            Timestamp: '2026-06-01T00:40:50Z',
+            Metrics: { stars: 4 },
+            Attributes: { volumeid: '1' },
+          },
+        ],
+      },
+      user,
+      device,
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[kobo.analytics.rating] [fail]'));
+    warnSpy.mockRestore();
   });
 
   it('warns and skips ingest when Events is not an array', async () => {

--- a/server/src/modules/kobo/services/kobo-analytics.service.ts
+++ b/server/src/modules/kobo/services/kobo-analytics.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import { sanitizeLogValue } from '../../../common/utils/log-sanitize.utils';
 import type { RequestUser } from '../../../common/types/request-user';
+import { BookService } from '../../book/book.service';
 import { ReadingSessionService } from '../../reading-session/reading-session.service';
 import type { KoboDeviceContext } from '../guards/kobo-token.guard';
 import type { KoboAnalyticsBody, KoboAnalyticsEvent } from '../kobo-analytics.types';
@@ -20,6 +21,18 @@ function parseKoboProgress(raw: unknown): number | null {
   const value = typeof raw === 'number' ? raw : typeof raw === 'string' && raw.trim() !== '' ? Number(raw.trim()) : Number.NaN;
   if (!Number.isFinite(value) || value < 0 || value > 100) return null;
   return value;
+}
+
+type KoboStarsValue = { kind: 'rating'; value: number } | { kind: 'clear' } | { kind: 'invalid' };
+
+function parseKoboStars(metrics: KoboAnalyticsEvent['Metrics'] | undefined): KoboStarsValue {
+  if (metrics?.stars === undefined) return { kind: 'invalid' };
+
+  const stars = metrics.stars;
+  if (typeof stars !== 'number' || !Number.isInteger(stars)) return { kind: 'invalid' };
+  if (stars === 0) return { kind: 'clear' };
+  if (stars >= 1 && stars <= 5) return { kind: 'rating', value: stars };
+  return { kind: 'invalid' };
 }
 
 function parseKoboDurationSeconds(metrics: KoboAnalyticsEvent['Metrics'] | undefined): number | null {
@@ -58,6 +71,7 @@ export class KoboAnalyticsService {
     private readonly bookIdentityService: KoboBookIdentityService,
     private readonly resolver: KoboAnalyticsResolverService,
     private readonly readingSessionService: ReadingSessionService,
+    private readonly bookService: BookService,
   ) {}
 
   async ingest(body: KoboAnalyticsBody | null | undefined, user: RequestUser, device: KoboDeviceContext): Promise<void> {
@@ -66,13 +80,17 @@ export class KoboAnalyticsService {
     const leaveContentContexts = this.buildLeaveContentContexts(events);
 
     for (const ev of events) {
-      if (ev.EventType !== 'LeaveContent') continue;
       try {
-        await this.handleLeaveContent(ev, user, leaveContentContexts.get(ev) ?? { progressDelta: null, startedAtMs: null });
+        if (ev.EventType === 'LeaveContent') {
+          await this.handleLeaveContent(ev, user, leaveContentContexts.get(ev) ?? { progressDelta: null, startedAtMs: null });
+        } else if (ev.EventType === 'RateBook') {
+          await this.handleRateBook(ev, user);
+        }
       } catch (err) {
         const message = sanitizeLogValue(err instanceof Error ? err.message : 'unknown error');
+        const kind = ev.EventType === 'RateBook' ? 'rating' : 'session';
         this.logger.warn(
-          `[kobo.analytics.session] [fail] userId=${user.id} eventId=${ev.Id} error="${message}" event="${formatAnalyticsPayload(ev, 800)}" - leave content ingest failed`,
+          `[kobo.analytics.${kind}] [fail] userId=${user.id} eventId=${ev.Id} error="${message}" event="${formatAnalyticsPayload(ev, 800)}" - analytics ingest failed`,
         );
       }
     }
@@ -92,6 +110,28 @@ export class KoboAnalyticsService {
     this.logger.debug(
       `[kobo.analytics] batch userId=${userId} deviceId=${deviceId} eventCount=${events.length} types=${typeSummary} payload="${formatAnalyticsPayload(body)}"`,
     );
+  }
+
+  private async handleRateBook(ev: KoboAnalyticsEvent, user: RequestUser): Promise<void> {
+    const volumeid = this.extractVolumeId(ev);
+    const stars = parseKoboStars(ev.Metrics);
+    if (volumeid === null || stars.kind === 'invalid') {
+      this.logger.debug(
+        `[kobo.analytics.rating] [ignore] malformed RateBook userId=${user.id} eventId=${ev.Id} event="${formatAnalyticsPayload(ev, 800)}"`,
+      );
+      return;
+    }
+
+    const bookId = await this.bookIdentityService.resolveBookIdByEntitlementId(user.id, volumeid);
+    if (bookId === null) {
+      this.logger.debug(
+        `[kobo.analytics.rating] [ignore] invalid volumeid userId=${user.id} eventId=${ev.Id} volumeid="${sanitizeLogValue(volumeid)}" event="${formatAnalyticsPayload(ev, 800)}"`,
+      );
+      return;
+    }
+
+    const rating = stars.kind === 'clear' ? null : stars.value;
+    await this.bookService.bulkSetRating([bookId], rating, user);
   }
 
   private async handleLeaveContent(ev: KoboAnalyticsEvent, user: RequestUser, context: LeaveContentContext): Promise<void> {


### PR DESCRIPTION
## Before you submit

> **New feature?** Please open an issue first and get approval from the maintainers before writing any code.
> PRs that introduce features without a prior discussion will be closed.
>
> **Used AI assistance?** That's fine - but make sure you've read and understood every line of the diff
> before submitting. PRs that show no sign of self-review will be closed without detailed feedback.
>
> **Keep it focused.** One thing per PR. Don't bundle a bug fix with a refactor or unrelated cleanup.
> If it's not ready, open it as a draft instead.

---

## What does this PR do?

- Handle `RateBook` events in `KoboAnalyticsService`, alongside existing `LeaveContent` session ingestion (#245)
- Resolve `volumeid` → `bookId` via `KoboBookIdentityService` (UUID + legacy numeric)
- Persist ratings through `BookService.bulkSetRating`, reusing library access checks, metadata locks, achievements, and Hardcover auto-sync
- Map `stars: 0` to `bulkSetRating(..., null)` to clear ratings when unset on device (confirmed on Kobo Libra Colour)
- Import `BookModule` into `KoboModule` for `BookService` DI
Closes #259

## Behavior
| Kobo `Metrics.stars` | BookOrbit action |
|----------------------|------------------|
| `1`–`5` | Set user rating |
| `0` | Clear user rating |
| missing / out of range | Ignore event (debug log) |

`RateBook` and `LeaveContent` in the same analytics batch are processed independently; per-event try/catch prevents one failure from blocking the batch.

## How did you test this?

Tested on Kobo Libra Colour (firmware 4.45.23697) pointed at local dev instance:
- [x] Rate book at end-of-book flow (`stars: 5`, UUID `volumeid`) → 5 stars in BookOrbit UI
- [x] Clear rating (`stars: 0`, sent twice by device) → empty stars in BookOrbit UI
- [x] Analytics batch logged with `types=...RateBook:...` at `LOG_LEVEL=debug`

## All tests pass
- [x] `pnpm exec vitest run src/modules/kobo/services/kobo-analytics.service.test.ts`
- [x] `pnpm exec vitest run src/modules/kobo/` (174 tests)
- [x] `pnpm run lint:check` (server)
- [x] Full server suite (5984 tests)


## Screenshots

<!-- If this touches the UI, please include a before/after screenshot or a short screen recording.
     You can drag and drop images directly here. -->
     
<img width="585" height="279" alt="image" src="https://github.com/user-attachments/assets/1e30f23f-26c1-44fd-95e5-c86ac96476a5" />
<img width="1695" height="932" alt="image" src="https://github.com/user-attachments/assets/ae4991d4-1b3c-4cba-bdf9-04190e29d553" />


<img width="585" height="279" alt="image" src="https://github.com/user-attachments/assets/7f6a24b6-befe-491b-a071-4aa9bfd867ea" />
<img width="1704" height="717" alt="image" src="https://github.com/user-attachments/assets/0c46c4a3-0de2-4385-adae-60e0ae484e4c" />



## Anything non-obvious in the diff?

<!-- Did you make any tricky decisions or trade-offs? Anything you'd want a reviewer to pay
     extra attention to? This is your chance to guide the review. -->

## Checklist

- [X] I've read through my own diff
- [X] This PR was discussed in an issue and has maintainer approval (for new features)
- [X] Lint and tests pass locally
- [X] No unintended files included (build artifacts, `.env`, personal configs)

AI tools used: Cursor/Claude
Extent: Reviewing changes, implementing tests and wiring up imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kobo analytics now supports submitting and clearing book ratings (1–5 stars and clear).

* **Reliability**
  * Improved analytics ingest resilience with per-event error handling and clearer warning logs.
  * Kobo module updated to include book-related integration for ratings.

* **Tests**
  * Expanded test coverage for rating events, malformed payloads, mapping resolution, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->