### PR TITLE
fix(koreader): Made catalog service follow RFC8178 for Content-Disposition header

### DIFF
--- a/server/src/modules/koreader/koreader-catalog.service.test.ts
+++ b/server/src/modules/koreader/koreader-catalog.service.test.ts
@@ -460,10 +460,56 @@ describe('KoreaderCatalogService', () => {
     await service.streamFile(makeUser({ permissions: [] }), 100, reply as never);
 
     expect(bookService.verifyFileAccess).toHaveBeenCalledWith(100, expect.objectContaining({ permissions: [] }));
-    expect(reply.header).toHaveBeenCalledWith('Content-Disposition', 'attachment; filename="Dune - Frank Herbert.epub"');
+    expect(reply.header).toHaveBeenCalledWith('Content-Disposition', "attachment; filename*=utf-8''Dune%20-%20Frank%20Herbert.epub");
     expect(reply.header).toHaveBeenCalledWith('Content-Length', 1234);
     expect(reply.type).toHaveBeenCalledWith('application/epub+zip');
     expect(mockCreateReadStream).toHaveBeenCalledWith('/books/dune.epub');
+  });
+
+  it('streams content files with non-ascii filenames', async () => {
+    const { service, bookService } = makeService();
+    const reply = makeReply();
+
+    bookService.verifyFileAccess.mockResolvedValueOnce({
+      id: 300,
+      role: 'content',
+      bookId: 33,
+      libraryId: 1,
+      absolutePath: '/books/人間失格.epub',
+      format: 'epub',
+    });
+
+    bookService.getDetail.mockResolvedValueOnce(
+      makeDetail({
+        id: 33,
+        title: '人間失格',
+        publisher: '筑摩書房',
+        authors: [{ id: 2, name: '太宰治', sortName: '太宰治' }],
+        files: [
+          {
+            id: 300,
+            format: 'epub',
+            role: 'primary',
+            sizeBytes: 1234,
+            absolutePath: '/books/人間失格.epub',
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            filename: '人間失格.epub',
+            durationSeconds: null,
+          },
+        ],
+      }),
+    );
+
+    await service.streamFile(makeUser({ permissions: [] }), 300, reply as never);
+
+    expect(bookService.verifyFileAccess).toHaveBeenCalledWith(300, expect.objectContaining({ permissions: [] }));
+    expect(reply.header).toHaveBeenCalledWith(
+      'Content-Disposition',
+      "attachment; filename*=utf-8''%E4%BA%BA%E9%96%93%E5%A4%B1%E6%A0%BC%20-%20%E5%A4%AA%E5%AE%B0%E6%B2%BB.epub",
+    );
+    expect(reply.header).toHaveBeenCalledWith('Content-Length', 1234);
+    expect(reply.type).toHaveBeenCalledWith('application/epub+zip');
+    expect(mockCreateReadStream).toHaveBeenCalledWith('/books/人間失格.epub');
   });
 
   it('rejects non-content file downloads and missing thumbnails', async () => {

--- a/server/src/modules/koreader/koreader-catalog.service.test.ts
+++ b/server/src/modules/koreader/koreader-catalog.service.test.ts
@@ -460,7 +460,10 @@ describe('KoreaderCatalogService', () => {
     await service.streamFile(makeUser({ permissions: [] }), 100, reply as never);
 
     expect(bookService.verifyFileAccess).toHaveBeenCalledWith(100, expect.objectContaining({ permissions: [] }));
-    expect(reply.header).toHaveBeenCalledWith('Content-Disposition', "attachment; filename*=utf-8''Dune%20-%20Frank%20Herbert.epub");
+    expect(reply.header).toHaveBeenCalledWith(
+      'Content-Disposition',
+      `attachment; filename="Dune - Frank Herbert.epub"; filename*=utf-8''Dune%20-%20Frank%20Herbert.epub`,
+    );
     expect(reply.header).toHaveBeenCalledWith('Content-Length', 1234);
     expect(reply.type).toHaveBeenCalledWith('application/epub+zip');
     expect(mockCreateReadStream).toHaveBeenCalledWith('/books/dune.epub');
@@ -505,7 +508,7 @@ describe('KoreaderCatalogService', () => {
     expect(bookService.verifyFileAccess).toHaveBeenCalledWith(300, expect.objectContaining({ permissions: [] }));
     expect(reply.header).toHaveBeenCalledWith(
       'Content-Disposition',
-      "attachment; filename*=utf-8''%E4%BA%BA%E9%96%93%E5%A4%B1%E6%A0%BC%20-%20%E5%A4%AA%E5%AE%B0%E6%B2%BB.epub",
+      `attachment; filename="____ - ___.epub"; filename*=utf-8''%E4%BA%BA%E9%96%93%E5%A4%B1%E6%A0%BC%20-%20%E5%A4%AA%E5%AE%B0%E6%B2%BB.epub`,
     );
     expect(reply.header).toHaveBeenCalledWith('Content-Length', 1234);
     expect(reply.type).toHaveBeenCalledWith('application/epub+zip');

--- a/server/src/modules/koreader/koreader-catalog.service.ts
+++ b/server/src/modules/koreader/koreader-catalog.service.ts
@@ -254,7 +254,7 @@ export class KoreaderCatalogService {
 
     try {
       const { size } = await stat(file.absolutePath);
-      reply.header('Content-Disposition', `attachment; filename="${filename}"`);
+      reply.header('Content-Disposition', `attachment; filename*=utf-8''${encodeURIComponent(filename)}`);
       reply.header('Content-Length', size);
       reply.type(fileMimeType(format));
       reply.send(createReadStream(file.absolutePath));

--- a/server/src/modules/koreader/koreader-catalog.service.ts
+++ b/server/src/modules/koreader/koreader-catalog.service.ts
@@ -38,6 +38,34 @@ import { OpdsBookEntry, OpdsBookService } from '../opds/opds-book.service';
 import { UserBookStatusService } from '../user-book-status/user-book-status.service';
 import { KoreaderCatalogBooksQueryDto } from './dto/koreader-catalog-query.dto';
 
+function stripLoneSurrogates(value: string): string {
+  let out = '';
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        out += value[i] + value[i + 1];
+        i += 1;
+      }
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) continue;
+    out += value[i];
+  }
+  return out;
+}
+
+function encodeFilenameStar(value: string): string | null {
+  try {
+    const cleaned = stripLoneSurrogates(value);
+    if (!cleaned) return null;
+    return encodeURIComponent(cleaned).replace(/[!'()*]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`);
+  } catch {
+    return null;
+  }
+}
+
 type OpdsSortOrder = Parameters<OpdsBookService['getBooksPage']>[1];
 type BookProgressRow = Awaited<ReturnType<BookReadService['findProgressByBook']>>[number];
 type ProgressCandidate = BookProgressRow & { percentage: number; updatedAt: Date };
@@ -251,10 +279,13 @@ export class KoreaderCatalogService {
     const detail = await this.bookService.getDetail(file.bookId, user);
     const format = this.normalizeFormat(file.format);
     const filename = this.downloadFilename(detail, fileId, format);
+    const asciiFilename = filename.replace(/[^\x20-\x7E]|["\\]/g, '_') || 'download';
+    const encodedFilename = encodeFilenameStar(filename);
 
     try {
       const { size } = await stat(file.absolutePath);
-      reply.header('Content-Disposition', `attachment; filename*=utf-8''${encodeURIComponent(filename)}`);
+      const disposition = `attachment; filename="${asciiFilename}"`;
+      reply.header('Content-Disposition', encodedFilename ? `${disposition}; filename*=utf-8''${encodedFilename}` : disposition);
       reply.header('Content-Length', size);
       reply.type(fileMimeType(format));
       reply.send(createReadStream(file.absolutePath));


### PR DESCRIPTION
## What does this PR do?

Set Content-Disposition to use utf-8 and uri encoding for the filename to follow [RFC8178](https://www.rfc-editor.org/rfc/rfc8187.txt), and added a relevant test.

Closes #448

## How did you test this?

I spun up docker, added a book with non-ascii characters, and downloaded the book using curl to confirm the header's correctness. I then connected koreader directly and it downloaded the book successfully and saved the file to the correct (uri decoded) filename.

## Anything non-obvious in the diff?

I'm not super confident in formatting/style of the test I wrote for this, reviewers may want to move parts of it around. I copied an existing test and used AI to understand how to add a book to the `bookService` to make it work, and it passes.

## Checklist

- [x] I've read through my own diff
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB download `Content-Disposition` headers by adding RFC 5987-style UTF-8 `filename*` encoding alongside a sanitized ASCII `filename` fallback for better client compatibility.
  * Added/updated tests to verify non-ASCII (e.g., Japanese) download filenames: confirming the expected encoded header values and the correct file stream path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->