### PR TITLE
feat(metadata): parse Calibre #extra_tags custom column into book tags

### DIFF
--- a/server/src/modules/metadata/lib/opf-parser.test.ts
+++ b/server/src/modules/metadata/lib/opf-parser.test.ts
@@ -716,6 +716,39 @@ describe('parseOpf', () => {
       const r = parseOpf(epub3Opf(`<meta property="calibre:user_metadata">{"#pagecount":{"#value#":"lots"}}</meta>`));
       expect(r.pageCount).toBeNull();
     });
+
+    it('parses extra tags from a #extra_tags column with a JSON array value', () => {
+      const xml = epub3Opf(`<meta property="calibre:user_metadata">{"#extra_tags":{"#value#":["Horror","Historical Fiction"]}}</meta>`);
+      expect(parseOpf(xml).tags).toEqual(['Horror', 'Historical Fiction']);
+    });
+
+    it('parses extra tags from a #extra_tags column with a pipe-delimited string value', () => {
+      const xml = epub3Opf(`<meta property="calibre:user_metadata">{"#extra_tags":{"#value#":"Horror|Historical Fiction"}}</meta>`);
+      expect(parseOpf(xml).tags).toEqual(['Horror', 'Historical Fiction']);
+    });
+
+    it('parses extra tags from a #extra_tags column with a comma-delimited string value (Calibre tags column format)', () => {
+      const xml = epub3Opf(`<meta property="calibre:user_metadata">{"#extra_tags":{"#value#":"Horror, Historical Fiction"}}</meta>`);
+      expect(parseOpf(xml).tags).toEqual(['Horror', 'Historical Fiction']);
+    });
+
+    it('merges #extra_tags with bookorbit:tags and deduplicates', () => {
+      const xml = epub3Opf(`
+        <meta property="bookorbit:tags">["Horror","Classic"]</meta>
+        <meta property="calibre:user_metadata">{"#extra_tags":{"#value#":["Classic","Historical Fiction"]}}</meta>
+      `);
+      expect(parseOpf(xml).tags).toEqual(['Horror', 'Classic', 'Historical Fiction']);
+    });
+
+    it('contributes nothing when #extra_tags value is an empty array', () => {
+      const xml = epub3Opf(`<meta property="calibre:user_metadata">{"#extra_tags":{"#value#":[]}}</meta>`);
+      expect(parseOpf(xml).tags).toHaveLength(0);
+    });
+
+    it('ignores a non-string, non-array #extra_tags value', () => {
+      const xml = epub3Opf(`<meta property="calibre:user_metadata">{"#extra_tags":{"#value#":42}}</meta>`);
+      expect(parseOpf(xml).tags).toHaveLength(0);
+    });
   });
 
   describe('graceful handling of bad input', () => {

--- a/server/src/modules/metadata/lib/opf-parser.test.ts
+++ b/server/src/modules/metadata/lib/opf-parser.test.ts
@@ -732,6 +732,11 @@ describe('parseOpf', () => {
       expect(parseOpf(xml).tags).toEqual(['Horror', 'Historical Fiction']);
     });
 
+    it('prefers pipe over comma when both are present in a #extra_tags string value', () => {
+      const xml = epub3Opf(`<meta property="calibre:user_metadata">{"#extra_tags":{"#value#":"History, Modern|Fantasy"}}</meta>`);
+      expect(parseOpf(xml).tags).toEqual(['History, Modern', 'Fantasy']);
+    });
+
     it('merges #extra_tags with bookorbit:tags and deduplicates', () => {
       const xml = epub3Opf(`
         <meta property="bookorbit:tags">["Horror","Classic"]</meta>

--- a/server/src/modules/metadata/lib/opf-parser.ts
+++ b/server/src/modules/metadata/lib/opf-parser.ts
@@ -179,7 +179,7 @@ function parseCalibreUserMetadata(raw: string | null): { pageCount: number | nul
     if (Array.isArray(v)) return v.map((item) => String(item).trim()).filter(Boolean);
     if (typeof v === 'string')
       return v
-        .split(/[|,]/)
+        .split(v.includes('|') ? '|' : ',')
         .map((item) => item.trim())
         .filter(Boolean);
     return [];

--- a/server/src/modules/metadata/lib/opf-parser.ts
+++ b/server/src/modules/metadata/lib/opf-parser.ts
@@ -151,9 +151,9 @@ function normalizeProviderId(provider: ProviderKey, raw: string): string | null 
 }
 
 // Calibre stores custom-column values in a `calibre:user_metadata` JSON blob keyed by column name,
-// each value carrying the actual value under `#value#`. Used only to fill page count / subtitle when null.
-function parseCalibreUserMetadata(raw: string | null): { pageCount: number | null; subtitle: string | null } {
-  const empty = { pageCount: null, subtitle: null };
+// each value carrying the actual value under `#value#`. Used only to fill page count / subtitle / extra tags when null/empty.
+function parseCalibreUserMetadata(raw: string | null): { pageCount: number | null; subtitle: string | null; extraTags: string[] } {
+  const empty = { pageCount: null, subtitle: null, extraTags: [] };
   if (!raw) return empty;
 
   let parsed: unknown;
@@ -174,11 +174,22 @@ function parseCalibreUserMetadata(raw: string | null): { pageCount: number | nul
     const n = Number(v);
     return Number.isFinite(n) && n > 0 ? Math.round(n) : null;
   };
+  const coerceExtraTags = (v: unknown): string[] => {
+    if (v === undefined || v === null) return [];
+    if (Array.isArray(v)) return v.map((item) => String(item).trim()).filter(Boolean);
+    if (typeof v === 'string')
+      return v
+        .split(/[|,]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+    return [];
+  };
 
   const pageCount = coercePageCount(columnValue('#pagecount')) ?? coercePageCount(columnValue('#page_count'));
   const subRaw = columnValue('#subtitle');
   const subtitle = typeof subRaw === 'string' && subRaw.trim() ? subRaw.trim() : null;
-  return { pageCount, subtitle };
+  const extraTags = coerceExtraTags(columnValue('#extra_tags'));
+  return { pageCount, subtitle, extraTags };
 }
 
 function normalizeCreatorRole(role: string | null | undefined): string {
@@ -400,7 +411,8 @@ export function parseOpf(xml: string): ParsedOpf {
 
   // ── Genres and tags ────────────────────────────────────────────────────────
   const genres = toArray(metadata['subject']).map(getText).filter(Boolean);
-  const tags = parseBookOrbitTags(propertyMeta('bookorbit:tags') ?? namedMeta('bookorbit:tags'));
+  const tagsFromMeta = parseBookOrbitTags(propertyMeta('bookorbit:tags') ?? namedMeta('bookorbit:tags'));
+  const tags = [...new Set([...tagsFromMeta, ...calibreUser.extraTags])];
   let pageCount = parseNumber(propertyMeta('bookorbit:page_count') ?? namedMeta('bookorbit:page_count'));
   pageCount ??= calibreUser.pageCount;
   const rating = parseNumber(propertyMeta('bookorbit:rating') ?? namedMeta('bookorbit:rating'));


### PR DESCRIPTION
Fixes #365

Extends parseCalibreUserMetadata to extract the #extra_tags Calibre custom column and populate ParsedOpf.tags.

Supports comma-delimited string values. Tags from #extra_tags are merged with bookorbit:tags and deduplicated.

## What does this PR do?

Adds an additional CALIBRE custom column #extra_tags, that maps internally to Bookorbits's TAGS field in the Metadata.
This allows Calibre User's with CURATED metadata to bring over custom TAGS that do not FIT in the Genre's field.

This further enhances the metadata tracking of Bookorbit.

Requirements from Calibre user:

Custom Column MUST BE NAMED #extra_tags (# is added by Calibre) and must match the following setup:

<img width="640" height="764" alt="Calibre Column Details" src="https://github.com/user-attachments/assets/15c010f5-f584-43ff-b9b5-a3d3cde098fc" />

When Adding Tags to the custom column they will like this: (COMMA SEPARATED)


<img width="1280" height="401" alt="Calibre Extr Tags (Edit)" src="https://github.com/user-attachments/assets/e2da7010-9158-4873-b821-7e0ef79794bf" />


## How did you test this?

Added Test to opf-parser.test.ts To handle extraction of TAGS using both COMMA & PIPE Separated tags, Tested to make sure Existing Tags from Bookorbit extraction logic "merge" with the Calibre tags (deduplicated), tested if value was empty to make sure nothing froze.

Generated Docker image and tested live on a test server.

## Screenshots

Final Import of a book to Bookorbit with "extra_tags" inside the epub OPF.
<img width="1019" height="677" alt="tags" src="https://github.com/user-attachments/assets/6b58dae3-7dec-4c73-9deb-e801ab878b6e" />



<!-- If this touches the UI, please include a before/after screenshot or a short screen recording.
     You can drag and drop images directly here. -->

## Anything non-obvious in the diff?
I made sure to maintain same coding practices already stablished in code, nothing extra was added in terms of functions or work-arounds. Followed existing flow for already parsed Calibre custom column "subtitle & pagecount"

## Checklist

- [X] I've read through my own diff
- [X] This PR was discussed in an issue and has maintainer approval (for new features)
- [X] Lint and tests pass locally
- [X] No unintended files included (build artifacts, `.env`, personal configs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OPF metadata parsing now extracts additional tags from Calibre `#extra_tags` custom metadata and merges them with existing tags.
  * Merged tag lists are deduplicated for cleaner results.

* **Bug Fixes**
  * Calibre `#extra_tags` is now parsed from JSON arrays or delimited strings (comma- or pipe-delimited).
  * When delimiters are mixed, pipe-delimited splitting takes precedence.
  * Empty or invalid `#extra_tags` values are ignored to avoid unintended tags.

* **Tests**
  * Added coverage for `#extra_tags` parsing and merge/deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->