### PR TITLE
fix(kobo): enhance kobodeviceservice to manage device snapshots

### DIFF
--- a/server/src/modules/kobo/services/kobo-device.service.test.ts
+++ b/server/src/modules/kobo/services/kobo-device.service.test.ts
@@ -135,9 +135,14 @@ describe('KoboDeviceService', () => {
     const service = makeService(db);
 
     await expect(service.revokeDevice(8, 111)).rejects.toThrow(NotFoundException);
+    expect(syncService.invalidateSnapshot).not.toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
+    expect(db.deleteWhere).not.toHaveBeenCalled();
+
     await expect(service.revokeDevice(8, 7)).resolves.toBeUndefined();
-    expect(db.delete).toHaveBeenCalled();
-    expect(db.deleteWhere).toHaveBeenCalled();
+    expect(db.delete).toHaveBeenCalledTimes(1);
+    expect(db.deleteWhere).toHaveBeenCalledTimes(1);
+    expect(syncService.invalidateSnapshot).toHaveBeenCalledTimes(1);
     expect(syncService.invalidateSnapshot).toHaveBeenCalledWith(8);
   });
 });

--- a/server/src/modules/kobo/services/kobo-device.service.test.ts
+++ b/server/src/modules/kobo/services/kobo-device.service.test.ts
@@ -44,21 +44,29 @@ function makeDb() {
 }
 
 describe('KoboDeviceService', () => {
+  const syncService = { invalidateSnapshot: vi.fn() };
+
+  function makeService(db: ReturnType<typeof makeDb>) {
+    return new KoboDeviceService(db as never, syncService as never);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    syncService.invalidateSnapshot.mockResolvedValue(undefined);
   });
 
   it('lists devices for user ordered by creation time', async () => {
     const db = makeDb();
     const rows = [{ id: 1, name: 'Aura' }];
     db.select.mockReturnValueOnce(makeSelectChain(rows));
-    const service = new KoboDeviceService(db as never);
+    const service = makeService(db);
 
     await expect(service.listDevices(8)).resolves.toEqual(rows);
   });
 
   it('creates a device with hyphen-free token and returns persisted fields', async () => {
     const db = makeDb();
+    db.select.mockReturnValueOnce(makeSelectChain([], []));
     db.insertReturning.mockResolvedValueOnce([
       {
         id: 22,
@@ -68,7 +76,7 @@ describe('KoboDeviceService', () => {
         createdAt: new Date('2026-01-01T00:00:00.000Z'),
       },
     ]);
-    const service = new KoboDeviceService(db as never);
+    const service = makeService(db);
 
     await expect(service.createDevice(8, 'Libra')).resolves.toEqual({
       id: 22,
@@ -84,13 +92,33 @@ describe('KoboDeviceService', () => {
         token: expect.stringMatching(/^[0-9a-f]+$/i),
       }),
     );
+    expect(syncService.invalidateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the user snapshot when adding another device', async () => {
+    const db = makeDb();
+    db.select.mockReturnValueOnce(makeSelectChain([], [{ id: 3 }]));
+    db.insertReturning.mockResolvedValueOnce([
+      {
+        id: 22,
+        name: 'Libra',
+        token: 'server-generated-token',
+        lastSeenAt: null,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    ]);
+    const service = makeService(db);
+
+    await service.createDevice(8, 'Libra');
+
+    expect(syncService.invalidateSnapshot).toHaveBeenCalledWith(8);
   });
 
   it('renames existing devices and throws when device is missing', async () => {
     const db = makeDb();
     db.select.mockReturnValueOnce(makeSelectChain([], [])).mockReturnValueOnce(makeSelectChain([], [{ id: 5, userId: 8 }]));
     db.updateReturning.mockResolvedValueOnce([{ id: 5, name: 'Clara', lastSeenAt: null, createdAt: new Date('2026-01-01T00:00:00.000Z') }]);
-    const service = new KoboDeviceService(db as never);
+    const service = makeService(db);
 
     await expect(service.renameDevice(8, 404, 'Nope')).rejects.toThrow(NotFoundException);
     await expect(service.renameDevice(8, 5, 'Clara')).resolves.toEqual({
@@ -104,11 +132,12 @@ describe('KoboDeviceService', () => {
   it('revokes devices and rejects unknown ids', async () => {
     const db = makeDb();
     db.select.mockReturnValueOnce(makeSelectChain([], [])).mockReturnValueOnce(makeSelectChain([], [{ id: 7 }]));
-    const service = new KoboDeviceService(db as never);
+    const service = makeService(db);
 
     await expect(service.revokeDevice(8, 111)).rejects.toThrow(NotFoundException);
     await expect(service.revokeDevice(8, 7)).resolves.toBeUndefined();
     expect(db.delete).toHaveBeenCalled();
     expect(db.deleteWhere).toHaveBeenCalled();
+    expect(syncService.invalidateSnapshot).toHaveBeenCalledWith(8);
   });
 });

--- a/server/src/modules/kobo/services/kobo-device.service.ts
+++ b/server/src/modules/kobo/services/kobo-device.service.ts
@@ -5,12 +5,16 @@ import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
 import { DB } from '../../../db/db.module';
 import * as schema from '../../../db/schema';
+import { KoboSyncService } from './kobo-sync.service';
 
 type Db = NodePgDatabase<typeof schema>;
 
 @Injectable()
 export class KoboDeviceService {
-  constructor(@Inject(DB) private readonly db: Db) {}
+  constructor(
+    @Inject(DB) private readonly db: Db,
+    private readonly syncService: KoboSyncService,
+  ) {}
 
   async listDevices(userId: number) {
     const rows = await this.db
@@ -27,8 +31,19 @@ export class KoboDeviceService {
   }
 
   async createDevice(userId: number, name: string) {
+    const [existingDevice] = await this.db
+      .select({ id: schema.koboDevices.id })
+      .from(schema.koboDevices)
+      .where(eq(schema.koboDevices.userId, userId))
+      .limit(1);
+
     const token = randomUUID().replace(/-/g, '');
     const [device] = await this.db.insert(schema.koboDevices).values({ userId, name, token }).returning();
+
+    if (existingDevice) {
+      await this.syncService.invalidateSnapshot(userId);
+    }
+
     return {
       id: device.id,
       name: device.name,
@@ -70,5 +85,6 @@ export class KoboDeviceService {
     if (!device) throw new NotFoundException('Device not found');
 
     await this.db.delete(schema.koboDevices).where(and(eq(schema.koboDevices.id, deviceId), eq(schema.koboDevices.userId, userId)));
+    await this.syncService.invalidateSnapshot(userId);
   }
 }

--- a/server/src/modules/kobo/services/kobo-sync.service.ts
+++ b/server/src/modules/kobo/services/kobo-sync.service.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { SQL, and, asc, eq, inArray, sql } from 'drizzle-orm';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
@@ -67,6 +67,8 @@ function encodeSyncToken(snapshotId: number): string {
 
 @Injectable()
 export class KoboSyncService {
+  private readonly logger = new Logger(KoboSyncService.name);
+
   constructor(
     @Inject(DB) private readonly db: Db,
     private readonly bookAccessService: KoboBookAccessService,
@@ -130,8 +132,20 @@ export class KoboSyncService {
     const snapshot = await this.db.query.koboLibrarySnapshots.findFirst({
       where: eq(schema.koboLibrarySnapshots.userId, userId),
     });
-    if (!snapshot) return;
-    await this.db.update(schema.koboSnapshotBooks).set({ synced: false }).where(eq(schema.koboSnapshotBooks.snapshotId, snapshot.id));
+    if (!snapshot) {
+      this.logger.debug(`[kobo.snapshot] invalidate skipped userId=${userId} reason=no_snapshot`);
+      return;
+    }
+
+    const resetRows = await this.db
+      .update(schema.koboSnapshotBooks)
+      .set({ synced: false })
+      .where(and(eq(schema.koboSnapshotBooks.snapshotId, snapshot.id), eq(schema.koboSnapshotBooks.synced, true)))
+      .returning({ bookId: schema.koboSnapshotBooks.bookId });
+
+    this.logger.debug(
+      `[kobo.snapshot] invalidated userId=${userId} snapshotId=${snapshot.id} resetSyncedCount=${resetRows.length} bookIds=${resetRows.map((row) => row.bookId).join(',') || 'none'}`,
+    );
   }
 
   private async createSnapshot(userId: number, books: EligibleSnapshotRow[]) {


### PR DESCRIPTION
## Before you submit

> **New feature?** Please open an issue first and get approval from the maintainers before writing any code.
> PRs that introduce features without a prior discussion will be closed.
>
> **Used AI assistance?** That's fine - but make sure you've read and understood every line of the diff
> before submitting. PRs that show no sign of self-review will be closed without detailed feedback.
>
> **Keep it focused.** One thing per PR. Don't bundle a bug fix with a refactor or unrelated cleanup.
> If it's not ready, open it as a draft instead.

---

## What does this PR do?


Closes (partially) #242
Implements the **narrow** fix from [#242](https://github.com/bookorbit/bookorbit/issues/242): when a user's Kobo device is revoked or a second device is added, reset the per-user library snapshot so `getPageFromSnapshot` re-delivers books that were previously marked `synced = true`.


**`KoboDeviceService`**
- Injects `KoboSyncService` and calls `invalidateSnapshot(userId)` after a successful **revoke**
- On **create**, invalidates only when the user already had another device (first device ever → no-op; revoke-then-replace → revoke already handled it)

**`KoboSyncService.invalidateSnapshot`**
- Only resets rows where `synced = true` (no-op update for already-pending books)
- Adds debug logging with `.returning({ bookId })` for observability during verification

**Out of scope:** per-(user, device) snapshots for concurrent multi-device sync - that would be the architectural fix described in the issue.

AI tools used: Cursor
Extent: implementatio and tests drafted with AI assistance; manually verified behavior via UI + `psql` and reviewed every line of the diff.

## How did you test this?

<!-- Tell us what you actually did to verify this works. What did you run? What did you click through?
     A quick note like "spun up Docker, added a book, confirmed it shows in the library" is perfect.
     This helps us review with confidence and speeds up the merge. -->

- `pnpm test` - all tests pass
- `pnpm verify` - all tests pass
- Targeted: `kobo-device.service.test.ts` (5 tests) and existing `invalidateSnapshot` test in `kobo-sync.service.test.ts`
- Manual (UI + DB, no Kobo hardware required for this fix):
  1. Set `kobo_snapshot_books.synced = true` for a test user with an existing snapshot
  2. **First device create** — confirmed `invalidateSnapshot` not called (no snapshot yet / no prior device)
  3. **Second device create** — confirmed `synced` reset to `false` and debug log `resetSyncedCount=1`
  4. **Revoke device** — confirmed same snapshot reset after delete

## Screenshots

<!-- If this touches the UI, please include a before/after screenshot or a short screen recording.
     You can drag and drop images directly here. -->

## Anything non-obvious in the diff?

<!-- Did you make any tricky decisions or trade-offs? Anything you'd want a reviewer to pay
     extra attention to? This is your chance to guide the review. -->

- **`createDevice` checks for an existing device before insert**, not after so "add second device" invalidates, but "revoke then create replacement" only invalidates once (on revoke).
- **Test file changes outside the new assertions** (`makeService`, `syncService` mock) are mechanical. `KoboDeviceService` now requires `KoboSyncService` in its constructor. Rename/list tests only updated instantiation; behavior unchanged.
- **`.returning()` on the update** is for debug logging (`resetSyncedCount`, `bookIds`), not required for the fix itself. Happy to drop the logging if reviewers prefer a leaner diff.


## Checklist

- [X] I've read through my own diff
- [X] This PR was discussed in an issue and has maintainer approval (for new features)
- [X] Lint and tests pass locally
- [X] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure cached Kobo snapshots are invalidated when an additional device is added and when a device is revoked; avoid invalidation when creating a user's first device.

* **Improvements**
  * Improved logging for snapshot invalidation to make reset activity and affected items more visible.

* **Tests**
  * Unit tests expanded to verify snapshot invalidation behavior across create, rename, and revoke flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->