### PR TITLE
fix(koreader): unify three-way progress sync with Kobo and support chapter fallback

### DIFF
--- a/server/src/modules/book/book.repository.test.ts
+++ b/server/src/modules/book/book.repository.test.ts
@@ -763,7 +763,10 @@ describe('BookRepository', () => {
   it('does not overwrite Kobo reading state without an exact KoboSpan location', async () => {
     const insertChain = makeInsertChain();
     const db = {
-      select: vi.fn().mockReturnValueOnce(makeSelectChain('limit', [{ bookId: 10, primaryFileId: 9, format: 'epub' }])),
+      select: vi
+        .fn()
+        .mockReturnValueOnce(makeSelectChain('limit', [{ bookId: 10, primaryFileId: 9, format: 'epub' }]))
+        .mockReturnValue(makeSelectChain('limit', [])),
       insert: vi.fn().mockReturnValue(insertChain),
       execute: vi.fn().mockResolvedValue(undefined),
     };
@@ -771,7 +774,7 @@ describe('BookRepository', () => {
 
     await expect(repo.syncKoboReadingStateFromProgress(5, 9, 80, 'OEBPS/ch14.xhtml', null, null, 33.5)).resolves.toBe(false);
 
-    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(db.select).toHaveBeenCalledTimes(2);
     expect(db.insert).not.toHaveBeenCalled();
     expect(db.execute).not.toHaveBeenCalled();
   });

--- a/server/src/modules/book/book.repository.ts
+++ b/server/src/modules/book/book.repository.ts
@@ -1384,14 +1384,62 @@ export class BookRepository {
       .where(eq(bookFiles.id, fileId))
       .limit(1);
 
-    if (!file || file.primaryFileId !== fileId || file.format !== 'epub') return false;
+    if (!file || file.primaryFileId !== fileId || (file.format !== 'epub' && file.format !== 'kepub')) return false;
 
     const clampedPercentage = this.clampProgressPercentage(percentage);
-    const normalizedKoboLocationSource = this.normalizeKoboLocationPart(koboLocationSource);
-    const normalizedKoboLocationType = this.normalizeKoboLocationPart(koboLocationType);
-    const normalizedKoboLocationValue = this.normalizeKoboLocationPart(koboLocationValue);
     const normalizedKoboContentSourceProgressPercent = this.clampNullableProgressPercentage(koboContentSourceProgressPercent);
-    if (!normalizedKoboLocationSource || normalizedKoboLocationType !== 'KoboSpan' || !normalizedKoboLocationValue) return false;
+
+    let resolvedSource = this.normalizeKoboLocationPart(koboLocationSource);
+    let resolvedType = this.normalizeKoboLocationPart(koboLocationType);
+    let resolvedValue = this.normalizeKoboLocationPart(koboLocationValue);
+
+    if (!resolvedSource || resolvedType !== 'KoboSpan' || !resolvedValue) {
+      // Try to resolve from chapters
+      const chapters = await this.db
+        .select()
+        .from(schema.bookFileChapters)
+        .where(eq(schema.bookFileChapters.bookFileId, fileId))
+        .orderBy(schema.bookFileChapters.chapterIndex);
+
+      if (chapters.length > 0) {
+        const [progress] = await this.db
+          .select({
+            cfi: readingProgress.cfi,
+            koreaderProgress: readingProgress.koreaderProgress,
+          })
+          .from(readingProgress)
+          .where(and(eq(readingProgress.userId, userId), eq(readingProgress.bookFileId, fileId)))
+          .limit(1);
+
+        let chapterIndex: number | null = null;
+        if (progress?.koreaderProgress) {
+          const match = progress.koreaderProgress.match(/DocFragment\[(\d+)\]/);
+          if (match) {
+            chapterIndex = parseInt(match[1]!, 10) - 1;
+          }
+        }
+        if (chapterIndex === null && progress?.cfi) {
+          const match = progress.cfi.match(/epubcfi\(\/6\/(\d+)/);
+          if (match) {
+            const spinePos = parseInt(match[1]!, 10);
+            chapterIndex = Math.floor(spinePos / 2) - 1;
+          }
+        }
+        if (chapterIndex === null) {
+          const pct = Math.max(0, Math.min(100, percentage));
+          chapterIndex = Math.min(chapters.length - 1, Math.floor((pct / 100) * chapters.length));
+        }
+
+        const chapter = chapters.find((c) => c.chapterIndex === chapterIndex) ?? chapters[0];
+        if (chapter?.href) {
+          resolvedSource = chapter.href.split('#')[0].split('?')[0];
+          resolvedType = 'KoboSpan';
+          resolvedValue = 'kobo.0.0';
+        }
+      }
+    }
+
+    if (!resolvedSource || resolvedType !== 'KoboSpan' || !resolvedValue) return false;
 
     const now = new Date();
     const nowIso = now.toISOString();
@@ -1413,9 +1461,9 @@ export class BookRepository {
       this.isKoboBookmarkCurrent(
         existingBookmark,
         clampedPercentage,
-        normalizedKoboLocationSource,
-        normalizedKoboLocationType,
-        normalizedKoboLocationValue,
+        resolvedSource,
+        resolvedType,
+        resolvedValue,
         normalizedKoboContentSourceProgressPercent,
       )
     ) {
@@ -1427,9 +1475,9 @@ export class BookRepository {
       LastModified: nowIso,
       ProgressPercent: clampedPercentage,
       Location: {
-        Source: normalizedKoboLocationSource,
-        Type: normalizedKoboLocationType,
-        Value: normalizedKoboLocationValue,
+        Source: resolvedSource,
+        Type: resolvedType,
+        Value: resolvedValue,
       },
     };
     if (normalizedKoboContentSourceProgressPercent !== null) {

--- a/server/src/modules/book/book.repository.ts
+++ b/server/src/modules/book/book.repository.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Optional } from '@nestjs/common';
-import { SQL, and, asc, count, eq, inArray, isNotNull, ne, or, sql } from 'drizzle-orm';
+import { SQL, and, asc, desc, count, eq, inArray, isNotNull, ne, or, sql } from 'drizzle-orm';
 import { SUPPORTED_BOOK_FORMATS } from '../upload/upload-validator.service';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
 
@@ -1395,36 +1395,77 @@ export class BookRepository {
 
     if (!resolvedSource || resolvedType !== 'KoboSpan' || !resolvedValue) {
       // Try to resolve from chapters
-      const chapters = await this.db
+      let chapters = await this.db
         .select()
         .from(schema.bookFileChapters)
         .where(eq(schema.bookFileChapters.bookFileId, fileId))
         .orderBy(schema.bookFileChapters.chapterIndex);
 
+      if (chapters.length === 0) {
+        const otherFiles = await this.db
+          .select({ id: bookFiles.id })
+          .from(bookFiles)
+          .where(eq(bookFiles.bookId, file.bookId));
+        for (const otherFile of otherFiles) {
+          if (otherFile.id !== fileId) {
+            const fallbackChapters = await this.db
+              .select()
+              .from(schema.bookFileChapters)
+              .where(eq(schema.bookFileChapters.bookFileId, otherFile.id))
+              .orderBy(schema.bookFileChapters.chapterIndex);
+            if (fallbackChapters.length > 0) {
+              chapters = fallbackChapters;
+              break;
+            }
+          }
+        }
+      }
+
       if (chapters.length > 0) {
-        const [progress] = await this.db
+        let chapterIndex: number | null = null;
+        const [deviceProgress] = await this.db
           .select({
-            cfi: readingProgress.cfi,
-            koreaderProgress: readingProgress.koreaderProgress,
+            chapterIndex: schema.koreaderDeviceProgress.chapterIndex,
           })
-          .from(readingProgress)
-          .where(and(eq(readingProgress.userId, userId), eq(readingProgress.bookFileId, fileId)))
+          .from(schema.koreaderDeviceProgress)
+          .where(
+            and(
+              eq(schema.koreaderDeviceProgress.userId, userId),
+              eq(schema.koreaderDeviceProgress.bookFileId, fileId),
+            ),
+          )
+          .orderBy(desc(schema.koreaderDeviceProgress.updatedAt))
           .limit(1);
 
-        let chapterIndex: number | null = null;
-        if (progress?.koreaderProgress) {
-          const match = progress.koreaderProgress.match(/DocFragment\[(\d+)\]/);
-          if (match) {
-            chapterIndex = parseInt(match[1]!, 10) - 1;
+        if (deviceProgress && deviceProgress.chapterIndex !== null) {
+          chapterIndex = deviceProgress.chapterIndex;
+        }
+
+        if (chapterIndex === null) {
+          const [progress] = await this.db
+            .select({
+              cfi: readingProgress.cfi,
+              koreaderProgress: readingProgress.koreaderProgress,
+            })
+            .from(readingProgress)
+            .where(and(eq(readingProgress.userId, userId), eq(readingProgress.bookFileId, fileId)))
+            .limit(1);
+
+          if (progress?.koreaderProgress) {
+            const match = progress.koreaderProgress.match(/DocFragment\[(\d+)\]/);
+            if (match) {
+              chapterIndex = parseInt(match[1]!, 10) - 1;
+            }
+          }
+          if (chapterIndex === null && progress?.cfi) {
+            const match = progress.cfi.match(/epubcfi\(\/6\/(\d+)/);
+            if (match) {
+              const spinePos = parseInt(match[1]!, 10);
+              chapterIndex = Math.floor(spinePos / 2) - 1;
+            }
           }
         }
-        if (chapterIndex === null && progress?.cfi) {
-          const match = progress.cfi.match(/epubcfi\(\/6\/(\d+)/);
-          if (match) {
-            const spinePos = parseInt(match[1]!, 10);
-            chapterIndex = Math.floor(spinePos / 2) - 1;
-          }
-        }
+
         if (chapterIndex === null) {
           const pct = Math.max(0, Math.min(100, percentage));
           chapterIndex = Math.min(chapters.length - 1, Math.floor((pct / 100) * chapters.length));
@@ -1432,7 +1473,7 @@ export class BookRepository {
 
         const chapter = chapters.find((c) => c.chapterIndex === chapterIndex) ?? chapters[0];
         if (chapter?.href) {
-          resolvedSource = chapter.href.split('#')[0].split('?')[0];
+          resolvedSource = chapter.href.split('#')[0]!.split('?')[0]!;
           resolvedType = 'KoboSpan';
           resolvedValue = 'kobo.0.0';
         }

--- a/server/src/modules/book/book.service.ts
+++ b/server/src/modules/book/book.service.ts
@@ -1808,7 +1808,7 @@ export class BookService {
       dto.koboContentSourceProgressPercent ?? null,
       dto.koreaderProgress ?? null,
     );
-    if (file.format === 'epub' && this.hasPermission(user, Permission.KoboSync) && (await this.bookRepo.isKoboTwoWayProgressSyncEnabled(userId))) {
+    if (['epub', 'kepub'].includes(file.format) && this.hasPermission(user, Permission.KoboSync) && (await this.bookRepo.isKoboTwoWayProgressSyncEnabled(userId))) {
       await this.bookRepo.syncKoboReadingStateFromProgress(
         userId,
         fileId,
@@ -1825,6 +1825,30 @@ export class BookService {
         this.userBookStatusService.autoUpdate(userId, file.bookId, dto.percentage, lib.readingThreshold, lib.markAsFinishedPercentComplete),
       )
       .catch((err: Error) => this.logger.warn(`Auto status update failed for book ${file.bookId}: ${err.message}`));
+  }
+
+  async syncKoboReadingStateFromProgress(
+    userId: number,
+    fileId: number,
+    percentage: number,
+    koboLocationSource?: string | null,
+    koboLocationType?: string | null,
+    koboLocationValue?: string | null,
+    koboContentSourceProgressPercent?: number | null,
+  ): Promise<boolean> {
+    return this.bookRepo.syncKoboReadingStateFromProgress(
+      userId,
+      fileId,
+      percentage,
+      koboLocationSource,
+      koboLocationType,
+      koboLocationValue,
+      koboContentSourceProgressPercent,
+    );
+  }
+
+  async isKoboTwoWayProgressSyncEnabled(userId: number): Promise<boolean> {
+    return this.bookRepo.isKoboTwoWayProgressSyncEnabled(userId);
   }
 
   async clearFileProgress(userId: number, fileId: number, user: RequestUser): Promise<void> {

--- a/server/src/modules/koreader/koreader.module.ts
+++ b/server/src/modules/koreader/koreader.module.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '../../common/common.module';
 import { AchievementModule } from '../achievement/achievement.module';
 import { UserModule } from '../user/user.module';
 import { UserBookStatusModule } from '../user-book-status/user-book-status.module';
+import { BookModule } from '../book/book.module';
 import { KoreaderAuthGuard } from './koreader-auth.guard';
 import { KoreaderChapterExtractorService } from './koreader-chapter-extractor.service';
 import { KoreaderChapterService } from './koreader-chapter.service';
@@ -12,7 +13,7 @@ import { KoreaderRepository } from './koreader.repository';
 import { KoreaderService } from './koreader.service';
 
 @Module({
-  imports: [CommonModule, UserModule, UserBookStatusModule, AchievementModule],
+  imports: [CommonModule, UserModule, UserBookStatusModule, AchievementModule, BookModule],
   controllers: [KoreaderController],
   providers: [KoreaderService, KoreaderRepository, KoreaderAuthGuard, KoreaderChapterService, KoreaderChapterExtractorService],
   exports: [KoreaderService, KoreaderRepository],

--- a/server/src/modules/koreader/koreader.repository.ts
+++ b/server/src/modules/koreader/koreader.repository.ts
@@ -36,13 +36,13 @@ export class KoreaderRepository {
     await this.db.delete(schema.koreaderUsers).where(eq(schema.koreaderUsers.userId, userId));
   }
 
-  async resolveBookFileByHash(hash: string, accessibleLibraryIds: number[] | null): Promise<{ id: number; bookId: number } | null> {
+  async resolveBookFileByHash(hash: string, accessibleLibraryIds: number[] | null): Promise<{ id: number; bookId: number; primaryFileId: number | null } | null> {
     if (accessibleLibraryIds !== null && accessibleLibraryIds.length === 0) return null;
 
     const libraryFilter = accessibleLibraryIds ? inArray(schema.books.libraryId, accessibleLibraryIds) : undefined;
 
     const [byFileHash] = await this.db
-      .select({ id: schema.bookFiles.id, bookId: schema.bookFiles.bookId })
+      .select({ id: schema.bookFiles.id, bookId: schema.bookFiles.bookId, primaryFileId: schema.books.primaryFileId })
       .from(schema.bookFiles)
       .innerJoin(schema.books, eq(schema.books.id, schema.bookFiles.bookId))
       .where(and(eq(schema.bookFiles.fileHash, hash), libraryFilter))
@@ -51,7 +51,7 @@ export class KoreaderRepository {
     if (byFileHash) return byFileHash;
 
     const [byFileHashHistory] = await this.db
-      .select({ id: schema.bookFiles.id, bookId: schema.bookFiles.bookId })
+      .select({ id: schema.bookFiles.id, bookId: schema.bookFiles.bookId, primaryFileId: schema.books.primaryFileId })
       .from(schema.bookFileHashHistory)
       .innerJoin(schema.bookFiles, eq(schema.bookFiles.id, schema.bookFileHashHistory.bookFileId))
       .innerJoin(schema.books, eq(schema.books.id, schema.bookFiles.bookId))

--- a/server/src/modules/koreader/koreader.service.test.ts
+++ b/server/src/modules/koreader/koreader.service.test.ts
@@ -22,6 +22,7 @@ import { KoreaderChapterExtractorService } from './koreader-chapter-extractor.se
 import { KoreaderChapterService } from './koreader-chapter.service';
 import { KoreaderRepository } from './koreader.repository';
 import { KoreaderService } from './koreader.service';
+import { BookService } from '../book/book.service';
 
 function md5Hex(value: string): string {
   return `md5:${value}:hex:0123456789abcdef0123456789abcdef`;
@@ -76,6 +77,10 @@ describe('KoreaderService', () => {
   };
   let mockAchievementEvents: {
     emit: ReturnType<typeof vi.fn>;
+  };
+  let mockBookService: {
+    isKoboTwoWayProgressSyncEnabled: ReturnType<typeof vi.fn>;
+    syncKoboReadingStateFromProgress: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -133,6 +138,13 @@ describe('KoreaderService', () => {
       emit: vi.fn(),
     };
 
+    mockBookService = {
+      isKoboTwoWayProgressSyncEnabled: vi.fn(),
+      syncKoboReadingStateFromProgress: vi.fn(),
+    };
+    mockBookService.isKoboTwoWayProgressSyncEnabled.mockResolvedValue(false);
+    mockBookService.syncKoboReadingStateFromProgress.mockResolvedValue(true);
+
     mockRepo.deleteKoreaderUser.mockResolvedValue(undefined);
     mockRepo.updateKoreaderUser.mockResolvedValue(undefined);
     mockRepo.upsertDeviceProgress.mockResolvedValue(undefined);
@@ -152,6 +164,7 @@ describe('KoreaderService', () => {
       mockChapterExtractor as unknown as KoreaderChapterExtractorService,
       mockUserBookStatusService as unknown as UserBookStatusService,
       mockAchievementEvents as unknown as AchievementEventsService,
+      mockBookService as unknown as BookService,
     );
   });
 
@@ -343,6 +356,23 @@ describe('KoreaderService', () => {
         document: 'abcdef1234567890fedcba',
         timestamp: 1700000000,
       });
+    });
+
+    it('triggers Kobo sync if twoWayProgressSync is enabled', async () => {
+      mockRepo.resolveBookFileByHash.mockResolvedValue({ id: 44, bookId: 55 });
+      mockBookService.isKoboTwoWayProgressSyncEnabled.mockResolvedValue(true);
+
+      await service.saveProgress(12, {
+        document: 'abcdef1234567890fedcba',
+        percentage: 0.5,
+        progress: '/body/DocFragment[7]',
+        device: 'Kobo Sage',
+        device_id: 'device-12',
+        timestamp: 1700000000,
+      });
+
+      expect(mockBookService.isKoboTwoWayProgressSyncEnabled).toHaveBeenCalledWith(12);
+      expect(mockBookService.syncKoboReadingStateFromProgress).toHaveBeenCalledWith(12, 44, 50);
     });
 
     it('throws when the book file cannot be resolved', async () => {

--- a/server/src/modules/koreader/koreader.service.test.ts
+++ b/server/src/modules/koreader/koreader.service.test.ts
@@ -625,6 +625,28 @@ describe('KoreaderService', () => {
         timestamp: Math.floor(readerTime.getTime() / 1000),
       });
     });
+
+    it('resolves chapters fallback using requested bookFile.id instead of targetFileId', async () => {
+      mockRepo.resolveBookFileByHash.mockResolvedValue({ id: 10, bookId: 20, primaryFileId: 15 });
+      mockRepo.getLatestDeviceProgress.mockResolvedValue(null);
+      mockRepo.getReadingProgress.mockResolvedValue({
+        percentage: 50,
+        cfi: null,
+        koreaderProgress: null,
+        koboLocationSource: 'OEBPS/text/ch3.xhtml',
+        updatedAt: new Date('2026-02-01T11:00:00.000Z'),
+      });
+
+      mockRepo.getChapters.mockResolvedValue([
+        { chapterIndex: 0, href: 'OEBPS/text/ch1.xhtml' },
+        { chapterIndex: 1, href: 'OEBPS/text/ch2.xhtml' },
+        { chapterIndex: 2, href: 'OEBPS/text/ch3.xhtml' },
+      ]);
+
+      await service.getProgress(7, 'doc-hash');
+
+      expect(mockRepo.getChapters).toHaveBeenCalledWith(10); // NOT 15
+    });
   });
 
   describe('getSyncStatus', () => {

--- a/server/src/modules/koreader/koreader.service.test.ts
+++ b/server/src/modules/koreader/koreader.service.test.ts
@@ -150,6 +150,7 @@ describe('KoreaderService', () => {
     mockRepo.upsertDeviceProgress.mockResolvedValue(undefined);
     mockRepo.upsertReadingProgress.mockResolvedValue(undefined);
     mockRepo.getAccessibleLibraryIds.mockResolvedValue([1, 2]);
+    mockRepo.getChapters.mockResolvedValue([]);
     mockChapterService.parseChapterIndexFromProgress.mockReturnValue(null);
     mockChapterExtractor.extractAndStoreChapters.mockResolvedValue([]);
     mockUserBookStatusService.autoUpdate.mockResolvedValue(undefined);
@@ -473,7 +474,7 @@ describe('KoreaderService', () => {
       await expect(service.getProgress(7, 'doc-hash')).resolves.toEqual({
         document: 'doc-hash',
         percentage: 0.7321,
-        progress: null,
+        progress: '',
         device: 'web',
         device_id: 'bookorbit-web',
         timestamp: Math.floor(readerTime.getTime() / 1000),
@@ -537,7 +538,35 @@ describe('KoreaderService', () => {
       mockChapterService.parseChapterIndexFromCfi.mockReturnValue(null);
 
       const result = await service.getProgress(7, 'doc-hash');
-      expect(result?.progress).toBeNull();
+      expect(result?.progress).toBe('');
+    });
+
+    it('resolves progress using chapters fallback when koreaderProgress and cfi are null', async () => {
+      const readerTime = new Date('2026-02-01T11:00:00.000Z');
+      mockRepo.resolveBookFileByHash.mockResolvedValue({ id: 10, bookId: 20 });
+      mockRepo.getLatestDeviceProgress.mockResolvedValue(null);
+      mockRepo.getReadingProgress.mockResolvedValue({
+        percentage: 50,
+        cfi: null,
+        koboLocationSource: 'OEBPS/text/ch3.xhtml',
+        updatedAt: readerTime,
+      });
+
+      mockRepo.getChapters.mockResolvedValue([
+        { chapterIndex: 0, href: 'OEBPS/text/ch1.xhtml' },
+        { chapterIndex: 1, href: 'OEBPS/text/ch2.xhtml' },
+        { chapterIndex: 2, href: 'OEBPS/text/ch3.xhtml' },
+      ]);
+
+      await expect(service.getProgress(7, 'doc-hash')).resolves.toEqual({
+        document: 'doc-hash',
+        percentage: 0.5,
+        progress: '/body/DocFragment[3]/body',
+        device: 'web',
+        device_id: 'bookorbit-web',
+        timestamp: Math.floor(readerTime.getTime() / 1000),
+      });
+      expect(mockRepo.getChapters).toHaveBeenCalledWith(10);
     });
 
     it('returns null when neither device nor web reader progress exists', async () => {

--- a/server/src/modules/koreader/koreader.service.test.ts
+++ b/server/src/modules/koreader/koreader.service.test.ts
@@ -582,6 +582,49 @@ describe('KoreaderService', () => {
 
       await expect(service.getProgress(7, 'doc-hash')).resolves.toBeNull();
     });
+
+    it('uses primaryFileId if available when resolving progress', async () => {
+      mockRepo.resolveBookFileByHash.mockResolvedValue({ id: 10, bookId: 20, primaryFileId: 15 });
+      mockRepo.getLatestDeviceProgress.mockResolvedValue(null);
+      mockRepo.getReadingProgress.mockResolvedValue({
+        percentage: 50,
+        cfi: null,
+        koreaderProgress: '/body/DocFragment[3]/body',
+        updatedAt: new Date('2026-02-01T11:00:00.000Z'),
+      });
+
+      await service.getProgress(7, 'doc-hash');
+
+      expect(mockRepo.getLatestDeviceProgress).toHaveBeenCalledWith(15, 7);
+      expect(mockRepo.getReadingProgress).toHaveBeenCalledWith(15, 7);
+    });
+
+    it('compares syncTimestamp instead of updatedAt for latest device check', async () => {
+      const readerTime = new Date('2026-02-01T11:00:00.000Z');
+      mockRepo.resolveBookFileByHash.mockResolvedValue({ id: 10, bookId: 20, primaryFileId: null });
+      mockRepo.getLatestDeviceProgress.mockResolvedValue({
+        percentage: 0.66,
+        progress: '/body/DocFragment[8]/body',
+        device: 'Kobo Libra',
+        deviceId: 'device-1',
+        syncTimestamp: 1700000000, // 2023-11-14 (older than 2026 readerTime)
+        updatedAt: new Date('2026-02-01T12:00:00.000Z'), // updatedAt is newer, but syncTimestamp is older
+      });
+      mockRepo.getReadingProgress.mockResolvedValue({
+        percentage: 80,
+        koreaderProgress: '/body/DocFragment[5]/body',
+        updatedAt: readerTime,
+      });
+
+      await expect(service.getProgress(7, 'doc-hash')).resolves.toEqual({
+        document: 'doc-hash',
+        percentage: 0.8,
+        progress: '/body/DocFragment[5]/body',
+        device: 'web',
+        device_id: 'bookorbit-web',
+        timestamp: Math.floor(readerTime.getTime() / 1000),
+      });
+    });
   });
 
   describe('getSyncStatus', () => {

--- a/server/src/modules/koreader/koreader.service.ts
+++ b/server/src/modules/koreader/koreader.service.ts
@@ -123,7 +123,7 @@ export class KoreaderService {
     const targetFileId = bookFile.primaryFileId || bookFile.id;
     const chapterIndex = this.chapterService.parseChapterIndexFromProgress(data.progress ?? null);
 
-    this.chapterExtractor.extractAndStoreChapters(targetFileId).catch(() => {});
+    this.chapterExtractor.extractAndStoreChapters(bookFile.id).catch(() => {});
 
     await this.repo.upsertDeviceProgress({
       bookFileId: targetFileId,
@@ -204,7 +204,7 @@ export class KoreaderService {
         }
 
         if (chapterIndex === null) {
-          const chapters = await this.repo.getChapters(targetFileId);
+          const chapters = await this.repo.getChapters(bookFile.id);
           if (chapters.length > 0) {
             if (readingProg.koboLocationSource) {
               const cleanSource = readingProg.koboLocationSource.split('#')[0].split('?')[0];

--- a/server/src/modules/koreader/koreader.service.ts
+++ b/server/src/modules/koreader/koreader.service.ts
@@ -195,8 +195,29 @@ export class KoreaderService {
 
     if (readingProg) {
       let xpointer = readingProg.koreaderProgress ?? null;
-      if (!xpointer && readingProg.cfi) {
-        const chapterIndex = this.chapterService.parseChapterIndexFromCfi(readingProg.cfi);
+      if (!xpointer) {
+        let chapterIndex: number | null = null;
+        if (readingProg.cfi) {
+          chapterIndex = this.chapterService.parseChapterIndexFromCfi(readingProg.cfi);
+        }
+
+        if (chapterIndex === null) {
+          const chapters = await this.repo.getChapters(bookFile.id);
+          if (chapters.length > 0) {
+            if (readingProg.koboLocationSource) {
+              const cleanSource = readingProg.koboLocationSource.split('#')[0].split('?')[0];
+              const chapter = chapters.find((c) => c.href && c.href.split('#')[0].split('?')[0] === cleanSource);
+              if (chapter) {
+                chapterIndex = chapter.chapterIndex;
+              }
+            }
+            if (chapterIndex === null) {
+              const pct = Math.max(0, Math.min(100, readingProg.percentage));
+              chapterIndex = Math.min(chapters.length - 1, Math.floor((pct / 100) * chapters.length));
+            }
+          }
+        }
+
         if (chapterIndex !== null && chapterIndex >= 0) {
           xpointer = `/body/DocFragment[${chapterIndex + 1}]/body`;
         }
@@ -205,7 +226,7 @@ export class KoreaderService {
       return {
         document: documentHash,
         percentage: toKoreaderPercentage(readingProg.percentage),
-        progress: xpointer,
+        progress: xpointer ?? '',
         device: 'web',
         device_id: 'bookorbit-web',
         timestamp: Math.floor(readerTime / 1000),

--- a/server/src/modules/koreader/koreader.service.ts
+++ b/server/src/modules/koreader/koreader.service.ts
@@ -8,6 +8,7 @@ import { KoreaderChapterService } from './koreader-chapter.service';
 import { KoreaderChapterExtractorService } from './koreader-chapter-extractor.service';
 import { UserBookStatusService } from '../user-book-status/user-book-status.service';
 import { AchievementEventsService, ACHIEVEMENT_EVENT_BOOK_PROGRESS_CHANGED } from '../achievement/achievement-events.service';
+import { BookService } from '../book/book.service';
 
 const BCRYPT_ROUNDS = 12;
 const SYNC_EVENT = 'koreader.sync';
@@ -24,6 +25,7 @@ export class KoreaderService {
     private readonly chapterExtractor: KoreaderChapterExtractorService,
     private readonly userBookStatusService: UserBookStatusService,
     private readonly achievementEvents: AchievementEventsService,
+    private readonly bookService: BookService,
   ) {}
 
   async createCredentials(userId: number, username: string, password: string) {
@@ -143,6 +145,18 @@ export class KoreaderService {
       progress: bookorbitPercentage,
       source: 'koreader',
     });
+
+    if (await this.bookService.isKoboTwoWayProgressSyncEnabled(userId)) {
+      try {
+        await this.bookService.syncKoboReadingStateFromProgress(
+          userId,
+          bookFile.id,
+          bookorbitPercentage,
+        );
+      } catch (err: any) {
+        this.logger.warn(`Failed to sync Kobo reading state from KOReader progress: ${err.message}`);
+      }
+    }
 
     this.logger.debug(
       `[${SYNC_EVENT}] [end] userId=${userId} bookFileId=${bookFile.id} device=${device} durationMs=${Date.now() - startedAt} percentage=${data.percentage} - save progress completed`,

--- a/server/src/modules/koreader/koreader.service.ts
+++ b/server/src/modules/koreader/koreader.service.ts
@@ -120,12 +120,13 @@ export class KoreaderService {
       throw new NotFoundException('Book not found for the given document hash');
     }
 
+    const targetFileId = bookFile.primaryFileId || bookFile.id;
     const chapterIndex = this.chapterService.parseChapterIndexFromProgress(data.progress ?? null);
 
-    this.chapterExtractor.extractAndStoreChapters(bookFile.id).catch(() => {});
+    this.chapterExtractor.extractAndStoreChapters(targetFileId).catch(() => {});
 
     await this.repo.upsertDeviceProgress({
-      bookFileId: bookFile.id,
+      bookFileId: targetFileId,
       userId,
       device,
       deviceId,
@@ -136,12 +137,12 @@ export class KoreaderService {
     });
 
     const bookorbitPercentage = toBookorbitPercentage(data.percentage);
-    await this.repo.upsertReadingProgress(bookFile.id, userId, bookorbitPercentage);
+    await this.repo.upsertReadingProgress(targetFileId, userId, bookorbitPercentage);
     await this.userBookStatusService.autoUpdate(userId, bookFile.bookId, bookorbitPercentage);
     this.achievementEvents.emit(ACHIEVEMENT_EVENT_BOOK_PROGRESS_CHANGED, {
       userId,
       bookId: bookFile.bookId,
-      bookFileId: bookFile.id,
+      bookFileId: targetFileId,
       progress: bookorbitPercentage,
       source: 'koreader',
     });
@@ -150,7 +151,7 @@ export class KoreaderService {
       try {
         await this.bookService.syncKoboReadingStateFromProgress(
           userId,
-          bookFile.id,
+          targetFileId,
           bookorbitPercentage,
         );
       } catch (err: any) {
@@ -159,7 +160,7 @@ export class KoreaderService {
     }
 
     this.logger.debug(
-      `[${SYNC_EVENT}] [end] userId=${userId} bookFileId=${bookFile.id} device=${device} durationMs=${Date.now() - startedAt} percentage=${data.percentage} - save progress completed`,
+      `[${SYNC_EVENT}] [end] userId=${userId} bookFileId=${targetFileId} device=${device} durationMs=${Date.now() - startedAt} percentage=${data.percentage} - save progress completed`,
     );
 
     return { document: data.document, timestamp: data.timestamp ?? Math.floor(Date.now() / 1000) };
@@ -171,15 +172,16 @@ export class KoreaderService {
 
     if (!bookFile) return null;
 
-    const latestDevice = await this.repo.getLatestDeviceProgress(bookFile.id, userId);
-    const readingProg = await this.repo.getReadingProgress(bookFile.id, userId);
+    const targetFileId = bookFile.primaryFileId || bookFile.id;
+
+    const latestDevice = await this.repo.getLatestDeviceProgress(targetFileId, userId);
+    const readingProg = await this.repo.getReadingProgress(targetFileId, userId);
 
     if (!latestDevice && !readingProg) return null;
 
-    // Compare server timestamps to find the most recent source.
-    // reading_progress.updatedAt is only set by the web reader (KOReader sync deliberately
-    // preserves the existing value), so this comparison is accurate.
-    const deviceTime = latestDevice?.updatedAt?.getTime() ?? 0;
+    const deviceTime = latestDevice?.syncTimestamp
+      ? latestDevice.syncTimestamp * 1000
+      : (latestDevice?.updatedAt?.getTime() ?? 0);
     const readerTime = readingProg?.updatedAt?.getTime() ?? 0;
 
     if (latestDevice && deviceTime >= readerTime) {
@@ -202,7 +204,7 @@ export class KoreaderService {
         }
 
         if (chapterIndex === null) {
-          const chapters = await this.repo.getChapters(bookFile.id);
+          const chapters = await this.repo.getChapters(targetFileId);
           if (chapters.length > 0) {
             if (readingProg.koboLocationSource) {
               const cleanSource = readingProg.koboLocationSource.split('#')[0].split('?')[0];
@@ -264,7 +266,9 @@ export class KoreaderService {
 
     const chapters = await this.repo.getChapters(bookFileId);
     const latestDevice = deviceProgress[0];
-    const deviceTime = latestDevice?.updatedAt?.getTime() ?? 0;
+    const deviceTime = latestDevice?.syncTimestamp
+      ? latestDevice.syncTimestamp * 1000
+      : (latestDevice?.updatedAt?.getTime() ?? 0);
     const readerTime = readingProgress?.updatedAt?.getTime() ?? 0;
 
     const isKoreaderLatest = latestDevice && deviceTime >= readerTime;


### PR DESCRIPTION
### Context & Problem

Previously, progress sync between KOReader, Kobo devices, and the BookOrbit dashboard was fragmented. While unifying KOReader progress sync under the book's  `primaryFileId` (typically KEPBUP format) solved page reset and metadata mismatches, it introduced a new issue when syncing progress back to Kobo devices:

1. Empty Chapters List: Drizzle queries inside `syncKoboReadingStateFromProgress` look up chapters for the target `fileId`. Since the target KEPUB format file ( primaryFileId ) does not have chapters populated in the database (they are parsed and saved under the EPUB format's file record instead), the lookup yielded  0  chapters.
2. Failure to Resolve Bookmark: Because of the empty chapters list, the system failed to resolve a valid Kobo bookmark location ( Source ,  Type ,  Value ), returning  false  early and failing to update the `kobo_reading_states` table.
3. Missing XPointer: KOReader sync clears the `koreaderProgress` field in the `reading_progress` table and stores the active location XPointer inside the  koreaderDeviceProgress  table instead.

The bookmark resolution logic only checked the `reading_progress` table, failing to extract the correct chapter index.

──────

### Solution

1. Fallback Chapter Retrieval: Updated the database query in `BookRepository.syncKoboReadingStateFromProgress`. If the target file format (KEPUB) contains no chapters in the database, the repository falls back to querying the chapters of any other format of the same book (typically EPUB) that has chapters populated.
2. Koreader Device Progress Lookup: Added a query to check the latest synced progress record in `koreaderDeviceProgress` for the user and file. This allows the system to read the exact parsed `chapterIndex` directly from the device's latest push event before falling back to `readingProgress` CFI extraction or percentage-based math.

──────

### Verification & Testing

Bootstrapped the NestJS application context inside the running docker container and triggered progress synchronization manually:

• Progress syncing from KOReader (e.g. 89.16%) successfully resolves the chapter location 
• The `kobo_reading_states` database entry is correctly updated with the calculated Kobo bookmark and progress percent, allowing downstream Kobo sync events to pick up KOReader's latest progress successfully.

## Checklist

- [x] I've read through my own diff
- [ ] This PR was discussed in an issue and has maintainer approval (for new features)
- [ ] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)

<img width="484" height="1186" alt="image" src="https://github.com/user-attachments/assets/e5a34a6e-f04f-4ac4-8c4e-437a6c49c197" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kobo progress syncing now works for more ebook formats.
  * Progress tracking can better recover reading position from chapter information when direct location data is incomplete.

* **Bug Fixes**
  * Improved consistency when saving and displaying reading progress across devices.
  * Fixed edge cases where progress could appear empty or fail to map correctly.
  * Progress sync now respects updated Kobo state handling without interrupting reading updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->