### PR TITLE
fix(reader): skip throttling for EPUB file streams

### DIFF
--- a/server/src/modules/reader/epub/epub.controller.test.ts
+++ b/server/src/modules/reader/epub/epub.controller.test.ts
@@ -82,6 +82,10 @@ describe('EpubController', () => {
     expect(reply.header).toHaveBeenCalledWith('Cache-Control', 'public, max-age=3600');
   });
 
+  it('skips global throttling for EPUB archive file streams', () => {
+    expect(Reflect.getMetadata('THROTTLER:SKIPdefault', EpubController.prototype.getFile)).toBe(true);
+  });
+
   it('rejects malformed encoded file paths', async () => {
     await expect(
       controller.getFile(9, 'OPS/text/%E0%A4%A', undefined, { id: 1, isSuperuser: false, permissions: [] } as any, {} as any),

--- a/server/src/modules/reader/epub/epub.controller.ts
+++ b/server/src/modules/reader/epub/epub.controller.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Controller, Get, Param, ParseIntPipe, Query, Res } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
 import type { FastifyReply } from 'fastify';
 
 import { CurrentUser } from '../../../common/decorators/current-user.decorator';
@@ -14,6 +15,7 @@ export class EpubController {
     return this.epubService.getBookInfo(bookId, this.parseFileId(fileId), user);
   }
 
+  @SkipThrottle()
   @Get(':bookId/file/*')
   async getFile(
     @Param('bookId', ParseIntPipe) bookId: number,


### PR DESCRIPTION
## What does this PR do?

Closes #409

EPUB reader pages stream each internal archive entry through `/api/v1/epub/:bookId/file/*`.
Large or heavily split EPUBs can request many XHTML parts in a short burst, which lets the
global `120/minute` throttle reject the reader's own asset requests with HTTP 429.

This exempts only the EPUB archive file stream route from the global throttler. The route still
keeps the existing authenticated user, library access, file ownership, EPUB format, and archive
manifest path checks in place.

## How did you test this?

- `pnpm --filter server exec vitest run src/modules/reader/epub/epub.controller.test.ts`
- `pnpm --filter server lint:check`
- `pnpm --filter server type-check`
- `pnpm run verify:fast` via the pre-push hook

Local note: these commands emitted the repo's Node engine warning because this machine is running
Node v22.22.1 while the repository expects Node >=24, but the listed checks completed successfully.

## Screenshots

N/A - backend reader route behavior only.

## Anything non-obvious in the diff?

The bypass is scoped to `getFile()`, not the whole EPUB controller. `/info` remains globally
throttled, and the file stream endpoint still validates access and only serves whitelisted archive
entries. The regression test asserts throttler metadata directly because the app disables throttling
under `NODE_ENV=test`.

AI tools used: OpenAI Codex
Extent: Helped investigate the issue, make the small code/test change, and draft this PR description; I reviewed the final diff and test results.

## Checklist

- [x] I've read through my own diff
- [x] This is a bug fix linked to an existing issue; no new feature approval needed
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test verifying EPUB file download throttling behavior.

* **Chores**
  * EPUB file downloads are now exempt from global rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->