### PR TITLE
Update totalBookDuration computation to account for metadata duration

### DIFF
--- a/client/src/features/reader/audiobook/AudiobookReaderView.vue
+++ b/client/src/features/reader/audiobook/AudiobookReaderView.vue
@@ -587,7 +587,15 @@ const absolutePositionSeconds = computed(() => {
 
 const absolutePositionMs = computed(() => absolutePositionSeconds.value * 1000)
 
-const totalBookDuration = computed(() => audioFiles.value.reduce((sum, f) => sum + (f.durationSeconds ?? 0), 0))
+const totalBookDuration = computed(() => {
+  const durationFromFiles = audioFiles.value.reduce((sum, f) => sum + (f.durationSeconds ?? 0), 0)
+
+  if (durationFromFiles === 0) {
+    return detail.value?.audioMetadata?.durationSeconds ?? 0
+  }
+
+  return durationFromFiles
+})
 
 const progressPct = computed(() => {
   const total = totalBookDuration.value


### PR DESCRIPTION
Update totalBookDuration computation to account for metadata duration when files lack duration data.

Previously the UI only looked at the total duration by summing all the file durations, however if the file duration is missing and there is one in audio metadata, this was never used.

It could be that there should always be a duration on the file and there is another bug somewhere with extraction of this value, if this is the case, happy to close this PR and investigate that, but would need steer from maintainers!

## What does this PR do?

<!--
A short summary of the change and why it's needed.
Link at least one issue using a GitHub closing keyword, for example:
- Closes #123
- Fixes: #123
- RESOLVED owner/repo#123
-->

Closes https://github.com/bookorbit/bookorbit/issues/330

## How did you test this?

<!-- Tell us what you actually did to verify this works. What did you run? What did you click through?
     A quick note like "spun up Docker, added a book, confirmed it shows in the library" is perfect.
     This helps us review with confidence and speeds up the merge. -->

Tested on a locally running dev server using the provided instructions in the original issue and can see the total duration post fix.

## Screenshots

<!-- If this touches the UI, please include a before/after screenshot or a short screen recording.
     You can drag and drop images directly here. -->

## Anything non-obvious in the diff?

<!-- Did you make any tricky decisions or trade-offs? Anything you'd want a reviewer to pay
     extra attention to? This is your chance to guide the review. -->

I did not add any tests as cannot see an existing test suite for this feature, if I have missed it though, please let me know.

## Checklist

- [x] I've read through my own diff
- [ ] This PR was discussed in an issue and has maintainer approval (for new features)
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audiobook progress and bookmark calculations to use metadata duration when file-based duration information is unavailable, ensuring more accurate progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->