### PR TITLE
feat(i18n): add multi-language support with Dutch translation

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -66,11 +66,13 @@
     "vue": "^3.5.38",
     "vue-draggable-plus": "^0.6.1",
     "vue-echarts": "8.1.0-beta.2",
+    "vue-i18n": "^11.4.6",
     "vue-router": "^5.1.0",
     "vue-sonner": "^2.0.9",
     "vue-virtual-scroller": "^3.0.4"
   },
   "devDependencies": {
+    "@intlify/unplugin-vue-i18n": "^11.2.4",
     "@tsconfig/node24": "^24.0.4",
     "@types/canvas-confetti": "^1.9.0",
     "@types/jsdom": "^28.0.3",

--- a/client/src/components/AppHeader.vue
+++ b/client/src/components/AppHeader.vue
@@ -21,6 +21,7 @@ import {
   Highlighter,
 } from '@lucide/vue'
 import { useRouter, useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { SidebarTrigger } from '@/components/ui/sidebar'
 import { Separator } from '@/components/ui/separator'
@@ -58,6 +59,7 @@ import { DEFAULT_FORMAT_PRIORITY } from '@bookorbit/types'
 import { useThemeStore } from '@/stores/theme'
 import { getFormatColor } from '@/features/book/lib/format-colors'
 
+const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const { user, logout } = useAuth()
@@ -144,12 +146,13 @@ const showDropdown = computed(
 )
 
 const globalSearchLoadMoreLabel = computed(() =>
-  globalSearchLoadingMore.value ? 'Loading more...' : `Load more (${globalResults.value.length}/${globalSearchTotal.value})`,
+  globalSearchLoadingMore.value
+    ? t('components.appHeader.loadingMore')
+    : t('components.appHeader.loadMore', { loaded: globalResults.value.length, total: globalSearchTotal.value }),
 )
-const globalSearchAllLoadedLabel = computed(() => {
-  const count = globalSearchTotal.value
-  return count === 1 ? 'All 1 match shown' : `All ${count.toLocaleString()} matches shown`
-})
+const globalSearchAllLoadedLabel = computed(() =>
+  t('components.appHeader.allMatchesShown', { count: globalSearchTotal.value.toLocaleString() }, globalSearchTotal.value),
+)
 const globalSearchVirtualHeightStyle = computed(() => ({
   height: `${globalResults.value.length * GLOBAL_SEARCH_ROW_HEIGHT}px`,
 }))
@@ -283,19 +286,19 @@ onMounted(() => {
 const stopLibraryUploadListener = onLibraryUploadCompleted((event) => {
   if (event.uploadedCount === 0 && event.failedCount === 0) return
 
-  const uploadedLabel = `${event.uploadedCount} book${event.uploadedCount === 1 ? '' : 's'}`
-  const failedLabel = `${event.failedCount} file${event.failedCount === 1 ? '' : 's'}`
+  const uploadedLabel = t('components.appHeader.bookCount', { count: event.uploadedCount }, event.uploadedCount)
+  const failedLabel = t('components.appHeader.fileCount', { count: event.failedCount }, event.failedCount)
 
   if (event.failedCount === 0) {
-    toast.success(`Uploaded ${uploadedLabel}`)
+    toast.success(t('components.appHeader.uploadedToast', { uploaded: uploadedLabel }))
     return
   }
   if (event.uploadedCount === 0) {
-    toast.error(`Upload failed for ${failedLabel}`)
+    toast.error(t('components.appHeader.uploadFailedToast', { failed: failedLabel }))
     return
   }
 
-  toast.warning(`Uploaded ${uploadedLabel}, ${failedLabel} failed`)
+  toast.warning(t('components.appHeader.uploadPartialToast', { uploaded: uploadedLabel, failed: failedLabel }))
 })
 
 onUnmounted(() => {
@@ -357,7 +360,7 @@ function formatBadgeStyle(fmt: string) {
           ref="mobileSearchInput"
           v-model="globalSearchQuery"
           @keydown="handleSearchKeydown"
-          placeholder="Search all books..."
+          :placeholder="t('components.appHeader.searchAllBooks')"
           class="w-full h-8 pl-8 pr-7 text-sm rounded-md border border-input bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary transition-shadow"
         />
         <button v-if="globalSearchQuery" @click="clearSearch()" class="absolute right-2 text-muted-foreground hover:text-foreground">
@@ -374,12 +377,14 @@ function formatBadgeStyle(fmt: string) {
             @scroll.passive="handleSearchDropdownScroll"
             class="absolute top-full left-0 right-0 mt-1 bg-background border border-border rounded-md shadow-lg z-50 overflow-hidden max-h-72 overflow-y-auto"
           >
-            <div v-if="globalSearchLoading && globalResults.length === 0" class="p-3 text-xs text-muted-foreground text-center">Searching...</div>
+            <div v-if="globalSearchLoading && globalResults.length === 0" class="p-3 text-xs text-muted-foreground text-center">
+              {{ t('components.appHeader.searching') }}
+            </div>
             <div
               v-else-if="globalSearchSettled && !globalSearchLoading && globalResults.length === 0"
               class="p-3 text-xs text-muted-foreground text-center"
             >
-              No results
+              {{ t('components.appHeader.noResults') }}
             </div>
             <div v-if="globalResults.length > 0" class="relative" :style="globalSearchVirtualHeightStyle">
               <button
@@ -467,7 +472,7 @@ function formatBadgeStyle(fmt: string) {
           @focus="searchFocused = true"
           @blur="onSearchBlur"
           @keydown="handleSearchKeydown"
-          placeholder="Search all books..."
+          :placeholder="t('components.appHeader.searchAllBooks')"
           class="w-full h-8 pl-9 pr-8 text-[13.5px] rounded-full border-none bg-primary/5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1.5 focus:ring-primary/30 transition-all duration-300 shadow-inner shadow-black/5"
         />
         <div class="absolute inset-y-0 right-2.5 flex items-center gap-1.5">
@@ -497,12 +502,14 @@ function formatBadgeStyle(fmt: string) {
             @scroll.passive="handleSearchDropdownScroll"
             class="absolute top-full left-0 right-0 mt-1 bg-background border border-border rounded-md shadow-lg z-50 overflow-hidden max-h-80 overflow-y-auto"
           >
-            <div v-if="globalSearchLoading && globalResults.length === 0" class="p-3 text-xs text-muted-foreground text-center">Searching...</div>
+            <div v-if="globalSearchLoading && globalResults.length === 0" class="p-3 text-xs text-muted-foreground text-center">
+              {{ t('components.appHeader.searching') }}
+            </div>
             <div
               v-else-if="globalSearchSettled && !globalSearchLoading && globalResults.length === 0"
               class="p-3 text-xs text-muted-foreground text-center"
             >
-              No results
+              {{ t('components.appHeader.noResults') }}
             </div>
             <div v-if="globalResults.length > 0" class="relative" :style="globalSearchVirtualHeightStyle">
               <button
@@ -587,7 +594,7 @@ function formatBadgeStyle(fmt: string) {
               <Search :size="15" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Search</TooltipContent>
+          <TooltipContent>{{ t('common.search') }}</TooltipContent>
         </Tooltip>
 
         <!-- Mobile: Notifications bell -->
@@ -612,7 +619,7 @@ function formatBadgeStyle(fmt: string) {
           <DropdownMenuContent align="end" class="w-44">
             <DropdownMenuItem v-if="hasPermission('book_dock_access')" @click="navigateToBookDock">
               <PackageOpen :size="15" class="mr-2 text-muted-foreground" />
-              Book Dock
+              {{ t('components.appHeader.bookDock') }}
               <span
                 v-if="bookDockSummary.total > 0"
                 class="ml-auto flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground tabular-nums leading-none"
@@ -622,15 +629,15 @@ function formatBadgeStyle(fmt: string) {
             </DropdownMenuItem>
             <DropdownMenuItem @click="navigateToStatistics">
               <BarChart3 :size="15" class="mr-2 text-muted-foreground" />
-              Statistics
+              {{ t('components.appHeader.statistics') }}
             </DropdownMenuItem>
             <DropdownMenuItem @click="navigateToAchievements">
               <Trophy :size="15" class="mr-2 text-muted-foreground" />
-              Achievements
+              {{ t('components.appHeader.achievements') }}
             </DropdownMenuItem>
             <DropdownMenuItem v-if="hasPermission('library_upload')" @click="uploadOpen = true">
               <Upload :size="15" class="mr-2 text-muted-foreground" />
-              Upload books
+              {{ t('components.appHeader.uploadBooks') }}
             </DropdownMenuItem>
 
             <DropdownMenuSeparator />
@@ -638,24 +645,24 @@ function formatBadgeStyle(fmt: string) {
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <Palette :size="15" class="mr-2 text-muted-foreground" />
-                Appearance
+                {{ t('components.appHeader.appearance') }}
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent class="w-72 p-4">
                 <div class="space-y-4">
                   <div class="space-y-1.5">
-                    <span class="text-xs text-muted-foreground">Theme</span>
+                    <span class="text-xs text-muted-foreground">{{ t('components.appHeader.theme') }}</span>
                     <ThemePicker />
                   </div>
                   <div class="space-y-1.5">
-                    <span class="text-xs text-muted-foreground">Accent</span>
+                    <span class="text-xs text-muted-foreground">{{ t('components.appHeader.accent') }}</span>
                     <AccentPicker />
                   </div>
                   <div class="space-y-1.5">
-                    <span class="text-xs text-muted-foreground">Radius</span>
+                    <span class="text-xs text-muted-foreground">{{ t('components.appHeader.radius') }}</span>
                     <RadiusPicker />
                   </div>
                   <div class="space-y-1.5">
-                    <span class="text-xs text-muted-foreground">Background</span>
+                    <span class="text-xs text-muted-foreground">{{ t('components.appHeader.background') }}</span>
                     <BackgroundPicker />
                   </div>
                 </div>
@@ -664,20 +671,20 @@ function formatBadgeStyle(fmt: string) {
 
             <DropdownMenuItem @click="navigateToSettings">
               <Settings :size="15" class="mr-2 text-muted-foreground" />
-              Settings
+              {{ t('components.appHeader.settings') }}
             </DropdownMenuItem>
 
             <DropdownMenuSeparator />
 
             <DropdownMenuItem @click="navigateToWhatsNew">
               <Sparkles :size="15" class="mr-2 text-muted-foreground" />
-              What's New
-              <span v-if="hasUnseenWhatsNew" class="ml-auto h-1.5 w-1.5 rounded-full bg-primary" aria-label="New" />
+              {{ t('components.appHeader.whatsNew') }}
+              <span v-if="hasUnseenWhatsNew" class="ml-auto h-1.5 w-1.5 rounded-full bg-primary" :aria-label="t('components.appHeader.new')" />
             </DropdownMenuItem>
             <DropdownMenuItem as-child>
               <a :href="documentationUrl" target="_blank" rel="noopener noreferrer">
                 <BadgeQuestionMark :size="15" class="mr-2 text-muted-foreground" />
-                Documentation
+                {{ t('components.appHeader.documentation') }}
                 <ExternalLink :size="12" class="ml-auto text-muted-foreground" />
               </a>
             </DropdownMenuItem>
@@ -711,7 +718,7 @@ function formatBadgeStyle(fmt: string) {
                 </span>
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Book Dock</TooltipContent>
+            <TooltipContent>{{ t('components.appHeader.bookDock') }}</TooltipContent>
           </Tooltip>
 
           <!-- Notifications button -->
@@ -735,7 +742,7 @@ function formatBadgeStyle(fmt: string) {
                 <Highlighter :size="15" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Annotations</TooltipContent>
+            <TooltipContent>{{ t('components.appHeader.annotations') }}</TooltipContent>
           </Tooltip>
 
           <!-- Statistics button -->
@@ -757,7 +764,7 @@ function formatBadgeStyle(fmt: string) {
                 <BarChart3 :size="15" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Statistics</TooltipContent>
+            <TooltipContent>{{ t('components.appHeader.statistics') }}</TooltipContent>
           </Tooltip>
 
           <!-- Achievements button -->
@@ -778,7 +785,7 @@ function formatBadgeStyle(fmt: string) {
                 <Trophy :size="15" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Achievements</TooltipContent>
+            <TooltipContent>{{ t('components.appHeader.achievements') }}</TooltipContent>
           </Tooltip>
 
           <!-- Upload button -->
@@ -797,7 +804,7 @@ function formatBadgeStyle(fmt: string) {
                 <Upload :size="15" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Upload books</TooltipContent>
+            <TooltipContent>{{ t('components.appHeader.uploadBooks') }}</TooltipContent>
           </Tooltip>
         </div>
 
@@ -821,7 +828,7 @@ function formatBadgeStyle(fmt: string) {
                     <span
                       v-if="hasUnseenWhatsNew"
                       class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-primary ring-2 ring-background"
-                      aria-label="New release notes available"
+                      :aria-label="t('components.appHeader.newReleaseNotes')"
                     />
                   </Button>
                 </DropdownMenuTrigger>
@@ -830,18 +837,18 @@ function formatBadgeStyle(fmt: string) {
                 <DropdownMenuItem as-child>
                   <a :href="documentationUrl" target="_blank" rel="noopener noreferrer">
                     <BadgeQuestionMark :size="14" class="mr-2 text-muted-foreground" />
-                    Documentation
+                    {{ t('components.appHeader.documentation') }}
                     <ExternalLink :size="12" class="ml-auto text-muted-foreground" />
                   </a>
                 </DropdownMenuItem>
                 <DropdownMenuItem @click="navigateToWhatsNew">
                   <Sparkles :size="14" class="mr-2 text-muted-foreground" />
-                  What's New
-                  <span v-if="hasUnseenWhatsNew" class="ml-auto h-1.5 w-1.5 rounded-full bg-primary" aria-label="New" />
+                  {{ t('components.appHeader.whatsNew') }}
+                  <span v-if="hasUnseenWhatsNew" class="ml-auto h-1.5 w-1.5 rounded-full bg-primary" :aria-label="t('components.appHeader.new')" />
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <TooltipContent>Help</TooltipContent>
+            <TooltipContent>{{ t('components.appHeader.help') }}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -866,27 +873,26 @@ function formatBadgeStyle(fmt: string) {
                   variant="ghost"
                   size="icon"
                   class="absolute right-2 top-2 h-6 w-6 text-muted-foreground hover:text-foreground"
-                  aria-label="Close"
+                  :aria-label="t('common.close')"
                   @click="closeGithubStarPopover"
                 >
                   <X :size="13" />
                 </Button>
                 <div class="space-y-3 pr-5">
-                  <p class="text-sm font-medium text-foreground">Enjoying BookOrbit?</p>
+                  <p class="text-sm font-medium text-foreground">{{ t('components.appHeader.githubStar.title') }}</p>
                   <p class="text-xs leading-relaxed text-muted-foreground">
-                    If BookOrbit is helping with your library, please consider starring the project on GitHub. It helps more people discover the app
-                    and supports ongoing development.
+                    {{ t('components.appHeader.githubStar.body') }}
                   </p>
                   <Button as-child class="w-full">
                     <a :href="githubRepositoryUrl" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center gap-1.5">
-                      <span>Star BookOrbit on GitHub</span>
+                      <span>{{ t('components.appHeader.githubStar.cta') }}</span>
                       <ExternalLink :size="14" />
                     </a>
                   </Button>
                 </div>
               </PopoverContent>
             </Popover>
-            <TooltipContent>Star on GitHub</TooltipContent>
+            <TooltipContent>{{ t('components.appHeader.starOnGithub') }}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -905,27 +911,27 @@ function formatBadgeStyle(fmt: string) {
               </TooltipTrigger>
               <PopoverContent class="w-72 p-4" align="end">
                 <div class="space-y-4">
-                  <p class="text-xs font-semibold text-foreground uppercase tracking-wider">Appearance</p>
+                  <p class="text-xs font-semibold text-foreground uppercase tracking-wider">{{ t('components.appHeader.appearance') }}</p>
                   <div class="space-y-1.5">
-                    <span class="text-xs text-muted-foreground">Theme</span>
+                    <span class="text-xs text-muted-foreground">{{ t('components.appHeader.theme') }}</span>
                     <ThemePicker />
                   </div>
                   <div class="space-y-1.5">
-                    <span class="text-xs text-muted-foreground">Accent</span>
+                    <span class="text-xs text-muted-foreground">{{ t('components.appHeader.accent') }}</span>
                     <AccentPicker />
                   </div>
                   <div class="space-y-1.5">
-                    <span class="text-xs text-muted-foreground">Radius</span>
+                    <span class="text-xs text-muted-foreground">{{ t('components.appHeader.radius') }}</span>
                     <RadiusPicker />
                   </div>
                   <div class="space-y-1.5">
-                    <span class="text-xs text-muted-foreground">Background</span>
+                    <span class="text-xs text-muted-foreground">{{ t('components.appHeader.background') }}</span>
                     <BackgroundPicker />
                   </div>
                 </div>
               </PopoverContent>
             </Popover>
-            <TooltipContent>Appearance</TooltipContent>
+            <TooltipContent>{{ t('components.appHeader.appearance') }}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -943,7 +949,7 @@ function formatBadgeStyle(fmt: string) {
                 <Settings :size="15" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Settings</TooltipContent>
+            <TooltipContent>{{ t('components.appHeader.settings') }}</TooltipContent>
           </Tooltip>
         </div>
 
@@ -970,17 +976,17 @@ function formatBadgeStyle(fmt: string) {
             <DropdownMenuSeparator />
             <DropdownMenuItem @click="navigateToAccount">
               <User :size="13" class="mr-2 text-muted-foreground" />
-              Account
+              {{ t('components.appHeader.account') }}
             </DropdownMenuItem>
             <DropdownMenuSeparator v-if="canChangePassword" />
             <DropdownMenuItem v-if="canChangePassword" @click="openChangePassword()">
               <KeyRound :size="13" class="mr-2 text-muted-foreground" />
-              Change Password
+              {{ t('components.appHeader.changePassword') }}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem @click="logout" class="text-destructive focus:text-destructive">
               <LogOut :size="13" class="mr-2" />
-              Sign out
+              {{ t('components.appHeader.signOut') }}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/client/src/components/AppSidebar.vue
+++ b/client/src/components/AppSidebar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import * as Icons from '@lucide/vue'
 import { VueDraggable } from 'vue-draggable-plus'
@@ -43,6 +44,7 @@ function useSidebarSection(key: string) {
   return { isOpen, toggle }
 }
 
+const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const { isMobile, setOpenMobile } = useSidebar()
@@ -183,7 +185,7 @@ onUnmounted(() => stopLibraryUploadListener())
           <span class="text-lg font-serif font-semibold text-sidebar-foreground leading-tight tracking-tight">
             Book<span class="text-primary"> Orbit</span>
           </span>
-          <span class="mt-0.5 text-[10px] uppercase tracking-[0.16em] text-sidebar-foreground/65">Your Reading Space</span>
+          <span class="mt-0.5 text-[10px] uppercase tracking-[0.16em] text-sidebar-foreground/65">{{ t('components.sidebar.tagline') }}</span>
         </div>
       </div>
     </SidebarHeader>
@@ -195,31 +197,31 @@ onUnmounted(() => stopLibraryUploadListener())
           <SidebarMenu class="gap-0">
             <SidebarNavItem
               :is-active="isDashboardActive"
-              tooltip="Dashboard"
+              :tooltip="t('components.sidebar.dashboard')"
               :icon="Icons.LayoutDashboard"
-              label="Dashboard"
+              :label="t('components.sidebar.dashboard')"
               @click="navigateFromSidebar({ name: 'dashboard' })"
             />
             <SidebarNavItem
               :is-active="isAuthorsActive"
-              tooltip="Authors"
+              :tooltip="t('components.sidebar.authors')"
               :icon="Icons.Users"
-              label="Authors"
+              :label="t('components.sidebar.authors')"
               @click="navigateFromSidebar({ name: 'authors' })"
             />
             <SidebarNavItem
               :is-active="isSeriesActive"
-              tooltip="Series"
+              :tooltip="t('components.sidebar.series')"
               :icon="Icons.Library"
-              label="Series"
+              :label="t('components.sidebar.series')"
               @click="navigateFromSidebar({ name: 'series' })"
             />
             <SidebarNavItem
               v-if="hasPermission('manage_libraries')"
               :is-active="isToolsActive"
-              tooltip="Tools"
+              :tooltip="t('components.sidebar.tools')"
               :icon="Icons.Wrench"
-              label="Tools"
+              :label="t('components.sidebar.tools')"
               @click="navigateFromSidebar({ name: 'tools-entity-manager' })"
             />
           </SidebarMenu>
@@ -232,11 +234,11 @@ onUnmounted(() => stopLibraryUploadListener())
       <SidebarGroup>
         <SidebarSectionHeader
           data-tour="sidebar-libraries"
-          label="Libraries"
+          :label="t('components.sidebar.libraries')"
           :is-open="librariesOpen"
           :collapsed-count="libraries.length"
           :can-add="hasPermission('manage_libraries')"
-          add-title="New Library"
+          :add-title="t('components.sidebar.newLibrary')"
           :can-reorder="hasPermission('manage_libraries')"
           :is-reordering="isReorderingLibraries"
           @toggle="toggleLibraries"
@@ -260,7 +262,11 @@ onUnmounted(() => stopLibraryUploadListener())
                   v-for="lib in localLibraries"
                   :key="lib.id"
                   :is-active="activeLibraryId === lib.id"
-                  :tooltip="getProgress(lib.id)?.status === 'running' ? `${lib.name} - Scanning ${scanPct(lib.id)}%` : lib.name"
+                  :tooltip="
+                    getProgress(lib.id)?.status === 'running'
+                      ? t('components.sidebar.libraryScanning', { name: lib.name, pct: scanPct(lib.id) })
+                      : lib.name
+                  "
                   :icon="lib.icon || 'BookCopy'"
                   fallback-icon="BookCopy"
                   :icon-class="''"
@@ -299,7 +305,12 @@ onUnmounted(() => stopLibraryUploadListener())
                           />
                         </div>
                         <p class="mt-0.5 text-[10px] text-sidebar-foreground/45">
-                          {{ getProgress(lib.id)!.processed.toLocaleString() }} / {{ getProgress(lib.id)!.total.toLocaleString() }} books
+                          {{
+                            t('components.sidebar.scanProgress', {
+                              processed: getProgress(lib.id)!.processed.toLocaleString(),
+                              total: getProgress(lib.id)!.total.toLocaleString(),
+                            })
+                          }}
                         </p>
                       </div>
                     </Transition>
@@ -317,11 +328,11 @@ onUnmounted(() => stopLibraryUploadListener())
       <SidebarGroup>
         <SidebarSectionHeader
           data-tour="sidebar-smartScopes"
-          label="Smart Scopes"
+          :label="t('components.sidebar.smartScopes')"
           :is-open="smartScopesOpen"
           :collapsed-count="smartScopes.length"
           :can-add="true"
-          add-title="New Smart Scope"
+          :add-title="t('components.sidebar.newSmartScope')"
           :can-reorder="smartScopes.length > 1"
           :is-reordering="isReorderingSmartScopes"
           @toggle="toggleSmartScopes"
@@ -367,7 +378,9 @@ onUnmounted(() => stopLibraryUploadListener())
                 </SidebarNavItem>
               </VueDraggable>
               <div v-if="localSmartScopes.length === 0">
-                <span class="px-2 py-1 text-[11px] text-sidebar-foreground/40 group-data-[collapsible=icon]:hidden">No Smart Scopes yet</span>
+                <span class="px-2 py-1 text-[11px] text-sidebar-foreground/40 group-data-[collapsible=icon]:hidden">{{
+                  t('components.sidebar.noSmartScopes')
+                }}</span>
               </div>
             </SidebarGroupContent>
           </div>
@@ -380,11 +393,11 @@ onUnmounted(() => stopLibraryUploadListener())
       <SidebarGroup>
         <SidebarSectionHeader
           data-tour="sidebar-collections"
-          label="Collections"
+          :label="t('components.sidebar.collections')"
           :is-open="collectionsOpen"
           :collapsed-count="collections.length"
           :can-add="true"
-          add-title="New Collection"
+          :add-title="t('components.sidebar.newCollection')"
           :can-reorder="collections.length > 1"
           :is-reordering="isReorderingCollections"
           @toggle="toggleCollections"
@@ -430,7 +443,9 @@ onUnmounted(() => stopLibraryUploadListener())
                 </SidebarNavItem>
               </VueDraggable>
               <div v-if="localCollections.length === 0">
-                <span class="px-2 py-1 text-[11px] text-sidebar-foreground/40 group-data-[collapsible=icon]:hidden">No collections yet</span>
+                <span class="px-2 py-1 text-[11px] text-sidebar-foreground/40 group-data-[collapsible=icon]:hidden">{{
+                  t('components.sidebar.noCollections')
+                }}</span>
               </div>
             </SidebarGroupContent>
           </div>
@@ -443,7 +458,7 @@ onUnmounted(() => stopLibraryUploadListener())
         <div class="flex flex-wrap items-center justify-center gap-2 text-center text-[12px] font-medium leading-none text-sidebar-foreground/80">
           <RouterLink to="/whats-new" class="inline-flex items-center gap-1.5 transition-colors hover:text-sidebar-foreground">
             {{ versionUi.currentLabel }}
-            <span v-if="hasUnseenWhatsNew" class="h-1.5 w-1.5 rounded-full bg-primary" aria-label="New release notes available" />
+            <span v-if="hasUnseenWhatsNew" class="h-1.5 w-1.5 rounded-full bg-primary" :aria-label="t('components.sidebar.newReleaseNotes')" />
           </RouterLink>
 
           <span v-if="versionUi.showLatest" class="text-sidebar-foreground/45">•</span>
@@ -455,7 +470,7 @@ onUnmounted(() => stopLibraryUploadListener())
             rel="noopener noreferrer"
             class="font-semibold text-primary transition-colors hover:text-primary/85"
           >
-            Latest {{ versionUi.latestLabel }}
+            {{ t('components.sidebar.latest', { version: versionUi.latestLabel }) }}
           </a>
         </div>
       </div>

--- a/client/src/components/EntityNotFound.vue
+++ b/client/src/components/EntityNotFound.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { SearchX } from '@lucide/vue'
+
+const { t } = useI18n()
 
 defineProps<{ entity: string }>()
 
@@ -21,14 +24,14 @@ function goBack() {
       <SearchX :size="28" />
     </div>
     <div class="space-y-1">
-      <h2 class="text-lg font-semibold text-foreground">{{ entity }} not found</h2>
-      <p class="text-sm text-muted-foreground">This {{ entity.toLowerCase() }} doesn't exist or has been deleted.</p>
+      <h2 class="text-lg font-semibold text-foreground">{{ t('components.entityNotFound.title', { entity }) }}</h2>
+      <p class="text-sm text-muted-foreground">{{ t('components.entityNotFound.description', { entity: entity.toLowerCase() }) }}</p>
     </div>
     <button
       class="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-border bg-background text-sm font-medium text-foreground hover:bg-muted transition-colors mt-1"
       @click="goBack"
     >
-      Go back
+      {{ t('components.entityNotFound.goBack') }}
     </button>
   </div>
 </template>

--- a/client/src/components/IconPicker.vue
+++ b/client/src/components/IconPicker.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import * as LucideIcons from '@lucide/vue'
 import { ChevronDown, Search, X } from '@lucide/vue'
 import { RecycleScroller } from 'vue-virtual-scroller'
@@ -19,6 +20,8 @@ const emit = defineEmits<{
   'update:modelValue': [value: string]
   'open-change': [value: boolean]
 }>()
+
+const { t } = useI18n()
 
 // ── Icon list ─────────────────────────────────────────────────────────────
 
@@ -129,7 +132,9 @@ const customRows = computed<CustomIconRow[]>(() => {
 })
 
 const activeCount = computed(() => (activeSource.value === 'lucide' ? filteredIcons.value.length : filteredCustomIcons.value.length))
-const searchPlaceholder = computed(() => (activeSource.value === 'lucide' ? 'Search Lucide icons...' : 'Search custom icons...'))
+const searchPlaceholder = computed(() =>
+  activeSource.value === 'lucide' ? t('components.iconPicker.searchLucide') : t('components.iconPicker.searchCustom'),
+)
 const customIconsSearching = computed(
   () =>
     serverSearchLoading.value ||
@@ -272,11 +277,11 @@ onUnmounted(() => {
 
     <template v-if="!modelValue">
       <span v-if="!hideText" class="text-muted-foreground flex-1 text-left font-normal truncate">
-        {{ placeholder ?? 'Choose an icon...' }}
+        {{ placeholder ?? t('components.iconPicker.chooseIcon') }}
       </span>
       <span v-else class="text-foreground flex items-center gap-1.5">
         <component :is="LucideIcons.Shapes" :size="14" class="text-muted-foreground" />
-        {{ placeholder ?? 'Select icon' }}
+        {{ placeholder ?? t('components.iconPicker.selectIcon') }}
       </span>
       <ChevronDown
         v-if="!hideText"
@@ -327,7 +332,7 @@ onUnmounted(() => {
               :class="activeSource === 'custom' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'"
               @click="selectCustomTab"
             >
-              Custom
+              {{ t('components.iconPicker.customTab') }}
             </button>
           </div>
           <div class="flex items-center gap-2 px-3 py-2 border-border shrink-0">
@@ -350,11 +355,11 @@ onUnmounted(() => {
 
         <!-- No results -->
         <div v-if="activeCount === 0" class="flex items-center justify-center py-12 text-xs text-muted-foreground">
-          <span v-if="activeSource === 'custom' && (customIconsLoading || customIconsSearching)">Searching...</span>
-          <span v-else-if="query">No icons match "{{ query }}"</span>
-          <span v-else-if="activeSource === 'custom' && catalogTruncated">Type to search all icons</span>
-          <span v-else-if="activeSource === 'custom'">No custom icons uploaded</span>
-          <span v-else>No icons available</span>
+          <span v-if="activeSource === 'custom' && (customIconsLoading || customIconsSearching)">{{ t('components.iconPicker.searching') }}</span>
+          <span v-else-if="query">{{ t('components.iconPicker.noIconsMatch', { query }) }}</span>
+          <span v-else-if="activeSource === 'custom' && catalogTruncated">{{ t('components.iconPicker.typeToSearch') }}</span>
+          <span v-else-if="activeSource === 'custom'">{{ t('components.iconPicker.noCustomIcons') }}</span>
+          <span v-else>{{ t('components.iconPicker.noIconsAvailable') }}</span>
         </div>
 
         <!-- Virtual icon grid -->

--- a/client/src/components/SelectionActionBar.vue
+++ b/client/src/components/SelectionActionBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, useSlots, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import {
   BookOpen,
   Download,
@@ -87,6 +88,7 @@ const emit = defineEmits<{
   exit: []
 }>()
 
+const { t } = useI18n()
 const { hasPermission, isDemoRestrictedAccount } = usePermissions()
 const { search: searchPublisher } = usePublisherSearch()
 const { search: searchSeriesName } = useSeriesNameSearch()
@@ -107,7 +109,9 @@ const canShowMoreMenu = computed(() => canDownload.value || canEditMetadata.valu
 const canShare = computed(() => hasPermission('email_send') || canDownload.value)
 const numericFieldSelected = computed(() => bulkField.value === 'publishedYear')
 const arrayFieldSelected = computed(() => (BULK_EDITABLE_ARRAY_FIELDS as readonly string[]).includes(bulkField.value))
-const fieldValuePlaceholder = computed(() => (arrayFieldSelected.value ? 'Comma-separated (leave blank to clear)' : 'Leave blank to clear'))
+const fieldValuePlaceholder = computed(() =>
+  arrayFieldSelected.value ? t('components.selectionActionBar.fieldPlaceholderArray') : t('components.selectionActionBar.fieldPlaceholder'),
+)
 const typeaheadSearchFn = computed<((q: string) => Promise<string[]>) | null>(() => {
   if (bulkField.value === 'seriesName') return searchSeriesName
   if (bulkField.value === 'publisher') return searchPublisher
@@ -262,7 +266,7 @@ watch(
                         data-testid="action-bulk-set-status"
                         :disabled="count === 0"
                         :class="[BTN_ICON, count > 0 ? BTN_PRIMARY : BTN_DISABLED]"
-                        aria-label="Set reading status"
+                        :aria-label="t('components.selectionActionBar.setReadingStatus')"
                       >
                         <BookOpen :size="ICON_SIZE" />
                       </button>
@@ -276,7 +280,7 @@ watch(
                   </DropdownMenu>
                 </span>
               </TooltipTrigger>
-              <TooltipContent side="top">Set reading status</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.setReadingStatus') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip v-if="canEditMetadata">
@@ -290,7 +294,7 @@ watch(
                   <Star :size="ICON_SIZE" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">Set rating</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.setRating') }}</TooltipContent>
             </Tooltip>
 
             <div v-if="canEditMetadata" :class="DIVIDER" />
@@ -306,7 +310,7 @@ watch(
                   <Pencil :size="ICON_SIZE" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">Open metadata editor</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.openMetadataEditor') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip v-if="canEditMetadata && !queryScoped">
@@ -320,7 +324,7 @@ watch(
                   <SquareArrowOutUpRight :size="ICON_SIZE" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">Edit books individually</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.editIndividually') }}</TooltipContent>
             </Tooltip>
 
             <div v-if="canBulkActions" :class="DIVIDER" />
@@ -336,7 +340,7 @@ watch(
                   <FolderPlus :size="ICON_SIZE" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">Add to collection</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.addToCollection') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip v-if="inCollection">
@@ -349,7 +353,7 @@ watch(
                   <FolderMinus :size="ICON_SIZE" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">Remove from collection</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.removeFromCollection') }}</TooltipContent>
             </Tooltip>
 
             <div v-if="canShare" :class="DIVIDER" />
@@ -365,7 +369,7 @@ watch(
                   <Mail :size="ICON_SIZE" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">Send via email</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.sendViaEmail') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip v-if="canDownload">
@@ -379,7 +383,7 @@ watch(
                   <Download :size="ICON_SIZE" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">Download files as ZIP</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.downloadFilesZip') }}</TooltipContent>
             </Tooltip>
 
             <div v-if="canShowMoreMenu" :class="DIVIDER" />
@@ -393,7 +397,7 @@ watch(
                         data-testid="action-bulk-metadata-menu"
                         :disabled="count === 0"
                         :class="[BTN_ICON, count > 0 ? BTN_MUTED : BTN_DISABLED]"
-                        aria-label="More actions"
+                        :aria-label="t('components.selectionActionBar.moreActions')"
                       >
                         <MoreHorizontal :size="ICON_SIZE" />
                       </button>
@@ -402,31 +406,31 @@ watch(
                       <template v-if="canEditMetadata">
                         <DropdownMenuItem data-testid="action-bulk-set-field" @click="openFieldEditor">
                           <SquarePen :size="14" />
-                          <span>Set field</span>
+                          <span>{{ t('components.selectionActionBar.setField') }}</span>
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
                         <DropdownMenuItem data-testid="action-bulk-refresh-metadata" @click="onRefreshMetadata">
                           <RefreshCw :size="14" />
-                          <span>Refresh metadata</span>
+                          <span>{{ t('components.selectionActionBar.refreshMetadata') }}</span>
                         </DropdownMenuItem>
                         <DropdownMenuItem data-testid="action-bulk-re-extract-cover" @click="onReExtractCover">
                           <ImageDown :size="14" />
-                          <span>Re-extract cover</span>
+                          <span>{{ t('components.selectionActionBar.reExtractCover') }}</span>
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
                         <DropdownMenuSub>
                           <DropdownMenuSubTrigger data-testid="action-bulk-metadata-lock">
                             <Lock :size="14" />
-                            <span>Metadata lock</span>
+                            <span>{{ t('components.selectionActionBar.metadataLock') }}</span>
                           </DropdownMenuSubTrigger>
                           <DropdownMenuSubContent>
                             <DropdownMenuItem data-testid="action-bulk-lock-metadata" @click="lockAll">
                               <Lock :size="14" />
-                              <span>Lock all</span>
+                              <span>{{ t('components.selectionActionBar.lockAll') }}</span>
                             </DropdownMenuItem>
                             <DropdownMenuItem data-testid="action-bulk-unlock-metadata" @click="unlockAll">
                               <Unlock :size="14" />
-                              <span>Unlock all</span>
+                              <span>{{ t('components.selectionActionBar.unlockAll') }}</span>
                             </DropdownMenuItem>
                           </DropdownMenuSubContent>
                         </DropdownMenuSub>
@@ -435,14 +439,14 @@ watch(
                         <DropdownMenuSeparator v-if="canEditMetadata" />
                         <DropdownMenuItem data-testid="action-export-metadata" @click="emit('export-metadata')">
                           <FileSpreadsheet :size="14" />
-                          <span>Export metadata</span>
+                          <span>{{ t('components.selectionActionBar.exportMetadata') }}</span>
                         </DropdownMenuItem>
                       </template>
                     </DropdownMenuContent>
                   </DropdownMenu>
                 </span>
               </TooltipTrigger>
-              <TooltipContent side="top">More actions</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.moreActions') }}</TooltipContent>
             </Tooltip>
 
             <div v-if="hasPermission('library_delete_books')" :class="DIVIDER" />
@@ -458,7 +462,7 @@ watch(
                   <Trash2 :size="ICON_SIZE" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">Delete selected</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.deleteSelected') }}</TooltipContent>
             </Tooltip>
 
             <div :class="DIVIDER" />
@@ -469,34 +473,40 @@ watch(
                   <X :size="ICON_SIZE" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="top">Exit selection</TooltipContent>
+              <TooltipContent side="top">{{ t('components.selectionActionBar.exitSelection') }}</TooltipContent>
             </Tooltip>
           </template>
 
           <!-- Export scope picker -->
           <template v-else-if="exportMenuOpen">
-            <span class="hidden sm:inline px-3 text-sm font-semibold text-foreground whitespace-nowrap">Download files as ZIP:</span>
+            <span class="hidden sm:inline px-3 text-sm font-semibold text-foreground whitespace-nowrap">{{
+              t('components.selectionActionBar.downloadFilesZipLabel')
+            }}</span>
             <div :class="DIVIDER" />
-            <button :class="BTN_TEXT_PRIMARY" @click="onExport('primary')">Primary only</button>
-            <button :class="BTN_TEXT_PRIMARY" @click="onExport('all')">All formats</button>
-            <button :class="BTN_TEXT_PRIMARY" @click="onExport('audio')">Audio only</button>
+            <button :class="BTN_TEXT_PRIMARY" @click="onExport('primary')">{{ t('components.selectionActionBar.primaryOnly') }}</button>
+            <button :class="BTN_TEXT_PRIMARY" @click="onExport('all')">{{ t('components.selectionActionBar.allFormats') }}</button>
+            <button :class="BTN_TEXT_PRIMARY" @click="onExport('audio')">{{ t('components.selectionActionBar.audioOnly') }}</button>
             <div :class="DIVIDER" />
-            <button :class="BTN_TEXT_CANCEL" @click="exportMenuOpen = false">Cancel</button>
+            <button :class="BTN_TEXT_CANCEL" @click="exportMenuOpen = false">{{ t('common.cancel') }}</button>
           </template>
 
           <!-- Star rating picker -->
           <template v-else-if="ratingMenuOpen">
-            <span class="hidden sm:inline px-3 text-sm font-semibold text-foreground whitespace-nowrap">Set rating:</span>
+            <span class="hidden sm:inline px-3 text-sm font-semibold text-foreground whitespace-nowrap">{{
+              t('components.selectionActionBar.setRatingLabel')
+            }}</span>
             <div :class="DIVIDER" />
             <button v-for="n in [1, 2, 3, 4, 5]" :key="n" :class="BTN_TEXT_PRIMARY" @click="onSetRating(n)">{{ n }}</button>
-            <button :class="BTN_TEXT_CANCEL" @click="clearRating">Clear</button>
+            <button :class="BTN_TEXT_CANCEL" @click="clearRating">{{ t('components.selectionActionBar.clear') }}</button>
             <div :class="DIVIDER" />
-            <button :class="BTN_TEXT_CANCEL" @click="ratingMenuOpen = false">Cancel</button>
+            <button :class="BTN_TEXT_CANCEL" @click="ratingMenuOpen = false">{{ t('common.cancel') }}</button>
           </template>
 
           <!-- Field editor -->
           <template v-else-if="fieldMenuOpen">
-            <span class="hidden sm:inline px-3 text-sm font-semibold text-foreground whitespace-nowrap">Set field:</span>
+            <span class="hidden sm:inline px-3 text-sm font-semibold text-foreground whitespace-nowrap">{{
+              t('components.selectionActionBar.setFieldLabel')
+            }}</span>
             <div :class="DIVIDER" />
             <select
               v-model="bulkField"
@@ -523,19 +533,21 @@ watch(
               :class="[BTN_TEXT_PRIMARY, !canApplyFieldValue && 'cursor-not-allowed opacity-40']"
               @click="applyFieldEdit"
             >
-              Apply
+              {{ t('components.selectionActionBar.apply') }}
             </button>
-            <button :class="BTN_TEXT_CANCEL" @click="resetFieldEditor">Cancel</button>
+            <button :class="BTN_TEXT_CANCEL" @click="resetFieldEditor">{{ t('common.cancel') }}</button>
           </template>
 
           <!-- Delete confirmation -->
           <template v-else>
-            <span class="px-3 text-sm font-semibold text-destructive whitespace-nowrap"> Delete {{ count }} book{{ count === 1 ? '' : 's' }}? </span>
+            <span class="px-3 text-sm font-semibold text-destructive whitespace-nowrap">
+              {{ t('components.selectionActionBar.deleteConfirm', { count }, count) }}
+            </span>
             <template v-if="count > 50">
               <input
                 v-model="deleteInput"
                 class="h-7 w-24 rounded border border-border bg-background px-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-destructive"
-                placeholder="Type DELETE"
+                :placeholder="t('components.selectionActionBar.typeDelete')"
               />
             </template>
             <div :class="DIVIDER" />
@@ -544,9 +556,9 @@ watch(
               :class="[BTN_TEXT_DESTRUCTIVE, !canConfirmDelete && 'opacity-40 cursor-not-allowed']"
               @click="onConfirmDelete"
             >
-              Delete
+              {{ t('common.delete') }}
             </button>
-            <button :class="BTN_TEXT_CANCEL" @click="cancelDelete">Cancel</button>
+            <button :class="BTN_TEXT_CANCEL" @click="cancelDelete">{{ t('common.cancel') }}</button>
           </template>
         </TooltipProvider>
       </div>

--- a/client/src/components/ThemePicker.vue
+++ b/client/src/components/ThemePicker.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { Moon, Sun } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 import { useThemeStore } from '@/stores/theme'
 
+const { t } = useI18n()
 const themeStore = useThemeStore()
 </script>
 
@@ -12,14 +14,14 @@ const themeStore = useThemeStore()
       :class="themeStore.theme === 'light' ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground'"
       @click="themeStore.theme = 'light'"
     >
-      <Sun :size="12" /> Light
+      <Sun :size="12" /> {{ t('components.themePicker.light') }}
     </button>
     <button
       class="flex items-center gap-1.5 px-2.5 py-1 rounded text-[10px] font-medium transition-colors focus:outline-none"
       :class="themeStore.theme === 'dark' ? 'bg-background shadow-sm text-foreground' : 'text-muted-foreground hover:text-foreground'"
       @click="themeStore.theme = 'dark'"
     >
-      <Moon :size="12" /> Dark
+      <Moon :size="12" /> {{ t('components.themePicker.dark') }}
     </button>
   </div>
 </template>

--- a/client/src/components/UserAvatar.vue
+++ b/client/src/components/UserAvatar.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -47,7 +50,7 @@ watch(
     <img
       v-if="src && !imageFailed"
       :src="src"
-      :alt="props.name ? `${props.name} profile picture` : 'Profile picture'"
+      :alt="props.name ? t('components.userAvatar.profilePictureOf', { name: props.name }) : t('components.userAvatar.profilePicture')"
       class="h-full w-full object-cover"
       @error="imageFailed = true"
     />

--- a/client/src/components/ViewHeader.vue
+++ b/client/src/components/ViewHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { CheckSquare, LayoutGrid, List, SlidersHorizontal, Square, Table2 } from '@lucide/vue'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -60,6 +61,8 @@ const emit = defineEmits<{
   'update:searchQuery': [value: string]
 }>()
 
+const { t } = useI18n()
+
 const mobileDisplayOpen = ref(false)
 const mobileSearchOpen = ref(false)
 </script>
@@ -92,7 +95,7 @@ const mobileSearchOpen = ref(false)
       >
         <CheckSquare v-if="selectionMode" :size="13" />
         <Square v-else :size="13" />
-        Select
+        {{ t('components.viewHeader.select') }}
       </Button>
 
       <div v-if="showSelection" class="mx-1.5 hidden h-3.5 w-px bg-border/40 md:block" />
@@ -158,7 +161,7 @@ const mobileSearchOpen = ref(false)
           >
             <template #columns>
               <slot name="columns">
-                <p class="text-xs text-muted-foreground">Use the column visibility panel in the table header to show or hide columns.</p>
+                <p class="text-xs text-muted-foreground">{{ t('components.viewHeader.columnVisibilityHint') }}</p>
               </slot>
             </template>
           </ViewHeaderDisplayControls>
@@ -189,8 +192,8 @@ const mobileSearchOpen = ref(false)
   <Sheet v-model:open="mobileDisplayOpen">
     <SheetContent side="bottom">
       <SheetHeader>
-        <SheetTitle>Display</SheetTitle>
-        <SheetDescription class="sr-only">Adjust cover size, grid spacing, and view display options.</SheetDescription>
+        <SheetTitle>{{ t('components.viewHeader.display') }}</SheetTitle>
+        <SheetDescription class="sr-only">{{ t('components.viewHeader.displayDescription') }}</SheetDescription>
       </SheetHeader>
       <div class="px-4 pb-6">
         <ViewHeaderDisplayControls
@@ -210,7 +213,7 @@ const mobileSearchOpen = ref(false)
         >
           <template #columns>
             <slot name="columns">
-              <p class="text-xs text-muted-foreground">Column visibility can be managed from the table header.</p>
+              <p class="text-xs text-muted-foreground">{{ t('components.viewHeader.columnVisibilityMobileHint') }}</p>
             </slot>
           </template>
         </ViewHeaderDisplayControls>

--- a/client/src/components/sidebar/SidebarSectionHeader.vue
+++ b/client/src/components/sidebar/SidebarSectionHeader.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronDown, Plus, GripVertical, Check, MoreVertical } from '@lucide/vue'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { useThemeStore } from '@/stores/theme'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   label: string
@@ -54,13 +57,13 @@ const hasMenu = () => props.canAdd || props.canReorder
       <DropdownMenuContent align="end" :side-offset="4">
         <DropdownMenuItem v-if="canAdd" @click="emit('add')">
           <Plus class="size-4" />
-          {{ addTitle ?? 'Add' }}
+          {{ addTitle ?? t('components.sidebar.sectionHeader.add') }}
         </DropdownMenuItem>
         <DropdownMenuSeparator v-if="canAdd && canReorder" />
         <DropdownMenuItem v-if="canReorder" @click="emit('toggleReorder')">
           <Check v-if="isReordering" class="size-4 text-primary" />
           <GripVertical v-else class="size-4" />
-          {{ isReordering ? 'Done reordering' : 'Reorder' }}
+          {{ isReordering ? t('components.sidebar.sectionHeader.doneReordering') : t('components.sidebar.sectionHeader.reorder') }}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/client/src/components/ui/ChipInput.vue
+++ b/client/src/components/ui/ChipInput.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X } from '@lucide/vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   modelValue: string[]
@@ -91,7 +94,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
         v-model="query"
         enterkeyhint="enter"
         class="flex-1 min-w-24 bg-transparent outline-none placeholder:text-muted-foreground/50 disabled:cursor-not-allowed"
-        :placeholder="placeholder ?? (modelValue.length === 0 ? 'Type and press Enter to add' : 'Press Enter to add')"
+        :placeholder="placeholder ?? (modelValue.length === 0 ? t('components.ui.chipInput.typeAndEnter') : t('components.ui.chipInput.pressEnter'))"
         :disabled="props.disabled"
         @input="onInput"
         @keydown="onKeydown"

--- a/client/src/components/ui/sidebar/Sidebar.vue
+++ b/client/src/components/ui/sidebar/Sidebar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { SidebarProps } from '.'
+import { useI18n } from 'vue-i18n'
 import { cn } from '@/lib/utils'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import SheetDescription from '@/components/ui/sheet/SheetDescription.vue'
@@ -18,6 +19,7 @@ const props = withDefaults(defineProps<SidebarProps>(), {
 })
 
 const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+const { t } = useI18n()
 </script>
 
 <template>
@@ -42,8 +44,8 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
       }"
     >
       <SheetHeader class="sr-only">
-        <SheetTitle>Sidebar</SheetTitle>
-        <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+        <SheetTitle>{{ t('components.ui.sidebar.title') }}</SheetTitle>
+        <SheetDescription>{{ t('components.ui.sidebar.mobileDescription') }}</SheetDescription>
       </SheetHeader>
       <div class="flex h-full w-full flex-col">
         <slot />

--- a/client/src/components/ui/sidebar/SidebarRail.vue
+++ b/client/src/components/ui/sidebar/SidebarRail.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { onBeforeUnmount, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { cn } from '@/lib/utils'
 import { useSidebar } from './utils'
 
@@ -9,6 +10,7 @@ const props = defineProps<{
 }>()
 
 const { toggleSidebar, setWidth, widthPx, state } = useSidebar()
+const { t } = useI18n()
 
 const DRAG_THRESHOLD_PX = 3
 
@@ -88,7 +90,7 @@ onBeforeUnmount(() => {
   <button
     data-sidebar="rail"
     data-slot="sidebar-rail"
-    aria-label="Toggle Sidebar"
+    :aria-label="t('components.ui.sidebar.toggle')"
     :tabindex="-1"
     :class="
       cn(

--- a/client/src/components/ui/sidebar/SidebarTrigger.vue
+++ b/client/src/components/ui/sidebar/SidebarTrigger.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { PanelLeft } from '@lucide/vue'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
@@ -10,11 +11,12 @@ const props = defineProps<{
 }>()
 
 const { toggleSidebar } = useSidebar()
+const { t } = useI18n()
 </script>
 
 <template>
   <Button data-sidebar="trigger" data-slot="sidebar-trigger" variant="ghost" size="icon" :class="cn('h-7 w-7', props.class)" @click="toggleSidebar">
     <PanelLeft />
-    <span class="sr-only">Toggle Sidebar</span>
+    <span class="sr-only">{{ t('components.ui.sidebar.toggle') }}</span>
   </Button>
 </template>

--- a/client/src/components/view-header/ViewHeaderDesktopSearch.vue
+++ b/client/src/components/view-header/ViewHeaderDesktopSearch.vue
@@ -1,17 +1,19 @@
 <script setup lang="ts">
 import { nextTick, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Search, X } from '@lucide/vue'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     searchQuery?: string
     placeholder?: string
   }>(),
   {
     searchQuery: '',
-    placeholder: 'Search title, author, series, narrator...',
   },
 )
+
+const { t } = useI18n()
 
 const emit = defineEmits<{
   'update:searchQuery': [value: string]
@@ -61,7 +63,7 @@ function handleSearchKeydown(event: KeyboardEvent) {
       @input="handleSearchInput"
       @keydown="handleSearchKeydown"
       type="text"
-      :placeholder="placeholder"
+      :placeholder="props.placeholder ?? t('components.viewHeader.searchPlaceholder')"
       class="h-8 text-[13px] transition-all duration-300 focus:outline-none"
       :class="
         searchActive

--- a/client/src/components/view-header/ViewHeaderDisplayControls.vue
+++ b/client/src/components/view-header/ViewHeaderDisplayControls.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Circle, Square } from '@lucide/vue'
 import type { BookViewMode } from '@/composables/useDisplaySettings'
+
+const { t } = useI18n()
 
 withDefaults(
   defineProps<{
@@ -34,12 +37,12 @@ const emit = defineEmits<{
 
 <template>
   <div class="space-y-4">
-    <p class="text-xs font-semibold text-foreground uppercase tracking-wider">Display</p>
+    <p class="text-xs font-semibold text-foreground uppercase tracking-wider">{{ t('components.viewHeader.displayControls.display') }}</p>
 
     <template v-if="viewMode !== 'table'">
       <div class="space-y-1.5">
         <div class="flex items-center justify-between">
-          <span class="text-xs text-muted-foreground">Cover size</span>
+          <span class="text-xs text-muted-foreground">{{ t('components.viewHeader.displayControls.coverSize') }}</span>
           <span class="text-xs font-medium tabular-nums text-foreground">{{ coverSize }}px</span>
         </div>
         <input
@@ -55,7 +58,7 @@ const emit = defineEmits<{
 
       <div class="space-y-1.5">
         <div class="flex items-center justify-between">
-          <span class="text-xs text-muted-foreground">Grid gap</span>
+          <span class="text-xs text-muted-foreground">{{ t('components.viewHeader.displayControls.gridGap') }}</span>
           <span class="text-xs font-medium tabular-nums text-foreground">{{ gridGap }}px</span>
         </div>
         <input
@@ -72,12 +75,12 @@ const emit = defineEmits<{
 
     <template v-else>
       <slot name="columns">
-        <p class="text-xs text-muted-foreground">Use the column visibility panel in the table header to show or hide columns.</p>
+        <p class="text-xs text-muted-foreground">{{ t('components.viewHeader.displayControls.columnsHint') }}</p>
       </slot>
     </template>
 
     <div v-if="coverShape !== undefined && viewMode !== 'table'" class="space-y-1.5">
-      <span class="text-xs text-muted-foreground">Cover shape</span>
+      <span class="text-xs text-muted-foreground">{{ t('components.viewHeader.displayControls.coverShape') }}</span>
       <div class="mt-1.5 flex items-center gap-1">
         <button
           class="flex flex-1 items-center justify-center gap-1.5 rounded-md border py-1.5 text-xs font-medium transition-colors"
@@ -88,7 +91,7 @@ const emit = defineEmits<{
           "
           @click="emit('update:coverShape', 'circle')"
         >
-          <Circle :size="12" /> Circle
+          <Circle :size="12" /> {{ t('components.viewHeader.displayControls.circle') }}
         </button>
 
         <button
@@ -100,7 +103,7 @@ const emit = defineEmits<{
           "
           @click="emit('update:coverShape', 'square')"
         >
-          <Square :size="12" /> Square
+          <Square :size="12" /> {{ t('components.viewHeader.displayControls.square') }}
         </button>
       </div>
     </div>

--- a/client/src/components/view-header/ViewHeaderMobileMenu.vue
+++ b/client/src/components/view-header/ViewHeaderMobileMenu.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed, useSlots } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { CheckSquare, MoreHorizontal, Search, SlidersHorizontal, Square } from '@lucide/vue'
+
+const { t } = useI18n()
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -71,8 +74,12 @@ const hasActions = computed(
     <DropdownMenuContent align="end" class="w-44">
       <template v-if="showViewModeToggle && (allowedViewModes.includes('grid') || allowedViewModes.includes('list'))">
         <DropdownMenuRadioGroup :model-value="viewMode" @update:model-value="handleViewModeUpdate">
-          <DropdownMenuRadioItem v-if="allowedViewModes.includes('grid')" value="grid">Grid</DropdownMenuRadioItem>
-          <DropdownMenuRadioItem v-if="allowedViewModes.includes('list')" value="list">List</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem v-if="allowedViewModes.includes('grid')" value="grid">{{
+            t('components.viewHeader.mobileMenu.grid')
+          }}</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem v-if="allowedViewModes.includes('list')" value="list">{{
+            t('components.viewHeader.mobileMenu.list')
+          }}</DropdownMenuRadioItem>
         </DropdownMenuRadioGroup>
         <DropdownMenuSeparator />
       </template>
@@ -80,7 +87,7 @@ const hasActions = computed(
       <template v-if="showDisplayAction">
         <DropdownMenuItem @click="emit('open-display')">
           <SlidersHorizontal :size="14" class="mr-2" />
-          Display
+          {{ t('components.viewHeader.displayControls.display') }}
         </DropdownMenuItem>
       </template>
 
@@ -93,7 +100,7 @@ const hasActions = computed(
         <DropdownMenuSeparator />
         <DropdownMenuItem @click="emit('open-mobile-search')">
           <Search :size="14" class="mr-2" />
-          Search
+          {{ t('common.search') }}
         </DropdownMenuItem>
       </template>
 
@@ -102,7 +109,7 @@ const hasActions = computed(
         <DropdownMenuItem @click="emit('toggle-selection')">
           <CheckSquare v-if="selectionMode" :size="14" class="mr-2" />
           <Square v-else :size="14" class="mr-2" />
-          {{ selectionMode ? 'Exit Select' : 'Select' }}
+          {{ selectionMode ? t('components.viewHeader.mobileMenu.exitSelect') : t('components.viewHeader.mobileMenu.select') }}
         </DropdownMenuItem>
       </template>
     </DropdownMenuContent>

--- a/client/src/components/view-header/ViewHeaderMobileSearchSheet.vue
+++ b/client/src/components/view-header/ViewHeaderMobileSearchSheet.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Search, X } from '@lucide/vue'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
@@ -12,9 +13,10 @@ const props = withDefaults(
   }>(),
   {
     searchQuery: '',
-    placeholder: 'Search title, author, series, narrator...',
   },
 )
+
+const { t } = useI18n()
 
 const emit = defineEmits<{
   'update:open': [value: boolean]
@@ -54,8 +56,8 @@ function handleKeydown(event: KeyboardEvent) {
   <Sheet :open="open" @update:open="emit('update:open', $event)">
     <SheetContent side="top">
       <SheetHeader>
-        <SheetTitle>Search</SheetTitle>
-        <SheetDescription class="sr-only">Search items by title, author, series, or narrator.</SheetDescription>
+        <SheetTitle>{{ t('common.search') }}</SheetTitle>
+        <SheetDescription class="sr-only">{{ t('components.viewHeader.mobileSearch.description') }}</SheetDescription>
       </SheetHeader>
       <div class="space-y-3 px-4 pb-6">
         <div class="flex h-9 items-center rounded-md border border-input bg-background px-2.5">
@@ -66,7 +68,7 @@ function handleKeydown(event: KeyboardEvent) {
             @input="handleInput"
             @keydown="handleKeydown"
             type="search"
-            :placeholder="placeholder"
+            :placeholder="props.placeholder ?? t('components.viewHeader.searchPlaceholder')"
             class="view-header-mobile-search-input h-full w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/85"
           />
           <button
@@ -77,7 +79,7 @@ function handleKeydown(event: KeyboardEvent) {
             <X :size="12" />
           </button>
         </div>
-        <Button variant="outline" size="sm" class="w-full" @click="close">Done</Button>
+        <Button variant="outline" size="sm" class="w-full" @click="close">{{ t('components.viewHeader.mobileSearch.done') }}</Button>
       </div>
     </SheetContent>
   </Sheet>

--- a/client/src/composables/useLocaleSync.ts
+++ b/client/src/composables/useLocaleSync.ts
@@ -1,0 +1,132 @@
+import { isSupportedLocale, type Locale, type LocalePreferences } from '@bookorbit/types'
+import { watch } from 'vue'
+import { toast } from 'vue-sonner'
+import { useAuth } from '@/features/auth/composables/useAuth'
+import { api, getAccessToken } from '@/lib/api'
+import { useLocaleStore } from '@/stores/locale'
+
+let initialized = false
+let isApplyingServerPrefs = false
+let pendingSave: ReturnType<typeof setTimeout> | null = null
+let pagehideRegistered = false
+
+function isSyncEnabled(): boolean {
+  const { user } = useAuth()
+  return user.value?.settings?.syncThemePreferences === true
+}
+
+function getCurrentPrefs(): LocalePreferences {
+  const store = useLocaleStore()
+  return { locale: store.locale }
+}
+
+function sanitizeServerPrefs(raw: unknown): Locale | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const value = (raw as Record<string, unknown>).locale
+  return isSupportedLocale(value) ? value : null
+}
+
+function flushPendingSave(): void {
+  if (pendingSave === null || !isSyncEnabled()) return
+
+  clearTimeout(pendingSave)
+  pendingSave = null
+
+  const accessToken = getAccessToken()
+  if (!accessToken) return
+
+  void fetch('/api/v1/user-preferences/locale', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    credentials: 'include',
+    keepalive: true,
+    body: JSON.stringify({ settings: getCurrentPrefs() }),
+  })
+}
+
+export async function loadLocaleFromServer(): Promise<void> {
+  try {
+    const res = await api('/api/v1/user-preferences/locale')
+    if (!res.ok) return
+
+    const body = (await res.json()) as { settings: unknown }
+    const locale = sanitizeServerPrefs(body.settings)
+    if (locale === null) return
+
+    const store = useLocaleStore()
+    isApplyingServerPrefs = true
+    try {
+      // Apply without persisting locally; the server copy is the source of truth while syncing.
+      await store.setLocale(locale, false)
+    } finally {
+      isApplyingServerPrefs = false
+    }
+  } catch {
+    // Silent on startup.
+  }
+}
+
+export async function seedLocaleToServer(prefs: LocalePreferences): Promise<void> {
+  try {
+    await api('/api/v1/user-preferences/locale', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ settings: prefs }),
+    })
+  } catch {
+    // Silent seed failure.
+  }
+}
+
+export async function saveLocaleToServer(prefs: LocalePreferences): Promise<void> {
+  if (!isSyncEnabled()) return
+
+  try {
+    const res = await api('/api/v1/user-preferences/locale', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ settings: prefs }),
+    })
+
+    if (!res.ok) {
+      toast.error('Failed to save language preference')
+    }
+  } catch {
+    toast.error('Failed to save language preference')
+  }
+}
+
+export function cancelPendingLocaleSync(): void {
+  if (pendingSave !== null) {
+    clearTimeout(pendingSave)
+    pendingSave = null
+  }
+}
+
+export function initLocaleSync(): void {
+  if (initialized) return
+  initialized = true
+
+  const store = useLocaleStore()
+
+  watch(
+    () => store.locale,
+    () => {
+      if (isApplyingServerPrefs || !isSyncEnabled()) return
+
+      if (pendingSave !== null) clearTimeout(pendingSave)
+      pendingSave = setTimeout(() => {
+        pendingSave = null
+        void saveLocaleToServer(getCurrentPrefs())
+      }, 1500)
+    },
+  )
+
+  if (!pagehideRegistered && typeof window !== 'undefined') {
+    pagehideRegistered = true
+    window.addEventListener('pagehide', flushPendingSave)
+  }
+}

--- a/client/src/features/achievements/components/AchievementCard.vue
+++ b/client/src/features/achievements/components/AchievementCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Check, Lock } from '@lucide/vue'
 import type { AchievementItem, AchievementRarity } from '@bookorbit/types'
 import { resolveLucideIcon } from '../utils/resolveLucideIcon'
@@ -8,16 +9,18 @@ const props = defineProps<{
   achievement: AchievementItem
 }>()
 
+const { t } = useI18n()
+
 const isExpanded = ref(false)
 
 const isHiddenAndLocked = computed<boolean>(() => props.achievement.hidden && !props.achievement.earned)
 
-const rarityLabel: Record<AchievementRarity, string> = {
-  common: 'Common',
-  rare: 'Rare',
-  epic: 'Epic',
-  legendary: 'Legendary',
-}
+const rarityLabel = computed<Record<AchievementRarity, string>>(() => ({
+  common: t('achievements.rarity.common'),
+  rare: t('achievements.rarity.rare'),
+  epic: t('achievements.rarity.epic'),
+  legendary: t('achievements.rarity.legendary'),
+}))
 
 const rarityPillClass: Record<AchievementRarity, string> = {
   common: 'bg-blue-500/15 text-blue-700 dark:text-blue-300',
@@ -113,14 +116,13 @@ function formatAchievementDate(dateStr: string | null): string | null {
     return null
   }
 
-  return (
-    'Earned ' +
-    new Date(dateStr).toLocaleDateString(undefined, {
+  return t('achievements.earnedOn', {
+    date: new Date(dateStr).toLocaleDateString(undefined, {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
-    })
-  )
+    }),
+  })
 }
 
 function handleClick(): void {
@@ -143,7 +145,7 @@ function handleClick(): void {
       <div :class="['min-w-0 flex-1', achievement.earned ? 'pr-6' : '']">
         <div class="flex items-start justify-between gap-2">
           <span :class="['text-sm font-semibold leading-tight', isLocked ? 'text-current' : 'text-foreground']">
-            {{ isHiddenAndLocked ? 'Secret Achievement' : achievement.name }}
+            {{ isHiddenAndLocked ? t('achievements.secretAchievement') : achievement.name }}
           </span>
           <span v-if="!isHiddenAndLocked" :class="['shrink-0 rounded-full px-2 py-0.5 text-xs font-medium', rarityClass(achievement.rarity)]">
             {{ rarityLabel[achievement.rarity] }}
@@ -169,7 +171,7 @@ function handleClick(): void {
       <p v-if="earnedDate" class="text-muted-foreground mt-5 text-xs">{{ earnedDate }}</p>
 
       <div v-if="isExpanded && achievement.earned" class="border-border mt-3 border-t pt-3">
-        <p v-if="contextBookTitle" class="text-muted-foreground text-xs">While reading &ldquo;{{ contextBookTitle }}&rdquo;</p>
+        <p v-if="contextBookTitle" class="text-muted-foreground text-xs">{{ t('achievements.whileReading', { title: contextBookTitle }) }}</p>
         <p class="text-muted-foreground mt-1 text-xs">{{ achievement.description }}</p>
       </div>
     </template>

--- a/client/src/features/achievements/components/AchievementCategorySection.vue
+++ b/client/src/features/achievements/components/AchievementCategorySection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, type Component } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { BookOpen, Compass, Flame, Library, TabletSmartphone } from '@lucide/vue'
 import type { AchievementCategory, AchievementCategoryGroup } from '@bookorbit/types'
 import { groupAchievements } from '../composables/useGroupedAchievements'
@@ -12,6 +13,8 @@ const props = defineProps<{
   group: AchievementCategoryGroup
   filter: FilterState
 }>()
+
+const { t } = useI18n()
 
 const CATEGORY_ICONS: Record<AchievementCategory, Component> = {
   reading: BookOpen,
@@ -96,7 +99,7 @@ const filteredItems = computed<DisplayItem[]>(() => {
       </div>
     </div>
 
-    <p v-if="filteredItems.length === 0" class="text-muted-foreground py-4 text-center text-sm">No achievements match this filter</p>
+    <p v-if="filteredItems.length === 0" class="text-muted-foreground py-4 text-center text-sm">{{ t('achievements.noMatchFilter') }}</p>
 
     <div v-else class="grid grid-cols-[repeat(auto-fill,minmax(min(100%,17rem),1fr))] gap-6">
       <template v-for="item in filteredItems" :key="item.type === 'tiered' ? item.groupKey : item.achievement.key">

--- a/client/src/features/achievements/components/AchievementFilterBar.vue
+++ b/client/src/features/achievements/components/AchievementFilterBar.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Medal, Trophy } from '@lucide/vue'
 import type { FilterState } from '../types'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   activeFilter: FilterState
@@ -48,8 +51,10 @@ function pillClass(filter: FilterState): string {
           <Trophy class="size-6 text-primary" />
         </div>
         <div class="min-w-0">
-          <h1 class="text-base font-semibold tracking-tight text-foreground/90 sm:text-md">Achievements</h1>
-          <span class="text-muted-foreground text-sm tabular-nums">{{ totalEarned }} / {{ totalAvailable }} tiers</span>
+          <h1 class="text-base font-semibold tracking-tight text-foreground/90 sm:text-md">{{ t('achievements.title') }}</h1>
+          <span class="text-muted-foreground text-sm tabular-nums">{{
+            t('achievements.tiersCount', { earned: totalEarned, total: totalAvailable })
+          }}</span>
         </div>
       </div>
 
@@ -57,18 +62,20 @@ function pillClass(filter: FilterState): string {
 
       <div class="-mx-1 overflow-x-auto px-1 pb-0.5 sm:mx-0 sm:px-0 sm:pb-0">
         <div class="inline-flex min-w-max items-center gap-1 rounded-md border border-border/50 bg-background/70 p-1">
-          <button :class="['shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors', pillClass('all')]" @click="handleAll">All</button>
+          <button :class="['shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors', pillClass('all')]" @click="handleAll">
+            {{ t('achievements.filter.all') }}
+          </button>
           <button :class="['shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors', pillClass('earned')]" @click="handleEarned">
-            Earned ({{ earnedCount }})
+            {{ t('achievements.filter.earned', { count: earnedCount }) }}
           </button>
           <button
             :class="['shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors', pillClass('in-progress')]"
             @click="handleInProgress"
           >
-            In Progress ({{ inProgressCount }})
+            {{ t('achievements.filter.inProgress', { count: inProgressCount }) }}
           </button>
           <button :class="['shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors', pillClass('locked')]" @click="handleLocked">
-            Locked ({{ lockedCount }})
+            {{ t('achievements.filter.locked', { count: lockedCount }) }}
           </button>
         </div>
       </div>

--- a/client/src/features/achievements/components/AchievementsTab.vue
+++ b/client/src/features/achievements/components/AchievementsTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Loader2 } from '@lucide/vue'
 import { useAchievements } from '../composables/useAchievements'
 import { groupAchievements } from '../composables/useGroupedAchievements'
@@ -7,6 +8,7 @@ import type { FilterState } from '../types'
 import AchievementCategorySection from './AchievementCategorySection.vue'
 import AchievementFilterBar from './AchievementFilterBar.vue'
 
+const { t } = useI18n()
 const { categories, totalEarned, totalAvailable, loading, error, reload } = useAchievements()
 
 const activeFilter = ref<FilterState>('all')
@@ -44,8 +46,8 @@ function handleFilterChange(filter: FilterState): void {
     </div>
 
     <div v-else-if="error" class="flex flex-col items-center gap-3 py-16">
-      <p class="text-muted-foreground text-sm">Failed to load achievements</p>
-      <button class="text-primary hover:text-primary/80 text-sm font-medium" @click="reload">Try again</button>
+      <p class="text-muted-foreground text-sm">{{ t('achievements.loadFailed') }}</p>
+      <button class="text-primary hover:text-primary/80 text-sm font-medium" @click="reload">{{ t('achievements.tryAgain') }}</button>
     </div>
 
     <template v-else>

--- a/client/src/features/achievements/components/TieredAchievementCard.vue
+++ b/client/src/features/achievements/components/TieredAchievementCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Check, CheckCircle2, Circle } from '@lucide/vue'
 import type { AchievementRarity } from '@bookorbit/types'
 import type { TieredGroup } from '../types'
@@ -9,14 +10,16 @@ const props = defineProps<{
   group: TieredGroup
 }>()
 
+const { t } = useI18n()
+
 const isExpanded = ref(false)
 
-const rarityLabel: Record<AchievementRarity, string> = {
-  common: 'Common',
-  rare: 'Rare',
-  epic: 'Epic',
-  legendary: 'Legendary',
-}
+const rarityLabel = computed<Record<AchievementRarity, string>>(() => ({
+  common: t('achievements.rarity.common'),
+  rare: t('achievements.rarity.rare'),
+  epic: t('achievements.rarity.epic'),
+  legendary: t('achievements.rarity.legendary'),
+}))
 
 const rarityPillClass: Record<AchievementRarity, string> = {
   common: 'bg-blue-500/15 text-blue-700 dark:text-blue-300',
@@ -147,10 +150,16 @@ function handleClick(): void {
       <div class="flex shrink-0 items-center gap-1">
         <div v-for="tier in group.tiers" :key="tier.key" :class="['size-2 rounded-full', pipClass(tier.rarity, tier.earned)]" />
       </div>
-      <span class="shrink-0">Tier {{ group.earnedCount }} of {{ group.totalTiers }}</span>
+      <span class="shrink-0">{{ t('achievements.tierProgress', { earned: group.earnedCount, total: group.totalTiers }) }}</span>
       <template v-if="progressPercent != null">
         <span :class="['shrink-0', isLocked ? 'text-current/70' : 'text-muted-foreground/50']">·</span>
-        <span class="min-w-0">{{ group.currentProgress }} / {{ group.nextUnearned?.threshold }} to {{ group.nextUnearned?.name }}</span>
+        <span class="min-w-0">{{
+          t('achievements.progressToNext', {
+            current: group.currentProgress,
+            threshold: group.nextUnearned?.threshold,
+            name: group.nextUnearned?.name,
+          })
+        }}</span>
       </template>
     </div>
 

--- a/client/src/features/admin/ResetLinkModal.vue
+++ b/client/src/features/admin/ResetLinkModal.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X } from '@lucide/vue'
 import { copyToClipboard } from '@/lib/clipboard'
+
+const { t } = useI18n()
 
 defineProps<{ resetUrl: string }>()
 const emit = defineEmits<{ close: [] }>()
@@ -42,13 +45,13 @@ async function copy(url: string) {
   <div class="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 px-4" @click.self="emit('close')">
     <div class="w-full max-w-md rounded-lg border border-border bg-card p-6 shadow-xl">
       <div class="flex items-start justify-between mb-4">
-        <h2 class="text-base font-semibold text-foreground">Password Reset Link</h2>
+        <h2 class="text-base font-semibold text-foreground">{{ t('adminFeature.resetLink.title') }}</h2>
         <button @click="emit('close')" class="text-muted-foreground hover:text-foreground transition-colors">
           <X :size="16" />
         </button>
       </div>
 
-      <p class="text-sm text-muted-foreground mb-3">Share this link with the user. It expires in 15 minutes.</p>
+      <p class="text-sm text-muted-foreground mb-3">{{ t('adminFeature.resetLink.description') }}</p>
 
       <div class="flex gap-2">
         <input
@@ -60,11 +63,11 @@ async function copy(url: string) {
           @click="copy(resetUrl)"
           class="rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors whitespace-nowrap"
         >
-          {{ copied ? 'Copied!' : copyFailed ? 'Copy failed' : 'Copy' }}
+          {{ copied ? t('adminFeature.resetLink.copied') : copyFailed ? t('adminFeature.resetLink.copyFailed') : t('adminFeature.resetLink.copy') }}
         </button>
       </div>
 
-      <p class="mt-3 text-xs text-amber-600 dark:text-amber-400">This link will not be shown again.</p>
+      <p class="mt-3 text-xs text-amber-600 dark:text-amber-400">{{ t('adminFeature.resetLink.notShownAgain') }}</p>
     </div>
   </div>
 </template>

--- a/client/src/features/admin/UserFormDrawer.vue
+++ b/client/src/features/admin/UserFormDrawer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X } from '@lucide/vue'
 import { api } from '@/lib/api'
 import { Permission, PERMISSION_LABELS } from '@bookorbit/types'
@@ -30,28 +31,39 @@ const emit = defineEmits<{
   saved: [resetUrl?: string]
 }>()
 
-const PERMISSION_GROUPS: { label: string; permissions: Permission[] }[] = [
+const { t } = useI18n()
+
+const PERMISSION_GROUPS: { id: string; label: string; permissions: Permission[] }[] = [
   {
+    id: 'content',
     label: 'Content',
     permissions: [Permission.LibraryDownload, Permission.LibraryUpload, Permission.LibraryEditMetadata, Permission.LibraryDeleteBooks],
   },
   {
+    id: 'devicesAccess',
     label: 'Devices & Access',
     permissions: [Permission.KoboSync, Permission.KoreaderSync, Permission.HardcoverSync, Permission.OpdsAccess, Permission.BookDockAccess],
   },
   {
+    id: 'email',
     label: 'Email',
     permissions: [Permission.EmailSend, Permission.ManageEmail],
   },
   {
+    id: 'administration',
     label: 'Administration',
     permissions: [Permission.ManageLibraries, Permission.ManageMetadataConfig, Permission.ManageAppSettings, Permission.ManageUsers],
   },
   {
+    id: 'restrictions',
     label: 'Restrictions',
     permissions: [Permission.DemoRestricted],
   },
 ]
+
+const permissionGroups = computed(() =>
+  PERMISSION_GROUPS.map((group) => ({ ...group, label: t(`adminFeature.userForm.permissionGroups.${group.id}`) })),
+)
 
 const name = ref('')
 const username = ref('')
@@ -156,7 +168,7 @@ watch(
     }
 
     libraryAccessOpen.value = !isMobile.value
-    permissionGroupOpen.value = Object.fromEntries(PERMISSION_GROUPS.map((group) => [group.label, !isMobile.value]))
+    permissionGroupOpen.value = Object.fromEntries(PERMISSION_GROUPS.map((group) => [group.id, !isMobile.value]))
     contentFiltersOpen.value = false
     currentTab.value = 'general'
   },
@@ -165,7 +177,7 @@ watch(
 
 watch(isMobile, (mobile) => {
   libraryAccessOpen.value = !mobile
-  permissionGroupOpen.value = Object.fromEntries(PERMISSION_GROUPS.map((group) => [group.label, !mobile]))
+  permissionGroupOpen.value = Object.fromEntries(PERMISSION_GROUPS.map((group) => [group.id, !mobile]))
 })
 
 function togglePermission(permName: string) {
@@ -190,7 +202,7 @@ async function handleSubmit() {
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        error.value = err.message ?? 'Failed to update user'
+        error.value = err.message ?? t('adminFeature.userForm.errors.updateUser')
         return
       }
 
@@ -201,7 +213,7 @@ async function handleSubmit() {
       })
       if (!permRes.ok) {
         const err = await permRes.json().catch(() => ({}))
-        error.value = err.message ?? 'Failed to update permissions'
+        error.value = err.message ?? t('adminFeature.userForm.errors.updatePermissions')
         return
       }
 
@@ -212,7 +224,7 @@ async function handleSubmit() {
       })
       if (!libRes.ok) {
         const err = await libRes.json().catch(() => ({}))
-        error.value = err.message ?? 'Failed to update library access'
+        error.value = err.message ?? t('adminFeature.userForm.errors.updateLibraryAccess')
         return
       }
 
@@ -229,13 +241,13 @@ async function handleSubmit() {
         })
         if (!cfRes.ok) {
           const err = await cfRes.json().catch(() => ({}))
-          error.value = err.message ?? 'Failed to update content filters'
+          error.value = err.message ?? t('adminFeature.userForm.errors.updateContentFilters')
           return
         }
       }
     } else {
       if (!isSharedAccount.value && !trimmedEmail) {
-        error.value = 'Email is required'
+        error.value = t('adminFeature.userForm.errors.emailRequired')
         return
       }
 
@@ -253,7 +265,7 @@ async function handleSubmit() {
         })
         if (!res.ok) {
           const err = await res.json().catch(() => ({}))
-          error.value = err.message ?? 'Failed to create shared account'
+          error.value = err.message ?? t('adminFeature.userForm.errors.createSharedAccount')
           return
         }
         emit('saved')
@@ -273,7 +285,7 @@ async function handleSubmit() {
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        error.value = err.message ?? 'Failed to create user'
+        error.value = err.message ?? t('adminFeature.userForm.errors.createUser')
         return
       }
       const data = await res.json()
@@ -295,17 +307,23 @@ async function handleSubmit() {
       <div class="flex items-center justify-between px-6 pt-5 pb-4">
         <div class="flex items-center gap-3">
           <h2 class="text-base font-semibold text-foreground">
-            {{ isEdit ? name || username || 'Edit User' : isSharedAccount ? 'Create Shared Account' : 'Create User' }}
+            {{
+              isEdit
+                ? name || username || t('adminFeature.userForm.editUser')
+                : isSharedAccount
+                  ? t('adminFeature.userForm.createSharedAccount')
+                  : t('adminFeature.userForm.createUser')
+            }}
           </h2>
           <Badge
             v-if="isSharedAccount"
             variant="secondary"
             class="bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20 hover:bg-amber-500/20"
-            >Shared</Badge
+            >{{ t('adminFeature.userForm.sharedBadge') }}</Badge
           >
           <div v-if="isEdit" class="flex items-center gap-2">
             <ToggleSwitch v-model="active" />
-            <span class="text-xs text-muted-foreground">{{ active ? 'Active' : 'Suspended' }}</span>
+            <span class="text-xs text-muted-foreground">{{ active ? t('adminFeature.userForm.active') : t('adminFeature.userForm.suspended') }}</span>
           </div>
         </div>
         <button @click="emit('close')" class="text-muted-foreground hover:text-foreground">
@@ -322,7 +340,7 @@ async function handleSubmit() {
           :class="currentTab === tab ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
           @click="currentTab = tab"
         >
-          {{ tab }}
+          {{ t(`adminFeature.userForm.tabs.${tab}`) }}
         </button>
       </div>
 
@@ -332,18 +350,18 @@ async function handleSubmit() {
             <label class="flex items-start gap-3 cursor-pointer">
               <input id="isShared" v-model="isSharedAccount" type="checkbox" class="mt-0.5 h-4 w-4 rounded border-input" />
               <div>
-                <p class="text-sm font-medium text-foreground">Shared account</p>
-                <p class="text-xs text-muted-foreground mt-0.5">No password. Access is granted via magic links only.</p>
+                <p class="text-sm font-medium text-foreground">{{ t('adminFeature.userForm.sharedAccount') }}</p>
+                <p class="text-xs text-muted-foreground mt-0.5">{{ t('adminFeature.userForm.sharedAccountHint') }}</p>
               </div>
             </label>
           </div>
           <div v-else-if="isSharedAccount" class="rounded-md border border-amber-500/30 bg-amber-500/5 px-4 py-3">
-            <p class="text-sm text-amber-600 dark:text-amber-400 font-medium">Shared account</p>
-            <p class="text-xs text-muted-foreground mt-0.5">Manage login links from Settings - Magic Links.</p>
+            <p class="text-sm text-amber-600 dark:text-amber-400 font-medium">{{ t('adminFeature.userForm.sharedAccount') }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('adminFeature.userForm.sharedAccountManageHint') }}</p>
           </div>
 
           <div v-if="!isEdit" class="space-y-1.5">
-            <label class="settings-label">Username</label>
+            <label class="settings-label">{{ t('adminFeature.userForm.username') }}</label>
             <input
               v-model="username"
               type="text"
@@ -352,7 +370,7 @@ async function handleSubmit() {
             />
           </div>
           <div class="space-y-1.5">
-            <label class="settings-label">Full name</label>
+            <label class="settings-label">{{ t('adminFeature.userForm.fullName') }}</label>
             <input
               v-model="name"
               type="text"
@@ -362,8 +380,8 @@ async function handleSubmit() {
           </div>
           <div class="space-y-1.5">
             <label class="settings-label">
-              Email
-              <span v-if="isSharedAccount && !isEdit" class="text-muted-foreground font-normal">(optional)</span>
+              {{ t('adminFeature.userForm.email') }}
+              <span v-if="isSharedAccount && !isEdit" class="text-muted-foreground font-normal">{{ t('adminFeature.userForm.optional') }}</span>
             </label>
             <input
               v-model="email"
@@ -376,7 +394,7 @@ async function handleSubmit() {
 
         <div v-if="currentTab === 'access'" class="space-y-6">
           <div v-if="libraries.length > 0" class="space-y-3">
-            <label class="settings-label">Library Access</label>
+            <label class="settings-label">{{ t('adminFeature.userForm.libraryAccess') }}</label>
             <div class="space-y-1.5 rounded-md border border-border p-3">
               <label v-for="lib in libraries" :key="lib.id" class="flex cursor-pointer items-center gap-2">
                 <input
@@ -388,23 +406,29 @@ async function handleSubmit() {
                 <span class="text-sm text-foreground">{{ lib.name }}</span>
               </label>
             </div>
-            <p v-if="selectedLibraryIds.size === 0" class="text-xs text-muted-foreground">No libraries selected. User cannot view any books.</p>
+            <p v-if="selectedLibraryIds.size === 0" class="text-xs text-muted-foreground">{{ t('adminFeature.userForm.noLibrariesSelected') }}</p>
           </div>
 
           <div class="space-y-3">
             <div class="flex items-center justify-between">
-              <label class="settings-label">Permissions</label>
+              <label class="settings-label">{{ t('adminFeature.userForm.permissions') }}</label>
               <div class="flex items-center gap-2">
-                <button type="button" @click="applyPreset('standard')" class="text-xs text-muted-foreground hover:text-foreground">Standard</button>
+                <button type="button" @click="applyPreset('standard')" class="text-xs text-muted-foreground hover:text-foreground">
+                  {{ t('adminFeature.userForm.presetStandard') }}
+                </button>
                 <span class="text-muted-foreground/30">•</span>
-                <button type="button" @click="applyPreset('admin')" class="text-xs text-muted-foreground hover:text-foreground">Admin</button>
+                <button type="button" @click="applyPreset('admin')" class="text-xs text-muted-foreground hover:text-foreground">
+                  {{ t('adminFeature.userForm.presetAdmin') }}
+                </button>
                 <span class="text-muted-foreground/30">•</span>
-                <button type="button" @click="applyPreset('clear')" class="text-xs text-muted-foreground hover:text-foreground">Clear All</button>
+                <button type="button" @click="applyPreset('clear')" class="text-xs text-muted-foreground hover:text-foreground">
+                  {{ t('adminFeature.userForm.presetClearAll') }}
+                </button>
               </div>
             </div>
 
             <div class="space-y-5">
-              <div v-for="group in PERMISSION_GROUPS" :key="group.label" class="space-y-2">
+              <div v-for="group in permissionGroups" :key="group.id" class="space-y-2">
                 <p class="text-xs font-medium uppercase tracking-wide text-muted-foreground">{{ group.label }}</p>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
                   <label v-for="permName in group.permissions" :key="permName" class="flex cursor-pointer items-start gap-2">
@@ -424,8 +448,8 @@ async function handleSubmit() {
 
         <div v-if="currentTab === 'restrictions'" class="space-y-5">
           <div v-if="isSuperuserTarget" class="rounded-md border border-amber-500/30 bg-amber-500/5 px-4 py-3">
-            <p class="text-sm text-amber-600 dark:text-amber-400 font-medium">Superuser Target</p>
-            <p class="text-xs text-muted-foreground mt-0.5">Content restrictions cannot be applied to superusers.</p>
+            <p class="text-sm text-amber-600 dark:text-amber-400 font-medium">{{ t('adminFeature.userForm.superuserTarget') }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('adminFeature.userForm.superuserTargetHint') }}</p>
           </div>
           <template v-else>
             <div
@@ -433,53 +457,73 @@ async function handleSubmit() {
               class="rounded-md border border-dashed border-border px-4 py-8 text-center flex flex-col items-center gap-3"
             >
               <div class="space-y-1">
-                <p class="text-sm font-medium text-foreground">No content restrictions</p>
-                <p class="text-xs text-muted-foreground">This user has full access to all books in their assigned libraries.</p>
+                <p class="text-sm font-medium text-foreground">{{ t('adminFeature.userForm.noRestrictions') }}</p>
+                <p class="text-xs text-muted-foreground">{{ t('adminFeature.userForm.noRestrictionsHint') }}</p>
               </div>
               <button
                 type="button"
                 @click="restrictionsEnabled = true"
                 class="text-xs font-medium text-primary hover:text-primary/80 bg-primary/10 hover:bg-primary/20 px-3 py-1.5 rounded-md transition-colors"
               >
-                + Add Content Restrictions
+                {{ t('adminFeature.userForm.addRestrictions') }}
               </button>
             </div>
             <div v-else class="space-y-5">
               <div class="flex items-center justify-between">
-                <p class="text-sm font-medium text-foreground">Content Restrictions</p>
+                <p class="text-sm font-medium text-foreground">{{ t('adminFeature.userForm.contentRestrictions') }}</p>
                 <button
                   type="button"
                   v-if="!hasRestrictions"
                   @click="restrictionsEnabled = false"
                   class="text-xs text-muted-foreground hover:text-foreground"
                 >
-                  Remove
+                  {{ t('adminFeature.userForm.remove') }}
                 </button>
               </div>
 
               <div class="space-y-1.5">
                 <label class="text-xs font-medium text-foreground"
-                  >Include tags <span class="text-muted-foreground font-normal">(show only books with these tags)</span></label
+                  >{{ t('adminFeature.userForm.includeTags') }}
+                  <span class="text-muted-foreground font-normal">{{ t('adminFeature.userForm.includeTagsHint') }}</span></label
                 >
-                <ContentFilterChipInput v-model="includeTagItems" placeholder="Search tags..." :search-fn="searchTags" />
+                <ContentFilterChipInput
+                  v-model="includeTagItems"
+                  :placeholder="t('adminFeature.userForm.searchTagsPlaceholder')"
+                  :search-fn="searchTags"
+                />
               </div>
               <div class="space-y-1.5">
                 <label class="text-xs font-medium text-foreground"
-                  >Exclude tags <span class="text-muted-foreground font-normal">(hide books with these tags)</span></label
+                  >{{ t('adminFeature.userForm.excludeTags') }}
+                  <span class="text-muted-foreground font-normal">{{ t('adminFeature.userForm.excludeTagsHint') }}</span></label
                 >
-                <ContentFilterChipInput v-model="excludeTagItems" placeholder="Search tags..." :search-fn="searchTags" />
+                <ContentFilterChipInput
+                  v-model="excludeTagItems"
+                  :placeholder="t('adminFeature.userForm.searchTagsPlaceholder')"
+                  :search-fn="searchTags"
+                />
               </div>
               <div class="space-y-1.5">
                 <label class="text-xs font-medium text-foreground"
-                  >Include genres <span class="text-muted-foreground font-normal">(show only books with these genres)</span></label
+                  >{{ t('adminFeature.userForm.includeGenres') }}
+                  <span class="text-muted-foreground font-normal">{{ t('adminFeature.userForm.includeGenresHint') }}</span></label
                 >
-                <ContentFilterChipInput v-model="includeGenreItems" placeholder="Search genres..." :search-fn="searchGenres" />
+                <ContentFilterChipInput
+                  v-model="includeGenreItems"
+                  :placeholder="t('adminFeature.userForm.searchGenresPlaceholder')"
+                  :search-fn="searchGenres"
+                />
               </div>
               <div class="space-y-1.5">
                 <label class="text-xs font-medium text-foreground"
-                  >Exclude genres <span class="text-muted-foreground font-normal">(hide books with these genres)</span></label
+                  >{{ t('adminFeature.userForm.excludeGenres') }}
+                  <span class="text-muted-foreground font-normal">{{ t('adminFeature.userForm.excludeGenresHint') }}</span></label
                 >
-                <ContentFilterChipInput v-model="excludeGenreItems" placeholder="Search genres..." :search-fn="searchGenres" />
+                <ContentFilterChipInput
+                  v-model="excludeGenreItems"
+                  :placeholder="t('adminFeature.userForm.searchGenresPlaceholder')"
+                  :search-fn="searchGenres"
+                />
               </div>
             </div>
           </template>
@@ -494,7 +538,7 @@ async function handleSubmit() {
           type="button"
           class="rounded-md border border-border px-4 py-2 settings-label hover:bg-muted transition-colors"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           @click="handleSubmit"
@@ -502,7 +546,7 @@ async function handleSubmit() {
           :disabled="loading"
           class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
         >
-          {{ loading ? 'Saving...' : 'Save' }}
+          {{ loading ? t('adminFeature.userForm.saving') : t('common.save') }}
         </button>
       </div>
     </div>

--- a/client/src/features/admin/UsersPage.vue
+++ b/client/src/features/admin/UsersPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { UserPlus, Plus, Pencil, KeyRound, Trash2, ShieldCheck, MoreVertical, ShieldAlert } from '@lucide/vue'
 import { api } from '@/lib/api'
@@ -26,6 +27,7 @@ interface UserRow extends AuthUser {
   hasContentFilters?: boolean
 }
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { isSuperuser } = usePermissions()
@@ -69,14 +71,14 @@ async function loadData() {
   error.value = null
   try {
     const [usersRes, libsRes] = await Promise.all([api(`/api/v1/users?page=${page.value}&pageSize=50`), api('/api/v1/libraries')])
-    if (!usersRes.ok || !libsRes.ok) throw new Error('Failed to load data')
+    if (!usersRes.ok || !libsRes.ok) throw new Error(t('adminFeature.usersPage.errors.loadData'))
     const ud = await usersRes.json()
     users.value = ud.users ?? ud.items ?? ud
     total.value = ud.total ?? users.value.length
     const libData = await libsRes.json()
     libraries.value = libData.libraries ?? libData.items ?? libData
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Failed to load'
+    error.value = e instanceof Error ? e.message : t('adminFeature.usersPage.errors.load')
   } finally {
     loading.value = false
   }
@@ -113,13 +115,13 @@ async function confirmDeleteUser() {
     const res = await api(`/api/v1/users/${user.id}`, { method: 'DELETE' })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
-      error.value = data.message ?? 'Failed to delete user'
+      error.value = data.message ?? t('adminFeature.usersPage.errors.deleteUser')
       return
     }
     deleteConfirmUser.value = null
     loadData()
   } catch {
-    error.value = 'Failed to delete user'
+    error.value = t('adminFeature.usersPage.errors.deleteUser')
   } finally {
     deleting.value = false
   }
@@ -141,26 +143,28 @@ function openMagicLinkCreate() {
   <SettingsPageHeader
     v-if="!props.embedded"
     class="hidden md:flex"
-    :title="activeTab === 'users' ? 'Users' : 'Magic Links'"
-    :subtitle="activeTab === 'users' ? 'Manage user accounts and permission assignments.' : 'Create shareable login links for shared accounts.'"
+    :title="activeTab === 'users' ? t('adminFeature.usersPage.usersTitle') : t('adminFeature.usersPage.magicLinksTitle')"
+    :subtitle="activeTab === 'users' ? t('adminFeature.usersPage.usersSubtitle') : t('adminFeature.usersPage.magicLinksSubtitle')"
   >
     <button v-if="activeTab === 'users'" class="settings-btn-primary" @click="openCreate">
       <UserPlus :size="14" />
-      Create user
+      {{ t('adminFeature.usersPage.createUser') }}
     </button>
     <button v-else class="settings-btn-primary" @click="openMagicLinkCreate">
       <Plus :size="14" />
-      Create link
+      {{ t('adminFeature.usersPage.createLink') }}
     </button>
   </SettingsPageHeader>
 
   <!-- Mobile title -->
   <div v-if="!props.embedded" class="md:hidden px-1">
-    <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ activeTab === 'users' ? 'Users' : 'Magic Links' }}</h1>
+    <h1 class="text-xl font-semibold tracking-tight text-foreground">
+      {{ activeTab === 'users' ? t('adminFeature.usersPage.usersTitle') : t('adminFeature.usersPage.magicLinksTitle') }}
+    </h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
     >
-      {{ activeTab === 'users' ? 'Manage user accounts and permission assignments.' : 'Create shareable login links for shared accounts.' }}
+      {{ activeTab === 'users' ? t('adminFeature.usersPage.usersSubtitle') : t('adminFeature.usersPage.magicLinksSubtitle') }}
     </p>
   </div>
 
@@ -178,7 +182,7 @@ function openMagicLinkCreate() {
       "
       @click="selectTab('users')"
     >
-      Users
+      {{ t('adminFeature.usersPage.usersTab') }}
     </button>
     <button
       class="px-3 py-3 md:py-2 text-sm font-medium shrink-0 border-b-2 -mb-px transition-colors snap-start"
@@ -189,7 +193,7 @@ function openMagicLinkCreate() {
       "
       @click="selectTab('magic-links')"
     >
-      Magic Links
+      {{ t('adminFeature.usersPage.magicLinksTab') }}
     </button>
   </div>
 
@@ -197,7 +201,7 @@ function openMagicLinkCreate() {
   <div v-if="props.embedded && activeTab === 'users'" class="mb-4 flex items-center justify-end md:mb-5">
     <button class="settings-btn-primary w-full justify-center md:w-auto" @click="openCreate">
       <UserPlus :size="14" />
-      Create user
+      {{ t('adminFeature.usersPage.createUser') }}
     </button>
   </div>
 
@@ -208,25 +212,27 @@ function openMagicLinkCreate() {
   >
     <button class="settings-btn-primary w-full min-h-10 justify-center" @click="openCreate">
       <UserPlus :size="14" />
-      Create user
+      {{ t('adminFeature.usersPage.createUser') }}
     </button>
   </div>
 
   <!-- Users tab content -->
   <template v-if="activeTab === 'users'">
     <div v-if="error" class="mb-4 text-sm text-destructive">{{ error }}</div>
-    <div v-if="loading" class="text-sm text-muted-foreground">Loading...</div>
+    <div v-if="loading" class="text-sm text-muted-foreground">{{ t('common.loading') }}</div>
 
     <div v-else class="space-y-3">
       <div class="hidden md:block rounded-lg border border-border overflow-hidden shadow-xs">
         <table class="w-full text-sm">
           <thead class="bg-muted/50">
             <tr>
-              <th class="px-4 py-3 text-left font-medium text-muted-foreground">Name</th>
-              <th class="px-4 py-3 text-left font-medium text-muted-foreground">Username</th>
-              <th class="px-4 py-3 text-left font-medium text-muted-foreground hidden sm:table-cell">Email</th>
-              <th class="px-4 py-3 text-left font-medium text-muted-foreground">Access</th>
-              <th class="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
+              <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('adminFeature.usersPage.columns.name') }}</th>
+              <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('adminFeature.usersPage.columns.username') }}</th>
+              <th class="px-4 py-3 text-left font-medium text-muted-foreground hidden sm:table-cell">
+                {{ t('adminFeature.usersPage.columns.email') }}
+              </th>
+              <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('adminFeature.usersPage.columns.access') }}</th>
+              <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('adminFeature.usersPage.columns.status') }}</th>
               <th class="px-4 py-3" />
             </tr>
           </thead>
@@ -242,10 +248,10 @@ function openMagicLinkCreate() {
                     class="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary"
                   >
                     <ShieldCheck :size="11" />
-                    Admin
+                    {{ t('adminFeature.usersPage.adminBadge') }}
                   </span>
                   <span v-else class="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                    {{ user.permissions?.length ?? 0 }} permissions
+                    {{ t('adminFeature.usersPage.permissionCount', { count: user.permissions?.length ?? 0 }, user.permissions?.length ?? 0) }}
                   </span>
                   <Tooltip v-if="user.hasContentFilters">
                     <TooltipTrigger as-child>
@@ -253,10 +259,10 @@ function openMagicLinkCreate() {
                         class="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400"
                       >
                         <ShieldAlert :size="11" />
-                        Filtered
+                        {{ t('adminFeature.usersPage.filteredBadge') }}
                       </span>
                     </TooltipTrigger>
-                    <TooltipContent>Content restrictions active</TooltipContent>
+                    <TooltipContent>{{ t('adminFeature.usersPage.contentRestrictionsActive') }}</TooltipContent>
                   </Tooltip>
                 </div>
               </td>
@@ -265,7 +271,7 @@ function openMagicLinkCreate() {
                   class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
                   :class="user.active ? 'bg-green-500/15 text-green-600 dark:text-green-400' : 'bg-destructive/15 text-destructive'"
                 >
-                  {{ user.active ? 'Active' : 'Inactive' }}
+                  {{ user.active ? t('adminFeature.usersPage.statusActive') : t('adminFeature.usersPage.statusInactive') }}
                 </span>
               </td>
               <td class="px-4 py-3">
@@ -280,7 +286,7 @@ function openMagicLinkCreate() {
                           <Pencil :size="14" />
                         </button>
                       </TooltipTrigger>
-                      <TooltipContent>Edit</TooltipContent>
+                      <TooltipContent>{{ t('common.edit') }}</TooltipContent>
                     </Tooltip>
                     <Tooltip>
                       <TooltipTrigger as-child>
@@ -300,10 +306,10 @@ function openMagicLinkCreate() {
                       <TooltipContent>
                         {{
                           user.provisioningMethod === 'oidc'
-                            ? 'OIDC users reset passwords in their identity provider'
+                            ? t('adminFeature.usersPage.resetPasswordOidcHint')
                             : user.provisioningMethod === 'shared'
-                              ? 'Shared accounts do not have passwords'
-                              : 'Reset password'
+                              ? t('adminFeature.usersPage.resetPasswordSharedHint')
+                              : t('adminFeature.usersPage.resetPassword')
                         }}
                       </TooltipContent>
                     </Tooltip>
@@ -316,7 +322,7 @@ function openMagicLinkCreate() {
                           <Trash2 :size="14" />
                         </button>
                       </TooltipTrigger>
-                      <TooltipContent>Delete</TooltipContent>
+                      <TooltipContent>{{ t('common.delete') }}</TooltipContent>
                     </Tooltip>
                   </template>
                 </div>
@@ -334,7 +340,7 @@ function openMagicLinkCreate() {
               class="shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
               :class="user.active ? 'bg-green-500/15 text-green-600 dark:text-green-400' : 'bg-destructive/15 text-destructive'"
             >
-              {{ user.active ? 'Active' : 'Inactive' }}
+              {{ user.active ? t('adminFeature.usersPage.statusActive') : t('adminFeature.usersPage.statusInactive') }}
             </span>
           </div>
           <div class="mt-2 flex items-center justify-between gap-3">
@@ -344,10 +350,10 @@ function openMagicLinkCreate() {
               class="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2 py-0.5 text-xs font-medium text-primary"
             >
               <ShieldCheck :size="11" />
-              Admin
+              {{ t('adminFeature.usersPage.adminBadge') }}
             </span>
             <span v-else class="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-              {{ user.permissions?.length ?? 0 }} permissions
+              {{ t('adminFeature.usersPage.permissionCount', { count: user.permissions?.length ?? 0 }, user.permissions?.length ?? 0) }}
             </span>
           </div>
           <div v-if="isSuperuser || !user.isSuperuser" class="mt-3 flex items-center gap-2">
@@ -355,7 +361,7 @@ function openMagicLinkCreate() {
               class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
               @click="openEdit(user)"
             >
-              Edit
+              {{ t('common.edit') }}
             </button>
             <DropdownMenu>
               <DropdownMenuTrigger as-child>
@@ -367,15 +373,17 @@ function openMagicLinkCreate() {
                 <DropdownMenuItem
                   :disabled="user.provisioningMethod === 'oidc' || user.provisioningMethod === 'shared'"
                   @click="handleResetPassword(user.id)"
-                  >Reset password</DropdownMenuItem
+                  >{{ t('adminFeature.usersPage.resetPassword') }}</DropdownMenuItem
                 >
-                <DropdownMenuItem class="text-destructive focus:text-destructive" @click="requestDeleteUser(user)">Delete user</DropdownMenuItem>
+                <DropdownMenuItem class="text-destructive focus:text-destructive" @click="requestDeleteUser(user)">{{
+                  t('adminFeature.usersPage.deleteUserAction')
+                }}</DropdownMenuItem>
                 <DropdownMenuSeparator v-if="user.provisioningMethod === 'oidc' || user.provisioningMethod === 'shared'" />
                 <p v-if="user.provisioningMethod === 'oidc'" class="px-2 py-1.5 text-[11px] leading-4 text-muted-foreground">
-                  OIDC users reset passwords in their identity provider.
+                  {{ t('adminFeature.usersPage.resetPasswordOidcHintFull') }}
                 </p>
                 <p v-else-if="user.provisioningMethod === 'shared'" class="px-2 py-1.5 text-[11px] leading-4 text-muted-foreground">
-                  Shared accounts do not have passwords.
+                  {{ t('adminFeature.usersPage.resetPasswordSharedHintFull') }}
                 </p>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -394,21 +402,21 @@ function openMagicLinkCreate() {
     >
       <button class="absolute inset-0 bg-black/45" @click="deleteConfirmUser = null" />
       <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Delete user?</p>
-        <p class="mt-1 text-sm text-muted-foreground">Delete user "{{ deleteConfirmUser.username }}". This action cannot be undone.</p>
+        <p class="text-base font-semibold text-foreground">{{ t('adminFeature.usersPage.deleteDialogTitle') }}</p>
+        <p class="mt-1 text-sm text-muted-foreground">{{ t('adminFeature.usersPage.deleteDialogBody', { username: deleteConfirmUser.username }) }}</p>
         <div class="mt-4 flex items-center justify-end gap-2">
           <button
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="deleteConfirmUser = null"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
             :disabled="deleting"
             @click="confirmDeleteUser"
           >
-            {{ deleting ? 'Deleting...' : 'Delete' }}
+            {{ deleting ? t('adminFeature.usersPage.deleting') : t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/annotations/components/AnnotationBookCombobox.vue
+++ b/client/src/features/annotations/components/AnnotationBookCombobox.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronsUpDown, X } from '@lucide/vue'
 import type { AnnotationHubBookFacet } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   searchFn: (q: string) => Promise<AnnotationHubBookFacet[]>
@@ -58,7 +61,7 @@ function onInput(event: Event) {
 
 function select(option: AnnotationHubBookFacet) {
   model.value = option.bookId
-  selectedLabel.value = option.bookTitle ?? 'Unknown book'
+  selectedLabel.value = option.bookTitle ?? t('annotations.unknownBook')
   query.value = ''
   showDropdown.value = false
   isFocused.value = false
@@ -110,9 +113,9 @@ onUnmounted(() => {
       :value="inputValue"
       type="text"
       role="combobox"
-      aria-label="Filter by book"
+      :aria-label="t('annotations.combobox.filterByBook')"
       :aria-expanded="showDropdown"
-      :placeholder="placeholder ?? 'All books'"
+      :placeholder="placeholder ?? t('annotations.combobox.allBooks')"
       class="h-9 w-full rounded-md border border-border bg-background pl-2.5 pr-8 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
       @focus="onFocus"
       @input="onInput"
@@ -122,7 +125,7 @@ onUnmounted(() => {
     <button
       v-if="hasSelection"
       type="button"
-      aria-label="Clear book filter"
+      :aria-label="t('annotations.combobox.clearBookFilter')"
       class="absolute right-1.5 top-1/2 -translate-y-1/2 inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       @mousedown.prevent="clear"
     >
@@ -134,8 +137,8 @@ onUnmounted(() => {
       v-if="showDropdown"
       class="absolute top-full left-0 mt-1 z-50 w-full min-w-[16rem] max-h-64 overflow-y-auto rounded-md border border-border bg-popover shadow-md"
     >
-      <p v-if="loading && options.length === 0" class="px-3 py-2 text-sm text-muted-foreground">Searching...</p>
-      <p v-else-if="showEmpty" class="px-3 py-2 text-sm text-muted-foreground">No books found</p>
+      <p v-if="loading && options.length === 0" class="px-3 py-2 text-sm text-muted-foreground">{{ t('annotations.combobox.searching') }}</p>
+      <p v-else-if="showEmpty" class="px-3 py-2 text-sm text-muted-foreground">{{ t('annotations.combobox.noBooksFound') }}</p>
       <button
         v-for="(option, index) in options"
         :key="option.bookId"
@@ -146,7 +149,7 @@ onUnmounted(() => {
         :class="{ 'bg-accent': index === activeIndex }"
         @mousedown.prevent="select(option)"
       >
-        <span class="min-w-0 flex-1 truncate">{{ option.bookTitle ?? 'Unknown book' }}</span>
+        <span class="min-w-0 flex-1 truncate">{{ option.bookTitle ?? t('annotations.unknownBook') }}</span>
         <span class="shrink-0 text-xs text-muted-foreground">{{ option.count }}</span>
       </button>
     </div>

--- a/client/src/features/annotations/components/AnnotationBulkBar.vue
+++ b/client/src/features/annotations/components/AnnotationBulkBar.vue
@@ -1,20 +1,24 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Contrast, Highlighter, Palette, Strikethrough, Underline, Waves } from '@lucide/vue'
 import { ANNOTATION_HIGHLIGHT_COLORS } from '@bookorbit/types'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const { t } = useI18n()
 
 defineProps<{ count: number; allVisibleSelected: boolean; showRestyle?: boolean }>()
 
 const emit = defineEmits<{ selectPage: []; clear: []; recolor: [hex: string]; restyle: [style: string] }>()
 
 const COLORS = ANNOTATION_HIGHLIGHT_COLORS
-const STYLES = [
-  { value: 'highlight', label: 'Highlight', icon: Highlighter },
-  { value: 'underline', label: 'Underline', icon: Underline },
-  { value: 'strikethrough', label: 'Strike', icon: Strikethrough },
-  { value: 'squiggly', label: 'Squiggle', icon: Waves },
-  { value: 'invert', label: 'Invert', icon: Contrast },
-]
+const STYLES = computed(() => [
+  { value: 'highlight', label: t('annotations.styles.highlight'), icon: Highlighter },
+  { value: 'underline', label: t('annotations.styles.underline'), icon: Underline },
+  { value: 'strikethrough', label: t('annotations.styles.strike'), icon: Strikethrough },
+  { value: 'squiggly', label: t('annotations.styles.squiggle'), icon: Waves },
+  { value: 'invert', label: t('annotations.styles.invert'), icon: Contrast },
+])
 
 function handleSelectPage() {
   emit('selectPage')
@@ -35,20 +39,20 @@ function handleRestyle(style: string) {
 
 <template>
   <div class="flex flex-wrap items-center gap-2 rounded-md border border-primary/40 bg-primary/5 px-3 py-2 text-sm">
-    <span class="font-medium text-foreground">{{ count }} selected</span>
+    <span class="font-medium text-foreground">{{ t('annotations.bulk.countSelected', { count }) }}</span>
     <button
       type="button"
       class="rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       @click="handleSelectPage"
     >
-      {{ allVisibleSelected ? 'Page selected' : 'Select page' }}
+      {{ allVisibleSelected ? t('annotations.bulk.pageSelected') : t('annotations.bulk.selectPage') }}
     </button>
     <button
       type="button"
       class="rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       @click="handleClear"
     >
-      Clear
+      {{ t('annotations.bulk.clear') }}
     </button>
 
     <template v-if="showRestyle">
@@ -62,7 +66,7 @@ function handleRestyle(style: string) {
           class="h-6 w-6 rounded-full border border-border transition-transform hover:scale-110"
           :style="{ background: color.hex }"
           :title="color.label"
-          :aria-label="`Recolor to ${color.label}`"
+          :aria-label="t('annotations.bulk.recolorTo', { color: color.label })"
           @click="handleRecolor(color.hex)"
         />
       </div>
@@ -72,7 +76,7 @@ function handleRestyle(style: string) {
             <button
               type="button"
               class="flex h-7 w-7 items-center justify-center rounded border border-border bg-card text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              :aria-label="`Restyle to ${style.label}`"
+              :aria-label="t('annotations.bulk.restyleTo', { style: style.label })"
               @click="handleRestyle(style.value)"
             >
               <component :is="style.icon" :size="14" />

--- a/client/src/features/annotations/components/AnnotationFilterChips.vue
+++ b/client/src/features/annotations/components/AnnotationFilterChips.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { X } from '@lucide/vue'
 import type { ActiveFilterChip } from '../lib/filter-chips'
+
+const { t } = useI18n()
 
 defineProps<{ chips: ActiveFilterChip[] }>()
 const emit = defineEmits<{ remove: [id: string]; clearAll: [] }>()
@@ -16,13 +19,13 @@ function handleClearAll() {
 
 <template>
   <div class="flex flex-wrap items-center gap-2">
-    <span class="text-xs text-muted-foreground">Active:</span>
+    <span class="text-xs text-muted-foreground">{{ t('annotations.chips.active') }}</span>
     <button
       v-for="chip in chips"
       :key="chip.id"
       type="button"
       class="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2.5 py-1 text-xs text-foreground transition-colors hover:bg-muted/70"
-      :aria-label="`Remove filter ${chip.label}`"
+      :aria-label="t('annotations.chips.removeFilter', { label: chip.label })"
       @click="handleRemove(chip.id)"
     >
       {{ chip.label }}
@@ -33,7 +36,7 @@ function handleClearAll() {
       class="text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
       @click="handleClearAll"
     >
-      Clear all
+      {{ t('annotations.chips.clearAll') }}
     </button>
   </div>
 </template>

--- a/client/src/features/annotations/components/AnnotationFiltersPanel.vue
+++ b/client/src/features/annotations/components/AnnotationFiltersPanel.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Check, X } from '@lucide/vue'
 import { ANNOTATION_COLOR_FILTER_OPTIONS } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const colors = defineModel<string[]>('colors', { required: true })
 const dateFrom = defineModel<string>('dateFrom', { required: true })
@@ -32,7 +35,7 @@ function handleClearAll() {
 <template>
   <div class="flex flex-col gap-3">
     <div :class="FIELD_LABEL_CLASS">
-      <span>Colors</span>
+      <span>{{ t('annotations.filters.colors') }}</span>
       <div class="flex flex-wrap gap-1.5">
         <button
           v-for="option in COLOR_OPTIONS"
@@ -52,25 +55,25 @@ function handleClearAll() {
     </div>
 
     <div :class="FIELD_LABEL_CLASS">
-      <span>Date range</span>
+      <span>{{ t('annotations.filters.dateRange') }}</span>
       <div class="flex items-center gap-1.5">
         <input
           v-model="dateFrom"
           type="date"
-          aria-label="From date"
+          :aria-label="t('annotations.filters.fromDate')"
           class="h-9 min-w-0 flex-1 px-2 rounded-md border border-border bg-background text-sm"
         />
-        <span class="text-xs text-muted-foreground">to</span>
+        <span class="text-xs text-muted-foreground">{{ t('annotations.filters.to') }}</span>
         <input
           v-model="dateTo"
           type="date"
-          aria-label="To date"
+          :aria-label="t('annotations.filters.toDate')"
           class="h-9 min-w-0 flex-1 px-2 rounded-md border border-border bg-background text-sm"
         />
         <button
           v-if="dateFrom || dateTo"
           type="button"
-          aria-label="Clear date range"
+          :aria-label="t('annotations.filters.clearDateRange')"
           class="inline-flex h-9 items-center rounded-md border border-border bg-background px-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           @click="clearDates"
         >
@@ -82,7 +85,9 @@ function handleClearAll() {
     <slot name="extra" />
 
     <div class="flex justify-end border-t border-border pt-3">
-      <button type="button" class="text-sm text-muted-foreground transition-colors hover:text-foreground" @click="handleClearAll">Clear all</button>
+      <button type="button" class="text-sm text-muted-foreground transition-colors hover:text-foreground" @click="handleClearAll">
+        {{ t('annotations.filters.clearAll') }}
+      </button>
     </div>
   </div>
 </template>

--- a/client/src/features/annotations/components/AnnotationListItem.vue
+++ b/client/src/features/annotations/components/AnnotationListItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import {
   ArchiveRestore,
   BookOpen,
@@ -32,6 +33,8 @@ import { copyToClipboard } from '@/lib/clipboard'
 type AnnotationListItemMode = 'book' | 'hub'
 type AnnotationListDensity = 'compact' | 'comfortable'
 type AnnotationListItem = AnnotationItem | AnnotationHubItem
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -68,13 +71,13 @@ const emit = defineEmits<{
 
 const COLORS = ANNOTATION_HIGHLIGHT_COLORS
 
-const STYLES = [
-  { value: 'highlight', label: 'Highlight', icon: Highlighter },
-  { value: 'underline', label: 'Underline', icon: Underline },
-  { value: 'strikethrough', label: 'Strike', icon: Strikethrough },
-  { value: 'squiggly', label: 'Squiggle', icon: Waves },
-  { value: 'invert', label: 'Invert', icon: Contrast },
-]
+const STYLES = computed(() => [
+  { value: 'highlight', label: t('annotations.styles.highlight'), icon: Highlighter },
+  { value: 'underline', label: t('annotations.styles.underline'), icon: Underline },
+  { value: 'strikethrough', label: t('annotations.styles.strike'), icon: Strikethrough },
+  { value: 'squiggly', label: t('annotations.styles.squiggle'), icon: Waves },
+  { value: 'invert', label: t('annotations.styles.invert'), icon: Contrast },
+])
 
 const expanded = ref(false)
 const editingNote = ref(false)
@@ -90,16 +93,18 @@ const isLong = computed(() => props.annotation.text.length > (props.density === 
 const isApproximate = computed(() => props.annotation.cfi == null && props.annotation.origin !== 'web')
 const hasBookTitle = computed(() => 'bookTitle' in props.annotation && props.annotation.bookTitle != null)
 const showBookHeader = computed(() => props.mode === 'hub' && props.showBookHeader)
-const bookTitleText = computed(() => (hasBookTitle.value && 'bookTitle' in props.annotation ? props.annotation.bookTitle : 'Unknown book'))
+const bookTitleText = computed(() =>
+  hasBookTitle.value && 'bookTitle' in props.annotation ? props.annotation.bookTitle : t('annotations.unknownBook'),
+)
 const bookAuthor = computed(() => ('author' in props.annotation ? props.annotation.author : null))
 const bookLink = computed(() => ({ name: 'book-detail', params: { bookId: props.annotation.bookId }, query: { tab: 'highlights' } }))
 
 const styleLabel = computed(() => {
-  return STYLES.find((s) => s.value === props.annotation.style)?.label ?? props.annotation.style
+  return STYLES.value.find((s) => s.value === props.annotation.style)?.label ?? props.annotation.style
 })
 
 const styleIcon = computed(() => {
-  return STYLES.find((s) => s.value === props.annotation.style)?.icon ?? Highlighter
+  return STYLES.value.find((s) => s.value === props.annotation.style)?.icon ?? Highlighter
 })
 
 const originPill = computed(() => sourcePill(props.annotation.origin))
@@ -116,10 +121,11 @@ const noteClampClass = computed(() => (expanded.value ? '' : props.density === '
 
 const metadataItems = computed(() => {
   const items: string[] = []
-  if (props.mode !== 'hub' && hasBookTitle.value && 'bookTitle' in props.annotation) items.push(props.annotation.bookTitle ?? 'Unknown book')
+  if (props.mode !== 'hub' && hasBookTitle.value && 'bookTitle' in props.annotation)
+    items.push(props.annotation.bookTitle ?? t('annotations.unknownBook'))
   if (props.annotation.chapterTitle) items.push(props.annotation.chapterTitle)
-  if (props.annotation.pageno != null) items.push(`p. ${props.annotation.pageno}`)
-  if (props.annotation.chapterIndex != null) items.push(`chapter ${props.annotation.chapterIndex + 1}`)
+  if (props.annotation.pageno != null) items.push(t('annotations.listItem.pageNumber', { page: props.annotation.pageno }))
+  if (props.annotation.chapterIndex != null) items.push(t('annotations.listItem.chapterNumber', { chapter: props.annotation.chapterIndex + 1 }))
   const date = formatDate(props.annotation.createdAt)
   if (date) items.push(date)
   return items
@@ -223,7 +229,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
       type="checkbox"
       class="mt-1 h-4 w-4 shrink-0 accent-[var(--primary)] cursor-pointer"
       :checked="selected"
-      aria-label="Select annotation"
+      :aria-label="t('annotations.listItem.selectAnnotation')"
       @change="handleToggleSelect"
     />
 
@@ -261,7 +267,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
       >
         <ChevronUp v-if="expanded" :size="13" />
         <ChevronDown v-else :size="13" />
-        {{ expanded ? 'Collapse' : 'Expand' }}
+        {{ expanded ? t('annotations.listItem.collapse') : t('annotations.listItem.expand') }}
       </button>
 
       <p
@@ -343,15 +349,17 @@ function shouldSeparateMetadataItem(index: number): boolean {
                 {{ positionPill.label }}
               </button>
             </TooltipTrigger>
-            <TooltipContent>{{ showSyncDetail ? 'Hide sync detail' : 'Show sync detail' }}</TooltipContent>
+            <TooltipContent>{{
+              showSyncDetail ? t('annotations.listItem.hideSyncDetail') : t('annotations.listItem.showSyncDetail')
+            }}</TooltipContent>
           </Tooltip>
           <Tooltip v-if="isApproximate">
             <TooltipTrigger as-child>
               <TriangleAlert :size="12" class="text-muted-foreground" />
             </TooltipTrigger>
-            <TooltipContent>Exact reader position unavailable</TooltipContent>
+            <TooltipContent>{{ t('annotations.listItem.exactPositionUnavailable') }}</TooltipContent>
           </Tooltip>
-          <span v-if="saving" class="text-primary">Saving</span>
+          <span v-if="saving" class="text-primary">{{ t('annotations.listItem.saving') }}</span>
         </div>
 
         <div class="flex shrink-0 flex-wrap justify-start gap-0.5 sm:flex-nowrap sm:justify-end">
@@ -364,7 +372,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
                 <Info :size="15" />
               </RouterLink>
             </TooltipTrigger>
-            <TooltipContent>Book details</TooltipContent>
+            <TooltipContent>{{ t('annotations.listItem.bookDetails') }}</TooltipContent>
           </Tooltip>
 
           <Tooltip v-if="canJump">
@@ -377,7 +385,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
                 <BookOpen :size="15" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Open in reader</TooltipContent>
+            <TooltipContent>{{ t('annotations.listItem.openInReader') }}</TooltipContent>
           </Tooltip>
 
           <template v-if="trashed">
@@ -391,7 +399,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
                   <ArchiveRestore :size="15" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Restore</TooltipContent>
+              <TooltipContent>{{ t('annotations.listItem.restore') }}</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger as-child>
@@ -403,7 +411,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
                   <Trash2 :size="15" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Delete forever</TooltipContent>
+              <TooltipContent>{{ t('annotations.listItem.deleteForever') }}</TooltipContent>
             </Tooltip>
           </template>
 
@@ -418,7 +426,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
                   <FileEdit :size="14" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{{ annotation.note ? 'Edit note' : 'Add note' }}</TooltipContent>
+              <TooltipContent>{{ annotation.note ? t('annotations.listItem.editNote') : t('annotations.listItem.addNote') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip v-if="canEdit">
@@ -432,7 +440,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
                   <Palette :size="14" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Color and style</TooltipContent>
+              <TooltipContent>{{ t('annotations.listItem.colorAndStyle') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip>
@@ -446,14 +454,14 @@ function shouldSeparateMetadataItem(index: number): boolean {
                   <Copy v-else :size="14" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{{ copied ? 'Copied' : 'Copy text' }}</TooltipContent>
+              <TooltipContent>{{ copied ? t('annotations.listItem.copied') : t('annotations.listItem.copyText') }}</TooltipContent>
             </Tooltip>
 
             <template v-if="confirmTrash && mode === 'book'">
               <button
                 type="button"
                 class="flex h-7 w-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                title="Cancel"
+                :title="t('common.cancel')"
                 @click="handleCancelTrash"
               >
                 <X :size="14" />
@@ -463,7 +471,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
                 class="h-7 rounded bg-destructive/15 px-2 text-[10px] font-medium uppercase text-destructive ring-1 ring-destructive/40"
                 @click="handleTrash"
               >
-                Trash
+                {{ t('annotations.listItem.trash') }}
               </button>
             </template>
             <Tooltip v-else>
@@ -476,7 +484,7 @@ function shouldSeparateMetadataItem(index: number): boolean {
                   <Trash2 :size="14" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Move to trash</TooltipContent>
+              <TooltipContent>{{ t('annotations.listItem.moveToTrash') }}</TooltipContent>
             </Tooltip>
           </template>
         </div>

--- a/client/src/features/annotations/components/AnnotationPagination.vue
+++ b/client/src/features/annotations/components/AnnotationPagination.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from '@lucide/vue'
 import { Button } from '@/components/ui/button'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   page: number
@@ -37,19 +40,19 @@ function lastPage() {
 
 <template>
   <div class="mt-6 flex items-center justify-between gap-3 text-sm text-muted-foreground">
-    <span>Showing {{ rangeStart }}-{{ rangeEnd }} of {{ total }}{{ unit ? ` ${unit}` : '' }}</span>
+    <span>{{ t('annotations.pagination.showing', { start: rangeStart, end: rangeEnd, total }) }}{{ unit ? ` ${unit}` : '' }}</span>
     <div v-if="totalPages > 1" class="flex items-center gap-1.5">
-      <Button variant="outline" size="icon-sm" :disabled="page <= 1" aria-label="First page" @click="firstPage">
+      <Button variant="outline" size="icon-sm" :disabled="page <= 1" :aria-label="t('annotations.pagination.firstPage')" @click="firstPage">
         <ChevronsLeft :size="14" />
       </Button>
-      <Button variant="outline" size="icon-sm" :disabled="page <= 1" aria-label="Previous page" @click="previousPage">
+      <Button variant="outline" size="icon-sm" :disabled="page <= 1" :aria-label="t('annotations.pagination.previousPage')" @click="previousPage">
         <ChevronLeft :size="14" />
       </Button>
-      <span class="px-1">Page {{ page }} of {{ totalPages }}</span>
-      <Button variant="outline" size="icon-sm" :disabled="page >= totalPages" aria-label="Next page" @click="nextPage">
+      <span class="px-1">{{ t('annotations.pagination.pageOf', { page, totalPages }) }}</span>
+      <Button variant="outline" size="icon-sm" :disabled="page >= totalPages" :aria-label="t('annotations.pagination.nextPage')" @click="nextPage">
         <ChevronRight :size="14" />
       </Button>
-      <Button variant="outline" size="icon-sm" :disabled="page >= totalPages" aria-label="Last page" @click="lastPage">
+      <Button variant="outline" size="icon-sm" :disabled="page >= totalPages" :aria-label="t('annotations.pagination.lastPage')" @click="lastPage">
         <ChevronsRight :size="14" />
       </Button>
     </div>

--- a/client/src/features/annotations/components/AnnotationSyncDetailPanel.vue
+++ b/client/src/features/annotations/components/AnnotationSyncDetailPanel.vue
@@ -1,37 +1,40 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Globe, Loader2, MonitorSmartphone, RefreshCw, Tablet } from '@lucide/vue'
 import type { AnnotationPositionFormat } from '@bookorbit/types'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAnnotationSyncDetail } from '../composables/useAnnotationSyncDetail'
 
+const { t } = useI18n()
+
 const props = defineProps<{ annotationId: number }>()
 
 const { detail, loading, retrying, error, load, retry } = useAnnotationSyncDetail()
 
-const FORMAT_LABELS: Record<AnnotationPositionFormat, string> = {
-  cfi: 'Web reader',
-  xpointer: 'KOReader',
-  pdf: 'PDF',
-  kobo_span: 'Kobo',
-}
+const FORMAT_LABELS = computed<Record<AnnotationPositionFormat, string>>(() => ({
+  cfi: t('annotations.sync.format.webReader'),
+  xpointer: t('annotations.sync.format.koreader'),
+  pdf: t('annotations.sync.format.pdf'),
+  kobo_span: t('annotations.sync.format.kobo'),
+}))
 
-const STATUS_LABELS: Record<string, string> = {
-  exact: 'Exact',
-  repaired: 'Repaired',
-  failed: 'Failed',
-  pending: 'Pending',
-}
+const STATUS_LABELS = computed<Record<string, string>>(() => ({
+  exact: t('annotations.sync.status.exact'),
+  repaired: t('annotations.sync.status.repaired'),
+  failed: t('annotations.sync.status.failed'),
+  pending: t('annotations.sync.status.pending'),
+}))
 
 const positions = computed(() => detail.value?.positions ?? [])
 const devices = computed(() => detail.value?.devices ?? [])
 
 function formatLabel(format: AnnotationPositionFormat): string {
-  return FORMAT_LABELS[format] ?? format
+  return FORMAT_LABELS.value[format] ?? format
 }
 
 function statusLabel(status: string): string {
-  return STATUS_LABELS[status] ?? status
+  return STATUS_LABELS.value[status] ?? status
 }
 
 function statusClass(status: string): string {
@@ -64,13 +67,13 @@ onMounted(() => {
   <div class="mt-2 rounded-md border border-border bg-background p-2.5 text-xs">
     <div v-if="loading" class="flex items-center gap-2 text-muted-foreground">
       <Loader2 :size="13" class="animate-spin" />
-      Loading sync detail
+      {{ t('annotations.sync.loading') }}
     </div>
 
     <div v-else-if="error" class="text-destructive">{{ error }}</div>
 
     <template v-else-if="detail">
-      <p class="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Positions</p>
+      <p class="mb-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{{ t('annotations.sync.positions') }}</p>
       <ul class="flex flex-col gap-1">
         <li v-for="position in positions" :key="position.format" class="flex flex-wrap items-center gap-2">
           <span class="w-24 shrink-0 text-muted-foreground">{{ formatLabel(position.format) }}</span>
@@ -90,13 +93,13 @@ onMounted(() => {
                 <RefreshCw v-else :size="12" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Retry conversion</TooltipContent>
+            <TooltipContent>{{ t('annotations.sync.retryConversion') }}</TooltipContent>
           </Tooltip>
         </li>
-        <li v-if="positions.length === 0" class="text-muted-foreground">No stored positions.</li>
+        <li v-if="positions.length === 0" class="text-muted-foreground">{{ t('annotations.sync.noStoredPositions') }}</li>
       </ul>
 
-      <p class="mb-1.5 mt-3 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Devices</p>
+      <p class="mb-1.5 mt-3 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{{ t('annotations.sync.devices') }}</p>
       <ul class="flex flex-col gap-1">
         <li v-for="device in devices" :key="`${device.source}-${device.deviceId}`" class="flex flex-wrap items-center gap-2">
           <span class="inline-flex w-40 shrink-0 items-center gap-1.5 truncate text-foreground">
@@ -108,13 +111,13 @@ onMounted(() => {
             class="inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-medium"
             :class="device.upToDate ? 'border-primary/30 bg-primary/10 text-primary' : 'border-border bg-muted text-muted-foreground'"
           >
-            {{ device.upToDate ? 'Up to date' : `Pending v${detail.version}` }}
+            {{ device.upToDate ? t('annotations.sync.upToDate') : t('annotations.sync.pendingVersion', { version: detail.version }) }}
           </span>
-          <span class="text-muted-foreground">synced {{ formatDate(device.lastSyncedAt) }}</span>
+          <span class="text-muted-foreground">{{ t('annotations.sync.syncedAt', { date: formatDate(device.lastSyncedAt) }) }}</span>
         </li>
         <li v-if="devices.length === 0" class="flex items-center gap-1.5 text-muted-foreground">
           <Globe :size="12" />
-          Not synced to any device yet.
+          {{ t('annotations.sync.notSynced') }}
         </li>
       </ul>
     </template>

--- a/client/src/features/annotations/components/AnnotationToolbar.vue
+++ b/client/src/features/annotations/components/AnnotationToolbar.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Maximize2, Minimize2, Search, SlidersHorizontal } from '@lucide/vue'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
@@ -7,6 +8,8 @@ import { Button } from '@/components/ui/button'
 import AnnotationFilterChips from './AnnotationFilterChips.vue'
 import type { ActiveFilterChip } from '../lib/filter-chips'
 import type { AnnotationDensity } from '../composables/useDensity'
+
+const { t } = useI18n()
 
 defineProps<{
   sortOptions: { value: string; label: string }[]
@@ -42,7 +45,7 @@ function handleClearFilters() {
         <input
           v-model="search"
           type="search"
-          :placeholder="searchPlaceholder ?? 'Search text and notes'"
+          :placeholder="searchPlaceholder ?? t('annotations.toolbar.searchPlaceholder')"
           class="w-full h-9 pl-8 pr-3 rounded-md border border-border bg-background text-sm focus:outline-none focus:ring-1 focus:ring-primary"
         />
       </div>
@@ -54,7 +57,7 @@ function handleClearFilters() {
           <PopoverTrigger as-child>
             <Button variant="outline" size="sm" class="gap-1.5">
               <SlidersHorizontal :size="14" />
-              Filters
+              {{ t('annotations.toolbar.filters') }}
               <Badge v-if="filterCount > 0" variant="secondary" class="ml-0.5 h-5 min-w-5 justify-center px-1">{{ filterCount }}</Badge>
             </Button>
           </PopoverTrigger>
@@ -68,13 +71,13 @@ function handleClearFilters() {
           <SheetTrigger as-child>
             <Button variant="outline" size="sm" class="gap-1.5">
               <SlidersHorizontal :size="14" />
-              Filters
+              {{ t('annotations.toolbar.filters') }}
               <Badge v-if="filterCount > 0" variant="secondary" class="ml-0.5 h-5 min-w-5 justify-center px-1">{{ filterCount }}</Badge>
             </Button>
           </SheetTrigger>
           <SheetContent side="bottom" class="max-h-[85vh] overflow-y-auto">
             <SheetHeader>
-              <SheetTitle>Filters</SheetTitle>
+              <SheetTitle>{{ t('annotations.toolbar.filters') }}</SheetTitle>
             </SheetHeader>
             <div class="px-4 pb-6">
               <slot name="filters" />
@@ -83,13 +86,17 @@ function handleClearFilters() {
         </Sheet>
       </div>
 
-      <select v-model="sortKey" aria-label="Sort order" class="h-9 px-2 rounded-md border border-border bg-background text-sm">
+      <select
+        v-model="sortKey"
+        :aria-label="t('annotations.toolbar.sortOrder')"
+        class="h-9 px-2 rounded-md border border-border bg-background text-sm"
+      >
         <option v-for="option in sortOptions" :key="option.value" :value="option.value">{{ option.label }}</option>
       </select>
       <button
         type="button"
-        :aria-label="density === 'comfortable' ? 'Switch to compact view' : 'Switch to comfortable view'"
-        :title="density === 'comfortable' ? 'Compact view' : 'Comfortable view'"
+        :aria-label="density === 'comfortable' ? t('annotations.toolbar.switchToCompact') : t('annotations.toolbar.switchToComfortable')"
+        :title="density === 'comfortable' ? t('annotations.toolbar.compactView') : t('annotations.toolbar.comfortableView')"
         class="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         @click="toggleDensity"
       >

--- a/client/src/features/annotations/views/AnnotationsHubView.vue
+++ b/client/src/features/annotations/views/AnnotationsHubView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { Download, Highlighter, RotateCcw, StickyNote, Trash2 } from '@lucide/vue'
 import { toast } from 'vue-sonner'
@@ -20,6 +21,7 @@ import { useAnnotationsHub } from '../composables/useAnnotationsHub'
 import { useAnnotationsUrlSync } from '../composables/useAnnotationsUrlSync'
 import { useDensity } from '../composables/useDensity'
 
+const { t } = useI18n()
 const router = useRouter()
 const hub = useAnnotationsHub()
 useAnnotationsUrlSync(hub)
@@ -35,7 +37,7 @@ const groupedByBook = computed(() => {
   let current: (typeof groups)[number] | null = null
   for (const item of hub.items.value) {
     if (!current || current.bookId !== item.bookId) {
-      current = { bookId: item.bookId, bookTitle: item.bookTitle ?? 'Unknown book', author: item.author, items: [] }
+      current = { bookId: item.bookId, bookTitle: item.bookTitle ?? t('annotations.unknownBook'), author: item.author, items: [] }
       groups.push(current)
     }
     current.items.push(item)
@@ -47,8 +49,8 @@ const summaryTexts = computed(() => {
   const stats = hub.stats.value
   if (!stats) return []
   const texts: string[] = []
-  if (stats.books > 0) texts.push(`${stats.books} ${stats.books === 1 ? 'book' : 'books'}`)
-  if (stats.withNotes > 0) texts.push(`${stats.withNotes} ${stats.withNotes === 1 ? 'note' : 'notes'}`)
+  if (stats.books > 0) texts.push(t('annotations.hub.bookCount', { count: stats.books }, stats.books))
+  if (stats.withNotes > 0) texts.push(t('annotations.hub.noteCount', { count: stats.withNotes }, stats.withNotes))
   return texts
 })
 
@@ -89,38 +91,38 @@ function handleJump(annotation: AnnotationHubItem) {
 async function handleTrash(id: number) {
   hub.selectedIds.value = new Set([id])
   const affected = await hub.bulk('trash')
-  if (affected > 0) toast.success('Moved to trash')
+  if (affected > 0) toast.success(t('annotations.hub.toast.movedToTrash'))
 }
 
 async function handleRestore(id: number) {
   const ok = await hub.restore(id)
-  if (ok) toast.success('Annotation restored')
+  if (ok) toast.success(t('annotations.hub.toast.annotationRestored'))
 }
 
 async function handlePurge(id: number) {
   const result = await hub.purge(id)
-  if (result.ok) toast.success('Annotation deleted forever')
-  else toast.error(result.message ?? 'Failed to delete')
+  if (result.ok) toast.success(t('annotations.hub.toast.annotationDeletedForever'))
+  else toast.error(result.message ?? t('annotations.hub.toast.failedToDelete'))
 }
 
 async function handleBulkTrash() {
   const affected = await hub.bulk('trash')
-  if (affected > 0) toast.success(`Moved ${affected} annotation(s) to trash`)
+  if (affected > 0) toast.success(t('annotations.hub.toast.bulkTrashed', { count: affected }, affected))
 }
 
 async function handleBulkRestore() {
   const affected = await hub.bulk('restore')
-  if (affected > 0) toast.success(`Restored ${affected} annotation(s)`)
+  if (affected > 0) toast.success(t('annotations.hub.toast.bulkRestored', { count: affected }, affected))
 }
 
 async function handleBulkRecolor(color: string) {
   const affected = await hub.bulk('restyle', { color })
-  if (affected > 0) toast.success(`Recolored ${affected} annotation(s)`)
+  if (affected > 0) toast.success(t('annotations.hub.toast.bulkRecolored', { count: affected }, affected))
 }
 
 async function handleBulkRestyle(style: string) {
   const affected = await hub.bulk('restyle', { style })
-  if (affected > 0) toast.success(`Restyled ${affected} annotation(s)`)
+  if (affected > 0) toast.success(t('annotations.hub.toast.bulkRestyled', { count: affected }, affected))
 }
 
 function handleExport(format: 'md' | 'csv' | 'json') {
@@ -145,8 +147,8 @@ function handleExportJson() {
     <div class="flex flex-wrap items-center justify-between gap-3 mb-5">
       <div class="flex flex-wrap items-center gap-2.5">
         <Highlighter :size="22" class="text-primary" />
-        <h1 class="text-xl font-semibold">Annotations</h1>
-        <span class="text-sm text-muted-foreground">{{ hub.total.value }} total</span>
+        <h1 class="text-xl font-semibold">{{ t('annotations.hub.title') }}</h1>
+        <span class="text-sm text-muted-foreground">{{ t('annotations.hub.totalCount', { count: hub.total.value }) }}</span>
         <template v-if="summaryTexts.length > 0 || originSummary.length > 0">
           <span class="hidden h-5 w-px bg-border sm:block" />
           <AnnotationSummaryBar
@@ -163,13 +165,13 @@ function handleExportJson() {
           <DropdownMenuTrigger as-child>
             <Button variant="outline" size="sm" class="gap-1.5">
               <Download :size="14" />
-              Export
+              {{ t('annotations.hub.export') }}
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem @click="handleExportMarkdown">Markdown</DropdownMenuItem>
-            <DropdownMenuItem @click="handleExportCsv">CSV</DropdownMenuItem>
-            <DropdownMenuItem @click="handleExportJson">JSON</DropdownMenuItem>
+            <DropdownMenuItem @click="handleExportMarkdown">{{ t('annotations.hub.exportMarkdown') }}</DropdownMenuItem>
+            <DropdownMenuItem @click="handleExportCsv">{{ t('annotations.hub.exportCsv') }}</DropdownMenuItem>
+            <DropdownMenuItem @click="handleExportJson">{{ t('annotations.hub.exportJson') }}</DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
@@ -182,7 +184,7 @@ function handleExportJson() {
         :class="hub.status.value === 'active' ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'"
         @click="setActiveTab"
       >
-        Highlights
+        {{ t('annotations.hub.tabs.highlights') }}
       </button>
       <button
         type="button"
@@ -191,7 +193,7 @@ function handleExportJson() {
         @click="setTrashTab"
       >
         <Trash2 :size="13" />
-        Trash
+        {{ t('annotations.hub.tabs.trash') }}
       </button>
     </div>
 
@@ -220,7 +222,7 @@ function handleExportJson() {
           @click="hub.toggleNotesOnly"
         >
           <StickyNote :size="14" />
-          Notes only
+          {{ t('annotations.hub.notesOnly') }}
         </button>
       </template>
       <template #filters>
@@ -232,13 +234,13 @@ function handleExportJson() {
         >
           <template #extra>
             <label :class="FIELD_LABEL_CLASS">
-              Style
+              {{ t('annotations.hub.style') }}
               <select v-model="hub.styleFilter.value" :class="SELECT_CLASS">
                 <option v-for="option in STYLE_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
               </select>
             </label>
             <label :class="FIELD_LABEL_CLASS">
-              Source
+              {{ t('annotations.hub.source') }}
               <select v-model="hub.originFilter.value" :class="SELECT_CLASS">
                 <option v-for="option in ORIGIN_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
               </select>
@@ -262,9 +264,9 @@ function handleExportJson() {
       <template #trailing>
         <Button v-if="hub.status.value === 'active'" variant="destructive" size="sm" class="gap-1.5" @click="handleBulkTrash">
           <Trash2 :size="13" />
-          Trash
+          {{ t('annotations.hub.bulkTrash') }}
         </Button>
-        <Button v-else variant="outline" size="sm" @click="handleBulkRestore">Restore</Button>
+        <Button v-else variant="outline" size="sm" @click="handleBulkRestore">{{ t('annotations.hub.bulkRestore') }}</Button>
       </template>
     </AnnotationBulkBar>
 
@@ -274,18 +276,18 @@ function handleExportJson() {
     <div v-else-if="hub.error.value" class="py-12 text-center text-sm text-destructive">{{ hub.error.value }}</div>
     <div v-else-if="hub.items.value.length === 0" class="py-12 text-center">
       <template v-if="hub.hasActiveFilters.value">
-        <p class="text-sm text-muted-foreground">No highlights match your filters.</p>
+        <p class="text-sm text-muted-foreground">{{ t('annotations.hub.empty.noMatch') }}</p>
         <button
           type="button"
           class="mt-3 inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-muted"
           @click="hub.resetAllFilters"
         >
           <RotateCcw :size="14" />
-          Reset filters
+          {{ t('annotations.hub.empty.resetFilters') }}
         </button>
       </template>
       <p v-else class="text-sm text-muted-foreground">
-        {{ hub.status.value === 'trashed' ? 'Trash is empty' : 'No annotations yet. Highlights you create on the web or your e-reader appear here.' }}
+        {{ hub.status.value === 'trashed' ? t('annotations.hub.empty.trashEmpty') : t('annotations.hub.empty.noAnnotations') }}
       </p>
     </div>
     <div v-else class="transition-opacity" :class="{ 'opacity-50 pointer-events-none': hub.loading.value }">

--- a/client/src/features/audit/AuditLogPage.vue
+++ b/client/src/features/audit/AuditLogPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { RefreshCw, Search, X, ChevronDown, ChevronUp, ChevronLeft, ChevronRight } from '@lucide/vue'
 import { AuditAction } from '@bookorbit/types'
 import SettingsPageHeader from '@/features/settings/SettingsPageHeader.vue'
@@ -9,6 +10,7 @@ import { useMediaQuery } from '@vueuse/core'
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
 
 const { entries, total, page, pageSize, loading, error, filters, fetchPage, applyFilters, clearFilters, goToPage } = useAuditLog()
+const { t } = useI18n()
 
 const totalPages = computed(() => Math.ceil(total.value / pageSize))
 const hasFilters = computed(() => filters.action || filters.userId || filters.dateFrom || filters.dateTo)
@@ -19,10 +21,10 @@ const expandedTextIds = ref<number[]>([])
 
 const activeFilterChips = computed(() => {
   const chips: string[] = []
-  if (filters.action) chips.push(`Action: ${filters.action}`)
-  if (filters.userId) chips.push(`User: ${filters.userId}`)
-  if (filters.dateFrom) chips.push(`From: ${filters.dateFrom}`)
-  if (filters.dateTo) chips.push(`To: ${filters.dateTo}`)
+  if (filters.action) chips.push(t('audit.chips.action', { value: filters.action }))
+  if (filters.userId) chips.push(t('audit.chips.user', { value: filters.userId }))
+  if (filters.dateFrom) chips.push(t('audit.chips.from', { value: filters.dateFrom }))
+  if (filters.dateTo) chips.push(t('audit.chips.to', { value: filters.dateTo }))
   return chips
 })
 
@@ -85,18 +87,13 @@ watch(
 </script>
 
 <template>
-  <SettingsPageHeader
-    v-if="!props.embedded"
-    class="hidden md:flex"
-    title="Audit Log"
-    subtitle="A record of admin-significant actions performed across the system."
-  />
+  <SettingsPageHeader v-if="!props.embedded" class="hidden md:flex" :title="t('audit.pageTitle')" :subtitle="t('audit.pageSubtitle')" />
   <div v-if="!props.embedded" class="md:hidden px-1">
-    <h1 class="text-xl font-semibold tracking-tight text-foreground">Audit Log</h1>
+    <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('audit.pageTitle') }}</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
     >
-      A record of admin-significant actions performed across the system.
+      {{ t('audit.pageSubtitle') }}
     </p>
   </div>
 
@@ -107,8 +104,8 @@ watch(
         @click="filtersOpen = !filtersOpen"
       >
         <div class="min-w-0">
-          <p class="text-sm font-medium text-foreground">Filters</p>
-          <p v-if="activeFilterChips.length === 0" class="text-xs text-muted-foreground">No active filters</p>
+          <p class="text-sm font-medium text-foreground">{{ t('audit.filters') }}</p>
+          <p v-if="activeFilterChips.length === 0" class="text-xs text-muted-foreground">{{ t('audit.noActiveFilters') }}</p>
           <div v-else class="mt-1 flex flex-wrap gap-1.5">
             <span
               v-for="chip in activeFilterChips"
@@ -126,25 +123,25 @@ watch(
       <div v-if="filtersOpen" class="border-t border-border p-4">
         <div class="grid gap-3 md:flex md:flex-wrap md:items-end md:gap-2">
           <div class="flex flex-col gap-1 md:w-auto">
-            <label class="text-xs text-muted-foreground">Action</label>
+            <label class="text-xs text-muted-foreground">{{ t('audit.filterLabels.action') }}</label>
             <input
               v-model="filters.action"
               class="h-9 md:h-8 rounded-md border border-input bg-background px-2.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring md:w-44"
-              placeholder="e.g. auth.login"
+              :placeholder="t('audit.filterPlaceholders.action')"
               @keydown.enter="handleSearch"
             />
           </div>
           <div class="flex flex-col gap-1 md:w-auto">
-            <label class="text-xs text-muted-foreground">User ID</label>
+            <label class="text-xs text-muted-foreground">{{ t('audit.filterLabels.userId') }}</label>
             <input
               v-model="filters.userId"
               class="h-9 md:h-8 rounded-md border border-input bg-background px-2.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring md:w-28"
-              placeholder="e.g. 1"
+              :placeholder="t('audit.filterPlaceholders.userId')"
               @keydown.enter="handleSearch"
             />
           </div>
           <div class="flex flex-col gap-1 md:w-auto">
-            <label class="text-xs text-muted-foreground">From</label>
+            <label class="text-xs text-muted-foreground">{{ t('audit.filterLabels.from') }}</label>
             <input
               v-model="filters.dateFrom"
               type="date"
@@ -152,7 +149,7 @@ watch(
             />
           </div>
           <div class="flex flex-col gap-1 md:w-auto">
-            <label class="text-xs text-muted-foreground">To</label>
+            <label class="text-xs text-muted-foreground">{{ t('audit.filterLabels.to') }}</label>
             <input
               v-model="filters.dateTo"
               type="date"
@@ -162,11 +159,11 @@ watch(
           <div class="hidden md:flex gap-2">
             <button class="settings-btn-primary h-8" @click="handleSearch">
               <Search :size="13" />
-              Search
+              {{ t('common.search') }}
             </button>
             <button v-if="hasFilters" class="settings-btn-outline h-8" @click="handleClear">
               <X :size="13" />
-              Clear
+              {{ t('audit.clear') }}
             </button>
             <button class="settings-btn-outline h-8" :disabled="loading" @click="fetchPage">
               <RefreshCw :size="13" :class="loading ? 'animate-spin' : ''" />
@@ -180,11 +177,11 @@ watch(
       <div class="flex items-center gap-2">
         <button class="settings-btn-primary h-9 flex-1 justify-center" @click="handleSearch">
           <Search :size="13" />
-          Search
+          {{ t('common.search') }}
         </button>
         <button v-if="hasFilters" class="settings-btn-outline h-9" @click="handleClear">
           <X :size="13" />
-          Clear
+          {{ t('audit.clear') }}
         </button>
         <button class="settings-btn-outline h-9 px-2.5" :disabled="loading" @click="fetchPage">
           <RefreshCw :size="13" :class="loading ? 'animate-spin' : ''" />
@@ -198,19 +195,19 @@ watch(
       <table class="w-full text-sm">
         <thead class="bg-muted/50">
           <tr>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">When</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">User</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">Action</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Description</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap hidden md:table-cell">IP</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">{{ t('audit.columns.when') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">{{ t('audit.columns.user') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap">{{ t('audit.columns.action') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('audit.columns.description') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground whitespace-nowrap hidden md:table-cell">{{ t('audit.columns.ip') }}</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-border">
           <tr v-if="loading">
-            <td colspan="5" class="px-4 py-8 text-center text-sm text-muted-foreground">Loading...</td>
+            <td colspan="5" class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('common.loading') }}</td>
           </tr>
           <tr v-else-if="entries.length === 0">
-            <td colspan="5" class="px-4 py-8 text-center text-sm text-muted-foreground">No audit logs found</td>
+            <td colspan="5" class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('audit.empty') }}</td>
           </tr>
           <tr
             v-else
@@ -237,8 +234,8 @@ watch(
     </div>
 
     <div class="md:hidden border border-border rounded-lg bg-card overflow-hidden divide-y divide-border shadow-xs">
-      <div v-if="loading" class="px-4 py-8 text-center text-sm text-muted-foreground">Loading...</div>
-      <div v-else-if="entries.length === 0" class="px-4 py-8 text-center text-sm text-muted-foreground">No audit logs found</div>
+      <div v-if="loading" class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('common.loading') }}</div>
+      <div v-else-if="entries.length === 0" class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('audit.empty') }}</div>
       <div v-else v-for="entry in entries" :key="entry.id" class="px-4 py-3" :class="isFailedAuth(entry.action) ? 'bg-destructive/5' : 'bg-card'">
         <div class="flex items-start justify-between gap-3">
           <p class="text-xs text-muted-foreground">{{ formatDate(entry.createdAt) }}</p>
@@ -253,24 +250,24 @@ watch(
         <p class="mt-2 text-sm text-muted-foreground" :class="isTextOpen(entry.id) ? '' : 'line-clamp-2'">{{ entry.description }}</p>
         <div class="mt-2 flex items-center gap-3">
           <button v-if="hasLongText(entry)" class="text-xs text-primary hover:underline" @click="toggleText(entry.id)">
-            {{ isTextOpen(entry.id) ? 'Show less' : 'Show more' }}
+            {{ isTextOpen(entry.id) ? t('audit.showLess') : t('audit.showMore') }}
           </button>
           <button class="text-xs text-muted-foreground hover:text-foreground" @click="toggleDetails(entry.id)">
-            {{ isDetailsOpen(entry.id) ? 'Hide details' : 'Details' }}
+            {{ isDetailsOpen(entry.id) ? t('audit.hideDetails') : t('audit.details') }}
           </button>
         </div>
         <div
           v-if="isDetailsOpen(entry.id)"
           class="mt-2 rounded-md border border-border bg-background px-3 py-2 text-xs text-muted-foreground space-y-1"
         >
-          <p class="font-mono">Action: {{ entry.action }}</p>
-          <p class="font-mono">IP: {{ entry.ip ?? '-' }}</p>
+          <p class="font-mono">{{ t('audit.detailAction', { value: entry.action }) }}</p>
+          <p class="font-mono">{{ t('audit.detailIp', { value: entry.ip ?? '-' }) }}</p>
         </div>
       </div>
     </div>
 
     <div v-if="totalPages > 1" class="hidden md:flex items-center justify-between text-sm text-muted-foreground">
-      <span>Showing {{ (page - 1) * pageSize + 1 }}-{{ Math.min(page * pageSize, total) }} of {{ total }}</span>
+      <span>{{ t('audit.showing', { from: (page - 1) * pageSize + 1, to: Math.min(page * pageSize, total), total }) }}</span>
       <div class="flex items-center gap-1">
         <button
           class="p-1.5 rounded hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
@@ -297,7 +294,7 @@ watch(
           :disabled="page <= 1"
           @click="goToPage(page - 1)"
         >
-          Prev
+          {{ t('audit.prev') }}
         </button>
         <span class="text-xs text-muted-foreground text-center">
           {{ (page - 1) * pageSize + 1 }}-{{ Math.min(page * pageSize, total) }} / {{ total }}
@@ -307,7 +304,7 @@ watch(
           :disabled="page >= totalPages"
           @click="goToPage(page + 1)"
         >
-          Next
+          {{ t('common.next') }}
         </button>
       </div>
     </div>

--- a/client/src/features/auth/ChangePasswordDialog.vue
+++ b/client/src/features/auth/ChangePasswordDialog.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X } from '@lucide/vue'
 import { api } from '@/lib/api'
 import { useAuth } from './composables/useAuth'
 import { useChangePasswordDialog } from '@/composables/useChangePasswordDialog'
 
+const { t } = useI18n()
 const { me } = useAuth()
 const { isForced, close } = useChangePasswordDialog()
 
@@ -18,7 +20,7 @@ async function handleSubmit() {
   error.value = null
 
   if (newPassword.value !== confirmPassword.value) {
-    error.value = 'Passwords do not match'
+    error.value = t('auth.errors.passwordsDoNotMatch')
     return
   }
 
@@ -32,7 +34,7 @@ async function handleSubmit() {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      error.value = err.message ?? 'Failed to change password'
+      error.value = err.message ?? t('auth.changePassword.errors.failed')
       return
     }
 
@@ -41,7 +43,7 @@ async function handleSubmit() {
     await me().catch(() => {})
     close()
   } catch {
-    error.value = 'Something went wrong. Please try again.'
+    error.value = t('auth.errors.generic')
   } finally {
     loading.value = false
   }
@@ -53,19 +55,19 @@ async function handleSubmit() {
     <div class="fixed inset-0 z-[70] flex items-center justify-center bg-black/50 px-4">
       <div class="w-full max-w-sm rounded-lg border border-border bg-card shadow-xl p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-base font-semibold text-foreground">Change password</h2>
+          <h2 class="text-base font-semibold text-foreground">{{ t('auth.changePassword.title') }}</h2>
           <button v-if="!isForced" @click="close" class="text-muted-foreground hover:text-foreground transition-colors">
             <X :size="16" />
           </button>
         </div>
 
         <div v-if="isForced" class="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-400">
-          You must set a new password before continuing.
+          {{ t('auth.changePassword.forcedNotice') }}
         </div>
 
         <form @submit.prevent="handleSubmit" class="space-y-4">
           <div class="space-y-1.5">
-            <label for="cp-current" class="text-sm font-medium text-foreground">Current password</label>
+            <label for="cp-current" class="text-sm font-medium text-foreground">{{ t('auth.fields.currentPassword') }}</label>
             <input
               id="cp-current"
               v-model="currentPassword"
@@ -77,7 +79,7 @@ async function handleSubmit() {
           </div>
 
           <div class="space-y-1.5">
-            <label for="cp-new" class="text-sm font-medium text-foreground">New password</label>
+            <label for="cp-new" class="text-sm font-medium text-foreground">{{ t('auth.fields.newPassword') }}</label>
             <input
               id="cp-new"
               v-model="newPassword"
@@ -86,11 +88,11 @@ async function handleSubmit() {
               required
               class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
             />
-            <p class="text-xs text-muted-foreground">Min. 8 characters with uppercase, lowercase, and a digit</p>
+            <p class="text-xs text-muted-foreground">{{ t('auth.fields.passwordHint') }}</p>
           </div>
 
           <div class="space-y-1.5">
-            <label for="cp-confirm" class="text-sm font-medium text-foreground">Confirm new password</label>
+            <label for="cp-confirm" class="text-sm font-medium text-foreground">{{ t('auth.fields.confirmNewPassword') }}</label>
             <input
               id="cp-confirm"
               v-model="confirmPassword"
@@ -110,14 +112,14 @@ async function handleSubmit() {
               @click="close"
               class="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               type="submit"
               :disabled="loading"
               class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
             >
-              {{ loading ? 'Saving…' : 'Change password' }}
+              {{ loading ? t('auth.changePassword.saving') : t('auth.changePassword.title') }}
             </button>
           </div>
         </form>

--- a/client/src/features/auth/ForgotPasswordPage.vue
+++ b/client/src/features/auth/ForgotPasswordPage.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Moon, Sun, Wallpaper } from '@lucide/vue'
 import { ACCENT_VIVID, ACCENT_PASTEL, ACCENT_OPTIONS, RADIUS_OPTIONS, BACKGROUND_OPTIONS, useThemeStore } from '@/stores/theme'
 import { api } from '@/lib/api'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
+const { t } = useI18n()
 const themeStore = useThemeStore()
 const accentOpen = ref(false)
 const radiusOpen = ref(false)
@@ -60,12 +62,12 @@ async function handleSubmit() {
       body: JSON.stringify({ email: email.value }),
     })
     if (res.status === 503) {
-      error.value = 'Password reset via email is not available. Contact your administrator.'
+      error.value = t('auth.forgotPassword.errors.emailUnavailable')
       return
     }
     submitted.value = true
   } catch {
-    error.value = 'Something went wrong. Please try again.'
+    error.value = t('auth.errors.generic')
   } finally {
     loading.value = false
   }
@@ -84,7 +86,7 @@ async function handleSubmit() {
             <Moon v-else :size="14" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{{ themeStore.theme === 'dark' ? 'Switch to light' : 'Switch to dark' }}</TooltipContent>
+        <TooltipContent>{{ themeStore.theme === 'dark' ? t('auth.themePicker.switchToLight') : t('auth.themePicker.switchToDark') }}</TooltipContent>
       </Tooltip>
 
       <!-- Radius picker -->
@@ -117,7 +119,7 @@ async function handleSubmit() {
               <span class="w-3.5 h-3.5 border-2 border-current block" :style="{ borderRadius: radiusPreview(themeStore.radius) }" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change corner radius</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeRadius') }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -149,7 +151,7 @@ async function handleSubmit() {
               <Wallpaper :size="14" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change background</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeBackground') }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -199,7 +201,7 @@ async function handleSubmit() {
               <span class="w-3.5 h-3.5 rounded-full block" :style="{ backgroundColor: currentAccent?.color }" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change accent color</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeAccent') }}</TooltipContent>
         </Tooltip>
       </div>
     </div>
@@ -210,16 +212,16 @@ async function handleSubmit() {
     <div class="login-card relative z-10 w-full max-w-sm rounded-2xl p-8">
       <div class="text-center mb-8">
         <h1 class="text-2xl font-serif font-semibold text-foreground">Book<span class="text-primary"> Orbit</span></h1>
-        <p class="text-sm text-muted-foreground mt-1">Reset your password</p>
+        <p class="text-sm text-muted-foreground mt-1">{{ t('auth.forgotPassword.subtitle') }}</p>
       </div>
 
       <div v-if="submitted" class="rounded-md border border-border bg-card/60 backdrop-blur-sm p-4 text-sm text-foreground">
-        If an account with that email exists, a reset link has been sent. Check your inbox.
+        {{ t('auth.forgotPassword.submitted') }}
       </div>
 
       <form v-else @submit.prevent="handleSubmit" class="space-y-4">
         <div class="space-y-1.5">
-          <label for="email" class="text-sm font-medium text-foreground">Email address</label>
+          <label for="email" class="text-sm font-medium text-foreground">{{ t('auth.fields.emailAddress') }}</label>
           <input
             id="email"
             v-model="email"
@@ -237,12 +239,12 @@ async function handleSubmit() {
           :disabled="loading"
           class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
         >
-          {{ loading ? 'Sending...' : 'Send reset link' }}
+          {{ loading ? t('auth.forgotPassword.sending') : t('auth.forgotPassword.sendResetLink') }}
         </button>
       </form>
 
       <p class="mt-4 text-center text-sm text-muted-foreground">
-        <RouterLink to="/login" class="text-primary hover:underline">Back to sign in</RouterLink>
+        <RouterLink to="/login" class="text-primary hover:underline">{{ t('auth.backToSignIn') }}</RouterLink>
       </p>
     </div>
   </div>

--- a/client/src/features/auth/LoginPage.vue
+++ b/client/src/features/auth/LoginPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { OidcProviderPublic } from '@bookorbit/types'
 import { Moon, Sun, Wallpaper } from '@lucide/vue'
 import { ACCENT_VIVID, ACCENT_PASTEL, ACCENT_OPTIONS, RADIUS_OPTIONS, BACKGROUND_OPTIONS, useThemeStore } from '@/stores/theme'
@@ -8,6 +9,7 @@ import { useOidc } from './composables/useOidc'
 import { useSetupStatus } from './composables/useSetupStatus'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
+const { t } = useI18n()
 const themeStore = useThemeStore()
 const accentOpen = ref(false)
 const radiusOpen = ref(false)
@@ -60,17 +62,17 @@ const oidcProviders = ref<OidcProviderPublic[]>([])
 const oidcLoadingSlug = ref<string | null>(null)
 
 function resolveLoginError(err: unknown): string {
-  if (!(err instanceof Error)) return 'Invalid username or password'
+  if (!(err instanceof Error)) return t('auth.login.errors.invalidCredentials')
 
   const normalizedMessage = err.message.trim().toLowerCase()
   if (normalizedMessage.includes('too many requests')) {
-    return 'Too many login attempts. Please wait a minute and try again.'
+    return t('auth.login.errors.tooManyAttempts')
   }
   if (normalizedMessage.includes('invalid credentials')) {
-    return 'Invalid username or password'
+    return t('auth.login.errors.invalidCredentials')
   }
 
-  return err.message || 'Invalid username or password'
+  return err.message || t('auth.login.errors.invalidCredentials')
 }
 
 onMounted(async () => {
@@ -95,7 +97,7 @@ async function handleOidcLogin(provider: OidcProviderPublic) {
   try {
     await initiateLogin(provider)
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'OIDC login failed'
+    error.value = err instanceof Error ? err.message : t('auth.oidc.loginFailed')
     oidcLoadingSlug.value = null
   }
 }
@@ -113,7 +115,7 @@ async function handleOidcLogin(provider: OidcProviderPublic) {
             <Moon v-else :size="14" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{{ themeStore.theme === 'dark' ? 'Switch to light' : 'Switch to dark' }}</TooltipContent>
+        <TooltipContent>{{ themeStore.theme === 'dark' ? t('auth.themePicker.switchToLight') : t('auth.themePicker.switchToDark') }}</TooltipContent>
       </Tooltip>
 
       <!-- Radius picker -->
@@ -146,7 +148,7 @@ async function handleOidcLogin(provider: OidcProviderPublic) {
               <span class="w-3.5 h-3.5 border-2 border-current block" :style="{ borderRadius: radiusPreview(themeStore.radius) }" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change corner radius</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeRadius') }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -178,7 +180,7 @@ async function handleOidcLogin(provider: OidcProviderPublic) {
               <Wallpaper :size="14" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change background</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeBackground') }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -231,7 +233,7 @@ async function handleOidcLogin(provider: OidcProviderPublic) {
               <span class="w-3.5 h-3.5 rounded-full block" :style="{ backgroundColor: currentAccent?.color }" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change accent color</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeAccent') }}</TooltipContent>
         </Tooltip>
       </div>
     </div>
@@ -242,12 +244,12 @@ async function handleOidcLogin(provider: OidcProviderPublic) {
     <div class="login-card relative z-10 w-full max-w-sm rounded-2xl p-8">
       <div class="text-center mb-8 animate-fade-up">
         <h1 class="text-2xl font-serif font-semibold text-foreground">Book<span class="text-primary"> Orbit</span></h1>
-        <p class="text-sm text-muted-foreground mt-1">Sign in to your account</p>
+        <p class="text-sm text-muted-foreground mt-1">{{ t('auth.login.subtitle') }}</p>
       </div>
 
       <form @submit.prevent="handleSubmit" class="space-y-4">
         <div class="space-y-1.5 animate-fade-up" style="animation-delay: 80ms">
-          <label for="username" class="text-sm font-medium text-foreground">Username</label>
+          <label for="username" class="text-sm font-medium text-foreground">{{ t('auth.fields.username') }}</label>
           <input
             id="username"
             v-model="username"
@@ -259,7 +261,7 @@ async function handleOidcLogin(provider: OidcProviderPublic) {
         </div>
 
         <div class="space-y-1.5 animate-fade-up" style="animation-delay: 160ms">
-          <label for="password" class="text-sm font-medium text-foreground">Password</label>
+          <label for="password" class="text-sm font-medium text-foreground">{{ t('auth.fields.password') }}</label>
           <input
             id="password"
             v-model="password"
@@ -279,14 +281,14 @@ async function handleOidcLogin(provider: OidcProviderPublic) {
           class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors animate-fade-up"
           style="animation-delay: 240ms"
         >
-          {{ loading ? 'Signing in...' : 'Sign in' }}
+          {{ loading ? t('auth.login.signingIn') : t('auth.login.signIn') }}
         </button>
       </form>
 
       <template v-if="oidcProviders.length > 0">
         <div class="flex items-center gap-3 my-6">
           <div class="flex-1 h-px bg-border" />
-          <span class="text-sm text-muted-foreground">or</span>
+          <span class="text-sm text-muted-foreground">{{ t('auth.login.orDivider') }}</span>
           <div class="flex-1 h-px bg-border" />
         </div>
 
@@ -300,13 +302,13 @@ async function handleOidcLogin(provider: OidcProviderPublic) {
             @click="handleOidcLogin(provider)"
           >
             <img v-if="provider.iconUrl" :src="provider.iconUrl" alt="" class="h-4 w-4 shrink-0 object-contain" />
-            {{ oidcLoadingSlug === provider.slug ? 'Redirecting...' : `Sign in with ${provider.displayName}` }}
+            {{ oidcLoadingSlug === provider.slug ? t('auth.oidc.redirecting') : t('auth.oidc.signInWith', { provider: provider.displayName }) }}
           </button>
         </div>
       </template>
 
       <p class="mt-6 text-center text-sm text-muted-foreground">
-        <RouterLink to="/forgot-password" class="text-primary hover:underline">Forgot password?</RouterLink>
+        <RouterLink to="/forgot-password" class="text-primary hover:underline">{{ t('auth.login.forgotPassword') }}</RouterLink>
       </p>
     </div>
   </div>

--- a/client/src/features/auth/MagicLinkLoginView.vue
+++ b/client/src/features/auth/MagicLinkLoginView.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { Loader2, AlertCircle } from '@lucide/vue'
 import { useAuth } from '@/features/auth/composables/useAuth'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { loginWithMagicLink } = useAuth()
@@ -21,7 +23,7 @@ onMounted(async () => {
 
   if (!token) {
     status.value = 'error'
-    errorMessage.value = 'No token provided'
+    errorMessage.value = t('auth.magicLink.errors.noToken')
     return
   }
 
@@ -29,7 +31,7 @@ onMounted(async () => {
     await loginWithMagicLink(token)
   } catch (e) {
     status.value = 'error'
-    errorMessage.value = e instanceof Error ? e.message : 'Login failed'
+    errorMessage.value = e instanceof Error ? e.message : t('auth.magicLink.loginFailed')
   }
 })
 
@@ -43,7 +45,7 @@ function goToLogin() {
     <div class="w-full max-w-sm text-center">
       <div v-if="status === 'loading'" class="space-y-4">
         <Loader2 :size="32" class="mx-auto text-primary animate-spin" />
-        <p class="text-sm text-muted-foreground">Signing you in...</p>
+        <p class="text-sm text-muted-foreground">{{ t('auth.magicLink.signingIn') }}</p>
       </div>
 
       <div v-else class="space-y-4">
@@ -51,14 +53,14 @@ function goToLogin() {
           <AlertCircle :size="24" class="text-destructive" />
         </div>
         <div>
-          <p class="text-base font-semibold text-foreground">Login failed</p>
+          <p class="text-base font-semibold text-foreground">{{ t('auth.magicLink.loginFailed') }}</p>
           <p class="mt-1 text-sm text-muted-foreground">{{ errorMessage }}</p>
         </div>
         <button
           class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
           @click="goToLogin"
         >
-          Go to login
+          {{ t('auth.magicLink.goToLogin') }}
         </button>
       </div>
     </div>

--- a/client/src/features/auth/OidcCallbackPage.vue
+++ b/client/src/features/auth/OidcCallbackPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import type { OidcCallbackResponse } from '@bookorbit/types'
 import { OidcErrorCode } from '@bookorbit/types'
@@ -7,18 +8,20 @@ import { setAccessToken } from '@/lib/api'
 import { useAuth } from './composables/useAuth'
 import { useOidc, OidcLoginError } from './composables/useOidc'
 
-const OIDC_ERROR_MESSAGES: Record<string, string> = {
-  [OidcErrorCode.STATE_EXPIRED]: 'Your login session expired. Please try signing in again.',
-  [OidcErrorCode.TOKEN_EXCHANGE_FAILED]: 'Could not complete sign-in with your provider. Please try again or contact your administrator.',
-  [OidcErrorCode.USER_NOT_PROVISIONED]: 'Your account has not been set up. Contact your administrator for access.',
-  [OidcErrorCode.USER_INACTIVE]: 'Your account has been deactivated. Contact your administrator.',
-  [OidcErrorCode.PROVIDER_ERROR]: 'Your identity provider returned an error. Please try again.',
+const { t } = useI18n()
+
+const OIDC_ERROR_MESSAGE_KEYS: Record<string, string> = {
+  [OidcErrorCode.STATE_EXPIRED]: 'auth.oidc.errors.stateExpired',
+  [OidcErrorCode.TOKEN_EXCHANGE_FAILED]: 'auth.oidc.errors.tokenExchangeFailed',
+  [OidcErrorCode.USER_NOT_PROVISIONED]: 'auth.oidc.errors.userNotProvisioned',
+  [OidcErrorCode.USER_INACTIVE]: 'auth.oidc.errors.userInactive',
+  [OidcErrorCode.PROVIDER_ERROR]: 'auth.oidc.errors.providerError',
 }
 
-const PROVIDER_ERROR_DESCRIPTIONS: Record<string, string> = {
-  access_denied: 'Access was denied by the identity provider.',
-  login_required: 'Authentication is required. Please sign in again.',
-  interaction_required: 'Additional user interaction is required.',
+const PROVIDER_ERROR_DESCRIPTION_KEYS: Record<string, string> = {
+  access_denied: 'auth.oidc.providerErrors.accessDenied',
+  login_required: 'auth.oidc.providerErrors.loginRequired',
+  interaction_required: 'auth.oidc.providerErrors.interactionRequired',
 }
 
 const router = useRouter()
@@ -34,12 +37,13 @@ onMounted(async () => {
 
   if (errorParam) {
     const description = params.get('error_description')
-    error.value = PROVIDER_ERROR_DESCRIPTIONS[errorParam] ?? description ?? 'Your identity provider returned an error. Please try again.'
+    const descriptionKey = PROVIDER_ERROR_DESCRIPTION_KEYS[errorParam]
+    error.value = descriptionKey ? t(descriptionKey) : (description ?? t('auth.oidc.errors.providerError'))
     return
   }
 
   if (!code || !state) {
-    error.value = 'Missing code or state parameter'
+    error.value = t('auth.oidc.errors.missingCodeOrState')
     return
   }
 
@@ -67,10 +71,11 @@ onMounted(async () => {
       return
     }
   } catch (err) {
-    if (err instanceof OidcLoginError && err.errorCode && OIDC_ERROR_MESSAGES[err.errorCode]) {
-      error.value = OIDC_ERROR_MESSAGES[err.errorCode] ?? null
+    const messageKey = err instanceof OidcLoginError && err.errorCode ? OIDC_ERROR_MESSAGE_KEYS[err.errorCode] : undefined
+    if (messageKey) {
+      error.value = t(messageKey)
     } else {
-      error.value = err instanceof Error ? err.message : 'OIDC login failed'
+      error.value = err instanceof Error ? err.message : t('auth.oidc.loginFailed')
     }
   }
 })
@@ -85,12 +90,12 @@ onMounted(async () => {
         <div class="flex justify-center">
           <div class="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" />
         </div>
-        <p class="text-sm text-muted-foreground">Completing sign in...</p>
+        <p class="text-sm text-muted-foreground">{{ t('auth.oidc.completingSignIn') }}</p>
       </div>
 
       <div v-else class="space-y-4">
         <p class="text-sm text-destructive">{{ error }}</p>
-        <RouterLink to="/login" class="text-sm text-primary hover:underline">Try again</RouterLink>
+        <RouterLink to="/login" class="text-sm text-primary hover:underline">{{ t('auth.oidc.tryAgain') }}</RouterLink>
       </div>
     </div>
   </div>

--- a/client/src/features/auth/ResetPasswordPage.vue
+++ b/client/src/features/auth/ResetPasswordPage.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { Moon, Sun, Wallpaper } from '@lucide/vue'
 import { ACCENT_VIVID, ACCENT_PASTEL, ACCENT_OPTIONS, RADIUS_OPTIONS, BACKGROUND_OPTIONS, useThemeStore } from '@/stores/theme'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
+const { t } = useI18n()
 const themeStore = useThemeStore()
 const accentOpen = ref(false)
 const radiusOpen = ref(false)
@@ -57,7 +59,7 @@ const loading = ref(false)
 onMounted(() => {
   token.value = (route.query.token as string) ?? ''
   if (!token.value) {
-    error.value = 'Invalid reset link. Please request a new one.'
+    error.value = t('auth.resetPassword.errors.invalidLink')
   }
 })
 
@@ -65,7 +67,7 @@ async function handleSubmit() {
   error.value = null
 
   if (newPassword.value !== confirmPassword.value) {
-    error.value = 'Passwords do not match'
+    error.value = t('auth.errors.passwordsDoNotMatch')
     return
   }
 
@@ -79,13 +81,13 @@ async function handleSubmit() {
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      error.value = err.message ?? 'Invalid or expired reset link. Please request a new one.'
+      error.value = err.message ?? t('auth.resetPassword.errors.invalidOrExpired')
       return
     }
 
     router.push({ path: '/login', query: { reset: '1' } })
   } catch {
-    error.value = 'Something went wrong. Please try again.'
+    error.value = t('auth.errors.generic')
   } finally {
     loading.value = false
   }
@@ -104,7 +106,7 @@ async function handleSubmit() {
             <Moon v-else :size="14" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{{ themeStore.theme === 'dark' ? 'Switch to light' : 'Switch to dark' }}</TooltipContent>
+        <TooltipContent>{{ themeStore.theme === 'dark' ? t('auth.themePicker.switchToLight') : t('auth.themePicker.switchToDark') }}</TooltipContent>
       </Tooltip>
 
       <!-- Radius picker -->
@@ -137,7 +139,7 @@ async function handleSubmit() {
               <span class="w-3.5 h-3.5 border-2 border-current block" :style="{ borderRadius: radiusPreview(themeStore.radius) }" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change corner radius</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeRadius') }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -169,7 +171,7 @@ async function handleSubmit() {
               <Wallpaper :size="14" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change background</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeBackground') }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -219,7 +221,7 @@ async function handleSubmit() {
               <span class="w-3.5 h-3.5 rounded-full block" :style="{ backgroundColor: currentAccent?.color }" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change accent color</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeAccent') }}</TooltipContent>
         </Tooltip>
       </div>
     </div>
@@ -230,12 +232,12 @@ async function handleSubmit() {
     <div class="login-card relative z-10 w-full max-w-sm rounded-2xl p-8">
       <div class="text-center mb-8">
         <h1 class="text-2xl font-serif font-semibold text-foreground">Book<span class="text-primary"> Orbit</span></h1>
-        <p class="text-sm text-muted-foreground mt-1">Set a new password</p>
+        <p class="text-sm text-muted-foreground mt-1">{{ t('auth.resetPassword.subtitle') }}</p>
       </div>
 
       <form @submit.prevent="handleSubmit" class="space-y-4">
         <div class="space-y-1.5">
-          <label for="newPassword" class="text-sm font-medium text-foreground">New password</label>
+          <label for="newPassword" class="text-sm font-medium text-foreground">{{ t('auth.fields.newPassword') }}</label>
           <input
             id="newPassword"
             v-model="newPassword"
@@ -244,11 +246,11 @@ async function handleSubmit() {
             required
             class="w-full rounded-md border border-input bg-background/60 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 backdrop-blur-sm"
           />
-          <p class="text-xs text-muted-foreground">Min. 8 characters with uppercase, lowercase, and a digit</p>
+          <p class="text-xs text-muted-foreground">{{ t('auth.fields.passwordHint') }}</p>
         </div>
 
         <div class="space-y-1.5">
-          <label for="confirmPassword" class="text-sm font-medium text-foreground">Confirm password</label>
+          <label for="confirmPassword" class="text-sm font-medium text-foreground">{{ t('auth.fields.confirmPassword') }}</label>
           <input
             id="confirmPassword"
             v-model="confirmPassword"
@@ -266,12 +268,12 @@ async function handleSubmit() {
           :disabled="loading || !token"
           class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
         >
-          {{ loading ? 'Saving...' : 'Set new password' }}
+          {{ loading ? t('auth.resetPassword.saving') : t('auth.resetPassword.setNewPassword') }}
         </button>
       </form>
 
       <p class="mt-4 text-center text-sm text-muted-foreground">
-        <RouterLink to="/login" class="text-primary hover:underline">Back to sign in</RouterLink>
+        <RouterLink to="/login" class="text-primary hover:underline">{{ t('auth.backToSignIn') }}</RouterLink>
       </p>
     </div>
   </div>

--- a/client/src/features/auth/SetupPage.vue
+++ b/client/src/features/auth/SetupPage.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Moon, Sun, Wallpaper } from '@lucide/vue'
 import { ACCENT_VIVID, ACCENT_PASTEL, ACCENT_OPTIONS, RADIUS_OPTIONS, BACKGROUND_OPTIONS, useThemeStore } from '@/stores/theme'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAuth } from './composables/useAuth'
 
+const { t } = useI18n()
 const themeStore = useThemeStore()
 const accentOpen = ref(false)
 const radiusOpen = ref(false)
@@ -61,7 +63,7 @@ async function handleSubmit() {
   error.value = null
 
   if (password.value !== confirmPassword.value) {
-    error.value = 'Passwords do not match'
+    error.value = t('auth.errors.passwordsDoNotMatch')
     return
   }
 
@@ -75,7 +77,7 @@ async function handleSubmit() {
       setupToken: setupToken.value || undefined,
     })
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to complete setup'
+    error.value = err instanceof Error ? err.message : t('auth.setup.errors.failed')
   } finally {
     loading.value = false
   }
@@ -94,7 +96,7 @@ async function handleSubmit() {
             <Moon v-else :size="14" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{{ themeStore.theme === 'dark' ? 'Switch to light' : 'Switch to dark' }}</TooltipContent>
+        <TooltipContent>{{ themeStore.theme === 'dark' ? t('auth.themePicker.switchToLight') : t('auth.themePicker.switchToDark') }}</TooltipContent>
       </Tooltip>
 
       <!-- Radius picker -->
@@ -127,7 +129,7 @@ async function handleSubmit() {
               <span class="w-3.5 h-3.5 border-2 border-current block" :style="{ borderRadius: radiusPreview(themeStore.radius) }" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change corner radius</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeRadius') }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -159,7 +161,7 @@ async function handleSubmit() {
               <Wallpaper :size="14" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change background</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeBackground') }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -211,7 +213,7 @@ async function handleSubmit() {
               <span class="w-3.5 h-3.5 rounded-full block" :style="{ backgroundColor: currentAccent?.color }" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Change accent color</TooltipContent>
+          <TooltipContent>{{ t('auth.themePicker.changeAccent') }}</TooltipContent>
         </Tooltip>
       </div>
     </div>
@@ -221,13 +223,13 @@ async function handleSubmit() {
 
     <div class="login-card relative z-10 w-full max-w-md rounded-2xl p-8">
       <div class="mb-6">
-        <h1 class="text-xl font-semibold text-foreground">Initial setup</h1>
-        <p class="text-sm text-muted-foreground mt-1">Create the first administrator account.</p>
+        <h1 class="text-xl font-semibold text-foreground">{{ t('auth.setup.title') }}</h1>
+        <p class="text-sm text-muted-foreground mt-1">{{ t('auth.setup.subtitle') }}</p>
       </div>
 
       <form class="space-y-4" @submit.prevent="handleSubmit">
         <div class="space-y-1.5">
-          <label for="setup-username" class="text-sm font-medium text-foreground">Username</label>
+          <label for="setup-username" class="text-sm font-medium text-foreground">{{ t('auth.fields.username') }}</label>
           <input
             id="setup-username"
             v-model="username"
@@ -239,7 +241,7 @@ async function handleSubmit() {
         </div>
 
         <div class="space-y-1.5">
-          <label for="setup-name" class="text-sm font-medium text-foreground">Full name</label>
+          <label for="setup-name" class="text-sm font-medium text-foreground">{{ t('auth.fields.fullName') }}</label>
           <input
             id="setup-name"
             v-model="name"
@@ -251,7 +253,7 @@ async function handleSubmit() {
         </div>
 
         <div class="space-y-1.5">
-          <label for="setup-email" class="text-sm font-medium text-foreground">Email</label>
+          <label for="setup-email" class="text-sm font-medium text-foreground">{{ t('auth.fields.email') }}</label>
           <input
             id="setup-email"
             v-model="email"
@@ -263,7 +265,7 @@ async function handleSubmit() {
         </div>
 
         <div class="space-y-1.5">
-          <label for="setup-password" class="text-sm font-medium text-foreground">Password</label>
+          <label for="setup-password" class="text-sm font-medium text-foreground">{{ t('auth.fields.password') }}</label>
           <input
             id="setup-password"
             v-model="password"
@@ -272,11 +274,11 @@ async function handleSubmit() {
             required
             class="w-full rounded-md border border-input bg-background/60 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 backdrop-blur-sm"
           />
-          <p class="text-xs text-muted-foreground">Min. 8 characters with uppercase, lowercase, and a digit</p>
+          <p class="text-xs text-muted-foreground">{{ t('auth.fields.passwordHint') }}</p>
         </div>
 
         <div class="space-y-1.5">
-          <label for="setup-confirm-password" class="text-sm font-medium text-foreground">Confirm password</label>
+          <label for="setup-confirm-password" class="text-sm font-medium text-foreground">{{ t('auth.fields.confirmPassword') }}</label>
           <input
             id="setup-confirm-password"
             v-model="confirmPassword"
@@ -289,8 +291,8 @@ async function handleSubmit() {
 
         <div class="space-y-1.5">
           <label for="setup-token" class="text-sm font-medium text-foreground">
-            Setup token
-            <span class="text-muted-foreground">(required in production)</span>
+            {{ t('auth.setup.setupToken') }}
+            <span class="text-muted-foreground">{{ t('auth.setup.setupTokenHint') }}</span>
           </label>
           <input
             id="setup-token"
@@ -308,7 +310,7 @@ async function handleSubmit() {
           :disabled="loading"
           class="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
         >
-          {{ loading ? 'Creating account...' : 'Create administrator account' }}
+          {{ loading ? t('auth.setup.creatingAccount') : t('auth.setup.createAccount') }}
         </button>
       </form>
     </div>

--- a/client/src/features/auth/composables/useAuth.ts
+++ b/client/src/features/auth/composables/useAuth.ts
@@ -4,6 +4,7 @@ import { api, refreshAccessToken, setAccessToken, setOnAuthFailure } from '@/lib
 import router from '@/router'
 import { cancelPendingDisplaySettingsSync, initDisplaySettingsSync, loadDisplaySettingsFromServer } from '@/composables/useDisplaySettingsSync'
 import { cancelPendingThemeSync, initThemeSync, loadFromServer } from '@/composables/useThemeSync'
+import { cancelPendingLocaleSync, initLocaleSync, loadLocaleFromServer } from '@/composables/useLocaleSync'
 import { useSetupStatus } from './useSetupStatus'
 import { disconnectAuthorEnrichmentSocket } from '@/features/settings/composables/useAuthorEnrichmentStatus'
 import { disconnectBookMetadataFetchSocket } from '@/features/book-metadata-fetch/composables/useBookMetadataFetchStatus'
@@ -48,6 +49,7 @@ if (typeof document !== 'undefined') {
 function clearAuth() {
   cancelPendingThemeSync()
   cancelPendingDisplaySettingsSync()
+  cancelPendingLocaleSync()
   stopSessionRefresh()
   user.value = null
   setAccessToken(null)
@@ -76,10 +78,12 @@ async function hydrateThemeSync(options: { refreshUser?: boolean } = {}): Promis
   if (user.value?.settings?.syncThemePreferences) {
     await loadFromServer()
     await loadDisplaySettingsFromServer()
+    await loadLocaleFromServer()
   }
 
   initThemeSync()
   initDisplaySettingsSync()
+  initLocaleSync()
 }
 
 export function useAuth() {
@@ -95,6 +99,7 @@ export function useAuth() {
     } finally {
       initThemeSync()
       initDisplaySettingsSync()
+      initLocaleSync()
       isLoading.value = false
     }
   }

--- a/client/src/features/author/components/AuthorCard.vue
+++ b/client/src/features/author/components/AuthorCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { AuthorSummary } from '@bookorbit/types'
 import { BookCopy, Check, ExternalLink, Loader2, MoreHorizontal, RefreshCw, Trash2 } from '@lucide/vue'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
@@ -23,6 +24,8 @@ const emit = defineEmits<{
   refresh: [authorId: number]
   delete: [authorId: number]
 }>()
+
+const { t } = useI18n()
 
 const initial = computed(() => props.author.name.trim().charAt(0).toUpperCase() || '?')
 const fallbackStyle = computed(() => bookCoverStyle(props.author.name || String(props.author.id)))
@@ -76,7 +79,7 @@ function handleDelete() {
       <img
         v-if="hasImage"
         :src="imageSrc"
-        :alt="`${author.name} portrait`"
+        :alt="t('author.card.portraitAlt', { name: author.name })"
         class="absolute inset-0 h-full w-full object-cover transition-opacity duration-300 ease-out"
         loading="lazy"
         decoding="async"
@@ -126,12 +129,12 @@ function handleDelete() {
             <DropdownMenuContent align="end">
               <DropdownMenuItem @click="emit('open', author.id)">
                 <ExternalLink class="mr-2 h-4 w-4" />
-                View Author Details
+                {{ t('author.card.viewDetails') }}
               </DropdownMenuItem>
               <DropdownMenuItem :disabled="!canRefresh || refreshing" @click="handleRefresh">
                 <Loader2 v-if="refreshing" class="mr-2 h-4 w-4 animate-spin" />
                 <RefreshCw v-else class="mr-2 h-4 w-4" />
-                Refresh Metadata
+                {{ t('author.card.refreshMetadata') }}
               </DropdownMenuItem>
               <DropdownMenuItem
                 :disabled="!canDelete || deleting"
@@ -140,7 +143,7 @@ function handleDelete() {
               >
                 <Loader2 v-if="deleting" class="mr-2 h-4 w-4 animate-spin" />
                 <Trash2 v-else class="mr-2 h-4 w-4" />
-                Delete Author
+                {{ t('author.card.deleteAuthor') }}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -174,7 +177,7 @@ function handleDelete() {
         <img
           v-if="hasImage"
           :src="imageSrc"
-          :alt="`${author.name} portrait`"
+          :alt="t('author.card.portraitAlt', { name: author.name })"
           class="absolute inset-0 h-full w-full object-cover transition-opacity duration-300 ease-out"
           loading="lazy"
           decoding="async"
@@ -222,12 +225,12 @@ function handleDelete() {
         <DropdownMenuContent align="end">
           <DropdownMenuItem @click="emit('open', author.id)">
             <ExternalLink class="mr-2 h-4 w-4" />
-            View Author Details
+            {{ t('author.card.viewDetails') }}
           </DropdownMenuItem>
           <DropdownMenuItem :disabled="!canRefresh || refreshing" @click="handleRefresh">
             <Loader2 v-if="refreshing" class="mr-2 h-4 w-4 animate-spin" />
             <RefreshCw v-else class="mr-2 h-4 w-4" />
-            Refresh Metadata
+            {{ t('author.card.refreshMetadata') }}
           </DropdownMenuItem>
           <DropdownMenuItem
             :disabled="!canDelete || deleting"
@@ -236,7 +239,7 @@ function handleDelete() {
           >
             <Loader2 v-if="deleting" class="mr-2 h-4 w-4 animate-spin" />
             <Trash2 v-else class="mr-2 h-4 w-4" />
-            Delete Author
+            {{ t('author.card.deleteAuthor') }}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/client/src/features/author/components/AuthorConfirmDialog.vue
+++ b/client/src/features/author/components/AuthorConfirmDialog.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Loader2, TriangleAlert } from '@lucide/vue'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     open: boolean
     title: string
@@ -12,14 +14,19 @@ withDefaults(
     destructive?: boolean
   }>(),
   {
-    confirmLabel: 'Confirm',
-    cancelLabel: 'Cancel',
+    confirmLabel: undefined,
+    cancelLabel: undefined,
     loading: false,
     destructive: false,
   },
 )
 
 const emit = defineEmits<{ confirm: []; cancel: [] }>()
+
+const { t } = useI18n()
+
+const resolvedConfirmLabel = computed(() => props.confirmLabel ?? t('common.confirm'))
+const resolvedCancelLabel = computed(() => props.cancelLabel ?? t('common.cancel'))
 </script>
 
 <template>
@@ -43,7 +50,7 @@ const emit = defineEmits<{ confirm: []; cancel: [] }>()
             :disabled="loading"
             @click="emit('cancel')"
           >
-            {{ cancelLabel }}
+            {{ resolvedCancelLabel }}
           </button>
           <button
             class="inline-flex h-9 items-center gap-2 rounded-md px-4 text-sm font-medium transition-colors disabled:opacity-50"
@@ -56,7 +63,7 @@ const emit = defineEmits<{ confirm: []; cancel: [] }>()
             @click="emit('confirm')"
           >
             <Loader2 v-if="loading" :size="14" class="animate-spin" />
-            {{ confirmLabel }}
+            {{ resolvedConfirmLabel }}
           </button>
         </div>
       </div>

--- a/client/src/features/author/components/AuthorFilters.vue
+++ b/client/src/features/author/components/AuthorFilters.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import type { LibraryFilterOption } from '../types/author'
 
 defineProps<{
@@ -18,6 +19,8 @@ const emit = defineEmits<{
   clear: []
   close: []
 }>()
+
+const { t } = useI18n()
 
 function onClear() {
   emit('clear')
@@ -49,21 +52,21 @@ function onMinBookCountChange(event: Event) {
 <template>
   <section :class="embedded ? 'rounded-md border border-border bg-card p-3' : 'mb-4 rounded-md border border-border bg-card p-3'">
     <div class="mb-3 flex items-center justify-between">
-      <span class="text-xs font-medium text-muted-foreground">Author Filters</span>
+      <span class="text-xs font-medium text-muted-foreground">{{ t('author.filters.title') }}</span>
       <div class="flex items-center gap-2">
         <button
           v-if="(activeCount ?? 0) > 0"
           class="h-7 rounded-md border border-input px-2.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           @click="onClear"
         >
-          Clear all
+          {{ t('author.filters.clearAll') }}
         </button>
         <button
           v-if="closable"
           class="h-7 rounded-md border border-input px-2.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           @click="onClose"
         >
-          Close
+          {{ t('common.close') }}
         </button>
       </div>
     </div>
@@ -74,7 +77,7 @@ function onMinBookCountChange(event: Event) {
         class="h-9 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60"
         @change="onLibraryChange"
       >
-        <option value="">All Libraries</option>
+        <option value="">{{ t('author.filters.allLibraries') }}</option>
         <option v-for="library in libraries" :key="library.id" :value="library.id">{{ library.name }}</option>
       </select>
 
@@ -83,18 +86,18 @@ function onMinBookCountChange(event: Event) {
         class="h-9 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60"
         @change="onHasPhotoChange"
       >
-        <option value="">All authors</option>
-        <option value="true">Has photo</option>
-        <option value="false">Missing photo</option>
+        <option value="">{{ t('author.filters.allAuthors') }}</option>
+        <option value="true">{{ t('author.filters.hasPhoto') }}</option>
+        <option value="false">{{ t('author.filters.missingPhoto') }}</option>
       </select>
 
       <div class="flex h-9 items-center gap-1.5 rounded-md border border-input bg-background px-2.5">
-        <span class="text-sm text-muted-foreground">Min books</span>
+        <span class="text-sm text-muted-foreground">{{ t('author.filters.minBooks') }}</span>
         <input
           type="number"
           :value="minBookCount ?? ''"
           min="1"
-          placeholder="Any"
+          :placeholder="t('author.filters.anyPlaceholder')"
           class="w-14 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/85"
           @change="onMinBookCountChange"
         />

--- a/client/src/features/author/components/AuthorHeader.vue
+++ b/client/src/features/author/components/AuthorHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { AuthorDetail } from '@bookorbit/types'
 import { MoreHorizontal, Pencil, RefreshCcw, Trash2, UsersRound, X } from '@lucide/vue'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
@@ -24,6 +25,8 @@ const emit = defineEmits<{
   delete: []
 }>()
 
+const { t } = useI18n()
+
 const initials = computed(() => {
   const parts = props.author.name.trim().split(/\s+/).filter(Boolean)
   if (parts.length === 0) return '?'
@@ -40,9 +43,9 @@ const resolvedBio = computed(() => {
 const usesPreviewBio = computed(() => !props.author.description?.trim() && !!props.previewDescription?.trim())
 
 const lastAddedLabel = computed(() => {
-  if (!props.author.lastAddedAt) return 'Never'
+  if (!props.author.lastAddedAt) return t('author.header.never')
   const date = new Date(props.author.lastAddedAt)
-  if (Number.isNaN(date.getTime())) return 'Never'
+  if (Number.isNaN(date.getTime())) return t('author.header.never')
   return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
 })
 
@@ -76,7 +79,12 @@ watch(resolvedBio, () => {
           :class="canOpenImageLightbox ? 'cursor-zoom-in' : ''"
           @click="canOpenImageLightbox && (imageLightboxOpen = true)"
         >
-          <img v-if="displayImageUrl" :src="displayImageUrl" :alt="`${author.name} portrait`" class="h-full w-full object-cover" />
+          <img
+            v-if="displayImageUrl"
+            :src="displayImageUrl"
+            :alt="t('author.header.portraitAlt', { name: author.name })"
+            class="h-full w-full object-cover"
+          />
           <div
             v-else
             class="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/20 to-primary/5 text-3xl font-semibold text-primary"
@@ -98,27 +106,27 @@ watch(resolvedBio, () => {
                   class="mt-0.5 inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md bg-muted px-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
                 >
                   <MoreHorizontal :size="14" />
-                  Actions
+                  {{ t('author.header.actions') }}
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" class="w-44">
                 <DropdownMenuItem v-if="canUpdate" @click="emit('edit')">
                   <Pencil class="mr-2 h-4 w-4" />
-                  Edit Author
+                  {{ t('author.header.editAuthor') }}
                 </DropdownMenuItem>
                 <DropdownMenuItem v-if="canMerge" @click="emit('merge')">
                   <UsersRound class="mr-2 h-4 w-4" />
-                  Merge Authors
+                  {{ t('author.header.mergeAuthors') }}
                 </DropdownMenuItem>
                 <DropdownMenuSeparator v-if="canUpdate" />
                 <DropdownMenuItem v-if="canUpdate" :disabled="refreshing" @click="emit('refresh')">
                   <RefreshCcw class="mr-2 h-4 w-4" :class="refreshing ? 'animate-spin' : ''" />
-                  {{ refreshing ? 'Refreshing...' : 'Refresh Metadata' }}
+                  {{ refreshing ? t('author.header.refreshing') : t('author.header.refreshMetadata') }}
                 </DropdownMenuItem>
                 <DropdownMenuSeparator v-if="canDelete && (canUpdate || canMerge)" />
                 <DropdownMenuItem v-if="canDelete" class="text-destructive focus:text-destructive" @click="emit('delete')">
                   <Trash2 class="mr-2 h-4 w-4" />
-                  Delete Author
+                  {{ t('author.header.deleteAuthor') }}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -140,23 +148,23 @@ watch(resolvedBio, () => {
               class="mt-1 text-xs font-medium text-primary transition-colors hover:text-primary/80"
               @click="bioExpanded = !bioExpanded"
             >
-              {{ bioExpanded ? 'Show less' : 'Show more' }}
+              {{ bioExpanded ? t('author.header.showLess') : t('author.header.showMore') }}
             </button>
-            <p v-else-if="loadingPreview" class="text-sm text-muted-foreground">Looking up author metadata...</p>
-            <p v-else class="text-sm text-muted-foreground">No biography available. Use the menu to refresh metadata.</p>
+            <p v-else-if="loadingPreview" class="text-sm text-muted-foreground">{{ t('author.header.lookingUpMetadata') }}</p>
+            <p v-else class="text-sm text-muted-foreground">{{ t('author.header.noBiography') }}</p>
             <p v-if="usesPreviewBio && previewProviderLabel" class="mt-1.5 text-xs text-muted-foreground">
-              Preview from {{ previewProviderLabel }}. Save metadata to persist it.
+              {{ t('author.header.previewFrom', { provider: previewProviderLabel }) }}
             </p>
           </div>
 
           <div class="mt-4 flex gap-3">
             <div class="rounded-lg border border-border/70 bg-background/40 px-4 py-2.5">
               <p class="text-base font-semibold text-foreground">{{ author.bookCount.toLocaleString() }}</p>
-              <p class="text-xs text-muted-foreground">Books</p>
+              <p class="text-xs text-muted-foreground">{{ t('author.header.booksLabel') }}</p>
             </div>
             <div class="rounded-lg border border-border/70 bg-background/40 px-4 py-2.5">
               <p class="text-base font-semibold text-foreground">{{ lastAddedLabel }}</p>
-              <p class="text-xs text-muted-foreground">Last Added</p>
+              <p class="text-xs text-muted-foreground">{{ t('author.header.lastAdded') }}</p>
             </div>
           </div>
         </div>

--- a/client/src/features/author/components/AuthorListRow.vue
+++ b/client/src/features/author/components/AuthorListRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { AuthorSummary } from '@bookorbit/types'
 import { ArrowRight, BookCopy, Check, Clock3, Loader2 } from '@lucide/vue'
 import { toDisplayCoverUrl } from '@/features/book/lib/metadata-fetch'
@@ -16,10 +17,12 @@ const emit = defineEmits<{
   select: [event: MouseEvent]
 }>()
 
+const { t } = useI18n()
+
 const lastAddedLabel = computed(() => {
-  if (!props.author.lastAddedAt) return 'No recent additions'
+  if (!props.author.lastAddedAt) return t('author.listRow.noRecentAdditions')
   const date = new Date(props.author.lastAddedAt)
-  return Number.isNaN(date.getTime()) ? 'No recent additions' : date.toLocaleDateString()
+  return Number.isNaN(date.getTime()) ? t('author.listRow.noRecentAdditions') : date.toLocaleDateString()
 })
 
 const imageFailed = ref(false)
@@ -63,7 +66,7 @@ function handleClick(event: MouseEvent) {
         <img
           v-if="imageSrc && !imageFailed"
           :src="imageSrc"
-          :alt="`${author.name} portrait`"
+          :alt="t('author.listRow.portraitAlt', { name: author.name })"
           class="h-full w-full object-cover"
           loading="lazy"
           decoding="async"

--- a/client/src/features/author/views/AuthorDetailView.vue
+++ b/client/src/features/author/views/AuthorDetailView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useWindowSize } from '@vueuse/core'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { ArrowUpDown, ChevronDown, ChevronLeft, ImageMinus, LayoutGrid, List, Upload } from '@lucide/vue'
 import { toast } from 'vue-sonner'
@@ -32,6 +33,7 @@ import { useAuthorDetail } from '../composables/useAuthorDetail'
 import { useAuthorMetadataPreview } from '../composables/useAuthorMetadataPreview'
 import EntityNotFound from '@/components/EntityNotFound.vue'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const mainRef = ref<HTMLElement | null>(null)
@@ -49,8 +51,8 @@ const { author, loading: loadingAuthor, error: authorError, notFound: authorNotF
 const { items: books, total, loading: loadingBooks, error: booksError, hasMore, sort, order, libraryId, load: loadBooks } = useAuthorBooks(authorId)
 const authorName = computed(() => author.value?.name ?? '')
 const pageTitle = computed(() => {
-  if (author.value?.name) return `Author · ${author.value.name}`
-  return Number.isFinite(authorId.value) ? `Author #${authorId.value}` : 'Author'
+  if (author.value?.name) return t('author.detail.pageTitleNamed', { name: author.value.name })
+  return Number.isFinite(authorId.value) ? t('author.detail.pageTitleId', { id: authorId.value }) : t('author.detail.pageTitle')
 })
 usePageTitle(pageTitle)
 const {
@@ -96,11 +98,13 @@ const selectedMergeBookCount = computed(() => {
   return mergeCandidates.value.filter((candidate) => selected.has(candidate.id)).reduce((sum, candidate) => sum + candidate.bookCount, 0)
 })
 
-const BOOK_SORT_OPTIONS = [
-  { value: 'addedAt', label: 'Recently Added' },
-  { value: 'title', label: 'Title' },
-  { value: 'publishedYear', label: 'Published Year' },
-] as const
+const BOOK_SORT_OPTIONS = [{ value: 'addedAt' }, { value: 'title' }, { value: 'publishedYear' }] as const
+
+const bookSortOptions = computed(() => [
+  { value: 'addedAt', label: t('author.detail.books.sort.recentlyAdded') },
+  { value: 'title', label: t('author.detail.books.sort.title') },
+  { value: 'publishedYear', label: t('author.detail.books.sort.publishedYear') },
+])
 
 type BookActionType = 'quick-view' | 'edit-metadata' | 'add-to-collection' | 'delete'
 
@@ -126,10 +130,10 @@ const {
 
 function showRefreshResultToast(updated: { imageUrl?: string | null }) {
   if (!updated.imageUrl) {
-    toast.warning('Metadata refreshed, but no author image was found.')
+    toast.warning(t('author.detail.toast.refreshedNoImage'))
     return
   }
-  toast.success('Author metadata refreshed')
+  toast.success(t('author.detail.toast.refreshed'))
 }
 
 watch(
@@ -192,7 +196,7 @@ async function saveAuthorEdits() {
   if (!author.value || savingEdit.value) return
   const name = draftName.value.trim()
   if (!name) {
-    toast.error('Author name is required')
+    toast.error(t('author.detail.toast.nameRequired'))
     return
   }
 
@@ -205,9 +209,9 @@ async function saveAuthorEdits() {
     })
     author.value = updated
     editOpen.value = false
-    toast.success('Author updated')
+    toast.success(t('author.detail.toast.updated'))
   } catch (error) {
-    toast.error(error instanceof Error ? error.message : 'Failed to update author')
+    toast.error(error instanceof Error ? error.message : t('author.detail.toast.updateFailed'))
   } finally {
     savingEdit.value = false
   }
@@ -228,9 +232,9 @@ async function onAuthorImageSelected(event: Event) {
   try {
     const updated = await uploadAuthorImage(author.value.id, file)
     author.value = updated
-    toast.success('Author image updated')
+    toast.success(t('author.detail.toast.imageUpdated'))
   } catch (error) {
-    toast.error(error instanceof Error ? error.message : 'Failed to upload author image')
+    toast.error(error instanceof Error ? error.message : t('author.detail.toast.imageUploadFailed'))
   } finally {
     uploadingImage.value = false
   }
@@ -243,9 +247,9 @@ async function removeAuthorImage() {
   try {
     const updated = await deleteAuthorImage(author.value.id)
     author.value = updated
-    toast.success('Author image removed')
+    toast.success(t('author.detail.toast.imageRemoved'))
   } catch (error) {
-    toast.error(error instanceof Error ? error.message : 'Failed to remove author image')
+    toast.error(error instanceof Error ? error.message : t('author.detail.toast.imageRemoveFailed'))
   } finally {
     removingImage.value = false
   }
@@ -306,9 +310,9 @@ async function runMerge() {
     mergeOpen.value = false
 
     await loadBooks(true)
-    toast.success(`Merged ${result.mergedAuthorIds.length} author(s); affected ${result.affectedBookCount} books`)
+    toast.success(t('author.detail.toast.mergeSuccess', { count: result.mergedAuthorIds.length, books: result.affectedBookCount }))
   } catch (error) {
-    toast.error(error instanceof Error ? error.message : 'Failed to merge authors')
+    toast.error(error instanceof Error ? error.message : t('author.detail.toast.mergeFailed'))
   } finally {
     merging.value = false
   }
@@ -321,10 +325,10 @@ async function runDelete() {
   deleting.value = true
   try {
     const result = await deleteAuthors({ authorIds: [author.value.id] })
-    toast.success(`Deleted author; affected ${result.affectedBookCount} books`)
+    toast.success(t('author.detail.toast.deleteSuccess', { books: result.affectedBookCount }))
     await router.push({ name: 'authors' })
   } catch (error) {
-    toast.error(error instanceof Error ? error.message : 'Failed to delete author')
+    toast.error(error instanceof Error ? error.message : t('author.detail.toast.deleteFailed'))
   } finally {
     deleting.value = false
   }
@@ -336,13 +340,13 @@ function promptRunMerge() {
 }
 
 const mergeDialogTitle = computed(() => {
-  if (!author.value) return 'Merge selected authors?'
-  return `Merge ${selectedMergeIds.value.length} author(s) into "${author.value.name}"?`
+  if (!author.value) return t('author.detail.mergeDialog.titleFallback')
+  return t('author.detail.mergeDialog.title', { count: selectedMergeIds.value.length, name: author.value.name })
 })
 
 const mergeDialogDescription = computed(() => {
-  if (selectedMergeIds.value.length === 0) return 'This action cannot be undone.'
-  return 'This will merge selected authors into the current author and re-link associated books. This action cannot be undone.'
+  if (selectedMergeIds.value.length === 0) return t('author.detail.mergeDialog.descriptionEmpty')
+  return t('author.detail.mergeDialog.description')
 })
 
 const isMobileLayout = computed(() => windowWidth.value < 640)
@@ -384,7 +388,7 @@ async function refreshMetadata() {
     await loadMetadataPreview()
     showRefreshResultToast(updated)
   } catch (error) {
-    toast.error(error instanceof Error ? error.message : 'Failed to refresh author metadata')
+    toast.error(error instanceof Error ? error.message : t('author.detail.toast.refreshFailed'))
   } finally {
     refreshingMetadata.value = false
   }
@@ -454,12 +458,12 @@ defineOptions({ name: 'AuthorDetailView' })
           @click="goBack"
         >
           <ChevronLeft :size="14" />
-          Back
+          {{ t('common.back') }}
         </button>
       </div>
 
       <div v-if="authorNotFound">
-        <EntityNotFound entity="Author" />
+        <EntityNotFound :entity="t('author.detail.entityName')" />
       </div>
 
       <template v-else>
@@ -468,7 +472,7 @@ defineOptions({ name: 'AuthorDetailView' })
         </div>
 
         <div v-if="loadingAuthor && !author" class="mb-4 rounded-lg border border-border/70 bg-card/60 p-4 text-sm text-muted-foreground">
-          Loading author...
+          {{ t('author.detail.loadingAuthor') }}
         </div>
         <AuthorHeader
           v-else-if="author"
@@ -488,27 +492,27 @@ defineOptions({ name: 'AuthorDetailView' })
         />
 
         <div v-if="metadataPreviewError" class="mt-3 rounded-md border border-border/70 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-          Could not load external author preview metadata right now.
+          {{ t('author.detail.previewError') }}
         </div>
 
         <section v-if="author && (editOpen || mergeOpen)" class="mt-4 rounded-lg border border-border/70 bg-card/60 p-3 space-y-3">
           <div v-if="editOpen && canUpdate" class="space-y-2">
             <div class="grid gap-2 md:grid-cols-2">
               <label class="text-xs text-muted-foreground">
-                Name
+                {{ t('author.detail.edit.name') }}
                 <input v-model="draftName" class="mt-1 h-9 w-full rounded-md border border-input bg-background px-2.5 text-sm" />
               </label>
               <label class="text-xs text-muted-foreground">
-                Sort Name
+                {{ t('author.detail.edit.sortName') }}
                 <input v-model="draftSortName" class="mt-1 h-9 w-full rounded-md border border-input bg-background px-2.5 text-sm" />
               </label>
             </div>
             <label class="block text-xs text-muted-foreground">
-              Description
+              {{ t('author.detail.edit.description') }}
               <textarea v-model="draftDescription" rows="3" class="mt-1 w-full rounded-md border border-input bg-background px-2.5 py-2 text-sm" />
             </label>
             <div class="space-y-1.5">
-              <p class="text-xs text-muted-foreground">Image</p>
+              <p class="text-xs text-muted-foreground">{{ t('author.detail.edit.image') }}</p>
               <input ref="authorImageInput" type="file" accept="image/*" class="hidden" :disabled="authorImageBusy" @change="onAuthorImageSelected" />
               <div class="flex flex-wrap items-center gap-2">
                 <button
@@ -517,7 +521,13 @@ defineOptions({ name: 'AuthorDetailView' })
                   @click="openAuthorImagePicker"
                 >
                   <Upload :size="14" />
-                  {{ uploadingImage ? 'Uploading...' : author?.imageUrl ? 'Replace image' : 'Upload image' }}
+                  {{
+                    uploadingImage
+                      ? t('author.detail.edit.uploading')
+                      : author?.imageUrl
+                        ? t('author.detail.edit.replaceImage')
+                        : t('author.detail.edit.uploadImage')
+                  }}
                 </button>
                 <button
                   :disabled="authorImageBusy || !author?.imageUrl"
@@ -525,21 +535,23 @@ defineOptions({ name: 'AuthorDetailView' })
                   @click="removeAuthorImage"
                 >
                   <ImageMinus :size="14" />
-                  {{ removingImage ? 'Removing...' : 'Remove image' }}
+                  {{ removingImage ? t('author.detail.edit.removing') : t('author.detail.edit.removeImage') }}
                 </button>
               </div>
-              <p class="text-[11px] text-muted-foreground">PNG/JPEG/WEBP/GIF/BMP up to {{ Math.floor(MAX_AUTHOR_IMAGE_BYTES / 1024 / 1024) }} MB</p>
+              <p class="text-[11px] text-muted-foreground">
+                {{ t('author.detail.edit.imageHint', { size: Math.floor(MAX_AUTHOR_IMAGE_BYTES / 1024 / 1024) }) }}
+              </p>
             </div>
             <div class="flex items-center justify-end gap-2">
               <button class="h-8 rounded-md border border-input px-3 text-sm text-muted-foreground hover:bg-muted" @click="editOpen = false">
-                Cancel
+                {{ t('common.cancel') }}
               </button>
               <button
                 :disabled="savingEdit"
                 class="h-8 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground disabled:opacity-60"
                 @click="saveAuthorEdits"
               >
-                {{ savingEdit ? 'Saving...' : 'Save' }}
+                {{ savingEdit ? t('author.detail.edit.saving') : t('common.save') }}
               </button>
             </div>
           </div>
@@ -548,21 +560,23 @@ defineOptions({ name: 'AuthorDetailView' })
             <input
               v-model="mergeQuery"
               class="h-9 w-full rounded-md border border-input bg-background px-2.5 text-sm"
-              placeholder="Search authors to merge into this author"
+              :placeholder="t('author.detail.merge.searchPlaceholder')"
             />
 
-            <div v-if="searchingMergeCandidates" class="text-xs text-muted-foreground">Searching...</div>
+            <div v-if="searchingMergeCandidates" class="text-xs text-muted-foreground">{{ t('author.detail.merge.searching') }}</div>
 
             <div v-if="mergeCandidates.length > 0" class="max-h-48 space-y-1 overflow-y-auto rounded-md border border-border/70 bg-background/50 p-2">
               <label v-for="candidate in mergeCandidates" :key="candidate.id" class="flex items-center gap-2 text-sm">
                 <input type="checkbox" :checked="selectedMergeIds.includes(candidate.id)" @change="onMergeCandidateToggle(candidate.id, $event)" />
                 <span class="min-w-0 flex-1 truncate">{{ candidate.name }}</span>
-                <span class="text-xs text-muted-foreground">{{ candidate.bookCount }} books</span>
+                <span class="text-xs text-muted-foreground">{{
+                  t('author.detail.merge.bookCount', { count: candidate.bookCount }, candidate.bookCount)
+                }}</span>
               </label>
             </div>
 
             <div v-if="selectedMergeIds.length > 0" class="text-xs text-muted-foreground">
-              Selected {{ selectedMergeIds.length }} author(s), approx. {{ selectedMergeBookCount }} books affected.
+              {{ t('author.detail.merge.selectedSummary', { count: selectedMergeIds.length, books: selectedMergeBookCount }) }}
             </div>
 
             <div class="flex items-center justify-end">
@@ -571,7 +585,7 @@ defineOptions({ name: 'AuthorDetailView' })
                 class="h-8 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground disabled:opacity-60"
                 @click="promptRunMerge"
               >
-                {{ merging ? 'Merging...' : 'Merge Selected' }}
+                {{ merging ? t('author.detail.merge.merging') : t('author.detail.merge.mergeSelected') }}
               </button>
             </div>
           </div>
@@ -579,7 +593,7 @@ defineOptions({ name: 'AuthorDetailView' })
 
         <section class="mt-4 rounded-lg border border-border/70 bg-card/60 p-3">
           <div class="mb-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-            <h2 class="text-sm font-semibold text-foreground">Books</h2>
+            <h2 class="text-sm font-semibold text-foreground">{{ t('author.detail.books.heading') }}</h2>
             <div class="w-full space-y-2 sm:hidden">
               <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] gap-2">
                 <div class="relative min-w-0">
@@ -588,7 +602,7 @@ defineOptions({ name: 'AuthorDetailView' })
                     class="h-8 w-full appearance-none rounded-md border border-input bg-background px-2.5 pr-8 text-sm text-foreground outline-none transition-colors focus:border-primary/60"
                     @change="onMobileSortChange"
                   >
-                    <option v-for="opt in BOOK_SORT_OPTIONS" :key="opt.value" :value="opt.value">
+                    <option v-for="opt in bookSortOptions" :key="opt.value" :value="opt.value">
                       {{ opt.label }}
                     </option>
                   </select>
@@ -599,7 +613,7 @@ defineOptions({ name: 'AuthorDetailView' })
                   class="h-8 rounded-md border border-input bg-background px-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   @click="toggleBookOrder"
                 >
-                  {{ order === 'asc' ? 'Asc' : 'Desc' }}
+                  {{ order === 'asc' ? t('author.detail.books.asc') : t('author.detail.books.desc') }}
                 </button>
 
                 <div class="flex items-center rounded-md border border-input bg-background">
@@ -630,7 +644,7 @@ defineOptions({ name: 'AuthorDetailView' })
                   class="h-8 w-full appearance-none rounded-md border border-input bg-background px-2.5 pr-8 text-sm text-foreground outline-none transition-colors focus:border-primary/60"
                   @change="onLibraryFilterChange"
                 >
-                  <option value="">All Libraries</option>
+                  <option value="">{{ t('author.detail.books.allLibraries') }}</option>
                   <option v-for="library in libraries" :key="library.id" :value="library.id">
                     {{ library.name }}
                   </option>
@@ -644,17 +658,17 @@ defineOptions({ name: 'AuthorDetailView' })
                 v-model="sort"
                 class="h-8 w-full min-w-0 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60 sm:w-auto"
               >
-                <option value="addedAt">Recently Added</option>
-                <option value="title">Title</option>
-                <option value="publishedYear">Published Year</option>
+                <option value="addedAt">{{ t('author.detail.books.sort.recentlyAdded') }}</option>
+                <option value="title">{{ t('author.detail.books.sort.title') }}</option>
+                <option value="publishedYear">{{ t('author.detail.books.sort.publishedYear') }}</option>
               </select>
 
               <select
                 v-model="order"
                 class="h-8 w-full min-w-0 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60 sm:w-auto"
               >
-                <option value="desc">Descending</option>
-                <option value="asc">Ascending</option>
+                <option value="desc">{{ t('author.detail.books.descending') }}</option>
+                <option value="asc">{{ t('author.detail.books.ascending') }}</option>
               </select>
 
               <select
@@ -662,7 +676,7 @@ defineOptions({ name: 'AuthorDetailView' })
                 class="h-8 w-full min-w-0 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60 sm:w-auto"
                 @change="onLibraryFilterChange"
               >
-                <option value="">All Libraries</option>
+                <option value="">{{ t('author.detail.books.allLibraries') }}</option>
                 <option v-for="library in libraries" :key="library.id" :value="library.id">{{ library.name }}</option>
               </select>
 
@@ -694,8 +708,8 @@ defineOptions({ name: 'AuthorDetailView' })
           </div>
 
           <div v-if="!loadingBooks && books.length === 0" class="flex flex-col items-center justify-center gap-2 py-16 text-center">
-            <p class="text-sm font-medium text-foreground">No books found for this author</p>
-            <p class="text-xs text-muted-foreground">Try changing sort/order or selecting another library.</p>
+            <p class="text-sm font-medium text-foreground">{{ t('author.detail.books.empty.title') }}</p>
+            <p class="text-xs text-muted-foreground">{{ t('author.detail.books.empty.hint') }}</p>
           </div>
 
           <VirtualBookGrid
@@ -712,8 +726,10 @@ defineOptions({ name: 'AuthorDetailView' })
           </div>
 
           <div ref="sentinel" class="mt-4 flex h-8 items-center justify-center">
-            <span v-if="loadingBooks" class="text-xs text-muted-foreground">Loading...</span>
-            <span v-else-if="!hasMore && books.length > 0" class="text-xs text-muted-foreground">All {{ total.toLocaleString() }} books loaded</span>
+            <span v-if="loadingBooks" class="text-xs text-muted-foreground">{{ t('common.loading') }}</span>
+            <span v-else-if="!hasMore && books.length > 0" class="text-xs text-muted-foreground">{{
+              t('author.detail.books.allLoaded', { total: total.toLocaleString() })
+            }}</span>
           </div>
         </section>
       </template>
@@ -721,9 +737,9 @@ defineOptions({ name: 'AuthorDetailView' })
 
     <AuthorConfirmDialog
       :open="confirmDeleteOpen"
-      title="Delete author?"
-      description="This removes the author from the catalog and unlinks it from associated books. This action cannot be undone."
-      confirm-label="Delete"
+      :title="t('author.detail.deleteDialog.title')"
+      :description="t('author.detail.deleteDialog.description')"
+      :confirm-label="t('common.delete')"
       :loading="deleting"
       destructive
       @confirm="runDelete"
@@ -734,7 +750,7 @@ defineOptions({ name: 'AuthorDetailView' })
       :open="confirmMergeOpen"
       :title="mergeDialogTitle"
       :description="mergeDialogDescription"
-      confirm-label="Merge"
+      :confirm-label="t('author.detail.merge.confirmLabel')"
       :loading="merging"
       @confirm="runMerge"
       @cancel="confirmMergeOpen = false"

--- a/client/src/features/author/views/AuthorsView.vue
+++ b/client/src/features/author/views/AuthorsView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { ArrowUpDown, CheckCheck, Filter, RefreshCcw, Search, SlidersHorizontal, Trash2, X } from '@lucide/vue'
 import { toast } from 'vue-sonner'
@@ -23,6 +24,7 @@ import { useRefreshingAuthors } from '../composables/useRefreshingAuthors'
 import type { AuthorListSort, SortDirection } from '../types/author'
 import type { BookViewMode } from '@/composables/useDisplaySettings'
 
+const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const mainRef = ref<HTMLElement | null>(null)
@@ -64,17 +66,17 @@ const authorViewMode = computed<BookViewMode>({
   },
 })
 
-const SORT_LABELS: Record<AuthorListSort, string> = {
-  name: 'Name',
-  sortName: 'Sort Name',
-  bookCount: 'Book Count',
-  lastAddedAt: 'Recent Additions',
-  lastEnrichedAt: 'Last Enriched',
-}
+const sortLabels = computed<Record<AuthorListSort, string>>(() => ({
+  name: t('author.list.sort.name'),
+  sortName: t('author.list.sort.sortName'),
+  bookCount: t('author.list.sort.bookCount'),
+  lastAddedAt: t('author.list.sort.recentAdditions'),
+  lastEnrichedAt: t('author.list.sort.lastEnriched'),
+}))
 
 const isDefaultSort = computed(() => sort.value === 'name' && order.value === 'asc')
 
-const sortSummary = computed(() => `${SORT_LABELS[sort.value]} ${order.value === 'asc' ? '↑' : '↓'}`)
+const sortSummary = computed(() => `${sortLabels.value[sort.value]} ${order.value === 'asc' ? '↑' : '↓'}`)
 
 const activeFilterCount = computed(() => {
   let count = 0
@@ -93,23 +95,23 @@ const deleteDialogLoading = computed(() => {
 })
 
 const deleteDialogTitle = computed(() => {
-  if (pendingDeleteIds.value.length > 1) return `Delete ${pendingDeleteIds.value.length} authors?`
-  return 'Delete author?'
+  if (pendingDeleteIds.value.length > 1) return t('author.list.deleteDialog.titleMany', { count: pendingDeleteIds.value.length })
+  return t('author.list.deleteDialog.titleOne')
 })
 
 const deleteDialogDescription = computed(() => {
   if (pendingDeleteIds.value.length > 1) {
-    return 'This removes selected authors from the catalog and unlinks them from associated books. This action cannot be undone.'
+    return t('author.list.deleteDialog.descriptionMany')
   }
-  return 'This removes the author from the catalog and unlinks it from associated books. This action cannot be undone.'
+  return t('author.list.deleteDialog.descriptionOne')
 })
 
 function showRefreshResultToast(updated: { imageUrl?: string | null }) {
   if (!updated.imageUrl) {
-    toast.warning('Metadata refreshed, but no author image was found.')
+    toast.warning(t('author.list.toast.refreshedNoImage'))
     return
   }
-  toast.success('Author metadata refreshed')
+  toast.success(t('author.list.toast.refreshed'))
 }
 
 function parseSort(value: unknown): AuthorListSort {
@@ -269,12 +271,12 @@ async function refreshSelectedAuthorsMetadata() {
     })
 
     if (result.failed > 0) {
-      toast.warning(`Refreshed ${result.updated} author(s), ${result.failed} failed`)
+      toast.warning(t('author.list.toast.bulkRefreshPartial', { updated: result.updated, failed: result.failed }))
     } else {
-      toast.success(`Refreshed metadata for ${result.updated} author(s)`)
+      toast.success(t('author.list.toast.bulkRefreshSuccess', { updated: result.updated }))
     }
   } catch (actionError) {
-    toast.error(actionError instanceof Error ? actionError.message : 'Failed to refresh selected authors')
+    toast.error(actionError instanceof Error ? actionError.message : t('author.list.toast.bulkRefreshFailed'))
   } finally {
     clearRefreshing(ids)
     bulkRefreshing.value = false
@@ -297,7 +299,7 @@ async function refreshSingleAuthorMetadata(authorId: number) {
     }
     showRefreshResultToast(updated)
   } catch (actionError) {
-    toast.error(actionError instanceof Error ? actionError.message : 'Failed to refresh author metadata')
+    toast.error(actionError instanceof Error ? actionError.message : t('author.list.toast.refreshFailed'))
   } finally {
     clearRefreshing([authorId])
   }
@@ -340,10 +342,18 @@ async function confirmDeleteAuthors() {
     await load(true)
     if (ids.length > 1) exitSelectionMode()
 
-    const noun = result.deletedAuthorIds.length === 1 ? 'author' : 'authors'
-    toast.success(`Deleted ${result.deletedAuthorIds.length} ${noun}; affected ${result.affectedBookCount} books`)
+    toast.success(
+      t(
+        'author.list.toast.deleteSuccess',
+        {
+          count: result.deletedAuthorIds.length,
+          books: result.affectedBookCount,
+        },
+        result.deletedAuthorIds.length,
+      ),
+    )
   } catch (actionError) {
-    toast.error(actionError instanceof Error ? actionError.message : 'Failed to delete author(s)')
+    toast.error(actionError instanceof Error ? actionError.message : t('author.list.toast.deleteFailed'))
   } finally {
     if (singleAuthorId !== null) {
       deletingAuthorId.value = null
@@ -434,7 +444,7 @@ defineOptions({ name: 'AuthorsView' })
   <div class="flex h-full flex-col">
     <section class="flex flex-1 flex-col min-h-0">
       <ViewHeader
-        title="Authors"
+        :title="t('author.list.title')"
         icon="Users"
         fallback-icon="Users"
         :total="total"
@@ -452,7 +462,7 @@ defineOptions({ name: 'AuthorsView' })
             <input
               v-model="q"
               type="search"
-              placeholder="Search authors"
+              :placeholder="t('author.list.searchPlaceholder')"
               class="author-search-input h-full w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/85"
             />
             <button v-if="q.trim()" class="ml-1 text-muted-foreground/85 transition-colors hover:text-foreground" @click="clearSearchQuery">
@@ -475,11 +485,11 @@ defineOptions({ name: 'AuthorsView' })
                 >
                   <ArrowUpDown :size="13" />
                   <span class="hidden lg:inline">{{ sortSummary }}</span>
-                  <span class="lg:hidden">Sort</span>
+                  <span class="lg:hidden">{{ t('author.list.sortButton') }}</span>
                 </button>
               </PopoverTrigger>
               <PopoverContent align="start" class="w-56 p-2">
-                <div class="mb-2 px-1 text-xs font-medium text-muted-foreground">Sort by</div>
+                <div class="mb-2 px-1 text-xs font-medium text-muted-foreground">{{ t('author.list.sortBy') }}</div>
                 <div class="flex flex-col gap-0.5">
                   <button
                     v-for="field in ['name', 'sortName', 'bookCount', 'lastAddedAt', 'lastEnrichedAt'] as const"
@@ -488,7 +498,7 @@ defineOptions({ name: 'AuthorsView' })
                     :class="sort === field ? 'text-foreground font-medium' : 'text-muted-foreground'"
                     @click="setSortField(field)"
                   >
-                    {{ SORT_LABELS[field] }}
+                    {{ sortLabels[field] }}
                     <span v-if="sort === field" class="text-xs text-primary">{{ order === 'asc' ? '↑' : '↓' }}</span>
                   </button>
                 </div>
@@ -501,7 +511,7 @@ defineOptions({ name: 'AuthorsView' })
                     :class="order === dir ? 'bg-muted text-foreground font-medium' : 'text-muted-foreground'"
                     @click="setSortOrder(dir)"
                   >
-                    {{ dir === 'asc' ? 'Ascending' : 'Descending' }}
+                    {{ dir === 'asc' ? t('author.list.ascending') : t('author.list.descending') }}
                   </button>
                 </div>
               </PopoverContent>
@@ -527,7 +537,7 @@ defineOptions({ name: 'AuthorsView' })
             "
           >
             <Filter :size="13" />
-            <span>Filters</span>
+            <span>{{ t('author.list.filters') }}</span>
             <span v-if="activeFilterCount > 0" class="text-xs font-semibold">({{ activeFilterCount }})</span>
           </button>
 
@@ -537,7 +547,7 @@ defineOptions({ name: 'AuthorsView' })
             class="hidden sm:flex h-8 items-center gap-1 rounded-md px-2 text-sm text-muted-foreground transition-colors hover:text-destructive"
           >
             <X :size="13" />
-            Clear
+            {{ t('author.list.clear') }}
           </button>
 
           <button
@@ -567,7 +577,7 @@ defineOptions({ name: 'AuthorsView' })
             ref="mobileSearchInput"
             v-model="q"
             type="search"
-            placeholder="Search authors"
+            :placeholder="t('author.list.searchPlaceholder')"
             class="mobile-search-input h-9 w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/85"
           />
           <button v-if="q.trim()" class="text-muted-foreground/85 transition-colors hover:text-foreground" @click="clearSearchQuery">
@@ -583,7 +593,7 @@ defineOptions({ name: 'AuthorsView' })
               @change="onMobileSortChange"
             >
               <option v-for="field in ['name', 'sortName', 'bookCount', 'lastAddedAt', 'lastEnrichedAt'] as const" :key="field" :value="field">
-                {{ SORT_LABELS[field] }}
+                {{ sortLabels[field] }}
               </option>
             </select>
             <ArrowUpDown :size="13" class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground/85" />
@@ -598,7 +608,7 @@ defineOptions({ name: 'AuthorsView' })
             "
             @click="setSortOrder(order === 'asc' ? 'desc' : 'asc')"
           >
-            {{ order === 'asc' ? 'Asc' : 'Desc' }}
+            {{ order === 'asc' ? t('author.list.asc') : t('author.list.desc') }}
           </button>
 
           <button
@@ -606,7 +616,7 @@ defineOptions({ name: 'AuthorsView' })
             class="h-8 rounded-md px-2 text-sm text-muted-foreground transition-colors hover:text-destructive"
             @click="clearFilters"
           >
-            Clear
+            {{ t('author.list.clear') }}
           </button>
         </div>
 
@@ -654,8 +664,8 @@ defineOptions({ name: 'AuthorsView' })
         </div>
 
         <div v-if="!loading && items.length === 0" class="flex flex-col items-center justify-center gap-2 py-24 text-center">
-          <p class="text-sm font-medium text-foreground">No authors found</p>
-          <p class="text-xs text-muted-foreground">Try changing search text, sort, or library filter.</p>
+          <p class="text-sm font-medium text-foreground">{{ t('author.list.empty.title') }}</p>
+          <p class="text-xs text-muted-foreground">{{ t('author.list.empty.hint') }}</p>
         </div>
 
         <div
@@ -695,9 +705,9 @@ defineOptions({ name: 'AuthorsView' })
         </div>
 
         <div ref="sentinel" class="mt-4 flex h-8 items-center justify-center">
-          <span v-if="loading" class="text-xs text-muted-foreground">Loading...</span>
+          <span v-if="loading" class="text-xs text-muted-foreground">{{ t('common.loading') }}</span>
           <span v-else-if="initialLoadComplete && !hasMore && items.length > 0" class="text-xs text-muted-foreground">
-            All {{ total.toLocaleString() }} authors loaded
+            {{ t('author.list.allLoaded', { total: total.toLocaleString() }) }}
           </span>
         </div>
       </main>
@@ -725,7 +735,7 @@ defineOptions({ name: 'AuthorsView' })
                 <CheckCheck :size="17" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top">Select visible</TooltipContent>
+            <TooltipContent side="top">{{ t('author.list.selection.selectVisible') }}</TooltipContent>
           </Tooltip>
 
           <Tooltip v-if="canRefreshMetadata">
@@ -739,7 +749,9 @@ defineOptions({ name: 'AuthorsView' })
                 <RefreshCcw :size="17" :class="bulkRefreshing ? 'animate-spin' : ''" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top">{{ bulkRefreshing ? 'Refreshing metadata...' : 'Refresh metadata' }}</TooltipContent>
+            <TooltipContent side="top">{{
+              bulkRefreshing ? t('author.list.selection.refreshingMetadata') : t('author.list.selection.refreshMetadata')
+            }}</TooltipContent>
           </Tooltip>
 
           <Tooltip v-if="canDeleteAuthors">
@@ -757,7 +769,9 @@ defineOptions({ name: 'AuthorsView' })
                 <Trash2 :size="17" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top">{{ bulkDeleting ? 'Deleting...' : 'Delete selected' }}</TooltipContent>
+            <TooltipContent side="top">{{
+              bulkDeleting ? t('author.list.selection.deleting') : t('author.list.selection.deleteSelected')
+            }}</TooltipContent>
           </Tooltip>
 
           <div class="w-px h-5 bg-border mx-1 shrink-0" />
@@ -771,14 +785,14 @@ defineOptions({ name: 'AuthorsView' })
                 <X :size="17" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top">Exit selection</TooltipContent>
+            <TooltipContent side="top">{{ t('author.list.selection.exitSelection') }}</TooltipContent>
           </Tooltip>
         </template>
 
         <template v-else>
-          <span class="px-3 text-sm font-semibold text-destructive whitespace-nowrap"
-            >Delete {{ selectedCount }} author{{ selectedCount === 1 ? '' : 's' }}?</span
-          >
+          <span class="px-3 text-sm font-semibold text-destructive whitespace-nowrap">{{
+            t('author.list.selection.confirmDeleteCount', { count: selectedCount }, selectedCount)
+          }}</span>
 
           <div class="w-px h-5 bg-border mx-1 shrink-0" />
 
@@ -787,7 +801,7 @@ defineOptions({ name: 'AuthorsView' })
             :disabled="bulkDeleting"
             @click="confirmDeleteSelectedFromPopover"
           >
-            {{ bulkDeleting ? 'Deleting...' : 'Delete' }}
+            {{ bulkDeleting ? t('author.list.selection.deleting') : t('common.delete') }}
           </button>
 
           <button
@@ -795,7 +809,7 @@ defineOptions({ name: 'AuthorsView' })
             :disabled="bulkDeleting"
             @click="confirmingBulkDelete = false"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
         </template>
       </template>
@@ -805,7 +819,7 @@ defineOptions({ name: 'AuthorsView' })
       :open="deleteDialogOpen"
       :title="deleteDialogTitle"
       :description="deleteDialogDescription"
-      confirm-label="Delete"
+      :confirm-label="t('common.delete')"
       :loading="deleteDialogLoading"
       destructive
       @confirm="confirmDeleteAuthors"

--- a/client/src/features/book-dock/components/BookDockBulkEditDialog.vue
+++ b/client/src/features/book-dock/components/BookDockBulkEditDialog.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { computed, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X, Loader2 } from '@lucide/vue'
 import type { BookDockBulkEditResult, BookDockMetadata } from '@bookorbit/types'
 import { api } from '@/lib/api'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   selectionPayload: { fileIds?: number[]; selectAll?: boolean; excludedIds?: number[]; status?: string; search?: string }
@@ -18,18 +21,18 @@ const loading = ref(false)
 const error = ref<string | null>(null)
 const result = ref<BookDockBulkEditResult | null>(null)
 
-const FIELDS: { key: keyof BookDockMetadata; label: string; type: 'text' | 'number' | 'array' }[] = [
-  { key: 'title', label: 'Title', type: 'text' },
-  { key: 'authors', label: 'Authors', type: 'array' },
-  { key: 'publisher', label: 'Publisher', type: 'text' },
-  { key: 'publishedYear', label: 'Year', type: 'number' },
-  { key: 'language', label: 'Language', type: 'text' },
-  { key: 'isbn13', label: 'ISBN-13', type: 'text' },
-  { key: 'isbn10', label: 'ISBN-10', type: 'text' },
-  { key: 'seriesName', label: 'Series', type: 'text' },
-  { key: 'seriesIndex', label: 'Series #', type: 'number' },
-  { key: 'genres', label: 'Genres', type: 'array' },
-]
+const FIELDS = computed<{ key: keyof BookDockMetadata; label: string; type: 'text' | 'number' | 'array' }[]>(() => [
+  { key: 'title', label: t('bookDock.field.title'), type: 'text' },
+  { key: 'authors', label: t('bookDock.field.authors'), type: 'array' },
+  { key: 'publisher', label: t('bookDock.field.publisher'), type: 'text' },
+  { key: 'publishedYear', label: t('bookDock.field.year'), type: 'number' },
+  { key: 'language', label: t('bookDock.field.language'), type: 'text' },
+  { key: 'isbn13', label: t('bookDock.field.isbn13'), type: 'text' },
+  { key: 'isbn10', label: t('bookDock.field.isbn10'), type: 'text' },
+  { key: 'seriesName', label: t('bookDock.field.series'), type: 'text' },
+  { key: 'seriesIndex', label: t('bookDock.field.seriesIndex'), type: 'number' },
+  { key: 'genres', label: t('bookDock.field.genres'), type: 'array' },
+])
 
 const enabledFields = reactive<Set<string>>(new Set())
 const values = reactive<Record<string, string>>({})
@@ -46,7 +49,7 @@ async function submit() {
   error.value = null
 
   const fields: Partial<BookDockMetadata> = {}
-  for (const f of FIELDS) {
+  for (const f of FIELDS.value) {
     if (!enabledFields.has(f.key)) continue
     const raw = values[f.key] ?? ''
     if (f.type === 'array') {
@@ -77,10 +80,10 @@ async function submit() {
       result.value = await res.json()
     } else {
       const body = await res.json().catch(() => null)
-      error.value = (body as { message?: string } | null)?.message ?? `Error ${res.status}`
+      error.value = (body as { message?: string } | null)?.message ?? t('bookDock.errorStatus', { status: res.status })
     }
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Bulk edit failed'
+    error.value = e instanceof Error ? e.message : t('bookDock.bulkEdit.failed')
   } finally {
     loading.value = false
   }
@@ -99,7 +102,7 @@ function handleClose() {
       <div class="relative z-10 w-full max-w-md mx-4 bg-card border border-border rounded-lg shadow-2xl overflow-hidden">
         <div class="flex items-center justify-between px-5 py-4 border-b border-border">
           <h2 class="text-base font-semibold text-foreground">
-            {{ result ? 'Bulk Edit Results' : `Bulk Edit ${selectionCount} file${selectionCount === 1 ? '' : 's'}` }}
+            {{ result ? t('bookDock.bulkEdit.resultTitle') : t('bookDock.bulkEdit.title', { count: selectionCount }, selectionCount) }}
           </h2>
           <button
             class="size-7 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
@@ -110,7 +113,7 @@ function handleClose() {
         </div>
 
         <div v-if="!result" class="px-5 py-4 space-y-4 max-h-[70vh] overflow-y-auto">
-          <p class="text-xs text-muted-foreground">Toggle the fields you want to update. Only enabled fields will be applied.</p>
+          <p class="text-xs text-muted-foreground">{{ t('bookDock.bulkEdit.instructions') }}</p>
 
           <div class="space-y-2">
             <div v-for="f in FIELDS" :key="f.key" class="flex items-center gap-2">
@@ -125,7 +128,7 @@ function handleClose() {
                 <input
                   v-model="values[f.key]"
                   :disabled="!enabledFields.has(f.key)"
-                  :placeholder="f.type === 'array' ? 'comma-separated' : ''"
+                  :placeholder="f.type === 'array' ? t('bookDock.commaSeparated') : ''"
                   class="w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring disabled:opacity-40"
                 />
               </label>
@@ -134,14 +137,14 @@ function handleClose() {
 
           <label class="flex items-center gap-2 text-xs text-muted-foreground">
             <input v-model="mergeArrays" type="checkbox" class="size-3.5 rounded border-input accent-primary" />
-            Merge arrays (add to existing values instead of replacing)
+            {{ t('bookDock.bulkEdit.mergeArrays') }}
           </label>
 
           <p v-if="error" class="text-xs text-red-500 bg-red-500/10 rounded-lg p-2">{{ error }}</p>
 
           <div class="flex items-center justify-end gap-2 pt-2">
             <button class="h-8 px-4 rounded-lg text-sm text-muted-foreground hover:text-foreground transition-all" @click="handleClose">
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               class="flex items-center gap-1.5 h-8 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
@@ -149,22 +152,22 @@ function handleClose() {
               @click="submit"
             >
               <Loader2 v-if="loading" class="size-3.5 animate-spin" />
-              Apply
+              {{ t('bookDock.apply') }}
             </button>
           </div>
         </div>
 
         <div v-else class="px-5 py-4 space-y-4">
           <div class="rounded-lg bg-emerald-500/10 p-3">
-            <p class="text-sm font-medium">Updated {{ result.updated }} of {{ result.total }} files</p>
-            <p v-if="result.failed > 0" class="text-xs text-muted-foreground mt-0.5">{{ result.failed }} failed</p>
+            <p class="text-sm font-medium">{{ t('bookDock.updatedOfFiles', { updated: result.updated, total: result.total }) }}</p>
+            <p v-if="result.failed > 0" class="text-xs text-muted-foreground mt-0.5">{{ t('bookDock.nFailed', { count: result.failed }) }}</p>
           </div>
           <div class="flex justify-end">
             <button
               class="h-8 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-all hover:opacity-90 active:scale-95"
               @click="handleClose"
             >
-              Done
+              {{ t('bookDock.done') }}
             </button>
           </div>
         </div>

--- a/client/src/features/book-dock/components/BookDockFileList.vue
+++ b/client/src/features/book-dock/components/BookDockFileList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { BookOpen, FileText, Wand2, Pencil, X, ArrowRight } from '@lucide/vue'
 import type { BookDockFile, BookDockMetadata } from '@bookorbit/types'
 import {
@@ -21,6 +22,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useLibraries } from '@/features/library/composables/useLibraries'
 import { toDisplayCoverUrl } from '@/features/book/lib/metadata-fetch'
 
+const { t } = useI18n()
+
 const props = withDefaults(
   defineProps<{
     items: BookDockFile[]
@@ -33,9 +36,11 @@ const props = withDefaults(
   }>(),
   {
     namePreviewByFileId: () => ({}),
-    emptyMessage: 'Upload files or drop them in the Book Dock folder',
+    emptyMessage: undefined,
   },
 )
+
+const resolvedEmptyMessage = computed(() => props.emptyMessage ?? t('bookDock.fileList.emptyMessageDefault'))
 
 const emit = defineEmits<{
   select: [number, boolean]
@@ -177,18 +182,18 @@ function joinTargetPath(folderPath: string, fileName: string): string {
 function targetSummary(file: BookDockFile): string {
   const lib = file.targetLibraryId != null ? libraries.value.find((l) => l.id === file.targetLibraryId) : null
   const folder = file.targetFolderId != null ? lib?.folders.find((f) => f.id === file.targetFolderId) : null
-  const libLabel = lib?.name ?? (file.targetLibraryId != null ? 'Unknown library' : 'Unassigned')
+  const libLabel = lib?.name ?? (file.targetLibraryId != null ? t('bookDock.fileList.unknownLibrary') : t('bookDock.fileList.unassigned'))
   const previewName = props.namePreviewByFileId?.[file.id] ?? file.fileName
 
   if (lib && folder?.path) {
-    return `Target: ${libLabel} · ${joinTargetPath(folder.path, previewName)}`
+    return t('bookDock.fileList.targetPath', { library: libLabel, path: joinTargetPath(folder.path, previewName) })
   }
 
   if (file.targetLibraryId == null || file.targetFolderId == null) {
-    return 'Target: Unassigned'
+    return t('bookDock.fileList.targetUnassigned')
   }
 
-  return `Target: ${libLabel} · Unknown destination path`
+  return t('bookDock.fileList.targetUnknownPath', { library: libLabel })
 }
 </script>
 
@@ -210,21 +215,21 @@ function targetSummary(file: BookDockFile): string {
       <div class="size-12 rounded-full bg-muted flex items-center justify-center">
         <FileText class="size-6" />
       </div>
-      <p class="text-sm font-medium text-foreground">No files in Book Dock</p>
-      <p class="text-xs">{{ emptyMessage }}</p>
+      <p class="text-sm font-medium text-foreground">{{ t('bookDock.fileList.emptyTitle') }}</p>
+      <p class="text-xs">{{ resolvedEmptyMessage }}</p>
     </div>
 
     <div v-else class="divide-y divide-border">
       <div class="flex items-center gap-3 px-4 py-2 bg-muted/30 border-b border-border">
         <input type="checkbox" :checked="selectAll" class="size-3.5 rounded border-input accent-primary" @change="$emit('selectAll')" />
-        <span class="text-xs font-medium text-muted-foreground w-12 text-center shrink-0">Current</span>
-        <span class="text-xs font-medium text-muted-foreground w-12 text-center shrink-0">New</span>
-        <span class="text-xs font-medium text-muted-foreground flex-1">File</span>
-        <span class="text-xs font-medium text-muted-foreground w-16 text-right hidden sm:block">Size</span>
-        <span class="text-xs font-medium text-muted-foreground w-12 text-center hidden sm:block">Format</span>
-        <span class="text-xs font-medium text-muted-foreground w-14 text-center hidden sm:block">Match</span>
-        <span class="text-xs font-medium text-muted-foreground w-7 text-center hidden sm:block">Apply</span>
-        <span class="text-xs font-medium text-muted-foreground w-16 text-center">Status</span>
+        <span class="text-xs font-medium text-muted-foreground w-12 text-center shrink-0">{{ t('bookDock.fileList.colCurrent') }}</span>
+        <span class="text-xs font-medium text-muted-foreground w-12 text-center shrink-0">{{ t('bookDock.fileList.colNew') }}</span>
+        <span class="text-xs font-medium text-muted-foreground flex-1">{{ t('bookDock.fileList.colFile') }}</span>
+        <span class="text-xs font-medium text-muted-foreground w-16 text-right hidden sm:block">{{ t('bookDock.fileList.colSize') }}</span>
+        <span class="text-xs font-medium text-muted-foreground w-12 text-center hidden sm:block">{{ t('bookDock.fileList.colFormat') }}</span>
+        <span class="text-xs font-medium text-muted-foreground w-14 text-center hidden sm:block">{{ t('bookDock.fileList.colMatch') }}</span>
+        <span class="text-xs font-medium text-muted-foreground w-7 text-center hidden sm:block">{{ t('bookDock.fileList.colApply') }}</span>
+        <span class="text-xs font-medium text-muted-foreground w-16 text-center">{{ t('bookDock.fileList.colStatus') }}</span>
       </div>
 
       <button
@@ -247,7 +252,13 @@ function targetSummary(file: BookDockFile): string {
               <div class="w-12 shrink-0 flex justify-center">
                 <div
                   class="relative w-8 h-12 rounded-md bg-muted flex items-center justify-center overflow-hidden cursor-zoom-in ring-1 ring-border"
-                  @click.stop="openCoverLightbox(currentCoverUrl(file), `${displayTitle(file)} current cover`, currentCoverLightboxFallback())"
+                  @click.stop="
+                    openCoverLightbox(
+                      currentCoverUrl(file),
+                      t('bookDock.fileList.currentCoverAlt', { title: displayTitle(file) }),
+                      currentCoverLightboxFallback(),
+                    )
+                  "
                 >
                   <img
                     :src="currentCoverUrl(file)"
@@ -264,7 +275,7 @@ function targetSummary(file: BookDockFile): string {
                 <div
                   v-if="newCoverUrl(file)"
                   class="relative w-8 h-12 rounded-md bg-amber-500/5 border border-amber-500/30 flex items-center justify-center overflow-hidden cursor-zoom-in"
-                  @click.stop="openCoverLightbox(newCoverUrl(file)!, `${displayTitle(file)} new cover`)"
+                  @click.stop="openCoverLightbox(newCoverUrl(file)!, t('bookDock.fileList.newCoverAlt', { title: displayTitle(file) }))"
                 >
                   <img
                     :src="newCoverUrl(file)!"
@@ -308,7 +319,7 @@ function targetSummary(file: BookDockFile): string {
                     <img :src="currentCoverUrl(file)" alt="" class="size-full object-cover" @error="onCurrentCoverError" />
                     <BookOpen class="size-5 text-muted-foreground absolute" />
                   </div>
-                  <span class="text-[10px] font-medium text-muted-foreground">Current</span>
+                  <span class="text-[10px] font-medium text-muted-foreground">{{ t('bookDock.fileList.colCurrent') }}</span>
                 </div>
                 <template v-if="newCoverUrl(file)">
                   <ArrowRight class="size-4 text-muted-foreground shrink-0" />
@@ -318,7 +329,7 @@ function targetSummary(file: BookDockFile): string {
                     >
                       <img :src="newCoverUrl(file)!" alt="" class="size-full object-cover" @error="onFetchedCoverError" />
                     </div>
-                    <span class="text-[10px] font-medium text-amber-600 dark:text-amber-400">New</span>
+                    <span class="text-[10px] font-medium text-amber-600 dark:text-amber-400">{{ t('bookDock.fileList.colNew') }}</span>
                   </div>
                 </template>
               </div>
@@ -367,7 +378,7 @@ function targetSummary(file: BookDockFile): string {
                   <Wand2 class="size-3.5" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Apply fetched metadata</TooltipContent>
+              <TooltipContent>{{ t('bookDock.fileList.applyFetchedMetadata') }}</TooltipContent>
             </Tooltip>
           </div>
 
@@ -386,8 +397,8 @@ function targetSummary(file: BookDockFile): string {
         <DialogContent
           class="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 max-w-[90vw] max-h-[90vh] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
         >
-          <DialogTitle class="sr-only">{{ coverLightbox?.title ?? 'Cover preview' }}</DialogTitle>
-          <DialogDescription class="sr-only">Enlarged cover image preview dialog.</DialogDescription>
+          <DialogTitle class="sr-only">{{ coverLightbox?.title ?? t('bookDock.fileList.coverPreview') }}</DialogTitle>
+          <DialogDescription class="sr-only">{{ t('bookDock.fileList.coverPreviewDescription') }}</DialogDescription>
           <img
             v-if="coverLightbox"
             :src="coverLightbox.src"

--- a/client/src/features/book-dock/components/BookDockFileSheet.vue
+++ b/client/src/features/book-dock/components/BookDockFileSheet.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X, BookOpen, Check, Trash2, Sparkles, ArrowLeft, Wand2, AlertCircle } from '@lucide/vue'
 import type { BookDockFile, BookDockMetadata, MetadataCandidate, MetadataSource, MetadataProviderKey } from '@bookorbit/types'
 import BookDockStatusBadge from './BookDockStatusBadge.vue'
@@ -11,6 +12,8 @@ import { useMetadataSearch } from '@/features/book/composables/useMetadataSearch
 import type { MetadataPatch } from '@/features/book/composables/useMetadataDiff'
 import { formatBytes } from '@/lib/formatting'
 import { toDisplayCoverUrl } from '@/features/book/lib/metadata-fetch'
+
+const { t } = useI18n()
 
 const props = defineProps<{ file: BookDockFile }>()
 
@@ -364,7 +367,7 @@ onMounted(() => {
         </div>
         <div v-if="saved" class="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
           <Check class="size-3.5" />
-          Saved
+          {{ t('bookDock.sheet.saved') }}
         </div>
       </div>
 
@@ -384,19 +387,19 @@ onMounted(() => {
           <div v-if="hasFetchedMetadata" class="flex items-center gap-2.5 p-3 rounded-lg border border-amber-500/30 bg-amber-500/5">
             <Wand2 class="size-4 text-amber-600 dark:text-amber-400 shrink-0" />
             <p class="flex-1 text-sm text-amber-700 dark:text-amber-300">
-              {{ file.metadataEditedAt ? 'Provider metadata found - bulk apply will skip this file (you have edits)' : 'Provider metadata found' }}
+              {{ file.metadataEditedAt ? t('bookDock.sheet.providerMetadataFoundEdited') : t('bookDock.sheet.providerMetadataFound') }}
             </p>
             <button
               class="shrink-0 flex items-center gap-1.5 h-7 px-3 rounded-lg border border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-medium hover:bg-amber-500/20 transition-all active:scale-95"
               @click="openFetchedDiff"
             >
-              Review
+              {{ t('bookDock.sheet.review') }}
             </button>
           </div>
 
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <label class="sm:col-span-2">
-              <span class="text-xs font-medium text-muted-foreground">Title</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.title') }}</span>
               <input
                 v-model="form.title"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
@@ -404,7 +407,7 @@ onMounted(() => {
               />
             </label>
             <label class="sm:col-span-2">
-              <span class="text-xs font-medium text-muted-foreground">Subtitle</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.subtitle') }}</span>
               <input
                 v-model="form.subtitle"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
@@ -412,7 +415,7 @@ onMounted(() => {
               />
             </label>
             <label class="sm:col-span-2">
-              <span class="text-xs font-medium text-muted-foreground">Authors (comma-separated)</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.authorsCommaSeparated') }}</span>
               <input
                 v-model="form.authors"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
@@ -420,7 +423,7 @@ onMounted(() => {
               />
             </label>
             <label>
-              <span class="text-xs font-medium text-muted-foreground">Publisher</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.publisher') }}</span>
               <input
                 v-model="form.publisher"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
@@ -428,7 +431,7 @@ onMounted(() => {
               />
             </label>
             <label>
-              <span class="text-xs font-medium text-muted-foreground">Year</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.year') }}</span>
               <input
                 v-model="form.publishedYear"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
@@ -436,7 +439,7 @@ onMounted(() => {
               />
             </label>
             <label>
-              <span class="text-xs font-medium text-muted-foreground">Language</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.language') }}</span>
               <input
                 v-model="form.language"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
@@ -444,7 +447,7 @@ onMounted(() => {
               />
             </label>
             <label>
-              <span class="text-xs font-medium text-muted-foreground">ISBN-13</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.isbn13') }}</span>
               <input
                 v-model="form.isbn13"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm font-mono outline-none focus:ring-1 focus:ring-ring"
@@ -452,7 +455,7 @@ onMounted(() => {
               />
             </label>
             <label>
-              <span class="text-xs font-medium text-muted-foreground">ISBN-10</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.isbn10') }}</span>
               <input
                 v-model="form.isbn10"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm font-mono outline-none focus:ring-1 focus:ring-ring"
@@ -460,7 +463,7 @@ onMounted(() => {
               />
             </label>
             <label>
-              <span class="text-xs font-medium text-muted-foreground">Series</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.series') }}</span>
               <input
                 v-model="form.seriesName"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
@@ -468,7 +471,7 @@ onMounted(() => {
               />
             </label>
             <label>
-              <span class="text-xs font-medium text-muted-foreground">Series #</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.seriesIndex') }}</span>
               <input
                 v-model="form.seriesIndex"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
@@ -476,7 +479,7 @@ onMounted(() => {
               />
             </label>
             <label class="sm:col-span-2">
-              <span class="text-xs font-medium text-muted-foreground">Genres (comma-separated)</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.genresCommaSeparated') }}</span>
               <input
                 v-model="form.genres"
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
@@ -484,7 +487,7 @@ onMounted(() => {
               />
             </label>
             <label class="sm:col-span-2">
-              <span class="text-xs font-medium text-muted-foreground">Description</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.field.description') }}</span>
               <textarea
                 v-model="form.description"
                 rows="3"
@@ -496,7 +499,7 @@ onMounted(() => {
 
           <div class="space-y-3 pt-1">
             <label class="block">
-              <span class="text-xs font-medium text-muted-foreground">Destination Library</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.destinationLibrary') }}</span>
               <select
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
                 :value="targetLibraryId ?? ''"
@@ -506,7 +509,7 @@ onMounted(() => {
               </select>
             </label>
             <label class="block">
-              <span class="text-xs font-medium text-muted-foreground">Destination Folder</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.destinationFolder') }}</span>
               <select
                 class="mt-1 w-full h-8 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
                 :value="targetFolderId ?? ''"
@@ -517,7 +520,7 @@ onMounted(() => {
             </label>
           </div>
 
-          <p class="text-xs text-muted-foreground">Added {{ formatDate(file.createdAt) }}</p>
+          <p class="text-xs text-muted-foreground">{{ t('bookDock.sheet.added', { date: formatDate(file.createdAt) }) }}</p>
         </div>
 
         <div class="flex items-center justify-between gap-2 px-4 py-3 border-t border-border shrink-0">
@@ -526,7 +529,7 @@ onMounted(() => {
             @click="handleDiscard"
           >
             <Trash2 class="size-3.5" />
-            Discard
+            {{ t('bookDock.discard') }}
           </button>
           <div class="flex items-center gap-2">
             <button
@@ -538,13 +541,13 @@ onMounted(() => {
               @click="openSearch"
             >
               <Sparkles class="size-3.5" />
-              Search
+              {{ t('common.search') }}
             </button>
             <button
               class="relative h-8 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-all hover:opacity-90 active:scale-95"
               @click="$emit('close')"
             >
-              Done
+              {{ t('bookDock.done') }}
             </button>
           </div>
         </div>
@@ -560,7 +563,7 @@ onMounted(() => {
             <ArrowLeft class="size-4" />
           </button>
           <Sparkles class="size-3.5 text-primary" />
-          <span class="text-sm font-medium">Search Metadata</span>
+          <span class="text-sm font-medium">{{ t('bookDock.sheet.searchMetadata') }}</span>
         </div>
         <div class="flex-1 min-h-0">
           <MetadataSearchPanel
@@ -589,7 +592,7 @@ onMounted(() => {
             :initial-candidate="selectedCandidate"
             :filtered-results="diffSource === 'fetched' ? [selectedCandidate] : filteredResults"
             :providers="providers"
-            :back-label="diffSource === 'fetched' ? 'Back' : 'Results'"
+            :back-label="diffSource === 'fetched' ? t('common.back') : t('bookDock.sheet.results')"
             :current-cover-url="currentBookDockCoverUrl"
             :provider-ids="(file.fetchedMetadataSources as any) ?? undefined"
             @back="backFromDiff"

--- a/client/src/features/book-dock/components/BookDockFinalizeDialog.vue
+++ b/client/src/features/book-dock/components/BookDockFinalizeDialog.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { X, Check, AlertCircle, Copy, Loader2, ExternalLink, ChevronDown, FileText } from '@lucide/vue'
 
 import { api } from '@/lib/api'
 import { useLibraries } from '@/features/library/composables/useLibraries'
 import { useBookDockFinalize } from '../composables/useBookDockFinalize'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   selectionPayload: { fileIds?: number[]; selectAll?: boolean; excludedIds?: number[]; status?: string; search?: string }
@@ -242,7 +245,7 @@ async function handleReimportDuplicate(fileId: number) {
       <div class="relative z-10 w-full max-w-2xl mx-4 bg-card border border-border rounded-lg shadow-2xl overflow-hidden">
         <div class="flex items-center justify-between px-5 py-4 border-b border-border">
           <h2 class="text-base font-semibold text-foreground">
-            {{ result ? 'Finalize Results' : `Finalize ${selectionCount} file${selectionCount === 1 ? '' : 's'}` }}
+            {{ result ? t('bookDock.finalizeDialog.resultTitle') : t('bookDock.finalizeDialog.title', { count: selectionCount }, selectionCount) }}
           </h2>
           <button
             class="size-7 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
@@ -257,15 +260,22 @@ async function handleReimportDuplicate(fileId: number) {
             <p class="text-xs text-muted-foreground">
               {{
                 requiresDefaultDestination
-                  ? `${selectionSummary.withoutDestination} of ${selectionSummary.total} selected file${selectionSummary.total === 1 ? '' : 's'} need a destination`
-                  : 'All selected files already have destination set'
+                  ? t(
+                      'bookDock.finalizeDialog.needDestination',
+                      {
+                        count: selectionSummary.total,
+                        without: selectionSummary.withoutDestination,
+                      },
+                      selectionSummary.total,
+                    )
+                  : t('bookDock.finalizeDialog.allHaveDestination')
               }}
             </p>
           </div>
 
           <div v-if="requiresDefaultDestination" class="space-y-3">
             <label class="block">
-              <span class="text-xs font-medium text-muted-foreground">Default Destination Library</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.finalizeDialog.defaultDestinationLibrary') }}</span>
               <select
                 class="mt-1 w-full h-9 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
                 :value="defaultLibraryId ?? ''"
@@ -276,7 +286,7 @@ async function handleReimportDuplicate(fileId: number) {
             </label>
 
             <label class="block">
-              <span class="text-xs font-medium text-muted-foreground">Default Destination Folder</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.finalizeDialog.defaultDestinationFolder') }}</span>
               <select
                 class="mt-1 w-full h-9 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
                 :value="defaultFolderId ?? ''"
@@ -290,15 +300,15 @@ async function handleReimportDuplicate(fileId: number) {
           <div v-if="namePreview.length || previewLoading" class="space-y-1.5">
             <div class="flex items-center gap-1.5">
               <FileText class="size-3.5 text-muted-foreground" />
-              <span class="text-xs font-medium text-muted-foreground">Rename preview</span>
-              <span v-if="previewLoading" class="text-xs text-muted-foreground italic">Loading...</span>
+              <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.finalizeDialog.renamePreview') }}</span>
+              <span v-if="previewLoading" class="text-xs text-muted-foreground italic">{{ t('common.loading') }}</span>
             </div>
             <div class="rounded-lg border border-border bg-muted/20 divide-y divide-border max-h-48 overflow-y-auto">
               <div v-for="p in namePreview.slice(0, 8)" :key="p.fileId" class="px-3 py-1.5 text-xs">
                 <span class="text-foreground font-medium font-mono break-all">{{ p.newName }}</span>
               </div>
               <div v-if="namePreview.length > 8" class="px-3 py-1.5 text-xs text-muted-foreground italic">
-                +{{ namePreview.length - 8 }} more files
+                {{ t('bookDock.finalizeDialog.moreFiles', { count: namePreview.length - 8 }) }}
               </div>
             </div>
           </div>
@@ -307,7 +317,7 @@ async function handleReimportDuplicate(fileId: number) {
 
           <div class="flex items-center justify-end gap-2 pt-2">
             <button class="h-8 px-4 rounded-lg text-sm text-muted-foreground hover:text-foreground transition-all" @click="handleClose">
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               class="flex items-center gap-1.5 h-8 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
@@ -315,7 +325,7 @@ async function handleReimportDuplicate(fileId: number) {
               @click="start"
             >
               <Loader2 v-if="loading" class="size-3.5 animate-spin" />
-              Start
+              {{ t('bookDock.finalizeDialog.start') }}
             </button>
           </div>
         </div>
@@ -325,9 +335,15 @@ async function handleReimportDuplicate(fileId: number) {
             <Check v-if="result.failed === 0" class="size-5 text-emerald-600 dark:text-emerald-400 shrink-0" />
             <AlertCircle v-else class="size-5 text-amber-600 dark:text-amber-400 shrink-0" />
             <div>
-              <p class="text-sm font-medium">{{ result.succeeded }} of {{ result.total }} files finalized</p>
+              <p class="text-sm font-medium">
+                {{ t('bookDock.finalizeDialog.filesFinalized', { succeeded: result.succeeded, total: result.total }) }}
+              </p>
               <p v-if="result.failed > 0" class="text-xs text-muted-foreground mt-0.5">
-                {{ result.failed }} failed{{ duplicateCount > 0 ? ` (${duplicateCount} duplicate${duplicateCount !== 1 ? 's' : ''})` : '' }}
+                {{
+                  duplicateCount > 0
+                    ? t('bookDock.finalizeDialog.failedWithDuplicates', { failed: result.failed, count: duplicateCount }, duplicateCount)
+                    : t('bookDock.nFailed', { count: result.failed })
+                }}
               </p>
             </div>
           </div>
@@ -349,14 +365,14 @@ async function handleReimportDuplicate(fileId: number) {
                   class="text-xs text-primary hover:underline flex items-center gap-1 shrink-0"
                   @click="goToBook(r.bookId!)"
                 >
-                  View <ExternalLink class="size-3" />
+                  {{ t('bookDock.finalizeDialog.view') }} <ExternalLink class="size-3" />
                 </button>
                 <button
                   v-if="!r.success && r.isDuplicate && r.existingBookId"
                   class="text-xs text-amber-600 dark:text-amber-400 hover:underline flex items-center gap-1 shrink-0"
                   @click="goToBook(r.existingBookId!)"
                 >
-                  View existing <ExternalLink class="size-3" />
+                  {{ t('bookDock.finalizeDialog.viewExisting') }} <ExternalLink class="size-3" />
                 </button>
                 <button
                   v-if="!r.success && r.isDuplicate"
@@ -365,24 +381,24 @@ async function handleReimportDuplicate(fileId: number) {
                   @click="handleReimportDuplicate(r.fileId)"
                 >
                   <Loader2 v-if="reimportingIds.has(r.fileId)" class="size-3 animate-spin" />
-                  Import anyway
+                  {{ t('bookDock.finalizeDialog.importAnyway') }}
                 </button>
                 <button
                   v-if="!r.success && !r.isDuplicate && r.message && !isFileExistsError(r.message)"
                   class="text-xs text-red-500 flex items-center gap-1 shrink-0 hover:text-red-600 transition-colors"
                   @click="expandedErrors.has(r.fileId) ? expandedErrors.delete(r.fileId) : expandedErrors.add(r.fileId)"
                 >
-                  {{ expandedErrors.has(r.fileId) ? 'Hide' : 'Details' }}
+                  {{ expandedErrors.has(r.fileId) ? t('bookDock.finalizeDialog.hide') : t('bookDock.finalizeDialog.details') }}
                   <ChevronDown class="size-3 transition-transform" :class="expandedErrors.has(r.fileId) ? 'rotate-180' : ''" />
                 </button>
               </div>
               <div v-if="!r.success && isFileExistsError(r.message)" class="px-3 pb-2.5">
                 <div class="flex items-center gap-1.5">
-                  <span class="text-xs text-muted-foreground shrink-0">Already exists - save as:</span>
+                  <span class="text-xs text-muted-foreground shrink-0">{{ t('bookDock.finalizeDialog.alreadyExistsSaveAs') }}</span>
                   <input
                     type="text"
                     :value="getRenameInput(r.fileId)"
-                    :placeholder="'e.g. ' + r.fileName.replace(/\.[^.]+$/, '') + ' (2)'"
+                    :placeholder="t('bookDock.finalizeDialog.renamePlaceholder', { name: r.fileName.replace(/\.[^.]+$/, '') })"
                     class="flex-1 min-w-0 h-7 rounded-md border border-input bg-background px-2 text-xs outline-none focus:ring-1 focus:ring-ring"
                     @input="setRenameInput(r.fileId, ($event.target as HTMLInputElement).value)"
                   />
@@ -393,7 +409,7 @@ async function handleReimportDuplicate(fileId: number) {
                     @click="handleRenameAndRetry(r.fileId)"
                   >
                     <Loader2 v-if="reimportingIds.has(r.fileId)" class="size-3 animate-spin" />
-                    Import
+                    {{ t('bookDock.finalizeDialog.import') }}
                   </button>
                 </div>
               </div>
@@ -408,7 +424,7 @@ async function handleReimportDuplicate(fileId: number) {
               class="h-8 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-all hover:opacity-90 active:scale-95"
               @click="handleClose"
             >
-              Done
+              {{ t('bookDock.done') }}
             </button>
           </div>
         </div>

--- a/client/src/features/book-dock/components/BookDockSetDestinationDialog.vue
+++ b/client/src/features/book-dock/components/BookDockSetDestinationDialog.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X, Loader2, FolderPlus } from '@lucide/vue'
 import { api } from '@/lib/api'
 import { useLibraries } from '@/features/library/composables/useLibraries'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   selectionPayload: { fileIds?: number[]; selectAll?: boolean; excludedIds?: number[]; status?: string; search?: string }
@@ -73,7 +76,7 @@ async function applyDestination() {
       error.value = (body as { message?: string } | null)?.message ?? `Error ${res.status}`
     }
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Failed to set destination'
+    error.value = e instanceof Error ? e.message : t('bookDock.setDestination.failed')
   } finally {
     loading.value = false
   }
@@ -92,7 +95,7 @@ function handleClose() {
       <div class="relative z-10 w-full max-w-xl mx-4 bg-card border border-border rounded-lg shadow-2xl overflow-hidden">
         <div class="flex items-center justify-between px-5 py-4 border-b border-border">
           <h2 class="text-base font-semibold text-foreground">
-            {{ result ? 'Destination Updated' : `Set Destination for ${selectionCount} file${selectionCount === 1 ? '' : 's'}` }}
+            {{ result ? t('bookDock.setDestination.resultTitle') : t('bookDock.setDestination.title', { count: selectionCount }, selectionCount) }}
           </h2>
           <button
             class="size-7 rounded-full flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
@@ -104,7 +107,7 @@ function handleClose() {
 
         <div v-if="!result" class="px-5 py-4 space-y-4">
           <label class="block">
-            <span class="text-xs font-medium text-muted-foreground">Destination Library</span>
+            <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.destinationLibrary') }}</span>
             <select
               class="mt-1 w-full h-9 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
               :value="targetLibraryId ?? ''"
@@ -115,7 +118,7 @@ function handleClose() {
           </label>
 
           <label class="block">
-            <span class="text-xs font-medium text-muted-foreground">Destination Folder</span>
+            <span class="text-xs font-medium text-muted-foreground">{{ t('bookDock.destinationFolder') }}</span>
             <select
               class="mt-1 w-full h-9 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring"
               :value="targetFolderId ?? ''"
@@ -129,7 +132,7 @@ function handleClose() {
 
           <div class="flex items-center justify-end gap-2 pt-1">
             <button class="h-8 px-4 rounded-lg text-sm text-muted-foreground hover:text-foreground transition-all" @click="handleClose">
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               class="flex items-center gap-1.5 h-8 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-all hover:opacity-90 active:scale-95 disabled:opacity-50"
@@ -138,22 +141,22 @@ function handleClose() {
             >
               <Loader2 v-if="loading" class="size-3.5 animate-spin" />
               <FolderPlus v-else class="size-3.5" />
-              Apply
+              {{ t('bookDock.apply') }}
             </button>
           </div>
         </div>
 
         <div v-else class="px-5 py-4 space-y-4">
           <div class="rounded-lg bg-emerald-500/10 p-3">
-            <p class="text-sm font-medium">Updated {{ result.updated }} of {{ result.total }} files</p>
-            <p v-if="result.failed > 0" class="text-xs text-muted-foreground mt-0.5">{{ result.failed }} failed</p>
+            <p class="text-sm font-medium">{{ t('bookDock.updatedOfFiles', { updated: result.updated, total: result.total }) }}</p>
+            <p v-if="result.failed > 0" class="text-xs text-muted-foreground mt-0.5">{{ t('bookDock.nFailed', { count: result.failed }) }}</p>
           </div>
           <div class="flex justify-end">
             <button
               class="h-8 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-all hover:opacity-90 active:scale-95"
               @click="handleClose"
             >
-              Done
+              {{ t('bookDock.done') }}
             </button>
           </div>
         </div>

--- a/client/src/features/book-dock/components/BookDockStatusBadge.vue
+++ b/client/src/features/book-dock/components/BookDockStatusBadge.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Loader2 } from '@lucide/vue'
 import type { BookDockFileStatus } from '@bookorbit/types'
 
 defineProps<{ status: BookDockFileStatus }>()
+
+const { t } = useI18n()
 
 const styles: Record<BookDockFileStatus, string> = {
   pending: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
@@ -12,13 +16,13 @@ const styles: Record<BookDockFileStatus, string> = {
   error: 'bg-red-500/15 text-red-600 dark:text-red-400',
 }
 
-const labels: Record<BookDockFileStatus, string> = {
-  pending: 'Pending',
-  extracting: 'Extracting',
-  fetching: 'Fetching',
-  ready: 'Ready',
-  error: 'Error',
-}
+const labels = computed<Record<BookDockFileStatus, string>>(() => ({
+  pending: t('bookDock.status.pending'),
+  extracting: t('bookDock.status.extracting'),
+  fetching: t('bookDock.status.fetching'),
+  ready: t('bookDock.status.ready'),
+  error: t('bookDock.status.error'),
+}))
 </script>
 
 <template>

--- a/client/src/features/book-dock/components/BookDockToolbar.vue
+++ b/client/src/features/book-dock/components/BookDockToolbar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Upload, RotateCw, Trash2, PenLine, FileText, Search, X, Wand2, RefreshCw, FolderPlus, Loader2 } from '@lucide/vue'
 import type { BookDockFileStatus } from '@bookorbit/types'
 import { api } from '@/lib/api'
@@ -29,6 +30,7 @@ const emit = defineEmits<{
   applyFetched: []
 }>()
 
+const { t } = useI18n()
 const { files: uploadFiles, isUploading, addFiles, clearCompleted } = useBookDockUpload()
 const { isDemoRestrictedAccount } = usePermissions()
 const fileInput = ref<HTMLInputElement | null>(null)
@@ -61,12 +63,12 @@ onUnmounted(() => {
   if (popoverTimer) clearTimeout(popoverTimer)
 })
 
-const tabs: { label: string; value: BookDockFileStatus | undefined }[] = [
-  { label: 'All', value: undefined },
-  { label: 'Pending', value: 'pending' },
-  { label: 'Ready', value: 'ready' },
-  { label: 'Error', value: 'error' },
-]
+const tabs = computed<{ label: string; value: BookDockFileStatus | undefined }[]>(() => [
+  { label: t('bookDock.tab.all'), value: undefined },
+  { label: t('bookDock.tab.pending'), value: 'pending' },
+  { label: t('bookDock.tab.ready'), value: 'ready' },
+  { label: t('bookDock.tab.error'), value: 'error' },
+])
 
 function openFilePicker() {
   clearCompleted()
@@ -129,7 +131,7 @@ function clearSearch() {
         <Search class="size-3.5 text-muted-foreground shrink-0" />
         <input
           v-model="searchQuery"
-          placeholder="Search files..."
+          :placeholder="t('bookDock.searchPlaceholder')"
           class="h-full w-32 sm:w-44 bg-transparent text-xs outline-none placeholder:text-muted-foreground/80"
           @input="onSearchInput"
         />
@@ -157,7 +159,7 @@ function clearSearch() {
         @click="rescan"
       >
         <RotateCw class="size-3.5" :class="rescanning ? 'animate-spin' : ''" />
-        Rescan
+        {{ t('bookDock.rescan') }}
       </button>
 
       <div class="relative">
@@ -168,7 +170,7 @@ function clearSearch() {
         >
           <Loader2 v-if="isUploading" class="size-3.5 animate-spin" />
           <Upload v-else class="size-3.5" />
-          Upload
+          {{ t('bookDock.uploadAction') }}
         </button>
 
         <div
@@ -176,7 +178,7 @@ function clearSearch() {
           class="absolute right-0 top-full mt-1.5 z-20 w-52 rounded-lg border border-border bg-card shadow-lg p-3 space-y-2.5"
         >
           <div class="flex items-center justify-between">
-            <span class="text-xs font-medium text-foreground">{{ isUploading ? 'Uploading...' : 'Done' }}</span>
+            <span class="text-xs font-medium text-foreground">{{ isUploading ? t('bookDock.uploading') : t('bookDock.done') }}</span>
             <button class="text-muted-foreground hover:text-foreground transition-colors" @click="showUploadPopover = false">
               <X class="size-3" />
             </button>
@@ -189,16 +191,16 @@ function clearSearch() {
             />
           </div>
           <div class="flex items-center gap-3 text-[11px]">
-            <span class="text-emerald-600 dark:text-emerald-400 tabular-nums">{{ uploadDone }} done</span>
-            <span v-if="uploadError > 0" class="text-destructive tabular-nums">{{ uploadError }} failed</span>
-            <span class="text-muted-foreground tabular-nums ml-auto">{{ uploadTotal }} total</span>
+            <span class="text-emerald-600 dark:text-emerald-400 tabular-nums">{{ t('bookDock.upload.nDone', { count: uploadDone }) }}</span>
+            <span v-if="uploadError > 0" class="text-destructive tabular-nums">{{ t('bookDock.upload.nFailed', { count: uploadError }) }}</span>
+            <span class="text-muted-foreground tabular-nums ml-auto">{{ t('bookDock.upload.nTotal', { count: uploadTotal }) }}</span>
           </div>
         </div>
       </div>
     </div>
 
     <div v-if="hasSelection" class="flex flex-wrap items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2">
-      <span class="text-xs font-medium text-foreground">{{ selectionCount }} selected</span>
+      <span class="text-xs font-medium text-foreground">{{ t('bookDock.nSelected', { count: selectionCount }) }}</span>
       <div class="flex-1" />
       <button
         data-testid="book-dock-finalize"
@@ -206,7 +208,7 @@ function clearSearch() {
         @click="$emit('finalize')"
       >
         <FileText class="size-3.5" />
-        Finalize
+        {{ t('bookDock.finalize') }}
       </button>
       <button
         data-testid="book-dock-set-destination"
@@ -214,7 +216,7 @@ function clearSearch() {
         @click="$emit('setDestination')"
       >
         <FolderPlus class="size-3.5" />
-        Set Destination
+        {{ t('bookDock.setDestinationAction') }}
       </button>
       <Tooltip v-if="fetchedCount > 0">
         <TooltipTrigger as-child>
@@ -224,14 +226,14 @@ function clearSearch() {
             @click="$emit('applyFetched')"
           >
             <Wand2 class="size-3.5" />
-            Apply Fetched
+            {{ t('bookDock.applyFetched') }}
             <span
               class="ml-0.5 inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-amber-500/20 text-[10px] font-semibold tabular-nums"
               >{{ fetchedCount }}</span
             >
           </button>
         </TooltipTrigger>
-        <TooltipContent>Apply auto-fetched provider metadata to {{ fetchedCount }} file{{ fetchedCount !== 1 ? 's' : '' }}</TooltipContent>
+        <TooltipContent>{{ t('bookDock.applyFetchedTooltip', { count: fetchedCount }, fetchedCount) }}</TooltipContent>
       </Tooltip>
       <Tooltip v-if="errorCount > 0">
         <TooltipTrigger as-child>
@@ -241,14 +243,14 @@ function clearSearch() {
             @click="$emit('retryFetch')"
           >
             <RefreshCw class="size-3.5" />
-            Retry Errors
+            {{ t('bookDock.retryErrors') }}
             <span
               class="ml-0.5 inline-flex items-center justify-center min-w-4 h-4 px-1 rounded-full bg-muted-foreground/20 text-[10px] font-semibold tabular-nums"
               >{{ errorCount }}</span
             >
           </button>
         </TooltipTrigger>
-        <TooltipContent>Retry metadata fetch for {{ errorCount }} error file{{ errorCount !== 1 ? 's' : '' }}</TooltipContent>
+        <TooltipContent>{{ t('bookDock.retryErrorsTooltip', { count: errorCount }, errorCount) }}</TooltipContent>
       </Tooltip>
       <button
         v-if="canBulkEdit"
@@ -257,7 +259,7 @@ function clearSearch() {
         @click="$emit('bulkEdit')"
       >
         <PenLine class="size-3.5" />
-        Bulk Edit
+        {{ t('bookDock.bulkEditAction') }}
       </button>
       <button
         data-testid="book-dock-bulk-discard"
@@ -265,7 +267,7 @@ function clearSearch() {
         @click="$emit('bulkDiscard')"
       >
         <Trash2 class="size-3.5" />
-        Discard
+        {{ t('bookDock.discard') }}
       </button>
     </div>
   </div>

--- a/client/src/features/book-metadata-fetch/components/AuthorEnrichmentExpanded.vue
+++ b/client/src/features/book-metadata-fetch/components/AuthorEnrichmentExpanded.vue
@@ -3,7 +3,10 @@ import { ref } from 'vue'
 import { X, Play, Square, AlertTriangle } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import type { AuthorEnrichmentStatusEvent } from '@bookorbit/types'
+import { useI18n } from 'vue-i18n'
 import { useAuthorEnrichmentActions } from '@/features/settings/composables/useAuthorEnrichmentActions'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   status: AuthorEnrichmentStatusEvent
@@ -24,7 +27,7 @@ async function handlePause() {
   try {
     await pause()
   } catch {
-    toast.error('Failed to pause')
+    toast.error(t('bookMetadataFetch.toast.failedToPause'))
   } finally {
     acting.value = false
   }
@@ -36,7 +39,7 @@ async function handleResume() {
   try {
     await resume()
   } catch {
-    toast.error('Failed to resume')
+    toast.error(t('bookMetadataFetch.toast.failedToResume'))
   } finally {
     acting.value = false
   }
@@ -49,7 +52,7 @@ async function handleCancelConfirm() {
   try {
     await cancelPending()
   } catch {
-    toast.error('Failed to cancel')
+    toast.error(t('bookMetadataFetch.toast.failedToCancel'))
   } finally {
     acting.value = false
   }
@@ -59,22 +62,22 @@ async function handleCancelConfirm() {
 <template>
   <div class="flex flex-col gap-3 p-3 min-w-[220px]">
     <div class="flex items-center justify-between">
-      <span class="text-sm font-medium text-emerald-500">Author Enrichment</span>
+      <span class="text-sm font-medium text-emerald-500">{{ t('bookMetadataFetch.author.title') }}</span>
       <button class="text-muted-foreground hover:text-foreground" @click="emit('close')">
         <X :size="14" />
       </button>
     </div>
 
     <div class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-      <span class="text-muted-foreground">Queued</span>
+      <span class="text-muted-foreground">{{ t('bookMetadataFetch.stats.queued') }}</span>
       <span class="text-right font-medium">{{ props.status.queued }}</span>
-      <span class="text-muted-foreground">Processing</span>
+      <span class="text-muted-foreground">{{ t('bookMetadataFetch.stats.processing') }}</span>
       <span class="text-right font-medium">{{ props.status.processing }}</span>
       <template v-if="props.status.rateLimited > 0">
-        <span class="text-muted-foreground">Rate limited</span>
+        <span class="text-muted-foreground">{{ t('bookMetadataFetch.stats.rateLimited') }}</span>
         <span class="text-right font-medium text-amber-500">{{ props.status.rateLimited }}</span>
       </template>
-      <span class="text-muted-foreground">Failed</span>
+      <span class="text-muted-foreground">{{ t('bookMetadataFetch.stats.failed') }}</span>
       <span class="text-right font-medium" :class="props.status.failed > 0 ? 'text-destructive' : ''">{{ props.status.failed }}</span>
     </div>
 
@@ -86,7 +89,7 @@ async function handleCancelConfirm() {
         @click="handlePause"
       >
         <Square :size="12" />
-        Pause
+        {{ t('bookMetadataFetch.actions.pause') }}
       </button>
       <button
         v-if="props.status.paused && (props.status.queued > 0 || props.status.processing > 0 || props.status.rateLimited > 0)"
@@ -95,7 +98,7 @@ async function handleCancelConfirm() {
         @click="handleResume"
       >
         <Play :size="12" />
-        Resume
+        {{ t('bookMetadataFetch.actions.resume') }}
       </button>
       <button
         v-if="props.status.queued > 0 || props.status.rateLimited > 0"
@@ -103,14 +106,14 @@ async function handleCancelConfirm() {
         class="px-2 py-1 text-xs rounded border border-border hover:bg-muted text-destructive disabled:opacity-50"
         @click="confirmingCancel = true"
       >
-        Cancel queued
+        {{ t('bookMetadataFetch.actions.cancelQueued') }}
       </button>
     </div>
 
     <div v-else class="flex flex-col gap-1.5">
       <div class="flex items-center gap-1 text-xs text-muted-foreground">
         <AlertTriangle :size="11" class="text-amber-500 shrink-0" />
-        Currently processing items will finish.
+        {{ t('bookMetadataFetch.cancel.processingWillFinish') }}
       </div>
       <div class="flex gap-1.5">
         <button
@@ -118,14 +121,16 @@ async function handleCancelConfirm() {
           class="px-2 py-1 text-xs rounded bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
           @click="handleCancelConfirm"
         >
-          Confirm cancel
+          {{ t('bookMetadataFetch.cancel.confirm') }}
         </button>
-        <button class="px-2 py-1 text-xs rounded border border-border hover:bg-muted" @click="confirmingCancel = false">Keep running</button>
+        <button class="px-2 py-1 text-xs rounded border border-border hover:bg-muted" @click="confirmingCancel = false">
+          {{ t('bookMetadataFetch.cancel.keepRunning') }}
+        </button>
       </div>
     </div>
 
     <button v-if="props.status.failed > 0" class="text-xs text-emerald-500 hover:underline text-left" @click="emit('openReport')">
-      View {{ props.status.failed }} failed
+      {{ t('bookMetadataFetch.viewFailed', { count: props.status.failed }, props.status.failed) }}
     </button>
   </div>
 </template>

--- a/client/src/features/book-metadata-fetch/components/AuthorEnrichmentReportModal.vue
+++ b/client/src/features/book-metadata-fetch/components/AuthorEnrichmentReportModal.vue
@@ -4,7 +4,10 @@ import { X, RefreshCw } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import type { AuthorEnrichmentFailedPage } from '@bookorbit/types'
 import { api } from '@/lib/api'
+import { useI18n } from 'vue-i18n'
 import { useAuthorEnrichmentActions } from '@/features/settings/composables/useAuthorEnrichmentActions'
+
+const { t } = useI18n()
 
 const emit = defineEmits<{ close: [] }>()
 
@@ -33,10 +36,10 @@ async function handleRetryAll() {
   retrying.value = true
   try {
     await retryFailed()
-    toast.success('Failed items requeued')
+    toast.success(t('bookMetadataFetch.toast.failedItemsRequeued'))
     emit('close')
   } catch {
-    toast.error('Failed to retry')
+    toast.error(t('bookMetadataFetch.toast.failedToRetry'))
   } finally {
     retrying.value = false
   }
@@ -49,28 +52,30 @@ onMounted(() => loadPage(1))
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="emit('close')">
     <div class="bg-background border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col">
       <div class="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
-        <h2 class="text-sm font-semibold">Failed Author Enrichments</h2>
+        <h2 class="text-sm font-semibold">{{ t('bookMetadataFetch.report.authorTitle') }}</h2>
         <button class="text-muted-foreground hover:text-foreground" @click="emit('close')">
           <X :size="16" />
         </button>
       </div>
 
       <div class="flex-1 overflow-y-auto">
-        <div v-if="loading" class="p-6 text-center text-sm text-muted-foreground">Loading...</div>
+        <div v-if="loading" class="p-6 text-center text-sm text-muted-foreground">{{ t('common.loading') }}</div>
 
-        <div v-else-if="!data || data.items.length === 0" class="p-6 text-center text-sm text-muted-foreground">No failed items.</div>
+        <div v-else-if="!data || data.items.length === 0" class="p-6 text-center text-sm text-muted-foreground">
+          {{ t('bookMetadataFetch.report.noFailedItems') }}
+        </div>
 
         <table v-else class="w-full text-xs">
           <thead class="sticky top-0 bg-background border-b border-border">
             <tr>
-              <th class="text-left px-4 py-2 text-muted-foreground font-medium">Author</th>
-              <th class="text-left px-4 py-2 text-muted-foreground font-medium">Error</th>
-              <th class="text-right px-4 py-2 text-muted-foreground font-medium">HTTP</th>
+              <th class="text-left px-4 py-2 text-muted-foreground font-medium">{{ t('bookMetadataFetch.report.columns.author') }}</th>
+              <th class="text-left px-4 py-2 text-muted-foreground font-medium">{{ t('bookMetadataFetch.report.columns.error') }}</th>
+              <th class="text-right px-4 py-2 text-muted-foreground font-medium">{{ t('bookMetadataFetch.report.columns.http') }}</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="item in data.items" :key="item.authorId" class="border-b border-border/50 hover:bg-muted/40">
-              <td class="px-4 py-2 max-w-[200px] truncate">{{ item.name ?? `Author #${item.authorId}` }}</td>
+              <td class="px-4 py-2 max-w-[200px] truncate">{{ item.name ?? t('bookMetadataFetch.report.authorFallback', { id: item.authorId }) }}</td>
               <td class="px-4 py-2 text-muted-foreground max-w-[320px] truncate" :title="item.error ?? ''">{{ item.error ?? '-' }}</td>
               <td class="px-4 py-2 text-right text-muted-foreground">{{ item.httpStatus ?? '-' }}</td>
             </tr>
@@ -85,7 +90,7 @@ onMounted(() => loadPage(1))
             class="px-2 py-1 text-xs border border-border rounded hover:bg-muted disabled:opacity-40"
             @click="loadPage(page - 1)"
           >
-            Prev
+            {{ t('common.previous') }}
           </button>
           <span class="text-xs text-muted-foreground">{{ page }} / {{ Math.ceil(data.total / limit) }}</span>
           <button
@@ -93,7 +98,7 @@ onMounted(() => loadPage(1))
             class="px-2 py-1 text-xs border border-border rounded hover:bg-muted disabled:opacity-40"
             @click="loadPage(page + 1)"
           >
-            Next
+            {{ t('common.next') }}
           </button>
         </div>
         <button
@@ -102,7 +107,7 @@ onMounted(() => loadPage(1))
           @click="handleRetryAll"
         >
           <RefreshCw :size="12" :class="retrying ? 'animate-spin' : ''" />
-          Retry all failed
+          {{ t('bookMetadataFetch.report.retryAllFailed') }}
         </button>
       </div>
     </div>

--- a/client/src/features/book-metadata-fetch/components/BookMetadataFetchExpanded.vue
+++ b/client/src/features/book-metadata-fetch/components/BookMetadataFetchExpanded.vue
@@ -3,7 +3,10 @@ import { ref } from 'vue'
 import { X, Play, Square, AlertTriangle } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import type { BookMetadataFetchStatusEvent } from '@bookorbit/types'
+import { useI18n } from 'vue-i18n'
 import { useBookMetadataFetchActions } from '../composables/useBookMetadataFetchActions'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   status: BookMetadataFetchStatusEvent
@@ -24,7 +27,7 @@ async function handlePause() {
   try {
     await pause()
   } catch {
-    toast.error('Failed to pause')
+    toast.error(t('bookMetadataFetch.toast.failedToPause'))
   } finally {
     acting.value = false
   }
@@ -36,7 +39,7 @@ async function handleResume() {
   try {
     await resume()
   } catch {
-    toast.error('Failed to resume')
+    toast.error(t('bookMetadataFetch.toast.failedToResume'))
   } finally {
     acting.value = false
   }
@@ -49,7 +52,7 @@ async function handleCancelConfirm() {
   try {
     await cancelPending()
   } catch {
-    toast.error('Failed to cancel')
+    toast.error(t('bookMetadataFetch.toast.failedToCancel'))
   } finally {
     acting.value = false
   }
@@ -59,18 +62,18 @@ async function handleCancelConfirm() {
 <template>
   <div class="flex flex-col gap-3 p-3 min-w-[220px]">
     <div class="flex items-center justify-between">
-      <span class="text-sm font-medium text-violet-500">Metadata Fetch</span>
+      <span class="text-sm font-medium text-violet-500">{{ t('bookMetadataFetch.book.title') }}</span>
       <button class="text-muted-foreground hover:text-foreground" @click="emit('close')">
         <X :size="14" />
       </button>
     </div>
 
     <div class="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
-      <span class="text-muted-foreground">Queued</span>
+      <span class="text-muted-foreground">{{ t('bookMetadataFetch.stats.queued') }}</span>
       <span class="text-right font-medium">{{ props.status.queued }}</span>
-      <span class="text-muted-foreground">Processing</span>
+      <span class="text-muted-foreground">{{ t('bookMetadataFetch.stats.processing') }}</span>
       <span class="text-right font-medium">{{ props.status.processing }}</span>
-      <span class="text-muted-foreground">Failed</span>
+      <span class="text-muted-foreground">{{ t('bookMetadataFetch.stats.failed') }}</span>
       <span class="text-right font-medium" :class="props.status.failed > 0 ? 'text-destructive' : ''">{{ props.status.failed }}</span>
     </div>
 
@@ -82,7 +85,7 @@ async function handleCancelConfirm() {
         @click="handlePause"
       >
         <Square :size="12" />
-        Pause
+        {{ t('bookMetadataFetch.actions.pause') }}
       </button>
       <button
         v-if="props.status.paused && (props.status.queued > 0 || props.status.processing > 0)"
@@ -91,7 +94,7 @@ async function handleCancelConfirm() {
         @click="handleResume"
       >
         <Play :size="12" />
-        Resume
+        {{ t('bookMetadataFetch.actions.resume') }}
       </button>
       <button
         v-if="props.status.queued > 0"
@@ -99,14 +102,14 @@ async function handleCancelConfirm() {
         class="px-2 py-1 text-xs rounded border border-border hover:bg-muted text-destructive disabled:opacity-50"
         @click="confirmingCancel = true"
       >
-        Cancel queued
+        {{ t('bookMetadataFetch.actions.cancelQueued') }}
       </button>
     </div>
 
     <div v-else class="flex flex-col gap-1.5">
       <div class="flex items-center gap-1 text-xs text-muted-foreground">
         <AlertTriangle :size="11" class="text-amber-500 shrink-0" />
-        Currently processing items will finish.
+        {{ t('bookMetadataFetch.cancel.processingWillFinish') }}
       </div>
       <div class="flex gap-1.5">
         <button
@@ -114,14 +117,16 @@ async function handleCancelConfirm() {
           class="px-2 py-1 text-xs rounded bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
           @click="handleCancelConfirm"
         >
-          Confirm cancel
+          {{ t('bookMetadataFetch.cancel.confirm') }}
         </button>
-        <button class="px-2 py-1 text-xs rounded border border-border hover:bg-muted" @click="confirmingCancel = false">Keep running</button>
+        <button class="px-2 py-1 text-xs rounded border border-border hover:bg-muted" @click="confirmingCancel = false">
+          {{ t('bookMetadataFetch.cancel.keepRunning') }}
+        </button>
       </div>
     </div>
 
     <button v-if="props.status.failed > 0" class="text-xs text-violet-500 hover:underline text-left" @click="emit('openReport')">
-      View {{ props.status.failed }} failed
+      {{ t('bookMetadataFetch.viewFailed', { count: props.status.failed }, props.status.failed) }}
     </button>
   </div>
 </template>

--- a/client/src/features/book-metadata-fetch/components/BookMetadataFetchReportModal.vue
+++ b/client/src/features/book-metadata-fetch/components/BookMetadataFetchReportModal.vue
@@ -4,7 +4,10 @@ import { X, RefreshCw } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import type { BookMetadataFetchFailedPage } from '@bookorbit/types'
 import { api } from '@/lib/api'
+import { useI18n } from 'vue-i18n'
 import { useBookMetadataFetchActions } from '../composables/useBookMetadataFetchActions'
+
+const { t } = useI18n()
 
 const emit = defineEmits<{ close: [] }>()
 
@@ -33,10 +36,10 @@ async function handleRetryAll() {
   retrying.value = true
   try {
     await retryFailed()
-    toast.success('Failed items requeued')
+    toast.success(t('bookMetadataFetch.toast.failedItemsRequeued'))
     emit('close')
   } catch {
-    toast.error('Failed to retry')
+    toast.error(t('bookMetadataFetch.toast.failedToRetry'))
   } finally {
     retrying.value = false
   }
@@ -49,29 +52,31 @@ onMounted(() => loadPage(1))
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="emit('close')">
     <div class="bg-background border border-border rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col">
       <div class="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
-        <h2 class="text-sm font-semibold">Failed Metadata Fetches</h2>
+        <h2 class="text-sm font-semibold">{{ t('bookMetadataFetch.report.bookTitle') }}</h2>
         <button @click="emit('close')" class="text-muted-foreground hover:text-foreground">
           <X :size="16" />
         </button>
       </div>
 
       <div class="flex-1 overflow-y-auto">
-        <div v-if="loading" class="p-6 text-center text-sm text-muted-foreground">Loading...</div>
+        <div v-if="loading" class="p-6 text-center text-sm text-muted-foreground">{{ t('common.loading') }}</div>
 
-        <div v-else-if="!data || data.items.length === 0" class="p-6 text-center text-sm text-muted-foreground">No failed items.</div>
+        <div v-else-if="!data || data.items.length === 0" class="p-6 text-center text-sm text-muted-foreground">
+          {{ t('bookMetadataFetch.report.noFailedItems') }}
+        </div>
 
         <table v-else class="w-full text-xs">
           <thead class="sticky top-0 bg-background border-b border-border">
             <tr>
-              <th class="text-left px-4 py-2 text-muted-foreground font-medium">Title</th>
-              <th class="text-left px-4 py-2 text-muted-foreground font-medium">Library</th>
-              <th class="text-left px-4 py-2 text-muted-foreground font-medium">Error</th>
-              <th class="text-right px-4 py-2 text-muted-foreground font-medium">HTTP</th>
+              <th class="text-left px-4 py-2 text-muted-foreground font-medium">{{ t('bookMetadataFetch.report.columns.title') }}</th>
+              <th class="text-left px-4 py-2 text-muted-foreground font-medium">{{ t('bookMetadataFetch.report.columns.library') }}</th>
+              <th class="text-left px-4 py-2 text-muted-foreground font-medium">{{ t('bookMetadataFetch.report.columns.error') }}</th>
+              <th class="text-right px-4 py-2 text-muted-foreground font-medium">{{ t('bookMetadataFetch.report.columns.http') }}</th>
             </tr>
           </thead>
           <tbody>
             <tr v-for="item in data.items" :key="item.bookId" class="border-b border-border/50 hover:bg-muted/40">
-              <td class="px-4 py-2 max-w-[200px] truncate">{{ item.title ?? `Book #${item.bookId}` }}</td>
+              <td class="px-4 py-2 max-w-[200px] truncate">{{ item.title ?? t('bookMetadataFetch.report.bookFallback', { id: item.bookId }) }}</td>
               <td class="px-4 py-2 text-muted-foreground max-w-[120px] truncate">{{ item.libraryName ?? '-' }}</td>
               <td class="px-4 py-2 text-muted-foreground max-w-[240px] truncate" :title="item.error ?? ''">{{ item.error ?? '-' }}</td>
               <td class="px-4 py-2 text-right text-muted-foreground">{{ item.httpStatus ?? '-' }}</td>
@@ -87,7 +92,7 @@ onMounted(() => loadPage(1))
             @click="loadPage(page - 1)"
             class="px-2 py-1 text-xs border border-border rounded hover:bg-muted disabled:opacity-40"
           >
-            Prev
+            {{ t('common.previous') }}
           </button>
           <span class="text-xs text-muted-foreground">{{ page }} / {{ Math.ceil(data.total / limit) }}</span>
           <button
@@ -95,7 +100,7 @@ onMounted(() => loadPage(1))
             @click="loadPage(page + 1)"
             class="px-2 py-1 text-xs border border-border rounded hover:bg-muted disabled:opacity-40"
           >
-            Next
+            {{ t('common.next') }}
           </button>
         </div>
         <button
@@ -104,7 +109,7 @@ onMounted(() => loadPage(1))
           class="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50"
         >
           <RefreshCw :size="12" :class="retrying ? 'animate-spin' : ''" />
-          Retry all failed
+          {{ t('bookMetadataFetch.report.retryAllFailed') }}
         </button>
       </div>
     </div>

--- a/client/src/features/book-metadata-fetch/components/BookMetadataFetchWidget.vue
+++ b/client/src/features/book-metadata-fetch/components/BookMetadataFetchWidget.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { Sparkles, Users } from '@lucide/vue'
 import { toast } from 'vue-sonner'
+import { useI18n } from 'vue-i18n'
 import { useBookMetadataFetchStatus } from '../composables/useBookMetadataFetchStatus'
 import { useAuthorEnrichmentStatus } from '@/features/settings/composables/useAuthorEnrichmentStatus'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
@@ -13,6 +14,7 @@ import AuthorEnrichmentReportModal from './AuthorEnrichmentReportModal.vue'
 const { status, subscribe } = useBookMetadataFetchStatus()
 const { status: authorStatus, subscribe: subscribeAuthors } = useAuthorEnrichmentStatus()
 const { hasPermission, isSuperuser } = usePermissions()
+const { t } = useI18n()
 
 const canView = computed(() => isSuperuser.value || hasPermission('manage_metadata_config'))
 
@@ -60,20 +62,20 @@ const authorProgressPercent = computed(() => {
 })
 
 const bookRemainingLabel = computed(() => {
-  if (status.value.paused) return 'Paused'
+  if (status.value.paused) return t('bookMetadataFetch.label.paused')
   const { queued, processing, failed } = status.value
-  if (queued > 0) return `${queued + processing} remaining`
-  if (processing > 0) return `${processing} processing`
-  if (failed > 0) return `${failed} failed`
+  if (queued > 0) return t('bookMetadataFetch.label.remaining', { count: queued + processing })
+  if (processing > 0) return t('bookMetadataFetch.label.processing', { count: processing })
+  if (failed > 0) return t('bookMetadataFetch.label.failed', { count: failed })
   return ''
 })
 const authorRemainingLabel = computed(() => {
-  if (authorStatus.value.paused) return 'Paused'
+  if (authorStatus.value.paused) return t('bookMetadataFetch.label.paused')
   const { queued, processing, rateLimited, failed } = authorStatus.value
-  if (rateLimited > 0) return `${rateLimited} rate limited`
-  if (queued > 0) return `${queued + processing} remaining`
-  if (processing > 0) return `${processing} processing`
-  if (failed > 0) return `${failed} failed`
+  if (rateLimited > 0) return t('bookMetadataFetch.label.rateLimited', { count: rateLimited })
+  if (queued > 0) return t('bookMetadataFetch.label.remaining', { count: queued + processing })
+  if (processing > 0) return t('bookMetadataFetch.label.processing', { count: processing })
+  if (failed > 0) return t('bookMetadataFetch.label.failed', { count: failed })
   return ''
 })
 
@@ -105,8 +107,8 @@ watch(status, (newVal, oldVal) => {
     bookSessionToasted = true
     const msg =
       newVal.failed > 0
-        ? `Metadata fetch done - ${newVal.sessionDone} processed, ${newVal.failed} failed`
-        : `Metadata fetch complete - ${newVal.sessionDone} books updated`
+        ? t('bookMetadataFetch.toast.bookDoneWithFailures', { done: newVal.sessionDone, failed: newVal.failed })
+        : t('bookMetadataFetch.toast.bookComplete', { done: newVal.sessionDone })
     toast.success(msg)
   }
   if (newVal.sessionTotal === 0) bookSessionToasted = false
@@ -121,8 +123,8 @@ watch(authorStatus, (newVal, oldVal) => {
     authorSessionToasted = true
     const msg =
       newVal.failed > 0
-        ? `Author enrichment done - ${newVal.sessionDone} processed, ${newVal.failed} failed`
-        : `Author enrichment complete - ${newVal.sessionDone} authors updated`
+        ? t('bookMetadataFetch.toast.authorDoneWithFailures', { done: newVal.sessionDone, failed: newVal.failed })
+        : t('bookMetadataFetch.toast.authorComplete', { done: newVal.sessionDone })
     toast.success(msg)
   }
   if (newVal.sessionTotal === 0) authorSessionToasted = false
@@ -192,7 +194,7 @@ onMounted(() => {
         <Sparkles :size="20" class="text-violet-500" :class="[bookIconOpacity, showBookDot ? 'animate-pulse' : '']" />
       </div>
       <div class="flex flex-col items-start gap-0.5 min-w-0">
-        <span class="text-xs font-semibold text-foreground leading-none">Fetching metadata</span>
+        <span class="text-xs font-semibold text-foreground leading-none">{{ t('bookMetadataFetch.card.fetchingMetadata') }}</span>
         <span class="text-xs text-muted-foreground leading-none">{{ bookRemainingLabel }}</span>
         <span class="text-xs text-muted-foreground/80 leading-none truncate mt-0.5" :class="lastBookName ? '' : 'invisible'">{{
           lastBookName ?? '\u00a0'
@@ -218,7 +220,7 @@ onMounted(() => {
         <Users :size="20" class="text-emerald-500" :class="[authorIconOpacity, showAuthorDot ? 'animate-pulse' : '']" />
       </div>
       <div class="flex flex-col items-start gap-0.5 min-w-0">
-        <span class="text-xs font-semibold text-foreground leading-none">Enriching authors</span>
+        <span class="text-xs font-semibold text-foreground leading-none">{{ t('bookMetadataFetch.card.enrichingAuthors') }}</span>
         <span class="text-xs text-muted-foreground leading-none">{{ authorRemainingLabel }}</span>
         <span class="text-xs text-muted-foreground/80 leading-none truncate mt-0.5" :class="lastAuthorName ? '' : 'invisible'">{{
           lastAuthorName ?? '\u00a0'

--- a/client/src/features/book/components/BookCoverCard.vue
+++ b/client/src/features/book/components/BookCoverCard.vue
@@ -50,6 +50,9 @@ import SendBookDialog from '@/features/email/components/SendBookDialog.vue'
 import BookCoverArtwork from './BookCoverArtwork.vue'
 import BookCoverSurface from './BookCoverSurface.vue'
 import { fetchAuthors } from '@/features/author/api/author'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const route = useRoute()
 const router = useRouter()
@@ -505,7 +508,7 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
           <div v-if="isMissing" class="absolute top-1.5 right-1.5 z-20">
             <span class="flex items-center gap-1 text-[9px] font-semibold uppercase tracking-widest px-1.5 py-0.5 rounded bg-amber-600/95 text-white">
               <TriangleAlert class="size-2.5 shrink-0" />
-              Missing
+              {{ t('book.card.missing') }}
             </span>
           </div>
 
@@ -579,24 +582,26 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem v-if="openableFiles.length <= 1 && primaryFile && !isMissing" @click="openFile(primaryFile)">
                     <BookOpen class="size-4 mr-2" />
-                    Read
+                    {{ t('book.actions.read') }}
                   </DropdownMenuItem>
                   <DropdownMenuSub v-else-if="openableFiles.length > 1 && !isMissing">
                     <DropdownMenuSubTrigger>
                       <BookOpen class="size-4 mr-2" />
-                      Read
+                      {{ t('book.actions.read') }}
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent>
                       <DropdownMenuItem v-for="file in openableFiles" :key="file.id" @click="openFile(file)">
-                        <span v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">Audiobook</span>
+                        <span v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">{{ t('book.file.audiobook') }}</span>
                         <span v-else>{{ file.format?.toUpperCase() ?? '?' }}</span>
-                        <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="ml-auto pl-4 text-[10px] text-primary/70">Primary</span>
+                        <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="ml-auto pl-4 text-[10px] text-primary/70">{{
+                          t('book.file.primary')
+                        }}</span>
                       </DropdownMenuItem>
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
                   <DropdownMenuItem v-if="primaryFile && !isMissing" @click="peekPrimaryFile">
                     <Eye class="size-4 mr-2" />
-                    Peek
+                    {{ t('book.actions.peek') }}
                   </DropdownMenuItem>
 
                   <!-- Download submenu -->
@@ -605,54 +610,56 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
                     @click="handleDownloadFile(primaryFile)"
                   >
                     <Download class="size-4 mr-2" />
-                    Download
+                    {{ t('book.actions.download') }}
                   </DropdownMenuItem>
                   <DropdownMenuSub v-else-if="hasPermission('library_download') && openableFiles.length > 1">
                     <DropdownMenuSubTrigger>
                       <Download class="size-4 mr-2" />
-                      Download
+                      {{ t('book.actions.download') }}
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent>
                       <DropdownMenuItem v-for="file in openableFiles" :key="file.id" @click="handleDownloadFile(file)">
-                        <span v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">Audiobook</span>
+                        <span v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">{{ t('book.file.audiobook') }}</span>
                         <span v-else>{{ file.format?.toUpperCase() ?? '?' }}</span>
-                        <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="ml-auto pl-4 text-[10px] text-primary/70">Primary</span>
+                        <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="ml-auto pl-4 text-[10px] text-primary/70">{{
+                          t('book.file.primary')
+                        }}</span>
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
-                      <DropdownMenuItem @click="handleExportAll"> All formats (ZIP) </DropdownMenuItem>
+                      <DropdownMenuItem @click="handleExportAll"> {{ t('book.download.allFormatsZip') }} </DropdownMenuItem>
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
 
                   <DropdownMenuItem @click="openBookDetails">
                     <BookText class="size-4 mr-2" />
-                    Book Details
+                    {{ t('book.actions.bookDetails') }}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator v-if="hasPermission('library_edit_metadata')" />
                   <DropdownMenuSub v-if="hasPermission('library_edit_metadata')">
                     <DropdownMenuSubTrigger>
                       <Pencil class="size-4 mr-2" />
-                      Metadata
+                      {{ t('book.actions.metadata') }}
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent>
                       <DropdownMenuItem @click="router.push({ name: 'book-detail', params: { bookId: book.id }, query: { tab: 'edit' } })">
                         <Pencil class="size-4 mr-2" />
-                        Edit Metadata
+                        {{ t('book.actions.editMetadata') }}
                       </DropdownMenuItem>
                       <DropdownMenuItem :disabled="anyRefreshing" @click="handleRefreshMetadata">
                         <Loader2 v-if="anyRefreshing" class="size-4 mr-2 animate-spin" />
                         <RefreshCw v-else class="size-4 mr-2" />
-                        Refresh Metadata
+                        {{ t('book.actions.refreshMetadata') }}
                       </DropdownMenuItem>
                       <DropdownMenuItem :disabled="reExtractingCover" @click="reExtractCover()">
                         <Loader2 v-if="reExtractingCover" class="size-4 mr-2 animate-spin" />
                         <Image v-else class="size-4 mr-2" />
-                        Regenerate Cover
+                        {{ t('book.actions.regenerateCover') }}
                       </DropdownMenuItem>
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
                   <DropdownMenuItem @click="emit('action', 'add-to-collection')">
                     <FolderPlus class="size-4 mr-2" />
-                    Add to Collection
+                    {{ t('book.actions.addToCollection') }}
                   </DropdownMenuItem>
                   <DropdownMenuSub>
                     <DropdownMenuSubTrigger>
@@ -661,7 +668,7 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
                         class="size-4 mr-2"
                         :class="STATUS_COLORS[localReadStatus ?? 'unread']"
                       />
-                      Set Status
+                      {{ t('book.actions.setStatus') }}
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent>
                       <DropdownMenuItem v-for="opt in STATUS_OPTIONS" :key="opt.value" @click="handleSetStatus(opt.value)">
@@ -673,7 +680,7 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
                   </DropdownMenuSub>
                   <DropdownMenuItem v-if="hasPermission('email_send')" @click="showSendDialog = true">
                     <Send class="size-4 mr-2" />
-                    Send via Email
+                    {{ t('book.actions.sendViaEmail') }}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator v-if="hasPermission('email_send') || hasPermission('library_delete_books')" />
                   <DropdownMenuItem
@@ -682,7 +689,7 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
                     @click="emit('action', 'delete')"
                   >
                     <Trash2 class="size-4 mr-2" />
-                    Delete
+                    {{ t('common.delete') }}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -714,24 +721,26 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
           <DropdownMenuContent align="end">
             <DropdownMenuItem v-if="openableFiles.length <= 1 && primaryFile && !isMissing" @click="openFile(primaryFile)">
               <BookOpen class="size-4 mr-2" />
-              Read
+              {{ t('book.actions.read') }}
             </DropdownMenuItem>
             <DropdownMenuSub v-else-if="openableFiles.length > 1 && !isMissing">
               <DropdownMenuSubTrigger>
                 <BookOpen class="size-4 mr-2" />
-                Read
+                {{ t('book.actions.read') }}
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 <DropdownMenuItem v-for="file in openableFiles" :key="file.id" @click="openFile(file)">
-                  <span v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">Audiobook</span>
+                  <span v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">{{ t('book.file.audiobook') }}</span>
                   <span v-else>{{ file.format?.toUpperCase() ?? '?' }}</span>
-                  <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="ml-auto pl-4 text-[10px] text-primary/70">Primary</span>
+                  <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="ml-auto pl-4 text-[10px] text-primary/70">{{
+                    t('book.file.primary')
+                  }}</span>
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
             <DropdownMenuItem v-if="primaryFile && !isMissing" @click="peekPrimaryFile">
               <Eye class="size-4 mr-2" />
-              Peek
+              {{ t('book.actions.peek') }}
             </DropdownMenuItem>
 
             <DropdownMenuItem
@@ -739,59 +748,61 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
               @click="handleDownloadFile(primaryFile)"
             >
               <Download class="size-4 mr-2" />
-              Download
+              {{ t('book.actions.download') }}
             </DropdownMenuItem>
             <DropdownMenuSub v-else-if="hasPermission('library_download') && openableFiles.length > 1">
               <DropdownMenuSubTrigger>
                 <Download class="size-4 mr-2" />
-                Download
+                {{ t('book.actions.download') }}
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 <DropdownMenuItem v-for="file in openableFiles" :key="file.id" @click="handleDownloadFile(file)">
-                  <span v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">Audiobook</span>
+                  <span v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">{{ t('book.file.audiobook') }}</span>
                   <span v-else>{{ file.format?.toUpperCase() ?? '?' }}</span>
-                  <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="ml-auto pl-4 text-[10px] text-primary/70">Primary</span>
+                  <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="ml-auto pl-4 text-[10px] text-primary/70">{{
+                    t('book.file.primary')
+                  }}</span>
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem @click="handleExportAll"> All formats (ZIP) </DropdownMenuItem>
+                <DropdownMenuItem @click="handleExportAll"> {{ t('book.download.allFormatsZip') }} </DropdownMenuItem>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
 
             <DropdownMenuItem @click="openBookDetails">
               <BookText class="size-4 mr-2" />
-              Book Details
+              {{ t('book.actions.bookDetails') }}
             </DropdownMenuItem>
             <DropdownMenuSeparator v-if="hasPermission('library_edit_metadata')" />
             <DropdownMenuSub v-if="hasPermission('library_edit_metadata')">
               <DropdownMenuSubTrigger>
                 <Pencil class="size-4 mr-2" />
-                Metadata
+                {{ t('book.actions.metadata') }}
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 <DropdownMenuItem @click="router.push({ name: 'book-detail', params: { bookId: book.id }, query: { tab: 'edit' } })">
                   <Pencil class="size-4 mr-2" />
-                  Edit Metadata
+                  {{ t('book.actions.editMetadata') }}
                 </DropdownMenuItem>
                 <DropdownMenuItem :disabled="anyRefreshing" @click="handleRefreshMetadata">
                   <Loader2 v-if="anyRefreshing" class="size-4 mr-2 animate-spin" />
                   <RefreshCw v-else class="size-4 mr-2" />
-                  Refresh Metadata
+                  {{ t('book.actions.refreshMetadata') }}
                 </DropdownMenuItem>
                 <DropdownMenuItem :disabled="reExtractingCover" @click="reExtractCover()">
                   <Loader2 v-if="reExtractingCover" class="size-4 mr-2 animate-spin" />
                   <Image v-else class="size-4 mr-2" />
-                  Regenerate Cover
+                  {{ t('book.actions.regenerateCover') }}
                 </DropdownMenuItem>
               </DropdownMenuSubContent>
             </DropdownMenuSub>
             <DropdownMenuItem @click="emit('action', 'add-to-collection')">
               <FolderPlus class="size-4 mr-2" />
-              Add to Collection
+              {{ t('book.actions.addToCollection') }}
             </DropdownMenuItem>
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <component :is="STATUS_ICONS[localReadStatus ?? 'unread']" class="size-4 mr-2" :class="STATUS_COLORS[localReadStatus ?? 'unread']" />
-                Set Status
+                {{ t('book.actions.setStatus') }}
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 <DropdownMenuItem v-for="opt in STATUS_OPTIONS" :key="opt.value" @click="handleSetStatus(opt.value)">
@@ -803,7 +814,7 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
             </DropdownMenuSub>
             <DropdownMenuItem v-if="hasPermission('email_send')" @click="showSendDialog = true">
               <Send class="size-4 mr-2" />
-              Send via Email
+              {{ t('book.actions.sendViaEmail') }}
             </DropdownMenuItem>
             <DropdownMenuSeparator v-if="hasPermission('email_send') || hasPermission('library_delete_books')" />
             <DropdownMenuItem
@@ -812,7 +823,7 @@ const secondaryLabelText = computed(() => resolveBookLabel(gridCardSecondaryLabe
               @click="emit('action', 'delete')"
             >
               <Trash2 class="size-4 mr-2" />
-              Delete
+              {{ t('common.delete') }}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/client/src/features/book/components/BookCoverPlaceholder.vue
+++ b/client/src/features/book/components/BookCoverPlaceholder.vue
@@ -3,6 +3,9 @@ import { computed } from 'vue'
 import { getActivePinia, storeToRefs } from 'pinia'
 import { bookCoverPalette } from '../lib/book-cover'
 import { useThemeStore } from '@/stores/theme'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   title: string | null
@@ -43,7 +46,7 @@ const fsize = computed(() => {
 const lh = computed(() => Math.round(fsize.value * 1.25))
 
 const lines = computed(() => {
-  const text = (props.title ?? 'Untitled').trim()
+  const text = (props.title ?? t('book.untitled')).trim()
   // Use 0.60 factor (vs raw 0.55) to better account for bold/heavy font width.
   const cpl = Math.max(4, Math.floor((vb.value.w - 28) / (fsize.value * 0.6)))
   const words = text.split(/\s+/).filter(Boolean)

--- a/client/src/features/book/components/BookDownloadButton.vue
+++ b/client/src/features/book/components/BookDownloadButton.vue
@@ -7,6 +7,9 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { getFormatColor } from '@/features/book/lib/format-colors'
 import { useBookDownload } from '@/features/book/composables/useBookDownload'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   files: BookDetailFile[]
@@ -78,7 +81,7 @@ function handleExportPrimary() {
         <Download class="size-3.5" />
       </button>
     </TooltipTrigger>
-    <TooltipContent>Download</TooltipContent>
+    <TooltipContent>{{ t('book.download.action') }}</TooltipContent>
   </Tooltip>
 
   <Popover v-else>
@@ -86,7 +89,7 @@ function handleExportPrimary() {
       <button
         class="flex w-full items-center justify-center gap-1.5 h-9 rounded-md border border-input bg-background text-sm hover:bg-muted transition-colors disabled:opacity-50"
         :disabled="!primaryFile || isDownloading"
-        title="Download"
+        :title="t('book.download.action')"
       >
         <Download class="size-3.5" />
         <ChevronDown class="size-3" />
@@ -97,7 +100,7 @@ function handleExportPrimary() {
       <template v-if="isMultiTrackAudio">
         <button class="flex w-full items-center gap-2 px-2 py-1.5 rounded text-sm hover:bg-muted transition-colors" @click="handleExportPrimary">
           <Download class="size-3.5 shrink-0" />
-          <span>Audiobook (ZIP)</span>
+          <span>{{ t('book.download.audiobookZip') }}</span>
         </button>
         <button
           v-for="file in nonAudioFiles"
@@ -128,7 +131,7 @@ function handleExportPrimary() {
             >{{ file.format ?? '?' }}</span
           >
           <span class="flex-1 text-left text-muted-foreground text-xs truncate">{{ formatFileSize(file.sizeBytes) }}</span>
-          <span v-if="file.role === 'primary'" class="text-[10px] text-primary font-medium shrink-0">Primary</span>
+          <span v-if="file.role === 'primary'" class="text-[10px] text-primary font-medium shrink-0">{{ t('book.file.primary') }}</span>
         </button>
         <div class="my-1 border-t border-border" />
         <button
@@ -136,14 +139,14 @@ function handleExportPrimary() {
           @click="handleExportAll"
         >
           <Download class="size-3.5 shrink-0" />
-          <span>All formats (ZIP)</span>
+          <span>{{ t('book.download.allFormatsZip') }}</span>
         </button>
         <button
           class="flex w-full items-center gap-2 px-2 py-1.5 rounded text-sm hover:bg-muted transition-colors text-muted-foreground"
           @click="handleExportPrimary"
         >
           <Download class="size-3.5 shrink-0" />
-          <span>Primary only (ZIP)</span>
+          <span>{{ t('book.download.primaryOnlyZip') }}</span>
         </button>
       </template>
     </PopoverContent>

--- a/client/src/features/book/components/BookFilterBuilder.vue
+++ b/client/src/features/book/components/BookFilterBuilder.vue
@@ -19,6 +19,9 @@ import { useLibraries } from '@/features/library/composables/useLibraries'
 import FilterChipTypeahead from './FilterChipTypeahead.vue'
 import FilterFormatPicker from './FilterFormatPicker.vue'
 import FilterTextTypeahead from './FilterTextTypeahead.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   modelValue: GroupRule | undefined
@@ -49,33 +52,33 @@ const BETWEEN_OPERATORS: RuleOperator[] = ['between']
 const COLLECTION_OPERATORS: RuleOperator[] = ['includesAny', 'includesAll', 'excludesAll']
 
 const SCORE_PRESETS = [
-  { label: 'Outstanding', gte: 90 },
-  { label: 'Good', gte: 70 },
-  { label: 'Fair', gte: 50 },
-  { label: 'Poor', lt: 50 },
+  { label: 'outstanding', gte: 90 },
+  { label: 'good', gte: 70 },
+  { label: 'fair', gte: 50 },
+  { label: 'poor', lt: 50 },
 ] as const
 
 const CHIP_TYPEAHEAD_FIELDS: RuleField[] = ['author', 'genre', 'tag', 'collection']
 const TEXT_TYPEAHEAD_FIELDS: RuleField[] = ['publisher', 'series', 'language']
 
-const READ_STATUS_LABELS: Record<string, string> = {
-  unread: 'Unread',
-  want_to_read: 'Want to Read',
-  reading: 'Reading',
-  on_hold: 'On Hold',
-  rereading: 'Rereading',
-  read: 'Read',
-  skimmed: 'Skimmed',
-  abandoned: 'Abandoned',
-}
+const READ_STATUS_LABELS = computed<Record<string, string>>(() => ({
+  unread: t('book.readStatus.unread'),
+  want_to_read: t('book.readStatus.wantToRead'),
+  reading: t('book.readStatus.reading'),
+  on_hold: t('book.readStatus.onHold'),
+  rereading: t('book.readStatus.rereading'),
+  read: t('book.readStatus.read'),
+  skimmed: t('book.readStatus.skimmed'),
+  abandoned: t('book.readStatus.abandoned'),
+}))
 
-const COMMUNITY_RATING_PROVIDER_OPTIONS: { value: CommunityRatingProvider; label: string }[] = [
-  { value: 'any', label: 'Any provider' },
+const COMMUNITY_RATING_PROVIDER_OPTIONS = computed<{ value: CommunityRatingProvider; label: string }[]>(() => [
+  { value: 'any', label: t('book.filter.anyProvider') },
   ...COMMUNITY_RATING_PROVIDER_KEYS.map((provider) => ({
     value: provider,
     label: PROVIDER_SHORT_LABELS[provider] ?? provider,
   })),
-]
+])
 
 const ENDPOINT_BY_FIELD: Partial<Record<RuleField, string>> = {
   author: '/api/v1/metadata/authors',
@@ -363,24 +366,24 @@ function showValueToInput(operator: RuleOperator): boolean {
   <div class="flex flex-col gap-2.5">
     <!-- AND / OR join toggle — always visible in sub-groups, shown at root only when 2+ nodes -->
     <div v-if="nodes.length > 1 || (depth ?? 0) > 0" class="flex items-center gap-2 mb-0.5">
-      <span class="text-xs text-muted-foreground">Match</span>
+      <span class="text-xs text-muted-foreground">{{ t('book.filter.match') }}</span>
       <div class="flex rounded-md border border-input overflow-hidden">
         <button
           @click="setJoin('AND')"
           class="px-3 py-1 text-xs font-semibold transition-colors"
           :class="join === 'AND' ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground hover:bg-muted/80'"
         >
-          ALL
+          {{ t('book.filter.all') }}
         </button>
         <button
           @click="setJoin('OR')"
           class="px-3 py-1 text-xs font-semibold border-l border-input transition-colors"
           :class="join === 'OR' ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground hover:bg-muted/80'"
         >
-          ANY
+          {{ t('book.filter.any') }}
         </button>
       </div>
-      <span class="text-xs text-muted-foreground">of the following rules</span>
+      <span class="text-xs text-muted-foreground">{{ t('book.filter.ofFollowingRules') }}</span>
     </div>
 
     <template v-for="(node, index) in nodes" :key="node.id">
@@ -415,7 +418,7 @@ function showValueToInput(operator: RuleOperator): boolean {
           <select
             v-model="node.rule.provider"
             class="h-7 bg-transparent text-foreground text-sm outline-none"
-            aria-label="Community rating provider"
+            :aria-label="t('book.filter.communityRatingProvider')"
             @change="emitUpdate"
           >
             <option v-for="provider in COMMUNITY_RATING_PROVIDER_OPTIONS" :key="provider.value" :value="provider.value">
@@ -455,7 +458,13 @@ function showValueToInput(operator: RuleOperator): boolean {
               @change="addLibraryChip(index, $event)"
             >
               <option value="" disabled>
-                {{ librariesLoading ? 'Loading libraries...' : libraryOptions.length === 0 ? 'No libraries available' : 'Select library...' }}
+                {{
+                  librariesLoading
+                    ? t('book.filter.loadingLibraries')
+                    : libraryOptions.length === 0
+                      ? t('book.filter.noLibrariesAvailable')
+                      : t('book.filter.selectLibrary')
+                }}
               </option>
               <option
                 v-for="libraryName in libraryOptions"
@@ -486,7 +495,7 @@ function showValueToInput(operator: RuleOperator): boolean {
               class="h-7 flex-1 min-w-32 bg-transparent text-foreground text-sm outline-none"
               @change="addStatusChip(index, $event)"
             >
-              <option value="" disabled>Select status...</option>
+              <option value="" disabled>{{ t('book.filter.selectStatus') }}</option>
               <option v-for="status in READ_STATUSES" :key="status" :value="status" :disabled="node.rule.valueChips.includes(status)">
                 {{ READ_STATUS_LABELS[status] ?? status }}
               </option>
@@ -499,7 +508,7 @@ function showValueToInput(operator: RuleOperator): boolean {
             v-model="node.rule.value"
             type="number"
             min="1"
-            placeholder="e.g. 7"
+            :placeholder="t('book.filter.withinLastPlaceholder')"
             class="h-9 w-20 rounded-md border border-input bg-background text-foreground text-sm px-2 focus:outline-none focus:ring-2 focus:ring-primary"
             @input="emitUpdate"
           />
@@ -508,9 +517,9 @@ function showValueToInput(operator: RuleOperator): boolean {
             class="h-9 rounded-md border border-input bg-background text-foreground text-sm px-2 focus:outline-none focus:ring-2 focus:ring-primary"
             @change="emitUpdate"
           >
-            <option value="days">days</option>
-            <option value="weeks">weeks</option>
-            <option value="months">months</option>
+            <option value="days">{{ t('book.filter.unit.days') }}</option>
+            <option value="weeks">{{ t('book.filter.unit.weeks') }}</option>
+            <option value="months">{{ t('book.filter.unit.months') }}</option>
           </select>
         </template>
         <!-- Text typeahead: publisher, series, language -->
@@ -536,7 +545,7 @@ function showValueToInput(operator: RuleOperator): boolean {
               "
               @click="applyScorePreset(index, preset)"
             >
-              {{ preset.label }}
+              {{ t(`book.filter.scorePreset.${preset.label}`) }}
             </button>
           </div>
           <input
@@ -546,11 +555,11 @@ function showValueToInput(operator: RuleOperator): boolean {
             min="0"
             :max="numericInputMax(node.rule.field)"
             :step="numericInputStep(node.rule.field)"
-            placeholder="0-100"
+            :placeholder="t('book.filter.scoreRangePlaceholder')"
             class="h-9 rounded-md border border-input bg-background text-foreground text-sm px-2 focus:outline-none focus:ring-2 focus:ring-primary w-24"
           />
           <template v-if="showValueToInput(node.rule.operator)">
-            <span class="text-xs text-muted-foreground">to</span>
+            <span class="text-xs text-muted-foreground">{{ t('book.filter.to') }}</span>
             <input
               v-model="node.rule.valueTo"
               @input="emitUpdate"
@@ -572,11 +581,11 @@ function showValueToInput(operator: RuleOperator): boolean {
             :min="numericInputMin(node.rule.field)"
             :max="numericInputMax(node.rule.field)"
             :step="numericInputStep(node.rule.field)"
-            placeholder="value"
+            :placeholder="t('book.filter.valuePlaceholder')"
             class="h-9 rounded-md border border-input bg-background text-foreground text-sm px-2 focus:outline-none focus:ring-2 focus:ring-primary min-w-32 flex-1"
           />
           <template v-if="showValueToInput(node.rule.operator)">
-            <span class="text-xs text-muted-foreground">to</span>
+            <span class="text-xs text-muted-foreground">{{ t('book.filter.to') }}</span>
             <input
               v-model="node.rule.valueTo"
               @input="emitUpdate"
@@ -584,7 +593,7 @@ function showValueToInput(operator: RuleOperator): boolean {
               :min="numericInputMin(node.rule.field)"
               :max="numericInputMax(node.rule.field)"
               :step="numericInputStep(node.rule.field)"
-              placeholder="max"
+              :placeholder="t('book.filter.maxPlaceholder')"
               class="h-9 rounded-md border border-input bg-background text-foreground text-sm px-2 focus:outline-none focus:ring-2 focus:ring-primary w-24"
             />
           </template>
@@ -602,7 +611,7 @@ function showValueToInput(operator: RuleOperator): boolean {
       <div v-else-if="node.kind === 'group'" class="flex items-start gap-2">
         <div class="flex-1 rounded-lg border border-primary/20 bg-primary/3 p-3">
           <div class="flex items-center justify-between mb-3">
-            <span class="text-[10px] font-semibold uppercase tracking-widest text-primary/50">Group</span>
+            <span class="text-[10px] font-semibold uppercase tracking-widest text-primary/50">{{ t('book.filter.group') }}</span>
           </div>
           <BookFilterBuilder :model-value="node.group" :depth="(depth ?? 0) + 1" @update:model-value="onSubGroupUpdate(index, $event)" />
         </div>
@@ -622,7 +631,7 @@ function showValueToInput(operator: RuleOperator): boolean {
         class="flex items-center gap-1.5 h-9 px-4 rounded-lg border border-dashed border-input text-sm text-muted-foreground hover:text-foreground hover:border-foreground hover:bg-muted/30 transition-colors"
       >
         <Plus :size="13" />
-        Add rule
+        {{ t('book.filter.addRule') }}
       </button>
       <button
         v-if="(depth ?? 0) < MAX_DEPTH"
@@ -630,7 +639,7 @@ function showValueToInput(operator: RuleOperator): boolean {
         class="flex items-center gap-1.5 h-9 px-4 rounded-lg border border-dashed border-primary/30 text-sm text-primary/50 hover:text-primary hover:border-primary hover:bg-primary/5 transition-colors"
       >
         <Plus :size="13" />
-        Add group
+        {{ t('book.filter.addGroup') }}
       </button>
     </div>
   </div>

--- a/client/src/features/book/components/BookListRow.vue
+++ b/client/src/features/book/components/BookListRow.vue
@@ -31,6 +31,9 @@ import { usePermissions } from '@/features/auth/composables/usePermissions'
 import SendBookDialog from '@/features/email/components/SendBookDialog.vue'
 import { RATING_STARS, getRatingStarClass } from '@/features/book/lib/rating-stars'
 import { useDisplaySettings } from '@/composables/useDisplaySettings'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const router = useRouter()
 
@@ -225,7 +228,7 @@ function handleRowClick(event: MouseEvent) {
               <Star class="size-3" :class="getRatingStarClass(star, displayRating)" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Rate {{ star }}</TooltipContent>
+          <TooltipContent>{{ t('book.actions.rate', { star }) }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -236,7 +239,7 @@ function handleRowClick(event: MouseEvent) {
           class="flex items-center gap-1 text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400"
         >
           <TriangleAlert class="size-3 shrink-0" />
-          <span class="hidden sm:inline">Missing</span>
+          <span class="hidden sm:inline">{{ t('book.card.missing') }}</span>
         </span>
         <Tooltip v-if="primaryFile && !isMissing">
           <TooltipTrigger as-child>
@@ -247,7 +250,7 @@ function handleRowClick(event: MouseEvent) {
               {{ primaryFile.format ?? '?' }}
             </button>
           </TooltipTrigger>
-          <TooltipContent>Open as {{ primaryFile.format?.toUpperCase() ?? 'unknown' }}</TooltipContent>
+          <TooltipContent>{{ t('book.actions.openAs', { format: primaryFile.format?.toUpperCase() ?? t('book.unknownFormat') }) }}</TooltipContent>
         </Tooltip>
         <Tooltip v-for="file in uniqueSecondaryFiles" :key="file.id">
           <TooltipTrigger as-child>
@@ -258,7 +261,7 @@ function handleRowClick(event: MouseEvent) {
               {{ file.format ?? '?' }}
             </button>
           </TooltipTrigger>
-          <TooltipContent>Open as {{ file.format?.toUpperCase() ?? 'unknown' }}</TooltipContent>
+          <TooltipContent>{{ t('book.actions.openAs', { format: file.format?.toUpperCase() ?? t('book.unknownFormat') }) }}</TooltipContent>
         </Tooltip>
       </div>
 
@@ -271,19 +274,19 @@ function handleRowClick(event: MouseEvent) {
         <DropdownMenuContent align="end">
           <DropdownMenuItem :disabled="!primaryFile || isMissing" @click="primaryFile && !isMissing && openFile(primaryFile)">
             <BookOpen class="size-4 mr-2" />
-            Read
+            {{ t('book.actions.read') }}
           </DropdownMenuItem>
           <DropdownMenuItem :disabled="!primaryFile || isMissing" @click="peekPrimaryFile">
             <Eye class="size-4 mr-2" />
-            Peek
+            {{ t('book.actions.peek') }}
           </DropdownMenuItem>
           <DropdownMenuItem @click="emit('action', 'quick-view')">
             <PanelRight class="size-4 mr-2" />
-            Quick View
+            {{ t('book.actions.quickView') }}
           </DropdownMenuItem>
           <DropdownMenuItem @click="openBookDetails">
             <ExternalLink class="size-4 mr-2" />
-            Book Details
+            {{ t('book.actions.bookDetails') }}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
@@ -291,20 +294,20 @@ function handleRowClick(event: MouseEvent) {
             @click="router.push({ name: 'book-detail', params: { bookId: book.id }, query: { tab: 'edit' } })"
           >
             <Pencil class="size-4 mr-2" />
-            Edit Metadata
+            {{ t('book.actions.editMetadata') }}
           </DropdownMenuItem>
           <DropdownMenuItem v-if="hasPermission('library_edit_metadata')" :disabled="refreshing" @click="refreshWithFeedback(book.id)">
             <Loader2 v-if="refreshing" class="size-4 mr-2 animate-spin" />
             <RefreshCw v-else class="size-4 mr-2" />
-            Refresh Metadata
+            {{ t('book.actions.refreshMetadata') }}
           </DropdownMenuItem>
           <DropdownMenuItem @click="emit('action', 'add-to-collection')">
             <FolderPlus class="size-4 mr-2" />
-            Add to Collection
+            {{ t('book.actions.addToCollection') }}
           </DropdownMenuItem>
           <DropdownMenuItem v-if="hasPermission('email_send')" @click="showSendDialog = true">
             <Send class="size-4 mr-2" />
-            Send via Email
+            {{ t('book.actions.sendViaEmail') }}
           </DropdownMenuItem>
           <DropdownMenuSeparator v-if="hasPermission('library_delete_books')" />
           <DropdownMenuItem
@@ -313,7 +316,7 @@ function handleRowClick(event: MouseEvent) {
             @click="emit('action', 'delete')"
           >
             <Trash2 class="size-4 mr-2" />
-            Delete
+            {{ t('common.delete') }}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/client/src/features/book/components/BookQuickView.vue
+++ b/client/src/features/book/components/BookQuickView.vue
@@ -20,6 +20,9 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useSafeHtml } from '@/features/book/composables/useSafeHtml'
 import BookCoverArtwork from './BookCoverArtwork.vue'
 import BookCoverSurface from './BookCoverSurface.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{ bookId: number | null; open: boolean }>()
 const { hasPermission } = usePermissions()
@@ -273,8 +276,10 @@ function handleDelete() {
   <TooltipProvider :delay-duration="0">
     <Sheet :open="props.open" @update:open="emit('update:open', $event)">
       <SheetContent side="right" class="sm:max-w-100 p-0 overflow-hidden">
-        <SheetTitle class="sr-only">{{ detail?.title ? `Quick view for ${detail.title}` : 'Book quick view' }}</SheetTitle>
-        <SheetDescription class="sr-only">Preview book details and run quick actions.</SheetDescription>
+        <SheetTitle class="sr-only">{{
+          detail?.title ? t('book.quickView.titleFor', { title: detail.title }) : t('book.quickView.title')
+        }}</SheetTitle>
+        <SheetDescription class="sr-only">{{ t('book.quickView.description') }}</SheetDescription>
         <div class="flex flex-col h-full">
           <!-- Header: cover + title block -->
           <div class="p-5 pt-10 border-b shrink-0">
@@ -318,7 +323,7 @@ function handleDelete() {
               <!-- Info -->
               <div class="flex-1 min-w-0 pr-2">
                 <h2 class="text-sm font-bold leading-snug line-clamp-3">
-                  {{ detail.title ?? 'Untitled' }}
+                  {{ detail.title ?? t('book.untitled') }}
                 </h2>
                 <p v-if="detail.subtitle" class="text-xs text-muted-foreground mt-0.5 line-clamp-2">
                   {{ detail.subtitle }}
@@ -330,7 +335,7 @@ function handleDelete() {
                     :href="link.url"
                     target="_blank"
                     rel="noopener noreferrer"
-                    :title="`Open in ${link.label}`"
+                    :title="t('book.quickView.openIn', { provider: link.label })"
                     class="inline-flex size-6 items-center justify-center rounded border transition-colors hover:bg-muted/60"
                     :style="providerLinkStyle(link.key)"
                   >
@@ -384,7 +389,7 @@ function handleDelete() {
                   {{ fmt }}
                 </span>
                 <span v-if="detail.pageCount" class="text-[10px] font-semibold px-2 py-0.5 rounded bg-muted text-muted-foreground">
-                  {{ detail.pageCount }} pages
+                  {{ t('book.quickView.pages', { count: detail.pageCount }, detail.pageCount) }}
                 </span>
                 <span v-if="detail.publishedYear" class="text-[10px] font-semibold px-2 py-0.5 rounded bg-muted text-muted-foreground">
                   {{ detail.publishedYear }}
@@ -404,8 +409,10 @@ function handleDelete() {
 
               <!-- Primary file summary -->
               <div v-if="primaryFile" class="rounded-md border border-border bg-muted/20 px-3 py-2.5">
-                <p class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Primary File</p>
-                <p class="text-xs text-foreground mt-1 truncate">{{ primaryFile.filename ?? `File #${primaryFile.id}` }}</p>
+                <p class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.quickView.primaryFile') }}</p>
+                <p class="text-xs text-foreground mt-1 truncate">
+                  {{ primaryFile.filename ?? t('book.quickView.fileNumber', { id: primaryFile.id }) }}
+                </p>
                 <div class="mt-1.5 flex items-center gap-1.5">
                   <span
                     class="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded border"
@@ -443,13 +450,13 @@ function handleDelete() {
                   class="text-xs text-muted-foreground hover:text-foreground mt-1.5 transition-colors"
                   @click="toggleGenres"
                 >
-                  {{ genresExpanded ? 'Show less' : 'Show more' }}
+                  {{ genresExpanded ? t('book.quickView.showLess') : t('book.quickView.showMore') }}
                 </button>
               </div>
 
               <!-- Collections -->
               <div v-if="detail.collections.length" class="border-t pt-4">
-                <p class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground mb-2">Collections</p>
+                <p class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground mb-2">{{ t('book.quickView.collections') }}</p>
                 <div class="flex flex-wrap gap-1.5">
                   <span
                     v-for="col in detail.collections"
@@ -474,10 +481,10 @@ function handleDelete() {
                     class="text-xs text-muted-foreground hover:text-foreground mt-1.5 transition-colors"
                     @click="descriptionExpanded = !descriptionExpanded"
                   >
-                    {{ descriptionExpanded ? 'Show less' : 'Show more' }}
+                    {{ descriptionExpanded ? t('book.quickView.showLess') : t('book.quickView.showMore') }}
                   </button>
                 </div>
-                <p v-else class="text-xs text-muted-foreground italic">No description available.</p>
+                <p v-else class="text-xs text-muted-foreground italic">{{ t('book.quickView.noDescription') }}</p>
               </div>
             </template>
           </div>
@@ -487,33 +494,33 @@ function handleDelete() {
             <button
               class="flex flex-1 items-center justify-center gap-2 h-9 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
               :disabled="!primaryFile"
-              :aria-label="isPrimaryAudio ? 'Listen' : 'Read'"
+              :aria-label="isPrimaryAudio ? t('book.actions.listen') : t('book.actions.read')"
               @click="openBook"
             >
               <Headphones v-if="isPrimaryAudio" class="size-4" />
               <BookOpen v-else class="size-4" />
-              <span class="hidden sm:inline">{{ isPrimaryAudio ? 'Listen' : 'Read' }}</span>
+              <span class="hidden sm:inline">{{ isPrimaryAudio ? t('book.actions.listen') : t('book.actions.read') }}</span>
             </button>
             <button
               class="flex flex-1 items-center justify-center text-primary-foreground gap-2 h-9 rounded-md bg-sky-600 text-sm font-medium hover:bg-sky-700 dark:bg-sky-500 dark:hover:bg-sky-600 transition-colors"
-              aria-label="Details"
+              :aria-label="t('book.actions.details')"
               @click="openDetails"
             >
               <ExternalLink class="size-4" />
-              <span class="hidden sm:inline">Details</span>
+              <span class="hidden sm:inline">{{ t('book.actions.details') }}</span>
             </button>
             <Tooltip>
               <TooltipTrigger as-child>
                 <button
                   class="flex items-center justify-center gap-1.5 h-9 px-3 rounded-md border border-input bg-background text-sm hover:bg-muted transition-colors disabled:opacity-50"
                   :disabled="!primaryFile"
-                  aria-label="Peek"
+                  :aria-label="t('book.actions.peek')"
                   @click="peekBook"
                 >
                   <Eye class="size-3.5" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Peek</TooltipContent>
+              <TooltipContent>{{ t('book.actions.peek') }}</TooltipContent>
             </Tooltip>
             <Tooltip v-if="hasPermission('library_edit_metadata')">
               <TooltipTrigger as-child>
@@ -524,7 +531,7 @@ function handleDelete() {
                   <Pencil class="size-3.5" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Open metadata editor</TooltipContent>
+              <TooltipContent>{{ t('book.quickView.openMetadataEditor') }}</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger as-child>
@@ -536,7 +543,7 @@ function handleDelete() {
                   <FolderPlus class="size-3.5" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Add to collection</TooltipContent>
+              <TooltipContent>{{ t('book.actions.addToCollection') }}</TooltipContent>
             </Tooltip>
             <Tooltip v-if="hasPermission('library_delete_books')">
               <TooltipTrigger as-child>
@@ -548,7 +555,7 @@ function handleDelete() {
                   <Trash2 class="size-3.5" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Delete</TooltipContent>
+              <TooltipContent>{{ t('common.delete') }}</TooltipContent>
             </Tooltip>
           </div>
         </div>
@@ -564,8 +571,10 @@ function handleDelete() {
         <DialogContent
           class="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 max-w-[90vw] max-h-[90vh] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
         >
-          <DialogTitle class="sr-only">{{ detail?.title ? `${detail.title} cover preview` : 'Book cover preview' }}</DialogTitle>
-          <DialogDescription class="sr-only">Enlarged cover image preview dialog.</DialogDescription>
+          <DialogTitle class="sr-only">{{
+            detail?.title ? t('book.quickView.coverPreviewFor', { title: detail.title }) : t('book.quickView.coverPreview')
+          }}</DialogTitle>
+          <DialogDescription class="sr-only">{{ t('book.quickView.coverPreviewDescription') }}</DialogDescription>
           <img v-if="detail" :src="coverSrc ?? ''" :alt="detail.title ?? ''" class="max-w-[90vw] max-h-[90vh] rounded-md shadow-2xl object-contain" />
           <DialogClose
             class="absolute -top-3 -right-3 p-1 rounded-full bg-background border border-border text-muted-foreground hover:text-foreground transition-colors"

--- a/client/src/features/book/components/BookSortBuilder.vue
+++ b/client/src/features/book/components/BookSortBuilder.vue
@@ -5,6 +5,9 @@ import type { SortField, SortSpec } from '@bookorbit/types'
 import { SORT_FIELDS } from '@bookorbit/types'
 import { SORT_FIELD_LABELS } from '@/features/book/lib/filter-labels'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   modelValue: SortSpec[]
@@ -71,7 +74,7 @@ const canAddMore = computed(() => props.modelValue.length < SORT_FIELDS.length)
               <ChevronUp :size="14" stroke-width="2.5" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Move up</TooltipContent>
+          <TooltipContent>{{ t('book.sort.moveUp') }}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger as-child>
@@ -83,7 +86,7 @@ const canAddMore = computed(() => props.modelValue.length < SORT_FIELDS.length)
               <ChevronDown :size="14" stroke-width="2.5" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Move down</TooltipContent>
+          <TooltipContent>{{ t('book.sort.moveDown') }}</TooltipContent>
         </Tooltip>
       </div>
       <select
@@ -105,7 +108,7 @@ const canAddMore = computed(() => props.modelValue.length < SORT_FIELDS.length)
             <ArrowUpAZ v-else :size="15" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{{ spec.dir === 'asc' ? 'Ascending' : 'Descending' }}</TooltipContent>
+        <TooltipContent>{{ spec.dir === 'asc' ? t('book.sort.ascending') : t('book.sort.descending') }}</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger as-child>
@@ -116,11 +119,11 @@ const canAddMore = computed(() => props.modelValue.length < SORT_FIELDS.length)
             <Trash2 :size="13" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Remove</TooltipContent>
+        <TooltipContent>{{ t('book.sort.remove') }}</TooltipContent>
       </Tooltip>
     </div>
 
-    <p v-if="modelValue.length === 0" class="text-sm text-muted-foreground">No sort configured. Title ascending will be used.</p>
+    <p v-if="modelValue.length === 0" class="text-sm text-muted-foreground">{{ t('book.sort.emptyState') }}</p>
 
     <button
       v-if="canAddMore"
@@ -128,7 +131,7 @@ const canAddMore = computed(() => props.modelValue.length < SORT_FIELDS.length)
       class="flex items-center gap-1.5 h-9 px-4 rounded-lg border border-dashed border-input text-sm text-muted-foreground hover:text-foreground hover:border-foreground hover:bg-muted/30 transition-colors self-start"
     >
       <Plus :size="13" />
-      Add sort level
+      {{ t('book.sort.addLevel') }}
     </button>
   </div>
 </template>

--- a/client/src/features/book/components/BulkEditMetadataDialog.vue
+++ b/client/src/features/book/components/BulkEditMetadataDialog.vue
@@ -18,6 +18,9 @@ import {
   type BulkEditableScalarField,
   type BulkEditableField,
 } from '@/features/book/composables/useBookBulkActions'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 type UIArrayMode = ArrayMode | 'clear'
 
@@ -41,12 +44,12 @@ type FieldKey = BulkEditableField
 
 const FIELD_LABELS = BULK_EDITABLE_FIELD_LABELS
 
-const MODE_LABELS: Record<UIArrayMode, string> = {
-  add: 'Add',
-  remove: 'Remove',
-  replace: 'Replace',
-  clear: 'Clear',
-}
+const MODE_LABELS = computed<Record<UIArrayMode, string>>(() => ({
+  add: t('book.bulkEdit.mode.add'),
+  remove: t('book.bulkEdit.mode.remove'),
+  replace: t('book.bulkEdit.mode.replace'),
+  clear: t('book.bulkEdit.mode.clear'),
+}))
 
 const { search: searchAuthors } = useAuthorSearch()
 const { search: searchGenres } = useGenreSearch()
@@ -108,7 +111,7 @@ const yearError = computed(() => {
   if (!enabledFields.publishedYear) return null
   const raw = scalarValues.publishedYear.trim()
   if (!raw) return null
-  if (!/^\d+$/.test(raw)) return 'Enter a valid year (numbers only)'
+  if (!/^\d+$/.test(raw)) return t('book.bulkEdit.invalidYear')
   return null
 })
 
@@ -205,7 +208,7 @@ watch(
       <div class="relative z-10 w-full max-w-lg mx-4 max-h-[90vh] bg-card border border-border rounded-lg shadow-2xl flex flex-col">
         <!-- Header -->
         <div class="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
-          <h2 class="text-base font-semibold text-foreground">Edit metadata - {{ bookCount }} book{{ bookCount === 1 ? '' : 's' }}</h2>
+          <h2 class="text-base font-semibold text-foreground">{{ t('book.bulkEdit.title', { count: bookCount }, bookCount) }}</h2>
           <button
             type="button"
             class="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
@@ -218,7 +221,7 @@ watch(
 
         <!-- Scrollable body -->
         <div class="overflow-y-auto px-6 py-4 space-y-4 min-h-0">
-          <p class="text-sm text-muted-foreground">Toggle fields to edit, then configure values. Only toggled fields will be changed.</p>
+          <p class="text-sm text-muted-foreground">{{ t('book.bulkEdit.instructions') }}</p>
 
           <!-- Array fields -->
           <div v-for="key in ARRAY_FIELDS" :key="key" class="space-y-2">
@@ -266,13 +269,13 @@ watch(
               </div>
 
               <p v-if="arrayModes[key] === 'clear'" class="text-xs text-destructive">
-                This will remove all {{ FIELD_LABELS[key].toLowerCase() }} from the selected books.
+                {{ t('book.bulkEdit.clearWarning', { field: FIELD_LABELS[key].toLowerCase() }) }}
               </p>
               <ChipInput
                 v-else
                 v-model="arrayValues[key]"
                 :search-fn="SEARCH_FNS[key]"
-                :placeholder="`Search ${FIELD_LABELS[key].toLowerCase()}...`"
+                :placeholder="t('book.bulkEdit.searchPlaceholder', { field: FIELD_LABELS[key].toLowerCase() })"
               />
             </div>
           </div>
@@ -313,7 +316,7 @@ watch(
                 v-else-if="SUGGESTION_FNS[key]"
                 :model-value="scalarValues[key] || null"
                 :search-fn="SUGGESTION_FNS[key]!"
-                :placeholder="`Enter ${FIELD_LABELS[key].toLowerCase()}`"
+                :placeholder="t('book.bulkEdit.enterPlaceholder', { field: FIELD_LABELS[key].toLowerCase() })"
                 class="w-full h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
                 @update:model-value="scalarValues[key] = $event ?? ''"
               />
@@ -322,13 +325,17 @@ watch(
                 v-model="scalarValues[key]"
                 type="text"
                 :inputmode="key === 'publishedYear' ? 'numeric' : undefined"
-                :placeholder="key === 'publishedYear' ? 'e.g. 2024' : `Enter ${FIELD_LABELS[key].toLowerCase()}`"
+                :placeholder="
+                  key === 'publishedYear'
+                    ? t('book.bulkEdit.yearPlaceholder')
+                    : t('book.bulkEdit.enterPlaceholder', { field: FIELD_LABELS[key].toLowerCase() })
+                "
                 class="w-full h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
               />
               <p v-if="key === 'publishedYear' && yearError" class="text-xs text-destructive mt-1">
                 {{ yearError }}
               </p>
-              <p v-else class="text-xs text-muted-foreground mt-1">Leave empty to clear this field on all selected books.</p>
+              <p v-else class="text-xs text-muted-foreground mt-1">{{ t('book.bulkEdit.leaveEmptyHint') }}</p>
             </div>
           </div>
         </div>
@@ -341,7 +348,7 @@ watch(
             :disabled="submitting"
             @click="handleClose"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             type="button"
@@ -353,7 +360,7 @@ watch(
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
               <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
             </svg>
-            {{ submitting ? 'Applying...' : 'Apply' }}
+            {{ submitting ? t('book.bulkEdit.applying') : t('book.bulkEdit.apply') }}
           </button>
         </div>
       </div>

--- a/client/src/features/book/components/DeleteBookDialog.vue
+++ b/client/src/features/book/components/DeleteBookDialog.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { Loader2, Trash2 } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 
 defineProps<{ open: boolean; deleting: boolean }>()
 const emit = defineEmits<{ confirm: []; cancel: [] }>()
+
+const { t } = useI18n()
 </script>
 
 <template>
@@ -15,9 +18,9 @@ const emit = defineEmits<{ confirm: []; cancel: [] }>()
             <Trash2 class="text-destructive" :size="18" />
           </div>
           <div>
-            <h2 class="text-base font-semibold text-foreground">Delete book?</h2>
+            <h2 class="text-base font-semibold text-foreground">{{ t('book.deleteDialog.title') }}</h2>
             <p class="text-sm text-muted-foreground mt-1">
-              This will permanently delete the book and all its metadata, files, reading progress, and bookmarks. This cannot be undone.
+              {{ t('book.deleteDialog.description') }}
             </p>
           </div>
         </div>
@@ -27,7 +30,7 @@ const emit = defineEmits<{ confirm: []; cancel: [] }>()
             :disabled="deleting"
             @click="emit('cancel')"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="h-9 px-4 rounded-md text-sm font-medium bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors flex items-center gap-2 disabled:opacity-50"
@@ -35,7 +38,7 @@ const emit = defineEmits<{ confirm: []; cancel: [] }>()
             @click="emit('confirm')"
           >
             <Loader2 v-if="deleting" class="animate-spin" :size="14" />
-            Delete
+            {{ t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/book/components/FilterChipTypeahead.vue
+++ b/client/src/features/book/components/FilterChipTypeahead.vue
@@ -2,6 +2,9 @@
 import { onUnmounted, ref, watch } from 'vue'
 import { X } from '@lucide/vue'
 import { api } from '@/lib/api'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   modelValue: string[]
@@ -103,7 +106,7 @@ function onBlur() {
     <input
       v-model="query"
       type="text"
-      :placeholder="modelValue.length === 0 ? (placeholder ?? 'Type to search...') : ''"
+      :placeholder="modelValue.length === 0 ? (placeholder ?? t('book.filter.typeToSearch')) : ''"
       class="flex-1 min-w-20 bg-transparent text-foreground text-sm outline-none placeholder:text-muted-foreground"
       @keydown="onKeydown"
       @blur="onBlur"

--- a/client/src/features/book/components/FilterSummary.vue
+++ b/client/src/features/book/components/FilterSummary.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import type { GroupRule, Rule } from '@bookorbit/types'
 import { ruleToParts } from '@/features/book/lib/filter-labels'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 defineProps<{
   node: GroupRule
@@ -14,7 +17,7 @@ defineProps<{
       class="text-[9px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded shrink-0"
       :class="node.join === 'OR' ? 'bg-amber-500/15 text-amber-500' : 'bg-sky-500/15 text-sky-500'"
     >
-      {{ node.join === 'AND' ? 'ALL' : 'ANY' }}
+      {{ node.join === 'AND' ? t('book.filter.all') : t('book.filter.any') }}
     </span>
 
     <template v-for="(rule, i) in node.rules" :key="i">

--- a/client/src/features/book/components/FilterTextTypeahead.vue
+++ b/client/src/features/book/components/FilterTextTypeahead.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { onUnmounted, ref, watch } from 'vue'
 import { api } from '@/lib/api'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   modelValue: string
@@ -80,7 +83,7 @@ function onBlur() {
     <input
       :value="modelValue"
       type="text"
-      :placeholder="placeholder ?? 'value'"
+      :placeholder="placeholder ?? t('book.filter.valuePlaceholder')"
       class="h-9 w-full rounded-md border border-input bg-background text-foreground text-sm px-2 focus:outline-none focus:ring-2 focus:ring-primary placeholder:text-muted-foreground"
       @input="onInput"
       @keydown="onKeydown"

--- a/client/src/features/book/components/JumpRail.vue
+++ b/client/src/features/book/components/JumpRail.vue
@@ -2,6 +2,9 @@
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { TransitionPresets, useElementSize, useMediaQuery, useTransition } from '@vueuse/core'
 import type { JumpBucket, JumpBucketKind } from '@bookorbit/types'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const SLOT_PX = 20
 const RAIL_PAD_PX = 8
@@ -197,7 +200,7 @@ function handleAfterLeave() {
       ref="railEl"
       class="jump-rail fixed right-1.5 top-1/2 z-30 flex max-h-[85vh] -translate-y-1/2 select-none flex-col items-stretch overflow-hidden rounded-full border border-border bg-background/85 py-2 shadow-sm backdrop-blur"
       :class="[engaged ? 'px-1.5' : 'px-1', reducedMotion ? '' : 'transition-[padding] duration-300 ease-out']"
-      aria-label="Jump to section"
+      :aria-label="t('book.jumpRail.jumpToSection')"
       data-testid="jump-rail"
       @pointerdown="handlePointerDown"
       @pointermove="handlePointerMove"
@@ -234,7 +237,7 @@ function handleAfterLeave() {
           index === hoveredIndex ? 'scale-[1.35] font-semibold text-foreground' : '',
         ]"
         :disabled="!slot.bucket"
-        :aria-label="`Jump to ${slot.label}`"
+        :aria-label="t('book.jumpRail.jumpTo', { label: slot.label })"
         :aria-current="slot.key === activeKey ? 'true' : undefined"
         :data-key="slot.key"
         @click="handleSlotClick(slot)"

--- a/client/src/features/book/components/KeyboardShortcutOverlay.vue
+++ b/client/src/features/book/components/KeyboardShortcutOverlay.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { X } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 
 defineProps<{ open: boolean }>()
 const emit = defineEmits<{ 'update:open': [value: boolean] }>()
+
+const { t } = useI18n()
 
 const isMac = computed(() => typeof navigator !== 'undefined' && /Mac/i.test(navigator.userAgent))
 const modKey = computed(() => (isMac.value ? '⌘' : 'Ctrl'))
@@ -14,29 +17,29 @@ function handleClose() {
 
 const sections = computed(() => [
   {
-    title: 'Navigation',
+    title: t('book.shortcuts.navigation.title'),
     shortcuts: [
-      { keys: ['↑', '↓'], label: 'Move focus up/down' },
-      { keys: ['←', '→'], label: 'Move focus left/right' },
-      { keys: ['Home'], label: 'Jump to first column' },
-      { keys: ['End'], label: 'Jump to last column' },
-      { keys: [`${modKey.value}+Home`], label: 'Jump to first row' },
-      { keys: [`${modKey.value}+End`], label: 'Jump to last row' },
+      { keys: ['↑', '↓'], label: t('book.shortcuts.navigation.moveFocusVertical') },
+      { keys: ['←', '→'], label: t('book.shortcuts.navigation.moveFocusHorizontal') },
+      { keys: ['Home'], label: t('book.shortcuts.navigation.jumpFirstColumn') },
+      { keys: ['End'], label: t('book.shortcuts.navigation.jumpLastColumn') },
+      { keys: [`${modKey.value}+Home`], label: t('book.shortcuts.navigation.jumpFirstRow') },
+      { keys: [`${modKey.value}+End`], label: t('book.shortcuts.navigation.jumpLastRow') },
     ],
   },
   {
-    title: 'Actions',
+    title: t('book.shortcuts.actions.title'),
     shortcuts: [
-      { keys: ['Enter'], label: 'Edit focused cell' },
-      { keys: ['Escape'], label: 'Cancel editing / Close overlay' },
-      { keys: ['Space'], label: 'Toggle row selection' },
-      { keys: [`${modKey.value}+C`], label: 'Copy cell value' },
-      { keys: [`${modKey.value}+Shift+C`], label: 'Copy focused row' },
+      { keys: ['Enter'], label: t('book.shortcuts.actions.editCell') },
+      { keys: ['Escape'], label: t('book.shortcuts.actions.cancelEditing') },
+      { keys: ['Space'], label: t('book.shortcuts.actions.toggleRowSelection') },
+      { keys: [`${modKey.value}+C`], label: t('book.shortcuts.actions.copyCell') },
+      { keys: [`${modKey.value}+Shift+C`], label: t('book.shortcuts.actions.copyRow') },
     ],
   },
   {
-    title: 'General',
-    shortcuts: [{ keys: ['?'], label: 'Toggle this help overlay' }],
+    title: t('book.shortcuts.general.title'),
+    shortcuts: [{ keys: ['?'], label: t('book.shortcuts.general.toggleHelp') }],
   },
 ])
 </script>
@@ -50,9 +53,9 @@ const sections = computed(() => [
         @click.self="handleClose"
         @keydown.escape="handleClose"
       >
-        <div class="relative w-full max-w-md rounded-xl border border-border bg-card shadow-xl" role="dialog" aria-label="Keyboard shortcuts">
+        <div class="relative w-full max-w-md rounded-xl border border-border bg-card shadow-xl" role="dialog" :aria-label="t('book.shortcuts.title')">
           <div class="flex items-center justify-between border-b border-border px-5 py-3">
-            <h2 class="text-sm font-semibold text-foreground">Keyboard Shortcuts</h2>
+            <h2 class="text-sm font-semibold text-foreground">{{ t('book.shortcuts.title') }}</h2>
             <button
               class="h-7 w-7 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors"
               @click="handleClose"

--- a/client/src/features/book/components/MetadataExportDialog.vue
+++ b/client/src/features/book/components/MetadataExportDialog.vue
@@ -13,6 +13,9 @@ import {
   type MetadataExportViewType,
   type MetadataExportPreflight,
 } from '@/features/book/composables/useBookMetadataExport'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -70,8 +73,8 @@ const canRun = computed(() => {
 })
 
 const scopeSummary = computed(() => {
-  if (scope.value === 'selected') return `${selectedCountLabel.value} selected row${props.selectedCount === 1 ? '' : 's'}`
-  return `${totalCountLabel.value} matching row${props.totalCount === 1 ? '' : 's'}`
+  if (scope.value === 'selected') return t('book.export.selectedRowsSummary', { count: selectedCountLabel.value }, props.selectedCount)
+  return t('book.export.matchingRowsSummary', { count: totalCountLabel.value }, props.totalCount)
 })
 
 const sizeHintClass = computed(() => {
@@ -146,7 +149,7 @@ async function refreshPreflight() {
   try {
     preflight.value = await requestPreflight(request)
   } catch (error) {
-    preflightError.value = error instanceof Error ? error.message : 'Failed to prepare export'
+    preflightError.value = error instanceof Error ? error.message : t('book.export.prepareFailed')
   } finally {
     preflighting.value = false
   }
@@ -162,10 +165,10 @@ async function runExport() {
 
   try {
     await download(request)
-    toast.success(`Metadata export started: ${preflight.value.fileName}`)
+    toast.success(t('book.export.exportStarted', { fileName: preflight.value.fileName }))
     closeDialog()
   } catch (error) {
-    toast.error(error instanceof Error ? error.message : 'Metadata export failed')
+    toast.error(error instanceof Error ? error.message : t('book.export.exportFailed'))
   }
 }
 
@@ -214,7 +217,7 @@ watch(
         <div class="flex items-center justify-between border-b border-border px-5 py-4">
           <div class="flex items-center gap-2">
             <FileSpreadsheet :size="16" class="text-primary" />
-            <h2 class="text-base font-semibold text-foreground">Export Metadata</h2>
+            <h2 class="text-base font-semibold text-foreground">{{ t('book.export.title') }}</h2>
           </div>
           <button class="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground" @click="closeDialog">
             <X :size="14" />
@@ -223,7 +226,7 @@ watch(
 
         <div class="space-y-5 px-5 py-4">
           <section class="space-y-2">
-            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Scope</p>
+            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{{ t('book.export.scope') }}</p>
             <div class="grid gap-2 sm:grid-cols-2">
               <button
                 class="rounded-md border px-3 py-2 text-left text-sm transition-colors"
@@ -233,8 +236,8 @@ watch(
                 :disabled="!hasSelectedRows"
                 @click="scope = 'selected'"
               >
-                <p class="font-medium">Selected rows</p>
-                <p class="text-xs text-muted-foreground">{{ selectedCountLabel }} currently selected</p>
+                <p class="font-medium">{{ t('book.export.selectedRows') }}</p>
+                <p class="text-xs text-muted-foreground">{{ t('book.export.currentlySelected', { count: selectedCountLabel }) }}</p>
               </button>
               <button
                 class="rounded-md border px-3 py-2 text-left text-sm transition-colors"
@@ -246,14 +249,14 @@ watch(
                 :disabled="!hasAllMatchingScope"
                 @click="scope = 'all-matching'"
               >
-                <p class="font-medium">All matching rows</p>
-                <p class="text-xs text-muted-foreground">{{ totalCountLabel }} rows in current result</p>
+                <p class="font-medium">{{ t('book.export.allMatchingRows') }}</p>
+                <p class="text-xs text-muted-foreground">{{ t('book.export.rowsInResult', { count: totalCountLabel }) }}</p>
               </button>
             </div>
           </section>
 
           <section class="space-y-2">
-            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Format</p>
+            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{{ t('book.export.format') }}</p>
             <div class="grid gap-2 sm:grid-cols-2">
               <button
                 class="rounded-md border px-3 py-2 text-left text-sm transition-colors"
@@ -265,7 +268,7 @@ watch(
                 @click="settings.format = 'csv'"
               >
                 <p class="flex items-center gap-1.5 font-medium"><FileSpreadsheet :size="14" /> CSV</p>
-                <p class="text-xs text-muted-foreground">Spreadsheet-friendly, UTF-8 BOM included</p>
+                <p class="text-xs text-muted-foreground">{{ t('book.export.csvDescription') }}</p>
               </button>
               <button
                 class="rounded-md border px-3 py-2 text-left text-sm transition-colors"
@@ -277,56 +280,56 @@ watch(
                 @click="settings.format = 'json'"
               >
                 <p class="flex items-center gap-1.5 font-medium"><FileJson2 :size="14" /> JSON</p>
-                <p class="text-xs text-muted-foreground">Structured export with metadata context</p>
+                <p class="text-xs text-muted-foreground">{{ t('book.export.jsonDescription') }}</p>
               </button>
             </div>
           </section>
 
           <section class="space-y-2">
-            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Columns</p>
+            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{{ t('book.export.columns') }}</p>
             <div class="flex flex-wrap items-center gap-4 text-sm">
               <label class="inline-flex items-center gap-2">
                 <input type="radio" class="accent-primary" value="canonical" v-model="settings.columnsMode" />
-                Stable canonical schema
+                {{ t('book.export.canonicalSchema') }}
               </label>
               <label class="inline-flex items-center gap-2">
                 <input type="radio" class="accent-primary" value="visible" v-model="settings.columnsMode" />
-                Current visible columns
+                {{ t('book.export.visibleColumns') }}
               </label>
             </div>
           </section>
 
           <section class="space-y-2">
-            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Options</p>
+            <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{{ t('book.export.options') }}</p>
             <div class="grid gap-2 text-sm sm:grid-cols-2">
               <label class="inline-flex items-center gap-2">
                 <input v-model="settings.includePersonalData" type="checkbox" class="accent-primary" />
-                Include personal reading data
+                {{ t('book.export.includePersonalData') }}
               </label>
               <label class="inline-flex items-center gap-2">
                 <input v-model="settings.includeFilePaths" type="checkbox" class="accent-primary" />
-                Include file paths (advanced)
+                {{ t('book.export.includeFilePaths') }}
               </label>
               <label class="inline-flex items-center gap-2">
                 <input v-model="settings.includeContextMeta" type="checkbox" class="accent-primary" />
-                Include context metadata
+                {{ t('book.export.includeContextMeta') }}
               </label>
             </div>
           </section>
 
           <section class="rounded-md border border-border/70 bg-muted/30 p-3 text-sm">
-            <p class="font-medium text-foreground">Preflight</p>
-            <p class="mt-1 text-muted-foreground">Scope: {{ scopeSummary }}</p>
+            <p class="font-medium text-foreground">{{ t('book.export.preflight') }}</p>
+            <p class="mt-1 text-muted-foreground">{{ t('book.export.scopeLabel', { summary: scopeSummary }) }}</p>
             <p v-if="preflighting" class="mt-1 inline-flex items-center gap-2 text-muted-foreground">
-              <Loader2 :size="14" class="animate-spin" /> Calculating export size...
+              <Loader2 :size="14" class="animate-spin" /> {{ t('book.export.calculatingSize') }}
             </p>
             <template v-else-if="preflight">
               <p class="mt-1 text-muted-foreground">
-                Estimated size:
+                {{ t('book.export.estimatedSize') }}
                 <span :class="sizeHintClass">{{ (preflight.estimatedBytes / 1024 / 1024).toFixed(2) }} MB</span>
                 ({{ preflight.sizeCategory }})
               </p>
-              <p class="mt-1 text-muted-foreground">File: {{ preflight.fileName }}</p>
+              <p class="mt-1 text-muted-foreground">{{ t('book.export.fileLabel', { fileName: preflight.fileName }) }}</p>
             </template>
             <p v-else-if="preflightError" class="mt-1 text-destructive">{{ preflightError }}</p>
           </section>
@@ -338,7 +341,7 @@ watch(
             :disabled="loading"
             @click="closeDialog"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
@@ -347,7 +350,7 @@ watch(
           >
             <Loader2 v-if="loading" :size="14" class="animate-spin" />
             <Download v-else :size="14" />
-            Export
+            {{ t('book.export.exportAction') }}
           </button>
         </div>
       </div>

--- a/client/src/features/book/components/TableColumnPanel.vue
+++ b/client/src/features/book/components/TableColumnPanel.vue
@@ -5,6 +5,9 @@ import type { TableDensity } from '@/composables/useDisplaySettings'
 import type { SavedView } from '@/features/book/composables/useSavedViews'
 import type { ColumnDef } from '@/features/book/composables/useTableColumns'
 import type { TablePreset } from '@/features/book/composables/useTablePresets'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -60,7 +63,7 @@ function handleSaveView() {
 
 function promptForRename(currentName: string): string | null {
   if (typeof window === 'undefined') return null
-  const nextName = window.prompt('Enter a new name', currentName)
+  const nextName = window.prompt(t('book.columnPanel.renamePrompt'), currentName)
   return nextName ? nextName.trim() : null
 }
 
@@ -95,65 +98,65 @@ function densityButtonClass(density: TableDensity) {
 }
 
 function pinBadge(column: ColumnDef & { visible: boolean }): string | null {
-  if (column.pinned === 'left') return 'Pinned left'
-  if (column.pinned === 'right') return 'Pinned right'
+  if (column.pinned === 'left') return t('book.columnPanel.pinnedLeft')
+  if (column.pinned === 'right') return t('book.columnPanel.pinnedRight')
   return null
 }
 
 function columnLabel(column: ColumnDef & { visible: boolean }): string {
   if (column.header) return column.header
-  if (column.id === 'cover') return 'Cover'
-  if (column.id === 'read') return 'Read'
-  return column.id === 'actions' ? 'Actions' : column.id
+  if (column.id === 'cover') return t('book.columnPanel.columns.cover')
+  if (column.id === 'read') return t('book.columnPanel.columns.read')
+  return column.id === 'actions' ? t('book.columnPanel.columns.actions') : column.id
 }
 </script>
 
 <template>
   <div class="space-y-3">
     <div class="flex items-center justify-between">
-      <span class="text-xs font-semibold uppercase tracking-wide text-foreground">Columns</span>
+      <span class="text-xs font-semibold uppercase tracking-wide text-foreground">{{ t('book.columnPanel.columnsHeading') }}</span>
       <button class="text-xs text-muted-foreground hover:text-foreground" @click="emit('reset')">
-        <RotateCcw :size="11" class="mr-0.5 inline" />Reset
+        <RotateCcw :size="11" class="mr-0.5 inline" />{{ t('book.columnPanel.reset') }}
       </button>
     </div>
 
     <div class="space-y-2 rounded-md border border-border/60 p-2">
-      <div class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Table density</div>
+      <div class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{{ t('book.columnPanel.tableDensity') }}</div>
       <div class="grid grid-cols-3 gap-1">
         <button
           class="h-8 rounded-md border text-xs transition-colors"
           :class="densityButtonClass('compact')"
           @click="emit('update:density', 'compact')"
         >
-          Compact
+          {{ t('book.columnPanel.density.compact') }}
         </button>
         <button
           class="h-8 rounded-md border text-xs transition-colors"
           :class="densityButtonClass('comfortable')"
           @click="emit('update:density', 'comfortable')"
         >
-          Comfortable
+          {{ t('book.columnPanel.density.comfortable') }}
         </button>
         <button class="h-8 rounded-md border text-xs transition-colors" :class="densityButtonClass('roomy')" @click="emit('update:density', 'roomy')">
-          Roomy
+          {{ t('book.columnPanel.density.roomy') }}
         </button>
       </div>
     </div>
 
     <div class="space-y-2 rounded-md border border-border/60 p-2">
       <div class="flex items-center justify-between gap-2">
-        <div class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Presets</div>
+        <div class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{{ t('book.columnPanel.presets') }}</div>
         <div class="flex items-center gap-1">
           <button
             class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-            title="Export presets and saved views"
+            :title="t('book.columnPanel.exportBackup')"
             @click="emit('export-backup')"
           >
             <Download :size="12" />
           </button>
           <button
             class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-            title="Import presets and saved views"
+            :title="t('book.columnPanel.importBackup')"
             @click="handleImportBackupClick"
           >
             <Upload :size="12" />
@@ -190,9 +193,9 @@ function columnLabel(column: ColumnDef & { visible: boolean }): string {
             class="rounded p-1 text-muted-foreground hover:bg-background hover:text-foreground"
             @click="handleRenamePreset(preset)"
           >
-            Rename
+            {{ t('book.columnPanel.rename') }}
           </button>
-          <span v-if="preset.isBuiltIn" class="text-[10px] text-muted-foreground">Built in</span>
+          <span v-if="preset.isBuiltIn" class="text-[10px] text-muted-foreground">{{ t('book.columnPanel.builtIn') }}</span>
           <button
             v-if="!preset.isBuiltIn"
             class="rounded p-1 text-muted-foreground hover:bg-background hover:text-destructive"
@@ -206,19 +209,19 @@ function columnLabel(column: ColumnDef & { visible: boolean }): string {
         <input
           v-model="presetName"
           class="h-8 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-xs text-foreground placeholder:text-muted-foreground"
-          placeholder="Save current preset"
+          :placeholder="t('book.columnPanel.saveCurrentPreset')"
         />
         <button
           class="h-8 shrink-0 rounded-md border border-input px-2 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
           @click="handleSavePreset"
         >
-          Save
+          {{ t('common.save') }}
         </button>
       </div>
     </div>
 
     <div class="space-y-2 rounded-md border border-border/60 p-2">
-      <div class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Saved views</div>
+      <div class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{{ t('book.columnPanel.savedViews') }}</div>
       <div v-if="savedViews.length > 0" class="space-y-1">
         <div v-for="view in savedViews" :key="view.id" class="flex items-center gap-2 rounded px-2 py-1 text-xs transition-colors hover:bg-accent">
           <button class="min-w-0 flex-1 text-left" @click="emit('apply-view', view)">
@@ -234,24 +237,26 @@ function columnLabel(column: ColumnDef & { visible: boolean }): string {
           <button class="rounded p-1 text-muted-foreground hover:bg-background hover:text-foreground" @click="emit('duplicate-view', view.id)">
             <Copy :size="11" />
           </button>
-          <button class="rounded p-1 text-muted-foreground hover:bg-background hover:text-foreground" @click="handleRenameView(view)">Rename</button>
+          <button class="rounded p-1 text-muted-foreground hover:bg-background hover:text-foreground" @click="handleRenameView(view)">
+            {{ t('book.columnPanel.rename') }}
+          </button>
           <button class="rounded p-1 text-muted-foreground hover:bg-background hover:text-destructive" @click="emit('delete-view', view.id)">
             <X :size="11" />
           </button>
         </div>
       </div>
-      <p v-else class="text-xs text-muted-foreground">Save sort, layout, and view-specific filters for quick reuse.</p>
+      <p v-else class="text-xs text-muted-foreground">{{ t('book.columnPanel.savedViewsEmpty') }}</p>
       <div class="flex items-center gap-2">
         <input
           v-model="viewName"
           class="h-8 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-xs text-foreground placeholder:text-muted-foreground"
-          placeholder="Save current view"
+          :placeholder="t('book.columnPanel.saveCurrentView')"
         />
         <button
           class="h-8 shrink-0 rounded-md border border-input px-2 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
           @click="handleSaveView"
         >
-          Save
+          {{ t('common.save') }}
         </button>
       </div>
     </div>

--- a/client/src/features/book/components/VirtualBookTable.vue
+++ b/client/src/features/book/components/VirtualBookTable.vue
@@ -40,6 +40,9 @@ import { useNarratorSearch } from '@/features/book/composables/useNarratorSearch
 import { SORT_FIELD_LABELS } from '@/features/book/lib/filter-labels'
 import { useDisplaySettings } from '@/composables/useDisplaySettings'
 import { useActiveCustomFields } from '@/features/book/composables/useActiveCustomFields'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -185,8 +188,8 @@ const rowPaddingClass = computed(() => {
 })
 
 function getTextCellOpenLinkLabel(colId: string): string | null {
-  if (colId === 'title') return 'Open book details'
-  if (colId === 'seriesName') return 'Open series'
+  if (colId === 'title') return t('book.tableView.openBookDetails')
+  if (colId === 'seriesName') return t('book.tableView.openSeries')
   return null
 }
 
@@ -216,7 +219,7 @@ function isCellChanged(bookId: number, colId: string): boolean {
 }
 
 function getRowFeedbackMessage(bookId: number): string {
-  return getRowFeedback(bookId)?.message ?? 'Metadata refresh failed'
+  return getRowFeedback(bookId)?.message ?? t('book.tableView.metadataRefreshFailed')
 }
 
 async function retryMetadataRefresh(book: BookCard) {
@@ -670,14 +673,14 @@ defineExpose({
   <div class="relative flex-1 min-h-0 flex flex-col overflow-hidden rounded-md border border-border">
     <!-- Screen-reader live region for dynamic announcements -->
     <div aria-live="polite" aria-atomic="true" class="sr-only">
-      <span v-if="selectionMode && selectedCount != null && selectedCount > 0"
-        >{{ selectedCount }} {{ selectedCount === 1 ? 'book' : 'books' }} selected</span
-      >
-      <span v-if="loading && initialized">Loading more books</span>
+      <span v-if="selectionMode && selectedCount != null && selectedCount > 0">{{
+        t('book.tableView.booksSelected', { count: selectedCount }, selectedCount)
+      }}</span>
+      <span v-if="loading && initialized">{{ t('book.tableView.loadingMoreBooks') }}</span>
     </div>
     <!-- Sort strip: visible when multiple sorts are active -->
     <div v-if="activeSorts.length > 1" class="shrink-0 flex items-center gap-1.5 border-b border-border/60 bg-muted/30 px-3 py-1">
-      <span class="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground shrink-0">Sort</span>
+      <span class="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground shrink-0">{{ t('book.tableView.sort') }}</span>
       <div class="flex flex-wrap items-center gap-1">
         <span
           v-for="(s, idx) in activeSorts"
@@ -698,14 +701,16 @@ defineExpose({
     <div v-if="metadataInFlight" class="shrink-0 flex items-center justify-between border-b border-border/60 bg-primary/5 px-3 py-1">
       <div class="flex items-center gap-1.5 text-xs font-medium text-primary">
         <Loader2 :size="12" class="animate-spin" />
-        <span>Refreshing metadata {{ metadataInFlight.processed }} / {{ metadataInFlight.total }}</span>
+        <span>{{ t('book.tableView.refreshingMetadata', { processed: metadataInFlight.processed, total: metadataInFlight.total }) }}</span>
       </div>
-      <span v-if="metadataFailed > 0" class="text-xs font-medium text-amber-700 dark:text-amber-400">{{ metadataFailed }} failed</span>
-      <span v-else class="text-xs text-muted-foreground">{{ metadataRemaining }} remaining</span>
+      <span v-if="metadataFailed > 0" class="text-xs font-medium text-amber-700 dark:text-amber-400">{{
+        t('book.tableView.failedCount', { count: metadataFailed })
+      }}</span>
+      <span v-else class="text-xs text-muted-foreground">{{ t('book.tableView.remainingCount', { count: metadataRemaining }) }}</span>
     </div>
 
     <div v-if="isReadOnly" class="shrink-0 border-b border-border/60 bg-amber-500/8 px-3 py-1.5 text-xs text-amber-700 dark:text-amber-300">
-      Table editing is disabled on smaller screens. Switch to list or grid for quicker actions.
+      {{ t('book.tableView.readOnlyNotice') }}
     </div>
 
     <div ref="scrollContainerRef" class="relative flex-1 min-h-0 overflow-auto" tabindex="0" @keydown="handleKeydownWithShortcuts">
@@ -904,21 +909,21 @@ defineExpose({
                       class="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/12 px-1.5 py-0.5 text-[10px] font-medium text-primary"
                     >
                       <Loader2 :size="10" class="animate-spin" />
-                      Fetching...
+                      {{ t('book.tableView.fetching') }}
                     </span>
                     <span
                       v-else-if="getRowFeedback(rowBook(vItem.index).id)?.state === 'success'"
                       class="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/12 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-300"
                     >
                       <CheckCircle2 :size="10" />
-                      Updated
+                      {{ t('book.tableView.updated') }}
                     </span>
                     <span
                       v-else
                       class="inline-flex items-center gap-1 rounded-full border border-destructive/40 bg-destructive/10 px-1 py-0.5 text-[10px] font-medium text-destructive"
                     >
                       <AlertTriangle :size="10" />
-                      Failed
+                      {{ t('book.tableView.failed') }}
                       <button
                         class="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full hover:bg-destructive/20"
                         :title="getRowFeedbackMessage(rowBook(vItem.index).id)"
@@ -949,7 +954,7 @@ defineExpose({
       class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 text-muted-foreground"
     >
       <BookOpen :size="36" class="opacity-30" />
-      <p class="text-sm">No books to display</p>
+      <p class="text-sm">{{ t('book.tableView.noBooks') }}</p>
     </div>
 
     <!-- Scroll to top FAB -->
@@ -962,7 +967,7 @@ defineExpose({
       <button
         v-if="showScrollTop"
         class="absolute bottom-10 right-4 z-20 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-md hover:bg-primary/90 transition-colors"
-        aria-label="Scroll to top"
+        :aria-label="t('book.tableView.scrollToTop')"
         @click="scrollToTop"
       >
         <ChevronUp :size="16" />
@@ -973,29 +978,31 @@ defineExpose({
     <div class="shrink-0 flex items-center justify-between border-t border-border/60 bg-muted/40 px-3 py-1 text-xs text-muted-foreground">
       <div class="flex items-center gap-2">
         <span v-if="selectionMode && selectedCount">
-          {{ selectedCount.toLocaleString() }} selected
+          {{ t('book.tableView.selectedStatus', { count: selectedCount.toLocaleString() }) }}
           <span class="text-muted-foreground/60">/ </span>
         </span>
         <span v-if="filterActive" class="flex items-center gap-1 text-primary">
           <span class="h-1.5 w-1.5 rounded-full bg-primary" />
-          Filtered
+          {{ t('book.tableView.filtered') }}
         </span>
-        <span v-if="hasMore">{{ books.length.toLocaleString() }} of {{ (total ?? 0).toLocaleString() }} loaded</span>
-        <span v-else>{{ (total ?? books.length).toLocaleString() }} {{ (total ?? books.length) === 1 ? 'book' : 'books' }}</span>
+        <span v-if="hasMore">{{
+          t('book.tableView.loadedStatus', { loaded: books.length.toLocaleString(), total: (total ?? 0).toLocaleString() })
+        }}</span>
+        <span v-else>{{ t('book.tableView.bookCount', { count: (total ?? books.length).toLocaleString() }, total ?? books.length) }}</span>
       </div>
       <div class="flex items-center gap-3">
         <button
           class="inline-flex h-5 w-5 items-center justify-center rounded border border-border/70 bg-background text-[11px] font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title="Keyboard shortcuts (?)"
-          aria-label="Show table keyboard shortcuts"
+          :title="t('book.tableView.keyboardShortcutsTitle')"
+          :aria-label="t('book.tableView.showKeyboardShortcuts')"
           @click="shortcutOverlayOpen = true"
         >
           ?
         </button>
-        <span class="hidden lg:inline text-[11px] text-muted-foreground/80">Copy cell: Ctrl/Cmd+C · Copy row: Ctrl/Cmd+Shift+C</span>
+        <span class="hidden lg:inline text-[11px] text-muted-foreground/80">{{ t('book.tableView.copyHint') }}</span>
         <span v-if="loading" class="flex items-center gap-1">
           <Loader2 :size="11" class="animate-spin" />
-          Loading...
+          {{ t('common.loading') }}
         </span>
       </div>
     </div>

--- a/client/src/features/book/components/detail/AuthorBooksRow.vue
+++ b/client/src/features/book/components/detail/AuthorBooksRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { watch, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { useAuthorBooks } from '@/features/book/composables/useAuthorBooks'
 import BookCarousel from '@/features/book/components/detail/BookCarousel.vue'
@@ -9,6 +10,7 @@ const props = defineProps<{
   authorCount: number
 }>()
 
+const { t } = useI18n()
 const { authorBooks, loading, fetch } = useAuthorBooks()
 
 watch(
@@ -17,7 +19,7 @@ watch(
   { immediate: true },
 )
 
-const headerText = computed(() => (props.authorCount > 1 ? 'Also by these authors' : 'Also by this author'))
+const headerText = computed(() => (props.authorCount > 1 ? t('book.detail.authorBooks.alsoByAuthors') : t('book.detail.authorBooks.alsoByAuthor')))
 
 const bookIds = computed(() => authorBooks.value.map((b) => b.id))
 

--- a/client/src/features/book/components/detail/BookDetailHeader.vue
+++ b/client/src/features/book/components/detail/BookDetailHeader.vue
@@ -2,11 +2,13 @@
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { ChevronLeft, ChevronRight } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 import BookDetailTabs from './BookDetailTabs.vue'
 import { useBookNavigation } from '../../composables/useBookNavigation'
 
 const props = defineProps<{ bookId: number }>()
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 
@@ -45,7 +47,7 @@ async function navigateToBook(id: number) {
         :disabled="!prevId"
         class="h-7 w-7 flex items-center justify-center rounded-md transition-colors"
         :class="prevId ? 'text-foreground hover:bg-muted' : 'text-muted-foreground/60 cursor-not-allowed'"
-        title="Previous book"
+        :title="t('book.detail.header.previousBook')"
       >
         <ChevronLeft :size="16" />
       </button>
@@ -54,7 +56,7 @@ async function navigateToBook(id: number) {
         :disabled="!nextId"
         class="h-7 w-7 flex items-center justify-center rounded-md transition-colors"
         :class="nextId ? 'text-foreground hover:bg-muted' : 'text-muted-foreground/60 cursor-not-allowed'"
-        title="Next book"
+        :title="t('book.detail.header.nextBook')"
       >
         <ChevronRight :size="16" />
       </button>

--- a/client/src/features/book/components/detail/BookDetailTabs.vue
+++ b/client/src/features/book/components/detail/BookDetailTabs.vue
@@ -1,24 +1,26 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { normalizeBookDetailTab, type BookDetailTab } from '@/features/book/lib/book-detail-tabs'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 
 const props = defineProps<{ bookId: number }>()
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 const { hasPermission } = usePermissions()
 
 const activeTab = computed(() => normalizeBookDetailTab(route.query.tab))
 
 const tabs = computed<{ label: string; tab: BookDetailTab }[]>(() => {
-  const result: { label: string; tab: BookDetailTab }[] = [{ label: 'Details', tab: 'details' }]
+  const result: { label: string; tab: BookDetailTab }[] = [{ label: t('book.detail.tabs.details'), tab: 'details' }]
   if (hasPermission('library_edit_metadata')) {
-    result.push({ label: 'Edit Metadata', tab: 'edit' })
+    result.push({ label: t('book.detail.tabs.editMetadata'), tab: 'edit' })
   }
-  result.push({ label: 'Files', tab: 'files' })
-  result.push({ label: 'Reading Log', tab: 'reading-log' })
-  result.push({ label: 'Highlights', tab: 'highlights' })
+  result.push({ label: t('book.detail.tabs.files'), tab: 'files' })
+  result.push({ label: t('book.detail.tabs.readingLog'), tab: 'reading-log' })
+  result.push({ label: t('book.detail.tabs.highlights'), tab: 'highlights' })
   return result
 })
 
@@ -30,13 +32,13 @@ function navigate(tab: BookDetailTab) {
 <template>
   <div class="flex items-stretch gap-0 overflow-x-auto scrollbar-none flex-1 min-w-0">
     <button
-      v-for="t in tabs"
-      :key="t.tab"
+      v-for="tabItem in tabs"
+      :key="tabItem.tab"
       class="px-3.5 sm:px-3 h-full text-[15px] sm:text-sm font-semibold sm:font-medium border-b-2 transition-colors whitespace-nowrap"
-      :class="activeTab === t.tab ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
-      @click="navigate(t.tab)"
+      :class="activeTab === tabItem.tab ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'"
+      @click="navigate(tabItem.tab)"
     >
-      {{ t.label }}
+      {{ tabItem.label }}
     </button>
   </div>
 </template>

--- a/client/src/features/book/components/detail/DiscoverRow.vue
+++ b/client/src/features/book/components/detail/DiscoverRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { BookOpen, User, Sparkles, ChevronLeft, ChevronRight } from '@lucide/vue'
 
 import type { BookRecommendation, SeriesBookRecommendation } from '@bookorbit/types'
@@ -13,6 +14,8 @@ const props = defineProps<{
   seriesName: string | null
   authorCount: number
 }>()
+
+const { t } = useI18n()
 
 const seriesBooks = ref<SeriesBookRecommendation[]>([])
 const authorBooks = ref<BookRecommendation[]>([])
@@ -58,11 +61,11 @@ const availablePills = computed<Section[]>(() => {
   return pills
 })
 
-const pillLabels: Record<Section, string> = {
-  series: 'More in Series',
-  author: 'By Author',
-  similar: 'Similar Books',
-}
+const pillLabels = computed<Record<Section, string>>(() => ({
+  series: t('book.detail.discover.moreInSeries'),
+  author: t('book.detail.discover.byAuthor'),
+  similar: t('book.detail.discover.similarBooks'),
+}))
 
 const pillIcons: Record<Section, typeof BookOpen> = {
   series: BookOpen,

--- a/client/src/features/book/components/detail/RecommendedBooksRow.vue
+++ b/client/src/features/book/components/detail/RecommendedBooksRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { watch, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { useRecommendations } from '@/features/book/composables/useRecommendations'
 import BookCarousel from '@/features/book/components/detail/BookCarousel.vue'
@@ -14,6 +15,7 @@ const props = withDefaults(
   },
 )
 
+const { t } = useI18n()
 const { recommendations, loading, fetch } = useRecommendations()
 
 watch(
@@ -33,7 +35,7 @@ const filteredRecommendations = computed(() => {
   <div v-if="loading || filteredRecommendations.length > 0" class="mt-8 pt-6 border-t border-border">
     <BookCarousel :books="filteredRecommendations" :loading="loading">
       <template #header>
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">More Like This</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">{{ t('book.detail.recommended.moreLikeThis') }}</p>
       </template>
     </BookCarousel>
   </div>

--- a/client/src/features/book/components/detail/SeriesBooksRow.vue
+++ b/client/src/features/book/components/detail/SeriesBooksRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { watch, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import { useSeriesBooks } from '@/features/book/composables/useSeriesBooks'
 import BookCarousel from '@/features/book/components/detail/BookCarousel.vue'
@@ -9,6 +10,7 @@ const props = defineProps<{
   seriesName: string
 }>()
 
+const { t } = useI18n()
 const { seriesBooks, loading, fetch } = useSeriesBooks()
 
 watch(
@@ -27,7 +29,8 @@ defineExpose({ bookIds })
     <BookCarousel :books="seriesBooks" :loading="loading" :current-book-id="bookId" :show-series-index="true">
       <template #header>
         <p class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
-          More in the <span class="italic">{{ seriesName }}</span> series
+          {{ t('book.detail.series.moreInSeriesPrefix') }} <span class="italic">{{ seriesName }}</span>
+          {{ t('book.detail.series.moreInSeriesSuffix') }}
         </p>
       </template>
     </BookCarousel>

--- a/client/src/features/book/components/detail/WriteAndRenameResultPanel.vue
+++ b/client/src/features/book/components/detail/WriteAndRenameResultPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { AlertTriangle, CheckCircle2, Info, X, XCircle } from '@lucide/vue'
 import type { BookWriteAndRenameResult } from '@bookorbit/types'
 
@@ -10,6 +11,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   dismiss: []
 }>()
+
+const { t } = useI18n()
 
 const writeStatusIcon = computed(() => {
   if (props.result.write.status === 'success') return CheckCircle2
@@ -37,19 +40,27 @@ const renameStatusClass = computed(() => {
 
 const writeLabel = computed(() => {
   const { status, reason, fieldsWritten } = props.result.write
-  if (status === 'success') return `Written (${fieldsWritten.length} field${fieldsWritten.length !== 1 ? 's' : ''})`
-  if (status === 'failed') return reason ?? 'Write failed'
-  return reason ?? 'Skipped'
+  if (status === 'success') return t('book.detail.writeRename.written', { count: fieldsWritten.length }, fieldsWritten.length)
+  if (status === 'failed') return reason ?? t('book.detail.writeRename.writeFailed')
+  return reason ?? t('book.detail.writeRename.skipped')
 })
 
 const renameLabel = computed(() => {
   const { status, reason, newPath } = props.result.rename
-  if (status === 'success') return newPath ? `Renamed to ${newPath.split('/').pop()}` : 'File renamed'
-  if (status === 'failed') return reason ?? 'Rename failed'
-  return reason ?? 'Skipped'
+  if (status === 'success')
+    return newPath ? t('book.detail.writeRename.renamedTo', { name: newPath.split('/').pop() }) : t('book.detail.writeRename.fileRenamed')
+  if (status === 'failed') return reason ?? t('book.detail.writeRename.renameFailed')
+  return reason ?? t('book.detail.writeRename.skipped')
 })
 
 const hasWarning = computed(() => !props.result.libraryAutoWriteEnabled || !props.result.libraryAutoRenameEnabled)
+
+const autoDisabledWarning = computed(() => {
+  const { libraryAutoWriteEnabled, libraryAutoRenameEnabled } = props.result
+  if (!libraryAutoWriteEnabled && !libraryAutoRenameEnabled) return t('book.detail.writeRename.autoWriteAndRenameDisabled')
+  if (!libraryAutoWriteEnabled) return t('book.detail.writeRename.autoWriteDisabled')
+  return t('book.detail.writeRename.autoRenameDisabled')
+})
 
 function handleDismiss() {
   emit('dismiss')
@@ -62,26 +73,17 @@ function handleDismiss() {
       <div class="space-y-1.5 min-w-0">
         <div class="flex items-center gap-2">
           <component :is="writeStatusIcon" :class="['size-3.5 shrink-0', writeStatusClass]" />
-          <span class="font-medium">Write:</span>
+          <span class="font-medium">{{ t('book.detail.writeRename.writeLabel') }}</span>
           <span class="text-muted-foreground truncate">{{ writeLabel }}</span>
         </div>
         <div class="flex items-center gap-2">
           <component :is="renameStatusIcon" :class="['size-3.5 shrink-0', renameStatusClass]" />
-          <span class="font-medium">Rename:</span>
+          <span class="font-medium">{{ t('book.detail.writeRename.renameLabel') }}</span>
           <span class="text-muted-foreground truncate">{{ renameLabel }}</span>
         </div>
         <div v-if="hasWarning" class="flex items-start gap-1.5 text-amber-600 dark:text-amber-400 pt-0.5">
           <AlertTriangle class="size-3.5 shrink-0 mt-px" />
-          <span>
-            Auto-{{
-              !result.libraryAutoWriteEnabled && !result.libraryAutoRenameEnabled
-                ? 'write and rename are'
-                : !result.libraryAutoWriteEnabled
-                  ? 'write is'
-                  : 'rename is'
-            }}
-            disabled in library settings. Changes won't sync automatically on future saves.
-          </span>
+          <span>{{ autoDisabledWarning }}</span>
         </div>
       </div>
       <button class="shrink-0 rounded p-0.5 hover:bg-muted transition-colors text-muted-foreground" @click="handleDismiss">

--- a/client/src/features/book/components/detail/tabs/AddBookFileModal.vue
+++ b/client/src/features/book/components/detail/tabs/AddBookFileModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { CheckCircle2, FileUp, Loader2, Plus, Upload, X, XCircle, RotateCcw } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 import { Permission } from '@bookorbit/types'
 import { SUPPORTED_FORMATS_ACCEPT, useAddBookFile } from '@/features/book/composables/useAddBookFile'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
@@ -14,6 +15,7 @@ const emit = defineEmits<{
   uploaded: []
 }>()
 
+const { t } = useI18n()
 const { hasPermission } = usePermissions()
 
 const isDragging = ref(false)
@@ -28,9 +30,9 @@ const allDone = computed(() => hasFiles.value && files.value.every((f) => f.stat
 const allSuccess = computed(() => allDone.value && errorCount.value === 0)
 
 const headerTitle = computed(() => {
-  if (isUploading.value) return 'Uploading...'
-  if (allDone.value) return 'Upload complete'
-  return 'Add File'
+  if (isUploading.value) return t('book.detail.addFile.uploading')
+  if (allDone.value) return t('book.detail.addFile.uploadComplete')
+  return t('book.detail.addFile.title')
 })
 
 const fileSummary = computed(() => {
@@ -169,8 +171,8 @@ function formatPillClass(filename: string): string {
               <FileUp :size="20" class="text-primary" />
             </div>
             <div>
-              <p class="text-sm font-medium text-foreground">Drop files here or click to browse</p>
-              <p class="text-xs text-muted-foreground mt-0.5">epub, pdf, mobi, cbz, m4b and more - up to 500 MB each</p>
+              <p class="text-sm font-medium text-foreground">{{ t('book.detail.addFile.dropzone.title') }}</p>
+              <p class="text-xs text-muted-foreground mt-0.5">{{ t('book.detail.addFile.dropzone.hint') }}</p>
             </div>
           </div>
 
@@ -189,20 +191,24 @@ function formatPillClass(filename: string): string {
             @click="openFilePicker"
           >
             <Plus :size="13" />
-            Add more files
+            {{ t('book.detail.addFile.addMore') }}
           </div>
 
           <!-- File list -->
           <div v-if="hasFiles" class="flex flex-col gap-2">
             <!-- Summary line -->
             <div v-if="fileSummary" class="flex items-center gap-1.5 flex-wrap text-xs text-muted-foreground">
-              <span class="font-medium text-foreground tabular-nums">{{ fileSummary.total }} file{{ fileSummary.total === 1 ? '' : 's' }}</span>
+              <span class="font-medium text-foreground tabular-nums">{{
+                t('book.detail.addFile.fileCount', { count: fileSummary.total }, fileSummary.total)
+              }}</span>
               <span>·</span>
               <span>{{ formatBytes(fileSummary.totalBytes) }}</span>
               <span>·</span>
               <span>{{ fileSummary.formatParts.join(', ') }}</span>
               <div class="flex-1" />
-              <button v-if="!isUploading" class="hover:text-foreground transition-colors" @click="reset">Clear all</button>
+              <button v-if="!isUploading" class="hover:text-foreground transition-colors" @click="reset">
+                {{ t('book.detail.addFile.clearAll') }}
+              </button>
             </div>
 
             <TransitionGroup name="file-row" tag="div" class="relative flex flex-col gap-1">
@@ -230,7 +236,9 @@ function formatPillClass(filename: string): string {
                     </span>
                     <span v-if="item.status === 'error'" class="text-[11px] text-destructive truncate">{{ item.error }}</span>
                     <span v-else-if="item.status === 'uploading'" class="text-[11px] text-primary tabular-nums">{{ item.progress }}%</span>
-                    <span v-else-if="item.status === 'done'" class="text-[11px] text-emerald-600 dark:text-emerald-400">Done</span>
+                    <span v-else-if="item.status === 'done'" class="text-[11px] text-emerald-600 dark:text-emerald-400">{{
+                      t('book.detail.addFile.done')
+                    }}</span>
                   </div>
 
                   <!-- Progress bar -->
@@ -244,7 +252,7 @@ function formatPillClass(filename: string): string {
                   <button
                     v-if="item.status === 'error'"
                     class="flex items-center justify-center w-6 h-6 rounded text-muted-foreground/85 hover:text-primary hover:bg-primary/10 transition-colors"
-                    title="Retry"
+                    :title="t('book.detail.addFile.retry')"
                     @click="retryFile(item.id)"
                   >
                     <RotateCcw :size="11" />
@@ -266,21 +274,25 @@ function formatPillClass(filename: string): string {
         <div v-if="allSuccess" class="shrink-0 px-5 py-4 border-t border-border flex items-center justify-between gap-3">
           <div class="flex items-center gap-2">
             <CheckCircle2 class="size-4 text-emerald-500 shrink-0" />
-            <span class="text-sm font-medium text-foreground">{{ doneCount }} file{{ doneCount === 1 ? '' : 's' }} added</span>
+            <span class="text-sm font-medium text-foreground">{{ t('book.detail.addFile.filesAdded', { count: doneCount }, doneCount) }}</span>
           </div>
           <button
             class="px-3 py-1.5 rounded-md border border-border text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
             @click="handleClose"
           >
-            Close
+            {{ t('common.close') }}
           </button>
         </div>
 
         <!-- Footer: normal / partial error state -->
         <div v-else class="shrink-0 px-5 py-4 border-t border-border flex items-center justify-between gap-3">
           <div class="flex items-center gap-3 min-w-0">
-            <span v-if="allDone && errorCount > 0" class="text-xs text-muted-foreground">{{ doneCount }} uploaded, {{ errorCount }} failed</span>
-            <span v-else-if="isUploading" class="text-xs text-muted-foreground tabular-nums">{{ doneCount }} of {{ files.length }} uploading...</span>
+            <span v-if="allDone && errorCount > 0" class="text-xs text-muted-foreground">{{
+              t('book.detail.addFile.uploadedFailed', { done: doneCount, failed: errorCount })
+            }}</span>
+            <span v-else-if="isUploading" class="text-xs text-muted-foreground tabular-nums">{{
+              t('book.detail.addFile.uploadingProgress', { done: doneCount, total: files.length })
+            }}</span>
             <label v-else-if="hasPermission(Permission.LibraryEditMetadata)" class="flex items-center gap-2 cursor-pointer select-none">
               <input
                 v-model="renameAfter"
@@ -288,7 +300,7 @@ function formatPillClass(filename: string): string {
                 class="w-3.5 h-3.5 rounded border-border accent-primary cursor-pointer"
                 :disabled="isUploading"
               />
-              <span class="text-xs text-muted-foreground">Rename all book files after upload</span>
+              <span class="text-xs text-muted-foreground">{{ t('book.detail.addFile.renameAfter') }}</span>
             </label>
             <span v-else class="text-xs text-muted-foreground" />
           </div>
@@ -298,7 +310,7 @@ function formatPillClass(filename: string): string {
               class="px-3 py-1.5 rounded-md border border-border text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
               @click="handleClose"
             >
-              {{ allDone ? 'Close' : 'Cancel' }}
+              {{ allDone ? t('common.close') : t('common.cancel') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-4 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
@@ -306,7 +318,7 @@ function formatPillClass(filename: string): string {
               @click="handleUpload"
             >
               <Upload :size="13" />
-              Upload{{ pendingCount > 0 ? ` (${pendingCount})` : '' }}
+              {{ pendingCount > 0 ? t('book.detail.addFile.uploadCount', { count: pendingCount }) : t('book.detail.addFile.upload') }}
             </button>
           </div>
         </div>

--- a/client/src/features/book/components/detail/tabs/AddSessionDialog.vue
+++ b/client/src/features/book/components/detail/tabs/AddSessionDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X } from '@lucide/vue'
 
 const props = defineProps<{
@@ -8,6 +9,8 @@ const props = defineProps<{
   saving: boolean
   error: string | null
 }>()
+
+const { t } = useI18n()
 
 const emit = defineEmits<{
   close: []
@@ -50,19 +53,19 @@ function handleSubmit() {
   localError.value = null
   const parsed = new Date(startedAt.value)
   if (!startedAt.value || Number.isNaN(parsed.getTime())) {
-    localError.value = 'Pick a valid date and time.'
+    localError.value = t('book.detail.addSession.errors.invalidDate')
     return
   }
   if (parsed.getTime() > Date.now()) {
-    localError.value = 'The session cannot start in the future.'
+    localError.value = t('book.detail.addSession.errors.future')
     return
   }
   if (!Number.isInteger(durationMinutes.value) || durationMinutes.value < 1 || durationMinutes.value > 1440) {
-    localError.value = 'Duration must be between 1 and 1440 minutes.'
+    localError.value = t('book.detail.addSession.errors.duration')
     return
   }
   if (endProgress.value != null && (endProgress.value < 0 || endProgress.value > 100)) {
-    localError.value = 'End progress must be between 0 and 100.'
+    localError.value = t('book.detail.addSession.errors.endProgress')
     return
   }
   emit('submit', {
@@ -80,7 +83,7 @@ function handleSubmit() {
       <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="handleClose" />
       <div class="relative z-10 w-full max-w-md mx-4 bg-card border border-border rounded-lg shadow-2xl p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-base font-semibold text-foreground">Add reading session</h2>
+          <h2 class="text-base font-semibold text-foreground">{{ t('book.detail.addSession.title') }}</h2>
           <button class="text-muted-foreground hover:text-foreground transition-colors" @click="handleClose">
             <X :size="18" />
           </button>
@@ -88,7 +91,7 @@ function handleSubmit() {
 
         <form class="flex flex-col gap-4" @submit.prevent="handleSubmit">
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground">Started at</label>
+            <label class="text-sm font-medium text-foreground">{{ t('book.detail.addSession.startedAt') }}</label>
             <input
               v-model="startedAt"
               type="datetime-local"
@@ -99,7 +102,7 @@ function handleSubmit() {
 
           <div class="grid grid-cols-2 gap-3">
             <div class="flex flex-col gap-1.5">
-              <label class="text-sm font-medium text-foreground">Duration (minutes)</label>
+              <label class="text-sm font-medium text-foreground">{{ t('book.detail.addSession.duration') }}</label>
               <input
                 v-model.number="durationMinutes"
                 type="number"
@@ -109,26 +112,26 @@ function handleSubmit() {
               />
             </div>
             <div class="flex flex-col gap-1.5">
-              <label class="text-sm font-medium text-foreground">End progress %</label>
+              <label class="text-sm font-medium text-foreground">{{ t('book.detail.addSession.endProgress') }}</label>
               <input
                 v-model.number="endProgress"
                 type="number"
                 min="0"
                 max="100"
                 step="0.1"
-                placeholder="Optional"
+                :placeholder="t('book.detail.addSession.optional')"
                 class="h-9 rounded-md border border-input bg-background text-foreground text-sm px-3 focus:outline-none focus:ring-2 focus:ring-primary placeholder:text-muted-foreground"
               />
             </div>
           </div>
 
           <div v-if="formats.length >= 2" class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground">Format</label>
+            <label class="text-sm font-medium text-foreground">{{ t('book.detail.addSession.format') }}</label>
             <select
               v-model="format"
               class="h-9 rounded-md border border-input bg-background text-foreground text-sm px-3 focus:outline-none focus:ring-2 focus:ring-primary"
             >
-              <option value="">No specific format</option>
+              <option value="">{{ t('book.detail.addSession.noFormat') }}</option>
               <option v-for="fmt in formats" :key="fmt" :value="fmt">{{ fmt.toUpperCase() }}</option>
             </select>
           </div>
@@ -141,14 +144,14 @@ function handleSubmit() {
               class="h-9 px-4 rounded-md border border-input bg-background text-sm text-foreground hover:bg-muted transition-colors"
               @click="handleClose"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               type="submit"
               :disabled="saving"
               class="h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {{ saving ? 'Saving...' : 'Add session' }}
+              {{ saving ? t('book.detail.addSession.saving') : t('book.detail.addSession.submit') }}
             </button>
           </div>
         </form>

--- a/client/src/features/book/components/detail/tabs/CoverEditorPanel.vue
+++ b/client/src/features/book/components/detail/tabs/CoverEditorPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, ref, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Image, ImagePlus, Link, Lock, LockOpen, Loader2, RotateCcw, Search, Upload, X } from '@lucide/vue'
 import type { BookDetail } from '@bookorbit/types'
 import { FORMAT_TO_GROUP } from '@bookorbit/types'
@@ -13,6 +14,8 @@ import CoverSearchDrawer from './CoverSearchDrawer.vue'
 
 const props = defineProps<{ book: BookDetail; locked?: boolean }>()
 const emit = defineEmits<{ coverChanged: ['extracted' | 'custom' | null]; toggleLock: [] }>()
+
+const { t } = useI18n()
 
 const bookIdRef = computed(() => props.book.id)
 const { uploading, error, previewSrc, pendingFile, pendingUrl, selectFile, setUrl, clearPending, confirm, revert } = useCoverEditor(bookIdRef)
@@ -116,7 +119,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
       <button
         type="button"
         class="absolute bottom-2 right-2 flex items-center justify-center size-6 rounded-md bg-background/90 shadow-sm border border-input hover:bg-muted transition-colors"
-        :title="props.locked ? 'Unlock cover' : 'Lock cover'"
+        :title="props.locked ? t('book.detail.coverEditor.unlockCover') : t('book.detail.coverEditor.lockCover')"
         @click.stop="emit('toggleLock')"
       >
         <Lock v-if="props.locked" class="size-3.5 text-primary/70" />
@@ -152,7 +155,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
           @click="switchMode('file')"
         >
           <ImagePlus class="size-3.5" />
-          File
+          {{ t('book.detail.coverEditor.fileTab') }}
         </button>
         <button
           class="flex flex-1 items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -161,7 +164,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
           @click="switchMode('url')"
         >
           <Link class="size-3.5" />
-          URL
+          {{ t('book.detail.coverEditor.urlTab') }}
         </button>
       </div>
 
@@ -172,7 +175,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
           :class="props.locked ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'"
         >
           <Upload class="size-3.5 shrink-0" />
-          <span class="truncate">{{ pendingFile ? pendingFile.name : 'Choose image...' }}</span>
+          <span class="truncate">{{ pendingFile ? pendingFile.name : t('book.detail.coverEditor.chooseImage') }}</span>
           <input type="file" accept="image/*" class="hidden" :disabled="props.locked" @change="onFileChange" />
         </label>
       </div>
@@ -194,7 +197,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
         @click="isSearchOpen = true"
       >
         <Search class="size-3.5" />
-        Find cover online
+        {{ t('book.detail.coverEditor.findCoverOnline') }}
       </button>
 
       <!-- Cover Search Drawer -->
@@ -218,7 +221,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
           :disabled="uploading || props.locked"
           @click="handleConfirm"
         >
-          {{ uploading ? 'Saving...' : 'Save cover' }}
+          {{ uploading ? t('book.detail.coverEditor.saving') : t('book.detail.coverEditor.saveCover') }}
         </button>
         <button
           v-if="hasPending"
@@ -226,7 +229,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
           :disabled="uploading || props.locked"
           @click="cancelPending"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           v-if="book.coverSource === 'custom'"
@@ -235,7 +238,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
           @click="handleRevert"
         >
           <RotateCcw class="size-3" />
-          Revert to original
+          {{ t('book.detail.coverEditor.revertToOriginal') }}
         </button>
         <button
           v-if="hasPermission('library_edit_metadata')"
@@ -245,7 +248,7 @@ onUnmounted(() => clearTimeout(debounceTimer))
         >
           <Loader2 v-if="reExtractingCover" class="size-3 animate-spin" />
           <Image v-else class="size-3" />
-          Regenerate Cover
+          {{ t('book.detail.coverEditor.regenerateCover') }}
         </button>
       </div>
     </div>

--- a/client/src/features/book/components/detail/tabs/CoverSearchDrawer.vue
+++ b/client/src/features/book/components/detail/tabs/CoverSearchDrawer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Search, Loader2, Image as ImageIcon, Check } from '@lucide/vue'
 import type { CoverSearchResult } from '@bookorbit/types'
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
@@ -10,6 +11,8 @@ const props = defineProps<{
   initialAuthor: string
   isAudiobook: boolean
 }>()
+
+const { t } = useI18n()
 
 const emit = defineEmits<{
   'update:open': [boolean]
@@ -84,8 +87,10 @@ function handleOpenChange(val: boolean) {
             <Search class="size-5" />
           </div>
           <div>
-            <SheetTitle class="text-sm font-semibold">Online Search</SheetTitle>
-            <SheetDescription class="text-[10px] text-muted-foreground uppercase tracking-wider font-medium">Search for book covers</SheetDescription>
+            <SheetTitle class="text-sm font-semibold">{{ t('book.detail.coverSearch.title') }}</SheetTitle>
+            <SheetDescription class="text-[10px] text-muted-foreground uppercase tracking-wider font-medium">{{
+              t('book.detail.coverSearch.subtitle')
+            }}</SheetDescription>
           </div>
         </div>
       </SheetHeader>
@@ -94,33 +99,39 @@ function handleOpenChange(val: boolean) {
       <div class="p-4 bg-muted/30 border-b space-y-3 shrink-0">
         <div class="grid grid-cols-2 md:grid-cols-3 gap-2 md:gap-3">
           <div class="space-y-1">
-            <label class="hidden md:block text-[10px] font-bold text-muted-foreground ml-1 uppercase">Title</label>
+            <label class="hidden md:block text-[10px] font-bold text-muted-foreground ml-1 uppercase">{{
+              t('book.detail.coverSearch.titleField')
+            }}</label>
             <input
               v-model="searchTitle"
               class="w-full h-9 md:h-10 rounded-lg border border-input bg-background px-3 text-sm focus:ring-2 focus:ring-primary/20 outline-none transition-all"
-              placeholder="Title"
+              :placeholder="t('book.detail.coverSearch.titleField')"
               @keyup.enter="performSearch"
             />
           </div>
           <div class="space-y-1">
-            <label class="hidden md:block text-[10px] font-bold text-muted-foreground ml-1 uppercase">Author</label>
+            <label class="hidden md:block text-[10px] font-bold text-muted-foreground ml-1 uppercase">{{
+              t('book.detail.coverSearch.authorField')
+            }}</label>
             <input
               v-model="searchAuthor"
               class="w-full h-9 md:h-10 rounded-lg border border-input bg-background px-3 text-sm focus:ring-2 focus:ring-primary/20 outline-none transition-all"
-              placeholder="Author"
+              :placeholder="t('book.detail.coverSearch.authorField')"
               @keyup.enter="performSearch"
             />
           </div>
           <div class="col-span-2 md:col-span-1 flex gap-2 md:block md:space-y-1">
             <div class="flex-1 md:space-y-1">
-              <label class="hidden md:block text-[10px] font-bold text-muted-foreground ml-1 uppercase">Source</label>
+              <label class="hidden md:block text-[10px] font-bold text-muted-foreground ml-1 uppercase">{{
+                t('book.detail.coverSearch.sourceField')
+              }}</label>
               <select
                 v-model="searchProvider"
                 class="w-full h-9 md:h-10 rounded-lg border border-input bg-background px-3 text-sm focus:ring-2 focus:ring-primary/20 outline-none transition-all"
               >
                 <option value="duckduckgo">DuckDuckGo</option>
                 <option value="itunes">iTunes</option>
-                <option value="all">All Sources</option>
+                <option value="all">{{ t('book.detail.coverSearch.allSources') }}</option>
               </select>
             </div>
             <button
@@ -144,8 +155,8 @@ function handleOpenChange(val: boolean) {
             @change="toggleAudiobookSearch"
           />
           <span class="text-xs text-muted-foreground">
-            Audiobook covers
-            <span class="text-[10px] font-semibold text-primary/70 ml-0.5">(square)</span>
+            {{ t('book.detail.coverSearch.audiobookCovers') }}
+            <span class="text-[10px] font-semibold text-primary/70 ml-0.5">{{ t('book.detail.coverSearch.squareHint') }}</span>
           </span>
         </label>
 
@@ -156,7 +167,7 @@ function handleOpenChange(val: boolean) {
         >
           <Loader2 v-if="isSearching" class="size-4 animate-spin" />
           <Search v-else class="size-4" />
-          {{ isSearching ? 'Searching...' : 'Find covers' }}
+          {{ isSearching ? t('book.detail.coverSearch.searching') : t('book.detail.coverSearch.findCovers') }}
         </button>
       </div>
 
@@ -183,7 +194,7 @@ function handleOpenChange(val: boolean) {
               <div class="p-2 rounded-full bg-primary text-white scale-75 group-hover:scale-100 transition-transform">
                 <Check class="size-5" />
               </div>
-              <span class="text-xs font-bold text-white uppercase tracking-widest">Select Cover</span>
+              <span class="text-xs font-bold text-white uppercase tracking-widest">{{ t('book.detail.coverSearch.selectCover') }}</span>
             </div>
             <div
               class="absolute top-2 right-2 px-1.5 py-0.5 rounded-md text-[10px] font-bold text-white backdrop-blur-md shadow-sm"
@@ -202,8 +213,8 @@ function handleOpenChange(val: boolean) {
             <ImageIcon class="size-10 text-muted-foreground" />
           </div>
           <div>
-            <h3 class="font-semibold">No results found</h3>
-            <p class="text-xs text-muted-foreground">Try adjusting your search terms</p>
+            <h3 class="font-semibold">{{ t('book.detail.coverSearch.noResultsTitle') }}</h3>
+            <p class="text-xs text-muted-foreground">{{ t('book.detail.coverSearch.noResultsHint') }}</p>
           </div>
         </div>
         <div v-else class="h-full flex flex-col items-center justify-center text-center space-y-3 opacity-60 py-12">
@@ -211,8 +222,8 @@ function handleOpenChange(val: boolean) {
             <Search class="size-10 text-muted-foreground" />
           </div>
           <div>
-            <h3 class="font-semibold">Ready to search</h3>
-            <p class="text-xs text-muted-foreground">Enter a title and author above</p>
+            <h3 class="font-semibold">{{ t('book.detail.coverSearch.readyTitle') }}</h3>
+            <p class="text-xs text-muted-foreground">{{ t('book.detail.coverSearch.readyHint') }}</p>
           </div>
         </div>
       </div>
@@ -221,7 +232,7 @@ function handleOpenChange(val: boolean) {
       <div class="p-4 border-t bg-muted/10 shrink-0">
         <p class="text-[11px] text-center text-muted-foreground flex items-center justify-center gap-1">
           <ImageIcon class="size-3" />
-          Tip: High resolution covers are marked in green
+          {{ t('book.detail.coverSearch.resolutionTip') }}
         </p>
       </div>
     </SheetContent>

--- a/client/src/features/book/components/detail/tabs/DetailsTab.vue
+++ b/client/src/features/book/components/detail/tabs/DetailsTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import {
   BookOpen,
@@ -80,6 +81,7 @@ type ProviderLink = {
 
 const props = defineProps<{ book: BookDetail }>()
 const emit = defineEmits<{ saved: [BookDetail] }>()
+const { t } = useI18n()
 const router = useRouter()
 
 const addToCollectionOpen = ref(false)
@@ -224,7 +226,7 @@ function scheduleGenreOverflowMeasure() {
 
 function formatCustomMetadataValue(field: CustomMetadataBookValue): string {
   if (field.value === null) return ''
-  if (field.type === 'boolean') return field.value ? 'Yes' : 'No'
+  if (field.type === 'boolean') return field.value ? t('common.yes') : t('common.no')
   return String(field.value)
 }
 
@@ -425,9 +427,9 @@ function normalizeReadStatusDates(readStatus: UserBookStatus | null | undefined)
 
 function validateReadingDates(values: { startedAt: string; finishedAt: string }): string | null {
   const { startedAt, finishedAt } = values
-  if (startedAt && startedAt > todayDateInput.value) return 'Date Started cannot be in the future.'
-  if (finishedAt && finishedAt > todayDateInput.value) return 'Date Finished cannot be in the future.'
-  if (startedAt && finishedAt && finishedAt < startedAt) return 'Date Finished must be on or after Date Started.'
+  if (startedAt && startedAt > todayDateInput.value) return t('book.detail.details.dateStartedFutureError')
+  if (finishedAt && finishedAt > todayDateInput.value) return t('book.detail.details.dateFinishedFutureError')
+  if (startedAt && finishedAt && finishedAt < startedAt) return t('book.detail.details.dateFinishedBeforeStartedError')
   return null
 }
 
@@ -519,7 +521,7 @@ async function saveReadingDateField(field: 'startedAt' | 'finishedAt') {
     applyReadStatusUpdate(updatedReadStatus)
     activeReadingDateField.value = null
   } catch {
-    readingDatesError.value = 'Failed to save reading dates.'
+    readingDatesError.value = t('book.detail.details.saveReadingDatesError')
   } finally {
     savingReadingDates.value = false
   }
@@ -753,9 +755,10 @@ const koboAnomaly = computed(() => {
   if (!canViewKobo.value) return null
   const snap = koboState.value?.snapshot
   if (!snap) return null
-  if (snap.pendingDelete) return { label: 'Pending delete from device', tooltip: 'Kobo will remove it on next sync.' }
-  if (snap.removedByDevice) return { label: 'Removed by device', tooltip: 'Kobo reported this book removed.' }
-  if (snap.synced === false) return { label: 'Not synced', tooltip: 'Queued for next Kobo sync.' }
+  if (snap.pendingDelete) return { label: t('book.detail.details.koboPendingDelete'), tooltip: t('book.detail.details.koboPendingDeleteTooltip') }
+  if (snap.removedByDevice)
+    return { label: t('book.detail.details.koboRemovedByDevice'), tooltip: t('book.detail.details.koboRemovedByDeviceTooltip') }
+  if (snap.synced === false) return { label: t('book.detail.details.koboNotSynced'), tooltip: t('book.detail.details.koboNotSyncedTooltip') }
   return null
 })
 
@@ -885,7 +888,7 @@ function setFileResetting(fileId: number, resetting: boolean): void {
 async function handleResetFileProgress(row: ProgressRow) {
   const fileId = row.resetFileId
   if (fileId == null || isResettingFile(fileId)) return
-  if (!window.confirm(`Reset stored reading progress for ${row.label}?`)) return
+  if (!window.confirm(t('book.detail.details.resetProgressConfirm', { label: row.label }))) return
 
   setFileResetting(fileId, true)
   try {
@@ -1005,9 +1008,9 @@ watch(
   <div v-if="book.status === 'missing'" class="mb-6 flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3">
     <TriangleAlert class="size-4 text-amber-500 shrink-0 mt-0.5" />
     <div>
-      <p class="text-sm font-medium text-amber-600 dark:text-amber-400">Files not found</p>
+      <p class="text-sm font-medium text-amber-600 dark:text-amber-400">{{ t('book.detail.details.filesNotFound') }}</p>
       <p class="text-xs text-muted-foreground mt-0.5">
-        The file(s) for this book can no longer be found on disk. Metadata is still available. Run a library scan to confirm, or remove the record.
+        {{ t('book.detail.details.filesNotFoundDescription') }}
       </p>
     </div>
   </div>
@@ -1045,7 +1048,7 @@ watch(
       </div>
       <!-- Identity info -->
       <div class="flex-1 min-w-0">
-        <h1 class="text-base font-bold leading-snug break-words">{{ book.title ?? 'Untitled' }}</h1>
+        <h1 class="text-base font-bold leading-snug break-words">{{ book.title ?? t('book.detail.details.untitled') }}</h1>
         <p v-if="book.subtitle" class="text-sm text-muted-foreground mt-1 leading-snug break-words">{{ book.subtitle }}</p>
 
         <div class="mt-2">
@@ -1054,7 +1057,7 @@ watch(
               <MetadataScoreBadge :score="book.metadataScore" />
             </PopoverTrigger>
             <PopoverContent class="w-72 p-4" align="start">
-              <p class="text-sm font-semibold mb-3">Metadata Score</p>
+              <p class="text-sm font-semibold mb-3">{{ t('book.detail.details.metadataScore') }}</p>
               <MetadataScoreBreakdown :book="book" :weights="scoreWeights" @edit-metadata="handleEditMetadataFromScore" />
             </PopoverContent>
           </Popover>
@@ -1063,7 +1066,7 @@ watch(
         <!-- Author / narrator / series -->
         <div class="mt-2 space-y-1 min-w-0">
           <p v-if="authorLinks.length" class="text-xs break-words">
-            <span class="text-muted-foreground">by</span>
+            <span class="text-muted-foreground">{{ t('book.detail.details.by') }}</span>
             <span class="ml-1 font-medium text-foreground">
               <template v-for="(author, index) in authorLinks" :key="`${author.id}-${index}`">
                 <RouterLink
@@ -1075,7 +1078,7 @@ watch(
             </span>
           </p>
           <p v-if="narratorLine" class="text-xs break-words">
-            <span class="text-muted-foreground">narrated by</span>
+            <span class="text-muted-foreground">{{ t('book.detail.details.narratedBy') }}</span>
             <span class="ml-1 font-medium text-foreground">{{ narratorLine }}</span>
           </p>
           <RouterLink
@@ -1103,7 +1106,9 @@ watch(
                     <Star class="size-4" :class="getRatingStarClass(star, displayRating)" />
                   </button>
                 </TooltipTrigger>
-                <TooltipContent>{{ isRatingLocked ? 'Rating is locked' : `Rate ${star}` }}</TooltipContent>
+                <TooltipContent>{{
+                  isRatingLocked ? t('book.detail.details.ratingLocked') : t('book.detail.details.rateStar', { star })
+                }}</TooltipContent>
               </Tooltip>
             </template>
             <template v-else>
@@ -1179,14 +1184,14 @@ watch(
         >
           <Headphones v-if="isPrimaryAudio" class="size-4" />
           <BookOpen v-else class="size-4" />
-          {{ isPrimaryAudio ? 'Listen' : 'Read' }}
+          {{ isPrimaryAudio ? t('book.detail.details.listen') : t('book.detail.details.read') }}
         </button>
         <div class="w-px bg-primary-foreground/20 shrink-0" />
         <Popover :open="mobileReadMenuOpen" @update:open="(v) => (mobileReadMenuOpen = v)">
           <PopoverTrigger as-child>
             <button
               class="w-8 shrink-0 flex items-center justify-center bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-              title="Choose format"
+              :title="t('book.detail.details.chooseFormat')"
             >
               <ChevronDown class="size-3.5" />
             </button>
@@ -1204,10 +1209,12 @@ watch(
                 >{{ file.format ?? '?' }}</span
               >
               <span class="flex-1 text-left text-muted-foreground text-xs truncate">
-                <template v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">Audiobook</template>
+                <template v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">{{ t('book.detail.details.audiobook') }}</template>
                 <template v-else>{{ formatFileSize(file.sizeBytes) }}</template>
               </span>
-              <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="text-[10px] text-primary font-medium shrink-0">Primary</span>
+              <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="text-[10px] text-primary font-medium shrink-0">{{
+                t('book.detail.details.primary')
+              }}</span>
             </button>
           </PopoverContent>
         </Popover>
@@ -1220,20 +1227,20 @@ watch(
       >
         <Headphones v-if="isPrimaryAudio" class="size-4" />
         <BookOpen v-else class="size-4" />
-        {{ isPrimaryAudio ? 'Listen' : 'Read' }}
+        {{ isPrimaryAudio ? t('book.detail.details.listen') : t('book.detail.details.read') }}
       </button>
       <Tooltip>
         <TooltipTrigger as-child>
           <button
             class="flex items-center justify-center h-9 w-12 rounded-md border border-input bg-background hover:bg-muted transition-colors disabled:opacity-50"
             :disabled="!primaryFile"
-            aria-label="Peek"
+            :aria-label="t('book.detail.details.peek')"
             @click="peekBook"
           >
             <Eye class="size-3.5" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Peek</TooltipContent>
+        <TooltipContent>{{ t('book.detail.details.peek') }}</TooltipContent>
       </Tooltip>
       <div v-if="hasPermission('library_download')" class="w-12 shrink-0">
         <BookDownloadButton :files="book.files" :book-id="book.id" />
@@ -1261,7 +1268,7 @@ watch(
             @click="handleSendFromMenu"
           >
             <Send class="size-3.5" />
-            Send via Email
+            {{ t('book.detail.details.sendViaEmail') }}
           </button>
           <button
             v-if="hasPermission('library_delete_books')"
@@ -1269,7 +1276,7 @@ watch(
             @click="handleDeleteFromMenu"
           >
             <Trash2 class="size-3.5" />
-            Delete
+            {{ t('common.delete') }}
           </button>
         </PopoverContent>
       </Popover>
@@ -1297,7 +1304,7 @@ watch(
                 <Pencil class="size-3" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Edit cover</TooltipContent>
+            <TooltipContent>{{ t('book.detail.details.editCover') }}</TooltipContent>
           </Tooltip>
           <BookCoverArtwork
             :src="coverSrc"
@@ -1328,14 +1335,14 @@ watch(
               >
                 <BookOpen v-if="isPrimaryAudio" class="size-4" />
                 <BookOpen v-else class="size-4" />
-                {{ isPrimaryAudio ? 'Listen' : 'Read' }}
+                {{ isPrimaryAudio ? t('book.detail.details.listen') : t('book.detail.details.read') }}
               </button>
               <div class="w-px bg-primary-foreground/20 shrink-0" />
               <Popover :open="readMenuOpen" @update:open="(v) => (readMenuOpen = v)">
                 <PopoverTrigger as-child>
                   <button
                     class="w-8 shrink-0 flex items-center justify-center bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-                    title="Choose format"
+                    :title="t('book.detail.details.chooseFormat')"
                   >
                     <ChevronDown class="size-3.5" />
                   </button>
@@ -1353,10 +1360,14 @@ watch(
                       >{{ file.format ?? '?' }}</span
                     >
                     <span class="flex-1 text-left text-muted-foreground text-xs truncate">
-                      <template v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">Audiobook</template>
+                      <template v-if="isMultiTrackAudio && FORMAT_TO_GROUP[file.format!] === 'audio'">{{
+                        t('book.detail.details.audiobook')
+                      }}</template>
                       <template v-else>{{ formatFileSize(file.sizeBytes) }}</template>
                     </span>
-                    <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="text-[10px] text-primary font-medium shrink-0">Primary</span>
+                    <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="text-[10px] text-primary font-medium shrink-0">{{
+                      t('book.detail.details.primary')
+                    }}</span>
                   </button>
                 </PopoverContent>
               </Popover>
@@ -1369,7 +1380,7 @@ watch(
             >
               <Headphones v-if="isPrimaryAudio" class="size-4" />
               <BookOpen v-else class="size-4" />
-              {{ isPrimaryAudio ? 'Listen' : 'Read' }}
+              {{ isPrimaryAudio ? t('book.detail.details.listen') : t('book.detail.details.read') }}
             </button>
 
             <Tooltip>
@@ -1377,13 +1388,13 @@ watch(
                 <button
                   class="flex items-center justify-center h-9 w-12 shrink-0 rounded-md border border-input bg-background hover:bg-muted transition-colors disabled:opacity-50"
                   :disabled="!primaryFile"
-                  aria-label="Peek"
+                  :aria-label="t('book.detail.details.peek')"
                   @click="peekBook"
                 >
                   <Eye class="size-4" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Peek</TooltipContent>
+              <TooltipContent>{{ t('book.detail.details.peek') }}</TooltipContent>
             </Tooltip>
           </div>
 
@@ -1416,7 +1427,7 @@ watch(
                   @click="handleSendFromMenu"
                 >
                   <Send class="size-3.5" />
-                  Send via Email
+                  {{ t('book.detail.details.sendViaEmail') }}
                 </button>
                 <button
                   v-if="hasPermission('library_delete_books')"
@@ -1424,7 +1435,7 @@ watch(
                   @click="handleDeleteFromMenu"
                 >
                   <Trash2 class="size-3.5" />
-                  Delete
+                  {{ t('common.delete') }}
                 </button>
               </PopoverContent>
             </Popover>
@@ -1447,23 +1458,27 @@ watch(
                 }"
               />
             </div>
-            <span v-if="row.finished" class="text-[11px] font-medium text-green-500 shrink-0">Finished</span>
+            <span v-if="row.finished" class="text-[11px] font-medium text-green-500 shrink-0">{{ t('book.detail.details.finished') }}</span>
             <span v-else class="text-[11px] text-muted-foreground shrink-0 w-7 text-right">{{ formatPercent(row.percentage) }}</span>
             <Tooltip v-if="row.resetFileId != null">
               <TooltipTrigger as-child>
                 <button
                   class="ml-1 inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label="Reset file progress"
+                  :aria-label="t('book.detail.details.resetFileProgress')"
                   :disabled="isResettingFile(row.resetFileId)"
                   @click.stop="void handleResetFileProgress(row)"
                 >
                   <RotateCcw class="size-3" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{{ isResettingFile(row.resetFileId) ? 'Resetting...' : 'Reset file progress' }}</TooltipContent>
+              <TooltipContent>{{
+                isResettingFile(row.resetFileId) ? t('book.detail.details.resetting') : t('book.detail.details.resetFileProgress')
+              }}</TooltipContent>
             </Tooltip>
           </div>
-          <p v-if="leftColumnProgressOverflow > 0" class="text-[11px] text-muted-foreground">+{{ leftColumnProgressOverflow }} more</p>
+          <p v-if="leftColumnProgressOverflow > 0" class="text-[11px] text-muted-foreground">
+            {{ t('book.detail.details.moreCount', { count: leftColumnProgressOverflow }) }}
+          </p>
         </div>
         <Tooltip v-if="koboAnomaly">
           <TooltipTrigger as-child>
@@ -1482,13 +1497,13 @@ watch(
       <div class="hidden md:block">
         <!-- Identity block -->
         <div class="flex items-center flex-wrap gap-x-3 gap-y-2 -mt-1">
-          <h1 class="text-2xl font-bold leading-tight">{{ book.title ?? 'Untitled' }}</h1>
+          <h1 class="text-2xl font-bold leading-tight">{{ book.title ?? t('book.detail.details.untitled') }}</h1>
           <Popover :open="scoreBreakdownOpen" @update:open="(v) => (scoreBreakdownOpen = v)">
             <PopoverTrigger as-child>
               <MetadataScoreBadge :score="book.metadataScore" />
             </PopoverTrigger>
             <PopoverContent class="w-72 p-4" align="start">
-              <p class="text-sm font-semibold mb-3">Metadata Score</p>
+              <p class="text-sm font-semibold mb-3">{{ t('book.detail.details.metadataScore') }}</p>
               <MetadataScoreBreakdown :book="book" :weights="scoreWeights" @edit-metadata="handleEditMetadataFromScore" />
             </PopoverContent>
           </Popover>
@@ -1497,7 +1512,7 @@ watch(
 
         <div class="flex items-baseline flex-wrap gap-x-2 gap-y-1 mt-3">
           <p v-if="authorLinks.length" class="text-sm">
-            <span class="text-muted-foreground">by</span>
+            <span class="text-muted-foreground">{{ t('book.detail.details.by') }}</span>
             <span class="ml-1 font-medium text-foreground">
               <template v-for="(author, index) in authorLinks" :key="`${author.id}-${index}`">
                 <RouterLink
@@ -1509,7 +1524,7 @@ watch(
             </span>
           </p>
           <p v-if="narratorLine" class="text-sm">
-            <span class="text-muted-foreground">narrated by</span>
+            <span class="text-muted-foreground">{{ t('book.detail.details.narratedBy') }}</span>
             <span class="ml-1 font-medium text-foreground">{{ narratorLine }}</span>
           </p>
           <template v-if="seriesLine">
@@ -1540,7 +1555,9 @@ watch(
                     <Star class="size-3.5" :class="getRatingStarClass(star, displayRating)" />
                   </button>
                 </TooltipTrigger>
-                <TooltipContent>{{ isRatingLocked ? 'Rating is locked' : `Rate ${star}` }}</TooltipContent>
+                <TooltipContent>{{
+                  isRatingLocked ? t('book.detail.details.ratingLocked') : t('book.detail.details.rateStar', { star })
+                }}</TooltipContent>
               </Tooltip>
             </template>
             <template v-else>
@@ -1555,7 +1572,7 @@ watch(
                   <Lock class="size-3" />
                 </div>
               </TooltipTrigger>
-              <TooltipContent>Rating is locked</TooltipContent>
+              <TooltipContent>{{ t('book.detail.details.ratingLocked') }}</TooltipContent>
             </Tooltip>
           </template>
 
@@ -1592,7 +1609,7 @@ watch(
             <TooltipTrigger as-child>
               <span class="size-1.5 rounded-full shrink-0" :style="{ backgroundColor: 'currentColor' }" />
             </TooltipTrigger>
-            <TooltipContent>Primary format</TooltipContent>
+            <TooltipContent>{{ t('book.detail.details.primaryFormat') }}</TooltipContent>
           </Tooltip>
           {{ fmt }}
         </span>
@@ -1604,7 +1621,7 @@ watch(
             :href="link.url"
             target="_blank"
             rel="noopener noreferrer"
-            :title="communityRatingByProvider[link.key]?.tooltip ?? `Open in ${link.label}`"
+            :title="communityRatingByProvider[link.key]?.tooltip ?? t('book.detail.details.openIn', { provider: link.label })"
             class="inline-flex h-7 items-center overflow-hidden rounded-md border transition-colors hover:bg-muted/60"
             :style="providerLinkStyle(link.key)"
           >
@@ -1670,7 +1687,7 @@ watch(
               class="text-xs font-medium text-foreground/75 hover:text-foreground transition-colors whitespace-nowrap"
               @click="genresExpanded = !genresExpanded"
             >
-              {{ genresExpanded ? 'Show less' : `+${genreHiddenCount} more` }}
+              {{ genresExpanded ? t('book.detail.details.showLess') : t('book.detail.details.moreCount', { count: genreHiddenCount }) }}
             </button>
           </div>
           <div
@@ -1703,7 +1720,7 @@ watch(
       <!-- Metadata grid -->
       <dl class="mt-5 pt-5 border-t border-border grid grid-cols-2 xl:grid-cols-4 gap-x-6 gap-y-4">
         <div class="min-w-0">
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Publisher</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.publisher') }}</dt>
           <template v-if="book.publisher">
             <Tooltip>
               <TooltipTrigger as-child>
@@ -1715,27 +1732,29 @@ watch(
           <dd v-else class="text-sm text-foreground mt-0.5">-</dd>
         </div>
         <div>
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Published</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.published') }}</dt>
           <dd class="text-sm text-foreground mt-0.5">{{ book.publishedYear || '-' }}</dd>
         </div>
         <div>
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Language</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.language') }}</dt>
           <dd class="text-sm text-foreground mt-0.5 capitalize">{{ book.language || '-' }}</dd>
         </div>
         <div>
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Pages</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.pages') }}</dt>
           <dd class="text-sm text-foreground mt-0.5">{{ book.pageCount || '-' }}</dd>
         </div>
         <div v-if="book.audioMetadata?.durationSeconds != null">
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Duration</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.duration') }}</dt>
           <dd class="text-sm text-foreground mt-0.5">{{ formatDuration(book.audioMetadata.durationSeconds) }}</dd>
         </div>
         <div v-if="book.audioMetadata?.durationSeconds != null">
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Edition</dt>
-          <dd class="text-sm text-foreground mt-0.5">{{ book.audioMetadata.abridged ? 'Abridged' : 'Unabridged' }}</dd>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.edition') }}</dt>
+          <dd class="text-sm text-foreground mt-0.5">
+            {{ book.audioMetadata.abridged ? t('book.detail.details.abridged') : t('book.detail.details.unabridged') }}
+          </dd>
         </div>
         <div class="min-w-0">
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">ISBN</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.isbn') }}</dt>
           <dd v-if="book.isbn13 || book.isbn10" class="text-sm text-foreground mt-0.5 font-mono space-y-0.5">
             <div v-if="book.isbn13">{{ book.isbn13 }}</div>
             <div v-if="book.isbn10" :class="book.isbn13 ? 'text-xs text-muted-foreground' : ''">{{ book.isbn10 }}</div>
@@ -1743,15 +1762,15 @@ watch(
           <dd v-else class="text-sm text-foreground mt-0.5">-</dd>
         </div>
         <div>
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">File Size</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.fileSize') }}</dt>
           <dd class="text-sm text-foreground mt-0.5">{{ formatFileSize(primaryFile?.sizeBytes) }}</dd>
         </div>
         <div class="min-w-0">
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Library</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.library') }}</dt>
           <dd class="text-sm text-foreground mt-0.5">{{ book.libraryName || '-' }}</dd>
         </div>
         <div class="min-w-0">
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Added</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.added') }}</dt>
           <template v-if="book.addedAt">
             <Tooltip>
               <TooltipTrigger as-child>
@@ -1764,7 +1783,7 @@ watch(
         </div>
         <HardcoverBookSyncGridItem :book-id="book.id" />
         <div class="min-w-0">
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Date Started</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.dateStarted') }}</dt>
           <template v-if="isEditingReadingDate('startedAt')">
             <dd class="mt-1">
               <div class="flex items-center gap-1.5">
@@ -1779,12 +1798,12 @@ watch(
                   :disabled="!hasReadingDateFieldChanges('startedAt') || savingReadingDates"
                   @click="saveReadingDateField('startedAt')"
                 >
-                  {{ savingReadingDates ? 'Saving...' : 'Save' }}
+                  {{ savingReadingDates ? t('book.detail.details.saving') : t('common.save') }}
                 </button>
                 <button
                   class="inline-flex h-6 w-6 items-center justify-center rounded border border-destructive/30 text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
-                  title="Cancel date started edit"
-                  aria-label="Cancel date started edit"
+                  :title="t('book.detail.details.cancelDateStartedEdit')"
+                  :aria-label="t('book.detail.details.cancelDateStartedEdit')"
                   :disabled="savingReadingDates"
                   @click="cancelReadingDateEdit('startedAt')"
                 >
@@ -1798,7 +1817,7 @@ watch(
             <span class="text-sm text-foreground">{{ formatDisplayDate(savedReadingDates.startedAt) }}</span>
             <button
               class="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
-              title="Edit date started"
+              :title="t('book.detail.details.editDateStarted')"
               :disabled="isEditingAnyReadingDate || savingReadingDates"
               @click="startEditingReadingDate('startedAt')"
             >
@@ -1807,7 +1826,7 @@ watch(
           </dd>
         </div>
         <div class="min-w-0">
-          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Date Finished</dt>
+          <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('book.detail.details.dateFinished') }}</dt>
           <template v-if="isEditingReadingDate('finishedAt')">
             <dd class="mt-1">
               <div class="flex items-center gap-1.5">
@@ -1822,12 +1841,12 @@ watch(
                   :disabled="!hasReadingDateFieldChanges('finishedAt') || savingReadingDates"
                   @click="saveReadingDateField('finishedAt')"
                 >
-                  {{ savingReadingDates ? 'Saving...' : 'Save' }}
+                  {{ savingReadingDates ? t('book.detail.details.saving') : t('common.save') }}
                 </button>
                 <button
                   class="inline-flex h-6 w-6 items-center justify-center rounded border border-destructive/30 text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
-                  title="Cancel date finished edit"
-                  aria-label="Cancel date finished edit"
+                  :title="t('book.detail.details.cancelDateFinishedEdit')"
+                  :aria-label="t('book.detail.details.cancelDateFinishedEdit')"
                   :disabled="savingReadingDates"
                   @click="cancelReadingDateEdit('finishedAt')"
                 >
@@ -1841,7 +1860,7 @@ watch(
             <span class="text-sm text-foreground">{{ formatDisplayDate(savedReadingDates.finishedAt) }}</span>
             <button
               class="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
-              title="Edit date finished"
+              :title="t('book.detail.details.editDateFinished')"
               :disabled="isEditingAnyReadingDate || savingReadingDates"
               @click="startEditingReadingDate('finishedAt')"
             >
@@ -1870,23 +1889,27 @@ watch(
                 }"
               />
             </div>
-            <span v-if="row.finished" class="text-[11px] font-medium text-green-500 shrink-0">Finished</span>
+            <span v-if="row.finished" class="text-[11px] font-medium text-green-500 shrink-0">{{ t('book.detail.details.finished') }}</span>
             <span v-else class="text-[11px] text-muted-foreground shrink-0 w-7 text-right">{{ formatPercent(row.percentage) }}</span>
             <Tooltip v-if="row.resetFileId != null">
               <TooltipTrigger as-child>
                 <button
                   class="ml-1 inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label="Reset file progress"
+                  :aria-label="t('book.detail.details.resetFileProgress')"
                   :disabled="isResettingFile(row.resetFileId)"
                   @click.stop="void handleResetFileProgress(row)"
                 >
                   <RotateCcw class="size-3" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{{ isResettingFile(row.resetFileId) ? 'Resetting...' : 'Reset file progress' }}</TooltipContent>
+              <TooltipContent>{{
+                isResettingFile(row.resetFileId) ? t('book.detail.details.resetting') : t('book.detail.details.resetFileProgress')
+              }}</TooltipContent>
             </Tooltip>
           </div>
-          <p v-if="leftColumnProgressOverflow > 0" class="text-[11px] text-muted-foreground">+{{ leftColumnProgressOverflow }} more</p>
+          <p v-if="leftColumnProgressOverflow > 0" class="text-[11px] text-muted-foreground">
+            {{ t('book.detail.details.moreCount', { count: leftColumnProgressOverflow }) }}
+          </p>
         </div>
         <Tooltip v-if="koboAnomaly">
           <TooltipTrigger as-child>
@@ -1900,7 +1923,7 @@ watch(
       </div>
 
       <div v-if="filledCustomMetadata.length > 0" class="mt-6 pt-5 border-t border-border">
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-3">Custom Metadata</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-3">{{ t('book.detail.details.customMetadata') }}</p>
         <dl class="grid gap-3 sm:grid-cols-2">
           <div v-for="field in filledCustomMetadata" :key="field.fieldId" class="min-w-0">
             <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ field.label }}</dt>
@@ -1922,7 +1945,7 @@ watch(
 
       <!-- Synopsis -->
       <div class="mt-6 pt-5 border-t border-border">
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-3">Synopsis</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-3">{{ t('book.detail.details.synopsis') }}</p>
         <div v-if="book.description">
           <div
             class="text-sm leading-relaxed text-foreground/80 transition-all"
@@ -1933,10 +1956,10 @@ watch(
             class="text-xs text-muted-foreground hover:text-foreground mt-2 transition-colors"
             @click="descriptionExpanded = !descriptionExpanded"
           >
-            {{ descriptionExpanded ? 'Show less' : 'Show more' }}
+            {{ descriptionExpanded ? t('book.detail.details.showLess') : t('book.detail.details.showMore') }}
           </button>
         </div>
-        <p v-else class="text-sm text-muted-foreground italic">No description available.</p>
+        <p v-else class="text-sm text-muted-foreground italic">{{ t('book.detail.details.noDescription') }}</p>
       </div>
     </div>
   </div>

--- a/client/src/features/book/components/detail/tabs/EditMetadataTab.vue
+++ b/client/src/features/book/components/detail/tabs/EditMetadataTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Check, ChevronDown, FileCheck, HardDriveDownload, HardDriveUpload, Loader2, Lock, LockOpen, RefreshCw, Sparkles, Star, X } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import type {
@@ -47,6 +48,8 @@ const emit = defineEmits<{
   coverChanged: ['extracted' | 'custom' | null]
   fileRenamed: []
 }>()
+
+const { t } = useI18n()
 
 const DIRECT_PATCH_FIELDS = [
   'title',
@@ -99,35 +102,37 @@ const fileWriteEnabledForBook = computed(() => fileWriteStatus.value?.enabled ==
 const fileWriteWritableFormats = computed(() => fileWriteStatus.value?.writableFormats ?? [])
 const fileWriteFormatLabels = computed(() => fileWriteWritableFormats.value.map((format) => format.toUpperCase()))
 const fileWriteFieldLabels = computed(() => (fileWriteStatus.value?.writableFields ?? []).map((field) => BOOK_FILE_WRITE_FIELD_LABELS[field]))
-const fileWriteFieldCountLabel = computed(() => `${fileWriteFieldLabels.value.length} field${fileWriteFieldLabels.value.length === 1 ? '' : 's'}`)
+const fileWriteFieldCountLabel = computed(() =>
+  t('book.detail.editMetadata.fieldCount', { count: fileWriteFieldLabels.value.length }, fileWriteFieldLabels.value.length),
+)
 const fileWriteTargetSummary = computed(() => {
   const formats = fileWriteWritableFormats.value
-  if (formats.length === 0) return 'book files'
-  return `${formatWritableFormatList(formats)} files`
+  if (formats.length === 0) return t('book.detail.editMetadata.bookFilesTarget')
+  return t('book.detail.editMetadata.formatFilesTarget', { formats: formatWritableFormatList(formats) })
 })
 const fileWriteManualDisabledReasonLabel = computed(() => {
-  if (!primaryFile.value) return 'No primary file available'
+  if (!primaryFile.value) return t('book.detail.editMetadata.noPrimaryFile')
   switch (fileWriteStatus.value?.reason) {
     case 'no_primary_file':
-      return 'No primary file available'
+      return t('book.detail.editMetadata.noPrimaryFile')
     case 'format_not_supported':
-      return 'This file format does not support write-back'
+      return t('book.detail.editMetadata.formatNotSupported')
     case 'format_disabled':
-      return 'Write-back is disabled for this format'
+      return t('book.detail.editMetadata.formatDisabled')
     case 'file_exceeds_size_limit':
-      return 'This file exceeds the write-back size limit'
+      return t('book.detail.editMetadata.fileExceedsSizeLimit')
     default:
       return null
   }
 })
 const fileWriteManualTooltip = computed(() => {
-  if (writingAndRenaming.value) return 'Writing...'
-  if (saving.value) return 'Save in progress'
+  if (writingAndRenaming.value) return t('book.detail.editMetadata.writing')
+  if (saving.value) return t('book.detail.editMetadata.saveInProgress')
   if (fileWriteManualDisabledReasonLabel.value) return fileWriteManualDisabledReasonLabel.value
   if (fileWriteStatus.value?.reason === 'library_disabled') {
-    return 'Write metadata to file and rename now; automatic write-back is disabled for this library'
+    return t('book.detail.editMetadata.writeManualLibraryDisabled')
   }
-  return `Write ${fileWriteFieldCountLabel.value} to ${fileWriteTargetSummary.value} and rename if pattern is set`
+  return t('book.detail.editMetadata.writeManualTooltip', { fields: fileWriteFieldCountLabel.value, target: fileWriteTargetSummary.value })
 })
 const comicSectionOpen = ref(true)
 
@@ -487,9 +492,9 @@ function applyPatchToForm(formPatch: MetadataPatch, coverUrl: string | undefined
 
 function showApplyResult(skippedFields: BookMetadataLockField[], updatedCount: number) {
   if (skippedFields.length === 0) return
-  const skippedPart = `Skipped ${skippedFields.length} locked field${skippedFields.length === 1 ? '' : 's'}`
-  const updatedPart = `updated ${updatedCount} field${updatedCount === 1 ? '' : 's'}`
-  toast.info(`${skippedPart}, ${updatedPart}`)
+  const skippedPart = t('book.detail.editMetadata.skippedLockedFields', { count: skippedFields.length }, skippedFields.length)
+  const updatedPart = t('book.detail.editMetadata.updatedFields', { count: updatedCount }, updatedCount)
+  toast.info(t('book.detail.editMetadata.applyResult', { skipped: skippedPart, updated: updatedPart }))
 }
 
 function handleApply({ formPatch, coverUrl }: { formPatch: MetadataPatch; coverUrl?: string }) {
@@ -509,7 +514,7 @@ const {
 let dismissTimer: ReturnType<typeof setTimeout> | null = null
 
 function pluralizeField(count: number): string {
-  return `${count} field${count === 1 ? '' : 's'}`
+  return t('book.detail.editMetadata.fieldCount', { count }, count)
 }
 
 function truncateReason(reason: string | null | undefined): string {
@@ -519,37 +524,37 @@ function truncateReason(reason: string | null | undefined): string {
 
 function showWriteResultToast(result: Pick<WriteResult, 'status' | 'fieldsWritten' | 'reason'>): void {
   if (result.status === 'success') {
-    toast.success(`Wrote ${pluralizeField(result.fieldsWritten.length)} to file`)
+    toast.success(t('book.detail.editMetadata.wroteFieldsToFile', { fields: pluralizeField(result.fieldsWritten.length) }))
     return
   }
 
   const reason = truncateReason(result.reason)
   if (result.status === 'failed') {
-    toast.error(reason ? `File write failed: ${reason}` : 'File write failed')
+    toast.error(reason ? t('book.detail.editMetadata.fileWriteFailedReason', { reason }) : t('book.detail.editMetadata.fileWriteFailed'))
     return
   }
 
-  toast.info(reason ? `File write skipped: ${reason}` : 'File write skipped')
+  toast.info(reason ? t('book.detail.editMetadata.fileWriteSkippedReason', { reason }) : t('book.detail.editMetadata.fileWriteSkipped'))
 }
 
 function showSaveResultToast(write: WriteResult | null, libraryAutoWriteEnabled: boolean): void {
   if (!write || (!libraryAutoWriteEnabled && write.status === 'skipped')) {
-    toast.success('Metadata saved')
+    toast.success(t('book.detail.editMetadata.metadataSaved'))
     return
   }
 
   if (write.status === 'success') {
-    toast.success('Metadata written to file')
+    toast.success(t('book.detail.editMetadata.metadataWrittenToFile'))
     return
   }
 
   const reason = truncateReason(write.reason)
   if (write.status === 'failed') {
-    toast.error(reason ? `Metadata saved, but file write failed: ${reason}` : 'Metadata saved, but file write failed')
+    toast.error(reason ? t('book.detail.editMetadata.savedButWriteFailedReason', { reason }) : t('book.detail.editMetadata.savedButWriteFailed'))
     return
   }
 
-  toast.info(reason ? `Metadata saved, file write skipped: ${reason}` : 'Metadata saved, file write skipped')
+  toast.info(reason ? t('book.detail.editMetadata.savedWriteSkippedReason', { reason }) : t('book.detail.editMetadata.savedWriteSkipped'))
 }
 
 function buildPreviewPatch(preview: MetadataRefreshPreview): MetadataPatch {
@@ -609,11 +614,11 @@ function applyFileMetadataToForm(meta: FileMetadata): number {
 async function handleLoadFromFile() {
   const meta = await loadFromFile(props.book.id)
   if (!meta) {
-    toast.error('Failed to load metadata from file')
+    toast.error(t('book.detail.editMetadata.loadFromFileFailed'))
     return
   }
   const count = applyFileMetadataToForm(meta)
-  toast.info(count > 0 ? `Loaded ${count} field${count === 1 ? '' : 's'} from file` : 'No metadata found in file')
+  toast.info(count > 0 ? t('book.detail.editMetadata.loadedFieldsFromFile', { count }, count) : t('book.detail.editMetadata.noMetadataInFile'))
 }
 
 async function handleWriteAndRename() {
@@ -703,11 +708,15 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               >
                 <Loader2 v-if="loadingFromFile" class="size-3.5 animate-spin" />
                 <HardDriveUpload v-else class="size-3.5" />
-                <span class="hidden sm:inline">Load from file</span>
+                <span class="hidden sm:inline">{{ t('book.detail.editMetadata.loadFromFile') }}</span>
               </button>
             </TooltipTrigger>
             <TooltipContent>{{
-              loadingFromFile ? 'Loading...' : !primaryFile ? 'No primary file available' : 'Load metadata from the primary book file'
+              loadingFromFile
+                ? t('common.loading')
+                : !primaryFile
+                  ? t('book.detail.editMetadata.noPrimaryFile')
+                  : t('book.detail.editMetadata.loadFromFileTooltip')
             }}</TooltipContent>
           </Tooltip>
 
@@ -720,7 +729,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               >
                 <Loader2 v-if="writingAndRenaming" class="size-3.5 animate-spin" />
                 <HardDriveDownload v-else class="size-3.5" />
-                <span class="hidden sm:inline">Write to file</span>
+                <span class="hidden sm:inline">{{ t('book.detail.editMetadata.writeToFile') }}</span>
               </button>
             </TooltipTrigger>
             <TooltipContent>{{ fileWriteManualTooltip }}</TooltipContent>
@@ -733,7 +742,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
             @click="searchOpen = true"
           >
             <Sparkles class="size-3.5" />
-            <span class="hidden sm:inline">Search</span>
+            <span class="hidden sm:inline">{{ t('common.search') }}</span>
           </button>
 
           <Tooltip>
@@ -745,11 +754,15 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               >
                 <Loader2 v-if="autoFilling" class="size-3.5 animate-spin" />
                 <RefreshCw v-else class="size-3.5" />
-                <span class="hidden sm:inline">Auto-fill</span>
+                <span class="hidden sm:inline">{{ t('book.detail.editMetadata.autoFill') }}</span>
               </button>
             </TooltipTrigger>
             <TooltipContent>{{
-              autoFilling ? 'Fetching metadata...' : areAllLocked ? 'All fields are locked' : 'Auto-fill fields using your metadata preferences'
+              autoFilling
+                ? t('book.detail.editMetadata.fetchingMetadata')
+                : areAllLocked
+                  ? t('book.detail.editMetadata.allFieldsLocked')
+                  : t('book.detail.editMetadata.autoFillTooltip')
             }}</TooltipContent>
           </Tooltip>
 
@@ -763,10 +776,10 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
                 @click="handleLockAll"
               >
                 <Lock class="size-3.5" />
-                <span class="hidden sm:inline">Lock all</span>
+                <span class="hidden sm:inline">{{ t('book.detail.editMetadata.lockAll') }}</span>
               </button>
             </TooltipTrigger>
-            <TooltipContent>Lock all fields</TooltipContent>
+            <TooltipContent>{{ t('book.detail.editMetadata.lockAllTooltip') }}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -777,18 +790,18 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
                 @click="handleUnlockAll"
               >
                 <LockOpen class="size-3.5" />
-                <span class="hidden sm:inline">Unlock all</span>
+                <span class="hidden sm:inline">{{ t('book.detail.editMetadata.unlockAll') }}</span>
               </button>
             </TooltipTrigger>
-            <TooltipContent>Unlock all fields</TooltipContent>
+            <TooltipContent>{{ t('book.detail.editMetadata.unlockAllTooltip') }}</TooltipContent>
           </Tooltip>
 
           <div class="flex-none w-px h-4 bg-border mx-0.5" />
 
           <button
             class="flex items-center justify-center h-8 px-2.5 rounded-lg border border-input bg-background text-sm hover:bg-muted transition-colors disabled:opacity-40"
-            title="Cancel"
-            aria-label="Cancel"
+            :title="t('common.cancel')"
+            :aria-label="t('common.cancel')"
             :disabled="!hasPendingChanges || saving || writingAndRenaming"
             @click="handleReset"
           >
@@ -801,14 +814,14 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           >
             <Loader2 v-if="saving" class="size-3.5 animate-spin" />
             <Check v-else class="size-3.5" />
-            <span class="hidden sm:inline">{{ saving ? 'Saving...' : 'Save' }}</span>
+            <span class="hidden sm:inline">{{ saving ? t('book.detail.editMetadata.saving') : t('common.save') }}</span>
           </button>
           <Popover v-if="fileWriteEnabledForBook">
             <PopoverTrigger as-child>
               <button
                 type="button"
                 class="flex-none inline-flex size-8 items-center justify-center rounded-lg border border-border bg-muted/40 text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                aria-label="File write-back details"
+                :aria-label="t('book.detail.editMetadata.fileWriteBackDetails')"
               >
                 <FileCheck class="size-3.5 text-primary" />
               </button>
@@ -821,18 +834,20 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
                   </span>
                   <div class="min-w-0 flex-1 space-y-1">
                     <div class="flex items-center justify-between gap-2">
-                      <p class="text-sm font-semibold text-foreground">File write-back</p>
+                      <p class="text-sm font-semibold text-foreground">{{ t('book.detail.editMetadata.fileWriteBack') }}</p>
                       <span class="rounded-full border border-primary/20 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase text-primary">
-                        Enabled
+                        {{ t('book.detail.editMetadata.enabled') }}
                       </span>
                     </div>
-                    <p class="text-xs leading-5 text-muted-foreground">'Save' writes metadata to {{ fileWriteTargetSummary }}</p>
+                    <p class="text-xs leading-5 text-muted-foreground">
+                      {{ t('book.detail.editMetadata.saveWritesMetadata', { target: fileWriteTargetSummary }) }}
+                    </p>
                   </div>
                 </div>
 
                 <div class="space-y-2 rounded-lg border border-border bg-muted/30 p-2.5 text-xs">
                   <div class="flex items-start justify-between gap-3">
-                    <span class="shrink-0 text-muted-foreground">Formats</span>
+                    <span class="shrink-0 text-muted-foreground">{{ t('book.detail.editMetadata.formats') }}</span>
                     <div v-if="fileWriteFormatLabels.length > 0" class="flex min-w-0 flex-wrap justify-end gap-1">
                       <span
                         v-for="format in fileWriteFormatLabels"
@@ -842,11 +857,11 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
                         {{ format }}
                       </span>
                     </div>
-                    <span v-else class="text-right font-medium text-foreground">Book files</span>
+                    <span v-else class="text-right font-medium text-foreground">{{ t('book.detail.editMetadata.bookFiles') }}</span>
                   </div>
                   <div class="space-y-1.5 border-t border-border/70 pt-2">
                     <div class="flex items-center justify-between gap-3">
-                      <span class="text-muted-foreground">Supported fields</span>
+                      <span class="text-muted-foreground">{{ t('book.detail.editMetadata.supportedFields') }}</span>
                       <span class="font-medium text-foreground">{{ fileWriteFieldCountLabel }}</span>
                     </div>
                     <div v-if="fileWriteFieldLabels.length > 0" class="flex max-h-28 flex-wrap gap-1 overflow-y-auto pr-1">
@@ -884,7 +899,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
       <div class="grid grid-cols-1 sm:grid-cols-4 gap-3">
         <MetadataFieldLabel
           class="sm:col-span-3"
-          label="Title"
+          :label="t('book.detail.editMetadata.titleLabel')"
           field="title"
           :locked="isLocked('title')"
           :is-updating="isUpdatingLock"
@@ -896,7 +911,13 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
             :disabled="isLocked('title')"
           />
         </MetadataFieldLabel>
-        <MetadataFieldLabel label="Subtitle" field="subtitle" :locked="isLocked('subtitle')" :is-updating="isUpdatingLock" @toggle="handleLockToggle">
+        <MetadataFieldLabel
+          :label="t('book.detail.editMetadata.subtitleLabel')"
+          field="subtitle"
+          :locked="isLocked('subtitle')"
+          :is-updating="isUpdatingLock"
+          @toggle="handleLockToggle"
+        >
           <input
             v-model="form.subtitle"
             class="w-full h-8 rounded-lg border border-input bg-background px-3 pr-12 text-sm outline-none focus:ring-1 focus:ring-ring transition-shadow disabled:opacity-50 disabled:cursor-not-allowed"
@@ -908,7 +929,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
       <!-- Authors | Narrators (audio only) -->
       <div class="grid gap-3" :class="isPrimaryAudio ? 'grid-cols-1 sm:grid-cols-2' : 'grid-cols-1'">
         <MetadataFieldLabel
-          label="Authors"
+          :label="t('book.detail.editMetadata.authorsLabel')"
           field="authors"
           :locked="isLocked('authors')"
           :is-updating="isUpdatingLock"
@@ -919,7 +940,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
         </MetadataFieldLabel>
         <MetadataFieldLabel
           v-if="isPrimaryAudio"
-          label="Narrators"
+          :label="t('book.detail.editMetadata.narratorsLabel')"
           field="narrators"
           :locked="isLocked('narrators')"
           :is-updating="isUpdatingLock"
@@ -932,7 +953,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
 
       <!-- Genres -->
       <MetadataFieldLabel
-        label="Genres"
+        :label="t('book.detail.editMetadata.genresLabel')"
         field="genres"
         :locked="isLocked('genres')"
         :is-updating="isUpdatingLock"
@@ -946,7 +967,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
       <div class="flex flex-col sm:flex-row items-start gap-3">
         <MetadataFieldLabel
           class="w-full sm:flex-1"
-          label="Tags"
+          :label="t('book.detail.editMetadata.tagsLabel')"
           field="tags"
           :locked="isLocked('tags')"
           :is-updating="isUpdatingLock"
@@ -957,7 +978,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
         </MetadataFieldLabel>
         <MetadataFieldLabel
           class="w-full sm:w-auto sm:shrink-0"
-          label="Rating"
+          :label="t('book.detail.editMetadata.ratingLabel')"
           field="rating"
           :locked="isLocked('rating')"
           :is-updating="isUpdatingLock"
@@ -980,7 +1001,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
                   <Star class="size-5 sm:size-4" :class="getRatingStarClass(star, displayRating)" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Rate {{ star }}</TooltipContent>
+              <TooltipContent>{{ t('book.detail.editMetadata.rateStar', { star }) }}</TooltipContent>
             </Tooltip>
             <button
               v-if="form.rating"
@@ -989,14 +1010,14 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               :disabled="isLocked('rating')"
               @click="clearRating"
             >
-              Clear
+              {{ t('book.detail.editMetadata.clear') }}
             </button>
           </div>
         </MetadataFieldLabel>
       </div>
 
       <MetadataFieldLabel
-        label="Community Ratings"
+        :label="t('book.detail.editMetadata.communityRatingsLabel')"
         field="communityRating"
         :locked="isLocked('communityRating')"
         :is-updating="isUpdatingLock"
@@ -1014,14 +1035,14 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               {{ line }}
             </span>
           </div>
-          <span v-else class="text-sm text-muted-foreground">No provider ratings</span>
+          <span v-else class="text-sm text-muted-foreground">{{ t('book.detail.editMetadata.noProviderRatings') }}</span>
         </div>
       </MetadataFieldLabel>
 
       <!-- Series | Publisher -->
       <div class="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_minmax(12rem,18rem)] gap-3">
         <MetadataFieldLabel
-          label="Series"
+          :label="t('book.detail.editMetadata.seriesLabel')"
           field="seriesName"
           :locked="isSeriesLocked"
           :is-updating="isUpdatingLock"
@@ -1037,7 +1058,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           />
         </MetadataFieldLabel>
         <MetadataFieldLabel
-          label="Publisher"
+          :label="t('book.detail.editMetadata.publisherLabel')"
           field="publisher"
           :locked="isLocked('publisher')"
           :is-updating="isUpdatingLock"
@@ -1056,7 +1077,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
       <div class="grid grid-cols-2 sm:flex sm:flex-wrap gap-3">
         <MetadataFieldLabel
           class="col-span-2 sm:w-32 sm:shrink-0"
-          label="Language"
+          :label="t('book.detail.editMetadata.languageLabel')"
           field="language"
           :locked="isLocked('language')"
           :is-updating="isUpdatingLock"
@@ -1072,7 +1093,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
         </MetadataFieldLabel>
         <MetadataFieldLabel
           class="sm:w-28 sm:shrink-0"
-          label="Year"
+          :label="t('book.detail.editMetadata.yearLabel')"
           field="publishedYear"
           :locked="isLocked('publishedYear')"
           :is-updating="isUpdatingLock"
@@ -1090,7 +1111,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
         </MetadataFieldLabel>
         <MetadataFieldLabel
           class="sm:w-28 sm:shrink-0"
-          label="Page Count"
+          :label="t('book.detail.editMetadata.pageCountLabel')"
           field="pageCount"
           :locked="isLocked('pageCount')"
           :is-updating="isUpdatingLock"
@@ -1107,7 +1128,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
         </MetadataFieldLabel>
         <MetadataFieldLabel
           class="sm:flex-1 sm:min-w-22.5"
-          label="ISBN-13"
+          :label="t('book.detail.editMetadata.isbn13Label')"
           field="isbn13"
           :locked="isLocked('isbn13')"
           :is-updating="isUpdatingLock"
@@ -1122,7 +1143,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
         </MetadataFieldLabel>
         <MetadataFieldLabel
           class="sm:flex-1 sm:min-w-21.25"
-          label="ISBN-10"
+          :label="t('book.detail.editMetadata.isbn10Label')"
           field="isbn10"
           :locked="isLocked('isbn10')"
           :is-updating="isUpdatingLock"
@@ -1138,7 +1159,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
         <MetadataFieldLabel
           v-if="isPrimaryAudio"
           class="sm:w-30 sm:shrink-0"
-          label="Duration (s)"
+          :label="t('book.detail.editMetadata.durationLabel')"
           field="durationSeconds"
           :locked="isLocked('durationSeconds')"
           :is-updating="isUpdatingLock"
@@ -1156,7 +1177,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
         <MetadataFieldLabel
           v-if="isPrimaryAudio"
           class="sm:w-20 sm:shrink-0"
-          label="Abridged"
+          :label="t('book.detail.editMetadata.abridgedLabel')"
           field="abridged"
           :locked="isLocked('abridged')"
           :is-updating="isUpdatingLock"
@@ -1171,7 +1192,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               v-model="form.abridged"
               type="checkbox"
               class="h-4 w-4 rounded border-input accent-primary"
-              aria-label="Abridged"
+              :aria-label="t('book.detail.editMetadata.abridgedLabel')"
               :disabled="isLocked('abridged')"
             />
           </div>
@@ -1185,7 +1206,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           class="w-full flex items-center justify-between px-3 py-2 bg-muted/40 hover:bg-muted/70 transition-colors"
           @click="providerIdsOpen = !providerIdsOpen"
         >
-          <span class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Provider IDs</span>
+          <span class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('book.detail.editMetadata.providerIds') }}</span>
           <ChevronDown class="size-3.5 text-muted-foreground transition-transform" :class="providerIdsOpen ? 'rotate-180' : ''" />
         </button>
         <div v-if="providerIdsOpen" class="p-3">
@@ -1210,14 +1231,14 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           class="w-full flex items-center justify-between px-3 py-2 bg-muted/40 hover:bg-muted/70 transition-colors"
           @click="toggleComicSection"
         >
-          <span class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Comic Details</span>
+          <span class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('book.detail.editMetadata.comicDetails') }}</span>
           <ChevronDown class="size-3.5 text-muted-foreground transition-transform" :class="comicSectionOpen ? 'rotate-180' : ''" />
         </button>
         <div v-if="comicSectionOpen" class="p-3 space-y-3">
           <!-- Issue Number | Volume -->
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <MetadataFieldLabel
-              label="Issue Number"
+              :label="t('book.detail.editMetadata.comicIssueNumberLabel')"
               field="comicIssueNumber"
               :locked="isLocked('comicIssueNumber')"
               :is-updating="isUpdatingLock"
@@ -1230,7 +1251,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               />
             </MetadataFieldLabel>
             <MetadataFieldLabel
-              label="Volume"
+              :label="t('book.detail.editMetadata.comicVolumeLabel')"
               field="comicVolumeName"
               :locked="isLocked('comicVolumeName')"
               :is-updating="isUpdatingLock"
@@ -1245,7 +1266,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           </div>
           <!-- Story Arcs -->
           <MetadataFieldLabel
-            label="Story Arcs"
+            :label="t('book.detail.editMetadata.comicStoryArcsLabel')"
             field="comicStoryArcs"
             :locked="isLocked('comicStoryArcs')"
             :is-updating="isUpdatingLock"
@@ -1257,7 +1278,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           <!-- Pencillers | Inkers -->
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <MetadataFieldLabel
-              label="Pencillers"
+              :label="t('book.detail.editMetadata.comicPencillersLabel')"
               field="comicPencillers"
               :locked="isLocked('comicPencillers')"
               :is-updating="isUpdatingLock"
@@ -1272,7 +1293,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               />
             </MetadataFieldLabel>
             <MetadataFieldLabel
-              label="Inkers"
+              :label="t('book.detail.editMetadata.comicInkersLabel')"
               field="comicInkers"
               :locked="isLocked('comicInkers')"
               :is-updating="isUpdatingLock"
@@ -1285,7 +1306,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           <!-- Colorists | Letterers -->
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <MetadataFieldLabel
-              label="Colorists"
+              :label="t('book.detail.editMetadata.comicColoristsLabel')"
               field="comicColorists"
               :locked="isLocked('comicColorists')"
               :is-updating="isUpdatingLock"
@@ -1300,7 +1321,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               />
             </MetadataFieldLabel>
             <MetadataFieldLabel
-              label="Letterers"
+              :label="t('book.detail.editMetadata.comicLetterersLabel')"
               field="comicLetterers"
               :locked="isLocked('comicLetterers')"
               :is-updating="isUpdatingLock"
@@ -1317,7 +1338,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           </div>
           <!-- Cover Artists -->
           <MetadataFieldLabel
-            label="Cover Artists"
+            :label="t('book.detail.editMetadata.comicCoverArtistsLabel')"
             field="comicCoverArtists"
             :locked="isLocked('comicCoverArtists')"
             :is-updating="isUpdatingLock"
@@ -1334,7 +1355,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           <!-- Characters | Teams -->
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <MetadataFieldLabel
-              label="Characters"
+              :label="t('book.detail.editMetadata.comicCharactersLabel')"
               field="comicCharacters"
               :locked="isLocked('comicCharacters')"
               :is-updating="isUpdatingLock"
@@ -1349,7 +1370,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
               />
             </MetadataFieldLabel>
             <MetadataFieldLabel
-              label="Teams"
+              :label="t('book.detail.editMetadata.comicTeamsLabel')"
               field="comicTeams"
               :locked="isLocked('comicTeams')"
               :is-updating="isUpdatingLock"
@@ -1361,7 +1382,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           </div>
           <!-- Locations -->
           <MetadataFieldLabel
-            label="Locations"
+            :label="t('book.detail.editMetadata.comicLocationsLabel')"
             field="comicLocations"
             :locked="isLocked('comicLocations')"
             :is-updating="isUpdatingLock"
@@ -1375,7 +1396,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
 
       <div v-if="form.customMetadata.length > 0" class="rounded-lg border border-border overflow-hidden">
         <div class="px-3 py-2 bg-muted/40">
-          <span class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Custom Metadata</span>
+          <span class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('book.detail.editMetadata.customMetadata') }}</span>
         </div>
         <div class="grid grid-cols-1 gap-3 p-3 sm:grid-cols-2">
           <label v-for="field in form.customMetadata" :key="field.fieldId" class="space-y-1">
@@ -1416,7 +1437,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
 
       <!-- Description -->
       <MetadataFieldLabel
-        label="Description"
+        :label="t('book.detail.editMetadata.descriptionLabel')"
         field="description"
         :locked="isLocked('description')"
         :is-updating="isUpdatingLock"
@@ -1436,7 +1457,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
           @click="handleReset"
         >
           <X class="size-3.5" />
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           class="flex flex-1 items-center justify-center gap-1.5 h-9 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-40"
@@ -1445,7 +1466,7 @@ function handleCoverChanged(source: 'extracted' | 'custom' | null) {
         >
           <Loader2 v-if="saving" class="size-3.5 animate-spin" />
           <Check v-else class="size-3.5" />
-          {{ saving ? 'Saving...' : 'Save' }}
+          {{ saving ? t('book.detail.editMetadata.saving') : t('common.save') }}
         </button>
       </div>
     </div>

--- a/client/src/features/book/components/detail/tabs/FilesTab.vue
+++ b/client/src/features/book/components/detail/tabs/FilesTab.vue
@@ -2,6 +2,7 @@
 import { ref, watch, computed } from 'vue'
 import { useLocalStorage } from '@vueuse/core'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { BookOpen, Download, Eye, FilePlus, Files, Headphones, History, FolderOpen, ArrowUpDown, MoreVertical } from '@lucide/vue'
 import type { BookDetail, BookDetailFile, WriteLogEntry } from '@bookorbit/types'
 import { Permission, READER_OPENABLE_FORMATS } from '@bookorbit/types'
@@ -15,6 +16,7 @@ import AddBookFileModal from './AddBookFileModal.vue'
 
 const props = defineProps<{ book: BookDetail }>()
 const emit = defineEmits<{ refetch: [] }>()
+const { t } = useI18n()
 const router = useRouter()
 
 const { downloadFile: downloadBookFile } = useBookDownload()
@@ -96,13 +98,13 @@ function formatDate(iso: string): string {
 function formatRelative(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
   const s = Math.floor(diff / 1000)
-  if (s < 60) return `${s}s ago`
+  if (s < 60) return t('book.detail.files.relative.seconds', { value: s })
   const m = Math.floor(s / 60)
-  if (m < 60) return `${m}m ago`
+  if (m < 60) return t('book.detail.files.relative.minutes', { value: m })
   const h = Math.floor(m / 60)
-  if (h < 24) return `${h}h ago`
+  if (h < 24) return t('book.detail.files.relative.hours', { value: h })
   const d = Math.floor(h / 24)
-  return `${d}d ago`
+  return t('book.detail.files.relative.days', { value: d })
 }
 
 function openFile(file: BookDetailFile, mode?: 'peek') {
@@ -163,7 +165,7 @@ async function submitRename() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ filename: renameInput.value.trim() }),
     })
-    if (!res.ok) throw new Error('Failed to rename file')
+    if (!res.ok) throw new Error(t('book.detail.files.renameFailed'))
     renameFileTarget.value = null
     emit('refetch')
   } catch (err) {
@@ -185,7 +187,7 @@ async function confirmDelete() {
     const res = await api(`/api/v1/books/files/${deleteFileTarget.value.id}`, {
       method: 'DELETE',
     })
-    if (!res.ok) throw new Error('Failed to delete file')
+    if (!res.ok) throw new Error(t('book.detail.files.deleteFailed'))
     emit('refetch')
   } catch (err) {
     alert(err instanceof Error ? err.message : String(err))
@@ -237,22 +239,22 @@ async function toggleWriteLog() {
             @click="openAddFileModal"
           >
             <FilePlus class="size-4 md:size-3" />
-            Add File
+            {{ t('book.detail.files.addFile') }}
           </button>
           <p v-if="book.lastWrittenAt" class="text-sm md:text-xs font-medium text-muted-foreground/90 truncate">
-            Last synced: {{ formatRelative(book.lastWrittenAt) }}
+            {{ t('book.detail.files.lastSynced', { time: formatRelative(book.lastWrittenAt) }) }}
           </p>
         </div>
         <div class="flex items-center gap-2 overflow-x-auto scrollbar-none pb-1 -mb-1 sm:overflow-visible sm:pb-0 sm:mb-0">
           <div class="flex items-center gap-1.5 whitespace-nowrap">
             <ArrowUpDown class="size-4 md:size-3 text-muted-foreground" />
-            <span class="text-sm md:text-xs font-medium text-muted-foreground">Sort:</span>
+            <span class="text-sm md:text-xs font-medium text-muted-foreground">{{ t('book.detail.files.sort.label') }}</span>
             <button
               v-for="opt in [
-                ['name', 'Name'],
-                ['format', 'Format'],
-                ['size', 'Size'],
-                ['date', 'Date'],
+                ['name', t('book.detail.files.sort.name')],
+                ['format', t('book.detail.files.sort.format')],
+                ['size', t('book.detail.files.sort.size')],
+                ['date', t('book.detail.files.sort.date')],
               ] as [SortKey, string][]"
               :key="opt[0]"
               class="h-8 md:h-6 px-2.5 md:px-1.5 rounded-md md:rounded text-sm md:text-xs transition-colors whitespace-nowrap"
@@ -267,7 +269,7 @@ async function toggleWriteLog() {
             @click="showPaths = !showPaths"
           >
             <FolderOpen class="size-4 md:size-3" />
-            {{ showPaths ? 'Hide paths' : 'Show paths' }}
+            {{ showPaths ? t('book.detail.files.hidePaths') : t('book.detail.files.showPaths') }}
           </button>
           <button
             v-if="book.lastWrittenAt"
@@ -275,7 +277,7 @@ async function toggleWriteLog() {
             @click="toggleWriteLog"
           >
             <History class="size-4 md:size-3" />
-            {{ writeLogOpen ? 'Hide log' : 'View sync log' }}
+            {{ writeLogOpen ? t('book.detail.files.hideLog') : t('book.detail.files.viewSyncLog') }}
           </button>
         </div>
       </div>
@@ -283,8 +285,8 @@ async function toggleWriteLog() {
 
     <!-- Inline sync log -->
     <div v-if="writeLogOpen" class="rounded-lg border border-border bg-muted/30 px-4 py-3 space-y-1.5">
-      <p v-if="writeLogLoading" class="text-sm md:text-xs text-muted-foreground">Loading...</p>
-      <p v-else-if="writeLog.length === 0" class="text-sm md:text-xs text-muted-foreground">No write history yet.</p>
+      <p v-if="writeLogLoading" class="text-sm md:text-xs text-muted-foreground">{{ t('common.loading') }}</p>
+      <p v-else-if="writeLog.length === 0" class="text-sm md:text-xs text-muted-foreground">{{ t('book.detail.files.noWriteHistory') }}</p>
       <div v-for="entry in writeLog" :key="entry.id" class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm md:text-xs">
         <span
           class="shrink-0 font-medium"
@@ -300,9 +302,9 @@ async function toggleWriteLog() {
         <span v-if="entry.status === 'failed' && entry.errorMessage" class="min-w-0 flex-1 basis-full sm:basis-auto text-destructive truncate">{{
           entry.errorMessage
         }}</span>
-        <span v-else-if="entry.fieldsWritten.length" class="min-w-0 flex-1 basis-full sm:basis-auto text-muted-foreground truncate"
-          >{{ entry.fieldsWritten.length }} fields</span
-        >
+        <span v-else-if="entry.fieldsWritten.length" class="min-w-0 flex-1 basis-full sm:basis-auto text-muted-foreground truncate">{{
+          t('book.detail.files.fieldsWritten', { count: entry.fieldsWritten.length }, entry.fieldsWritten.length)
+        }}</span>
       </div>
     </div>
 
@@ -350,12 +352,12 @@ async function toggleWriteLog() {
         <span
           v-if="isAudioFile(file) && audioTrackCount > 1"
           class="text-xs md:text-[11px] font-semibold md:font-medium px-2.5 md:px-2 py-1 md:py-0.5 rounded-md md:rounded bg-muted text-muted-foreground"
-          >Track {{ audioTrackIndex.get(file.id) }}</span
+          >{{ t('book.detail.files.track', { number: audioTrackIndex.get(file.id) }) }}</span
         >
         <span
           v-else-if="file.role === 'primary'"
           class="text-xs md:text-[11px] font-semibold md:font-medium px-2.5 md:px-2 py-1 md:py-0.5 rounded-md md:rounded bg-primary/10 text-primary"
-          >Primary</span
+          >{{ t('book.detail.files.primary') }}</span
         >
 
         <!-- Desktop actions -->
@@ -366,7 +368,7 @@ async function toggleWriteLog() {
             @click="openFile(file)"
           >
             <BookOpen class="size-3.5" />
-            Read
+            {{ t('book.detail.files.read') }}
           </button>
           <button
             v-if="isAudioFile(file)"
@@ -374,7 +376,7 @@ async function toggleWriteLog() {
             @click="openFile(file)"
           >
             <Headphones class="size-3.5" />
-            Play
+            {{ t('book.detail.files.play') }}
           </button>
           <button
             v-if="READER_OPENABLE_FORMATS.has(file.format ?? '')"
@@ -382,7 +384,7 @@ async function toggleWriteLog() {
             @click="openFile(file, 'peek')"
           >
             <Eye class="size-3.5" />
-            Peek
+            {{ t('book.detail.files.peek') }}
           </button>
           <Tooltip v-if="hasPermission('library_download')">
             <TooltipTrigger as-child>
@@ -393,27 +395,29 @@ async function toggleWriteLog() {
                 <Download class="size-3.5" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Download</TooltipContent>
+            <TooltipContent>{{ t('book.detail.files.download') }}</TooltipContent>
           </Tooltip>
 
           <DropdownMenu>
             <DropdownMenuTrigger as-child>
               <button
                 class="flex items-center justify-center h-7 w-7 rounded border border-input bg-background hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-                title="More actions"
+                :title="t('book.detail.files.moreActions')"
               >
                 <MoreVertical class="size-3.5" />
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem v-if="hasPermission('library_edit_metadata')" @click="openRenameModal(file)"> Rename </DropdownMenuItem>
+              <DropdownMenuItem v-if="hasPermission('library_edit_metadata')" @click="openRenameModal(file)">
+                {{ t('book.detail.files.rename') }}
+              </DropdownMenuItem>
 
               <DropdownMenuItem
                 v-if="hasPermission('library_delete_books')"
                 class="text-destructive focus:text-destructive"
                 @click="openDeleteModal(file)"
               >
-                Delete
+                {{ t('common.delete') }}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -424,7 +428,7 @@ async function toggleWriteLog() {
           <DropdownMenuTrigger as-child>
             <button
               class="flex md:hidden items-center justify-center h-11 w-11 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              title="More actions"
+              :title="t('book.detail.files.moreActions')"
             >
               <MoreVertical class="size-4" />
             </button>
@@ -432,23 +436,23 @@ async function toggleWriteLog() {
           <DropdownMenuContent align="end">
             <DropdownMenuItem v-if="READER_OPENABLE_FORMATS.has(file.format ?? '') && !isAudioFile(file)" @click="openFile(file)">
               <BookOpen class="mr-2 size-4" />
-              Read
+              {{ t('book.detail.files.read') }}
             </DropdownMenuItem>
             <DropdownMenuItem v-if="isAudioFile(file)" @click="openFile(file)">
               <Headphones class="mr-2 size-4" />
-              Play
+              {{ t('book.detail.files.play') }}
             </DropdownMenuItem>
             <DropdownMenuItem v-if="READER_OPENABLE_FORMATS.has(file.format ?? '')" @click="openFile(file, 'peek')">
               <Eye class="mr-2 size-4" />
-              Peek
+              {{ t('book.detail.files.peek') }}
             </DropdownMenuItem>
             <DropdownMenuItem v-if="hasPermission('library_download')" @click="downloadFile(file)">
               <Download class="mr-2 size-4" />
-              Download
+              {{ t('book.detail.files.download') }}
             </DropdownMenuItem>
             <DropdownMenuItem v-if="hasPermission('library_edit_metadata')" @click="openRenameModal(file)">
               <Pencil class="mr-2 size-4" />
-              Rename
+              {{ t('book.detail.files.rename') }}
             </DropdownMenuItem>
 
             <DropdownMenuItem
@@ -457,7 +461,7 @@ async function toggleWriteLog() {
               @click="openDeleteModal(file)"
             >
               <Trash2 class="mr-2 size-4" />
-              Delete
+              {{ t('common.delete') }}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -468,8 +472,8 @@ async function toggleWriteLog() {
       <div class="flex items-center justify-center w-12 h-12 rounded-lg bg-muted mb-3">
         <Files class="size-5 text-muted-foreground/70" />
       </div>
-      <p class="text-base md:text-sm font-semibold md:font-medium">No files attached</p>
-      <p class="text-sm md:text-xs text-muted-foreground/90 mt-1">This book has no associated files.</p>
+      <p class="text-base md:text-sm font-semibold md:font-medium">{{ t('book.detail.files.empty.title') }}</p>
+      <p class="text-sm md:text-xs text-muted-foreground/90 mt-1">{{ t('book.detail.files.empty.description') }}</p>
     </div>
 
     <!-- Rename Modal -->
@@ -480,13 +484,13 @@ async function toggleWriteLog() {
     >
       <button class="absolute inset-0 bg-black/45" @click="renameFileTarget = null" />
       <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Rename File</p>
-        <p class="mt-1 text-sm text-muted-foreground">Rename the physical file on disk.</p>
+        <p class="text-base font-semibold text-foreground">{{ t('book.detail.files.renameModal.title') }}</p>
+        <p class="mt-1 text-sm text-muted-foreground">{{ t('book.detail.files.renameModal.description') }}</p>
         <div class="mt-4">
           <input
             v-model="renameInput"
             class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1"
-            placeholder="New filename"
+            :placeholder="t('book.detail.files.renameModal.placeholder')"
             @keyup.enter="submitRename"
           />
         </div>
@@ -495,14 +499,14 @@ async function toggleWriteLog() {
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="renameFileTarget = null"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
             :disabled="renaming"
             @click="submitRename"
           >
-            {{ renaming ? 'Saving...' : 'Save' }}
+            {{ renaming ? t('book.detail.files.saving') : t('common.save') }}
           </button>
         </div>
       </div>
@@ -516,23 +520,23 @@ async function toggleWriteLog() {
     >
       <button class="absolute inset-0 bg-black/45" @click="deleteFileTarget = null" />
       <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Delete file?</p>
+        <p class="text-base font-semibold text-foreground">{{ t('book.detail.files.deleteModal.title') }}</p>
         <p class="mt-1 text-sm text-muted-foreground">
-          Are you sure you want to delete "{{ deleteFileTarget.filename }}"? This action cannot be undone.
+          {{ t('book.detail.files.deleteModal.description', { filename: deleteFileTarget.filename }) }}
         </p>
         <div class="mt-4 flex items-center justify-end gap-2">
           <button
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="deleteFileTarget = null"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
             :disabled="deletingFile"
             @click="confirmDelete"
           >
-            {{ deletingFile ? 'Deleting...' : 'Delete' }}
+            {{ deletingFile ? t('book.detail.files.deleting') : t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/book/components/detail/tabs/HighlightNoteEditor.vue
+++ b/client/src/features/book/components/detail/tabs/HighlightNoteEditor.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Save, X } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 
 const props = withDefaults(
   defineProps<{
@@ -9,6 +10,8 @@ const props = withDefaults(
   }>(),
   { saving: false },
 )
+
+const { t } = useI18n()
 
 const emit = defineEmits<{
   save: [note: string | null]
@@ -33,7 +36,7 @@ function handleCancel() {
   <div class="mt-2 space-y-2">
     <textarea
       v-model="noteText"
-      placeholder="Add a note..."
+      :placeholder="t('book.detail.highlights.note.placeholder')"
       rows="3"
       :disabled="saving"
       class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary resize-y"
@@ -46,7 +49,7 @@ function handleCancel() {
         @click="handleCancel"
       >
         <X :size="14" />
-        Cancel
+        {{ t('common.cancel') }}
       </button>
       <button
         type="button"
@@ -55,7 +58,7 @@ function handleCancel() {
         @click="handleSave"
       >
         <Save :size="14" />
-        {{ saving ? 'Saving' : 'Save' }}
+        {{ saving ? t('book.detail.highlights.note.saving') : t('common.save') }}
       </button>
     </div>
   </div>

--- a/client/src/features/book/components/detail/tabs/HighlightsExportMenu.vue
+++ b/client/src/features/book/components/detail/tabs/HighlightsExportMenu.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Download, FileText, FileJson, FileType } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 import type { AnnotationItem } from '@bookorbit/types'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 
@@ -10,8 +11,10 @@ const props = withDefaults(
     bookTitle: string
     label?: string
   }>(),
-  { label: 'Export' },
+  { label: '' },
 )
+
+const { t } = useI18n()
 
 const open = ref(false)
 
@@ -108,7 +111,7 @@ function exportJson() {
         :disabled="items.length === 0"
       >
         <Download :size="14" />
-        {{ label }}
+        {{ label || t('book.detail.highlights.export.trigger') }}
       </button>
     </PopoverTrigger>
     <PopoverContent align="end" class="w-44 p-1">
@@ -124,7 +127,7 @@ function exportJson() {
         @click="exportPlainText"
       >
         <FileType :size="14" class="text-muted-foreground" />
-        Plain Text
+        {{ t('book.detail.highlights.export.plainText') }}
       </button>
       <button class="flex items-center gap-2 w-full px-3 py-2 rounded text-sm text-foreground hover:bg-muted transition-colors" @click="exportJson">
         <FileJson :size="14" class="text-muted-foreground" />

--- a/client/src/features/book/components/detail/tabs/HighlightsTab.vue
+++ b/client/src/features/book/components/detail/tabs/HighlightsTab.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { Highlighter, RotateCcw, Trash2 } from '@lucide/vue'
 import type { AnnotationItem, BookDetail } from '@bookorbit/types'
 import { Button } from '@/components/ui/button'
@@ -18,16 +19,17 @@ import HighlightsExportMenu from './HighlightsExportMenu.vue'
 
 const props = defineProps<{ book: BookDetail }>()
 
+const { t } = useI18n()
 const router = useRouter()
 const bookIdRef = computed(() => props.book.id)
 const hl = useBookHighlights(bookIdRef)
 const { density } = useDensity()
 
-const SORT_OPTIONS = [
-  { value: 'position', label: 'Position' },
-  { value: 'newest', label: 'Newest first' },
-  { value: 'oldest', label: 'Oldest first' },
-]
+const SORT_OPTIONS = computed(() => [
+  { value: 'position', label: t('book.detail.highlights.sort.position') },
+  { value: 'newest', label: t('book.detail.highlights.sort.newest') },
+  { value: 'oldest', label: t('book.detail.highlights.sort.oldest') },
+])
 
 const groupedHighlights = computed(() => {
   const groups = new Map<string, AnnotationItem[]>()
@@ -46,10 +48,10 @@ const hasChapterGroups = computed(() => {
 })
 
 const summaryTexts = computed(() => {
-  const texts = [`${hl.total.value} ${hl.total.value === 1 ? 'highlight' : 'highlights'}`]
+  const texts = [t('book.detail.highlights.summary.highlights', { count: hl.total.value }, hl.total.value)]
   if (hl.stats.value) {
-    texts.push(`${hl.stats.value.highlightsWithNotes} notes`)
-    texts.push(`${hl.stats.value.chaptersWithHighlights} chapters`)
+    texts.push(t('book.detail.highlights.summary.notes', { count: hl.stats.value.highlightsWithNotes }, hl.stats.value.highlightsWithNotes))
+    texts.push(t('book.detail.highlights.summary.chapters', { count: hl.stats.value.chaptersWithHighlights }, hl.stats.value.chaptersWithHighlights))
   }
   return texts
 })
@@ -114,10 +116,10 @@ async function handleBulkTrash() {
         <select
           v-if="hl.chapters.value.length > 0"
           v-model="hl.chapter.value"
-          aria-label="Filter by chapter"
+          :aria-label="t('book.detail.highlights.filterByChapter')"
           class="h-9 max-w-[14rem] px-2 rounded-md border border-border bg-background text-sm"
         >
-          <option value="">All chapters</option>
+          <option value="">{{ t('book.detail.highlights.allChapters') }}</option>
           <option v-for="ch in hl.chapters.value" :key="ch" :value="ch">{{ ch }}</option>
         </select>
       </template>
@@ -133,7 +135,11 @@ async function handleBulkTrash() {
 
     <div v-if="hl.total.value > 0" class="flex flex-wrap items-center justify-between gap-2">
       <AnnotationSummaryBar :texts="summaryTexts" :origins="originSummary" />
-      <HighlightsExportMenu :items="hl.items.value" :book-title="book.title ?? 'Untitled'" label="Export page" />
+      <HighlightsExportMenu
+        :items="hl.items.value"
+        :book-title="book.title ?? t('book.detail.highlights.untitled')"
+        :label="t('book.detail.highlights.export.page')"
+      />
     </div>
 
     <AnnotationBulkBar
@@ -147,10 +153,14 @@ async function handleBulkTrash() {
       @restyle="handleBulkStyle"
     >
       <template #trailing>
-        <HighlightsExportMenu :items="hl.selectedItems.value" :book-title="book.title ?? 'Untitled'" label="Export selected" />
+        <HighlightsExportMenu
+          :items="hl.selectedItems.value"
+          :book-title="book.title ?? t('book.detail.highlights.untitled')"
+          :label="t('book.detail.highlights.export.selected')"
+        />
         <Button variant="destructive" size="sm" class="gap-1.5" @click="handleBulkTrash">
           <Trash2 :size="14" />
-          Trash
+          {{ t('book.detail.highlights.trash') }}
         </Button>
       </template>
     </AnnotationBulkBar>
@@ -161,19 +171,19 @@ async function handleBulkTrash() {
           <Highlighter :size="20" class="text-muted-foreground/60" />
         </div>
         <template v-if="hl.hasActiveFilters.value">
-          <p class="text-sm text-muted-foreground">No highlights match your filters.</p>
+          <p class="text-sm text-muted-foreground">{{ t('book.detail.highlights.empty.noMatch') }}</p>
           <button
             type="button"
             class="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground transition-colors hover:bg-muted"
             @click="hl.resetAllFilters"
           >
             <RotateCcw :size="14" />
-            Reset filters
+            {{ t('book.detail.highlights.empty.resetFilters') }}
           </button>
         </template>
         <template v-else>
-          <p class="text-sm text-muted-foreground">No highlights yet</p>
-          <p class="text-xs text-muted-foreground/70">Select text while reading to create highlights</p>
+          <p class="text-sm text-muted-foreground">{{ t('book.detail.highlights.empty.none') }}</p>
+          <p class="text-xs text-muted-foreground/70">{{ t('book.detail.highlights.empty.hint') }}</p>
         </template>
       </div>
 
@@ -182,7 +192,7 @@ async function handleBulkTrash() {
           <HighlightChapterGroup
             v-for="[chapterTitle, highlights] in groupedHighlights"
             :key="chapterTitle"
-            :chapter-title="chapterTitle || 'Uncategorized'"
+            :chapter-title="chapterTitle || t('book.detail.highlights.uncategorized')"
             :highlights="highlights"
             :selected-ids="hl.selectedIds.value"
             :density="density"
@@ -222,7 +232,7 @@ async function handleBulkTrash() {
       :range-start="hl.rangeStart.value"
       :range-end="hl.rangeEnd.value"
       :total="hl.total.value"
-      unit="highlights"
+      :unit="t('book.detail.highlights.paginationUnit')"
       @update:page="handleSetPage"
     />
   </div>

--- a/client/src/features/book/components/detail/tabs/MetadataDiffPanel.vue
+++ b/client/src/features/book/components/detail/tabs/MetadataDiffPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, onBeforeUnmount, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ArrowLeft, CopyCheck, Copy, CheckCheck, Eye, EyeOff, Info } from '@lucide/vue'
 import type {
   BookMetadataLockField,
@@ -31,6 +32,7 @@ const emit = defineEmits<{
   apply: [{ formPatch: MetadataPatch; coverUrl?: string }]
 }>()
 
+const { t } = useI18n()
 const coverAspectRatio = inject(COVER_ASPECT_RATIO_KEY, ref(DEFAULT_COVER_ASPECT_RATIO))
 
 const activeProvider = ref<MetadataProviderKey>(props.initialCandidate.provider)
@@ -99,9 +101,9 @@ const { fields, picksPerProvider, toggleField, pickFieldFromProvider, clearPicks
 const activeProviderLabel = computed(() => getProviderLabel(activeProvider.value, props.providers))
 const resultsForActiveProvider = computed(() => props.filteredResults.filter((candidate) => candidate.provider === activeProvider.value))
 
-const bookSeed = computed(() => props.current.title ?? 'Untitled')
+const bookSeed = computed(() => props.current.title ?? t('book.detail.editMetadata.diffPanel.untitled'))
 const bookAuthorLine = computed(() => props.current.authors.join(', ') || null)
-const candidateSeed = computed(() => activeCandidate.value.title ?? 'Untitled')
+const candidateSeed = computed(() => activeCandidate.value.title ?? t('book.detail.editMetadata.diffPanel.untitled'))
 const candidateAuthorLine = computed(() => activeCandidate.value.authors?.join(', ') || null)
 
 const selectedFieldCount = computed(() => {
@@ -113,8 +115,8 @@ const selectedFieldCount = computed(() => {
 })
 
 const selectedCountLabel = computed(() => {
-  if (!selectedFieldCount.value) return 'No fields selected'
-  return `${selectedFieldCount.value} field${selectedFieldCount.value === 1 ? '' : 's'} selected`
+  if (!selectedFieldCount.value) return t('book.detail.editMetadata.diffPanel.noFieldsSelected')
+  return t('book.detail.editMetadata.diffPanel.fieldsSelected', { count: selectedFieldCount.value }, selectedFieldCount.value)
 })
 
 const providerResultMeta = computed(() => {
@@ -233,7 +235,7 @@ onBeforeUnmount(() => {
           @click="goBack"
         >
           <ArrowLeft class="size-4 transition-transform group-hover:-translate-x-0.5" />
-          {{ backLabel ?? 'Results' }}
+          {{ backLabel ?? t('book.detail.editMetadata.diffPanel.results') }}
         </button>
 
         <div class="flex-1 min-w-0">
@@ -262,8 +264,12 @@ onBeforeUnmount(() => {
       <!-- Within-provider result picker -->
       <div v-if="resultsForActiveProvider.length > 1" class="mt-2.5">
         <div class="flex items-center justify-between gap-2 mb-1.5">
-          <p class="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">{{ activeProviderLabel }} matches</p>
-          <p class="text-[10px] text-muted-foreground">Selected {{ activeResultMeta.selectedIndex }} of {{ activeResultMeta.total }}</p>
+          <p class="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+            {{ t('book.detail.editMetadata.diffPanel.providerMatches', { provider: activeProviderLabel }) }}
+          </p>
+          <p class="text-[10px] text-muted-foreground">
+            {{ t('book.detail.editMetadata.diffPanel.selectedOf', { selected: activeResultMeta.selectedIndex, total: activeResultMeta.total }) }}
+          </p>
         </div>
         <div class="flex items-center gap-2 overflow-x-auto pb-0.5">
           <button
@@ -287,7 +293,8 @@ onBeforeUnmount(() => {
             <span class="min-w-0 flex-1">
               <span class="block text-xs font-medium text-foreground line-clamp-1">{{ candidate.title }}</span>
               <span class="block text-[10px] text-muted-foreground line-clamp-1">
-                {{ candidate.publishedYear ?? 'Year unknown' }} - {{ index + 1 }} of {{ resultsForActiveProvider.length }}
+                {{ candidate.publishedYear ?? t('book.detail.editMetadata.diffPanel.yearUnknown') }} -
+                {{ t('book.detail.editMetadata.diffPanel.indexOf', { index: index + 1, total: resultsForActiveProvider.length }) }}
               </span>
             </span>
           </button>
@@ -296,7 +303,7 @@ onBeforeUnmount(() => {
 
       <p v-if="showSwitchHint" class="mt-2 text-[11px] text-muted-foreground flex items-center gap-1.5">
         <Info class="size-3.5" />
-        Switched result. Previous selections from this provider were cleared.
+        {{ t('book.detail.editMetadata.diffPanel.switchedResult') }}
       </p>
     </div>
 
@@ -309,20 +316,20 @@ onBeforeUnmount(() => {
               <CheckCheck class="size-3.5 text-primary" />
               {{ selectedCountLabel }}
             </p>
-            <p v-else class="shrink-0 text-xs text-muted-foreground">Select fields to apply</p>
+            <p v-else class="shrink-0 text-xs text-muted-foreground">{{ t('book.detail.editMetadata.diffPanel.selectFieldsToApply') }}</p>
             <button
               class="flex items-center gap-1.5 h-7 px-2.5 rounded-lg border border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400 text-xs font-medium hover:bg-amber-500/20 transition-all active:scale-95"
               @click="handleCopyMissing"
             >
               <Copy class="size-3" />
-              Copy Missing
+              {{ t('book.detail.editMetadata.diffPanel.copyMissing') }}
             </button>
             <button
               class="flex items-center gap-1.5 h-7 px-2.5 rounded-lg border border-primary/40 bg-primary/10 text-primary text-xs font-medium hover:bg-primary/20 transition-all active:scale-95"
               @click="handleCopyAll"
             >
               <CopyCheck class="size-3" />
-              Copy All
+              {{ t('book.detail.editMetadata.diffPanel.copyAll') }}
             </button>
           </div>
           <button
@@ -331,14 +338,14 @@ onBeforeUnmount(() => {
           >
             <EyeOff v-if="showUnchanged" class="size-3.5" />
             <Eye v-else class="size-3.5" />
-            {{ showUnchanged ? 'Hide unchanged' : 'Show unchanged' }}
+            {{ showUnchanged ? t('book.detail.editMetadata.diffPanel.hideUnchanged') : t('book.detail.editMetadata.diffPanel.showUnchanged') }}
           </button>
         </div>
 
         <div class="grid grid-cols-[1fr_auto_1fr] gap-2 mt-2.5">
           <div class="flex items-center gap-1.5">
             <div class="size-1.5 rounded-full bg-muted-foreground/40" />
-            <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Current</p>
+            <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('book.detail.editMetadata.diffPanel.current') }}</p>
           </div>
           <div class="w-11" />
           <div class="flex items-center gap-1.5 min-w-0 overflow-hidden">
@@ -365,7 +372,7 @@ onBeforeUnmount(() => {
         @pick-from-provider="handlePickFromProvider"
       />
       <p v-if="visibleFields.length === 0" class="py-8 text-center text-sm text-muted-foreground">
-        {{ showUnchanged ? 'No metadata available from this source.' : 'No changed or missing fields. Use Show unchanged to inspect everything.' }}
+        {{ showUnchanged ? t('book.detail.editMetadata.diffPanel.noMetadata') : t('book.detail.editMetadata.diffPanel.noChangedFields') }}
       </p>
     </div>
 
@@ -373,7 +380,7 @@ onBeforeUnmount(() => {
     <div class="flex flex-wrap items-center justify-end gap-2 px-4 py-3 border-t border-border shrink-0 bg-card/30">
       <div class="flex flex-wrap items-center gap-2">
         <button class="h-8 px-3 rounded-lg border border-border bg-background text-sm hover:bg-muted transition-all active:scale-95" @click="goBack">
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           class="relative h-8 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-all disabled:opacity-40 hover:opacity-90 active:scale-95 overflow-hidden group"
@@ -381,7 +388,7 @@ onBeforeUnmount(() => {
           @click="apply"
         >
           <span class="absolute inset-0 bg-white/10 opacity-0 group-hover:opacity-100 transition-opacity" />
-          Apply to form
+          {{ t('book.detail.editMetadata.diffPanel.applyToForm') }}
         </button>
       </div>
     </div>

--- a/client/src/features/book/components/detail/tabs/MetadataDiffRow.vue
+++ b/client/src/features/book/components/detail/tabs/MetadataDiffRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ArrowLeft, RotateCcw, CheckCircle2, X, ZoomIn, Layers } from '@lucide/vue'
 import type { MetadataProviderInfo, MetadataProviderKey } from '@bookorbit/types'
 import type { DiffField, DiffFieldKey } from '../../../composables/useMetadataDiff'
@@ -23,6 +24,7 @@ const emit = defineEmits<{
   pickFromProvider: [key: DiffFieldKey, provider: MetadataProviderKey]
 }>()
 
+const { t } = useI18n()
 const coverAspectRatio = inject(COVER_ASPECT_RATIO_KEY, ref(DEFAULT_COVER_ASPECT_RATIO))
 
 const lightboxSrc = ref<string | null>(null)
@@ -92,7 +94,7 @@ watch(
     <div class="mb-2.5 flex items-center gap-2">
       <p class="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">{{ field.label }}</p>
       <span v-if="field.isLocked" class="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-[9px] font-medium text-primary">
-        Locked
+        {{ t('book.detail.editMetadata.diff.locked') }}
       </span>
     </div>
     <div class="grid grid-cols-[1fr_auto_1fr] gap-2 items-center">
@@ -112,11 +114,21 @@ watch(
             aria-hidden="true"
             class="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75"
           />
-          <img :src="field.pickedDisplay" alt="Preview" class="relative w-full h-full object-contain" @error="hideOnError" />
+          <img
+            :src="field.pickedDisplay"
+            :alt="t('book.detail.editMetadata.diff.previewAlt')"
+            class="relative w-full h-full object-contain"
+            @error="hideOnError"
+          />
         </template>
         <template v-else-if="field.bookValue">
           <img :src="field.bookValue" alt="" aria-hidden="true" class="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75" />
-          <img :src="field.bookValue" alt="Current cover" class="relative w-full h-full object-contain" @error="hideOnError" />
+          <img
+            :src="field.bookValue"
+            :alt="t('book.detail.editMetadata.diff.currentCoverAlt')"
+            class="relative w-full h-full object-contain"
+            @error="hideOnError"
+          />
         </template>
         <div v-else class="absolute inset-0">
           <BookCoverPlaceholder :title="bookSeed ?? null" :author-line="bookAuthorLine ?? null" :is-audio="false" :seed="bookSeed ?? 'book'" />
@@ -160,14 +172,16 @@ watch(
           <PopoverTrigger as-child>
             <button
               class="size-5 rounded-full flex items-center justify-center transition-all hover:bg-muted text-muted-foreground hover:text-foreground"
-              title="Pick cover from another provider"
+              :title="t('book.detail.editMetadata.diff.pickCoverFromProvider')"
             >
               <Layers class="size-3" />
             </button>
           </PopoverTrigger>
           <PopoverContent class="w-auto p-1.5" side="bottom" :side-offset="4">
             <div class="flex flex-col gap-1 min-w-48">
-              <p class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground px-2 py-1">Pick cover source</p>
+              <p class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground px-2 py-1">
+                {{ t('book.detail.editMetadata.diff.pickCoverSource') }}
+              </p>
               <button
                 v-for="pv in field.providerValues"
                 :key="pv.provider"
@@ -210,7 +224,12 @@ watch(
             aria-hidden="true"
             class="absolute inset-0 w-full h-full object-cover scale-110 blur-md brightness-75"
           />
-          <img :src="field.candidateDisplay" alt="New cover" class="relative w-full h-full object-contain" @error="hideOnError" />
+          <img
+            :src="field.candidateDisplay"
+            :alt="t('book.detail.editMetadata.diff.newCoverAlt')"
+            class="relative w-full h-full object-contain"
+            @error="hideOnError"
+          />
         </template>
         <div v-else class="absolute inset-0">
           <BookCoverPlaceholder
@@ -235,7 +254,7 @@ watch(
     <div class="mb-1.5 flex items-center gap-2">
       <p class="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">{{ field.label }}</p>
       <span v-if="field.isLocked" class="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-[9px] font-medium text-primary">
-        Locked
+        {{ t('book.detail.editMetadata.diff.locked') }}
       </span>
     </div>
 
@@ -250,10 +269,10 @@ watch(
           class="wrap-break-word leading-snug text-sm w-full"
           :class="[!field.currentDisplay ? 'text-muted-foreground/60 italic' : 'text-foreground', currentTextClass]"
         >
-          {{ field.currentDisplay || 'empty' }}
+          {{ field.currentDisplay || t('book.detail.editMetadata.diff.empty') }}
         </p>
         <button v-if="canClampCurrent" class="mt-1 text-[10px] font-medium text-primary hover:underline" @click="toggleCurrentExpanded">
-          {{ isCurrentExpanded ? 'Show less' : 'Show more' }}
+          {{ isCurrentExpanded ? t('book.detail.editMetadata.diff.showLess') : t('book.detail.editMetadata.diff.showMore') }}
         </button>
         <!-- Badge when value is picked from a different provider than the active tab -->
         <span
@@ -291,14 +310,16 @@ watch(
           <PopoverTrigger as-child>
             <button
               class="size-5 rounded-full flex items-center justify-center transition-all hover:bg-muted text-muted-foreground hover:text-foreground shrink-0"
-              title="Pick from another provider"
+              :title="t('book.detail.editMetadata.diff.pickFromProvider')"
             >
               <Layers class="size-3" />
             </button>
           </PopoverTrigger>
           <PopoverContent class="w-auto p-1.5" side="bottom" :side-offset="4" align="center">
             <div class="flex flex-col gap-0.5 min-w-44 max-w-72">
-              <p class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground px-2 py-1">Pick source</p>
+              <p class="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground px-2 py-1">
+                {{ t('book.detail.editMetadata.diff.pickSource') }}
+              </p>
               <button
                 v-for="pv in field.providerValues"
                 :key="pv.provider"
@@ -348,7 +369,7 @@ watch(
           class="mt-1 text-[10px] font-medium text-primary hover:underline"
           @click="toggleCandidateExpanded"
         >
-          {{ isCandidateExpanded ? 'Show less' : 'Show more' }}
+          {{ isCandidateExpanded ? t('book.detail.editMetadata.diff.showLess') : t('book.detail.editMetadata.diff.showMore') }}
         </button>
       </div>
     </div>
@@ -365,7 +386,7 @@ watch(
       </button>
       <img
         :src="lightboxSrc"
-        alt="Cover preview"
+        :alt="t('book.detail.editMetadata.diff.coverPreviewAlt')"
         class="max-h-[85vh] max-w-[85vw] rounded-lg shadow-2xl object-contain"
         @click.stop
         @error="hideOnError"

--- a/client/src/features/book/components/detail/tabs/MetadataFieldLabel.vue
+++ b/client/src/features/book/components/detail/tabs/MetadataFieldLabel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Loader2, Lock, LockOpen } from '@lucide/vue'
 import type { BookMetadataLockField } from '@bookorbit/types'
 
@@ -13,6 +14,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{ toggle: [field: BookMetadataLockField] }>()
 
+const { t } = useI18n()
 const loading = computed(() => props.isUpdating?.(props.field) ?? false)
 
 function handleToggle() {
@@ -29,8 +31,8 @@ function handleToggle() {
         type="button"
         class="absolute right-2 z-10 inline-flex size-6 cursor-pointer items-center justify-center rounded-md border border-input bg-background/95 text-muted-foreground shadow-sm transition-[colors,opacity] hover:text-foreground hover:bg-muted disabled:cursor-not-allowed"
         :class="[multiline ? 'top-1' : 'top-1/2 -translate-y-1/2', loading ? 'opacity-60' : 'opacity-100']"
-        :aria-label="locked ? `Unlock ${label}` : `Lock ${label}`"
-        :title="locked ? `Unlock ${label}` : `Lock ${label}`"
+        :aria-label="locked ? t('book.detail.editMetadata.unlockField', { field: label }) : t('book.detail.editMetadata.lockField', { field: label })"
+        :title="locked ? t('book.detail.editMetadata.unlockField', { field: label }) : t('book.detail.editMetadata.lockField', { field: label })"
         :disabled="loading"
         @click="handleToggle"
       >

--- a/client/src/features/book/components/detail/tabs/MetadataSearchDrawer.vue
+++ b/client/src/features/book/components/detail/tabs/MetadataSearchDrawer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X, Sparkles } from '@lucide/vue'
 import { isAudioFormat } from '@bookorbit/types'
 import type { BookDetail, BookMetadataLockField, MetadataCandidate, MetadataProviderKey, MetadataSource } from '@bookorbit/types'
@@ -15,6 +16,7 @@ const emit = defineEmits<{
   apply: [{ formPatch: MetadataPatch; coverUrl?: string }]
 }>()
 
+const { t } = useI18n()
 const { coverUrl } = useCoverVersions()
 const bookCoverUrl = computed(() => coverUrl(props.book.id, 'cover', props.book.updatedAt ?? props.book.addedAt))
 const searchDefaults = computed(() => ({
@@ -60,9 +62,11 @@ const {
 
 const view = ref<'search' | 'diff'>('search')
 const selectedCandidate = ref<MetadataCandidate | null>(null)
-const drawerTitle = computed(() => (view.value === 'search' ? 'Search Metadata' : 'Compare Metadata'))
+const drawerTitle = computed(() =>
+  view.value === 'search' ? t('book.detail.editMetadata.searchDrawer.searchTitle') : t('book.detail.editMetadata.searchDrawer.compareTitle'),
+)
 const drawerSubtitle = computed(() =>
-  view.value === 'search' ? 'Find the best provider match for this book.' : 'Review differences and apply only what you want.',
+  view.value === 'search' ? t('book.detail.editMetadata.searchDrawer.searchSubtitle') : t('book.detail.editMetadata.searchDrawer.compareSubtitle'),
 )
 
 onMounted(() => {
@@ -178,7 +182,7 @@ function handleApply(patch: { formPatch: MetadataPatch; coverUrl?: string }) {
             :provider-ids="book.providerIds"
             :locked-fields="props.lockedFields"
             :filtered-results="filteredResults"
-            back-label="Results"
+            :back-label="t('book.detail.editMetadata.diffPanel.results')"
             @back="backToSearch"
             @apply="handleApply"
           />

--- a/client/src/features/book/components/detail/tabs/MetadataSearchPanel.vue
+++ b/client/src/features/book/components/detail/tabs/MetadataSearchPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Search, BookOpen, Loader2, PencilLine } from '@lucide/vue'
 import type { MetadataCandidate, MetadataProviderInfo, MetadataProviderKey } from '@bookorbit/types'
 import MetadataResultCard from './MetadataResultCard.vue'
@@ -24,6 +25,7 @@ const emit = defineEmits<{
   select: [MetadataCandidate]
 }>()
 
+const { t } = useI18n()
 const coverAspectRatio = inject(COVER_ASPECT_RATIO_KEY, ref(DEFAULT_COVER_ASPECT_RATIO))
 
 const form = reactive({
@@ -36,7 +38,7 @@ const isFormCollapsed = ref(false)
 const canSearch = computed(() => !!(form.title.trim() || form.isbn.trim()))
 const searchSummary = computed(() => {
   const parts = [form.title.trim(), form.author.trim(), form.isbn.trim()].filter(Boolean)
-  return parts.length ? parts.join(' - ') : 'Untitled query'
+  return parts.length ? parts.join(' - ') : t('book.detail.editMetadata.searchPanel.untitledQuery')
 })
 const hasFieldRuleScope = computed(() => props.providers.some((provider) => provider.selectedByFieldRules !== undefined))
 const allProviderKeys = computed(() => props.providers.map((provider) => provider.key))
@@ -110,20 +112,20 @@ function sameProviderSelection(keys: MetadataProviderKey[]) {
             <input
               v-model="form.title"
               class="w-full h-8 rounded-lg border border-input bg-background pl-8 pr-3 text-sm outline-none focus:ring-1 focus:ring-ring transition-shadow"
-              placeholder="Title"
+              :placeholder="t('book.detail.editMetadata.searchPanel.titlePlaceholder')"
               @keydown.enter="runSearch"
             />
           </div>
           <input
             v-model="form.author"
             class="col-span-2 h-8 min-w-0 rounded-lg border border-input bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring transition-shadow md:col-span-1"
-            placeholder="Author"
+            :placeholder="t('book.detail.editMetadata.searchPanel.authorPlaceholder')"
             @keydown.enter="runSearch"
           />
           <input
             v-model="form.isbn"
             class="h-8 min-w-0 rounded-lg border border-input bg-background px-3 text-sm font-mono outline-none focus:ring-1 focus:ring-ring transition-shadow"
-            placeholder="ISBN"
+            :placeholder="t('book.detail.editMetadata.searchPanel.isbnPlaceholder')"
             @keydown.enter="runSearch"
           />
           <button
@@ -134,7 +136,7 @@ function sameProviderSelection(keys: MetadataProviderKey[]) {
             <span class="absolute inset-0 bg-white/10 opacity-0 group-hover:opacity-100 transition-opacity" />
             <Loader2 v-if="isStreaming" class="size-3.5 animate-spin" />
             <Search v-else class="size-3.5" />
-            {{ isStreaming ? 'Searching...' : 'Search' }}
+            {{ isStreaming ? t('book.detail.editMetadata.searchPanel.searching') : t('common.search') }}
           </button>
         </div>
       </div>
@@ -144,7 +146,9 @@ function sameProviderSelection(keys: MetadataProviderKey[]) {
         <div class="flex items-center gap-2">
           <Search class="size-3.5 text-muted-foreground shrink-0" />
           <div class="min-w-0 flex-1">
-            <p class="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">Active query</p>
+            <p class="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">
+              {{ t('book.detail.editMetadata.searchPanel.activeQuery') }}
+            </p>
             <p class="text-sm font-medium text-foreground truncate">{{ searchSummary }}</p>
           </div>
           <button
@@ -152,7 +156,7 @@ function sameProviderSelection(keys: MetadataProviderKey[]) {
             @click="expandSearchForm"
           >
             <PencilLine class="size-3.5" />
-            Edit
+            {{ t('common.edit') }}
           </button>
         </div>
       </div>
@@ -160,7 +164,10 @@ function sameProviderSelection(keys: MetadataProviderKey[]) {
 
     <!-- Provider filter pills -->
     <div v-if="providers.length" class="flex items-center gap-1.5 px-4 pb-2 flex-wrap shrink-0">
-      <div class="inline-flex h-6 items-stretch overflow-hidden rounded-full border border-border bg-background shadow-xs" aria-label="Search scope">
+      <div
+        class="inline-flex h-6 items-stretch overflow-hidden rounded-full border border-border bg-background shadow-xs"
+        :aria-label="t('book.detail.editMetadata.searchPanel.searchScope')"
+      >
         <button
           class="h-full px-2.5 text-[11px] font-medium transition-colors"
           :class="
@@ -168,7 +175,7 @@ function sameProviderSelection(keys: MetadataProviderKey[]) {
           "
           @click="handleClearFilter"
         >
-          {{ hasFieldRuleScope ? 'All enabled' : 'All' }}
+          {{ hasFieldRuleScope ? t('book.detail.editMetadata.searchPanel.allEnabled') : t('book.detail.editMetadata.searchPanel.all') }}
         </button>
         <button
           v-if="hasFieldRuleScopeOption"
@@ -178,20 +185,20 @@ function sameProviderSelection(keys: MetadataProviderKey[]) {
           "
           @click="handleSelectFieldRules"
         >
-          Field Rules
+          {{ t('book.detail.editMetadata.searchPanel.fieldRules') }}
         </button>
         <span
           v-if="customProviderSelection"
           class="h-full px-2.5 bg-primary text-primary-foreground text-[11px] font-medium shadow-sm flex items-center"
         >
-          Custom
+          {{ t('book.detail.editMetadata.searchPanel.custom') }}
         </span>
       </div>
       <button
         v-for="p in providers"
         :key="p.key"
         class="h-6 px-2.5 rounded-full text-xs font-medium transition-all flex items-center gap-1 active:scale-95"
-        :title="p.selectedByFieldRules === false ? `${p.label} is enabled but not in Field Rules` : p.label"
+        :title="p.selectedByFieldRules === false ? t('book.detail.editMetadata.searchPanel.providerNotInFieldRules', { provider: p.label }) : p.label"
         :class="selectedProviders.includes(p.key) ? '' : 'bg-muted text-muted-foreground hover:text-foreground hover:bg-muted/80'"
         :style="selectedProviders.includes(p.key) ? providerActivePillStyle(p.key) : {}"
         @click="handleToggleProvider(p.key)"
@@ -210,8 +217,8 @@ function sameProviderSelection(keys: MetadataProviderKey[]) {
       v-if="providersOutsideFieldRules.length"
       class="mx-4 mb-3 rounded-lg border border-border bg-muted/30 px-3 py-2 text-xs leading-relaxed text-muted-foreground shrink-0"
     >
-      <span class="font-medium text-foreground">Not in Field Rules:</span>
-      {{ providersOutsideFieldRuleText }}. Included in manual search with All enabled, but not used by automatic metadata fetch.
+      <span class="font-medium text-foreground">{{ t('book.detail.editMetadata.searchPanel.notInFieldRulesLabel') }}</span>
+      {{ t('book.detail.editMetadata.searchPanel.notInFieldRulesText', { providers: providersOutsideFieldRuleText }) }}
     </div>
 
     <!-- Results (scrollable) -->
@@ -234,14 +241,14 @@ function sameProviderSelection(keys: MetadataProviderKey[]) {
           <BookOpen class="size-5" />
         </div>
         <div class="text-center">
-          <p class="text-sm font-medium text-foreground">No results found</p>
-          <p class="text-xs text-muted-foreground mt-0.5">Try adjusting the title or author</p>
+          <p class="text-sm font-medium text-foreground">{{ t('book.detail.editMetadata.searchPanel.noResults') }}</p>
+          <p class="text-xs text-muted-foreground mt-0.5">{{ t('book.detail.editMetadata.searchPanel.noResultsHint') }}</p>
         </div>
       </div>
 
       <!-- Instructions when no search yet -->
       <div v-else-if="!hasSearched" class="py-12 flex flex-col items-center gap-2 text-muted-foreground">
-        <p class="text-sm">Search above, then click a result to start comparing metadata.</p>
+        <p class="text-sm">{{ t('book.detail.editMetadata.searchPanel.searchPrompt') }}</p>
       </div>
 
       <!-- Results grid -->

--- a/client/src/features/book/components/detail/tabs/ReadingLogExportMenu.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogExportMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Download, FileJson, FileSpreadsheet, Loader2 } from '@lucide/vue'
 import type { BookReadingSession } from '@bookorbit/types'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -9,6 +10,8 @@ const props = defineProps<{
   total: number
   exportAll: () => Promise<BookReadingSession[]>
 }>()
+
+const { t } = useI18n()
 
 const open = ref(false)
 const exporting = ref(false)
@@ -95,7 +98,7 @@ async function exportJson() {
       >
         <Loader2 v-if="exporting" :size="14" class="animate-spin" />
         <Download v-else :size="14" />
-        Export
+        {{ t('book.detail.readingLog.export.button') }}
       </button>
     </PopoverTrigger>
     <PopoverContent align="end" class="w-44 p-1">

--- a/client/src/features/book/components/detail/tabs/ReadingLogHeatmap.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogHeatmap.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { CalendarDays } from '@lucide/vue'
 import type { BookReadingSessionStats } from '@bookorbit/types'
@@ -12,8 +13,35 @@ const props = defineProps<{
   quickFilter: 'all' | 'last30' | 'last90' | 'thisYear'
 }>()
 
+const { t } = useI18n()
+
 const DAY_MS = 24 * 60 * 60 * 1000
-const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+const dayLabels = computed(
+  () =>
+    [
+      t('book.detail.readingLog.weekdays.sun'),
+      t('book.detail.readingLog.weekdays.mon'),
+      t('book.detail.readingLog.weekdays.tue'),
+      t('book.detail.readingLog.weekdays.wed'),
+      t('book.detail.readingLog.weekdays.thu'),
+      t('book.detail.readingLog.weekdays.fri'),
+      t('book.detail.readingLog.weekdays.sat'),
+    ] as const,
+)
+const monthLabels = computed(() => [
+  t('book.detail.readingLog.months.jan'),
+  t('book.detail.readingLog.months.feb'),
+  t('book.detail.readingLog.months.mar'),
+  t('book.detail.readingLog.months.apr'),
+  t('book.detail.readingLog.months.may'),
+  t('book.detail.readingLog.months.jun'),
+  t('book.detail.readingLog.months.jul'),
+  t('book.detail.readingLog.months.aug'),
+  t('book.detail.readingLog.months.sep'),
+  t('book.detail.readingLog.months.oct'),
+  t('book.detail.readingLog.months.nov'),
+  t('book.detail.readingLog.months.dec'),
+])
 
 const themeStore = useThemeStore()
 const option = shallowRef({})
@@ -58,8 +86,7 @@ const activeDays = computed(() => {
 const subtitle = computed(() => {
   if (consistencyWindowDays.value <= 0) return ''
   const ratio = Math.round((activeDays.value / consistencyWindowDays.value) * 100)
-  const dayWord = activeDays.value === 1 ? 'day' : 'days'
-  return `${activeDays.value} active ${dayWord} · ${ratio}% consistency`
+  return t('book.detail.readingLog.heatmap.subtitle', { count: activeDays.value, ratio }, activeDays.value)
 })
 
 const hasData = computed(() => (props.stats?.dailySummary ?? []).some((row) => row.totalMinutes > 0))
@@ -106,7 +133,7 @@ watchEffect(() => {
       textStyle: { color: palette.tooltipText, fontSize: 12 },
       formatter: (params: { value: [string, number] }) => {
         const [day, minutes] = params.value
-        return `${day}<br/><strong>${minutes}</strong> min`
+        return `${day}<br/><strong>${minutes}</strong> ${t('book.detail.readingLog.heatmap.minutesUnit')}`
       },
     },
     visualMap: {
@@ -137,7 +164,7 @@ watchEffect(() => {
         fontSize: 9,
         color: palette.axisColor,
         margin: 6,
-        nameMap: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+        nameMap: monthLabels.value,
       },
       dayLabel: {
         show: true,
@@ -145,7 +172,7 @@ watchEffect(() => {
         fontSize: 8,
         color: palette.axisColor,
         margin: 6,
-        nameMap: DAY_LABELS,
+        nameMap: dayLabels.value,
       },
       itemStyle: {
         color: 'transparent',
@@ -171,7 +198,7 @@ watchEffect(() => {
     <div class="mb-2 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
       <span class="flex items-center gap-2 text-sm font-medium text-foreground">
         <CalendarDays class="size-4 text-muted-foreground" />
-        Activity
+        {{ t('book.detail.readingLog.heatmap.title') }}
       </span>
       <span v-if="subtitle" class="text-xs text-muted-foreground">{{ subtitle }}</span>
     </div>
@@ -179,7 +206,7 @@ watchEffect(() => {
       <VChart :option autoresize class="absolute inset-0" />
     </div>
     <div v-else class="flex flex-1 items-center justify-center py-12 text-sm text-muted-foreground" style="min-height: 220px">
-      No reading activity in this window.
+      {{ t('book.detail.readingLog.heatmap.empty') }}
     </div>
   </div>
 </template>

--- a/client/src/features/book/components/detail/tabs/ReadingLogHero.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogHero.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Check, ChevronDown, Clock, Minus, Plus, TrendingDown, TrendingUp } from '@lucide/vue'
 import type { BookDetail, BookReadingSessionStats, ReadStatus, UserBookStatus } from '@bookorbit/types'
 import { isAudioFormat } from '@bookorbit/types'
@@ -19,6 +20,7 @@ const emit = defineEmits<{
   addSession: []
 }>()
 
+const { t } = useI18n()
 const { setStatus, updateStatus } = useBookStatus()
 
 const DAY_MS = 24 * 60 * 60 * 1000
@@ -40,7 +42,7 @@ function toDateInputValue(value: string | null | undefined): string {
 }
 
 function formatDisplayDate(dateKey: string): string {
-  if (!dateKey) return 'Not set'
+  if (!dateKey) return t('book.detail.readingLog.hero.notSet')
   const [year, month, day] = dateKey.split('-').map(Number)
   const d = new Date(year!, month! - 1, day!)
   return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
@@ -59,21 +61,21 @@ function formatRelative(iso: string | null): string {
   if (!iso) return '-'
   const diff = Date.now() - new Date(iso).getTime()
   const s = Math.floor(diff / 1000)
-  if (s < 60) return `${s}s ago`
+  if (s < 60) return t('book.detail.readingLog.hero.relative.seconds', { count: s })
   const m = Math.floor(s / 60)
-  if (m < 60) return `${m}m ago`
+  if (m < 60) return t('book.detail.readingLog.hero.relative.minutes', { count: m })
   const h = Math.floor(m / 60)
-  if (h < 24) return `${h}h ago`
+  if (h < 24) return t('book.detail.readingLog.hero.relative.hours', { count: h })
   const d = Math.floor(h / 24)
-  if (d < 30) return `${d}d ago`
+  if (d < 30) return t('book.detail.readingLog.hero.relative.days', { count: d })
   const mo = Math.floor(d / 30)
-  if (mo < 12) return `${mo} month${mo === 1 ? '' : 's'} ago`
+  if (mo < 12) return t('book.detail.readingLog.hero.relative.months', { count: mo }, mo)
   const yr = Math.floor(mo / 12)
-  return `${yr} year${yr === 1 ? '' : 's'} ago`
+  return t('book.detail.readingLog.hero.relative.years', { count: yr }, yr)
 }
 
 function formatSessionDate(iso: string | null): string {
-  if (!iso) return 'No sessions'
+  if (!iso) return t('book.detail.readingLog.hero.noSessions')
   return new Date(iso).toLocaleString(undefined, {
     year: 'numeric',
     month: 'short',
@@ -113,9 +115,10 @@ watch(
 )
 
 function validateDates(values: { startedAt: string; finishedAt: string }): string | null {
-  if (values.startedAt && values.startedAt > todayDateInput.value) return 'Start date cannot be in the future.'
-  if (values.finishedAt && values.finishedAt > todayDateInput.value) return 'Finish date cannot be in the future.'
-  if (values.startedAt && values.finishedAt && values.finishedAt < values.startedAt) return 'Finish date must be on or after the start date.'
+  if (values.startedAt && values.startedAt > todayDateInput.value) return t('book.detail.readingLog.hero.dateErrors.startFuture')
+  if (values.finishedAt && values.finishedAt > todayDateInput.value) return t('book.detail.readingLog.hero.dateErrors.finishFuture')
+  if (values.startedAt && values.finishedAt && values.finishedAt < values.startedAt)
+    return t('book.detail.readingLog.hero.dateErrors.finishBeforeStart')
   return null
 }
 
@@ -170,7 +173,7 @@ async function saveDateField(field: 'startedAt' | 'finishedAt') {
     applyReadStatusUpdate(updated)
     activeDateField.value = null
   } catch {
-    datesError.value = 'Failed to save reading dates.'
+    datesError.value = t('book.detail.readingLog.hero.dateErrors.saveFailed')
   } finally {
     savingDates.value = false
   }
@@ -256,13 +259,13 @@ const etaLabel = computed(() => {
   if (remaining <= 0) return null
   const totalMinutes = (remaining / pace) * 60
   if (!Number.isFinite(totalMinutes) || totalMinutes <= 0) return null
-  if (totalMinutes > 99 * 60) return '99h+ to finish'
+  if (totalMinutes > 99 * 60) return t('book.detail.readingLog.hero.eta.max')
   const rounded = Math.max(5, Math.round(totalMinutes / 5) * 5)
   const h = Math.floor(rounded / 60)
   const m = rounded % 60
-  if (h <= 0) return `~${m}m to finish`
-  if (m === 0) return `~${h}h to finish`
-  return `~${h}h ${m}m to finish`
+  if (h <= 0) return t('book.detail.readingLog.hero.eta.minutes', { m })
+  if (m === 0) return t('book.detail.readingLog.hero.eta.hours', { h })
+  return t('book.detail.readingLog.hero.eta.hoursMinutes', { h, m })
 })
 
 function toUtcDayStart(date: Date): number {
@@ -283,19 +286,31 @@ const momentum = computed(() => {
     last7 += map.get(toUtcDayKey(todayStart - offset * DAY_MS)) ?? 0
     prev7 += map.get(toUtcDayKey(todayStart - (offset + 7) * DAY_MS)) ?? 0
   }
-  if (last7 === 0 && prev7 === 0) return { direction: 'flat' as const, title: 'No activity in the last two weeks' }
-  if (prev7 <= 0) return { direction: 'up' as const, title: 'New activity this week' }
+  if (last7 === 0 && prev7 === 0) return { direction: 'flat' as const, title: t('book.detail.readingLog.hero.momentum.none') }
+  if (prev7 <= 0) return { direction: 'up' as const, title: t('book.detail.readingLog.hero.momentum.new') }
   const pct = Math.round(((last7 - prev7) / prev7) * 100)
-  if (pct > 0) return { direction: 'up' as const, title: `+${pct}% vs previous 7 days` }
-  if (pct < 0) return { direction: 'down' as const, title: `${pct}% vs previous 7 days` }
-  return { direction: 'flat' as const, title: 'Unchanged vs previous 7 days' }
+  if (pct > 0) return { direction: 'up' as const, title: t('book.detail.readingLog.hero.momentum.up', { pct }) }
+  if (pct < 0) return { direction: 'down' as const, title: t('book.detail.readingLog.hero.momentum.down', { pct }) }
+  return { direction: 'flat' as const, title: t('book.detail.readingLog.hero.momentum.flat') }
 })
 
 const statCells = computed(() => [
-  { label: 'Total Time', value: props.stats ? formatDuration(props.stats.totalSeconds) : '0s', withMomentum: true },
-  { label: 'Sessions', value: String(props.stats?.totalSessions ?? 0), withMomentum: false },
-  { label: 'Avg Session', value: props.stats ? formatDuration(props.stats.avgDurationSeconds) : '0s', withMomentum: false },
-  { label: 'Last Read', value: props.stats ? formatRelative(props.stats.lastSessionAt) : '-', withMomentum: false },
+  {
+    label: t('book.detail.readingLog.hero.stats.totalTime'),
+    value: props.stats ? formatDuration(props.stats.totalSeconds) : '0s',
+    withMomentum: true,
+  },
+  { label: t('book.detail.readingLog.hero.stats.sessions'), value: String(props.stats?.totalSessions ?? 0), withMomentum: false },
+  {
+    label: t('book.detail.readingLog.hero.stats.avgSession'),
+    value: props.stats ? formatDuration(props.stats.avgDurationSeconds) : '0s',
+    withMomentum: false,
+  },
+  {
+    label: t('book.detail.readingLog.hero.stats.lastRead'),
+    value: props.stats ? formatRelative(props.stats.lastSessionAt) : '-',
+    withMomentum: false,
+  },
 ])
 
 const currentStatusOption = computed(() => STATUS_OPTIONS.find((o) => o.value === (localReadStatus.value ?? 'unread')))
@@ -338,18 +353,18 @@ function handleAddSession() {
 
           <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
             <span class="flex items-center gap-1">
-              First Read
+              {{ t('book.detail.readingLog.hero.firstRead') }}
               <span class="font-medium text-foreground">{{ firstReadLabel }}</span>
             </span>
             <span class="flex items-center gap-1">
-              Last Read
+              {{ t('book.detail.readingLog.hero.lastRead') }}
               <span class="font-medium text-foreground">{{ lastReadLabel }}</span>
             </span>
           </div>
 
           <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
             <span class="flex items-center gap-1">
-              Date Started
+              {{ t('book.detail.readingLog.hero.dateStarted') }}
               <input
                 v-if="activeDateField === 'startedAt'"
                 v-model="draftDates.startedAt"
@@ -367,7 +382,7 @@ function handleAddSession() {
               </button>
             </span>
             <span class="flex items-center gap-1">
-              Date Finished
+              {{ t('book.detail.readingLog.hero.dateFinished') }}
               <input
                 v-if="activeDateField === 'finishedAt'"
                 v-model="draftDates.finishedAt"
@@ -423,7 +438,7 @@ function handleAddSession() {
           @click="handleAddSession"
         >
           <Plus :size="14" />
-          Add session
+          {{ t('book.detail.readingLog.hero.addSession') }}
         </button>
       </div>
     </div>

--- a/client/src/features/book/components/detail/tabs/ReadingLogJourneyChart.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogJourneyChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { TrendingUp } from '@lucide/vue'
 import type { BookReadingSessionStats } from '@bookorbit/types'
@@ -11,6 +12,7 @@ const props = defineProps<{
   loading: boolean
 }>()
 
+const { t } = useI18n()
 const themeStore = useThemeStore()
 const chartTheme = computed(() => getBookorbitThemeName(themeStore.theme, themeStore.accent))
 const option = shallowRef({})
@@ -40,7 +42,9 @@ watchEffect(() => {
         if (!params.length) return ''
         const day = params[0]!.value[0]
         const lines = params.map((p) =>
-          p.seriesName === 'Progress' ? `Progress: <strong>${p.value[1].toFixed(1)}%</strong>` : `Reading: <strong>${p.value[1]} min</strong>`,
+          p.seriesName === 'Progress'
+            ? `${t('book.detail.readingLog.journey.tooltipProgress')}: <strong>${p.value[1].toFixed(1)}%</strong>`
+            : `${t('book.detail.readingLog.journey.tooltipReading')}: <strong>${p.value[1]} ${t('book.detail.readingLog.journey.minutesUnit')}</strong>`,
         )
         return [day, ...lines].join('<br/>')
       },
@@ -94,13 +98,13 @@ watchEffect(() => {
   <div class="flex h-full flex-col rounded-lg border border-border bg-card p-3 sm:p-4">
     <div class="mb-2 flex items-center gap-2 text-sm font-medium text-foreground">
       <TrendingUp class="size-4 text-muted-foreground" />
-      Progress journey
+      {{ t('book.detail.readingLog.journey.title') }}
     </div>
     <div v-if="hasData" class="relative min-h-0 flex-1 transition-opacity" :class="{ 'opacity-50': loading }" style="min-height: 220px">
       <VChart :theme="chartTheme" :option autoresize class="absolute inset-0" />
     </div>
     <div v-else class="flex flex-1 items-center justify-center py-12 text-sm text-muted-foreground" style="min-height: 220px">
-      No progress data in this window.
+      {{ t('book.detail.readingLog.journey.empty') }}
     </div>
   </div>
 </template>

--- a/client/src/features/book/components/detail/tabs/ReadingLogSourceSplit.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogSourceSplit.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { MonitorSmartphone } from '@lucide/vue'
 import type { BookReadingSessionStats, ReadingSessionSourceBucket } from '@bookorbit/types'
 import { READING_SESSION_SOURCE_BUCKET_LABELS } from '@bookorbit/types'
@@ -7,6 +8,8 @@ import { READING_SESSION_SOURCE_BUCKET_LABELS } from '@bookorbit/types'
 const props = defineProps<{
   stats: BookReadingSessionStats | null
 }>()
+
+const { t } = useI18n()
 
 const BUCKET_TOKEN: Record<ReadingSessionSourceBucket, string> = {
   bookorbit: '--pill-web',
@@ -46,7 +49,7 @@ const shouldShow = computed(() => segments.value.length >= 2 && totalSeconds.val
   <div v-if="shouldShow" class="rounded-lg border border-border bg-card p-4">
     <p class="mb-3 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
       <MonitorSmartphone class="size-3.5" />
-      Where you read this book
+      {{ t('book.detail.readingLog.sourceSplit.title') }}
     </p>
     <div class="flex h-3 w-full overflow-hidden rounded-full bg-muted">
       <div

--- a/client/src/features/book/components/detail/tabs/ReadingLogTab.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { BookDetail, UserBookStatus } from '@bookorbit/types'
 import { useBookReadingLog, type AddReadingSessionPayload } from '@/features/book/composables/useBookReadingLog'
 import ReadingLogHero from './ReadingLogHero.vue'
@@ -15,6 +16,8 @@ const props = defineProps<{ book: BookDetail }>()
 const emit = defineEmits<{
   saved: [book: BookDetail]
 }>()
+
+const { t } = useI18n()
 
 const bookIdRef = computed(() => props.book.id)
 const {
@@ -46,7 +49,7 @@ const uniqueFormats = computed(() => {
 
 const hasMultipleFormats = computed(() => uniqueFormats.value.length >= 2)
 
-const bookTitle = computed(() => props.book.title ?? 'Untitled')
+const bookTitle = computed(() => props.book.title ?? t('book.detail.readingLog.untitled'))
 
 function buildDateFrom(q: QuickFilter): string | undefined {
   const now = new Date()
@@ -104,18 +107,18 @@ async function handleAddSessionSubmit(payload: AddReadingSessionPayload) {
     await addSession(payload)
     addDialogOpen.value = false
   } catch (e) {
-    addError.value = e instanceof Error ? e.message : 'Failed to add session'
+    addError.value = e instanceof Error ? e.message : t('book.detail.readingLog.addSessionFailed')
   } finally {
     addSaving.value = false
   }
 }
 
-const quickFilters: { label: string; value: QuickFilter }[] = [
-  { label: 'All time', value: 'all' },
-  { label: 'Last 30 days', value: 'last30' },
-  { label: 'Last 90 days', value: 'last90' },
-  { label: 'This year', value: 'thisYear' },
-]
+const quickFilters = computed<{ label: string; value: QuickFilter }[]>(() => [
+  { label: t('book.detail.readingLog.filters.allTime'), value: 'all' },
+  { label: t('book.detail.readingLog.filters.last30'), value: 'last30' },
+  { label: t('book.detail.readingLog.filters.last90'), value: 'last90' },
+  { label: t('book.detail.readingLog.filters.thisYear'), value: 'thisYear' },
+])
 </script>
 
 <template>
@@ -150,7 +153,7 @@ const quickFilters: { label: string; value: QuickFilter }[] = [
           :value="selectedFormat ?? ''"
           @change="handleFormatChange"
         >
-          <option value="">All formats</option>
+          <option value="">{{ t('book.detail.readingLog.filters.allFormats') }}</option>
           <option v-for="fmt in uniqueFormats" :key="fmt" :value="fmt">{{ fmt.toUpperCase() }}</option>
         </select>
 

--- a/client/src/features/book/components/detail/tabs/ReadingLogTable.vue
+++ b/client/src/features/book/components/detail/tabs/ReadingLogTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronDown, ChevronUp, ChevronsUpDown, Loader2, Trash2, X } from '@lucide/vue'
 import type { BookReadingSession, ReadingSessionSource } from '@bookorbit/types'
 
@@ -13,6 +14,8 @@ const props = defineProps<{
   hasMore: boolean
   hasMultipleFormats: boolean
 }>()
+
+const { t } = useI18n()
 
 const emit = defineEmits<{
   sortChange: [sortBy: string, sortDir: 'asc' | 'desc']
@@ -82,12 +85,12 @@ function formatPace(session: BookReadingSession): string {
 
 const PILL_BASE = 'inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium'
 
-const SESSION_SOURCE_PILLS: Record<ReadingSessionSource, { label: string; class: string }> = {
-  web: { label: 'Web', class: 'border-[var(--pill-web)]/40 bg-[var(--pill-web)]/10 text-[var(--pill-web)]' },
+const SESSION_SOURCE_PILLS = computed<Record<ReadingSessionSource, { label: string; class: string }>>(() => ({
+  web: { label: t('book.detail.readingLog.table.sourceWeb'), class: 'border-[var(--pill-web)]/40 bg-[var(--pill-web)]/10 text-[var(--pill-web)]' },
   koreader: { label: 'KOReader', class: 'border-[var(--pill-koreader)]/40 bg-[var(--pill-koreader)]/10 text-[var(--pill-koreader)]' },
   kobo: { label: 'Kobo', class: 'border-[var(--pill-kobo)]/40 bg-[var(--pill-kobo)]/10 text-[var(--pill-kobo)]' },
-  manual: { label: 'Manual', class: 'border-border bg-muted text-muted-foreground' },
-}
+  manual: { label: t('book.detail.readingLog.table.sourceManual'), class: 'border-border bg-muted text-muted-foreground' },
+}))
 
 const showSource = computed(() => props.sessions.some((s) => s.source != null))
 
@@ -115,15 +118,30 @@ function handleSort(col: string) {
   emit('sortChange', col, dir)
 }
 
-const SORTABLE_COLS = [
-  { id: 'startedAt', label: 'Date', mobileLabel: 'Date' },
-  { id: 'durationSeconds', label: 'Duration', mobileLabel: 'Duration' },
-  { id: 'progressDelta', label: 'Progress Change', mobileLabel: 'Delta' },
-  { id: 'endProgress', label: 'End Progress', mobileLabel: 'End' },
-] as const
+const SORTABLE_COLS = computed(
+  () =>
+    [
+      { id: 'startedAt', label: t('book.detail.readingLog.table.colDate'), mobileLabel: t('book.detail.readingLog.table.colDateMobile') },
+      {
+        id: 'durationSeconds',
+        label: t('book.detail.readingLog.table.colDuration'),
+        mobileLabel: t('book.detail.readingLog.table.colDurationMobile'),
+      },
+      {
+        id: 'progressDelta',
+        label: t('book.detail.readingLog.table.colProgressChange'),
+        mobileLabel: t('book.detail.readingLog.table.colProgressChangeMobile'),
+      },
+      {
+        id: 'endProgress',
+        label: t('book.detail.readingLog.table.colEndProgress'),
+        mobileLabel: t('book.detail.readingLog.table.colEndProgressMobile'),
+      },
+    ] as const,
+)
 
 const columnCount = computed(() => {
-  let count = SORTABLE_COLS.length + 2
+  let count = SORTABLE_COLS.value.length + 2
   if (showSource.value) count += 1
   if (props.hasMultipleFormats) count += 1
   return count
@@ -176,7 +194,7 @@ const rows = computed<TableRow[]>(() => {
 <template>
   <div @click.self="clearConfirmDelete">
     <div v-if="sessions.length === 0 && !loading" class="flex items-center justify-center py-16 text-muted-foreground text-sm">
-      No reading sessions recorded yet.
+      {{ t('book.detail.readingLog.table.empty') }}
     </div>
 
     <div v-else class="overflow-x-auto rounded-lg border border-border transition-opacity" :class="{ 'opacity-50 pointer-events-none': loading }">
@@ -199,20 +217,20 @@ const rows = computed<TableRow[]>(() => {
             <th
               class="hidden px-2 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:table-cell sm:px-4 sm:py-3 sm:text-xs"
             >
-              Pace
+              {{ t('book.detail.readingLog.table.colPace') }}
             </th>
             <th
               v-if="showSource"
               class="hidden px-2 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:table-cell sm:px-4 sm:py-3 sm:text-xs"
             >
-              Source
+              {{ t('book.detail.readingLog.table.colSource') }}
             </th>
             <th
               v-if="hasMultipleFormats"
               class="px-2 py-2.5 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide sm:px-4 sm:py-3 sm:text-xs"
             >
-              <span class="sm:hidden">Fmt</span>
-              <span class="hidden sm:inline">Format</span>
+              <span class="sm:hidden">{{ t('book.detail.readingLog.table.colFormatMobile') }}</span>
+              <span class="hidden sm:inline">{{ t('book.detail.readingLog.table.colFormat') }}</span>
             </th>
             <th class="w-28 px-2 py-2.5 sm:px-4 sm:py-3" />
           </tr>
@@ -273,26 +291,26 @@ const rows = computed<TableRow[]>(() => {
                   <template v-if="confirmDeleteId === row.session.id">
                     <button
                       class="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                      title="Cancel delete"
-                      aria-label="Cancel delete session"
+                      :title="t('book.detail.readingLog.table.cancelDelete')"
+                      :aria-label="t('book.detail.readingLog.table.cancelDeleteAria')"
                       @click="clearConfirmDelete"
                     >
                       <X :size="14" />
                     </button>
                     <button
                       class="inline-flex h-6 items-center justify-center rounded px-1.5 text-[10px] font-medium uppercase tracking-wide transition-colors bg-destructive/15 text-destructive ring-1 ring-destructive/40"
-                      title="Click again to confirm delete"
-                      aria-label="Confirm delete session"
+                      :title="t('book.detail.readingLog.table.confirmDeleteTitle')"
+                      :aria-label="t('book.detail.readingLog.table.confirmDeleteAria')"
                       @click="() => handleDeleteClick(row.session.id)"
                     >
-                      Confirm
+                      {{ t('common.confirm') }}
                     </button>
                   </template>
                   <button
                     v-else
                     class="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-destructive"
-                    title="Delete"
-                    aria-label="Delete session"
+                    :title="t('common.delete')"
+                    :aria-label="t('book.detail.readingLog.table.deleteAria')"
                     @click="() => handleDeleteClick(row.session.id)"
                   >
                     <Trash2 :size="14" />
@@ -313,9 +331,9 @@ const rows = computed<TableRow[]>(() => {
         @click="handleLoadMore"
       >
         <Loader2 v-if="loadingMore" :size="14" class="animate-spin" />
-        Load more
+        {{ t('book.detail.readingLog.table.loadMore') }}
       </button>
-      <span class="text-xs text-muted-foreground">Showing {{ sessions.length }} of {{ total }} sessions</span>
+      <span class="text-xs text-muted-foreground">{{ t('book.detail.readingLog.table.showing', { shown: sessions.length, total }) }}</span>
     </div>
   </div>
 </template>

--- a/client/src/features/book/components/detail/tabs/RichDescriptionEditor.vue
+++ b/client/src/features/book/components/detail/tabs/RichDescriptionEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import {
   Bold,
   Check,
@@ -34,6 +35,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update:modelValue': [value: string | null]
 }>()
+
+const { t } = useI18n()
 
 const linkPanelOpen = ref(false)
 const linkUrl = ref('')
@@ -212,7 +215,7 @@ function applyLink() {
   }
 
   if (!isAllowedLinkUrl(href)) {
-    linkError.value = 'Use http, https, or mailto.'
+    linkError.value = t('book.detail.richDescription.linkProtocolError')
     return
   }
 
@@ -253,152 +256,218 @@ function isAllowedLinkUrl(value: string): boolean {
     <div class="flex min-h-10 flex-wrap items-center gap-1 border-b border-border bg-muted/30 px-1.5 py-1">
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="boldButtonClass" :disabled="!canEdit" aria-label="Bold" @click="toggleBold">
+          <button type="button" :class="boldButtonClass" :disabled="!canEdit" :aria-label="t('book.detail.richDescription.bold')" @click="toggleBold">
             <Bold class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Bold</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.bold') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="italicButtonClass" :disabled="!canEdit" aria-label="Italic" @click="toggleItalic">
+          <button
+            type="button"
+            :class="italicButtonClass"
+            :disabled="!canEdit"
+            :aria-label="t('book.detail.richDescription.italic')"
+            @click="toggleItalic"
+          >
             <Italic class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Italic</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.italic') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="underlineButtonClass" :disabled="!canEdit" aria-label="Underline" @click="toggleUnderline">
+          <button
+            type="button"
+            :class="underlineButtonClass"
+            :disabled="!canEdit"
+            :aria-label="t('book.detail.richDescription.underline')"
+            @click="toggleUnderline"
+          >
             <Underline class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Underline</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.underline') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="strikeButtonClass" :disabled="!canEdit" aria-label="Strikethrough" @click="toggleStrike">
+          <button
+            type="button"
+            :class="strikeButtonClass"
+            :disabled="!canEdit"
+            :aria-label="t('book.detail.richDescription.strikethrough')"
+            @click="toggleStrike"
+          >
             <Strikethrough class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Strikethrough</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.strikethrough') }}</TooltipContent>
       </Tooltip>
 
       <div class="mx-0.5 h-5 w-px bg-border" />
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="bulletListButtonClass" :disabled="!canEdit" aria-label="Bullet list" @click="toggleBulletList">
+          <button
+            type="button"
+            :class="bulletListButtonClass"
+            :disabled="!canEdit"
+            :aria-label="t('book.detail.richDescription.bulletList')"
+            @click="toggleBulletList"
+          >
             <List class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Bullet list</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.bulletList') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="orderedListButtonClass" :disabled="!canEdit" aria-label="Numbered list" @click="toggleOrderedList">
+          <button
+            type="button"
+            :class="orderedListButtonClass"
+            :disabled="!canEdit"
+            :aria-label="t('book.detail.richDescription.numberedList')"
+            @click="toggleOrderedList"
+          >
             <ListOrdered class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Numbered list</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.numberedList') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="plainButtonClass" :disabled="!canOutdentList" aria-label="Outdent list item" @click="outdentList">
+          <button
+            type="button"
+            :class="plainButtonClass"
+            :disabled="!canOutdentList"
+            :aria-label="t('book.detail.richDescription.outdentAria')"
+            @click="outdentList"
+          >
             <IndentDecrease class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Outdent</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.outdent') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="plainButtonClass" :disabled="!canIndentList" aria-label="Indent list item" @click="indentList">
+          <button
+            type="button"
+            :class="plainButtonClass"
+            :disabled="!canIndentList"
+            :aria-label="t('book.detail.richDescription.indentAria')"
+            @click="indentList"
+          >
             <IndentIncrease class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Indent</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.indent') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="blockquoteButtonClass" :disabled="!canEdit" aria-label="Quote" @click="toggleBlockquote">
+          <button
+            type="button"
+            :class="blockquoteButtonClass"
+            :disabled="!canEdit"
+            :aria-label="t('book.detail.richDescription.quote')"
+            @click="toggleBlockquote"
+          >
             <Quote class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Quote</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.quote') }}</TooltipContent>
       </Tooltip>
 
       <div class="mx-0.5 h-5 w-px bg-border" />
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="linkButtonClass" :disabled="!canEdit" aria-label="Edit link" @click="toggleLinkPanel">
+          <button
+            type="button"
+            :class="linkButtonClass"
+            :disabled="!canEdit"
+            :aria-label="t('book.detail.richDescription.editLink')"
+            @click="toggleLinkPanel"
+          >
             <LinkIcon class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Link</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.link') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="plainButtonClass" :disabled="!canEdit || !isLinkActive" aria-label="Remove link" @click="removeLink">
+          <button
+            type="button"
+            :class="plainButtonClass"
+            :disabled="!canEdit || !isLinkActive"
+            :aria-label="t('book.detail.richDescription.removeLink')"
+            @click="removeLink"
+          >
             <Unlink class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Remove link</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.removeLink') }}</TooltipContent>
       </Tooltip>
 
       <div class="mx-0.5 h-5 w-px bg-border" />
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="plainButtonClass" :disabled="!canUndo" aria-label="Undo" @click="undo">
+          <button type="button" :class="plainButtonClass" :disabled="!canUndo" :aria-label="t('book.detail.richDescription.undo')" @click="undo">
             <Undo2 class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Undo</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.undo') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="plainButtonClass" :disabled="!canRedo" aria-label="Redo" @click="redo">
+          <button type="button" :class="plainButtonClass" :disabled="!canRedo" :aria-label="t('book.detail.richDescription.redo')" @click="redo">
             <Redo2 class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Redo</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.redo') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="plainButtonClass" :disabled="!canEdit" aria-label="Clear formatting" @click="clearFormatting">
+          <button
+            type="button"
+            :class="plainButtonClass"
+            :disabled="!canEdit"
+            :aria-label="t('book.detail.richDescription.clearFormatting')"
+            @click="clearFormatting"
+          >
             <Eraser class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Clear formatting</TooltipContent>
+        <TooltipContent>{{ t('book.detail.richDescription.clearFormatting') }}</TooltipContent>
       </Tooltip>
 
       <div class="mx-0.5 h-5 w-px bg-border" />
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button type="button" :class="previewButtonClass" aria-label="Preview description" @click="togglePreview">
+          <button type="button" :class="previewButtonClass" :aria-label="t('book.detail.richDescription.previewDescription')" @click="togglePreview">
             <PencilLine v-if="previewOpen" class="size-4" />
             <Eye v-else class="size-4" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{{ previewOpen ? 'Edit' : 'Preview' }}</TooltipContent>
+        <TooltipContent>{{ previewOpen ? t('common.edit') : t('book.detail.richDescription.preview') }}</TooltipContent>
       </Tooltip>
     </div>
 
     <div v-if="linkPanelOpen" class="flex flex-wrap items-start gap-2 border-b border-border bg-card px-2 py-2">
       <label class="min-w-0 flex-1">
-        <span class="sr-only">Link URL</span>
+        <span class="sr-only">{{ t('book.detail.richDescription.linkUrlLabel') }}</span>
         <input
           v-model="linkUrl"
           type="url"
@@ -415,26 +484,26 @@ function isAllowedLinkUrl(value: string): boolean {
             <button
               type="button"
               class="inline-flex size-8 items-center justify-center rounded-md border border-input hover:bg-muted"
-              aria-label="Apply link"
+              :aria-label="t('book.detail.richDescription.applyLink')"
               @click="applyLink"
             >
               <Check class="size-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Apply</TooltipContent>
+          <TooltipContent>{{ t('book.detail.richDescription.apply') }}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger as-child>
             <button
               type="button"
               class="inline-flex size-8 items-center justify-center rounded-md border border-input hover:bg-muted"
-              aria-label="Cancel link"
+              :aria-label="t('book.detail.richDescription.cancelLink')"
               @click="closeLinkPanel"
             >
               <X class="size-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Cancel</TooltipContent>
+          <TooltipContent>{{ t('common.cancel') }}</TooltipContent>
         </Tooltip>
       </div>
     </div>
@@ -445,7 +514,7 @@ function isAllowedLinkUrl(value: string): boolean {
     >
       <!-- eslint-disable-next-line vue/no-v-html -- sanitized by sanitizeDescriptionHtml -->
       <div v-if="previewHtml" v-html="previewHtml"></div>
-      <p v-else class="italic text-muted-foreground">No description available.</p>
+      <p v-else class="italic text-muted-foreground">{{ t('book.detail.richDescription.noDescription') }}</p>
     </div>
     <EditorContent v-else-if="editor" :editor="editor" :class="{ 'pointer-events-none opacity-50': disabled }" />
   </div>

--- a/client/src/features/book/components/detail/tabs/SeriesMembershipEditor.vue
+++ b/client/src/features/book/components/detail/tabs/SeriesMembershipEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ArrowDown, ArrowUp, Plus, Trash2 } from '@lucide/vue'
 import InputWithSuggestions from '@/components/ui/InputWithSuggestions.vue'
 import type { EditableSeriesMembership } from '../../../composables/useMetadataEditor'
@@ -9,6 +10,8 @@ const props = defineProps<{
   searchFn: (q: string) => Promise<string[]>
   disabled?: boolean
 }>()
+
+const { t } = useI18n()
 
 const emit = defineEmits<{ 'update:modelValue': [EditableSeriesMembership[]] }>()
 
@@ -105,7 +108,7 @@ function moveMembership(index: number, offset: -1 | 1) {
         type="button"
         class="flex h-8 w-8 items-center justify-center rounded-md border border-input bg-background text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
         :disabled="disabled"
-        title="Add series"
+        :title="t('book.detail.seriesMembership.addSeries')"
         @click="addMembership"
       >
         <Plus class="size-3.5" />
@@ -116,7 +119,7 @@ function moveMembership(index: number, offset: -1 | 1) {
         :model-value="membership.seriesName"
         :search-fn="searchFn"
         :disabled="disabled"
-        placeholder="Series"
+        :placeholder="t('book.detail.seriesMembership.seriesPlaceholder')"
         :class="'h-8 w-full rounded-lg border border-input bg-background px-3 text-sm outline-none transition-shadow focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50'"
         @update:model-value="updateSeriesName(index, $event)"
       />
@@ -135,7 +138,7 @@ function moveMembership(index: number, offset: -1 | 1) {
           type="button"
           class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
           :disabled="disabled || index === 0"
-          title="Move up"
+          :title="t('book.detail.seriesMembership.moveUp')"
           @click="moveMembership(index, -1)"
         >
           <ArrowUp class="size-3.5" />
@@ -144,7 +147,7 @@ function moveMembership(index: number, offset: -1 | 1) {
           type="button"
           class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
           :disabled="disabled || modelValue.length < 2 || index === visibleMemberships.length - 1"
-          title="Move down"
+          :title="t('book.detail.seriesMembership.moveDown')"
           @click="moveMembership(index, 1)"
         >
           <ArrowDown class="size-3.5" />
@@ -153,7 +156,7 @@ function moveMembership(index: number, offset: -1 | 1) {
           type="button"
           class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-40"
           :disabled="disabled || modelValue.length === 0"
-          title="Remove series"
+          :title="t('book.detail.seriesMembership.removeSeries')"
           @click="removeMembership(index)"
         >
           <Trash2 class="size-3.5" />

--- a/client/src/features/book/components/table/BookCoverDialog.vue
+++ b/client/src/features/book/components/table/BookCoverDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ArrowLeft, Loader2, Pencil, X } from '@lucide/vue'
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 import { DialogClose, DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogRoot, DialogTitle } from 'reka-ui'
@@ -21,6 +22,7 @@ const emit = defineEmits<{
   'update:book': [bookId: number, hasCover: boolean]
 }>()
 
+const { t } = useI18n()
 const { md } = useBreakpoints(breakpointsTailwind)
 const isEditEnabled = computed(() => !props.readOnly && md.value)
 
@@ -84,7 +86,7 @@ async function handleToggleCoverLock() {
         @escape-key-down="handleOpenChange(false)"
       >
         <DialogDescription class="sr-only">
-          {{ mode === 'view' ? 'Book cover preview' : 'Edit book cover' }}
+          {{ mode === 'view' ? t('book.table.cover.previewDescription') : t('book.table.cover.editDescription') }}
         </DialogDescription>
 
         <!-- Header -->
@@ -98,7 +100,7 @@ async function handleToggleCoverLock() {
               <ArrowLeft :size="15" />
             </button>
             <DialogTitle class="truncate text-sm font-semibold text-foreground">
-              {{ mode === 'view' ? book?.title : 'Edit cover' }}
+              {{ mode === 'view' ? book?.title : t('book.table.cover.editTitle') }}
             </DialogTitle>
           </div>
           <DialogClose
@@ -136,7 +138,7 @@ async function handleToggleCoverLock() {
               @click="switchToEdit"
             >
               <Pencil :size="14" />
-              Edit Cover
+              {{ t('book.table.cover.editCover') }}
             </button>
           </template>
 

--- a/client/src/features/book/components/table/BookTableActionsCell.vue
+++ b/client/src/features/book/components/table/BookTableActionsCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { BookOpen, ExternalLink, FolderPlus, MoreHorizontal, Pencil, RefreshCw, Send, Trash2 } from '@lucide/vue'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
@@ -24,6 +25,7 @@ const emit = defineEmits<{
 
 const router = useRouter()
 
+const { t } = useI18n()
 const { hasPermission } = usePermissions()
 const { refreshWithFeedback, refreshing } = useRefreshMetadata()
 const refreshFeedback = useBookRefreshFeedback()
@@ -59,11 +61,11 @@ async function handleRefresh() {
       <DropdownMenuContent align="end" class="w-44">
         <DropdownMenuItem @click="handleAction('quick-view')">
           <BookOpen :size="13" class="mr-2" />
-          Quick View
+          {{ t('book.table.actions.quickView') }}
         </DropdownMenuItem>
         <DropdownMenuItem @click="router.push({ name: 'book-detail', params: { bookId: book.id } })">
           <ExternalLink :size="13" class="mr-2" />
-          Book Details
+          {{ t('book.table.actions.bookDetails') }}
         </DropdownMenuItem>
         <DropdownMenuSeparator v-if="hasPermission('library_edit_metadata')" />
         <DropdownMenuItem
@@ -71,19 +73,19 @@ async function handleRefresh() {
           @click="router.push({ name: 'book-detail', params: { bookId: book.id }, query: { tab: 'edit' } })"
         >
           <Pencil :size="13" class="mr-2" />
-          Edit Metadata
+          {{ t('book.table.actions.editMetadata') }}
         </DropdownMenuItem>
         <DropdownMenuItem v-if="hasPermission('library_edit_metadata')" :disabled="anyRefreshing" @click="handleRefresh">
           <RefreshCw :size="13" class="mr-2" :class="{ 'animate-spin': anyRefreshing }" />
-          Refresh Metadata
+          {{ t('book.table.actions.refreshMetadata') }}
         </DropdownMenuItem>
         <DropdownMenuItem v-if="hasPermission('library_edit_metadata')" @click="handleAction('add-to-collection')">
           <FolderPlus :size="13" class="mr-2" />
-          Add to Collection
+          {{ t('book.table.actions.addToCollection') }}
         </DropdownMenuItem>
         <DropdownMenuItem v-if="hasPermission('email_send')" @click="showSendDialog = true">
           <Send :size="13" class="mr-2" />
-          Send to Device
+          {{ t('book.table.actions.sendToDevice') }}
         </DropdownMenuItem>
         <DropdownMenuSeparator v-if="hasPermission('library_delete_books')" />
         <DropdownMenuItem
@@ -92,7 +94,7 @@ async function handleRefresh() {
           @click="handleAction('delete')"
         >
           <Trash2 :size="13" class="mr-2" />
-          Delete
+          {{ t('common.delete') }}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/client/src/features/book/components/table/BookTableBooleanCell.vue
+++ b/client/src/features/book/components/table/BookTableBooleanCell.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
 const props = defineProps<{
   value: boolean | null
   isReadOnly?: boolean
@@ -17,8 +21,8 @@ function handleToggle() {
 }
 
 function ariaLabel(): string {
-  if (props.value === null) return 'Not set - click to set true'
-  return props.value ? 'True - click to set false' : 'False - click to clear'
+  if (props.value === null) return t('book.table.boolean.ariaNotSet')
+  return props.value ? t('book.table.boolean.ariaTrue') : t('book.table.boolean.ariaFalse')
 }
 </script>
 

--- a/client/src/features/book/components/table/BookTableCellDispatcher.vue
+++ b/client/src/features/book/components/table/BookTableCellDispatcher.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Lock, LockOpen } from '@lucide/vue'
 import { FORMAT_TO_GROUP, type BookCard } from '@bookorbit/types'
 import BookTableCoverCell from './BookTableCoverCell.vue'
@@ -55,6 +56,8 @@ const emit = defineEmits<{
   'update:book': [updated: BookCard]
 }>()
 
+const { t } = useI18n()
+
 function asString(v: unknown): string | null {
   return v as string | null
 }
@@ -87,7 +90,7 @@ const isComic = computed(() => primaryFile.value?.format != null && FORMAT_TO_GR
     <button
       class="flex h-6 w-6 items-center justify-center rounded transition-colors hover:bg-muted"
       :class="lockStateClass"
-      :aria-label="isFullyLocked ? 'Unlock all fields' : 'Lock all fields'"
+      :aria-label="isFullyLocked ? t('book.table.locks.unlockAll') : t('book.table.locks.lockAll')"
       @click.stop="isFullyLocked ? emit('unlockAll') : emit('lockAll')"
     >
       <Lock v-if="lockedFieldCount > 0" :size="13" />

--- a/client/src/features/book/components/table/BookTableChipsCell.vue
+++ b/client/src/features/book/components/table/BookTableChipsCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { RouterLink } from 'vue-router'
 import ChipInput from '@/components/ui/ChipInput.vue'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -19,6 +20,8 @@ const emit = defineEmits<{
   cancel: []
   navigate: [direction: 'next' | 'prev']
 }>()
+
+const { t } = useI18n()
 
 const defaultSearchFn = () => Promise.resolve([])
 
@@ -113,7 +116,7 @@ function handleChipAction(chip: string) {
         :style="{ minWidth: 'max(240px, var(--reka-popover-trigger-width))', maxWidth: 'min(400px, 90vw)' }"
         @keydown="handleKeydown"
       >
-        <ChipInput v-model="draft" :search-fn="searchFn ?? defaultSearchFn" placeholder="Add..." />
+        <ChipInput v-model="draft" :search-fn="searchFn ?? defaultSearchFn" :placeholder="t('book.table.chips.addPlaceholder')" />
       </PopoverContent>
     </Popover>
   </div>

--- a/client/src/features/book/components/table/BookTableCollapsedSeriesCell.vue
+++ b/client/src/features/book/components/table/BookTableCollapsedSeriesCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronRight, LibraryBig } from '@lucide/vue'
 import { FORMAT_TO_GROUP, type BookCard } from '@bookorbit/types'
 import BookCoverSurface from '../BookCoverSurface.vue'
@@ -9,6 +10,8 @@ const props = defineProps<{
   book: BookCard
   colId: string
 }>()
+
+const { t } = useI18n()
 
 const collapsed = computed(() => props.book.collapsedSeries!)
 const seriesName = computed(() => props.book.seriesName ?? '')
@@ -70,8 +73,10 @@ function thumbnailUrl(bookId: number): string {
 
   <div v-else-if="colId === 'title'" class="flex items-center gap-2 min-w-0 h-full px-1">
     <span class="font-medium text-sm truncate block">{{ seriesName }}</span>
-    <span class="text-xs text-muted-foreground shrink-0 mt-0.5">({{ bookCount }} {{ bookCount === 1 ? 'book' : 'books' }})</span>
-    <span v-if="readCount > 0" class="text-xs text-muted-foreground shrink-0 mt-0.5">&middot; {{ readCount }} of {{ bookCount }} read</span>
+    <span class="text-xs text-muted-foreground shrink-0 mt-0.5">{{ t('book.table.series.bookCount', { count: bookCount }, bookCount) }}</span>
+    <span v-if="readCount > 0" class="text-xs text-muted-foreground shrink-0 mt-0.5"
+      >&middot; {{ t('book.table.series.readOfCount', { read: readCount, total: bookCount }) }}</span
+    >
   </div>
 
   <div v-else-if="colId === 'actions'" class="flex h-full w-6 items-center justify-center">

--- a/client/src/features/book/components/table/BookTableContextMenu.vue
+++ b/client/src/features/book/components/table/BookTableContextMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { BookOpen, ExternalLink, FolderPlus, Pencil, RefreshCw, Send, Trash2 } from '@lucide/vue'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
@@ -24,6 +25,7 @@ const emit = defineEmits<{
 }>()
 
 const router = useRouter()
+const { t } = useI18n()
 const { hasPermission } = usePermissions()
 const { refreshWithFeedback, refreshing } = useRefreshMetadata()
 const refreshFeedback = useBookRefreshFeedback()
@@ -150,11 +152,11 @@ onBeforeUnmount(() => {
     >
       <button class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent" @click="emitAction('quick-view')">
         <BookOpen :size="14" />
-        Quick View
+        {{ t('book.table.actions.quickView') }}
       </button>
       <button class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent" @click="openBookDetails">
         <ExternalLink :size="14" />
-        Book Details
+        {{ t('book.table.actions.bookDetails') }}
       </button>
       <button
         v-if="hasPermission('library_edit_metadata')"
@@ -162,7 +164,7 @@ onBeforeUnmount(() => {
         @click="openEditMetadata"
       >
         <Pencil :size="14" />
-        Edit Metadata
+        {{ t('book.table.actions.editMetadata') }}
       </button>
       <button
         v-if="hasPermission('library_edit_metadata')"
@@ -171,11 +173,11 @@ onBeforeUnmount(() => {
         @click="refreshMetadata"
       >
         <RefreshCw :size="14" :class="{ 'animate-spin': anyRefreshing }" />
-        Refresh Metadata
+        {{ t('book.table.actions.refreshMetadata') }}
       </button>
       <button class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent" @click="emitAction('add-to-collection')">
         <FolderPlus :size="14" />
-        Add to Collection
+        {{ t('book.table.actions.addToCollection') }}
       </button>
       <button
         v-if="hasPermission('email_send')"
@@ -183,7 +185,7 @@ onBeforeUnmount(() => {
         @click="openSendDialog"
       >
         <Send :size="14" />
-        Send to Device
+        {{ t('book.table.actions.sendToDevice') }}
       </button>
       <button
         v-if="hasPermission('library_delete_books')"
@@ -191,7 +193,7 @@ onBeforeUnmount(() => {
         @click="emitAction('delete')"
       >
         <Trash2 :size="14" />
-        Delete
+        {{ t('common.delete') }}
       </button>
     </div>
   </Teleport>

--- a/client/src/features/book/components/table/BookTableCoverCell.vue
+++ b/client/src/features/book/components/table/BookTableCoverCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Loader2 } from '@lucide/vue'
 import { useCoverVersions } from '../../composables/useCoverVersions'
 import BookCoverArtwork from '../BookCoverArtwork.vue'
@@ -17,6 +18,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{ 'cover-click': [] }>()
+const { t } = useI18n()
 const { isRefreshing } = useRefreshingBooks()
 
 const seed = computed(() => props.title ?? String(props.bookId))
@@ -81,7 +83,7 @@ const adjustedTop = computed(() => {
       :is-comic="isComic"
       tabindex="0"
       role="button"
-      aria-label="View cover"
+      :aria-label="t('book.table.cover.view')"
       class="book-cover-surface--spine-fitted relative flex h-9 w-9 shrink-0 cursor-pointer overflow-hidden rounded-sm transition-opacity hover:opacity-80"
       @click="handleCoverClick"
       @keydown="handleKeydown"

--- a/client/src/features/book/components/table/BookTableDateCell.vue
+++ b/client/src/features/book/components/table/BookTableDateCell.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
 const props = defineProps<{
   value: string | null
   variant?: 'default' | 'relative'
@@ -23,7 +27,7 @@ function formatDate(isoDate: string | null): string {
 function formatRelativeTime(date: Date): string {
   const diffMs = date.getTime() - Date.now()
   const absMs = Math.abs(diffMs)
-  if (absMs < 5_000) return 'just now'
+  if (absMs < 5_000) return t('book.table.date.justNow')
 
   const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
   const units = [

--- a/client/src/features/book/components/table/BookTableFormatCell.vue
+++ b/client/src/features/book/components/table/BookTableFormatCell.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { getFormatColor } from '@/features/book/lib/format-colors'
 import type { BookFileRef } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   files: BookFileRef[]
@@ -44,7 +47,7 @@ const visibleFormats = computed(() => formats.value.slice(0, 2))
       </div>
     </TooltipTrigger>
     <TooltipContent>
-      <div v-for="file in formattedFiles" :key="file.id" class="text-xs">{{ file.format ?? 'unknown' }} ({{ file.role }})</div>
+      <div v-for="file in formattedFiles" :key="file.id" class="text-xs">{{ file.format ?? t('book.table.format.unknown') }} ({{ file.role }})</div>
     </TooltipContent>
   </Tooltip>
   <span v-else class="text-xs text-muted-foreground/40">-</span>

--- a/client/src/features/book/components/table/BookTableHeader.vue
+++ b/client/src/features/book/components/table/BookTableHeader.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { ArrowDown, ArrowUp, ArrowUpDown, GripVertical, Loader2 } from '@lucide/vue'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ColumnDef } from '@/features/book/composables/tableColumnSchema'
@@ -33,6 +34,8 @@ const emit = defineEmits<{
   autoFitColumn: [colId: string]
 }>()
 
+const { t } = useI18n()
+
 function getSortDir(sortField: string): 'asc' | 'desc' | null {
   return props.sort.find((s) => s.field === sortField)?.dir ?? null
 }
@@ -61,7 +64,7 @@ function isSortableColumn(col: ColumnDef): boolean {
           class="accent-primary h-3.5 w-3.5 cursor-pointer"
           :checked="allBooksSelected"
           :indeterminate="someBooksSelected"
-          aria-label="Select all books"
+          :aria-label="t('book.table.header.selectAllBooks')"
           @change="emit('selectAll', $event)"
         />
       </th>
@@ -134,7 +137,7 @@ function isSortableColumn(col: ColumnDef): boolean {
             </div>
           </TooltipTrigger>
           <TooltipContent>
-            {{ getSortDir(col.sortField!) ? 'Shift+click to add secondary sort' : 'Click to sort' }}
+            {{ getSortDir(col.sortField!) ? t('book.table.header.shiftClickSecondarySort') : t('book.table.header.clickToSort') }}
           </TooltipContent>
         </Tooltip>
         <div v-else data-col-label class="flex min-w-0 items-center gap-1 overflow-hidden pr-2">

--- a/client/src/features/book/components/table/BookTableHeaderContextMenu.vue
+++ b/client/src/features/book/components/table/BookTableHeaderContextMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch, nextTick, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ArrowDown, ArrowUp, Columns3, EyeOff, Filter, Pin, PinOff, X } from '@lucide/vue'
 import type { ColumnDef } from '@/features/book/composables/useTableColumns'
 
@@ -23,6 +24,8 @@ const emit = defineEmits<{
   'quick-filter': [key: string]
   close: []
 }>()
+
+const { t } = useI18n()
 
 const menuRef = ref<HTMLElement | null>(null)
 
@@ -101,7 +104,7 @@ onUnmounted(() => {
           @click="handleAction(() => emit('sort-asc'))"
         >
           <ArrowUp :size="14" />
-          Sort Ascending
+          {{ t('book.table.header.sortAscending') }}
         </button>
         <button
           class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent"
@@ -109,7 +112,7 @@ onUnmounted(() => {
           @click="handleAction(() => emit('sort-desc'))"
         >
           <ArrowDown :size="14" />
-          Sort Descending
+          {{ t('book.table.header.sortDescending') }}
         </button>
         <button
           v-if="sortDir"
@@ -117,7 +120,7 @@ onUnmounted(() => {
           @click="handleAction(() => emit('clear-sort'))"
         >
           <X :size="14" />
-          Clear Sort
+          {{ t('book.table.header.clearSort') }}
         </button>
         <div class="my-1 h-px bg-border" />
       </template>
@@ -141,7 +144,7 @@ onUnmounted(() => {
         @click="handleAction(() => emit('hide-column'))"
       >
         <EyeOff :size="14" />
-        Hide Column
+        {{ t('book.table.header.hideColumn') }}
       </button>
 
       <template v-if="column.pinned === null">
@@ -150,14 +153,14 @@ onUnmounted(() => {
           @click="handleAction(() => emit('pin-left'))"
         >
           <Pin :size="14" />
-          Pin Left
+          {{ t('book.table.header.pinLeft') }}
         </button>
         <button
           class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent"
           @click="handleAction(() => emit('pin-right'))"
         >
           <Pin :size="14" class="rotate-90" />
-          Pin Right
+          {{ t('book.table.header.pinRight') }}
         </button>
       </template>
       <button
@@ -166,7 +169,7 @@ onUnmounted(() => {
         @click="handleAction(() => emit('unpin'))"
       >
         <PinOff :size="14" />
-        Unpin Column
+        {{ t('book.table.header.unpinColumn') }}
       </button>
 
       <div class="my-1 h-px bg-border" />
@@ -176,14 +179,14 @@ onUnmounted(() => {
         @click="handleAction(() => emit('auto-fit'))"
       >
         <Columns3 :size="14" />
-        Auto-Fit Width
+        {{ t('book.table.header.autoFitWidth') }}
       </button>
       <button
         class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent"
         @click="handleAction(() => emit('auto-fit-all'))"
       >
         <Columns3 :size="14" />
-        Auto-Fit All Columns
+        {{ t('book.table.header.autoFitAllColumns') }}
       </button>
     </div>
   </Teleport>

--- a/client/src/features/book/components/table/BookTableLockableCell.vue
+++ b/client/src/features/book/components/table/BookTableLockableCell.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Lock, LockOpen } from '@lucide/vue'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const { t } = useI18n()
 
 defineProps<{
   isLocked: boolean
@@ -22,7 +25,7 @@ defineEmits<{
         <button
           type="button"
           :aria-pressed="isLocked"
-          :aria-label="isLocked ? 'Unlock field' : 'Lock field'"
+          :aria-label="isLocked ? t('book.table.locks.unlockField') : t('book.table.locks.lockField')"
           class="flex h-4 w-4 shrink-0 items-center justify-center rounded-sm transition-colors"
           :class="
             isLocked
@@ -36,7 +39,7 @@ defineEmits<{
         </button>
       </TooltipTrigger>
       <TooltipContent>
-        {{ isLocked ? 'Click to unlock' : 'Click to lock' }}
+        {{ isLocked ? t('book.table.locks.clickToUnlock') : t('book.table.locks.clickToLock') }}
       </TooltipContent>
     </Tooltip>
   </div>

--- a/client/src/features/book/components/table/BookTableProgressCell.vue
+++ b/client/src/features/book/components/table/BookTableProgressCell.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const { t } = useI18n()
 
 const props = defineProps<{ value: number | null }>()
 
@@ -24,7 +27,7 @@ const barColor = computed(() => {
         <span class="w-14 shrink-0 text-right text-sm font-medium tabular-nums text-muted-foreground">{{ displayPct }}</span>
       </div>
     </TooltipTrigger>
-    <TooltipContent>{{ displayPct }} complete</TooltipContent>
+    <TooltipContent>{{ t('book.table.progress.complete', { percent: displayPct }) }}</TooltipContent>
   </Tooltip>
   <span v-else class="text-xs text-muted-foreground/40">-</span>
 </template>

--- a/client/src/features/book/components/table/BookTableRatingCell.vue
+++ b/client/src/features/book/components/table/BookTableRatingCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Star } from '@lucide/vue'
 import { RATING_STARS, getRatingStarClass } from '@/features/book/lib/rating-stars'
 
@@ -11,6 +12,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   save: [value: number | null]
 }>()
+
+const { t } = useI18n()
 
 const STARS = RATING_STARS
 const groupRef = ref<HTMLDivElement | null>(null)
@@ -54,7 +57,7 @@ function handleStarKeydown(event: KeyboardEvent) {
 }
 
 function getAriaLabel(star: number): string {
-  return props.value === star ? 'Remove rating' : `Rate ${star} out of 5`
+  return props.value === star ? t('book.table.rating.remove') : t('book.table.rating.rate', { star })
 }
 
 function getTabIndex(star: number): number {
@@ -64,7 +67,7 @@ function getTabIndex(star: number): number {
 </script>
 
 <template>
-  <div ref="groupRef" role="group" aria-label="Rating" class="flex items-center gap-0.5">
+  <div ref="groupRef" role="group" :aria-label="t('book.table.rating.label')" class="flex items-center gap-0.5">
     <button
       v-for="star in STARS"
       :key="star"

--- a/client/src/features/book/components/table/BookTableReadButtonCell.vue
+++ b/client/src/features/book/components/table/BookTableReadButtonCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { BookOpen, ChevronDown, Eye, Play } from '@lucide/vue'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
@@ -12,6 +13,7 @@ const props = defineProps<{
 }>()
 
 const router = useRouter()
+const { t } = useI18n()
 
 const readableFiles = computed(() => {
   const normalized = props.book.files.filter((file) => {
@@ -66,7 +68,7 @@ const hasMultipleFormats = computed(() => openableFiles.value.length > 1)
 
 function actionVerb(file: BookFileRef | null): string {
   const format = file?.format?.toLowerCase()
-  return format && FORMAT_TO_GROUP[format] === 'audio' ? 'Play' : 'Read'
+  return format && FORMAT_TO_GROUP[format] === 'audio' ? t('book.table.read.play') : t('book.table.read.read')
 }
 
 function isAudioFile(file: BookFileRef | null): boolean {
@@ -75,7 +77,7 @@ function isAudioFile(file: BookFileRef | null): boolean {
 }
 
 function formatLabel(file: BookFileRef | null): string {
-  return file?.format?.trim().toUpperCase() ?? 'FILE'
+  return file?.format?.trim().toUpperCase() ?? t('book.table.read.fileFallback')
 }
 
 function formatBadgeStyle(format: string) {
@@ -124,7 +126,7 @@ function peekPrimaryFile() {
           <button
             type="button"
             class="inline-flex h-7 w-6 shrink-0 items-center justify-center rounded-r-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-            aria-label="Choose format to read or play"
+            :aria-label="t('book.table.read.chooseFormat')"
             @click.stop
           >
             <ChevronDown :size="12" />
@@ -139,11 +141,11 @@ function peekPrimaryFile() {
               {{ file.format }}
             </span>
             <span class="flex-1 truncate text-xs">{{ actionVerb(file) }} {{ formatLabel(file) }}</span>
-            <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="text-[10px] text-primary">Primary</span>
+            <span v-if="file.role === 'primary' && !isMultiTrackAudio" class="text-[10px] text-primary">{{ t('book.table.read.primary') }}</span>
           </DropdownMenuItem>
           <DropdownMenuItem v-for="file in openableFiles" :key="`peek-${file.id}`" class="gap-2" @select="openFile(file, 'peek')">
             <Eye :size="13" class="text-primary" />
-            <span class="flex-1 truncate text-xs">Peek {{ formatLabel(file) }}</span>
+            <span class="flex-1 truncate text-xs">{{ t('book.table.read.peekFormat', { format: formatLabel(file) }) }}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -164,8 +166,8 @@ function peekPrimaryFile() {
       <button
         type="button"
         class="inline-flex h-7 w-7 items-center justify-center rounded-r-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-        :aria-label="`Peek ${formatLabel(primaryFile)}`"
-        :title="`Peek ${formatLabel(primaryFile)}`"
+        :aria-label="t('book.table.read.peekFormat', { format: formatLabel(primaryFile) })"
+        :title="t('book.table.read.peekFormat', { format: formatLabel(primaryFile) })"
         @click.stop="peekPrimaryFile"
       >
         <Eye :size="13" class="text-primary" />

--- a/client/src/features/book/components/table/BookTableReadStatusCell.vue
+++ b/client/src/features/book/components/table/BookTableReadStatusCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronDown } from '@lucide/vue'
 import { STATUS_OPTIONS, STATUS_ICONS, STATUS_COLORS } from '@/features/book/composables/useBookStatus'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
@@ -18,13 +19,15 @@ const emit = defineEmits<{
   navigate: [direction: 'next' | 'prev']
 }>()
 
+const { t } = useI18n()
+
 const isOpen = ref(false)
 const saving = ref(false)
 
 const currentStatus = computed<ReadStatus>(() => props.value?.status ?? 'unread')
 const CurrentIcon = computed(() => STATUS_ICONS[currentStatus.value] as unknown)
 const currentColor = computed(() => STATUS_COLORS[currentStatus.value])
-const currentLabel = computed(() => STATUS_OPTIONS.find((o) => o.value === currentStatus.value)?.label ?? 'Unread')
+const currentLabel = computed(() => STATUS_OPTIONS.find((o) => o.value === currentStatus.value)?.label ?? t('book.table.readStatus.unread'))
 
 watch(
   () => props.isActive,

--- a/client/src/features/book/components/table/BookTableTextCell.vue
+++ b/client/src/features/book/components/table/BookTableTextCell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, nextTick, onBeforeUnmount } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { RouterLink } from 'vue-router'
 import { ExternalLink } from '@lucide/vue'
 
@@ -19,6 +20,8 @@ const emit = defineEmits<{
   cancel: []
   navigate: [direction: 'next' | 'prev' | 'rowUp' | 'rowDown']
 }>()
+
+const { t } = useI18n()
 
 const inputRef = ref<HTMLInputElement | null>(null)
 const draft = ref<string>(props.value ?? '')
@@ -244,8 +247,8 @@ function handleClick() {
             ? 'opacity-100'
             : 'pointer-events-none opacity-0 group-hover/text-cell:pointer-events-auto group-hover/text-cell:opacity-100 group-focus-within/text-cell:pointer-events-auto group-focus-within/text-cell:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100'
         "
-        :aria-label="openLinkLabel ?? 'Open details'"
-        :title="openLinkLabel ?? 'Open details'"
+        :aria-label="openLinkLabel ?? t('book.table.text.openDetails')"
+        :title="openLinkLabel ?? t('book.table.text.openDetails')"
         @click.stop
       >
         <ExternalLink :size="12" />

--- a/client/src/features/collection/components/AddToCollectionSheet.vue
+++ b/client/src/features/collection/components/AddToCollectionSheet.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { FolderMinus, Library, Loader2, Plus } from '@lucide/vue'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet'
@@ -23,6 +24,7 @@ const emit = defineEmits<{
 
 const { fetchCollectionsWithMembership, createCollection, addBooksToCollection, removeBooksFromCollection } = useCollections()
 const { keyboardHeight } = useVirtualKeyboard()
+const { t } = useI18n()
 
 const localCollections = ref<Collection[]>([])
 const changedCollectionIds = ref<Set<number>>(new Set())
@@ -45,7 +47,7 @@ watch(
       try {
         localCollections.value = await fetchCollectionsWithMembership(props.selectionPayload)
       } catch {
-        toast.error('Failed to load collections')
+        toast.error(t('collection.addToSheet.loadFailed'))
       }
     }
   },
@@ -73,12 +75,12 @@ function justAdded(collection: Collection): boolean {
 function membershipLabel(collection: Collection): string {
   const total = selectionCount()
   if (isFullyAdded(collection)) {
-    if (justAdded(collection)) return total === 1 ? 'Added' : `All ${total} added`
-    return total === 1 ? 'In this collection' : `All ${total} in this collection`
+    if (justAdded(collection)) return total === 1 ? t('collection.addToSheet.added') : t('collection.addToSheet.allAdded', { total })
+    return total === 1 ? t('collection.addToSheet.inCollection') : t('collection.addToSheet.allInCollection', { total })
   }
   const partial = partialCount(collection)
-  if (partial > 0) return `${partial} of ${total} in this collection`
-  return `${collection.bookCount} book${collection.bookCount === 1 ? '' : 's'}`
+  if (partial > 0) return t('collection.addToSheet.partialInCollection', { partial, total })
+  return t('collection.addToSheet.bookCount', { count: collection.bookCount }, collection.bookCount)
 }
 
 function markCollectionChanged(collectionId: number): void {
@@ -100,12 +102,12 @@ async function handleCreate() {
       const total = selectionCount()
       localCollections.value = localCollections.value.map((c) => (c.id === collection.id ? { ...c, memberCount: total } : c))
       markCollectionChanged(collection.id)
-      toast.success(`Created "${collection.name}" and added ${total} book${total === 1 ? '' : 's'}`)
+      toast.success(t('collection.addToSheet.createdAndAdded', { name: collection.name, count: total }, total))
     } catch {
-      toast.error(`Created "${collection.name}" but failed to add books`)
+      toast.error(t('collection.addToSheet.createdButAddFailed', { name: collection.name }))
     }
   } catch {
-    toast.error('Failed to create collection')
+    toast.error(t('collection.addToSheet.createFailed'))
   } finally {
     creating.value = false
   }
@@ -123,11 +125,11 @@ async function handleAddTo(collection: Collection) {
     const added = total - alreadyHad
     const msg =
       alreadyHad > 0
-        ? `Added ${added} new book${added === 1 ? '' : 's'} to "${collection.name}" (${alreadyHad} already there)`
-        : `Added ${total} book${total === 1 ? '' : 's'} to "${collection.name}"`
+        ? t('collection.addToSheet.addedNewWithExisting', { count: added, name: collection.name, alreadyHad }, added)
+        : t('collection.addToSheet.addedToCollection', { count: total, name: collection.name }, total)
     toast.success(msg)
   } catch {
-    toast.error('Failed to add to collection')
+    toast.error(t('collection.addToSheet.addFailed'))
   } finally {
     mutatingCollectionId.value = null
   }
@@ -141,9 +143,9 @@ async function handleRemoveFrom(collection: Collection) {
     await removeBooksFromCollection(collection.id, props.selectionPayload)
     markCollectionChanged(collection.id)
     localCollections.value = localCollections.value.map((c) => (c.id === collection.id ? { ...c, memberCount: 0 } : c))
-    toast.success(`Removed ${total} book${total === 1 ? '' : 's'} from "${collection.name}"`)
+    toast.success(t('collection.addToSheet.removedFromCollection', { count: total, name: collection.name }, total))
   } catch {
-    toast.error('Failed to remove from collection')
+    toast.error(t('collection.addToSheet.removeFailed'))
   } finally {
     mutatingCollectionId.value = null
   }
@@ -189,30 +191,32 @@ function handleFocusOut(e: FocusEvent) {
       <SheetHeader>
         <SheetTitle class="flex items-center gap-2">
           <Library :size="16" />
-          Manage Collections
+          {{ t('collection.addToSheet.title') }}
         </SheetTitle>
       </SheetHeader>
 
       <div class="px-4 pb-4 space-y-4">
-        <p class="text-xs text-muted-foreground animate-fade-up">{{ selectionCount() }} book{{ selectionCount() === 1 ? '' : 's' }} selected</p>
+        <p class="text-xs text-muted-foreground animate-fade-up">
+          {{ t('collection.addToSheet.selectedCount', { count: selectionCount() }, selectionCount()) }}
+        </p>
 
         <!-- Create new collection -->
         <div class="space-y-2 animate-fade-up" style="animation-delay: 50ms">
-          <p class="text-xs font-medium text-foreground uppercase tracking-wider">New Collection</p>
+          <p class="text-xs font-medium text-foreground uppercase tracking-wider">{{ t('collection.addToSheet.newCollection') }}</p>
           <div class="flex items-center gap-2">
-            <Input v-model="newName" placeholder="Collection name" class="flex-1 min-w-0" @keydown.enter="handleCreate" />
+            <Input v-model="newName" :placeholder="t('collection.addToSheet.namePlaceholder')" class="flex-1 min-w-0" @keydown.enter="handleCreate" />
             <IconPicker v-model="newIcon" hide-text class="shrink-0" />
             <Button :disabled="!newName.trim() || !newIcon.trim() || creating" class="shrink-0" @click="handleCreate">
               <Loader2 v-if="creating" :size="14" class="animate-spin mr-1" />
               <Plus v-else :size="14" class="mr-1" />
-              Create
+              {{ t('collection.addToSheet.create') }}
             </Button>
           </div>
         </div>
 
         <!-- Existing collections -->
         <div v-if="localCollections.length > 0" class="pt-4 border-t border-border space-y-2 animate-fade-up" style="animation-delay: 100ms">
-          <p class="text-xs font-medium text-foreground uppercase tracking-wider">Collections</p>
+          <p class="text-xs font-medium text-foreground uppercase tracking-wider">{{ t('collection.addToSheet.collections') }}</p>
           <div class="space-y-1">
             <button
               v-for="collection in localCollections"
@@ -242,12 +246,12 @@ function handleFocusOut(e: FocusEvent) {
         </div>
 
         <div v-else class="text-center py-4 border-t border-border">
-          <p class="text-xs text-muted-foreground">No collections yet. Create one above.</p>
+          <p class="text-xs text-muted-foreground">{{ t('collection.addToSheet.empty') }}</p>
         </div>
 
         <!-- Done -->
         <div class="pt-2 border-t border-border">
-          <Button variant="outline" class="w-full" @click="handleDone">Done</Button>
+          <Button variant="outline" class="w-full" @click="handleDone">{{ t('collection.addToSheet.done') }}</Button>
         </div>
       </div>
     </SheetContent>

--- a/client/src/features/collection/components/CreateCollectionDialog.vue
+++ b/client/src/features/collection/components/CreateCollectionDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { X } from '@lucide/vue'
 import { useCollections } from '../composables/useCollections'
@@ -10,6 +11,7 @@ const emit = defineEmits<{ close: [] }>()
 
 const router = useRouter()
 const { createCollection } = useCollections()
+const { t } = useI18n()
 
 const name = ref('')
 const icon = ref('')
@@ -20,11 +22,11 @@ const trimmedIcon = computed(() => icon.value.trim())
 
 async function submit() {
   if (!trimmedName.value) {
-    error.value = 'Name is required'
+    error.value = t('collection.dialog.nameRequired')
     return
   }
   if (!trimmedIcon.value) {
-    error.value = 'Choose an icon'
+    error.value = t('collection.dialog.iconRequired')
     return
   }
   saving.value = true
@@ -36,7 +38,7 @@ async function submit() {
     emit('close')
     router.push({ name: 'collection', params: { id: collection.id } })
   } catch {
-    error.value = 'Failed to create collection'
+    error.value = t('collection.dialog.createFailed')
   } finally {
     saving.value = false
   }
@@ -49,7 +51,7 @@ async function submit() {
       <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="emit('close')" />
       <div class="relative z-10 w-full max-w-md mx-4 bg-card border border-border rounded-lg shadow-2xl p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-base font-semibold text-foreground">New Collection</h2>
+          <h2 class="text-base font-semibold text-foreground">{{ t('collection.createDialog.title') }}</h2>
           <button @click="emit('close')" class="text-muted-foreground hover:text-foreground transition-colors">
             <X :size="18" />
           </button>
@@ -57,19 +59,19 @@ async function submit() {
 
         <form @submit.prevent="submit" class="flex flex-col gap-4">
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground">Name</label>
+            <label class="text-sm font-medium text-foreground">{{ t('collection.dialog.name') }}</label>
             <input
               v-model="name"
               type="text"
-              placeholder="e.g. Favorites"
+              :placeholder="t('collection.createDialog.namePlaceholder')"
               autofocus
               class="h-9 rounded-md border border-input bg-background text-foreground text-sm px-3 focus:outline-none focus:ring-2 focus:ring-primary placeholder:text-muted-foreground"
             />
           </div>
 
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground">Icon</label>
-            <IconPicker v-model="icon" placeholder="Choose an icon..." />
+            <label class="text-sm font-medium text-foreground">{{ t('collection.dialog.icon') }}</label>
+            <IconPicker v-model="icon" :placeholder="t('collection.dialog.iconPlaceholder')" />
           </div>
 
           <p v-if="error" class="text-sm text-destructive">{{ error }}</p>
@@ -80,14 +82,14 @@ async function submit() {
               @click="emit('close')"
               class="h-9 px-4 rounded-md border border-input bg-background text-sm text-foreground hover:bg-muted transition-colors"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               type="submit"
               :disabled="!trimmedName || !trimmedIcon || saving"
               class="h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {{ saving ? 'Creating...' : 'Create' }}
+              {{ saving ? t('collection.dialog.creating') : t('collection.addToSheet.create') }}
             </button>
           </div>
         </form>

--- a/client/src/features/collection/components/EditCollectionDialog.vue
+++ b/client/src/features/collection/components/EditCollectionDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { X } from '@lucide/vue'
 import { toast } from 'vue-sonner'
@@ -12,6 +13,7 @@ const emit = defineEmits<{ close: []; deleted: [id: number, name: string] }>()
 
 const router = useRouter()
 const { updateCollection, deleteCollection } = useCollections()
+const { t } = useI18n()
 
 const name = ref('')
 const icon = ref('')
@@ -38,11 +40,11 @@ watch(
 
 async function submit() {
   if (!trimmedName.value) {
-    error.value = 'Name is required'
+    error.value = t('collection.dialog.nameRequired')
     return
   }
   if (!trimmedIcon.value) {
-    error.value = 'Choose an icon'
+    error.value = t('collection.dialog.iconRequired')
     return
   }
   saving.value = true
@@ -51,7 +53,7 @@ async function submit() {
     await updateCollection(props.collection.id, trimmedName.value, trimmedIcon.value, syncToKobo.value)
     emit('close')
   } catch {
-    error.value = 'Failed to update collection'
+    error.value = t('collection.editDialog.updateFailed')
   } finally {
     saving.value = false
   }
@@ -83,12 +85,12 @@ async function confirmDelete() {
   error.value = null
   try {
     await deleteCollection(id)
-    toast.success(`"${name}" deleted`)
+    toast.success(t('collection.editDialog.deleted', { name }))
     router.replace({ name: 'dashboard' })
     emit('deleted', id, name)
     emit('close')
   } catch {
-    error.value = 'Failed to delete collection'
+    error.value = t('collection.editDialog.deleteFailed')
     confirmingDelete.value = false
   } finally {
     deleting.value = false
@@ -102,7 +104,7 @@ async function confirmDelete() {
       <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="emit('close')" />
       <div class="relative z-10 w-full max-w-md mx-4 bg-card border border-border rounded-lg shadow-2xl p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-base font-semibold text-foreground">Edit Collection</h2>
+          <h2 class="text-base font-semibold text-foreground">{{ t('collection.editDialog.title') }}</h2>
           <button @click="emit('close')" class="text-muted-foreground hover:text-foreground transition-colors">
             <X :size="18" />
           </button>
@@ -110,7 +112,7 @@ async function confirmDelete() {
 
         <form @submit.prevent="submit" class="flex flex-col gap-4">
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground">Name</label>
+            <label class="text-sm font-medium text-foreground">{{ t('collection.dialog.name') }}</label>
             <input
               v-model="name"
               type="text"
@@ -120,14 +122,14 @@ async function confirmDelete() {
           </div>
 
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground"> Icon </label>
-            <IconPicker v-model="icon" placeholder="Choose an icon..." />
+            <label class="text-sm font-medium text-foreground">{{ t('collection.dialog.icon') }}</label>
+            <IconPicker v-model="icon" :placeholder="t('collection.dialog.iconPlaceholder')" />
           </div>
 
           <div class="flex items-center justify-between py-1">
             <div>
-              <p class="text-sm font-medium text-foreground">Sync to Kobo</p>
-              <p class="text-xs text-muted-foreground mt-0.5">Books in this collection will appear on your Kobo device</p>
+              <p class="text-sm font-medium text-foreground">{{ t('collection.editDialog.syncToKobo') }}</p>
+              <p class="text-xs text-muted-foreground mt-0.5">{{ t('collection.editDialog.syncToKoboHint') }}</p>
             </div>
             <button
               type="button"
@@ -156,7 +158,13 @@ async function confirmDelete() {
               "
               @click="handleDeleteClick"
             >
-              {{ deleting ? 'Deleting...' : confirmingDelete ? 'Confirm?' : 'Delete collection' }}
+              {{
+                deleting
+                  ? t('collection.editDialog.deleting')
+                  : confirmingDelete
+                    ? t('collection.editDialog.confirmDelete')
+                    : t('collection.editDialog.deleteCollection')
+              }}
             </button>
 
             <div class="flex items-center gap-2">
@@ -166,14 +174,14 @@ async function confirmDelete() {
                 class="h-9 px-4 rounded-md border border-input bg-background text-sm text-foreground hover:bg-muted transition-colors disabled:opacity-50"
                 @click="handleCancelClick"
               >
-                Cancel
+                {{ t('common.cancel') }}
               </button>
               <button
                 type="submit"
                 :disabled="!trimmedName || !trimmedIcon || saving || deleting"
                 class="h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {{ saving ? 'Saving...' : 'Save' }}
+                {{ saving ? t('collection.editDialog.saving') : t('common.save') }}
               </button>
             </div>
           </div>

--- a/client/src/features/collection/components/__tests__/AddToCollectionSheet.spec.ts
+++ b/client/src/features/collection/components/__tests__/AddToCollectionSheet.spec.ts
@@ -138,7 +138,7 @@ describe('AddToCollectionSheet', () => {
 
     expect(addBooksToCollectionMock).toHaveBeenCalledWith(2, { bookIds: [1] })
     expect(removeBooksFromCollectionMock).not.toHaveBeenCalled()
-    expect(toastSuccess).toHaveBeenCalledWith('Added 1 book to "Queue"')
+    expect(toastSuccess).toHaveBeenCalledWith('Added one book to "Queue"')
 
     await findButtonByText(wrapper, 'Done').trigger('click')
 
@@ -158,7 +158,7 @@ describe('AddToCollectionSheet', () => {
 
     expect(removeBooksFromCollectionMock).toHaveBeenCalledWith(3, { bookIds: [1] })
     expect(addBooksToCollectionMock).not.toHaveBeenCalled()
-    expect(toastSuccess).toHaveBeenCalledWith('Removed 1 book from "Finished"')
+    expect(toastSuccess).toHaveBeenCalledWith('Removed one book from "Finished"')
 
     await findButtonByText(wrapper, 'Done').trigger('click')
 

--- a/client/src/features/custom-icons/components/IconUploadDialog.vue
+++ b/client/src/features/custom-icons/components/IconUploadDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { AlertTriangle, FileWarning, Loader2, UploadCloud, X } from '@lucide/vue'
 import { DialogClose, DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogRoot, DialogTitle } from 'reka-ui'
 import { toast } from 'vue-sonner'
@@ -10,6 +11,7 @@ import { useCustomIcons } from '@/features/custom-icons/composables/useCustomIco
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits<{ 'update:open': [value: boolean]; uploaded: [] }>()
 
+const { t } = useI18n()
 const { stageIcons, uploadStagedIcons } = useCustomIcons()
 
 interface StagedEntry {
@@ -34,9 +36,9 @@ const fileInputRef = ref<HTMLInputElement | null>(null)
 let entrySeq = 0
 
 function entryError(entry: StagedEntry): string | null {
-  if (!entry.ok) return entry.error ?? 'Invalid SVG'
+  if (!entry.ok) return entry.error ?? t('customIcons.invalidSvg')
   if (entry.skip) return null
-  if (!entry.name.trim()) return 'Name is required'
+  if (!entry.name.trim()) return t('customIcons.nameRequired')
   return null
 }
 
@@ -91,16 +93,16 @@ async function handleDrop(event: DragEvent) {
 async function addFiles(files: File[]) {
   const svgFiles = files.filter((file) => file.type === 'image/svg+xml' || file.name.toLowerCase().endsWith('.svg'))
   if (svgFiles.length === 0) {
-    if (files.length > 0) toast.error('Only SVG files are supported')
+    if (files.length > 0) toast.error(t('customIcons.onlySvgSupported'))
     return
   }
   const room = CUSTOM_ICON_MAX_UPLOAD_FILES - entries.value.length
   if (room <= 0) {
-    toast.error(`You can stage at most ${CUSTOM_ICON_MAX_UPLOAD_FILES} icons at once`)
+    toast.error(t('customIcons.maxStaged', { max: CUSTOM_ICON_MAX_UPLOAD_FILES }))
     return
   }
   const accepted = svgFiles.slice(0, room)
-  if (svgFiles.length > room) toast.warning(`Only ${room} more icon${room === 1 ? '' : 's'} can be staged`)
+  if (svgFiles.length > room) toast.warning(t('customIcons.onlyMoreCanStage', { count: room }, room))
 
   staging.value = true
   try {
@@ -123,7 +125,7 @@ async function addFiles(files: File[]) {
       })
     })
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to read SVG files')
+    toast.error(err instanceof Error ? err.message : t('customIcons.readFailed'))
   } finally {
     staging.value = false
   }
@@ -148,17 +150,17 @@ async function confirmUpload() {
     const failed = items.length - created
     if (created > 0) emit('uploaded')
     if (created > 0 && failed === 0) {
-      toast.success(`Uploaded ${created} icon${created === 1 ? '' : 's'}`)
+      toast.success(t('customIcons.uploadedCount', { count: created }, created))
       closeDialog()
     } else if (created > 0) {
-      toast.warning(`Uploaded ${created}, ${failed} failed`)
+      toast.warning(t('customIcons.uploadedPartial', { created, failed }))
       applyServerErrors(items)
     } else {
-      toast.error('No icons uploaded')
+      toast.error(t('customIcons.noIconsUploaded'))
       applyServerErrors(items)
     }
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to upload icons')
+    toast.error(err instanceof Error ? err.message : t('customIcons.uploadFailed'))
   } finally {
     uploading.value = false
   }
@@ -171,7 +173,7 @@ function applyServerErrors(items: { filename: string; status: string; error?: st
   for (const entry of entries.value) {
     if (failedByName.has(entry.file.name)) {
       entry.ok = false
-      entry.error = failedByName.get(entry.file.name) ?? 'Upload failed'
+      entry.error = failedByName.get(entry.file.name) ?? t('customIcons.uploadFailedEntry')
     }
   }
 }
@@ -187,8 +189,8 @@ function applyServerErrors(items: { filename: string; status: string; error?: st
       >
         <div class="flex items-center justify-between border-b border-border px-4 py-3">
           <div>
-            <DialogTitle class="text-sm font-semibold text-foreground">Upload custom icons</DialogTitle>
-            <DialogDescription class="text-xs text-muted-foreground">Review names before adding them to your library.</DialogDescription>
+            <DialogTitle class="text-sm font-semibold text-foreground">{{ t('customIcons.dialogTitle') }}</DialogTitle>
+            <DialogDescription class="text-xs text-muted-foreground">{{ t('customIcons.dialogDescription') }}</DialogDescription>
           </div>
           <DialogClose
             class="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
@@ -214,8 +216,8 @@ function applyServerErrors(items: { filename: string; status: string; error?: st
               <Loader2 v-if="staging" :size="18" class="animate-spin" />
               <UploadCloud v-else :size="18" />
             </span>
-            <span class="text-sm font-medium text-foreground">{{ staging ? 'Reading files...' : 'Drop SVG files or click to browse' }}</span>
-            <span class="text-xs text-muted-foreground">Up to {{ CUSTOM_ICON_MAX_UPLOAD_FILES }} files, 128 KB each</span>
+            <span class="text-sm font-medium text-foreground">{{ staging ? t('customIcons.readingFiles') : t('customIcons.dropPrompt') }}</span>
+            <span class="text-xs text-muted-foreground">{{ t('customIcons.fileLimit', { max: CUSTOM_ICON_MAX_UPLOAD_FILES }) }}</span>
           </button>
 
           <div v-if="entries.length > 0" class="space-y-2">
@@ -257,7 +259,7 @@ function applyServerErrors(items: { filename: string; status: string; error?: st
                         v-model="entry.name"
                         :disabled="entry.skip"
                         :maxlength="CUSTOM_ICON_NAME_MAX_LENGTH"
-                        placeholder="Name"
+                        :placeholder="t('customIcons.namePlaceholder')"
                         class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
                       />
                     </div>
@@ -272,21 +274,21 @@ function applyServerErrors(items: { filename: string; status: string; error?: st
                         class="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 font-medium text-amber-600 dark:text-amber-400"
                       >
                         <AlertTriangle :size="11" />
-                        Identical to "{{ entry.duplicateOfName ?? entry.duplicateOfSlug }}"
+                        {{ t('customIcons.identicalTo', { name: entry.duplicateOfName ?? entry.duplicateOfSlug }) }}
                       </span>
                       <button
                         type="button"
                         class="text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
                         @click="toggleSkip(entry)"
                       >
-                        {{ entry.skip ? 'Upload anyway' : 'Skip this one' }}
+                        {{ entry.skip ? t('customIcons.uploadAnyway') : t('customIcons.skipThisOne') }}
                       </button>
                     </div>
                   </template>
 
                   <p v-else class="flex items-center gap-1 text-xs text-destructive">
                     <AlertTriangle :size="12" />
-                    {{ entry.error ?? 'Invalid SVG file' }}
+                    {{ entry.error ?? t('customIcons.invalidSvgFile') }}
                   </p>
                 </div>
               </div>
@@ -296,14 +298,20 @@ function applyServerErrors(items: { filename: string; status: string; error?: st
 
         <div class="flex items-center justify-between gap-3 border-t border-border px-4 py-3">
           <p class="text-xs text-muted-foreground">
-            <span v-if="uploadableCount > 0">{{ uploadableCount }} ready to upload</span>
-            <span v-else>No icons staged yet</span>
+            <span v-if="uploadableCount > 0">{{ t('customIcons.readyToUpload', { count: uploadableCount }) }}</span>
+            <span v-else>{{ t('customIcons.noIconsStaged') }}</span>
           </p>
           <div class="flex items-center gap-2">
-            <Button type="button" variant="outline" size="sm" class="h-9" @click="closeDialog">Cancel</Button>
+            <Button type="button" variant="outline" size="sm" class="h-9" @click="closeDialog">{{ t('common.cancel') }}</Button>
             <Button type="button" size="sm" class="h-9" :disabled="!canConfirm" @click="confirmUpload">
               <Loader2 v-if="uploading" :size="14" class="animate-spin" />
-              {{ uploading ? 'Uploading...' : uploadableCount > 0 ? `Upload ${uploadableCount}` : 'Upload' }}
+              {{
+                uploading
+                  ? t('customIcons.uploading')
+                  : uploadableCount > 0
+                    ? t('customIcons.uploadCount', { count: uploadableCount })
+                    : t('customIcons.upload')
+              }}
             </Button>
           </div>
         </div>

--- a/client/src/features/dashboard/components/DashboardScroller.vue
+++ b/client/src/features/dashboard/components/DashboardScroller.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, useAttrs } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Aperture, BookMarked, BookmarkPlus, ChevronLeft, ChevronRight, Headphones, ListOrdered, RefreshCw, Shuffle, Sparkles } from '@lucide/vue'
 
 import { isAudioFormat, type BookCard, type CoverAspectRatio, type ScrollerType } from '@bookorbit/types'
@@ -22,6 +23,7 @@ const props = defineProps<{
 }>()
 
 const attrs = useAttrs()
+const { t } = useI18n()
 
 const { books, loading, error, refresh } = useDashboardScroller(props.type, props.limit, props.smartScopeId)
 
@@ -133,10 +135,10 @@ function coverAspectRatio(book: BookCard): CoverAspectRatio {
 
     <!-- Error -->
     <div v-else-if="error" class="flex items-center gap-2.5 px-5 pb-4 pt-1 text-sm text-muted-foreground">
-      <span>Failed to load.</span>
+      <span>{{ t('dashboard.scroller.failedToLoad') }}</span>
       <button class="flex items-center gap-1.5 text-xs text-primary hover:underline" @click="refresh">
         <RefreshCw :size="12" />
-        Retry
+        {{ t('dashboard.common.retry') }}
       </button>
     </div>
 
@@ -146,13 +148,13 @@ function coverAspectRatio(book: BookCard): CoverAspectRatio {
         <component :is="typeIcon" :size="20" class="text-muted-foreground/60" />
       </div>
       <p class="text-sm text-muted-foreground">
-        <template v-if="type === 'continue-reading'">No books in progress yet. Start reading one to see it here.</template>
-        <template v-else-if="type === 'continue-listening'">No audiobooks in progress yet. Start listening to one to see it here.</template>
-        <template v-else-if="type === 'want-to-read'">No books marked want to read yet.</template>
-        <template v-else-if="type === 'up-next-in-series'">No next-in-series picks yet. Finish a volume to surface the next one.</template>
-        <template v-else-if="type === 'recently-added'">No books in your library yet.</template>
-        <template v-else-if="type === 'smart-scope'">No books match this smartScope.</template>
-        <template v-else>No books found.</template>
+        <template v-if="type === 'continue-reading'">{{ t('dashboard.scroller.empty.continueReading') }}</template>
+        <template v-else-if="type === 'continue-listening'">{{ t('dashboard.scroller.empty.continueListening') }}</template>
+        <template v-else-if="type === 'want-to-read'">{{ t('dashboard.scroller.empty.wantToRead') }}</template>
+        <template v-else-if="type === 'up-next-in-series'">{{ t('dashboard.scroller.empty.upNextInSeries') }}</template>
+        <template v-else-if="type === 'recently-added'">{{ t('dashboard.scroller.empty.recentlyAdded') }}</template>
+        <template v-else-if="type === 'smart-scope'">{{ t('dashboard.scroller.empty.smartScope') }}</template>
+        <template v-else>{{ t('dashboard.scroller.empty.default') }}</template>
       </p>
     </div>
 

--- a/client/src/features/dashboard/components/DashboardSettingsSheet.vue
+++ b/client/src/features/dashboard/components/DashboardSettingsSheet.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronDown, ChevronUp, GripVertical, Plus, RotateCcw, Trash2 } from '@lucide/vue'
 
 import type { ScrollerConfig, ScrollerType, WidgetConfig } from '@bookorbit/types'
@@ -11,6 +12,8 @@ import { useDraggableList } from '../composables/useDraggableList'
 
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits<{ 'update:open': [value: boolean] }>()
+
+const { t } = useI18n()
 
 const { scrollers, saveScrollers, MAX_SCROLLERS } = useDashboardConfig()
 const { widgets, saveWidgets, WIDGET_LABELS, DEFAULT_WIDGETS } = useDashboardWidgets()
@@ -128,7 +131,7 @@ function resetToDefault() {
     <SheetContent side="right" class="flex w-[90vw] max-w-[420px] flex-col gap-0 p-0">
       <!-- Header -->
       <SheetHeader class="border-b border-border px-5 py-4">
-        <SheetTitle class="text-base font-semibold">Customize Dashboard</SheetTitle>
+        <SheetTitle class="text-base font-semibold">{{ t('dashboard.settings.title') }}</SheetTitle>
       </SheetHeader>
 
       <!-- Tabs -->
@@ -141,7 +144,7 @@ function resetToDefault() {
             ]"
             @click="activeTab = 'widgets'"
           >
-            Widgets
+            {{ t('dashboard.settings.tabs.widgets') }}
           </button>
           <button
             :class="[
@@ -150,7 +153,7 @@ function resetToDefault() {
             ]"
             @click="activeTab = 'shelves'"
           >
-            Shelves
+            {{ t('dashboard.settings.tabs.shelves') }}
           </button>
         </div>
       </div>
@@ -159,7 +162,7 @@ function resetToDefault() {
       <div class="flex-1 overflow-y-auto px-5 py-4">
         <!-- WIDGETS TAB -->
         <div v-show="activeTab === 'widgets'">
-          <p class="mb-4 text-xs text-muted-foreground">Drag to reorder. Toggle to show or hide a widget.</p>
+          <p class="mb-4 text-xs text-muted-foreground">{{ t('dashboard.settings.reorderHintWidget') }}</p>
 
           <div class="space-y-2">
             <div
@@ -216,7 +219,7 @@ function resetToDefault() {
 
         <!-- SHELVES TAB -->
         <div v-show="activeTab === 'shelves'">
-          <p class="mb-4 text-xs text-muted-foreground">Drag to reorder. Toggle to show or hide a shelf.</p>
+          <p class="mb-4 text-xs text-muted-foreground">{{ t('dashboard.settings.reorderHintShelf') }}</p>
 
           <div class="space-y-2">
             <div
@@ -291,7 +294,7 @@ function resetToDefault() {
 
               <!-- SmartScope picker (shown only when type = smartScope) -->
               <div v-if="scroller.type === 'smart-scope'" class="border-t border-border/50 px-3 pb-2.5 pt-2">
-                <label class="mb-1.5 block text-[11px] font-medium text-muted-foreground">Smart Scope</label>
+                <label class="mb-1.5 block text-[11px] font-medium text-muted-foreground">{{ t('dashboard.settings.smartScope') }}</label>
                 <select
                   v-if="smartScopes.length > 0"
                   v-model="scroller.smartScopeId"
@@ -300,7 +303,7 @@ function resetToDefault() {
                 >
                   <option v-for="smartScope in smartScopes" :key="smartScope.id" :value="smartScope.id">{{ smartScope.name }}</option>
                 </select>
-                <p v-else class="text-xs text-muted-foreground">No Smart Scopes yet. Create one from the sidebar.</p>
+                <p v-else class="text-xs text-muted-foreground">{{ t('dashboard.settings.noSmartScopes') }}</p>
               </div>
             </div>
           </div>
@@ -312,7 +315,7 @@ function resetToDefault() {
             @click="addScroller"
           >
             <Plus :size="15" />
-            Add shelf
+            {{ t('dashboard.settings.addShelf') }}
             <span class="text-xs opacity-60">({{ draft.length }}/{{ MAX_SCROLLERS }})</span>
           </button>
         </div>
@@ -322,21 +325,21 @@ function resetToDefault() {
       <div class="flex items-center justify-between border-t border-border px-5 py-4">
         <button class="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground" @click="resetToDefault">
           <RotateCcw :size="13" />
-          Reset to defaults
+          {{ t('dashboard.settings.resetToDefaults') }}
         </button>
         <div class="flex items-center gap-2">
           <button
             class="h-8 rounded-md border border-input px-3 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             @click="emit('update:open', false)"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="h-8 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             :disabled="widgetSaving"
             @click="handleSave"
           >
-            Save
+            {{ t('common.save') }}
           </button>
         </div>
       </div>

--- a/client/src/features/dashboard/components/DashboardWelcome.vue
+++ b/client/src/features/dashboard/components/DashboardWelcome.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { BookOpen, Plus, Users } from '@lucide/vue'
 import type { Library } from '@bookorbit/types'
 import LibraryCreatorModal from '@/features/library/components/LibraryCreatorModal.vue'
@@ -7,6 +8,7 @@ import { useLibraryCreationRedirect } from '@/features/library/composables/useLi
 
 defineProps<{ canCreate: boolean }>()
 
+const { t } = useI18n()
 const { handleLibraryCreated } = useLibraryCreationRedirect()
 const createOpen = ref(false)
 
@@ -46,15 +48,15 @@ async function handleSaved(library: Library) {
 
         <!-- Heading -->
         <h2 class="mb-2 text-lg font-bold tracking-tight text-foreground">
-          {{ canCreate ? 'Your library is empty' : 'No libraries yet' }}
+          {{ canCreate ? t('dashboard.welcome.emptyTitle') : t('dashboard.welcome.noLibrariesTitle') }}
         </h2>
 
         <!-- Description -->
         <p class="mb-8 max-w-xs text-sm leading-relaxed text-muted-foreground">
           <template v-if="canCreate">
-            Create a library to start organizing and reading your books. Point it to a folder and it will do the rest.
+            {{ t('dashboard.welcome.emptyDescription') }}
           </template>
-          <template v-else> Your administrator hasn't set up any libraries yet. Reach out to them to get started. </template>
+          <template v-else> {{ t('dashboard.welcome.noLibrariesDescription') }} </template>
         </p>
 
         <!-- CTA -->
@@ -64,7 +66,7 @@ async function handleSaved(library: Library) {
           @click="handleOpenCreate"
         >
           <Plus :size="15" />
-          Create your first library
+          {{ t('dashboard.welcome.createFirstLibrary') }}
         </button>
       </div>
     </div>

--- a/client/src/features/dashboard/components/widgets/CurrentlyReadingWidget.vue
+++ b/client/src/features/dashboard/components/widgets/CurrentlyReadingWidget.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { BookOpen, Play } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { FORMAT_TO_GROUP } from '@bookorbit/types'
 
@@ -9,6 +10,7 @@ import BookCoverSurface from '@/features/book/components/BookCoverSurface.vue'
 import { useCurrentlyReadingWidget } from '../../composables/useCurrentlyReadingWidget'
 
 const { data, loading, error } = useCurrentlyReadingWidget()
+const { t } = useI18n()
 const router = useRouter()
 const { coverUrl } = useCoverVersions()
 
@@ -33,7 +35,7 @@ function continueReading(bookId: number, fileId: number | null, fileFormat: stri
   <div class="flex h-full flex-col p-3">
     <div class="mb-3 flex items-center gap-2 self-start">
       <BookOpen :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Currently Reading</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.currentlyReading.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -49,14 +51,16 @@ function continueReading(bookId: number, fileId: number | null, fileFormat: stri
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Empty -->
     <div v-else-if="!data || data.books.length === 0" class="flex flex-1 flex-col items-center justify-center gap-2">
       <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
         <BookOpen :size="16" class="text-muted-foreground/60" />
       </div>
-      <p class="text-center text-xs text-muted-foreground">No books in progress. Start reading one to see it here.</p>
+      <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.currentlyReading.empty') }}</p>
     </div>
 
     <!-- Books list -->
@@ -81,7 +85,7 @@ function continueReading(bookId: number, fileId: number | null, fileFormat: stri
               :author-line="book.authors.length > 0 ? book.authors.join(', ') : null"
               :is-audio="false"
               :seed="book.title ?? String(book.bookId)"
-              :alt="book.title ?? 'Book cover'"
+              :alt="book.title ?? t('dashboard.common.bookCover')"
               frame-aspect-ratio="9/14"
               :is-comic="isComic(book.fileFormat)"
             />
@@ -89,7 +93,7 @@ function continueReading(bookId: number, fileId: number | null, fileFormat: stri
 
           <!-- Info -->
           <div class="flex min-w-0 flex-1 flex-col justify-center">
-            <p class="truncate text-xs font-semibold leading-tight">{{ book.title ?? 'Untitled' }}</p>
+            <p class="truncate text-xs font-semibold leading-tight">{{ book.title ?? t('dashboard.common.untitled') }}</p>
             <p v-if="book.authors.length > 0" class="truncate text-xs text-muted-foreground">
               {{ book.authors.join(', ') }}
             </p>
@@ -105,7 +109,7 @@ function continueReading(bookId: number, fileId: number | null, fileFormat: stri
           <!-- Continue button (hover) -->
           <button
             class="absolute right-2 top-1/3 -translate-y-1/2 flex h-7 w-7 items-center justify-center rounded-full bg-primary text-primary-foreground opacity-0 shadow transition-opacity group-hover/book:opacity-100"
-            title="Continue reading"
+            :title="t('dashboard.widgets.currentlyReading.continueReading')"
             @click.stop="continueReading(book.bookId, book.fileId, book.fileFormat)"
           >
             <Play :size="11" class="translate-x-px" />

--- a/client/src/features/dashboard/components/widgets/DiversityScoreWidget.vue
+++ b/client/src/features/dashboard/components/widgets/DiversityScoreWidget.vue
@@ -1,23 +1,29 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Compass } from '@lucide/vue'
 
 import { useDiversityScoreWidget } from '../../composables/useDiversityScoreWidget'
 
 const { data, loading, error } = useDiversityScoreWidget()
+const { t } = useI18n()
 
-const subScores = [
-  { key: 'genre', label: 'Genre' },
-  { key: 'author', label: 'Author' },
-  { key: 'era', label: 'Era' },
-  { key: 'language', label: 'Lang' },
-] as const
+const subScores = computed(
+  () =>
+    [
+      { key: 'genre', label: t('dashboard.widgets.diversityScore.subScores.genre') },
+      { key: 'author', label: t('dashboard.widgets.diversityScore.subScores.author') },
+      { key: 'era', label: t('dashboard.widgets.diversityScore.subScores.era') },
+      { key: 'language', label: t('dashboard.widgets.diversityScore.subScores.language') },
+    ] as const,
+)
 </script>
 
 <template>
   <div class="flex h-full flex-col p-3">
     <div class="mb-3 flex items-center gap-2 self-start">
       <Compass :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Diversity Score</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.diversityScore.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -27,14 +33,16 @@ const subScores = [
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Not enough data -->
     <div v-else-if="!data || data.booksAnalyzed < 3" class="flex flex-1 flex-col items-center justify-center gap-2">
       <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
         <Compass :size="16" class="text-muted-foreground/60" />
       </div>
-      <p class="text-center text-xs text-muted-foreground">Read at least 3 books to see your diversity score</p>
+      <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.diversityScore.notEnoughData') }}</p>
     </div>
 
     <!-- Score -->
@@ -54,7 +62,9 @@ const subScores = [
         </div>
       </div>
 
-      <p class="text-[10px] text-muted-foreground">{{ data.booksAnalyzed }} books analyzed</p>
+      <p class="text-[10px] text-muted-foreground">
+        {{ t('dashboard.widgets.diversityScore.booksAnalyzed', { count: data.booksAnalyzed }, data.booksAnalyzed) }}
+      </p>
     </div>
   </div>
 </template>

--- a/client/src/features/dashboard/components/widgets/HighlightOfTheDayWidget.vue
+++ b/client/src/features/dashboard/components/widgets/HighlightOfTheDayWidget.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Highlighter, ExternalLink } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
 import { useCoverVersions } from '@/features/book/composables/useCoverVersions'
@@ -8,6 +9,7 @@ import BookCoverSurface from '@/features/book/components/BookCoverSurface.vue'
 import { useHighlightOfTheDayWidget } from '../../composables/useHighlightOfTheDayWidget'
 
 const { data, loading, error } = useHighlightOfTheDayWidget()
+const { t } = useI18n()
 const router = useRouter()
 const { coverUrl } = useCoverVersions()
 
@@ -21,7 +23,7 @@ function goToBook() {
   <div class="flex h-full flex-col p-3">
     <div class="mb-2 flex items-center gap-2 self-start">
       <Highlighter :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Highlight of the Day</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.highlightOfTheDay.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -31,14 +33,16 @@ function goToBook() {
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Empty -->
     <div v-else-if="!data" class="flex flex-1 flex-col items-center justify-center gap-2">
       <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
         <Highlighter :size="16" class="text-muted-foreground/60" />
       </div>
-      <p class="text-center text-xs text-muted-foreground">Highlight passages while reading to see them here</p>
+      <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.highlightOfTheDay.empty') }}</p>
     </div>
 
     <!-- Quote -->
@@ -57,12 +61,12 @@ function goToBook() {
             :author-line="null"
             :is-audio="false"
             :seed="data.bookTitle ?? String(data.bookId)"
-            :alt="data.bookTitle ?? 'Cover'"
+            :alt="data.bookTitle ?? t('dashboard.common.cover')"
             frame-aspect-ratio="2/3"
           />
         </BookCoverSurface>
         <div class="min-w-0 flex-1">
-          <p class="truncate text-[12px] font-medium leading-tight">{{ data.bookTitle ?? 'Untitled' }}</p>
+          <p class="truncate text-[12px] font-medium leading-tight">{{ data.bookTitle ?? t('dashboard.common.untitled') }}</p>
           <p v-if="data.chapterTitle" class="truncate text-[11px] text-muted-foreground">{{ data.chapterTitle }}</p>
         </div>
         <ExternalLink :size="14" class="mr-1 shrink-0 text-muted-foreground/50" />

--- a/client/src/features/dashboard/components/widgets/LibraryOverviewWidget.vue
+++ b/client/src/features/dashboard/components/widgets/LibraryOverviewWidget.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, type Component } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { BookCopy, HardDrive, Library, Users } from '@lucide/vue'
 import { useRouter } from 'vue-router'
 import type { RouteLocationRaw } from 'vue-router'
@@ -8,6 +9,7 @@ import { useLibraries } from '@/features/library/composables/useLibraries'
 import { useLibraryOverviewWidget } from '../../composables/useLibraryOverviewWidget'
 
 const { data, loading, error } = useLibraryOverviewWidget()
+const { t } = useI18n()
 const router = useRouter()
 const { libraries } = useLibraries()
 
@@ -32,14 +34,14 @@ const stats = computed<Stat[]>(() => {
   const firstLibraryId = libraries.value[0]?.id ?? null
   return [
     {
-      label: 'Books',
+      label: t('dashboard.widgets.libraryOverview.stats.books'),
       value: data.value.totalBooks,
       icon: Library,
       route: firstLibraryId ? { name: 'library', params: { id: firstLibraryId } } : null,
     },
-    { label: 'Authors', value: data.value.totalAuthors, icon: Users, route: { name: 'authors' } },
-    { label: 'Series', value: data.value.totalSeries, icon: BookCopy, route: { name: 'series' } },
-    { label: 'Storage', value: formatStorage(data.value.totalStorageBytes), icon: HardDrive, route: null },
+    { label: t('dashboard.widgets.libraryOverview.stats.authors'), value: data.value.totalAuthors, icon: Users, route: { name: 'authors' } },
+    { label: t('dashboard.widgets.libraryOverview.stats.series'), value: data.value.totalSeries, icon: BookCopy, route: { name: 'series' } },
+    { label: t('dashboard.widgets.libraryOverview.stats.storage'), value: formatStorage(data.value.totalStorageBytes), icon: HardDrive, route: null },
   ]
 })
 
@@ -52,7 +54,7 @@ function navigate(route: StatRoute) {
   <div class="flex h-full flex-col p-3">
     <div class="mb-2 flex items-center gap-2 self-start">
       <Library :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Library Overview</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.libraryOverview.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -64,14 +66,16 @@ function navigate(route: StatRoute) {
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Empty -->
     <div v-else-if="!data || data.totalBooks === 0" class="flex flex-1 flex-col items-center justify-center gap-2">
       <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
         <Library :size="16" class="text-muted-foreground/60" />
       </div>
-      <p class="text-center text-xs text-muted-foreground">Your library is empty. Add some books to get started.</p>
+      <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.libraryOverview.empty') }}</p>
     </div>
 
     <!-- Stats grid -->
@@ -96,7 +100,9 @@ function navigate(route: StatRoute) {
 
       <!-- Added this year callout -->
       <div v-if="data.booksAddedThisYear > 0" class="shrink-0 rounded-md border border-primary/20 bg-primary/5 px-2 py-1 text-center">
-        <span class="text-[11px] font-medium leading-none text-primary">+{{ data.booksAddedThisYear }} added this year</span>
+        <span class="text-[11px] font-medium leading-none text-primary">{{
+          t('dashboard.widgets.libraryOverview.addedThisYear', { count: data.booksAddedThisYear })
+        }}</span>
       </div>
     </div>
   </div>

--- a/client/src/features/dashboard/components/widgets/LongWaitWidget.vue
+++ b/client/src/features/dashboard/components/widgets/LongWaitWidget.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Clock, Play } from '@lucide/vue'
 import { useRouter } from 'vue-router'
 import { FORMAT_TO_GROUP } from '@bookorbit/types'
@@ -10,6 +11,7 @@ import BookCoverSurface from '@/features/book/components/BookCoverSurface.vue'
 import { useLongWaitWidget } from '../../composables/useLongWaitWidget'
 
 const { data, loading, error } = useLongWaitWidget()
+const { t } = useI18n()
 const router = useRouter()
 const { coverUrl } = useCoverVersions()
 
@@ -41,7 +43,7 @@ function startReading() {
   <div class="flex h-full flex-col p-3">
     <div class="mb-3 flex items-center gap-2 self-start">
       <Clock :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">The Long Wait</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.longWait.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -51,14 +53,16 @@ function startReading() {
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Empty -->
     <div v-else-if="!data" class="flex flex-1 flex-col items-center justify-center gap-2">
       <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
         <Clock :size="16" class="text-muted-foreground/60" />
       </div>
-      <p class="text-center text-xs text-muted-foreground">No books waiting. You've started everything!</p>
+      <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.longWait.empty') }}</p>
     </div>
 
     <!-- Long wait book -->
@@ -79,7 +83,7 @@ function startReading() {
             :author-line="null"
             :is-audio="false"
             :seed="data.title ?? String(data.bookId)"
-            :alt="data.title ?? 'Cover'"
+            :alt="data.title ?? t('dashboard.common.cover')"
             frame-aspect-ratio="3/4"
             :is-comic="isComic"
           />
@@ -87,13 +91,13 @@ function startReading() {
 
         <div class="min-w-0 text-left">
           <button class="block cursor-pointer truncate text-xs font-semibold leading-tight hover:underline" @click="goToBook">
-            {{ data.title ?? 'Untitled' }}
+            {{ data.title ?? t('dashboard.common.untitled') }}
           </button>
           <p class="mt-2 text-2xl font-bold leading-none tabular-nums text-primary">{{ data.waitingDays }}</p>
-          <p class="text-[11px] text-muted-foreground">days waiting</p>
+          <p class="text-[11px] text-muted-foreground">{{ t('dashboard.widgets.longWait.daysWaiting') }}</p>
 
           <div class="mt-2 flex min-w-0 items-center gap-1 text-[10px] text-muted-foreground">
-            <span v-if="data.pageCount" class="shrink-0">{{ data.pageCount }} pages</span>
+            <span v-if="data.pageCount" class="shrink-0">{{ t('dashboard.widgets.longWait.pages', { count: data.pageCount }, data.pageCount) }}</span>
             <span v-if="data.pageCount && data.genre" class="shrink-0">&middot;</span>
             <span v-if="data.genre" class="truncate">{{ data.genre }}</span>
           </div>
@@ -106,7 +110,7 @@ function startReading() {
         @click="startReading"
       >
         <Play :size="12" class="translate-x-px" />
-        Start Reading
+        {{ t('dashboard.widgets.longWait.startReading') }}
       </button>
     </div>
   </div>

--- a/client/src/features/dashboard/components/widgets/MonthlyChallengeWidget.vue
+++ b/client/src/features/dashboard/components/widgets/MonthlyChallengeWidget.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Swords } from '@lucide/vue'
 
 import { useMonthlyChallengeWidget } from '../../composables/useMonthlyChallengeWidget'
 
 const { data, loading, error } = useMonthlyChallengeWidget()
+const { t } = useI18n()
 </script>
 
 <template>
   <div class="flex h-full flex-col p-3">
     <div class="mb-3 flex items-center gap-2 self-start">
       <Swords :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Monthly Challenge</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.monthlyChallenge.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -21,7 +23,9 @@ const { data, loading, error } = useMonthlyChallengeWidget()
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Data -->
     <div v-else-if="data" class="flex flex-1 flex-col items-center justify-center gap-2.5">
@@ -41,7 +45,7 @@ const { data, loading, error } = useMonthlyChallengeWidget()
         </div>
         <div class="mt-1 flex items-center justify-between text-[11px] text-muted-foreground">
           <span>{{ data.progress }} / {{ data.target }}</span>
-          <span v-if="data.completed" class="font-medium text-green-500">Complete!</span>
+          <span v-if="data.completed" class="font-medium text-green-500">{{ t('dashboard.widgets.monthlyChallenge.complete') }}</span>
         </div>
       </div>
     </div>

--- a/client/src/features/dashboard/components/widgets/NeglectedGemsWidget.vue
+++ b/client/src/features/dashboard/components/widgets/NeglectedGemsWidget.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Gem, Star, BookMarked, Check } from '@lucide/vue'
 import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
 import { useCoverVersions } from '@/features/book/composables/useCoverVersions'
@@ -10,6 +11,7 @@ import { useBookStatus } from '@/features/book/composables/useBookStatus'
 import { useNeglectedGemsWidget } from '../../composables/useNeglectedGemsWidget'
 
 const { data, loading, error } = useNeglectedGemsWidget()
+const { t } = useI18n()
 const router = useRouter()
 const { setStatus } = useBookStatus()
 const { coverUrl } = useCoverVersions()
@@ -40,7 +42,7 @@ async function addToQueue() {
   <div class="flex h-full flex-col p-3">
     <div class="mb-3 flex items-center gap-2 self-start">
       <Gem :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Neglected Gems</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.neglectedGems.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -50,14 +52,16 @@ async function addToQueue() {
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Empty -->
     <div v-else-if="!data || data.gems.length === 0" class="flex flex-1 flex-col items-center justify-center gap-2">
       <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
         <Gem :size="16" class="text-muted-foreground/60" />
       </div>
-      <p class="text-center text-xs text-muted-foreground">All your top-rated books have been read!</p>
+      <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.neglectedGems.empty') }}</p>
     </div>
 
     <!-- Gem -->
@@ -76,18 +80,18 @@ async function addToQueue() {
           :author-line="null"
           :is-audio="false"
           :seed="currentGem.title ?? String(currentGem.bookId)"
-          :alt="currentGem.title ?? 'Cover'"
+          :alt="currentGem.title ?? t('dashboard.common.cover')"
           frame-aspect-ratio="13/19"
         />
       </BookCoverSurface>
       <button class="max-w-full cursor-pointer truncate text-center text-xs font-semibold hover:underline" @click="goToBook">
-        {{ currentGem.title ?? 'Untitled' }}
+        {{ currentGem.title ?? t('dashboard.common.untitled') }}
       </button>
       <div class="flex items-center gap-1 text-[11px] text-muted-foreground">
         <Star :size="12" class="fill-amber-400 text-amber-400" />
-        <span>{{ currentGem.rating }}/5</span>
+        <span>{{ t('dashboard.widgets.neglectedGems.rating', { rating: currentGem.rating }) }}</span>
         <span>&middot;</span>
-        <span>{{ currentGem.waitingDays }}d waiting</span>
+        <span>{{ t('dashboard.widgets.neglectedGems.daysWaiting', { count: currentGem.waitingDays }) }}</span>
       </div>
 
       <!-- Actions -->
@@ -101,14 +105,14 @@ async function addToQueue() {
           @click="addToQueue"
         >
           <component :is="queuedIds.has(currentGem.bookId) ? Check : BookMarked" :size="11" />
-          {{ queuedIds.has(currentGem.bookId) ? 'Queued' : 'Add to queue' }}
+          {{ queuedIds.has(currentGem.bookId) ? t('dashboard.widgets.neglectedGems.queued') : t('dashboard.widgets.neglectedGems.addToQueue') }}
         </button>
         <button
           v-if="data.gems.length > 1"
           class="rounded-md border border-input px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted"
           @click="handleShuffle"
         >
-          Shuffle
+          {{ t('dashboard.widgets.neglectedGems.shuffle') }}
         </button>
       </div>
     </div>

--- a/client/src/features/dashboard/components/widgets/ReadingDnaWidget.vue
+++ b/client/src/features/dashboard/components/widgets/ReadingDnaWidget.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Dna } from '@lucide/vue'
 
 import { useReadingDnaWidget } from '../../composables/useReadingDnaWidget'
 
 const { data, loading, error } = useReadingDnaWidget()
+const { t } = useI18n()
 
 const traitColors: Record<string, string> = {
   length: 'bg-blue-500',
@@ -18,7 +20,7 @@ const traitColors: Record<string, string> = {
   <div class="flex h-full flex-col p-3">
     <div class="mb-2 flex items-center gap-2 self-start">
       <Dna :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Reading DNA</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.readingDna.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -28,14 +30,16 @@ const traitColors: Record<string, string> = {
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Not enough data -->
     <div v-else-if="!data || data.booksAnalyzed < 5" class="flex flex-1 flex-col items-center justify-center gap-2">
       <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
         <Dna :size="16" class="text-muted-foreground/60" />
       </div>
-      <p class="text-center text-xs text-muted-foreground">Read at least 5 books to unlock your Reading DNA</p>
+      <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.readingDna.notEnoughData') }}</p>
     </div>
 
     <!-- DNA Card -->
@@ -45,11 +49,11 @@ const traitColors: Record<string, string> = {
       <div class="space-y-1.5">
         <div
           v-for="trait in [
-            { key: 'length', label: 'Length', score: data.lengthScore, valueLabel: data.lengthLabel },
-            { key: 'variety', label: 'Variety', score: data.varietyScore, valueLabel: data.varietyLabel },
-            { key: 'rhythm', label: 'Rhythm', score: data.rhythmScore, valueLabel: data.rhythmLabel },
-            { key: 'time', label: 'Time', score: data.timeScore, valueLabel: data.timeLabel },
-            { key: 'speed', label: 'Speed', score: data.speedScore, valueLabel: data.speedLabel },
+            { key: 'length', label: t('dashboard.widgets.readingDna.traits.length'), score: data.lengthScore, valueLabel: data.lengthLabel },
+            { key: 'variety', label: t('dashboard.widgets.readingDna.traits.variety'), score: data.varietyScore, valueLabel: data.varietyLabel },
+            { key: 'rhythm', label: t('dashboard.widgets.readingDna.traits.rhythm'), score: data.rhythmScore, valueLabel: data.rhythmLabel },
+            { key: 'time', label: t('dashboard.widgets.readingDna.traits.time'), score: data.timeScore, valueLabel: data.timeLabel },
+            { key: 'speed', label: t('dashboard.widgets.readingDna.traits.speed'), score: data.speedScore, valueLabel: data.speedLabel },
           ]"
           :key="trait.key"
           class="flex items-center gap-2"
@@ -62,7 +66,9 @@ const traitColors: Record<string, string> = {
         </div>
       </div>
 
-      <p class="text-center text-[10px] text-muted-foreground">Based on {{ data.booksAnalyzed }} books</p>
+      <p class="text-center text-[10px] text-muted-foreground">
+        {{ t('dashboard.widgets.readingDna.basedOn', { count: data.booksAnalyzed }, data.booksAnalyzed) }}
+      </p>
     </div>
   </div>
 </template>

--- a/client/src/features/dashboard/components/widgets/ReadingGoalWidget.vue
+++ b/client/src/features/dashboard/components/widgets/ReadingGoalWidget.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Target, Pencil } from '@lucide/vue'
 
@@ -9,6 +10,7 @@ import { useDashboardWidgets } from '../../composables/useDashboardWidgets'
 
 const { data, loading, error, refresh } = useReadingGoalWidget()
 const { readingGoal, saveReadingGoal } = useDashboardWidgets()
+const { t } = useI18n()
 
 const editing = ref(false)
 const goalInput = ref('')
@@ -86,7 +88,7 @@ function handleCancelEdit() {
   <div class="flex h-full flex-col p-3">
     <div class="mb-3 flex items-center gap-2 self-start">
       <Target :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Reading Goal {{ data?.year ?? '' }}</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.readingGoal.title', { year: data?.year ?? '' }) }}</span>
     </div>
 
     <!-- Loading -->
@@ -95,17 +97,19 @@ function handleCancelEdit() {
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- No goal set -->
     <template v-else-if="!hasGoal && !editing">
       <div class="flex flex-1 flex-col items-center justify-center gap-2">
-        <p class="text-center text-xs text-muted-foreground">Set a reading goal to track your progress</p>
+        <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.readingGoal.setGoalPrompt') }}</p>
         <button
           class="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           @click="handleStartEditing"
         >
-          Set goal
+          {{ t('dashboard.widgets.readingGoal.setGoal') }}
         </button>
       </div>
     </template>
@@ -113,7 +117,7 @@ function handleCancelEdit() {
     <!-- Editing goal -->
     <template v-else-if="editing">
       <div class="flex flex-1 flex-col items-center justify-center gap-2">
-        <label class="text-xs text-muted-foreground">Books per year</label>
+        <label class="text-xs text-muted-foreground">{{ t('dashboard.widgets.readingGoal.booksPerYear') }}</label>
         <input
           v-model="goalInput"
           type="number"
@@ -127,14 +131,14 @@ function handleCancelEdit() {
             :disabled="saving"
             @click="handleCancelEdit"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             :disabled="saving"
             @click="handleSaveGoal"
           >
-            Save
+            {{ t('common.save') }}
           </button>
         </div>
       </div>
@@ -146,14 +150,16 @@ function handleCancelEdit() {
         <VChart :option="option" autoresize style="width: 124px; height: 124px" />
         <div class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
           <p class="text-xl leading-none font-semibold tabular-nums text-foreground">{{ data?.completedBooks ?? 0 }}</p>
-          <p class="mt-1 text-[11px] leading-none text-muted-foreground">of {{ data?.goalBooks ?? 0 }}</p>
+          <p class="mt-1 text-[11px] leading-none text-muted-foreground">
+            {{ t('dashboard.widgets.readingGoal.ofGoal', { goal: data?.goalBooks ?? 0 }) }}
+          </p>
         </div>
       </div>
       <div class="flex items-center justify-between">
-        <p class="text-xs text-muted-foreground">{{ percentage }}% complete</p>
+        <p class="text-xs text-muted-foreground">{{ t('dashboard.widgets.readingGoal.percentComplete', { percentage }) }}</p>
         <button
           class="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-muted hover:text-muted-foreground"
-          title="Edit goal"
+          :title="t('dashboard.widgets.readingGoal.editGoal')"
           @click="handleStartEditing"
         >
           <Pencil :size="12.5" />

--- a/client/src/features/dashboard/components/widgets/ReadingRhythmWidget.vue
+++ b/client/src/features/dashboard/components/widgets/ReadingRhythmWidget.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { HeartPulse } from '@lucide/vue'
 
 import { useReadingRhythmWidget } from '../../composables/useReadingRhythmWidget'
 
 const { data, loading, error } = useReadingRhythmWidget()
+const { t } = useI18n()
 
 const maxSeconds = computed(() => {
   if (!data.value) return 1
@@ -27,8 +29,11 @@ function getDayLabel(dateStr: string): string {
 
 const consistencyLabel = computed(() => {
   if (!data.value) return ''
-  const dayWord = data.value.activeDays === 1 ? 'day' : 'days'
-  return `${data.value.activeDays} active ${dayWord} · ${data.value.consistencyPercent}% consistency`
+  const activeDays = t('dashboard.widgets.readingRhythm.activeDays', { count: data.value.activeDays }, data.value.activeDays)
+  return t('dashboard.widgets.readingRhythm.consistency', {
+    activeDays,
+    percent: data.value.consistencyPercent,
+  })
 })
 </script>
 
@@ -36,7 +41,7 @@ const consistencyLabel = computed(() => {
   <div class="flex h-full flex-col p-3">
     <div class="mb-2 flex items-center gap-2 self-start">
       <HeartPulse :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Reading Rhythm</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.readingRhythm.title') }}</span>
     </div>
 
     <div v-if="loading" class="flex flex-1 flex-col gap-2">
@@ -44,13 +49,15 @@ const consistencyLabel = computed(() => {
       <div class="h-3 w-20 animate-pulse rounded bg-muted" />
     </div>
 
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <div v-else-if="!data || data.activeDays === 0" class="flex flex-1 flex-col items-center justify-center gap-2">
       <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
         <HeartPulse :size="16" class="text-muted-foreground/60" />
       </div>
-      <p class="text-center text-xs text-muted-foreground">Start reading to see your rhythm take shape</p>
+      <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.readingRhythm.empty') }}</p>
     </div>
 
     <div v-else class="flex flex-1 flex-col">
@@ -72,7 +79,9 @@ const consistencyLabel = computed(() => {
 
       <div class="flex flex-wrap items-center justify-between gap-x-2 gap-y-1 border-t border-border/30 pt-1.5">
         <span class="text-[11px] text-muted-foreground"> {{ consistencyLabel }} </span>
-        <span class="text-[11px] text-muted-foreground"> avg {{ formatTime(data.avgSecondsPerDay) }}/day </span>
+        <span class="text-[11px] text-muted-foreground">
+          {{ t('dashboard.widgets.readingRhythm.avgPerDay', { time: formatTime(data.avgSecondsPerDay) }) }}
+        </span>
       </div>
     </div>
   </div>

--- a/client/src/features/dashboard/components/widgets/ReadingStreakWidget.vue
+++ b/client/src/features/dashboard/components/widgets/ReadingStreakWidget.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Flame, Trophy } from '@lucide/vue'
 
 import { useReadingStreakWidget } from '../../composables/useReadingStreakWidget'
 
 const { data, loading, error } = useReadingStreakWidget()
+const { t } = useI18n()
 </script>
 
 <template>
   <div class="flex h-full flex-col p-3">
     <div class="mb-3 flex items-center gap-2 self-start">
       <Flame :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Reading Streak</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.readingStreak.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -20,14 +22,16 @@ const { data, loading, error } = useReadingStreakWidget()
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Empty (no reading at all) -->
     <div v-else-if="!data || (data.currentStreak === 0 && data.longestStreak === 0)" class="flex flex-1 flex-col items-center justify-center gap-2">
       <div class="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
         <Flame :size="16" class="text-muted-foreground/60" />
       </div>
-      <p class="text-center text-xs text-muted-foreground">Read today to start your streak</p>
+      <p class="text-center text-xs text-muted-foreground">{{ t('dashboard.widgets.readingStreak.empty') }}</p>
     </div>
 
     <!-- Streak data -->
@@ -38,13 +42,15 @@ const { data, loading, error } = useReadingStreakWidget()
           <Flame :size="20" class="text-orange-500" />
           <span class="text-3xl font-bold tabular-nums">{{ data.currentStreak }}</span>
         </div>
-        <span class="text-xs text-muted-foreground">{{ data.currentStreak === 1 ? 'day' : 'days' }} streak</span>
+        <span class="text-xs text-muted-foreground">{{
+          t('dashboard.widgets.readingStreak.streakLabel', { count: data.currentStreak }, data.currentStreak)
+        }}</span>
       </div>
 
       <!-- Best streak -->
       <div class="flex items-center gap-1 text-xs text-muted-foreground">
         <Trophy :size="12" />
-        <span>Best: {{ data.longestStreak }} {{ data.longestStreak === 1 ? 'day' : 'days' }}</span>
+        <span>{{ t('dashboard.widgets.readingStreak.best', { count: data.longestStreak }, data.longestStreak) }}</span>
       </div>
 
       <!-- Last 7 days dots -->
@@ -56,7 +62,7 @@ const { data, loading, error } = useReadingStreakWidget()
           :class="active ? 'bg-primary' : 'bg-muted'"
         />
       </div>
-      <p class="text-[11px] text-muted-foreground">Last 7 days</p>
+      <p class="text-[11px] text-muted-foreground">{{ t('dashboard.widgets.readingStreak.lastSevenDays') }}</p>
     </div>
   </div>
 </template>

--- a/client/src/features/dashboard/components/widgets/YearProjectionWidget.vue
+++ b/client/src/features/dashboard/components/widgets/YearProjectionWidget.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { TrendingUp, TrendingDown, Minus } from '@lucide/vue'
 
 import { useYearProjectionWidget } from '../../composables/useYearProjectionWidget'
 
 const { data, loading, error } = useYearProjectionWidget()
+const { t } = useI18n()
 
 const trendIcons = { up: TrendingUp, down: TrendingDown, stable: Minus }
 const trendColors = { up: 'text-green-500', down: 'text-red-400', stable: 'text-muted-foreground' }
@@ -13,7 +15,7 @@ const trendColors = { up: 'text-green-500', down: 'text-red-400', stable: 'text-
   <div class="flex h-full flex-col p-3">
     <div class="mb-3 flex items-center gap-2 self-start">
       <TrendingUp :size="16" class="text-primary/90" />
-      <span class="text-[15px] font-semibold text-foreground">Year Projection</span>
+      <span class="text-[15px] font-semibold text-foreground">{{ t('dashboard.widgets.yearProjection.title') }}</span>
     </div>
 
     <!-- Loading -->
@@ -23,32 +25,43 @@ const trendColors = { up: 'text-green-500', down: 'text-red-400', stable: 'text-
     </div>
 
     <!-- Error -->
-    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">Failed to load</div>
+    <div v-else-if="error" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+      {{ t('dashboard.common.failedToLoad') }}
+    </div>
 
     <!-- Data -->
     <div v-else-if="data" class="flex flex-1 flex-col items-center justify-center gap-3">
       <div class="text-center">
         <span class="text-3xl font-bold tabular-nums">{{ data.projectedBooks }}</span>
-        <span class="ml-1 text-xs text-muted-foreground">books</span>
+        <span class="ml-1 text-xs text-muted-foreground">{{ t('dashboard.widgets.yearProjection.books') }}</span>
       </div>
 
       <div class="flex items-center gap-1 text-xs" :class="trendColors[data.trend]">
         <component :is="trendIcons[data.trend]" :size="14" />
-        <span>{{ data.trend === 'up' ? 'Trending up' : data.trend === 'down' ? 'Trending down' : 'Steady pace' }}</span>
+        <span>{{
+          data.trend === 'up'
+            ? t('dashboard.widgets.yearProjection.trendUp')
+            : data.trend === 'down'
+              ? t('dashboard.widgets.yearProjection.trendDown')
+              : t('dashboard.widgets.yearProjection.trendSteady')
+        }}</span>
       </div>
 
       <div class="grid w-full grid-cols-2 gap-3 text-center">
         <div class="rounded-md bg-muted/30 px-2 py-1">
           <span class="block text-xs font-semibold tabular-nums">{{ data.projectedPages.toLocaleString() }}</span>
-          <span class="text-[11px] text-muted-foreground">pages</span>
+          <span class="text-[11px] text-muted-foreground">{{ t('dashboard.widgets.yearProjection.pages') }}</span>
         </div>
         <div class="rounded-md bg-muted/30 px-2 py-1">
           <span class="block text-xs font-semibold tabular-nums">{{ data.projectedHours }}</span>
-          <span class="text-[11px] text-muted-foreground">hours</span>
+          <span class="text-[11px] text-muted-foreground">{{ t('dashboard.widgets.yearProjection.hours') }}</span>
         </div>
       </div>
 
-      <p class="text-[11px] text-muted-foreground">{{ data.booksCompletedYtd }} read &middot; {{ data.daysRemaining }}d left</p>
+      <p class="text-[11px] text-muted-foreground">
+        {{ t('dashboard.widgets.yearProjection.readCount', { count: data.booksCompletedYtd }) }} &middot;
+        {{ t('dashboard.widgets.yearProjection.daysLeft', { count: data.daysRemaining }) }}
+      </p>
     </div>
   </div>
 </template>

--- a/client/src/features/email/components/EmailSettings.vue
+++ b/client/src/features/email/components/EmailSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { Permission } from '@bookorbit/types'
 import ProvidersTab from './ProvidersTab.vue'
@@ -14,8 +15,9 @@ import { useEmailRecipients } from '../composables/useEmailRecipients'
 import { useEmailTemplates } from '../composables/useEmailTemplates'
 import { useEmailGroups } from '../composables/useEmailGroups'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
-import { EMAIL_TAB_LABELS, normalizeEmailTab, type EmailTab as Tab } from '@/features/email/lib/email-tabs'
+import { normalizeEmailTab, type EmailTab as Tab } from '@/features/email/lib/email-tabs'
 
+const { t } = useI18n()
 const { fetchProviders } = useEmailProviders()
 const { fetchRecipients } = useEmailRecipients()
 const { fetchTemplates } = useEmailTemplates()
@@ -27,14 +29,14 @@ const canSendEmail = computed(() => hasPermission(Permission.EmailSend))
 
 const tabs = computed<{ id: Tab; label: string }[]>(() => {
   const result: { id: Tab; label: string }[] = []
-  if (canManageEmail.value || canSendEmail.value) result.push({ id: 'providers', label: EMAIL_TAB_LABELS['providers'] })
+  if (canManageEmail.value || canSendEmail.value) result.push({ id: 'providers', label: t('email.tabs.providers') })
   if (canSendEmail.value) {
     result.push(
-      { id: 'recipients', label: EMAIL_TAB_LABELS['recipients'] },
-      { id: 'groups', label: EMAIL_TAB_LABELS['groups'] },
-      { id: 'templates', label: EMAIL_TAB_LABELS['templates'] },
-      { id: 'preferences', label: EMAIL_TAB_LABELS['preferences'] },
-      { id: 'history', label: EMAIL_TAB_LABELS['history'] },
+      { id: 'recipients', label: t('email.tabs.recipients') },
+      { id: 'groups', label: t('email.tabs.groups') },
+      { id: 'templates', label: t('email.tabs.templates') },
+      { id: 'preferences', label: t('email.tabs.preferences') },
+      { id: 'history', label: t('email.tabs.history') },
     )
   }
   return result
@@ -77,7 +79,7 @@ onMounted(async () => {
     if (canSendEmail.value) fetches.push(fetchRecipients(), fetchTemplates(), fetchGroups())
     await Promise.all(fetches)
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Failed to load'
+    error.value = e instanceof Error ? e.message : t('email.loadFailed')
   } finally {
     loading.value = false
   }
@@ -85,17 +87,17 @@ onMounted(async () => {
 </script>
 
 <template>
-  <SettingsPageHeader class="hidden md:flex" title="Email" subtitle="Send books to your e-reader via email." />
+  <SettingsPageHeader class="hidden md:flex" :title="t('email.title')" :subtitle="t('email.subtitle')" />
   <div class="md:hidden px-1">
-    <h1 class="text-xl font-semibold tracking-tight text-foreground">Email</h1>
+    <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('email.title') }}</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
     >
-      Send books to your e-reader via email.
+      {{ t('email.subtitle') }}
     </p>
   </div>
 
-  <div v-if="loading" class="mt-5 md:mt-0 text-sm text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="mt-5 md:mt-0 text-sm text-muted-foreground">{{ t('common.loading') }}</div>
   <div v-else-if="error" class="text-sm text-destructive">{{ error }}</div>
   <template v-else>
     <!-- Tab bar -->

--- a/client/src/features/email/components/GroupsTab.vue
+++ b/client/src/features/email/components/GroupsTab.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Plus, Trash2, UserMinus, UserPlus, ChevronDown, ChevronRight } from '@lucide/vue'
 import { useEmailGroups, type EmailGroup } from '../composables/useEmailGroups'
 import { useEmailRecipients } from '../composables/useEmailRecipients'
 
+const { t } = useI18n()
 const { groups, createGroup, deleteGroup, addMember, removeMember } = useEmailGroups()
 const { recipients } = useEmailRecipients()
 
@@ -24,11 +26,11 @@ async function submitCreate() {
   createError.value = null
   try {
     await createGroup(newGroupName.value.trim())
-    toast.success('Group created')
+    toast.success(t('email.groups.created'))
     newGroupName.value = ''
     showCreate.value = false
   } catch (e) {
-    createError.value = e instanceof Error ? e.message : 'Failed to create group'
+    createError.value = e instanceof Error ? e.message : t('email.groups.createFailed')
   } finally {
     creating.value = false
   }
@@ -37,9 +39,9 @@ async function submitCreate() {
 async function remove(g: EmailGroup) {
   try {
     await deleteGroup(g.id)
-    toast.success(`"${g.name}" deleted`)
+    toast.success(t('email.groups.deleted', { name: g.name }))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to delete')
+    toast.error(e instanceof Error ? e.message : t('email.deleteFailed'))
   }
 }
 
@@ -73,20 +75,20 @@ async function submitAddMember(group: EmailGroup) {
   if (!selectedRecipientId.value) return
   try {
     await addMember(group.id, selectedRecipientId.value)
-    toast.success('Member added')
+    toast.success(t('email.groups.memberAdded'))
     addingToGroupId.value = null
     selectedRecipientId.value = null
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to add member')
+    toast.error(e instanceof Error ? e.message : t('email.groups.addMemberFailed'))
   }
 }
 
 async function removeMemberFromGroup(group: EmailGroup, recipientId: number) {
   try {
     await removeMember(group.id, recipientId)
-    toast.success('Member removed')
+    toast.success(t('email.groups.memberRemoved'))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to remove member')
+    toast.error(e instanceof Error ? e.message : t('email.groups.removeMemberFailed'))
   }
 }
 
@@ -99,18 +101,18 @@ function availableRecipients(group: EmailGroup) {
 <template>
   <div class="space-y-4">
     <div class="hidden md:flex items-center justify-between">
-      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Recipient Groups</p>
+      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.groups.heading') }}</p>
       <button
         v-if="!showCreate"
         class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
         @click="showCreate = true"
       >
         <Plus :size="12" />
-        Create group
+        {{ t('email.groups.create') }}
       </button>
     </div>
     <div class="md:hidden flex items-center justify-between">
-      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Recipient Groups</p>
+      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.groups.heading') }}</p>
     </div>
     <div v-if="!showCreate" class="md:hidden sticky top-11 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
       <button
@@ -118,19 +120,19 @@ function availableRecipients(group: EmailGroup) {
         @click="showCreate = true"
       >
         <Plus :size="13" />
-        Create group
+        {{ t('email.groups.create') }}
       </button>
     </div>
 
     <!-- Create form -->
     <div v-if="showCreate" class="border border-border rounded-lg p-4 bg-card space-y-3">
-      <p class="text-sm font-semibold text-foreground">New Group</p>
+      <p class="text-sm font-semibold text-foreground">{{ t('email.groups.newTitle') }}</p>
       <div>
-        <label class="block text-xs font-medium text-muted-foreground mb-1.5">Group name</label>
+        <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.groups.name') }}</label>
         <input
           v-model="newGroupName"
           type="text"
-          placeholder="e.g. Book Club"
+          :placeholder="t('email.groups.namePlaceholder')"
           autofocus
           class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
           @keydown.enter="submitCreate()"
@@ -144,25 +146,25 @@ function availableRecipients(group: EmailGroup) {
           :disabled="creating || !newGroupName.trim()"
           @click="submitCreate()"
         >
-          {{ creating ? 'Creating...' : 'Create' }}
+          {{ creating ? t('email.groups.creating') : t('email.create') }}
         </button>
         <button
           class="px-4 py-2 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
           @click="cancelCreate"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
       </div>
       <div class="md:hidden sticky bottom-2 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
         <div class="flex items-center gap-2">
           <button class="settings-btn-primary flex-1 min-h-10 justify-center" :disabled="creating || !newGroupName.trim()" @click="submitCreate()">
-            {{ creating ? 'Creating...' : 'Create' }}
+            {{ creating ? t('email.groups.creating') : t('email.create') }}
           </button>
           <button
             class="rounded-md border border-border px-3 min-h-10 text-sm text-foreground hover:bg-muted transition-colors"
             @click="cancelCreate"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
         </div>
       </div>
@@ -170,7 +172,7 @@ function availableRecipients(group: EmailGroup) {
 
     <!-- Empty state -->
     <div v-if="groups.length === 0 && !showCreate" class="border border-border rounded-lg px-5 py-8 bg-card text-center">
-      <p class="text-sm text-muted-foreground">No groups yet. Create a group to send to multiple recipients at once.</p>
+      <p class="text-sm text-muted-foreground">{{ t('email.groups.empty') }}</p>
     </div>
 
     <!-- Groups list -->
@@ -184,7 +186,7 @@ function availableRecipients(group: EmailGroup) {
           </button>
           <div class="flex-1 min-w-0">
             <span class="text-sm font-medium text-foreground">{{ g.name }}</span>
-            <span class="ml-2 text-xs text-muted-foreground">{{ g.members.length }} {{ g.members.length === 1 ? 'member' : 'members' }}</span>
+            <span class="ml-2 text-xs text-muted-foreground">{{ t('email.groups.memberCount', { count: g.members.length }, g.members.length) }}</span>
           </div>
           <Tooltip>
             <TooltipTrigger as-child>
@@ -195,13 +197,13 @@ function availableRecipients(group: EmailGroup) {
                 <Trash2 :size="13" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Delete group</TooltipContent>
+            <TooltipContent>{{ t('email.groups.deleteTooltip') }}</TooltipContent>
           </Tooltip>
         </div>
 
         <!-- Expanded members -->
         <div v-if="expandedGroupId === g.id" class="border-t border-border bg-background/50">
-          <div v-if="g.members.length === 0" class="px-8 py-3 text-xs text-muted-foreground">No members yet.</div>
+          <div v-if="g.members.length === 0" class="px-8 py-3 text-xs text-muted-foreground">{{ t('email.groups.noMembers') }}</div>
           <div v-for="m in g.members" :key="m.id" class="flex items-start md:items-center gap-3 px-4 md:px-8 py-2">
             <div class="flex-1 min-w-0">
               <span class="text-sm text-foreground">{{ m.name }}</span>
@@ -212,7 +214,7 @@ function availableRecipients(group: EmailGroup) {
               @click="removeMemberFromGroup(g, m.id)"
             >
               <UserMinus :size="12" />
-              Remove
+              {{ t('email.groups.removeMember') }}
             </button>
           </div>
 
@@ -223,7 +225,7 @@ function availableRecipients(group: EmailGroup) {
                 v-model="selectedRecipientId"
                 class="flex-1 h-8 px-2 text-xs border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
               >
-                <option :value="null" disabled>Select recipient...</option>
+                <option :value="null" disabled>{{ t('email.groups.selectRecipient') }}</option>
                 <option v-for="r in availableRecipients(g)" :key="r.id" :value="r.id">{{ r.name }} ({{ r.email }})</option>
               </select>
               <button
@@ -231,13 +233,13 @@ function availableRecipients(group: EmailGroup) {
                 :disabled="!selectedRecipientId"
                 @click="submitAddMember(g)"
               >
-                Add
+                {{ t('email.groups.add') }}
               </button>
               <button
                 class="px-3 py-1.5 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
                 @click="addingToGroupId = null"
               >
-                Cancel
+                {{ t('common.cancel') }}
               </button>
             </div>
             <button
@@ -246,9 +248,9 @@ function availableRecipients(group: EmailGroup) {
               @click="startAddMember(g.id)"
             >
               <UserPlus :size="12" />
-              Add member
+              {{ t('email.groups.addMember') }}
             </button>
-            <p v-else class="text-xs text-muted-foreground/80">All recipients are already in this group.</p>
+            <p v-else class="text-xs text-muted-foreground/80">{{ t('email.groups.allRecipientsInGroup') }}</p>
           </div>
         </div>
       </div>
@@ -257,20 +259,20 @@ function availableRecipients(group: EmailGroup) {
     <div v-if="deleteConfirm" class="fixed inset-0 z-[70] flex items-end justify-center md:items-center md:px-4" @click.self="deleteConfirm = null">
       <button class="absolute inset-0 bg-black/45" @click="deleteConfirm = null" />
       <div class="relative w-full rounded-t-xl border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Delete group?</p>
-        <p class="mt-1 text-sm text-muted-foreground">Delete "{{ deleteConfirm.name }}". This action cannot be undone.</p>
+        <p class="text-base font-semibold text-foreground">{{ t('email.groups.deleteTitle') }}</p>
+        <p class="mt-1 text-sm text-muted-foreground">{{ t('email.deleteConfirm', { name: deleteConfirm.name }) }}</p>
         <div class="mt-4 flex items-center justify-end gap-2">
           <button
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="deleteConfirm = null"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
             @click="confirmRemove"
           >
-            Delete
+            {{ t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/email/components/HistoryTab.vue
+++ b/client/src/features/email/components/HistoryTab.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Trash2, RefreshCw } from '@lucide/vue'
 import { useEmailSendLog, type EmailSendLogEntry } from '../composables/useEmailSendLog'
 
+const { t } = useI18n()
 const { logEntries, fetchLog, deleteEntry, resendEntry } = useEmailSendLog()
 
 const loading = ref(true)
@@ -29,9 +31,9 @@ async function loadMore() {
 async function remove(entry: EmailSendLogEntry) {
   try {
     await deleteEntry(entry.id)
-    toast.success('Entry deleted')
+    toast.success(t('email.history.entryDeleted'))
   } catch {
-    toast.error('Failed to delete')
+    toast.error(t('email.deleteFailed'))
   }
 }
 
@@ -50,9 +52,9 @@ async function resend(entry: EmailSendLogEntry) {
   resending.value = entry.id
   try {
     await resendEntry(entry.id)
-    toast.success('Queued for resend')
+    toast.success(t('email.history.queuedForResend'))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to resend')
+    toast.error(e instanceof Error ? e.message : t('email.history.resendFailed'))
   } finally {
     resending.value = null
   }
@@ -67,16 +69,24 @@ function statusClass(status: string): string {
   if (status === 'failed') return 'bg-destructive/15 text-destructive'
   return 'bg-muted text-muted-foreground'
 }
+
+function statusLabel(status: string): string {
+  if (status === 'sent') return t('email.history.statusSent')
+  if (status === 'failed') return t('email.history.statusFailed')
+  if (status === 'queued') return t('email.history.statusQueued')
+  if (status === 'pending') return t('email.history.statusPending')
+  return status
+}
 </script>
 
 <template>
   <div class="space-y-4">
-    <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Send History</p>
+    <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.history.heading') }}</p>
 
-    <div v-if="loading" class="text-sm text-muted-foreground">Loading...</div>
+    <div v-if="loading" class="text-sm text-muted-foreground">{{ t('common.loading') }}</div>
 
     <div v-else-if="logEntries.length === 0" class="border border-border rounded-lg px-5 py-8 bg-card text-center">
-      <p class="text-sm text-muted-foreground">No emails sent yet.</p>
+      <p class="text-sm text-muted-foreground">{{ t('email.history.empty') }}</p>
     </div>
 
     <div v-else class="border border-border rounded-lg overflow-hidden divide-y divide-border">
@@ -84,12 +94,12 @@ function statusClass(status: string): string {
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 flex-wrap mb-0.5">
             <span class="text-[10px] font-semibold px-1.5 py-0.5 rounded uppercase tracking-wide" :class="statusClass(entry.status)">
-              {{ entry.status }}
+              {{ statusLabel(entry.status) }}
             </span>
             <span class="text-sm text-foreground truncate">{{ entry.toName || entry.toEmail }}</span>
           </div>
           <p class="text-xs text-muted-foreground line-clamp-2">
-            {{ entry.subject ?? '(no subject)' }}
+            {{ entry.subject ?? t('email.history.noSubject') }}
           </p>
           <p class="text-xs text-muted-foreground mt-0.5">{{ formatDate(entry.createdAt) }}</p>
           <p v-if="entry.errorMessage" class="text-xs text-destructive mt-0.5 line-clamp-2">{{ entry.errorMessage }}</p>
@@ -106,7 +116,7 @@ function statusClass(status: string): string {
                 <RefreshCw :size="13" :class="resending === entry.id ? 'animate-spin' : ''" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Resend</TooltipContent>
+            <TooltipContent>{{ t('email.history.resend') }}</TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger as-child>
@@ -117,7 +127,7 @@ function statusClass(status: string): string {
                 <Trash2 :size="13" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Delete</TooltipContent>
+            <TooltipContent>{{ t('common.delete') }}</TooltipContent>
           </Tooltip>
         </div>
       </div>
@@ -128,26 +138,26 @@ function statusClass(status: string): string {
       class="w-full py-2 text-xs text-muted-foreground hover:text-foreground border border-border rounded-lg hover:bg-muted transition-colors"
       @click="loadMore()"
     >
-      Load more
+      {{ t('email.history.loadMore') }}
     </button>
 
     <div v-if="deleteConfirm" class="fixed inset-0 z-[70] flex items-end justify-center md:items-center md:px-4" @click.self="deleteConfirm = null">
       <button class="absolute inset-0 bg-black/45" @click="deleteConfirm = null" />
       <div class="relative w-full rounded-t-xl border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Delete history entry?</p>
-        <p class="mt-1 text-sm text-muted-foreground line-clamp-2">{{ deleteConfirm.subject ?? '(no subject)' }}</p>
+        <p class="text-base font-semibold text-foreground">{{ t('email.history.deleteTitle') }}</p>
+        <p class="mt-1 text-sm text-muted-foreground line-clamp-2">{{ deleteConfirm.subject ?? t('email.history.noSubject') }}</p>
         <div class="mt-4 flex items-center justify-end gap-2">
           <button
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="deleteConfirm = null"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
             @click="confirmRemove"
           >
-            Delete
+            {{ t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/email/components/PreferencesTab.vue
+++ b/client/src/features/email/components/PreferencesTab.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { useEmailPreferences } from '../composables/useEmailPreferences'
 import { useEmailProviders } from '../composables/useEmailProviders'
 import { useEmailRecipients } from '../composables/useEmailRecipients'
 import { useEmailTemplates } from '../composables/useEmailTemplates'
 
+const { t } = useI18n()
 const { preferences, fetchPreferences, savePreferences } = useEmailPreferences()
 const { providers } = useEmailProviders()
 const { recipients } = useEmailRecipients()
@@ -31,9 +33,9 @@ async function save() {
       defaultRecipientId: defaultRecipientId.value,
       defaultTemplateId: defaultTemplateId.value,
     })
-    toast.success('Preferences saved')
+    toast.success(t('email.preferences.saved'))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to save')
+    toast.error(e instanceof Error ? e.message : t('email.saveFailed'))
   } finally {
     saving.value = false
   }
@@ -42,41 +44,41 @@ async function save() {
 
 <template>
   <div class="space-y-5">
-    <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Email Preferences</p>
+    <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.preferences.heading') }}</p>
 
     <div class="border border-border rounded-lg p-4 md:p-5 bg-card space-y-5">
       <div>
-        <label class="block text-sm font-medium text-foreground mb-1">Default provider</label>
-        <p class="text-xs text-muted-foreground mb-2">Used when no provider is specified. If empty, the account default is used.</p>
+        <label class="block text-sm font-medium text-foreground mb-1">{{ t('email.preferences.defaultProvider') }}</label>
+        <p class="text-xs text-muted-foreground mb-2">{{ t('email.preferences.defaultProviderHint') }}</p>
         <select
           v-model="defaultProviderId"
           class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
         >
-          <option :value="null">None (use account default)</option>
+          <option :value="null">{{ t('email.preferences.noneAccountDefault') }}</option>
           <option v-for="p in providers" :key="p.id" :value="p.id">{{ p.name }} ({{ p.host }})</option>
         </select>
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-foreground mb-1">Default recipient</label>
-        <p class="text-xs text-muted-foreground mb-2">Used for quick send. Must be set to use the quick-send action on book cards.</p>
+        <label class="block text-sm font-medium text-foreground mb-1">{{ t('email.preferences.defaultRecipient') }}</label>
+        <p class="text-xs text-muted-foreground mb-2">{{ t('email.preferences.defaultRecipientHint') }}</p>
         <select
           v-model="defaultRecipientId"
           class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
         >
-          <option :value="null">None</option>
+          <option :value="null">{{ t('email.preferences.none') }}</option>
           <option v-for="r in recipients" :key="r.id" :value="r.id">{{ r.name }} ({{ r.email }})</option>
         </select>
       </div>
 
       <div>
-        <label class="block text-sm font-medium text-foreground mb-1">Default template</label>
-        <p class="text-xs text-muted-foreground mb-2">Used when no template is specified. Falls back to the system default if empty.</p>
+        <label class="block text-sm font-medium text-foreground mb-1">{{ t('email.preferences.defaultTemplate') }}</label>
+        <p class="text-xs text-muted-foreground mb-2">{{ t('email.preferences.defaultTemplateHint') }}</p>
         <select
           v-model="defaultTemplateId"
           class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
         >
-          <option :value="null">None (use system default)</option>
+          <option :value="null">{{ t('email.preferences.noneSystemDefault') }}</option>
           <option v-for="t in templates" :key="t.id" :value="t.id">{{ t.name }}</option>
         </select>
       </div>
@@ -86,11 +88,11 @@ async function save() {
         :disabled="saving"
         @click="save()"
       >
-        {{ saving ? 'Saving...' : 'Save preferences' }}
+        {{ saving ? t('email.saving') : t('email.preferences.save') }}
       </button>
       <div class="md:hidden sticky bottom-2 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
         <button class="settings-btn-primary w-full min-h-10 justify-center" :disabled="saving" @click="save()">
-          {{ saving ? 'Saving...' : 'Save preferences' }}
+          {{ saving ? t('email.saving') : t('email.preferences.save') }}
         </button>
       </div>
     </div>

--- a/client/src/features/email/components/ProvidersTab.vue
+++ b/client/src/features/email/components/ProvidersTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, reactive, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { ChevronDown, ChevronUp, Plus, Pencil, Trash2, Star, Share2, Wifi, Server, AlertTriangle } from '@lucide/vue'
 import { Permission } from '@bookorbit/types'
@@ -9,6 +10,7 @@ import { useAuth } from '@/features/auth/composables/useAuth'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useMediaQuery } from '@vueuse/core'
 
+const { t } = useI18n()
 const {
   providers,
   createProvider,
@@ -83,7 +85,7 @@ function cancelForm() {
 
 async function submitForm() {
   if (!form.name.trim() || !form.host.trim()) {
-    formError.value = 'Name and host are required'
+    formError.value = t('email.providers.nameHostRequired')
     return
   }
   saving.value = true
@@ -93,14 +95,14 @@ async function submitForm() {
       const payload: Partial<EmailProviderForm> = { ...form }
       if (!payload.password) delete payload.password
       await updateProvider(editingId.value, payload)
-      toast.success('Provider updated')
+      toast.success(t('email.providers.updated'))
     } else {
       await createProvider(form)
-      toast.success('Provider created')
+      toast.success(t('email.providers.created'))
     }
     cancelForm()
   } catch (e) {
-    formError.value = e instanceof Error ? e.message : 'Failed to save'
+    formError.value = e instanceof Error ? e.message : t('email.saveFailed')
   } finally {
     saving.value = false
   }
@@ -109,27 +111,27 @@ async function submitForm() {
 async function remove(p: EmailProvider) {
   try {
     await deleteProvider(p.id)
-    toast.success(`"${p.name}" deleted`)
+    toast.success(t('email.providers.deleted', { name: p.name }))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to delete')
+    toast.error(e instanceof Error ? e.message : t('email.deleteFailed'))
   }
 }
 
 async function setDefault(p: EmailProvider) {
   try {
     await setDefaultProvider(p.id)
-    toast.success(`"${p.name}" set as default`)
+    toast.success(t('email.providers.setDefaultSuccess', { name: p.name }))
   } catch {
-    toast.error('Failed to set default')
+    toast.error(t('email.setDefaultFailed'))
   }
 }
 
 async function toggleShare(p: EmailProvider) {
   try {
     await toggleSharedProvider(p.id)
-    toast.success(p.isShared ? 'Provider unshared' : 'Provider shared with all users')
+    toast.success(p.isShared ? t('email.providers.unshared') : t('email.providers.sharedWithAll'))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to update sharing')
+    toast.error(e instanceof Error ? e.message : t('email.providers.updateSharingFailed'))
   }
 }
 
@@ -137,13 +139,13 @@ async function setSystem(p: EmailProvider) {
   try {
     if (p.isSystemProvider) {
       await clearSystemProvider()
-      toast.success(`"${p.name}" removed as system mail provider`)
+      toast.success(t('email.providers.systemRemoved', { name: p.name }))
     } else {
       await setSystemProvider(p.id)
-      toast.success(`"${p.name}" set as system mail provider`)
+      toast.success(t('email.providers.systemSet', { name: p.name }))
     }
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to update system provider')
+    toast.error(e instanceof Error ? e.message : t('email.providers.updateSystemFailed'))
   }
 }
 
@@ -152,12 +154,12 @@ async function test(p: EmailProvider) {
   try {
     const result = await testProvider(p.id)
     if (result.success) {
-      toast.success('Connection successful')
+      toast.success(t('email.providers.connectionSuccess'))
     } else {
-      toast.error(result.error ?? 'Connection failed')
+      toast.error(result.error ?? t('email.providers.connectionFailed'))
     }
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Test failed')
+    toast.error(e instanceof Error ? e.message : t('email.providers.testFailed'))
   } finally {
     testing.value = null
   }
@@ -186,18 +188,18 @@ watch(
 <template>
   <div class="space-y-4">
     <div class="hidden md:flex items-center justify-between">
-      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">SMTP Providers</p>
+      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.providers.heading') }}</p>
       <button
         v-if="canManageEmail && !showForm"
         class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
         @click="openCreate()"
       >
         <Plus :size="12" />
-        Add provider
+        {{ t('email.providers.add') }}
       </button>
     </div>
     <div class="md:hidden flex items-center justify-between">
-      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">SMTP Providers</p>
+      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.providers.heading') }}</p>
     </div>
     <div
       v-if="canManageEmail && !showForm"
@@ -208,25 +210,25 @@ watch(
         @click="openCreate()"
       >
         <Plus :size="13" />
-        Add provider
+        {{ t('email.providers.add') }}
       </button>
     </div>
 
     <!-- Add/Edit form -->
     <div v-if="canManageEmail && showForm" class="border border-border rounded-lg p-4 md:p-5 bg-card space-y-4">
-      <p class="text-sm font-semibold text-foreground">{{ editingId ? 'Edit Provider' : 'New Provider' }}</p>
+      <p class="text-sm font-semibold text-foreground">{{ editingId ? t('email.providers.editTitle') : t('email.providers.newTitle') }}</p>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div class="col-span-2">
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Name</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.providers.name') }}</label>
           <input
             v-model="form.name"
             type="text"
-            placeholder="e.g. Gmail"
+            :placeholder="t('email.providers.namePlaceholder')"
             class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Host</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.providers.host') }}</label>
           <input
             v-model="form.host"
             type="text"
@@ -235,7 +237,7 @@ watch(
           />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Port</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.providers.port') }}</label>
           <input
             v-model.number="form.port"
             type="number"
@@ -243,7 +245,7 @@ watch(
           />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Username</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.providers.username') }}</label>
           <input
             v-model="form.username"
             type="text"
@@ -253,7 +255,7 @@ watch(
         </div>
         <div>
           <label class="block text-xs font-medium text-muted-foreground mb-1.5">
-            Password{{ editingId ? ' (leave blank to keep current)' : '' }}
+            {{ editingId ? t('email.providers.passwordEdit') : t('email.providers.password') }}
           </label>
           <input
             v-model="form.password"
@@ -263,16 +265,16 @@ watch(
           />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">From Name</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.providers.fromName') }}</label>
           <input
             v-model="form.fromName"
             type="text"
-            placeholder="My Library"
+            :placeholder="t('email.providers.fromNamePlaceholder')"
             class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">From Address</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.providers.fromAddress') }}</label>
           <input
             v-model="form.fromAddress"
             type="email"
@@ -285,7 +287,7 @@ watch(
       <div class="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-6">
         <label class="flex items-center gap-2 cursor-pointer">
           <input v-model="form.auth" type="checkbox" class="rounded border-border" />
-          <span class="text-xs text-foreground">Authentication</span>
+          <span class="text-xs text-foreground">{{ t('email.providers.authentication') }}</span>
         </label>
         <label class="flex items-center gap-2 cursor-pointer">
           <input v-model="form.ssl" type="checkbox" class="rounded border-border" />
@@ -297,14 +299,14 @@ watch(
         </label>
         <label class="flex items-center gap-2 cursor-pointer">
           <input v-model="form.tlsRejectUnauthorized" type="checkbox" class="rounded border-border" />
-          <span class="text-xs text-foreground">Verify TLS certificate</span>
+          <span class="text-xs text-foreground">{{ t('email.providers.verifyTls') }}</span>
         </label>
       </div>
 
       <div v-if="!form.tlsRejectUnauthorized" class="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2">
         <AlertTriangle :size="14" class="mt-0.5 shrink-0 text-amber-500" />
         <p class="text-xs text-amber-700 dark:text-amber-400">
-          TLS verification is disabled. The server's certificate will not be validated - use only for trusted internal servers.
+          {{ t('email.providers.tlsWarning') }}
         </p>
       </div>
 
@@ -316,25 +318,25 @@ watch(
           :disabled="saving"
           @click="submitForm()"
         >
-          {{ saving ? 'Saving...' : editingId ? 'Update' : 'Create' }}
+          {{ saving ? t('email.saving') : editingId ? t('email.update') : t('email.create') }}
         </button>
         <button
           class="px-4 py-2 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
           @click="cancelForm()"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
       </div>
       <div class="md:hidden sticky bottom-2 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
         <div class="flex items-center gap-2">
           <button class="settings-btn-primary flex-1 min-h-10 justify-center" :disabled="saving" @click="submitForm()">
-            {{ saving ? 'Saving...' : editingId ? 'Update' : 'Create' }}
+            {{ saving ? t('email.saving') : editingId ? t('email.update') : t('email.create') }}
           </button>
           <button
             class="rounded-md border border-border px-3 min-h-10 text-sm text-foreground hover:bg-muted transition-colors"
             @click="cancelForm()"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
         </div>
       </div>
@@ -343,11 +345,7 @@ watch(
     <!-- Empty state -->
     <div v-if="providers.length === 0 && !showForm" class="border border-border rounded-lg px-5 py-8 bg-card text-center">
       <p class="text-sm text-muted-foreground">
-        {{
-          canManageEmail
-            ? 'No providers yet. Add an SMTP provider to start sending emails.'
-            : 'No providers available. Ask an administrator to add one.'
-        }}
+        {{ canManageEmail ? t('email.providers.emptyManage') : t('email.providers.emptyReadonly') }}
       </p>
     </div>
 
@@ -357,14 +355,20 @@ watch(
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 flex-wrap">
             <span class="text-sm font-medium text-foreground">{{ p.name }}</span>
-            <span v-if="p.isDefault" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-primary/15 text-primary">Default</span>
-            <span v-if="p.isShared" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-muted text-muted-foreground">Shared</span>
-            <span v-if="p.isSystemProvider" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400"
-              >System</span
+            <span v-if="p.isDefault" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-primary/15 text-primary">{{
+              t('email.badge.default')
+            }}</span>
+            <span v-if="p.isShared" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{{
+              t('email.badge.shared')
+            }}</span>
+            <span
+              v-if="p.isSystemProvider"
+              class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400"
+              >{{ t('email.badge.system') }}</span
             >
           </div>
           <p class="text-xs text-muted-foreground mt-0.5 line-clamp-2">
-            {{ p.host }}:{{ p.port }} · {{ p.fromAddress || p.username || 'no from address' }}
+            {{ p.host }}:{{ p.port }} · {{ p.fromAddress || p.username || t('email.providers.noFromAddress') }}
           </p>
         </div>
 
@@ -379,7 +383,9 @@ watch(
                 <Server :size="13" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>{{ p.isSystemProvider ? 'Remove as system mail provider' : 'Set as system mail provider' }}</TooltipContent>
+            <TooltipContent>{{
+              p.isSystemProvider ? t('email.providers.removeSystemTooltip') : t('email.providers.setSystemTooltip')
+            }}</TooltipContent>
           </Tooltip>
           <Tooltip v-if="canManageEmail">
             <TooltipTrigger as-child>
@@ -391,7 +397,7 @@ watch(
                 <Wifi :size="13" :class="testing === p.id ? 'animate-pulse' : ''" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Test connection</TooltipContent>
+            <TooltipContent>{{ t('email.providers.testTooltip') }}</TooltipContent>
           </Tooltip>
           <Tooltip v-if="p.userId === user?.id">
             <TooltipTrigger as-child>
@@ -403,7 +409,7 @@ watch(
                 <Star :size="13" :class="p.isDefault ? 'fill-primary' : ''" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Set as default</TooltipContent>
+            <TooltipContent>{{ t('email.setAsDefault') }}</TooltipContent>
           </Tooltip>
           <Tooltip v-if="canManageEmail && (!p.isShared || p.userId !== null)">
             <TooltipTrigger as-child>
@@ -415,7 +421,7 @@ watch(
                 <Share2 :size="13" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Toggle sharing</TooltipContent>
+            <TooltipContent>{{ t('email.providers.toggleSharing') }}</TooltipContent>
           </Tooltip>
           <Tooltip v-if="canManageEmail">
             <TooltipTrigger as-child>
@@ -426,7 +432,7 @@ watch(
                 <Pencil :size="13" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Edit</TooltipContent>
+            <TooltipContent>{{ t('common.edit') }}</TooltipContent>
           </Tooltip>
           <Tooltip v-if="canManageEmail && p.userId !== null">
             <TooltipTrigger as-child>
@@ -444,7 +450,7 @@ watch(
               </button>
             </TooltipTrigger>
             <TooltipContent>
-              {{ p.isSystemProvider ? 'Remove the system designation before deleting' : 'Delete' }}
+              {{ p.isSystemProvider ? t('email.providers.removeSystemBeforeDelete') : t('common.delete') }}
             </TooltipContent>
           </Tooltip>
         </div>
@@ -453,33 +459,31 @@ watch(
 
     <div class="border border-border rounded-lg bg-card/50">
       <button class="w-full flex items-center justify-between gap-2 p-4 text-left" @click="helpOpen = !helpOpen">
-        <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Provider Notes</p>
+        <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.providers.notesHeading') }}</p>
         <ChevronUp v-if="helpOpen" :size="14" class="text-muted-foreground" />
         <ChevronDown v-else :size="14" class="text-muted-foreground" />
       </button>
-      <p v-if="helpOpen" class="px-4 pb-4 text-xs text-muted-foreground">
-        The <strong>System</strong> provider (superuser only) is used for password reset emails. The <strong>Default</strong> provider is used when
-        sending books with no explicit provider selected. Providers marked <strong>Shared</strong> are available to all users.
-      </p>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <p v-if="helpOpen" class="px-4 pb-4 text-xs text-muted-foreground" v-html="t('email.providers.notesBody')" />
     </div>
 
     <div v-if="deleteConfirm" class="fixed inset-0 z-[70] flex items-end justify-center md:items-center md:px-4" @click.self="deleteConfirm = null">
       <button class="absolute inset-0 bg-black/45" @click="deleteConfirm = null" />
       <div class="relative w-full rounded-t-xl border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Delete provider?</p>
-        <p class="mt-1 text-sm text-muted-foreground">Delete "{{ deleteConfirm.name }}". This action cannot be undone.</p>
+        <p class="text-base font-semibold text-foreground">{{ t('email.providers.deleteTitle') }}</p>
+        <p class="mt-1 text-sm text-muted-foreground">{{ t('email.deleteConfirm', { name: deleteConfirm.name }) }}</p>
         <div class="mt-4 flex items-center justify-end gap-2">
           <button
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="deleteConfirm = null"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
             @click="confirmRemove"
           >
-            Delete
+            {{ t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/email/components/RecipientsTab.vue
+++ b/client/src/features/email/components/RecipientsTab.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
-import { ref, reactive } from 'vue'
+import { ref, reactive, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Plus, Pencil, Trash2, Star } from '@lucide/vue'
 import { useEmailRecipients, type EmailRecipient, type EmailRecipientForm } from '../composables/useEmailRecipients'
 import { useEmailTemplates } from '../composables/useEmailTemplates'
 
+const { t } = useI18n()
 const { recipients, createRecipient, updateRecipient, deleteRecipient, setDefaultRecipient } = useEmailRecipients()
 const { templates, fetchTemplates } = useEmailTemplates()
 
-const DEVICE_TYPES = [
+const DEVICE_TYPES = computed(() => [
   { value: 'kindle', label: 'Kindle' },
   { value: 'kobo', label: 'Kobo' },
-  { value: 'other', label: 'Other' },
-]
+  { value: 'other', label: t('email.recipients.deviceOther') },
+])
 
 const FORMATS = ['epub', 'pdf', 'mobi', 'azw3', 'cbz', 'cbr']
 
@@ -63,7 +65,7 @@ function cancelForm() {
 
 async function submitForm() {
   if (!form.name.trim() || !form.email.trim()) {
-    formError.value = 'Name and email are required'
+    formError.value = t('email.recipients.nameEmailRequired')
     return
   }
   saving.value = true
@@ -71,14 +73,14 @@ async function submitForm() {
   try {
     if (editingId.value) {
       await updateRecipient(editingId.value, form)
-      toast.success('Recipient updated')
+      toast.success(t('email.recipients.updated'))
     } else {
       await createRecipient(form)
-      toast.success('Recipient created')
+      toast.success(t('email.recipients.created'))
     }
     cancelForm()
   } catch (e) {
-    formError.value = e instanceof Error ? e.message : 'Failed to save'
+    formError.value = e instanceof Error ? e.message : t('email.saveFailed')
   } finally {
     saving.value = false
   }
@@ -87,9 +89,9 @@ async function submitForm() {
 async function remove(r: EmailRecipient) {
   try {
     await deleteRecipient(r.id)
-    toast.success(`"${r.name}" deleted`)
+    toast.success(t('email.recipients.deleted', { name: r.name }))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to delete')
+    toast.error(e instanceof Error ? e.message : t('email.deleteFailed'))
   }
 }
 
@@ -107,32 +109,32 @@ async function confirmRemove() {
 async function setDefault(r: EmailRecipient) {
   try {
     await setDefaultRecipient(r.id)
-    toast.success(`"${r.name}" set as default`)
+    toast.success(t('email.recipients.setDefaultSuccess', { name: r.name }))
   } catch {
-    toast.error('Failed to set default')
+    toast.error(t('email.setDefaultFailed'))
   }
 }
 
 function deviceLabel(type: string | null): string {
-  return DEVICE_TYPES.find((d) => d.value === type)?.label ?? type ?? ''
+  return DEVICE_TYPES.value.find((d) => d.value === type)?.label ?? type ?? ''
 }
 </script>
 
 <template>
   <div class="space-y-4">
     <div class="hidden md:flex items-center justify-between">
-      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Recipients</p>
+      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.recipients.heading') }}</p>
       <button
         v-if="!showForm"
         class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
         @click="openCreate()"
       >
         <Plus :size="12" />
-        Add recipient
+        {{ t('email.recipients.add') }}
       </button>
     </div>
     <div class="md:hidden flex items-center justify-between">
-      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Recipients</p>
+      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.recipients.heading') }}</p>
     </div>
     <div v-if="!showForm" class="md:hidden sticky top-11 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2 mb-6">
       <button
@@ -140,25 +142,25 @@ function deviceLabel(type: string | null): string {
         @click="openCreate()"
       >
         <Plus :size="13" />
-        Add recipient
+        {{ t('email.recipients.add') }}
       </button>
     </div>
 
     <!-- Form -->
     <div v-if="showForm" class="border border-border rounded-lg p-4 md:p-5 bg-card space-y-4 shadow-xs">
-      <p class="text-sm font-semibold text-foreground">{{ editingId ? 'Edit Recipient' : 'New Recipient' }}</p>
+      <p class="text-sm font-semibold text-foreground">{{ editingId ? t('email.recipients.editTitle') : t('email.recipients.newTitle') }}</p>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Name</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.recipients.name') }}</label>
           <input
             v-model="form.name"
             type="text"
-            placeholder="My Kindle"
+            :placeholder="t('email.recipients.namePlaceholder')"
             class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Email address</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.recipients.emailAddress') }}</label>
           <input
             v-model="form.email"
             type="email"
@@ -167,39 +169,39 @@ function deviceLabel(type: string | null): string {
           />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Device type</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.recipients.deviceType') }}</label>
           <select
             v-model="form.deviceType"
             class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
           >
-            <option :value="null">None</option>
+            <option :value="null">{{ t('email.recipients.deviceNone') }}</option>
             <option v-for="d in DEVICE_TYPES" :key="d.value" :value="d.value">{{ d.label }}</option>
           </select>
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Preferred format</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.recipients.preferredFormat') }}</label>
           <select
             v-model="form.preferredFormat"
             class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
           >
-            <option :value="null">Auto</option>
+            <option :value="null">{{ t('email.recipients.formatAuto') }}</option>
             <option v-for="f in FORMATS" :key="f" :value="f">{{ f.toUpperCase() }}</option>
           </select>
         </div>
         <div class="col-span-2">
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Default template</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.recipients.defaultTemplate') }}</label>
           <select
             v-model="form.defaultTemplateId"
             class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
           >
-            <option :value="null">Use account default</option>
+            <option :value="null">{{ t('email.recipients.useAccountDefault') }}</option>
             <option v-for="t in templates" :key="t.id" :value="t.id">{{ t.name }}</option>
           </select>
         </div>
       </div>
 
       <div v-if="form.deviceType === 'kindle'" class="text-xs text-muted-foreground bg-muted/50 rounded px-3 py-2">
-        Kindle recipients automatically receive emails with subject "convert" to trigger format conversion.
+        {{ t('email.recipients.kindleNote') }}
       </div>
 
       <div v-if="formError" class="text-xs text-destructive">{{ formError }}</div>
@@ -210,25 +212,25 @@ function deviceLabel(type: string | null): string {
           :disabled="saving"
           @click="submitForm()"
         >
-          {{ saving ? 'Saving...' : editingId ? 'Update' : 'Create' }}
+          {{ saving ? t('email.saving') : editingId ? t('email.update') : t('email.create') }}
         </button>
         <button
           class="px-4 py-2 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
           @click="cancelForm()"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
       </div>
       <div class="md:hidden sticky bottom-2 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
         <div class="flex items-center gap-2">
           <button class="settings-btn-primary flex-1 min-h-10 justify-center" :disabled="saving" @click="submitForm()">
-            {{ saving ? 'Saving...' : editingId ? 'Update' : 'Create' }}
+            {{ saving ? t('email.saving') : editingId ? t('email.update') : t('email.create') }}
           </button>
           <button
             class="rounded-md border border-border px-3 min-h-10 text-sm text-foreground hover:bg-muted transition-colors"
             @click="cancelForm()"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
         </div>
       </div>
@@ -236,7 +238,7 @@ function deviceLabel(type: string | null): string {
 
     <!-- Empty state -->
     <div v-if="recipients.length === 0 && !showForm" class="border border-border rounded-lg px-5 py-8 bg-card text-center shadow-xs">
-      <p class="text-sm text-muted-foreground">No recipients yet.</p>
+      <p class="text-sm text-muted-foreground">{{ t('email.recipients.empty') }}</p>
     </div>
 
     <!-- List -->
@@ -245,14 +247,16 @@ function deviceLabel(type: string | null): string {
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 flex-wrap">
             <span class="text-sm font-medium text-foreground">{{ r.name }}</span>
-            <span v-if="r.isDefault" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-primary/15 text-primary">Default</span>
+            <span v-if="r.isDefault" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-primary/15 text-primary">{{
+              t('email.badge.default')
+            }}</span>
             <span v-if="r.deviceType" class="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">
               {{ deviceLabel(r.deviceType) }}
             </span>
           </div>
           <p class="text-xs text-muted-foreground mt-0.5 line-clamp-2">
             {{ r.email }}
-            <span v-if="r.preferredFormat"> · prefers {{ r.preferredFormat.toUpperCase() }}</span>
+            <span v-if="r.preferredFormat"> · {{ t('email.recipients.prefersFormat', { format: r.preferredFormat.toUpperCase() }) }}</span>
           </p>
         </div>
 
@@ -267,7 +271,7 @@ function deviceLabel(type: string | null): string {
                 <Star :size="13" :class="r.isDefault ? 'fill-primary' : ''" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Set as default</TooltipContent>
+            <TooltipContent>{{ t('email.setAsDefault') }}</TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger as-child>
@@ -278,7 +282,7 @@ function deviceLabel(type: string | null): string {
                 <Pencil :size="13" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Edit</TooltipContent>
+            <TooltipContent>{{ t('common.edit') }}</TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger as-child>
@@ -289,7 +293,7 @@ function deviceLabel(type: string | null): string {
                 <Trash2 :size="13" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Delete</TooltipContent>
+            <TooltipContent>{{ t('common.delete') }}</TooltipContent>
           </Tooltip>
         </div>
       </div>
@@ -298,20 +302,20 @@ function deviceLabel(type: string | null): string {
     <div v-if="deleteConfirm" class="fixed inset-0 z-[70] flex items-end justify-center md:items-center md:px-4" @click.self="deleteConfirm = null">
       <button class="absolute inset-0 bg-black/45" @click="deleteConfirm = null" />
       <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Delete recipient?</p>
-        <p class="mt-1 text-sm text-muted-foreground">Delete "{{ deleteConfirm.name }}". This action cannot be undone.</p>
+        <p class="text-base font-semibold text-foreground">{{ t('email.recipients.deleteTitle') }}</p>
+        <p class="mt-1 text-sm text-muted-foreground">{{ t('email.deleteConfirm', { name: deleteConfirm.name }) }}</p>
         <div class="mt-4 flex items-center justify-end gap-2">
           <button
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="deleteConfirm = null"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
             @click="confirmRemove"
           >
-            Delete
+            {{ t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/email/components/SendBookDialog.vue
+++ b/client/src/features/email/components/SendBookDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { X, Send, Loader2 } from '@lucide/vue'
 import { useEmailProviders } from '../composables/useEmailProviders'
@@ -28,6 +29,7 @@ const emit = defineEmits<{
   sent: []
 }>()
 
+const { t } = useI18n()
 const { providers, fetchProviders } = useEmailProviders()
 const { recipients, fetchRecipients } = useEmailRecipients()
 const { groups, fetchGroups } = useEmailGroups()
@@ -96,11 +98,11 @@ async function send() {
       templateId: selectedTemplateId.value ?? undefined,
       fileId: selectedFileId.value ?? undefined,
     })
-    toast.success(`${result.queued} email${result.queued !== 1 ? 's' : ''} queued`)
+    toast.success(t('email.send.queued', { count: result.queued }, result.queued))
     emit('update:open', false)
     emit('sent')
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to send')
+    toast.error(e instanceof Error ? e.message : t('email.send.failed'))
   } finally {
     sending.value = false
   }
@@ -121,9 +123,11 @@ function close() {
           <!-- Header -->
           <div class="flex items-center justify-between px-5 py-4 border-b border-border">
             <div>
-              <h2 class="text-sm font-semibold text-foreground">Send via Email</h2>
+              <h2 class="text-sm font-semibold text-foreground">{{ t('email.send.title') }}</h2>
               <p v-if="bookTitle" class="text-xs text-muted-foreground mt-0.5 truncate max-w-[280px]">{{ bookTitle }}</p>
-              <p v-else-if="selectionCount() > 1" class="text-xs text-muted-foreground mt-0.5">{{ selectionCount() }} books</p>
+              <p v-else-if="selectionCount() > 1" class="text-xs text-muted-foreground mt-0.5">
+                {{ t('email.send.bookCount', { count: selectionCount() }, selectionCount()) }}
+              </p>
             </div>
             <button class="text-muted-foreground hover:text-foreground transition-colors" @click="close()">
               <X :size="16" />
@@ -134,8 +138,8 @@ function close() {
           <div class="px-5 py-4 space-y-4 max-h-[70vh] overflow-y-auto">
             <!-- Recipients -->
             <div>
-              <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">Recipients</p>
-              <div v-if="recipients.length === 0" class="text-xs text-muted-foreground">No recipients configured. Add one in Email settings.</div>
+              <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">{{ t('email.send.recipients') }}</p>
+              <div v-if="recipients.length === 0" class="text-xs text-muted-foreground">{{ t('email.send.noRecipients') }}</div>
               <div v-else class="space-y-1">
                 <label
                   v-for="r in recipients"
@@ -153,14 +157,16 @@ function close() {
                     <p class="text-sm text-foreground">{{ r.name }}</p>
                     <p class="text-xs text-muted-foreground truncate">{{ r.email }}</p>
                   </div>
-                  <span v-if="r.isDefault" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-primary/15 text-primary">Default</span>
+                  <span v-if="r.isDefault" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-primary/15 text-primary">{{
+                    t('email.badge.default')
+                  }}</span>
                 </label>
               </div>
             </div>
 
             <!-- Groups -->
             <div v-if="groups.length > 0">
-              <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">Groups</p>
+              <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">{{ t('email.send.groups') }}</p>
               <div class="space-y-1">
                 <label
                   v-for="g in groups"
@@ -176,7 +182,7 @@ function close() {
                   />
                   <div class="flex-1 min-w-0">
                     <p class="text-sm text-foreground">{{ g.name }}</p>
-                    <p class="text-xs text-muted-foreground">{{ g.members.length }} {{ g.members.length === 1 ? 'member' : 'members' }}</p>
+                    <p class="text-xs text-muted-foreground">{{ t('email.groups.memberCount', { count: g.members.length }, g.members.length) }}</p>
                   </div>
                 </label>
               </div>
@@ -187,44 +193,45 @@ function close() {
               <summary
                 class="text-xs font-semibold text-muted-foreground uppercase tracking-wider cursor-pointer hover:text-foreground transition-colors list-none flex items-center gap-1"
               >
-                <span>Options</span>
+                <span>{{ t('email.send.options') }}</span>
                 <span class="text-muted-foreground/70 group-open:rotate-90 transition-transform inline-block">›</span>
               </summary>
               <div class="mt-3 space-y-3">
                 <!-- File picker -->
                 <div v-if="bookFiles && bookFiles.length > 1">
-                  <label class="block text-xs font-medium text-muted-foreground mb-1.5">File format</label>
+                  <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.send.fileFormat') }}</label>
                   <select
                     v-model="selectedFileId"
                     class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
                   >
-                    <option :value="null">Auto (use recipient preference)</option>
+                    <option :value="null">{{ t('email.send.autoRecipientPreference') }}</option>
                     <option v-for="f in bookFiles" :key="f.id" :value="f.id">
-                      {{ f.format?.toUpperCase() ?? 'Unknown' }}{{ f.role === 'primary' ? ' (primary)' : '' }}
+                      {{ f.format?.toUpperCase() ?? t('email.send.unknownFormat')
+                      }}{{ f.role === 'primary' ? ` ${t('email.send.primarySuffix')}` : '' }}
                     </option>
                   </select>
                 </div>
 
                 <!-- Provider picker -->
                 <div v-if="providers.length > 0">
-                  <label class="block text-xs font-medium text-muted-foreground mb-1.5">Provider</label>
+                  <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.send.provider') }}</label>
                   <select
                     v-model="selectedProviderId"
                     class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
                   >
-                    <option :value="null">Default</option>
+                    <option :value="null">{{ t('email.send.default') }}</option>
                     <option v-for="p in providers" :key="p.id" :value="p.id">{{ p.name }}</option>
                   </select>
                 </div>
 
                 <!-- Template picker -->
                 <div v-if="providers.length > 0">
-                  <label class="block text-xs font-medium text-muted-foreground mb-1.5">Template</label>
+                  <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.send.template') }}</label>
                   <select
                     v-model="selectedTemplateId"
                     class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
                   >
-                    <option :value="null">Default</option>
+                    <option :value="null">{{ t('email.send.default') }}</option>
                     <option v-for="t in templates" :key="t.id" :value="t.id">{{ t.name }}</option>
                   </select>
                 </div>
@@ -238,7 +245,7 @@ function close() {
               class="px-4 py-2 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
               @click="close()"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               class="flex items-center gap-2 px-4 py-2 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
@@ -247,7 +254,7 @@ function close() {
             >
               <Loader2 v-if="sending" :size="12" class="animate-spin" />
               <Send v-else :size="12" />
-              {{ sending ? 'Sending...' : 'Send' }}
+              {{ sending ? t('email.send.sending') : t('email.send.send') }}
             </button>
           </div>
         </div>

--- a/client/src/features/email/components/TemplatesTab.vue
+++ b/client/src/features/email/components/TemplatesTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, reactive, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Plus, Pencil, Trash2, Star, ChevronDown, ChevronRight, ChevronUp } from '@lucide/vue'
@@ -7,6 +8,7 @@ import { useEmailTemplates, type EmailTemplate, type EmailTemplateForm } from '.
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 import { useMediaQuery } from '@vueuse/core'
 
+const { t } = useI18n()
 const { templates, createTemplate, updateTemplate, deleteTemplate, setDefaultTemplate } = useEmailTemplates()
 const { isSuperuser } = usePermissions()
 
@@ -38,9 +40,9 @@ function openCreate() {
   showForm.value = true
 }
 
-function openEdit(t: EmailTemplate) {
-  Object.assign(form, { name: t.name, subject: t.subject, bodyText: t.bodyText })
-  editingId.value = t.id
+function openEdit(tpl: EmailTemplate) {
+  Object.assign(form, { name: tpl.name, subject: tpl.subject, bodyText: tpl.bodyText })
+  editingId.value = tpl.id
   formError.value = null
   showForm.value = true
 }
@@ -53,7 +55,7 @@ function cancelForm() {
 
 async function submitForm() {
   if (!form.name.trim() || !form.subject.trim()) {
-    formError.value = 'Name and subject are required'
+    formError.value = t('email.templates.nameSubjectRequired')
     return
   }
   saving.value = true
@@ -61,30 +63,30 @@ async function submitForm() {
   try {
     if (editingId.value) {
       await updateTemplate(editingId.value, form)
-      toast.success('Template updated')
+      toast.success(t('email.templates.updated'))
     } else {
       await createTemplate(form)
-      toast.success('Template created')
+      toast.success(t('email.templates.created'))
     }
     cancelForm()
   } catch (e) {
-    formError.value = e instanceof Error ? e.message : 'Failed to save'
+    formError.value = e instanceof Error ? e.message : t('email.saveFailed')
   } finally {
     saving.value = false
   }
 }
 
-async function remove(t: EmailTemplate) {
+async function remove(tpl: EmailTemplate) {
   try {
-    await deleteTemplate(t.id)
-    toast.success(`"${t.name}" deleted`)
+    await deleteTemplate(tpl.id)
+    toast.success(t('email.templates.deleted', { name: tpl.name }))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to delete')
+    toast.error(e instanceof Error ? e.message : t('email.deleteFailed'))
   }
 }
 
-function requestRemove(t: EmailTemplate) {
-  deleteConfirm.value = t
+function requestRemove(tpl: EmailTemplate) {
+  deleteConfirm.value = tpl
 }
 
 async function confirmRemove() {
@@ -94,12 +96,12 @@ async function confirmRemove() {
   await remove(template)
 }
 
-async function setDefault(t: EmailTemplate) {
+async function setDefault(tpl: EmailTemplate) {
   try {
-    await setDefaultTemplate(t.id)
-    toast.success(`"${t.name}" set as default`)
+    await setDefaultTemplate(tpl.id)
+    toast.success(t('email.templates.setDefaultSuccess', { name: tpl.name }))
   } catch {
-    toast.error('Failed to set default')
+    toast.error(t('email.setDefaultFailed'))
   }
 }
 
@@ -120,18 +122,18 @@ watch(
 <template>
   <div class="space-y-4">
     <div class="hidden md:flex items-center justify-between">
-      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Email Templates</p>
+      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.templates.heading') }}</p>
       <button
         v-if="!showForm"
         class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
         @click="openCreate()"
       >
         <Plus :size="12" />
-        New template
+        {{ t('email.templates.new') }}
       </button>
     </div>
     <div class="md:hidden flex items-center justify-between">
-      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Email Templates</p>
+      <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.templates.heading') }}</p>
     </div>
     <div v-if="!showForm" class="md:hidden sticky top-11 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
       <button
@@ -139,26 +141,26 @@ watch(
         @click="openCreate()"
       >
         <Plus :size="13" />
-        New template
+        {{ t('email.templates.new') }}
       </button>
     </div>
 
     <!-- Form -->
     <div v-if="showForm" class="border border-border rounded-lg p-4 md:p-5 bg-card space-y-4">
-      <p class="text-sm font-semibold text-foreground">{{ editingId ? 'Edit Template' : 'New Template' }}</p>
+      <p class="text-sm font-semibold text-foreground">{{ editingId ? t('email.templates.editTitle') : t('email.templates.newTitle') }}</p>
 
       <div>
-        <label class="block text-xs font-medium text-muted-foreground mb-1.5">Name</label>
+        <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.templates.name') }}</label>
         <input
           v-model="form.name"
           type="text"
-          placeholder="Default"
+          :placeholder="t('email.templates.namePlaceholder')"
           class="w-full h-9 px-3 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
         />
       </div>
 
       <div>
-        <label class="block text-xs font-medium text-muted-foreground mb-1.5">Subject</label>
+        <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.templates.subject') }}</label>
         <input
           v-model="form.subject"
           type="text"
@@ -167,7 +169,7 @@ watch(
       </div>
 
       <div>
-        <label class="block text-xs font-medium text-muted-foreground mb-1.5">Body</label>
+        <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('email.templates.body') }}</label>
         <textarea
           v-model="form.bodyText"
           rows="6"
@@ -177,7 +179,7 @@ watch(
 
       <div class="border border-border rounded-lg bg-card/60">
         <button class="w-full flex items-center justify-between gap-2 px-3 py-2.5 text-left" @click="variablesOpen = !variablesOpen">
-          <p class="text-xs font-medium text-muted-foreground">Available variables</p>
+          <p class="text-xs font-medium text-muted-foreground">{{ t('email.templates.availableVariables') }}</p>
           <ChevronUp v-if="variablesOpen" :size="14" class="text-muted-foreground" />
           <ChevronDown v-else :size="14" class="text-muted-foreground" />
         </button>
@@ -203,25 +205,25 @@ watch(
           :disabled="saving"
           @click="submitForm()"
         >
-          {{ saving ? 'Saving...' : editingId ? 'Update' : 'Create' }}
+          {{ saving ? t('email.saving') : editingId ? t('email.update') : t('email.create') }}
         </button>
         <button
           class="px-4 py-2 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
           @click="cancelForm()"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
       </div>
       <div class="md:hidden sticky bottom-2 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
         <div class="flex items-center gap-2">
           <button class="settings-btn-primary flex-1 min-h-10 justify-center" :disabled="saving" @click="submitForm()">
-            {{ saving ? 'Saving...' : editingId ? 'Update' : 'Create' }}
+            {{ saving ? t('email.saving') : editingId ? t('email.update') : t('email.create') }}
           </button>
           <button
             class="rounded-md border border-border px-3 min-h-10 text-sm text-foreground hover:bg-muted transition-colors"
             @click="cancelForm()"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
         </div>
       </div>
@@ -229,28 +231,30 @@ watch(
 
     <!-- Empty state -->
     <div v-if="templates.length === 0 && !showForm" class="border border-border rounded-lg px-5 py-8 bg-card text-center">
-      <p class="text-sm text-muted-foreground">No templates yet.</p>
+      <p class="text-sm text-muted-foreground">{{ t('email.templates.empty') }}</p>
     </div>
 
     <!-- List -->
     <div v-else-if="templates.length > 0" class="border border-border rounded-lg overflow-hidden divide-y divide-border">
-      <div v-for="t in templates" :key="t.id" class="bg-card">
+      <div v-for="tpl in templates" :key="tpl.id" class="bg-card">
         <div class="px-4 py-3 flex items-start gap-3">
           <button
             class="mt-0.5 text-muted-foreground hover:text-foreground transition-colors shrink-0"
-            @click="expandedId = expandedId === t.id ? null : t.id"
+            @click="expandedId = expandedId === tpl.id ? null : tpl.id"
           >
-            <ChevronDown v-if="expandedId === t.id" :size="14" />
+            <ChevronDown v-if="expandedId === tpl.id" :size="14" />
             <ChevronRight v-else :size="14" />
           </button>
 
-          <div class="flex-1 min-w-0 cursor-pointer" @click="expandedId = expandedId === t.id ? null : t.id">
+          <div class="flex-1 min-w-0 cursor-pointer" @click="expandedId = expandedId === tpl.id ? null : tpl.id">
             <div class="flex items-center gap-2 flex-wrap">
-              <span class="text-sm font-medium text-foreground">{{ t.name }}</span>
-              <span v-if="t.isDefault" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-primary/15 text-primary">Default</span>
-              <span v-if="t.isSystem" class="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">System</span>
+              <span class="text-sm font-medium text-foreground">{{ tpl.name }}</span>
+              <span v-if="tpl.isDefault" class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-primary/15 text-primary">{{
+                t('email.badge.default')
+              }}</span>
+              <span v-if="tpl.isSystem" class="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">{{ t('email.badge.system') }}</span>
             </div>
-            <p class="text-xs text-muted-foreground mt-0.5 line-clamp-2">{{ t.subject }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5 line-clamp-2">{{ tpl.subject }}</p>
           </div>
 
           <div class="flex items-center gap-1 shrink-0">
@@ -258,52 +262,52 @@ watch(
               <TooltipTrigger as-child>
                 <button
                   class="flex items-center justify-center w-7 h-7 rounded transition-colors"
-                  :class="t.isDefault ? 'text-primary' : 'text-muted-foreground hover:text-primary hover:bg-muted'"
-                  @click="setDefault(t)"
+                  :class="tpl.isDefault ? 'text-primary' : 'text-muted-foreground hover:text-primary hover:bg-muted'"
+                  @click="setDefault(tpl)"
                 >
-                  <Star :size="13" :class="t.isDefault ? 'fill-primary' : ''" />
+                  <Star :size="13" :class="tpl.isDefault ? 'fill-primary' : ''" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Set as default</TooltipContent>
+              <TooltipContent>{{ t('email.setAsDefault') }}</TooltipContent>
             </Tooltip>
-            <Tooltip v-if="!t.isSystem || isSuperuser">
+            <Tooltip v-if="!tpl.isSystem || isSuperuser">
               <TooltipTrigger as-child>
                 <button
                   class="flex items-center justify-center w-7 h-7 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                  @click="openEdit(t)"
+                  @click="openEdit(tpl)"
                 >
                   <Pencil :size="13" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Edit</TooltipContent>
+              <TooltipContent>{{ t('common.edit') }}</TooltipContent>
             </Tooltip>
-            <Tooltip v-if="!t.isSystem">
+            <Tooltip v-if="!tpl.isSystem">
               <TooltipTrigger as-child>
                 <button
                   class="flex items-center justify-center w-7 h-7 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
-                  @click="requestRemove(t)"
+                  @click="requestRemove(tpl)"
                 >
                   <Trash2 :size="13" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Delete</TooltipContent>
+              <TooltipContent>{{ t('common.delete') }}</TooltipContent>
             </Tooltip>
           </div>
         </div>
 
         <!-- Expanded body preview -->
-        <div v-if="expandedId === t.id" class="px-4 pb-4 border-t border-border/60 bg-muted/30">
-          <p class="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mt-3 mb-1.5">Subject</p>
-          <p class="text-xs text-foreground font-mono">{{ t.subject }}</p>
-          <p class="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mt-3 mb-1.5">Body</p>
-          <pre class="text-xs text-foreground font-mono whitespace-pre-wrap leading-relaxed">{{ t.bodyText }}</pre>
+        <div v-if="expandedId === tpl.id" class="px-4 pb-4 border-t border-border/60 bg-muted/30">
+          <p class="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mt-3 mb-1.5">{{ t('email.templates.subject') }}</p>
+          <p class="text-xs text-foreground font-mono">{{ tpl.subject }}</p>
+          <p class="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mt-3 mb-1.5">{{ t('email.templates.body') }}</p>
+          <pre class="text-xs text-foreground font-mono whitespace-pre-wrap leading-relaxed">{{ tpl.bodyText }}</pre>
           <button
-            v-if="!t.isSystem || isSuperuser"
+            v-if="!tpl.isSystem || isSuperuser"
             class="mt-3 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
-            @click="openEdit(t)"
+            @click="openEdit(tpl)"
           >
             <Pencil :size="11" />
-            Edit template
+            {{ t('email.templates.editTemplate') }}
           </button>
         </div>
       </div>
@@ -311,34 +315,31 @@ watch(
 
     <div class="border border-border rounded-lg bg-card/50">
       <button class="w-full flex items-center justify-between gap-2 p-4 text-left" @click="notesOpen = !notesOpen">
-        <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Template Notes</p>
+        <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('email.templates.notesHeading') }}</p>
         <ChevronUp v-if="notesOpen" :size="14" class="text-muted-foreground" />
         <ChevronDown v-else :size="14" class="text-muted-foreground" />
       </button>
-      <p v-if="notesOpen" class="px-4 pb-4 text-xs text-muted-foreground">
-        System templates cannot be deleted. Administrators can edit them. Use variables like
-        <code class="font-mono text-foreground/80">&#123;&#123;title&#125;&#125;</code>
-        in subjects and bodies - they are replaced with book details at send time.
-      </p>
+      <!-- eslint-disable-next-line vue/no-v-html -->
+      <p v-if="notesOpen" class="px-4 pb-4 text-xs text-muted-foreground" v-html="t('email.templates.notesBody')" />
     </div>
 
     <div v-if="deleteConfirm" class="fixed inset-0 z-[70] flex items-end justify-center md:items-center md:px-4" @click.self="deleteConfirm = null">
       <button class="absolute inset-0 bg-black/45" @click="deleteConfirm = null" />
       <div class="relative w-full rounded-t-xl border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Delete template?</p>
-        <p class="mt-1 text-sm text-muted-foreground">Delete "{{ deleteConfirm.name }}". This action cannot be undone.</p>
+        <p class="text-base font-semibold text-foreground">{{ t('email.templates.deleteTitle') }}</p>
+        <p class="mt-1 text-sm text-muted-foreground">{{ t('email.deleteConfirm', { name: deleteConfirm.name }) }}</p>
         <div class="mt-4 flex items-center justify-end gap-2">
           <button
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="deleteConfirm = null"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
             @click="confirmRemove"
           >
-            Delete
+            {{ t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/email/lib/email-tabs.ts
+++ b/client/src/features/email/lib/email-tabs.ts
@@ -2,15 +2,6 @@ export const EMAIL_TABS = ['providers', 'recipients', 'groups', 'templates', 'pr
 
 export type EmailTab = (typeof EMAIL_TABS)[number]
 
-export const EMAIL_TAB_LABELS: Record<EmailTab, string> = {
-  providers: 'Providers',
-  recipients: 'Recipients',
-  groups: 'Groups',
-  templates: 'Templates',
-  preferences: 'Preferences',
-  history: 'History',
-}
-
 export function normalizeEmailTab(value: unknown): EmailTab {
   if (typeof value === 'string' && EMAIL_TABS.includes(value as EmailTab)) {
     return value as EmailTab

--- a/client/src/features/hardcover/components/HardcoverBookSyncGridItem.vue
+++ b/client/src/features/hardcover/components/HardcoverBookSyncGridItem.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { RefreshCw } from '@lucide/vue'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import { useHardcoverBookSyncState } from '../composables/useHardcoverBookSyncState'
+
+const { t } = useI18n()
 
 const props = defineProps<{ bookId: number }>()
 const bookIdRef = computed(() => props.bookId)
@@ -11,9 +14,14 @@ const { visible, syncEnabled, canSyncNow, statusText, statusClass, disabled, syn
 
 <template>
   <div v-if="visible" class="min-w-0">
-    <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">Hardcover Sync</dt>
+    <dt class="text-[10px] uppercase tracking-wider font-medium text-muted-foreground">{{ t('hardcover.bookSync.label') }}</dt>
     <dd class="mt-0.5 flex flex-wrap items-center gap-2">
-      <ToggleSwitch :model-value="syncEnabled" :disabled="disabled" aria-label="Sync this book with Hardcover" @update:model-value="setSyncEnabled" />
+      <ToggleSwitch
+        :model-value="syncEnabled"
+        :disabled="disabled"
+        :aria-label="t('hardcover.bookSync.toggleAriaLabel')"
+        @update:model-value="setSyncEnabled"
+      />
       <span class="min-w-0 truncate text-sm" :class="statusClass">{{ statusText }}</span>
       <button
         v-if="canSyncNow"
@@ -23,7 +31,7 @@ const { visible, syncEnabled, canSyncNow, statusText, statusClass, disabled, syn
         @click="syncNow"
       >
         <RefreshCw class="size-3.5" />
-        Sync now
+        {{ t('hardcover.bookSync.syncNow') }}
       </button>
     </dd>
   </div>

--- a/client/src/features/hardcover/components/HardcoverConnectionCard.vue
+++ b/client/src/features/hardcover/components/HardcoverConnectionCard.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-import { onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Link, Save, CheckCircle2, AlertCircle, Info, Loader2, Unlink } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import { useHardcoverSettings } from '../composables/useHardcoverSettings'
+
+const { t } = useI18n()
 
 const { settings, saving, validating, error, fetchSettings, saveSettings, disconnect, validateToken } = useHardcoverSettings()
 
@@ -34,7 +37,7 @@ onMounted(async () => {
 
 async function handleValidateToken() {
   if (!tokenInput.value.trim()) {
-    toast.error('Enter your Hardcover API token first')
+    toast.error(t('hardcover.connection.toast.enterToken'))
     return
   }
   const result = await validateToken(tokenInput.value.trim())
@@ -53,9 +56,9 @@ async function handleSave() {
   })
   if (ok) {
     tokenInput.value = ''
-    toast.success('Hardcover settings saved')
+    toast.success(t('hardcover.connection.toast.saved'))
   } else {
-    toast.error(error.value ?? 'Failed to save settings')
+    toast.error(error.value ?? t('hardcover.connection.toast.saveFailed'))
   }
 }
 
@@ -63,31 +66,31 @@ async function handleDisconnect() {
   await disconnect()
   tokenInput.value = ''
   validationResult.value = null
-  toast.success('Hardcover disconnected')
+  toast.success(t('hardcover.connection.toast.disconnected'))
 }
 
 function toggleTokenVisible() {
   tokenVisible.value = !tokenVisible.value
 }
 
-const privacyOptions = [
-  { id: 1, label: 'Public' },
-  { id: 2, label: 'Followers only' },
-  { id: 3, label: 'Private' },
-]
+const privacyOptions = computed(() => [
+  { id: 1, label: t('hardcover.connection.privacy.public') },
+  { id: 2, label: t('hardcover.connection.privacy.followersOnly') },
+  { id: 3, label: t('hardcover.connection.privacy.private') },
+])
 
-const bookSyncModeOptions = [
+const bookSyncModeOptions = computed(() => [
   {
     id: 'all_eligible' as const,
-    label: 'All eligible books',
-    description: 'Sync everything unless you exclude a book.',
+    label: t('hardcover.connection.syncScope.allEligible.label'),
+    description: t('hardcover.connection.syncScope.allEligible.description'),
   },
   {
     id: 'selected_only' as const,
-    label: 'Selected books only',
-    description: 'Sync only books you explicitly include.',
+    label: t('hardcover.connection.syncScope.selectedOnly.label'),
+    description: t('hardcover.connection.syncScope.selectedOnly.description'),
   },
-]
+])
 
 function selectBookSyncMode(mode: 'all_eligible' | 'selected_only') {
   form.bookSyncMode = mode
@@ -99,22 +102,22 @@ function selectBookSyncMode(mode: 'all_eligible' | 'selected_only') {
     <div class="flex items-center gap-3">
       <Link class="size-5 text-primary shrink-0" />
       <div>
-        <p class="font-medium text-sm">Connection</p>
-        <p class="text-xs text-muted-foreground mt-0.5">Connect your Hardcover account to sync reading data.</p>
+        <p class="font-medium text-sm">{{ t('hardcover.connection.title') }}</p>
+        <p class="text-xs text-muted-foreground mt-0.5">{{ t('hardcover.connection.description') }}</p>
       </div>
       <div v-if="settings?.tokenConfigured" class="ml-auto flex items-center gap-1.5 text-xs text-green-600">
         <CheckCircle2 class="size-3.5" />
-        Connected
+        {{ t('hardcover.connection.connected') }}
       </div>
     </div>
 
     <div class="space-y-2">
-      <label class="text-xs font-medium text-muted-foreground uppercase tracking-wider"> API Token </label>
+      <label class="text-xs font-medium text-muted-foreground uppercase tracking-wider"> {{ t('hardcover.connection.apiToken') }} </label>
       <div class="flex gap-2">
         <input
           v-model="tokenInput"
           :type="tokenVisible ? 'text' : 'password'"
-          placeholder="Paste your Hardcover API token"
+          :placeholder="t('hardcover.connection.tokenPlaceholder')"
           class="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
           autocomplete="off"
         />
@@ -123,11 +126,11 @@ function selectBookSyncMode(mode: 'all_eligible' | 'selected_only') {
           class="px-3 py-2 text-xs rounded-md border border-border bg-muted text-muted-foreground hover:bg-muted/80 transition-colors"
           @click="toggleTokenVisible"
         >
-          {{ tokenVisible ? 'Hide' : 'Show' }}
+          {{ tokenVisible ? t('hardcover.connection.hide') : t('hardcover.connection.show') }}
         </button>
       </div>
       <p class="text-xs text-muted-foreground">
-        Find your token at
+        {{ t('hardcover.connection.findTokenAt') }}
         <a href="https://hardcover.app/account/api" target="_blank" rel="noopener" class="text-primary underline underline-offset-2"
           >hardcover.app/account/api</a
         >.
@@ -142,7 +145,7 @@ function selectBookSyncMode(mode: 'all_eligible' | 'selected_only') {
         @click="handleValidateToken"
       >
         <Loader2 v-if="validating" class="size-3 animate-spin" />
-        Validate token
+        {{ t('hardcover.connection.validateToken') }}
       </button>
       <span
         v-if="validationResult !== null"
@@ -151,22 +154,23 @@ function selectBookSyncMode(mode: 'all_eligible' | 'selected_only') {
       >
         <CheckCircle2 v-if="validationResult.valid" class="size-3.5" />
         <AlertCircle v-else class="size-3.5" />
-        {{ validationResult.valid ? `Valid (${validationResult.username})` : 'Invalid token' }}
+        {{
+          validationResult.valid ? t('hardcover.connection.valid', { username: validationResult.username }) : t('hardcover.connection.invalidToken')
+        }}
       </span>
     </div>
 
     <div v-if="settings?.tokenConfigured" class="space-y-3 pt-2 border-t border-border">
-      <p class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Sync options</p>
+      <p class="text-xs font-medium text-muted-foreground uppercase tracking-wider">{{ t('hardcover.connection.syncOptions') }}</p>
       <div class="flex items-start gap-2 rounded-md border border-border/70 bg-muted/40 px-2.5 py-2">
         <Info class="size-3.5 shrink-0 text-muted-foreground mt-0.5" />
         <p class="text-xs text-muted-foreground leading-relaxed">
-          Sync runs only for books that are not unread. This applies to status, progress, and rating triggers. These switches control when a sync
-          runs.
+          {{ t('hardcover.connection.syncInfo') }}
         </p>
       </div>
 
       <div class="space-y-2">
-        <p class="text-sm">Book sync scope</p>
+        <p class="text-sm">{{ t('hardcover.connection.syncScope.title') }}</p>
         <div class="grid gap-2 sm:grid-cols-2">
           <button
             v-for="option in bookSyncModeOptions"
@@ -188,40 +192,40 @@ function selectBookSyncMode(mode: 'all_eligible' | 'selected_only') {
 
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm">Enable sync</p>
-          <p class="text-xs text-muted-foreground mt-0.5">Pause all Hardcover syncing without disconnecting.</p>
+          <p class="text-sm">{{ t('hardcover.connection.enableSync.title') }}</p>
+          <p class="text-xs text-muted-foreground mt-0.5">{{ t('hardcover.connection.enableSync.description') }}</p>
         </div>
         <ToggleSwitch v-model="form.enabled" />
       </div>
 
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm">Sync on status change</p>
-          <p class="text-xs text-muted-foreground mt-0.5">Push updates when you mark a book as reading, read, etc.</p>
+          <p class="text-sm">{{ t('hardcover.connection.syncOnStatus.title') }}</p>
+          <p class="text-xs text-muted-foreground mt-0.5">{{ t('hardcover.connection.syncOnStatus.description') }}</p>
         </div>
         <ToggleSwitch v-model="form.autoSyncOnStatusChange" :disabled="!form.enabled" />
       </div>
 
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm">Sync on progress update</p>
-          <p class="text-xs text-muted-foreground mt-0.5">Push reading progress and dates when BookOrbit or KOReader progress changes.</p>
+          <p class="text-sm">{{ t('hardcover.connection.syncOnProgress.title') }}</p>
+          <p class="text-xs text-muted-foreground mt-0.5">{{ t('hardcover.connection.syncOnProgress.description') }}</p>
         </div>
         <ToggleSwitch v-model="form.autoSyncOnProgressUpdate" :disabled="!form.enabled" />
       </div>
 
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm">Sync on rating change</p>
-          <p class="text-xs text-muted-foreground mt-0.5">Push your star ratings to Hardcover.</p>
+          <p class="text-sm">{{ t('hardcover.connection.syncOnRating.title') }}</p>
+          <p class="text-xs text-muted-foreground mt-0.5">{{ t('hardcover.connection.syncOnRating.description') }}</p>
         </div>
         <ToggleSwitch v-model="form.autoSyncOnRatingChange" :disabled="!form.enabled" />
       </div>
 
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm">Privacy</p>
-          <p class="text-xs text-muted-foreground mt-0.5">Default visibility for synced books on Hardcover.</p>
+          <p class="text-sm">{{ t('hardcover.connection.privacy.title') }}</p>
+          <p class="text-xs text-muted-foreground mt-0.5">{{ t('hardcover.connection.privacy.description') }}</p>
         </div>
         <select
           v-model="form.privacySettingId"
@@ -242,7 +246,7 @@ function selectBookSyncMode(mode: 'all_eligible' | 'selected_only') {
         @click="handleDisconnect"
       >
         <Unlink class="size-3.5" />
-        Disconnect
+        {{ t('hardcover.connection.disconnect') }}
       </button>
       <div class="flex-1" />
       <button
@@ -253,7 +257,7 @@ function selectBookSyncMode(mode: 'all_eligible' | 'selected_only') {
       >
         <Loader2 v-if="saving" class="size-3.5 animate-spin" />
         <Save v-else class="size-3.5" />
-        Save
+        {{ t('common.save') }}
       </button>
     </div>
   </div>

--- a/client/src/features/hardcover/components/HardcoverImportReviewModal.vue
+++ b/client/src/features/hardcover/components/HardcoverImportReviewModal.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { CheckCircle2, ChevronLeft, ChevronRight, Download, Search, X, XCircle } from '@lucide/vue'
 import type { HardcoverImportMatchMethod, HardcoverImportPreview, HardcoverImportPreviewOutcome, HardcoverImportPreviewRow } from '@bookorbit/types'
 import { useModal } from '@/composables/useModal'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   preview: HardcoverImportPreview
@@ -41,20 +44,20 @@ useModal({
 })
 
 const tabs = computed<Array<{ id: OutcomeTab; label: string; count: number }>>(() => [
-  { id: 'all', label: 'All', count: props.preview.rows.length },
-  { id: 'will_update', label: 'Ready', count: props.preview.summary.willUpdate },
-  { id: 'needs_review', label: 'Review', count: props.preview.summary.needsReview },
-  { id: 'conflict', label: 'Conflicts', count: props.preview.summary.conflicts },
-  { id: 'unmatched', label: 'Unmatched', count: props.preview.summary.unmatched },
-  { id: 'skipped', label: 'Skipped', count: props.preview.summary.skipped },
+  { id: 'all', label: t('hardcover.review.tabs.all'), count: props.preview.rows.length },
+  { id: 'will_update', label: t('hardcover.review.tabs.ready'), count: props.preview.summary.willUpdate },
+  { id: 'needs_review', label: t('hardcover.review.tabs.review'), count: props.preview.summary.needsReview },
+  { id: 'conflict', label: t('hardcover.review.tabs.conflicts'), count: props.preview.summary.conflicts },
+  { id: 'unmatched', label: t('hardcover.review.tabs.unmatched'), count: props.preview.summary.unmatched },
+  { id: 'skipped', label: t('hardcover.review.tabs.skipped'), count: props.preview.summary.skipped },
 ])
 
-const matchOptions: Array<{ value: MatchFilter; label: string }> = [
-  { value: 'all', label: 'All match types' },
-  { value: 'hardcover_id', label: 'Hardcover ID' },
-  { value: 'isbn', label: 'ISBN' },
-  { value: 'title_author', label: 'Title + author' },
-]
+const matchOptions = computed<Array<{ value: MatchFilter; label: string }>>(() => [
+  { value: 'all', label: t('hardcover.review.matchOptions.all') },
+  { value: 'hardcover_id', label: t('hardcover.review.matchMethod.hardcoverId') },
+  { value: 'isbn', label: t('hardcover.review.matchMethod.isbn') },
+  { value: 'title_author', label: t('hardcover.review.matchMethod.titleAuthor') },
+])
 
 const filteredRows = computed(() => {
   const term = normalizeSearch(search.value)
@@ -87,7 +90,9 @@ const selectedReviewCount = computed(
 const selectedProgressCount = computed(
   () => props.preview.rows.filter((row) => row.progressOutcome === 'will_update' && selectedIds.value.has(row.hardcoverUserBookId)).length,
 )
-const selectedProgressLabel = computed(() => `${selectedProgressCount.value} progress update${selectedProgressCount.value === 1 ? '' : 's'}`)
+const selectedProgressLabel = computed(() =>
+  t('hardcover.review.selectedProgress', { count: selectedProgressCount.value }, selectedProgressCount.value),
+)
 const visibleImportableRows = computed(() => pagedRows.value.filter(isImportableRow))
 const allVisibleSelected = computed(
   () => visibleImportableRows.value.length > 0 && visibleImportableRows.value.every((row) => selectedIds.value.has(row.hardcoverUserBookId)),
@@ -160,7 +165,7 @@ function isImportableRow(row: HardcoverImportPreviewRow): boolean {
 }
 
 function rowTitle(row: HardcoverImportPreviewRow): string {
-  return row.localTitle ?? row.hardcoverTitle ?? 'Untitled'
+  return row.localTitle ?? row.hardcoverTitle ?? t('hardcover.review.untitled')
 }
 
 function rowSubtitle(row: HardcoverImportPreviewRow): string {
@@ -173,11 +178,11 @@ function rowSubtitle(row: HardcoverImportPreviewRow): string {
 function matchMethodLabel(row: HardcoverImportPreviewRow): string {
   switch (row.matchMethod) {
     case 'hardcover_id':
-      return 'Hardcover ID'
+      return t('hardcover.review.matchMethod.hardcoverId')
     case 'isbn':
-      return 'ISBN'
+      return t('hardcover.review.matchMethod.isbn')
     case 'title_author':
-      return 'Title + author'
+      return t('hardcover.review.matchMethod.titleAuthor')
     default:
       return '-'
   }
@@ -188,7 +193,7 @@ function statusLabel(row: HardcoverImportPreviewRow): string {
 }
 
 function localStatusLabel(row: HardcoverImportPreviewRow): string {
-  return row.localReadStatus?.replaceAll('_', ' ') ?? 'blank'
+  return row.localReadStatus?.replaceAll('_', ' ') ?? t('hardcover.review.blank')
 }
 
 function confidenceLabel(row: HardcoverImportPreviewRow): string {
@@ -203,11 +208,11 @@ function progressLabel(value: number | null): string {
 function progressOutcomeLabel(row: HardcoverImportPreviewRow): string {
   switch (row.progressOutcome) {
     case 'will_update':
-      return 'Ready'
+      return t('hardcover.review.outcome.ready')
     case 'conflict':
-      return 'Conflict'
+      return t('hardcover.review.outcome.conflict')
     case 'skipped':
-      return 'Skipped'
+      return t('hardcover.review.outcome.skipped')
   }
 }
 
@@ -225,15 +230,15 @@ function progressOutcomeClass(row: HardcoverImportPreviewRow): string {
 function outcomeLabel(row: HardcoverImportPreviewRow): string {
   switch (row.outcome) {
     case 'will_update':
-      return 'Ready'
+      return t('hardcover.review.outcome.ready')
     case 'needs_review':
-      return 'Review'
+      return t('hardcover.review.outcome.review')
     case 'conflict':
-      return 'Conflict'
+      return t('hardcover.review.outcome.conflict')
     case 'unmatched':
-      return 'Unmatched'
+      return t('hardcover.review.outcome.unmatched')
     case 'skipped':
-      return 'Skipped'
+      return t('hardcover.review.outcome.skipped')
   }
 }
 
@@ -269,9 +274,9 @@ function normalizeSearch(value: string): string {
       >
         <header class="flex shrink-0 items-start justify-between gap-4 border-b border-border px-4 py-3 md:px-5">
           <div class="min-w-0">
-            <h2 id="hardcover-import-review-title" class="text-sm font-semibold">Hardcover import review</h2>
+            <h2 id="hardcover-import-review-title" class="text-sm font-semibold">{{ t('hardcover.review.title') }}</h2>
             <p class="mt-0.5 text-xs text-muted-foreground">
-              {{ preview.summary.totalHardcoverBooks }} Hardcover books, {{ preview.summary.matchedBooks }} matched.
+              {{ t('hardcover.review.subtitle', { total: preview.summary.totalHardcoverBooks, matched: preview.summary.matchedBooks }) }}
             </p>
           </div>
           <button
@@ -279,7 +284,7 @@ function normalizeSearch(value: string): string {
             type="button"
             class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-40"
             :disabled="applying"
-            aria-label="Close import review"
+            :aria-label="t('hardcover.review.closeAriaLabel')"
             @click="handleClose"
           >
             <X class="size-4" />
@@ -288,23 +293,23 @@ function normalizeSearch(value: string): string {
 
         <div class="grid shrink-0 grid-cols-2 gap-2 border-b border-border px-4 py-3 sm:grid-cols-5 md:px-5">
           <div class="min-w-0 rounded-md border border-border bg-card px-3 py-2">
-            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">Ready</p>
+            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">{{ t('hardcover.review.summary.ready') }}</p>
             <p class="text-lg font-semibold tabular-nums">{{ preview.summary.willUpdate }}</p>
           </div>
           <div class="min-w-0 rounded-md border border-border bg-card px-3 py-2">
-            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">Review</p>
+            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">{{ t('hardcover.review.summary.review') }}</p>
             <p class="text-lg font-semibold tabular-nums">{{ preview.summary.needsReview }}</p>
           </div>
           <div class="min-w-0 rounded-md border border-border bg-card px-3 py-2">
-            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">Conflicts</p>
+            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">{{ t('hardcover.review.summary.conflicts') }}</p>
             <p class="text-lg font-semibold tabular-nums">{{ preview.summary.conflicts }}</p>
           </div>
           <div class="min-w-0 rounded-md border border-border bg-card px-3 py-2">
-            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">Unmatched</p>
+            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">{{ t('hardcover.review.summary.unmatched') }}</p>
             <p class="text-lg font-semibold tabular-nums">{{ preview.summary.unmatched }}</p>
           </div>
           <div class="min-w-0 rounded-md border border-border bg-card px-3 py-2">
-            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">Skipped</p>
+            <p class="text-[10px] uppercase tracking-wider text-muted-foreground">{{ t('hardcover.review.summary.skipped') }}</p>
             <p class="text-lg font-semibold tabular-nums">{{ preview.summary.skipped }}</p>
           </div>
         </div>
@@ -317,7 +322,7 @@ function normalizeSearch(value: string): string {
                 v-model="search"
                 type="search"
                 class="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm outline-none transition-shadow focus:ring-2 focus:ring-primary/40"
-                placeholder="Search title or author"
+                :placeholder="t('hardcover.review.searchPlaceholder')"
               />
             </label>
             <select
@@ -333,7 +338,7 @@ function normalizeSearch(value: string): string {
                 class="size-4 rounded border-border text-primary focus:ring-primary/40"
                 :disabled="applying"
               />
-              <span>Import progress</span>
+              <span>{{ t('hardcover.review.importProgress') }}</span>
             </label>
           </div>
 
@@ -353,12 +358,12 @@ function normalizeSearch(value: string): string {
 
           <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
             <p class="text-xs text-muted-foreground">
-              {{ selectedCount }} selected: {{ selectedReadyCount }} ready, {{ selectedReviewCount }} reviewed.
+              {{ t('hardcover.review.selectionSummary', { count: selectedCount, ready: selectedReadyCount, reviewed: selectedReviewCount }) }}
               <span v-if="importProgressModel">{{ selectedProgressLabel }}.</span>
             </p>
             <div class="flex flex-wrap gap-2">
               <button type="button" class="rounded-md border border-border px-2.5 py-1.5 text-xs hover:bg-muted" @click="handleSelectSafe">
-                Select ready
+                {{ t('hardcover.review.selectReady') }}
               </button>
               <button
                 type="button"
@@ -366,7 +371,7 @@ function normalizeSearch(value: string): string {
                 :disabled="visibleImportableRows.length === 0 || allVisibleSelected"
                 @click="handleSelectVisible"
               >
-                Select page
+                {{ t('hardcover.review.selectPage') }}
               </button>
               <button
                 type="button"
@@ -374,7 +379,7 @@ function normalizeSearch(value: string): string {
                 :disabled="visibleImportableRows.length === 0"
                 @click="handleClearVisible"
               >
-                Clear page
+                {{ t('hardcover.review.clearPage') }}
               </button>
               <button
                 type="button"
@@ -382,14 +387,14 @@ function normalizeSearch(value: string): string {
                 :disabled="selectedCount === 0"
                 @click="handleClearSelection"
               >
-                Clear selection
+                {{ t('hardcover.review.clearSelection') }}
               </button>
             </div>
           </div>
         </div>
 
         <div class="min-h-0 flex-1 overflow-y-auto">
-          <div v-if="pagedRows.length === 0" class="px-4 py-10 text-center text-sm text-muted-foreground">No rows match the current filters.</div>
+          <div v-if="pagedRows.length === 0" class="px-4 py-10 text-center text-sm text-muted-foreground">{{ t('hardcover.review.noRows') }}</div>
 
           <div v-else class="divide-y divide-border">
             <article
@@ -403,7 +408,7 @@ function normalizeSearch(value: string): string {
                   class="mt-1 size-4 rounded border-border text-primary focus:ring-primary/40 disabled:opacity-30"
                   :checked="selectedIds.has(row.hardcoverUserBookId)"
                   :disabled="!isImportableRow(row) || applying"
-                  :aria-label="`Select ${rowTitle(row)}`"
+                  :aria-label="t('hardcover.review.selectRowAriaLabel', { title: rowTitle(row) })"
                   @change="toggleRow(row)"
                 />
               </div>
@@ -427,7 +432,7 @@ function normalizeSearch(value: string): string {
               </div>
 
               <div class="min-w-0 text-xs">
-                <p class="font-medium text-muted-foreground">Progress</p>
+                <p class="font-medium text-muted-foreground">{{ t('hardcover.review.column.progress') }}</p>
                 <p class="truncate">{{ progressLabel(row.importedProgressPercent) }} Hardcover</p>
                 <p class="truncate text-muted-foreground">{{ progressLabel(row.localProgressPercent) }} BookOrbit</p>
                 <p class="truncate" :class="progressOutcomeClass(row)">{{ progressOutcomeLabel(row) }}</p>
@@ -447,17 +452,19 @@ function normalizeSearch(value: string): string {
               type="button"
               class="rounded-md border border-border p-1.5 text-muted-foreground hover:bg-muted disabled:opacity-40"
               :disabled="!canGoPrevious"
-              aria-label="Previous page"
+              :aria-label="t('hardcover.review.previousPage')"
               @click="goPrevious"
             >
               <ChevronLeft class="size-4" />
             </button>
-            <p class="text-xs text-muted-foreground">{{ displayStart }}-{{ displayEnd }} of {{ filteredRows.length }}</p>
+            <p class="text-xs text-muted-foreground">
+              {{ t('hardcover.review.pageRange', { start: displayStart, end: displayEnd, total: filteredRows.length }) }}
+            </p>
             <button
               type="button"
               class="rounded-md border border-border p-1.5 text-muted-foreground hover:bg-muted disabled:opacity-40"
               :disabled="!canGoNext"
-              aria-label="Next page"
+              :aria-label="t('hardcover.review.nextPage')"
               @click="goNext"
             >
               <ChevronRight class="size-4" />
@@ -472,7 +479,7 @@ function normalizeSearch(value: string): string {
               @click="handleClose"
             >
               <XCircle class="size-3.5" />
-              Close
+              {{ t('common.close') }}
             </button>
             <button
               type="button"
@@ -482,7 +489,7 @@ function normalizeSearch(value: string): string {
             >
               <CheckCircle2 v-if="applying" class="size-3.5 animate-pulse" />
               <Download v-else class="size-3.5" />
-              Import selected
+              {{ t('hardcover.review.importSelected') }}
             </button>
           </div>
         </footer>

--- a/client/src/features/hardcover/components/HardcoverImportStatus.vue
+++ b/client/src/features/hardcover/components/HardcoverImportStatus.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { AlertCircle, CheckCircle2, Download, FileSearch, Loader2, Table2, XCircle } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import HardcoverImportReviewModal from './HardcoverImportReviewModal.vue'
 import { useHardcoverImport } from '../composables/useHardcoverImport'
 import { useHardcoverSettings } from '../composables/useHardcoverSettings'
+
+const { t } = useI18n()
 
 const { settings } = useHardcoverSettings()
 const { preview, result, previewing, applying, error, loadPreview, applyPreview, clearImport } = useHardcoverImport()
@@ -15,11 +18,11 @@ const importProgress = ref(true)
 const importUnavailableReason = computed(() => {
   switch (settings.value?.disabledReason) {
     case 'permission_denied':
-      return 'You do not have permission to use Hardcover sync.'
+      return t('hardcover.import.unavailable.permissionDenied')
     case 'missing_token':
-      return 'Connect Hardcover before importing.'
+      return t('hardcover.import.unavailable.missingToken')
     case 'user_disabled':
-      return 'Sync is paused in your Hardcover settings.'
+      return t('hardcover.import.unavailable.userDisabled')
     default:
       return null
   }
@@ -32,25 +35,26 @@ const summaryItems = computed(() => {
   const summary = preview.value?.summary
   if (!summary) return []
   return [
-    { label: 'Ready', value: summary.willUpdate },
-    { label: 'Review', value: summary.needsReview },
-    { label: 'Conflicts', value: summary.conflicts },
-    { label: 'Unmatched', value: summary.unmatched },
-    { label: 'Skipped', value: summary.skipped },
+    { label: t('hardcover.import.summary.ready'), value: summary.willUpdate },
+    { label: t('hardcover.import.summary.review'), value: summary.needsReview },
+    { label: t('hardcover.import.summary.conflicts'), value: summary.conflicts },
+    { label: t('hardcover.import.summary.unmatched'), value: summary.unmatched },
+    { label: t('hardcover.import.summary.skipped'), value: summary.skipped },
   ]
 })
 const progressPreviewLabel = computed(() => {
   const summary = preview.value?.summary
   if (!summary) return null
-  const ready = `${summary.progressWillUpdate} progress update${summary.progressWillUpdate === 1 ? '' : 's'} available`
+  const ready = t('hardcover.import.progressAvailable', { count: summary.progressWillUpdate }, summary.progressWillUpdate)
   if (summary.progressConflicts === 0) return ready
-  return `${ready}, ${summary.progressConflicts} conflict${summary.progressConflicts === 1 ? '' : 's'}`
+  return `${ready}, ${t('hardcover.import.progressConflicts', { count: summary.progressConflicts }, summary.progressConflicts)}`
 })
 
 const resultLabel = computed(() => {
   if (!result.value) return null
-  const progress = result.value.progressApplied > 0 ? `, ${result.value.progressApplied} progress updated` : ''
-  return `${result.value.applied} imported${progress}, ${result.value.failed} failed`
+  const progress =
+    result.value.progressApplied > 0 ? `, ${t('hardcover.import.result.progressUpdated', { count: result.value.progressApplied })}` : ''
+  return t('hardcover.import.result.summary', { applied: result.value.applied, progress, failed: result.value.failed })
 })
 
 async function handlePreview(): Promise<void> {
@@ -82,12 +86,14 @@ async function handleApplySelected(hardcoverUserBookIds: number[]): Promise<void
 async function applyRows(hardcoverUserBookIds?: number[]): Promise<void> {
   const applied = await applyPreview(hardcoverUserBookIds, importProgress.value)
   if (!applied) {
-    toast.error(error.value ?? 'Failed to import Hardcover read status')
+    toast.error(error.value ?? t('hardcover.import.toast.importFailed'))
     return
   }
   reviewOpen.value = false
-  const progress = importProgress.value ? `, ${applied.progressApplied} progress update${applied.progressApplied === 1 ? '' : 's'}` : ''
-  toast.success(`${applied.applied} read status${applied.applied === 1 ? '' : 'es'} imported${progress}`)
+  const progress = importProgress.value
+    ? `, ${t('hardcover.import.toast.progressUpdates', { count: applied.progressApplied }, applied.progressApplied)}`
+    : ''
+  toast.success(t('hardcover.import.toast.imported', { count: applied.applied, progress }, applied.applied))
 }
 </script>
 
@@ -95,8 +101,8 @@ async function applyRows(hardcoverUserBookIds?: number[]): Promise<void> {
   <div class="space-y-4 rounded-lg border border-border bg-card px-4 py-4 shadow-xs md:px-5 md:py-5">
     <div class="flex items-start justify-between gap-4">
       <div class="min-w-0">
-        <p class="text-sm font-medium">Pull read status</p>
-        <p class="mt-0.5 text-xs text-muted-foreground">Preview Hardcover matches before filling blank BookOrbit statuses.</p>
+        <p class="text-sm font-medium">{{ t('hardcover.import.title') }}</p>
+        <p class="mt-0.5 text-xs text-muted-foreground">{{ t('hardcover.import.description') }}</p>
         <p v-if="importUnavailableReason" class="mt-1 text-xs text-muted-foreground">{{ importUnavailableReason }}</p>
         <p v-else-if="resultLabel && !preview" class="mt-1 flex items-center gap-1 text-xs text-primary">
           <CheckCircle2 class="size-3.5" />
@@ -117,7 +123,7 @@ async function applyRows(hardcoverUserBookIds?: number[]): Promise<void> {
           @click="handleClear"
         >
           <XCircle class="size-3.5" />
-          Clear
+          {{ t('hardcover.import.clear') }}
         </button>
         <button
           type="button"
@@ -127,7 +133,7 @@ async function applyRows(hardcoverUserBookIds?: number[]): Promise<void> {
         >
           <Loader2 v-if="previewing" class="size-3.5 animate-spin" />
           <FileSearch v-else class="size-3.5" />
-          Preview
+          {{ t('hardcover.import.preview') }}
         </button>
       </div>
     </div>
@@ -142,7 +148,7 @@ async function applyRows(hardcoverUserBookIds?: number[]): Promise<void> {
 
       <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div class="space-y-2">
-          <p class="text-xs text-muted-foreground">{{ readyRows.length }} exact matches can be imported without review.</p>
+          <p class="text-xs text-muted-foreground">{{ t('hardcover.import.exactMatches', { count: readyRows.length }, readyRows.length) }}</p>
           <label class="flex w-fit items-center gap-2 text-xs text-muted-foreground">
             <input
               v-model="importProgress"
@@ -150,7 +156,7 @@ async function applyRows(hardcoverUserBookIds?: number[]): Promise<void> {
               class="size-4 rounded border-border text-primary focus:ring-primary/40"
               :disabled="applying"
             />
-            <span>Import progress</span>
+            <span>{{ t('hardcover.import.importProgress') }}</span>
             <span v-if="progressPreviewLabel">({{ progressPreviewLabel }})</span>
           </label>
         </div>
@@ -161,7 +167,7 @@ async function applyRows(hardcoverUserBookIds?: number[]): Promise<void> {
             @click="handleOpenReview"
           >
             <Table2 class="size-3.5" />
-            Review matches
+            {{ t('hardcover.import.reviewMatches') }}
           </button>
           <button
             type="button"
@@ -171,7 +177,7 @@ async function applyRows(hardcoverUserBookIds?: number[]): Promise<void> {
           >
             <Loader2 v-if="applying" class="size-3.5 animate-spin" />
             <Download v-else class="size-3.5" />
-            Import ready
+            {{ t('hardcover.import.importReady') }}
           </button>
         </div>
       </div>

--- a/client/src/features/hardcover/components/HardcoverSettings.vue
+++ b/client/src/features/hardcover/components/HardcoverSettings.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import SettingsPageHeader from '@/features/settings/SettingsPageHeader.vue'
 import HardcoverConnectionCard from '../components/HardcoverConnectionCard.vue'
 import HardcoverImportStatus from '../components/HardcoverImportStatus.vue'
 import HardcoverSyncProgress from '../components/HardcoverSyncProgress.vue'
 import { useHardcoverSettings } from '../composables/useHardcoverSettings'
 import { useHardcoverSync } from '../composables/useHardcoverSync'
+
+const { t } = useI18n()
 
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
 
@@ -23,7 +26,7 @@ onUnmounted(() => {
 
 <template>
   <div class="space-y-6">
-    <SettingsPageHeader v-if="!props.embedded" title="Hardcover" subtitle="Sync your reading progress, status, and ratings to Hardcover." />
+    <SettingsPageHeader v-if="!props.embedded" title="Hardcover" :subtitle="t('hardcover.settings.subtitle')" />
 
     <HardcoverConnectionCard />
 

--- a/client/src/features/hardcover/components/HardcoverSyncProgress.vue
+++ b/client/src/features/hardcover/components/HardcoverSyncProgress.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { AlertCircle, RefreshCw, XCircle, Loader2 } from '@lucide/vue'
 import { useHardcoverSync } from '../composables/useHardcoverSync'
 import { useHardcoverSettings } from '../composables/useHardcoverSettings'
+
+const { t } = useI18n()
 
 const { activeSyncStatus, syncing, isSyncing, syncProgress, pendingSummary, loadingPending, error, startSync, cancelSync } = useHardcoverSync()
 const { settings } = useHardcoverSettings()
@@ -10,25 +13,27 @@ const { settings } = useHardcoverSettings()
 const progressLabel = computed(() => {
   const s = activeSyncStatus.value
   if (!s) return ''
-  return `${s.syncedBooks} / ${s.totalBooks} books`
+  return t('hardcover.sync.progressCount', { synced: s.syncedBooks, total: s.totalBooks })
 })
 
 const hasPending = computed(() => pendingSummary.value.pendingBooks > 0)
-const syncScopeLabel = computed(() => (settings.value?.bookSyncMode === 'selected_only' ? 'selected books' : 'eligible books'))
+const syncScopeLabel = computed(() =>
+  settings.value?.bookSyncMode === 'selected_only' ? t('hardcover.sync.scope.selected') : t('hardcover.sync.scope.eligible'),
+)
 const syncUnavailableReason = computed(() => {
   switch (settings.value?.disabledReason) {
     case 'permission_denied':
-      return 'You do not have permission to use Hardcover sync.'
+      return t('hardcover.sync.unavailable.permissionDenied')
     case 'user_disabled':
-      return 'Sync is paused in your Hardcover settings.'
+      return t('hardcover.sync.unavailable.userDisabled')
     default:
       return null
   }
 })
 const syncButtonDisabled = computed(() => syncing.value || loadingPending.value || !hasPending.value || syncUnavailableReason.value !== null)
 const syncButtonLabel = computed(() => {
-  if (syncUnavailableReason.value) return 'Sync unavailable'
-  return hasPending.value ? `Sync now (${pendingSummary.value.pendingBooks})` : 'Sync now'
+  if (syncUnavailableReason.value) return t('hardcover.sync.button.unavailable')
+  return hasPending.value ? t('hardcover.sync.button.syncNowCount', { count: pendingSummary.value.pendingBooks }) : t('hardcover.sync.button.syncNow')
 })
 
 const lastSyncedLabel = computed(() => {
@@ -38,10 +43,10 @@ const lastSyncedLabel = computed(() => {
   const minutes = Math.floor(diff / 60_000)
   const hours = Math.floor(diff / 3_600_000)
   const days = Math.floor(diff / 86_400_000)
-  if (minutes < 1) return 'Just now'
-  if (minutes < 60) return `${minutes} min ago`
-  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`
-  return `${days} day${days === 1 ? '' : 's'} ago`
+  if (minutes < 1) return t('hardcover.sync.lastSynced.justNow')
+  if (minutes < 60) return t('hardcover.sync.lastSynced.minutesAgo', { count: minutes })
+  if (hours < 24) return t('hardcover.sync.lastSynced.hoursAgo', { count: hours }, hours)
+  return t('hardcover.sync.lastSynced.daysAgo', { count: days }, days)
 })
 </script>
 
@@ -49,20 +54,20 @@ const lastSyncedLabel = computed(() => {
   <div class="border border-border rounded-lg bg-card px-4 py-4 md:px-5 md:py-5 shadow-xs space-y-4">
     <div class="flex items-center justify-between gap-4">
       <div>
-        <p class="font-medium text-sm">Manual sync</p>
-        <p class="text-xs text-muted-foreground mt-0.5">Push your {{ syncScopeLabel }} to Hardcover now.</p>
+        <p class="font-medium text-sm">{{ t('hardcover.sync.title') }}</p>
+        <p class="text-xs text-muted-foreground mt-0.5">{{ t('hardcover.sync.description', { scope: syncScopeLabel }) }}</p>
         <p v-if="!isSyncing" class="text-xs text-muted-foreground mt-1">
-          <template v-if="loadingPending">Checking pending items...</template>
+          <template v-if="loadingPending">{{ t('hardcover.sync.checkingPending') }}</template>
           <template v-else-if="hasPending">
-            {{ pendingSummary.pendingBooks }} pending of {{ pendingSummary.totalBooks }} books.
+            {{ t('hardcover.sync.pendingOf', { pending: pendingSummary.pendingBooks, total: pendingSummary.totalBooks }) }}
             <span v-if="syncUnavailableReason">{{ syncUnavailableReason }}</span>
           </template>
           <template v-else-if="syncUnavailableReason">{{ syncUnavailableReason }}</template>
-          <template v-else-if="pendingSummary.totalBooks === 0">No books in sync scope.</template>
-          <template v-else>All books are already synced.</template>
+          <template v-else-if="pendingSummary.totalBooks === 0">{{ t('hardcover.sync.noBooksInScope') }}</template>
+          <template v-else>{{ t('hardcover.sync.allSynced') }}</template>
         </p>
         <p v-if="lastSyncedLabel && !isSyncing" class="text-xs text-muted-foreground mt-0.5">
-          {{ syncUnavailableReason ? 'Last successful sync' : 'Last synced' }}: {{ lastSyncedLabel }}
+          {{ syncUnavailableReason ? t('hardcover.sync.lastSuccessfulSync') : t('hardcover.sync.lastSyncedLabel') }}: {{ lastSyncedLabel }}
         </p>
         <p v-if="error && !isSyncing" class="flex items-center gap-1 text-xs text-destructive mt-1">
           <AlertCircle class="size-3.5" />
@@ -89,14 +94,14 @@ const lastSyncedLabel = computed(() => {
           @click="cancelSync"
         >
           <XCircle class="size-3.5" />
-          Cancel
+          {{ t('common.cancel') }}
         </button>
       </div>
     </div>
 
     <div v-if="isSyncing" class="space-y-1.5">
       <div class="flex justify-between text-xs text-muted-foreground">
-        <span>Syncing...</span>
+        <span>{{ t('hardcover.sync.syncing') }}</span>
         <span>{{ progressLabel }}</span>
       </div>
       <div class="h-1.5 rounded-full bg-muted overflow-hidden">

--- a/client/src/features/hardcover/components/__tests__/HardcoverImportStatus.spec.ts
+++ b/client/src/features/hardcover/components/__tests__/HardcoverImportStatus.spec.ts
@@ -303,6 +303,6 @@ describe('HardcoverImportStatus', () => {
       .trigger('click')
     await flushPromises()
 
-    expect(mockToast.success).toHaveBeenCalledWith('2 read statuses imported, 0 progress updates')
+    expect(mockToast.success).toHaveBeenCalledWith('2 read statuses imported, no progress updates')
   })
 })

--- a/client/src/features/library/components/BookUploadModal.vue
+++ b/client/src/features/library/components/BookUploadModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { CheckCircle2, FileUp, Loader2, Plus, RotateCcw, Upload, X, XCircle } from '@lucide/vue'
 import { api } from '@/lib/api'
 import type { Library } from '@bookorbit/types'
@@ -18,6 +19,7 @@ const emit = defineEmits<{
 }>()
 
 const router = useRouter()
+const { t } = useI18n()
 const { libraries, fetchLibraries } = useLibraries()
 
 const selectedLibraryId = ref<number | undefined>(props.libraryId)
@@ -36,10 +38,10 @@ const allDone = computed(() => hasFiles.value && files.value.every((f) => f.stat
 const allSuccess = computed(() => allDone.value && errorCount.value === 0)
 
 const headerTitle = computed(() => {
-  if (isUploading.value) return 'Uploading...'
-  if (allDone.value) return 'Upload complete'
-  if (libraryName.value) return `Upload to ${libraryName.value}`
-  return 'Upload Books'
+  if (isUploading.value) return t('library.upload.header.uploading')
+  if (allDone.value) return t('library.upload.header.complete')
+  if (libraryName.value) return t('library.upload.header.uploadTo', { library: libraryName.value })
+  return t('library.upload.header.uploadBooks')
 })
 
 const fileSummary = computed(() => {
@@ -215,19 +217,19 @@ function formatPillClass(filename: string): string {
         <div class="flex-1 overflow-y-auto p-5 flex flex-col gap-4">
           <!-- Library selector (only when not pre-scoped to a library) -->
           <div v-if="!libraryId" class="flex flex-col gap-1.5">
-            <label class="text-xs font-medium text-muted-foreground">Library</label>
+            <label class="text-xs font-medium text-muted-foreground">{{ t('library.upload.library') }}</label>
             <select
               v-model="selectedLibraryId"
               class="h-8 rounded-md border border-input bg-background px-2.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
             >
-              <option :value="undefined" disabled>Select a library...</option>
+              <option :value="undefined" disabled>{{ t('library.upload.selectLibrary') }}</option>
               <option v-for="lib in libraries" :key="lib.id" :value="lib.id">{{ lib.name }}</option>
             </select>
           </div>
 
           <!-- Folder selector (only shown when library has multiple folders) -->
           <div v-if="folders.length > 1" class="flex flex-col gap-1.5">
-            <label class="text-xs font-medium text-muted-foreground">Target folder</label>
+            <label class="text-xs font-medium text-muted-foreground">{{ t('library.upload.targetFolder') }}</label>
             <select
               v-model="selectedFolderId"
               class="h-8 rounded-md border border-input bg-background px-2.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
@@ -253,8 +255,8 @@ function formatPillClass(filename: string): string {
               <FileUp :size="20" class="text-primary" />
             </div>
             <div>
-              <p class="text-sm font-medium text-foreground">Drop files here or click to browse</p>
-              <p class="text-xs text-muted-foreground mt-0.5">{{ SUPPORTED_FORMATS.join(', ') }} - up to 500 MB each</p>
+              <p class="text-sm font-medium text-foreground">{{ t('library.upload.dropzone.title') }}</p>
+              <p class="text-xs text-muted-foreground mt-0.5">{{ t('library.upload.dropzone.hint', { formats: SUPPORTED_FORMATS.join(', ') }) }}</p>
             </div>
           </div>
 
@@ -273,20 +275,22 @@ function formatPillClass(filename: string): string {
             @click="openFilePicker"
           >
             <Plus :size="13" />
-            Add more files
+            {{ t('library.upload.addMoreFiles') }}
           </div>
 
           <!-- File list -->
           <div v-if="hasFiles" class="flex flex-col gap-2">
             <!-- Summary line -->
             <div v-if="fileSummary" class="flex items-center gap-1.5 flex-wrap text-xs text-muted-foreground">
-              <span class="font-medium text-foreground tabular-nums">{{ fileSummary.total }} file{{ fileSummary.total === 1 ? '' : 's' }}</span>
+              <span class="font-medium text-foreground tabular-nums">{{
+                t('library.upload.fileCount', { count: fileSummary.total }, fileSummary.total)
+              }}</span>
               <span>·</span>
               <span>{{ formatBytes(fileSummary.totalBytes) }}</span>
               <span>·</span>
               <span>{{ fileSummary.formatParts.join(', ') }}</span>
               <div class="flex-1" />
-              <button v-if="!isUploading" class="hover:text-foreground transition-colors" @click="reset">Clear all</button>
+              <button v-if="!isUploading" class="hover:text-foreground transition-colors" @click="reset">{{ t('library.upload.clearAll') }}</button>
             </div>
 
             <TransitionGroup name="file-row" tag="div" class="relative flex flex-col gap-1">
@@ -314,7 +318,9 @@ function formatPillClass(filename: string): string {
                     </span>
                     <span v-if="item.status === 'error'" class="text-[11px] text-destructive truncate">{{ item.error }}</span>
                     <span v-else-if="item.status === 'uploading'" class="text-[11px] text-primary tabular-nums">{{ item.progress }}%</span>
-                    <span v-else-if="item.status === 'done'" class="text-[11px] text-emerald-600 dark:text-emerald-400">Done</span>
+                    <span v-else-if="item.status === 'done'" class="text-[11px] text-emerald-600 dark:text-emerald-400">{{
+                      t('library.upload.done')
+                    }}</span>
                   </div>
 
                   <!-- Progress bar -->
@@ -328,7 +334,7 @@ function formatPillClass(filename: string): string {
                   <button
                     v-if="item.status === 'error'"
                     class="flex items-center justify-center w-6 h-6 rounded text-muted-foreground/85 hover:text-primary hover:bg-primary/10 transition-colors"
-                    title="Retry"
+                    :title="t('library.upload.retry')"
                     @click="retryFile(item.id)"
                   >
                     <RotateCcw :size="11" />
@@ -350,28 +356,32 @@ function formatPillClass(filename: string): string {
         <div v-if="allSuccess" class="shrink-0 px-5 py-4 border-t border-border flex items-center justify-between gap-3">
           <div class="flex items-center gap-2">
             <CheckCircle2 class="size-4 text-emerald-500 shrink-0" />
-            <span class="text-sm font-medium text-foreground">{{ doneCount }} book{{ doneCount === 1 ? '' : 's' }} added</span>
+            <span class="text-sm font-medium text-foreground">{{ t('library.upload.booksAdded', { count: doneCount }, doneCount) }}</span>
           </div>
           <div class="flex items-center gap-2">
             <button
               class="px-3 py-1.5 rounded-md border border-border text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
               @click="handleClose"
             >
-              Close
+              {{ t('common.close') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-4 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
               @click="goToLibrary"
             >
-              View in Library
+              {{ t('library.upload.viewInLibrary') }}
             </button>
           </div>
         </div>
 
         <!-- Footer: normal / partial error state -->
         <div v-else class="shrink-0 px-5 py-4 border-t border-border flex items-center justify-between gap-3">
-          <span v-if="allDone && errorCount > 0" class="text-xs text-muted-foreground"> {{ doneCount }} uploaded, {{ errorCount }} failed </span>
-          <span v-else-if="isUploading" class="text-xs text-muted-foreground tabular-nums"> {{ doneCount }} of {{ files.length }} uploading... </span>
+          <span v-if="allDone && errorCount > 0" class="text-xs text-muted-foreground">
+            {{ t('library.upload.uploadedFailed', { done: doneCount, failed: errorCount }) }}
+          </span>
+          <span v-else-if="isUploading" class="text-xs text-muted-foreground tabular-nums">
+            {{ t('library.upload.progress', { done: doneCount, total: files.length }) }}
+          </span>
           <span v-else class="text-xs text-muted-foreground" />
 
           <div class="flex items-center gap-2">
@@ -379,7 +389,7 @@ function formatPillClass(filename: string): string {
               class="px-3 py-1.5 rounded-md border border-border text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
               @click="handleClose"
             >
-              {{ allDone ? 'Close' : 'Cancel' }}
+              {{ allDone ? t('common.close') : t('common.cancel') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-4 py-1.5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
@@ -387,7 +397,7 @@ function formatPillClass(filename: string): string {
               @click="handleUpload"
             >
               <Upload :size="13" />
-              Upload{{ pendingCount > 0 ? ` (${pendingCount})` : '' }}
+              {{ pendingCount > 0 ? t('library.upload.uploadWithCount', { count: pendingCount }) : t('library.upload.upload') }}
             </button>
           </div>
         </div>

--- a/client/src/features/library/components/FolderPickerModal.vue
+++ b/client/src/features/library/components/FolderPickerModal.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Folder, FolderOpen, FolderPlus, ChevronRight, ChevronUp, Search, X, Check, Loader2, HardDrive } from '@lucide/vue'
 import type { CreateFolderResult } from '@bookorbit/types'
 import { api } from '@/lib/api'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const { t } = useI18n()
 
 interface DirEntry {
   name: string
@@ -59,11 +62,11 @@ async function loadEntries(path: string) {
     if (res.ok) {
       entries.value = await res.json()
     } else {
-      error.value = 'Could not read directory'
+      error.value = t('library.folderPicker.errors.readDirectory')
       entries.value = []
     }
   } catch {
-    error.value = 'Could not connect'
+    error.value = t('library.folderPicker.errors.connect')
     entries.value = []
   } finally {
     loading.value = false
@@ -101,7 +104,7 @@ async function submitNewFolder() {
   const name = newFolderName.value.trim()
   if (!name || createLoading.value) return
   if (name.includes('/') || name.includes('\\') || name === '.' || name === '..' || name.startsWith('.')) {
-    createError.value = 'Enter a single folder name without slashes or leading dots'
+    createError.value = t('library.folderPicker.errors.invalidName')
     return
   }
   createLoading.value = true
@@ -120,10 +123,10 @@ async function submitNewFolder() {
     } else {
       const body = await res.json().catch(() => ({}))
       const message = Array.isArray(body?.message) ? body.message[0] : body?.message
-      createError.value = message ?? 'Could not create folder'
+      createError.value = message ?? t('library.folderPicker.errors.createFolder')
     }
   } catch {
-    createError.value = 'Could not connect'
+    createError.value = t('library.folderPicker.errors.connect')
   } finally {
     createLoading.value = false
   }
@@ -153,7 +156,7 @@ function onNewFolderKeydown(e: KeyboardEvent) {
         <div class="flex items-center justify-between px-4 py-3 border-b border-border shrink-0">
           <div class="flex items-center gap-2">
             <HardDrive :size="15" class="text-primary" />
-            <span class="text-sm font-semibold text-foreground">Browse folders</span>
+            <span class="text-sm font-semibold text-foreground">{{ t('library.folderPicker.title') }}</span>
           </div>
           <div class="flex items-center gap-1">
             <button
@@ -161,7 +164,7 @@ function onNewFolderKeydown(e: KeyboardEvent) {
               @click="toggleNewFolder"
             >
               <FolderPlus :size="13" />
-              New folder
+              {{ t('library.folderPicker.newFolder') }}
             </button>
             <button
               class="flex items-center justify-center w-7 h-7 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
@@ -184,7 +187,7 @@ function onNewFolderKeydown(e: KeyboardEvent) {
                 <ChevronUp :size="13" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Go up</TooltipContent>
+            <TooltipContent>{{ t('library.folderPicker.goUp') }}</TooltipContent>
           </Tooltip>
           <template v-for="(crumb, i) in breadcrumbs" :key="crumb.path">
             <ChevronRight v-if="i > 0" :size="12" class="text-muted-foreground/70 shrink-0" />
@@ -204,7 +207,7 @@ function onNewFolderKeydown(e: KeyboardEvent) {
           <input
             v-model="search"
             type="text"
-            placeholder="Filter folders…"
+            :placeholder="t('library.folderPicker.filterPlaceholder')"
             class="flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
           />
           <button v-if="search" class="text-muted-foreground hover:text-foreground" @click="search = ''">
@@ -220,7 +223,7 @@ function onNewFolderKeydown(e: KeyboardEvent) {
               ref="newFolderInput"
               v-model="newFolderName"
               type="text"
-              placeholder="New folder name"
+              :placeholder="t('library.folderPicker.newFolderNamePlaceholder')"
               class="flex-1 bg-transparent text-xs text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
               @keydown="onNewFolderKeydown"
             />
@@ -230,13 +233,13 @@ function onNewFolderKeydown(e: KeyboardEvent) {
               @click="submitNewFolder"
             >
               <Loader2 v-if="createLoading" :size="12" class="animate-spin" />
-              Create
+              {{ t('library.folderPicker.create') }}
             </button>
             <button
               class="px-2.5 py-1 rounded-md border border-border text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
               @click="cancelNewFolder"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
           </div>
           <p v-if="createError" class="mt-1.5 pl-5 text-xs text-destructive">{{ createError }}</p>
@@ -253,7 +256,7 @@ function onNewFolderKeydown(e: KeyboardEvent) {
           </div>
 
           <div v-else-if="filteredEntries.length === 0" class="flex items-center justify-center h-full">
-            <p class="text-sm text-muted-foreground">No folders found</p>
+            <p class="text-sm text-muted-foreground">{{ t('library.folderPicker.noFolders') }}</p>
           </div>
 
           <div v-else class="py-1">
@@ -279,14 +282,14 @@ function onNewFolderKeydown(e: KeyboardEvent) {
               class="px-3 py-1.5 rounded-md border border-border text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
               @click="emit('close')"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium hover:opacity-90 transition-opacity"
               @click="selectCurrent"
             >
               <Check :size="12" />
-              Select this folder
+              {{ t('library.folderPicker.selectFolder') }}
             </button>
           </div>
         </div>

--- a/client/src/features/library/components/LibraryCreatorAccess.vue
+++ b/client/src/features/library/components/LibraryCreatorAccess.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { UserPlus, Trash2 } from '@lucide/vue'
 import { api } from '@/lib/api'
 import type { LibraryAccessEntry } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   libraryId: number | null
@@ -48,7 +51,7 @@ async function grant() {
   })
   if (!res.ok) {
     const body = await res.json().catch(() => null)
-    error.value = body?.message ?? 'Failed to grant access'
+    error.value = body?.message ?? t('library.creator.access.errors.grant')
     return
   }
   grantUserId.value = null
@@ -65,7 +68,7 @@ async function changeLevel(userId: number, accessLevel: 'viewer' | 'editor' | 'o
   })
   if (!res.ok) {
     const body = await res.json().catch(() => null)
-    error.value = body?.message ?? 'Failed to update access level'
+    error.value = body?.message ?? t('library.creator.access.errors.updateLevel')
     return
   }
   await loadAccess()
@@ -77,7 +80,7 @@ async function revoke(userId: number) {
   const res = await api(`/api/v1/libraries/${props.libraryId}/access/${userId}`, { method: 'DELETE' })
   if (!res.ok) {
     const body = await res.json().catch(() => null)
-    error.value = body?.message ?? 'Failed to revoke access'
+    error.value = body?.message ?? t('library.creator.access.errors.revoke')
     return
   }
   await loadAccess()
@@ -90,13 +93,13 @@ onMounted(loadAccess)
   <div class="px-6 py-6 space-y-6">
     <div v-if="!libraryId" class="rounded-lg border border-dashed border-border px-5 py-8 text-center">
       <UserPlus :size="22" class="text-muted-foreground/60 mx-auto mb-2" />
-      <p class="text-sm text-muted-foreground">Access can be configured after the library is created.</p>
+      <p class="text-sm text-muted-foreground">{{ t('library.creator.access.notYetCreated') }}</p>
     </div>
 
     <template v-else>
       <div>
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">Access control</p>
-        <p class="text-xs text-muted-foreground mb-3">Superusers always have full access. Grant access to other users below.</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">{{ t('library.creator.access.title') }}</p>
+        <p class="text-xs text-muted-foreground mb-3">{{ t('library.creator.access.description') }}</p>
 
         <p v-if="error" class="text-xs text-destructive mb-3">{{ error }}</p>
 
@@ -106,16 +109,16 @@ onMounted(loadAccess)
             v-model="grantUserId"
             class="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           >
-            <option :value="null" disabled>Select a user…</option>
+            <option :value="null" disabled>{{ t('library.creator.access.selectUser') }}</option>
             <option v-for="u in availableUsers" :key="u.id" :value="u.id">{{ u.name }} ({{ u.username }})</option>
           </select>
           <select
             v-model="grantLevel"
             class="rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           >
-            <option value="viewer">Viewer</option>
-            <option value="editor">Editor</option>
-            <option value="owner">Owner</option>
+            <option value="viewer">{{ t('library.creator.access.levels.viewer') }}</option>
+            <option value="editor">{{ t('library.creator.access.levels.editor') }}</option>
+            <option value="owner">{{ t('library.creator.access.levels.owner') }}</option>
           </select>
           <button
             class="flex items-center gap-1.5 px-3 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50 shrink-0"
@@ -123,7 +126,7 @@ onMounted(loadAccess)
             @click="grant"
           >
             <UserPlus :size="14" />
-            Grant
+            {{ t('library.creator.access.grant') }}
           </button>
         </div>
 
@@ -132,8 +135,8 @@ onMounted(loadAccess)
           <table class="w-full text-sm">
             <thead class="bg-muted/50">
               <tr>
-                <th class="px-4 py-3 text-left font-medium text-muted-foreground text-xs">User</th>
-                <th class="px-4 py-3 text-left font-medium text-muted-foreground text-xs">Access level</th>
+                <th class="px-4 py-3 text-left font-medium text-muted-foreground text-xs">{{ t('library.creator.access.columns.user') }}</th>
+                <th class="px-4 py-3 text-left font-medium text-muted-foreground text-xs">{{ t('library.creator.access.columns.accessLevel') }}</th>
                 <th class="px-4 py-3 w-10" />
               </tr>
             </thead>
@@ -149,9 +152,9 @@ onMounted(loadAccess)
                     class="rounded border border-border bg-background px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                     @change="changeLevel(entry.userId, ($event.target as HTMLSelectElement).value as 'viewer' | 'editor' | 'owner')"
                   >
-                    <option value="viewer">Viewer</option>
-                    <option value="editor">Editor</option>
-                    <option value="owner">Owner</option>
+                    <option value="viewer">{{ t('library.creator.access.levels.viewer') }}</option>
+                    <option value="editor">{{ t('library.creator.access.levels.editor') }}</option>
+                    <option value="owner">{{ t('library.creator.access.levels.owner') }}</option>
                   </select>
                 </td>
                 <td class="px-4 py-3">
@@ -164,7 +167,7 @@ onMounted(loadAccess)
                 </td>
               </tr>
               <tr v-if="accessList.length === 0">
-                <td colspan="3" class="px-4 py-6 text-center text-xs text-muted-foreground">No users have been granted access yet.</td>
+                <td colspan="3" class="px-4 py-6 text-center text-xs text-muted-foreground">{{ t('library.creator.access.empty') }}</td>
               </tr>
             </tbody>
           </table>

--- a/client/src/features/library/components/LibraryCreatorDetails.vue
+++ b/client/src/features/library/components/LibraryCreatorDetails.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { CoverAspectRatio } from '@bookorbit/types'
 import AppIcon from '@/components/AppIcon.vue'
 import IconPicker from '@/components/IconPicker.vue'
 
-const ASPECT_RATIO_OPTIONS: { value: CoverAspectRatio; label: string }[] = [
-  { value: '2/3', label: 'Portrait' },
-  { value: '1/1', label: 'Square' },
-]
+const { t } = useI18n()
+
+const aspectRatioOptions = computed<{ value: CoverAspectRatio; label: string }[]>(() => [
+  { value: '2/3', label: t('library.creator.details.coverStyle.portrait') },
+  { value: '1/1', label: t('library.creator.details.coverStyle.square') },
+])
 
 defineProps<{
   name: string
@@ -29,7 +33,9 @@ function updateIcon(value: string) {
   <div class="px-6 py-6 flex flex-col gap-7 h-full min-h-0">
     <!-- Name row with inline icon preview -->
     <div>
-      <label class="block text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-3">Library name</label>
+      <label class="block text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-3">{{
+        t('library.creator.details.libraryName')
+      }}</label>
       <div class="flex items-center gap-3">
         <!-- Icon preview -->
         <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/20">
@@ -39,7 +45,7 @@ function updateIcon(value: string) {
         <input
           type="text"
           :value="name"
-          placeholder="My Library"
+          :placeholder="t('library.creator.details.namePlaceholder')"
           maxlength="255"
           class="flex-1 rounded-lg border border-border bg-background px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-ring"
           @input="emit('update:name', ($event.target as HTMLInputElement).value)"
@@ -50,10 +56,12 @@ function updateIcon(value: string) {
     <!-- Cover aspect ratio -->
     <div>
       <div class="flex items-center justify-between mb-1">
-        <label class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">Cover style</label>
+        <label class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">{{
+          t('library.creator.details.coverStyle.title')
+        }}</label>
         <div class="flex rounded-md border border-border bg-muted/40 p-0.5 gap-0.5">
           <button
-            v-for="option in ASPECT_RATIO_OPTIONS"
+            v-for="option in aspectRatioOptions"
             :key="option.value"
             class="px-3 py-1 rounded text-xs font-medium transition-colors"
             :class="
@@ -65,14 +73,16 @@ function updateIcon(value: string) {
           </button>
         </div>
       </div>
-      <p class="text-xs text-muted-foreground">Portrait for ebook or mixed libraries. Square for audiobook-only libraries.</p>
+      <p class="text-xs text-muted-foreground">{{ t('library.creator.details.coverStyle.hint') }}</p>
     </div>
 
     <div>
-      <label class="block text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-3">Icon</label>
-      <IconPicker :model-value="icon ?? ''" placeholder="Choose an icon..." @update:model-value="updateIcon" />
+      <label class="block text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-3">{{
+        t('library.creator.details.icon.label')
+      }}</label>
+      <IconPicker :model-value="icon ?? ''" :placeholder="t('library.creator.details.icon.placeholder')" @update:model-value="updateIcon" />
       <p v-if="icon" class="mt-2 text-xs text-muted-foreground truncate">
-        Selected <span class="font-medium text-foreground">{{ icon }}</span>
+        {{ t('library.creator.details.icon.selected') }} <span class="font-medium text-foreground">{{ icon }}</span>
       </p>
     </div>
   </div>

--- a/client/src/features/library/components/LibraryCreatorFileWrite.vue
+++ b/client/src/features/library/components/LibraryCreatorFileWrite.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
 const props = defineProps<{
   fileRenameEnabled: boolean
   fileWriteEnabled: boolean
@@ -90,7 +94,7 @@ function onAudioMaxSizeInput(e: Event) {
   <div class="px-6 py-6 space-y-6">
     <div>
       <div class="flex items-center justify-between mb-1">
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">Rename files on metadata update</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">{{ t('library.creator.fileWrite.rename.title') }}</p>
         <button
           class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none"
           :class="fileRenameEnabled ? 'bg-primary' : 'bg-muted-foreground/30'"
@@ -105,13 +109,13 @@ function onAudioMaxSizeInput(e: Event) {
         </button>
       </div>
       <p class="text-xs text-muted-foreground">
-        When enabled, updating title, author, series, or year will rename the physical file using the library naming pattern.
+        {{ t('library.creator.fileWrite.rename.hint') }}
       </p>
     </div>
 
     <div>
       <div class="flex items-center justify-between mb-1">
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">Write metadata to files</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">{{ t('library.creator.fileWrite.write.title') }}</p>
         <button
           class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none"
           :class="fileWriteEnabled ? 'bg-primary' : 'bg-muted-foreground/30'"
@@ -125,14 +129,14 @@ function onAudioMaxSizeInput(e: Event) {
           />
         </button>
       </div>
-      <p class="text-xs text-muted-foreground">When enabled, saving metadata will also write changes back into the physical file on disk.</p>
+      <p class="text-xs text-muted-foreground">{{ t('library.creator.fileWrite.write.hint') }}</p>
     </div>
 
     <template v-if="fileWriteEnabled">
       <div class="flex items-center justify-between">
         <div>
-          <p class="text-sm font-medium text-foreground">Include cover image</p>
-          <p class="text-xs text-muted-foreground mt-0.5">Writes the stored cover back into supported file formats.</p>
+          <p class="text-sm font-medium text-foreground">{{ t('library.creator.fileWrite.cover.title') }}</p>
+          <p class="text-xs text-muted-foreground mt-0.5">{{ t('library.creator.fileWrite.cover.hint') }}</p>
         </div>
         <button
           class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none"
@@ -153,8 +157,8 @@ function onAudioMaxSizeInput(e: Event) {
       <div class="space-y-3">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-foreground">EPUB</p>
-            <p class="text-xs text-muted-foreground mt-0.5">Writes metadata into the OPF file inside the EPUB archive.</p>
+            <p class="text-sm font-medium text-foreground">{{ t('library.creator.fileWrite.epub.title') }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('library.creator.fileWrite.epub.hint') }}</p>
           </div>
           <button
             class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none"
@@ -170,7 +174,7 @@ function onAudioMaxSizeInput(e: Event) {
           </button>
         </div>
         <div v-if="fileWriteEpubEnabled" class="flex items-center justify-between gap-4">
-          <p class="text-xs text-muted-foreground">Max file size (MB)</p>
+          <p class="text-xs text-muted-foreground">{{ t('library.creator.fileWrite.maxFileSizeMb') }}</p>
           <input
             type="number"
             :value="fileWriteEpubMaxFileSizeMb"
@@ -185,8 +189,8 @@ function onAudioMaxSizeInput(e: Event) {
       <div class="space-y-3">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-foreground">PDF</p>
-            <p class="text-xs text-muted-foreground mt-0.5">Embeds metadata into PDF Info dictionary and XMP stream.</p>
+            <p class="text-sm font-medium text-foreground">{{ t('library.creator.fileWrite.pdf.title') }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('library.creator.fileWrite.pdf.hint') }}</p>
           </div>
           <button
             class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none"
@@ -202,7 +206,7 @@ function onAudioMaxSizeInput(e: Event) {
           </button>
         </div>
         <div v-if="fileWritePdfEnabled" class="flex items-center justify-between gap-4">
-          <p class="text-xs text-muted-foreground">Max file size (MB)</p>
+          <p class="text-xs text-muted-foreground">{{ t('library.creator.fileWrite.maxFileSizeMb') }}</p>
           <input
             type="number"
             :value="fileWritePdfMaxFileSizeMb"
@@ -217,8 +221,8 @@ function onAudioMaxSizeInput(e: Event) {
       <div class="space-y-3">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-foreground">Comic archives (CBX)</p>
-            <p class="text-xs text-muted-foreground mt-0.5">Writes ComicInfo.xml into CBZ and CB7 archives.</p>
+            <p class="text-sm font-medium text-foreground">{{ t('library.creator.fileWrite.cbx.title') }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('library.creator.fileWrite.cbx.hint') }}</p>
           </div>
           <button
             class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none"
@@ -234,7 +238,7 @@ function onAudioMaxSizeInput(e: Event) {
           </button>
         </div>
         <div v-if="fileWriteCbxEnabled" class="flex items-center justify-between gap-4">
-          <p class="text-xs text-muted-foreground">Max file size (MB)</p>
+          <p class="text-xs text-muted-foreground">{{ t('library.creator.fileWrite.maxFileSizeMb') }}</p>
           <input
             type="number"
             :value="fileWriteCbxMaxFileSizeMb"
@@ -249,8 +253,8 @@ function onAudioMaxSizeInput(e: Event) {
       <div v-if="fileWriteWriteCover" class="space-y-3">
         <div class="flex items-center justify-between">
           <div>
-            <p class="text-sm font-medium text-foreground">Audio</p>
-            <p class="text-xs text-muted-foreground mt-0.5">Embeds the stored cover into M4B, M4A, MP3, and FLAC files.</p>
+            <p class="text-sm font-medium text-foreground">{{ t('library.creator.fileWrite.audio.title') }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('library.creator.fileWrite.audio.hint') }}</p>
           </div>
           <button
             class="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:outline-none"
@@ -266,7 +270,7 @@ function onAudioMaxSizeInput(e: Event) {
           </button>
         </div>
         <div v-if="fileWriteAudioEnabled" class="flex items-center justify-between gap-4">
-          <p class="text-xs text-muted-foreground">Max file size (MB)</p>
+          <p class="text-xs text-muted-foreground">{{ t('library.creator.fileWrite.maxFileSizeMb') }}</p>
           <input
             type="number"
             :value="fileWriteAudioMaxFileSizeMb"

--- a/client/src/features/library/components/LibraryCreatorFolders.vue
+++ b/client/src/features/library/components/LibraryCreatorFolders.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Plus, Trash2, RefreshCw, FolderOpen, AlertTriangle, CheckCircle2, XCircle, Loader2 } from '@lucide/vue'
 import type { PrescanResult } from '@bookorbit/types'
 import { api } from '@/lib/api'
 import FolderPickerModal from './FolderPickerModal.vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   folders: string[]
@@ -84,8 +87,8 @@ function onManualKeydown(e: KeyboardEvent) {
 <template>
   <div class="px-6 py-6 space-y-6">
     <div>
-      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">Scan folders</p>
-      <p class="text-xs text-muted-foreground mb-3">Add one or more directories to scan for books.</p>
+      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">{{ t('library.creator.folders.title') }}</p>
+      <p class="text-xs text-muted-foreground mb-3">{{ t('library.creator.folders.description') }}</p>
 
       <!-- Browse button -->
       <button
@@ -93,18 +96,18 @@ function onManualKeydown(e: KeyboardEvent) {
         @click="pickerOpen = true"
       >
         <Plus :size="15" class="shrink-0" />
-        Browse and add a folder
+        {{ t('library.creator.folders.browseAdd') }}
       </button>
 
       <!-- Manual entry -->
       <div class="mt-3">
-        <p class="text-xs text-muted-foreground mb-2">Or enter a path manually:</p>
+        <p class="text-xs text-muted-foreground mb-2">{{ t('library.creator.folders.manualEntry') }}</p>
         <div class="flex gap-2">
           <div class="relative flex-1">
             <input
               v-model="manualPath"
               type="text"
-              placeholder="/path/to/books"
+              :placeholder="t('library.creator.folders.pathPlaceholder')"
               class="w-full rounded-md border bg-background px-3 py-2 text-sm text-foreground font-mono placeholder:text-muted-foreground/60 placeholder:font-sans focus:outline-none focus:ring-2 focus:ring-ring transition-colors"
               :class="testResult === 'ok' ? 'border-emerald-500' : testResult === 'error' ? 'border-destructive' : 'border-border'"
               @input="onManualInput"
@@ -123,7 +126,7 @@ function onManualKeydown(e: KeyboardEvent) {
             @click="testPath"
           >
             <Loader2 v-if="testLoading" :size="12" class="animate-spin" />
-            Test
+            {{ t('library.creator.folders.test') }}
           </button>
           <button
             class="flex items-center gap-1.5 px-3 py-2 rounded-md bg-primary text-primary-foreground text-xs font-medium hover:opacity-90 transition-opacity shrink-0 disabled:opacity-50"
@@ -131,11 +134,13 @@ function onManualKeydown(e: KeyboardEvent) {
             @click="addManual"
           >
             <Plus :size="12" />
-            Add
+            {{ t('library.creator.folders.add') }}
           </button>
         </div>
-        <p v-if="testResult === 'error'" class="mt-1.5 text-xs text-destructive">Path is not accessible on the server.</p>
-        <p v-else-if="testResult === 'ok'" class="mt-1.5 text-xs text-emerald-600 dark:text-emerald-400">Path is accessible.</p>
+        <p v-if="testResult === 'error'" class="mt-1.5 text-xs text-destructive">{{ t('library.creator.folders.pathNotAccessible') }}</p>
+        <p v-else-if="testResult === 'ok'" class="mt-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+          {{ t('library.creator.folders.pathAccessible') }}
+        </p>
       </div>
 
       <!-- Folder list -->
@@ -156,16 +161,16 @@ function onManualKeydown(e: KeyboardEvent) {
           <div v-if="prescanStatusFor(folder)" class="mt-2 ml-6">
             <div v-if="!prescanStatusFor(folder)!.accessible" class="flex items-center gap-1.5 text-xs text-destructive">
               <XCircle :size="12" />
-              Path is not accessible
+              {{ t('library.creator.folders.pathNotAccessibleShort') }}
             </div>
             <div v-else class="flex items-center gap-3 text-xs text-muted-foreground">
               <span class="flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
                 <CheckCircle2 :size="12" />
-                {{ prescanStatusFor(folder)!.fileCount }} book file{{ prescanStatusFor(folder)!.fileCount === 1 ? '' : 's' }} found
+                {{ t('library.creator.folders.bookFilesFound', { count: prescanStatusFor(folder)!.fileCount }, prescanStatusFor(folder)!.fileCount) }}
               </span>
               <span v-if="prescanStatusFor(folder)!.overlapLibrary" class="flex items-center gap-1 text-amber-600 dark:text-amber-400">
                 <AlertTriangle :size="12" />
-                Overlaps with "{{ prescanStatusFor(folder)!.overlapLibrary }}"
+                {{ t('library.creator.folders.overlapsWith', { library: prescanStatusFor(folder)!.overlapLibrary }) }}
               </span>
             </div>
           </div>
@@ -173,24 +178,23 @@ function onManualKeydown(e: KeyboardEvent) {
 
         <div v-if="folders.length === 0" class="rounded-lg border border-dashed border-border px-4 py-6 text-center">
           <FolderOpen :size="22" class="text-muted-foreground/60 mx-auto mb-2" />
-          <p class="text-xs text-muted-foreground">No folders added yet</p>
+          <p class="text-xs text-muted-foreground">{{ t('library.creator.folders.noneAdded') }}</p>
         </div>
       </div>
 
       <!-- Prescan button -->
       <div class="flex items-center justify-between mt-4 pt-4 border-t border-border">
         <div v-if="prescanResult" class="text-xs text-muted-foreground">
-          {{ prescanResult.totalFiles }} book file{{ prescanResult.totalFiles === 1 ? '' : 's' }} found - actual book count may be lower if multiple
-          formats of the same book exist
+          {{ t('library.creator.folders.totalFilesFound', { count: prescanResult.totalFiles }, prescanResult.totalFiles) }}
         </div>
-        <div v-else class="text-xs text-muted-foreground">Run a prescan to validate paths before saving.</div>
+        <div v-else class="text-xs text-muted-foreground">{{ t('library.creator.folders.runPrescanHint') }}</div>
         <button
           class="flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50"
           :disabled="folders.length === 0 || prescanLoading"
           @click="emit('prescan')"
         >
           <RefreshCw :size="12" :class="prescanLoading ? 'animate-spin' : ''" />
-          {{ prescanLoading ? 'Scanning…' : 'Prescan' }}
+          {{ prescanLoading ? t('library.creator.folders.scanning') : t('library.creator.folders.prescan') }}
         </button>
       </div>
     </div>

--- a/client/src/features/library/components/LibraryCreatorMetadata.vue
+++ b/client/src/features/library/components/LibraryCreatorMetadata.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { GripVertical } from '@lucide/vue'
 import { METADATA_LABELS, FORMAT_LABELS } from '../composables/useLibraryCreator'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   metadataPrecedence: string[]
@@ -55,8 +58,10 @@ const fmtDrag = useDragList(
   <div class="px-6 py-6 space-y-6">
     <!-- Source precedence -->
     <div>
-      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">Source precedence</p>
-      <p class="text-xs text-muted-foreground mb-3">The highest source in the list is preferred when multiple are available.</p>
+      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">
+        {{ t('library.creator.metadata.sourcePrecedence.title') }}
+      </p>
+      <p class="text-xs text-muted-foreground mb-3">{{ t('library.creator.metadata.sourcePrecedence.hint') }}</p>
       <div class="rounded-lg border border-border overflow-hidden divide-y divide-border">
         <div
           v-for="(key, index) in metadataPrecedence"
@@ -81,8 +86,10 @@ const fmtDrag = useDragList(
 
     <!-- Format priority -->
     <div>
-      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">Format priority</p>
-      <p class="text-xs text-muted-foreground mb-3">When a book has multiple formats, the format highest in the list is preferred.</p>
+      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">
+        {{ t('library.creator.metadata.formatPriority.title') }}
+      </p>
+      <p class="text-xs text-muted-foreground mb-3">{{ t('library.creator.metadata.formatPriority.hint') }}</p>
       <div class="rounded-lg border border-border overflow-hidden divide-y divide-border">
         <div
           v-for="(fmt, index) in formatPriority"

--- a/client/src/features/library/components/LibraryCreatorModal.vue
+++ b/client/src/features/library/components/LibraryCreatorModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X, ChevronLeft, ChevronRight, Check, Info, FolderOpen, ScanLine, Clock, Users, Tags, BookOpen, FileEdit } from '@lucide/vue'
 import type { CoverAspectRatio, Library, OrganizationMode } from '@bookorbit/types'
 import { api } from '@/lib/api'
@@ -22,24 +23,26 @@ const emit = defineEmits<{
   saved: [library: Library]
 }>()
 
+const { t } = useI18n()
+
 const creator = useLibraryCreator()
 const { form, mode, editingLibraryId, loading, prescanLoading, prescanResult, error } = creator
 
 type SectionId = 'details' | 'folders' | 'scanner' | 'metadata' | 'fileWrite' | 'reading' | 'schedule' | 'access'
 
-const ALL_SECTIONS: { id: SectionId; label: string; icon: unknown; component: unknown }[] = [
-  { id: 'details', label: 'Details', icon: Info, component: LibraryCreatorDetails },
-  { id: 'folders', label: 'Folders', icon: FolderOpen, component: LibraryCreatorFolders },
-  { id: 'scanner', label: 'Scanner', icon: ScanLine, component: LibraryCreatorScanner },
-  { id: 'metadata', label: 'Metadata', icon: Tags, component: LibraryCreatorMetadata },
-  { id: 'fileWrite', label: 'File Write', icon: FileEdit, component: LibraryCreatorFileWrite },
-  { id: 'reading', label: 'Reading', icon: BookOpen, component: LibraryCreatorReading },
-  { id: 'schedule', label: 'Schedule', icon: Clock, component: LibraryCreatorSchedule },
-  { id: 'access', label: 'Access', icon: Users, component: LibraryCreatorAccess },
-]
+const allSections = computed<{ id: SectionId; label: string; icon: unknown; component: unknown }[]>(() => [
+  { id: 'details', label: t('library.creator.sections.details'), icon: Info, component: LibraryCreatorDetails },
+  { id: 'folders', label: t('library.creator.sections.folders'), icon: FolderOpen, component: LibraryCreatorFolders },
+  { id: 'scanner', label: t('library.creator.sections.scanner'), icon: ScanLine, component: LibraryCreatorScanner },
+  { id: 'metadata', label: t('library.creator.sections.metadata'), icon: Tags, component: LibraryCreatorMetadata },
+  { id: 'fileWrite', label: t('library.creator.sections.fileWrite'), icon: FileEdit, component: LibraryCreatorFileWrite },
+  { id: 'reading', label: t('library.creator.sections.reading'), icon: BookOpen, component: LibraryCreatorReading },
+  { id: 'schedule', label: t('library.creator.sections.schedule'), icon: Clock, component: LibraryCreatorSchedule },
+  { id: 'access', label: t('library.creator.sections.access'), icon: Users, component: LibraryCreatorAccess },
+])
 
 // Access is only meaningful after a library exists
-const sections = computed(() => (mode.value === 'create' ? ALL_SECTIONS.slice(0, 7) : ALL_SECTIONS))
+const sections = computed(() => (mode.value === 'create' ? allSections.value.slice(0, 7) : allSections.value))
 
 // ── Stepper state ──────────────────────────────────────────────────────────
 
@@ -88,7 +91,7 @@ onMounted(async () => {
     const res = await api(`/api/v1/libraries/${props.library.id}`)
     const full: Library = res.ok ? await res.json() : props.library
     creator.initEdit(full)
-    visitedUpTo.value = ALL_SECTIONS.length - 1 // all unlocked in edit
+    visitedUpTo.value = allSections.value.length - 1 // all unlocked in edit
   } else {
     creator.initCreate()
     visitedUpTo.value = 0
@@ -114,7 +117,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
 
 // ── Section props / events ─────────────────────────────────────────────────
 
-const title = computed(() => (props.library ? `Edit: ${props.library.name}` : 'Create Library'))
+const title = computed(() => (props.library ? t('library.creator.editTitle', { name: props.library.name }) : t('library.creator.createTitle')))
 
 const stepValid = computed(() => {
   const id = activeId.value
@@ -229,14 +232,14 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                 class="px-4 py-2 rounded-md border border-border text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                 @click="emit('close')"
               >
-                Cancel
+                {{ t('common.cancel') }}
               </button>
               <button
                 class="px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
                 :disabled="loading"
                 @click="handleSave"
               >
-                {{ loading ? 'Saving…' : 'Save changes' }}
+                {{ loading ? t('library.creator.actions.saving') : t('library.creator.actions.saveChanges') }}
               </button>
             </div>
           </div>
@@ -252,7 +255,7 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                 @click="mobileView = 'nav'"
               >
                 <ChevronLeft :size="18" />
-                <span class="text-sm">Back</span>
+                <span class="text-sm">{{ t('common.back') }}</span>
               </button>
               <span class="flex-1 text-sm font-medium text-foreground text-center" :class="mode === 'edit' ? 'pr-16' : ''">
                 {{ activeSection?.label }}
@@ -307,7 +310,7 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                   >
                     <X v-if="isFirstStep" :size="14" />
                     <ChevronLeft v-else :size="14" />
-                    {{ isFirstStep ? 'Cancel' : 'Back' }}
+                    {{ isFirstStep ? t('common.cancel') : t('common.back') }}
                   </button>
                   <button
                     v-if="!isLastStep"
@@ -315,7 +318,7 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                     :disabled="!stepValid"
                     @click="next"
                   >
-                    Next
+                    {{ t('common.next') }}
                     <ChevronRight :size="14" />
                   </button>
                   <button
@@ -324,7 +327,7 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                     :disabled="loading"
                     @click="handleSave"
                   >
-                    {{ loading ? 'Creating…' : 'Create library' }}
+                    {{ loading ? t('library.creator.actions.creating') : t('library.creator.actions.createLibrary') }}
                   </button>
                 </template>
                 <!-- Edit mode: Cancel / Save -->
@@ -334,14 +337,14 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                     @click="emit('close')"
                   >
                     <X :size="14" />
-                    Cancel
+                    {{ t('common.cancel') }}
                   </button>
                   <button
                     class="px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
                     :disabled="loading"
                     @click="handleSave"
                   >
-                    {{ loading ? 'Saving…' : 'Save changes' }}
+                    {{ loading ? t('library.creator.actions.saving') : t('library.creator.actions.saveChanges') }}
                   </button>
                 </template>
               </div>
@@ -447,10 +450,12 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                 >
                   <X v-if="isFirstStep" :size="14" />
                   <ChevronLeft v-else :size="14" />
-                  {{ isFirstStep ? 'Cancel' : 'Back' }}
+                  {{ isFirstStep ? t('common.cancel') : t('common.back') }}
                 </button>
 
-                <span class="text-xs text-muted-foreground"> Step {{ stepIndex + 1 }} of {{ sections.length }} </span>
+                <span class="text-xs text-muted-foreground">
+                  {{ t('library.creator.stepOf', { current: stepIndex + 1, total: sections.length }) }}
+                </span>
 
                 <button
                   v-if="!isLastStep"
@@ -458,7 +463,7 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                   :disabled="!stepValid"
                   @click="next"
                 >
-                  Next
+                  {{ t('common.next') }}
                   <ChevronRight :size="14" />
                 </button>
                 <button
@@ -467,7 +472,7 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                   :disabled="loading"
                   @click="handleSave"
                 >
-                  {{ loading ? 'Creating…' : 'Create library' }}
+                  {{ loading ? t('library.creator.actions.creating') : t('library.creator.actions.createLibrary') }}
                 </button>
               </div>
 
@@ -478,14 +483,14 @@ function onSectionEvent(id: SectionId, event: string, value: unknown) {
                   @click="emit('close')"
                 >
                   <X :size="14" />
-                  Cancel
+                  {{ t('common.cancel') }}
                 </button>
                 <button
                   class="px-5 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
                   :disabled="loading"
                   @click="handleSave"
                 >
-                  {{ loading ? 'Saving…' : 'Save changes' }}
+                  {{ loading ? t('library.creator.actions.saving') : t('library.creator.actions.saveChanges') }}
                 </button>
               </div>
             </div>

--- a/client/src/features/library/components/LibraryCreatorReading.vue
+++ b/client/src/features/library/components/LibraryCreatorReading.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
 defineProps<{
   readingThreshold: number
   markAsFinishedPercentComplete: number
@@ -25,10 +29,10 @@ function onFinishPercentInput(e: Event) {
     <!-- Reading start -->
     <div>
       <div class="flex items-center justify-between mb-1">
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">Reading start</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">{{ t('library.creator.reading.readingStart.title') }}</p>
         <span class="text-sm font-medium text-foreground tabular-nums">{{ readingThreshold }}%</span>
       </div>
-      <p class="text-xs text-muted-foreground mb-3">A book is marked as "reading" once this percentage of progress is reached.</p>
+      <p class="text-xs text-muted-foreground mb-3">{{ t('library.creator.reading.readingStart.hint') }}</p>
       <input type="range" :value="readingThreshold" min="0.05" max="5" step="0.05" class="w-full accent-primary" @input="onReadingThresholdInput" />
       <div class="flex justify-between text-xs text-muted-foreground mt-1">
         <span>0.05%</span>
@@ -39,10 +43,10 @@ function onFinishPercentInput(e: Event) {
     <!-- Mark as finished -->
     <div>
       <div class="flex items-center justify-between mb-1">
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">Mark as finished</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">{{ t('library.creator.reading.markAsFinished.title') }}</p>
         <span class="text-sm font-medium text-foreground tabular-nums">{{ markAsFinishedPercentComplete }}%</span>
       </div>
-      <p class="text-xs text-muted-foreground mb-3">A book is automatically marked as "read" when this percentage of progress is reached.</p>
+      <p class="text-xs text-muted-foreground mb-3">{{ t('library.creator.reading.markAsFinished.hint') }}</p>
       <input
         type="range"
         :value="markAsFinishedPercentComplete"

--- a/client/src/features/library/components/LibraryCreatorScanner.vue
+++ b/client/src/features/library/components/LibraryCreatorScanner.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Lock, Plus, X } from '@lucide/vue'
 import type { OrganizationMode } from '@bookorbit/types'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FORMAT_LABELS } from '../composables/useLibraryCreator'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   organizationMode: OrganizationMode
@@ -19,9 +22,6 @@ const emit = defineEmits<{
 }>()
 
 // ── Scan mode ─────────────────────────────────────────────────────────────────
-
-const ORGANIZATION_MODE_LOCK_TOOLTIP =
-  'Organization mode is fixed after library creation because changing it can create duplicate or missing book entries. To use a different mode, create a new library and rescan.'
 
 function handleSelectMode(mode: OrganizationMode) {
   if (props.organizationModeLocked) return
@@ -85,18 +85,18 @@ function onPatternKeydown(e: KeyboardEvent) {
     <!-- Scan mode -->
     <div>
       <div class="flex items-center gap-2 mb-3">
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">Scan mode</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">{{ t('library.creator.scanner.scanMode.title') }}</p>
         <Tooltip v-if="organizationModeLocked">
           <TooltipTrigger as-child>
             <span
               class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-border text-muted-foreground cursor-help"
-              aria-label="Organization mode is locked"
+              :aria-label="t('library.creator.scanner.scanMode.lockedAria')"
             >
               <Lock :size="11" />
             </span>
           </TooltipTrigger>
           <TooltipContent class="max-w-72 text-xs leading-relaxed">
-            {{ ORGANIZATION_MODE_LOCK_TOOLTIP }}
+            {{ t('library.creator.scanner.scanMode.lockTooltip') }}
           </TooltipContent>
         </Tooltip>
       </div>
@@ -120,11 +120,13 @@ function onPatternKeydown(e: KeyboardEvent) {
             >
               <span v-if="organizationMode === 'book_per_folder'" class="w-1.5 h-1.5 rounded-full bg-primary" />
             </span>
-            <span class="text-sm font-semibold text-foreground">Folder as Book</span>
-            <span class="ml-auto text-[10px] font-medium text-primary bg-primary/10 px-1.5 py-0.5 rounded">Recommended</span>
+            <span class="text-sm font-semibold text-foreground">{{ t('library.creator.scanner.scanMode.folderAsBook.title') }}</span>
+            <span class="ml-auto text-[10px] font-medium text-primary bg-primary/10 px-1.5 py-0.5 rounded">{{
+              t('library.creator.scanner.scanMode.recommended')
+            }}</span>
           </div>
           <p class="text-xs text-muted-foreground leading-relaxed">
-            All files in a folder are grouped into one book. Works well when you keep multiple formats, like EPUB and MOBI, together.
+            {{ t('library.creator.scanner.scanMode.folderAsBook.hint') }}
           </p>
         </button>
 
@@ -147,11 +149,10 @@ function onPatternKeydown(e: KeyboardEvent) {
             >
               <span v-if="organizationMode === 'book_per_file'" class="w-1.5 h-1.5 rounded-full bg-primary" />
             </span>
-            <span class="text-sm font-semibold text-foreground">File as Book</span>
+            <span class="text-sm font-semibold text-foreground">{{ t('library.creator.scanner.scanMode.fileAsBook.title') }}</span>
           </div>
           <p class="text-xs text-muted-foreground leading-relaxed">
-            Treats every file as an individual book. Best suited for libraries with one format per title. Avoid if your audiobooks span multiple
-            files.
+            {{ t('library.creator.scanner.scanMode.fileAsBook.hint') }}
           </p>
         </button>
       </div>
@@ -162,17 +163,23 @@ function onPatternKeydown(e: KeyboardEvent) {
       <!-- Allowed formats -->
       <div class="mb-8">
         <div class="flex items-center justify-between mb-1">
-          <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">Allowed formats</p>
+          <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80">
+            {{ t('library.creator.scanner.allowedFormats.title') }}
+          </p>
           <button
             v-if="allowedFormats.length > 0"
             class="text-xs text-muted-foreground hover:text-foreground transition-colors"
             @click="selectAllFormats"
           >
-            Allow all
+            {{ t('library.creator.scanner.allowedFormats.allowAll') }}
           </button>
         </div>
         <p class="text-xs text-muted-foreground mb-3">
-          {{ allowedFormats.length === 0 ? 'All formats are allowed.' : 'Only the selected formats will be imported.' }}
+          {{
+            allowedFormats.length === 0
+              ? t('library.creator.scanner.allowedFormats.allAllowed')
+              : t('library.creator.scanner.allowedFormats.onlySelected')
+          }}
         </p>
         <div class="flex flex-wrap gap-2">
           <button
@@ -190,15 +197,18 @@ function onPatternKeydown(e: KeyboardEvent) {
           </button>
         </div>
         <p v-if="allowedFormats.length > 0" class="mt-2 text-xs text-amber-600 dark:text-amber-400">
-          Books in other formats already in the library will be marked as missing on the next scan.
+          {{ t('library.creator.scanner.allowedFormats.warning') }}
         </p>
       </div>
 
       <!-- Exclude patterns -->
       <div>
-        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">Exclude patterns</p>
+        <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-1">
+          {{ t('library.creator.scanner.excludePatterns.title') }}
+        </p>
         <p class="text-xs text-muted-foreground mb-3">
-          Glob patterns to skip during scanning (e.g. <code class="font-mono bg-muted px-1 rounded">**/samples/**</code>).
+          {{ t('library.creator.scanner.excludePatterns.hintBefore') }} <code class="font-mono bg-muted px-1 rounded">**/samples/**</code
+          >{{ t('library.creator.scanner.excludePatterns.hintAfter') }}
         </p>
         <div class="flex gap-2 mb-2">
           <input
@@ -213,11 +223,13 @@ function onPatternKeydown(e: KeyboardEvent) {
             @click="addPattern"
           >
             <Plus :size="13" />
-            Add
+            {{ t('library.creator.scanner.excludePatterns.add') }}
           </button>
         </div>
         <div class="min-h-[40px] rounded-md border border-border bg-muted/30 p-2 flex flex-wrap gap-1.5 overflow-y-auto" style="max-height: 80px">
-          <span v-if="excludePatterns.length === 0" class="text-xs text-muted-foreground/50 self-center px-1"> No patterns added. </span>
+          <span v-if="excludePatterns.length === 0" class="text-xs text-muted-foreground/50 self-center px-1">
+            {{ t('library.creator.scanner.excludePatterns.empty') }}
+          </span>
           <span
             v-for="(pattern, i) in excludePatterns"
             :key="pattern"

--- a/client/src/features/library/components/LibraryCreatorSchedule.vue
+++ b/client/src/features/library/components/LibraryCreatorSchedule.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Eye } from '@lucide/vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   watch: boolean
@@ -12,21 +15,21 @@ const emit = defineEmits<{
   'update:autoScanCronExpression': [value: string | null]
 }>()
 
-const PRESETS = [
-  { label: 'Never', value: null },
-  { label: 'Every hour', value: '0 * * * *' },
-  { label: 'Every 6 hours', value: '0 */6 * * *' },
-  { label: 'Every 12 hours', value: '0 */12 * * *' },
-  { label: 'Daily', value: '0 0 * * *' },
-  { label: 'Weekly', value: '0 0 * * 1' },
-  { label: 'Custom', value: '__custom__' },
-]
+const presets = computed(() => [
+  { label: t('library.creator.schedule.presets.never'), value: null },
+  { label: t('library.creator.schedule.presets.hourly'), value: '0 * * * *' },
+  { label: t('library.creator.schedule.presets.every6Hours'), value: '0 */6 * * *' },
+  { label: t('library.creator.schedule.presets.every12Hours'), value: '0 */12 * * *' },
+  { label: t('library.creator.schedule.presets.daily'), value: '0 0 * * *' },
+  { label: t('library.creator.schedule.presets.weekly'), value: '0 0 * * 1' },
+  { label: t('library.creator.schedule.presets.custom'), value: '__custom__' },
+])
 
 const CRON_REGEX = /^((\*|\d+(-\d+)?(,\d+(-\d+)?)*)(\/\d+)? ){4}(\*|\d+(-\d+)?(,\d+(-\d+)?)*)(\/\d+)?$/
 
 const isCustom = computed(() => {
   if (props.autoScanCronExpression === null) return false
-  return !PRESETS.some((p) => p.value === props.autoScanCronExpression)
+  return !presets.value.some((p) => p.value === props.autoScanCronExpression)
 })
 
 const isCronValid = computed(() => {
@@ -49,15 +52,15 @@ function selectPreset(value: string | null) {
 }
 
 function humanReadableCron(cron: string | null): string {
-  if (!cron) return 'Auto-scan disabled'
+  if (!cron) return t('library.creator.schedule.human.disabled')
   const map: Record<string, string> = {
-    '0 * * * *': 'Every hour',
-    '0 */6 * * *': 'Every 6 hours',
-    '0 */12 * * *': 'Every 12 hours',
-    '0 0 * * *': 'Daily at midnight',
-    '0 0 * * 1': 'Weekly on Monday at midnight',
+    '0 * * * *': t('library.creator.schedule.human.hourly'),
+    '0 */6 * * *': t('library.creator.schedule.human.every6Hours'),
+    '0 */12 * * *': t('library.creator.schedule.human.every12Hours'),
+    '0 0 * * *': t('library.creator.schedule.human.dailyMidnight'),
+    '0 0 * * 1': t('library.creator.schedule.human.weeklyMonday'),
   }
-  return map[cron] ?? `Cron: ${cron}`
+  return map[cron] ?? t('library.creator.schedule.human.cron', { cron })
 }
 </script>
 
@@ -65,12 +68,12 @@ function humanReadableCron(cron: string | null): string {
   <div class="px-6 py-6 space-y-8">
     <!-- Watch folders -->
     <div>
-      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-3">File watching</p>
+      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-3">{{ t('library.creator.schedule.fileWatching') }}</p>
       <div class="rounded-lg border border-border overflow-hidden divide-y divide-border">
         <label class="flex items-center justify-between px-5 py-4 bg-card cursor-pointer">
           <div>
-            <p class="text-sm font-medium text-foreground">Watch folders</p>
-            <p class="text-xs text-muted-foreground mt-0.5">Automatically detect new files added to library folders.</p>
+            <p class="text-sm font-medium text-foreground">{{ t('library.creator.schedule.watchFolders.title') }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('library.creator.schedule.watchFolders.hint') }}</p>
           </div>
           <button
             role="switch"
@@ -90,10 +93,10 @@ function humanReadableCron(cron: string | null): string {
 
     <!-- Auto-scan schedule -->
     <div>
-      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-3">Auto-scan schedule</p>
+      <p class="text-[11px] font-semibold uppercase tracking-widest text-foreground/80 mb-3">{{ t('library.creator.schedule.autoScanSchedule') }}</p>
       <div class="grid grid-cols-3 gap-2 mb-4">
         <button
-          v-for="preset in PRESETS"
+          v-for="preset in presets"
           :key="String(preset.value)"
           class="px-3 py-2 rounded-lg border text-xs font-medium transition-colors"
           :class="
@@ -109,7 +112,7 @@ function humanReadableCron(cron: string | null): string {
 
       <!-- Custom cron input -->
       <div v-if="isCustom || selectedPreset === '__custom__'" class="mt-2">
-        <label class="block text-xs font-medium text-muted-foreground mb-1.5">Cron expression</label>
+        <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('library.creator.schedule.cronExpression') }}</label>
         <input
           type="text"
           :value="autoScanCronExpression ?? ''"
@@ -118,8 +121,8 @@ function humanReadableCron(cron: string | null): string {
           :class="isCronValid ? 'border-border focus:ring-ring' : 'border-destructive focus:ring-destructive'"
           @input="emit('update:autoScanCronExpression', ($event.target as HTMLInputElement).value || null)"
         />
-        <p v-if="!isCronValid" class="mt-1 text-xs text-destructive">Invalid cron expression.</p>
-        <p v-else class="mt-1 text-xs text-muted-foreground">Format: minute hour day month weekday</p>
+        <p v-if="!isCronValid" class="mt-1 text-xs text-destructive">{{ t('library.creator.schedule.cronInvalid') }}</p>
+        <p v-else class="mt-1 text-xs text-muted-foreground">{{ t('library.creator.schedule.cronFormat') }}</p>
       </div>
 
       <!-- Human readable preview -->

--- a/client/src/features/metadata-score/components/MetadataScoreBreakdown.vue
+++ b/client/src/features/metadata-score/components/MetadataScoreBreakdown.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Check, Minus } from '@lucide/vue'
 import type { BookDetail, MetadataScoreWeights } from '@bookorbit/types'
 import { METADATA_SCORE_FIELDS, METADATA_SCORE_GROUP_LABELS, type MetadataScoreField, type MetadataScoreGroup } from '@bookorbit/types'
@@ -12,6 +13,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   editMetadata: []
 }>()
+
+const { t } = useI18n()
 
 function handleEditMetadata() {
   emit('editMetadata')
@@ -126,7 +129,7 @@ const missingCount = computed(() => groups.value.flatMap((g) => g.fields).filter
     </div>
     <div v-if="missingCount > 0" class="pt-1 border-t border-border/50">
       <button type="button" class="text-xs text-primary hover:underline" @click="handleEditMetadata">
-        {{ missingCount }} field{{ missingCount === 1 ? '' : 's' }} missing - edit metadata
+        {{ t('metadataScore.missingFields', { count: missingCount }, missingCount) }}
       </button>
     </div>
   </div>

--- a/client/src/features/migration/components/MigrationModal.vue
+++ b/client/src/features/migration/components/MigrationModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Eye, EyeOff, Loader2, X, ChevronLeft, ChevronRight, Check, AlertCircle, RotateCcw } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import SearchableUserSelect from './SearchableUserSelect.vue'
@@ -44,6 +45,8 @@ interface StepDefinition {
 }
 
 const emit = defineEmits<{ close: [] }>()
+
+const { t } = useI18n()
 
 const { subscribeRun, unsubscribeRun, getProgress: getSocketProgress, progressMap: socketProgressMap } = useMigrationProgress()
 
@@ -138,18 +141,18 @@ const mediaRootPathHint = computed(() => {
   if (!path) {
     return {
       className: 'text-amber-600',
-      text: 'Required for migrating book covers.',
+      text: t('migration.source.mediaPath.hintRequired'),
     }
   }
   if (!path.startsWith('/')) {
     return {
       className: 'text-amber-600',
-      text: 'Use an absolute path (for example: /books). Relative paths are not supported.',
+      text: t('migration.source.mediaPath.hintAbsolute'),
     }
   }
   return {
     className: 'text-muted-foreground',
-    text: 'Cover import path configured. Use Test Connection to verify access and Booklore images folder structure.',
+    text: t('migration.source.mediaPath.hintConfigured'),
   }
 })
 
@@ -179,15 +182,15 @@ const preflight = computed(() => {
     dryRunFresh = currentPlan.profileId === currentProfile.id && planCreated >= profileUpdated && planCreated >= sourceValidatedAt
   }
 
-  if (!currentSource) issues.push('Save source connection settings')
-  else if (!sourceValidated) issues.push('Validate source connection')
-  if (!currentProfile) issues.push('Save user and path mappings')
-  else if (!pathMappingsValidated) issues.push('Save path mappings to validate them')
-  if (!dryRunFresh) issues.push('Run a fresh dry-run')
+  if (!currentSource) issues.push(t('migration.preflight.issues.saveSource'))
+  else if (!sourceValidated) issues.push(t('migration.preflight.issues.validateSource'))
+  if (!currentProfile) issues.push(t('migration.preflight.issues.saveMappings'))
+  else if (!pathMappingsValidated) issues.push(t('migration.preflight.issues.savePathMappings'))
+  if (!dryRunFresh) issues.push(t('migration.preflight.issues.freshDryRun'))
   else if ((currentPlan?.summary?.duplicateBookMatches ?? 0) > 0 || currentPlan?.summary?.status === 'blocked') {
-    issues.push('Resolve duplicate target book matches in the dry-run')
+    issues.push(t('migration.preflight.issues.resolveDuplicates'))
   }
-  if (hasActiveRun.value) issues.push('Wait for active run to finish')
+  if (hasActiveRun.value) issues.push(t('migration.preflight.issues.waitForRun'))
 
   return { sourceValidated, pathMappingsValidated, dryRunFresh, ready: issues.length === 0, issues }
 })
@@ -211,11 +214,11 @@ const stepStatus = computed(() => {
 const stepperSteps = computed<StepDefinition[]>(() => {
   const s = stepStatus.value
   return [
-    { label: 'Source Connection', status: s.source === 'done' ? 'done' : s.source === 'saved' ? 'saved' : 'pending' },
-    { label: 'User & Path Mapping', status: s.mappings },
-    { label: 'Dry Run', status: s.dryRun },
-    { label: 'Run Migration', status: s.migration },
-    { label: 'Report', status: run.value ? 'done' : 'pending' },
+    { label: t('migration.steps.source.short'), status: s.source === 'done' ? 'done' : s.source === 'saved' ? 'saved' : 'pending' },
+    { label: t('migration.steps.mappings.short'), status: s.mappings },
+    { label: t('migration.steps.dryRun.short'), status: s.dryRun },
+    { label: t('migration.steps.migration.short'), status: s.migration },
+    { label: t('migration.steps.report.short'), status: run.value ? 'done' : 'pending' },
   ]
 })
 
@@ -276,33 +279,45 @@ function onBackOrCancel() {
   else handleClose()
 }
 
-const stepTitles = ['Source Connection', 'User & Path Mapping', 'Dry Run', 'Run Migration', 'Migration Report']
-const stepSubtitles = [
-  'Configure the database connection to your source Booklore instance.',
-  'Map source users to target users and translate file paths.',
-  'Preview what will be imported before running the live migration.',
-  'Start the live import and monitor its progress.',
-  'Review what was imported and export a detailed report.',
-]
-const continueLabels = ['Continue to Mappings', 'Continue to Dry Run', 'Continue to Migration', 'View Report', '']
+const stepTitles = computed(() => [
+  t('migration.steps.source.title'),
+  t('migration.steps.mappings.title'),
+  t('migration.steps.dryRun.title'),
+  t('migration.steps.migration.title'),
+  t('migration.steps.report.title'),
+])
+const stepSubtitles = computed(() => [
+  t('migration.steps.source.subtitle'),
+  t('migration.steps.mappings.subtitle'),
+  t('migration.steps.dryRun.subtitle'),
+  t('migration.steps.migration.subtitle'),
+  t('migration.steps.report.subtitle'),
+])
+const continueLabels = computed(() => [
+  t('migration.footer.continueToMappings'),
+  t('migration.footer.continueToDryRun'),
+  t('migration.footer.continueToMigration'),
+  t('migration.footer.viewReport'),
+  '',
+])
 
-const currentStepTitle = computed(() => stepTitles[currentStep.value] ?? '')
-const currentStepSubtitle = computed(() => stepSubtitles[currentStep.value] ?? '')
-const continueLabel = computed(() => continueLabels[currentStep.value] ?? '')
+const currentStepTitle = computed(() => stepTitles.value[currentStep.value] ?? '')
+const currentStepSubtitle = computed(() => stepSubtitles.value[currentStep.value] ?? '')
+const continueLabel = computed(() => continueLabels.value[currentStep.value] ?? '')
 
 const currentStepBadge = computed((): { label: string; cls: string } | null => {
   const s = stepStatus.value
   const n = currentStep.value
   if (n === 0) {
-    if (s.source === 'done') return { label: 'Validated', cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
-    if (s.source === 'saved') return { label: 'Saved', cls: 'text-amber-700 bg-amber-500/10 border-amber-500/20' }
+    if (s.source === 'done') return { label: t('migration.badge.validated'), cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
+    if (s.source === 'saved') return { label: t('migration.status.saved'), cls: 'text-amber-700 bg-amber-500/10 border-amber-500/20' }
   }
-  if (n === 1 && s.mappings === 'done') return { label: 'Saved', cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
-  if (n === 2 && s.dryRun === 'done') return { label: 'Up to date', cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
+  if (n === 1 && s.mappings === 'done') return { label: t('migration.status.saved'), cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
+  if (n === 2 && s.dryRun === 'done') return { label: t('migration.badge.upToDate'), cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
   if (n === 3) {
-    if (s.migration === 'done') return { label: 'Completed', cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
-    if (s.migration === 'running') return { label: 'Running', cls: 'text-sky-700 bg-sky-500/10 border-sky-500/20' }
-    if (s.migration === 'failed') return { label: 'Failed', cls: 'text-red-700 bg-red-500/10 border-red-500/20' }
+    if (s.migration === 'done') return { label: t('migration.badge.completed'), cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
+    if (s.migration === 'running') return { label: t('migration.status.running'), cls: 'text-sky-700 bg-sky-500/10 border-sky-500/20' }
+    if (s.migration === 'failed') return { label: t('migration.status.failed'), cls: 'text-red-700 bg-red-500/10 border-red-500/20' }
   }
   return null
 })
@@ -365,16 +380,16 @@ function sourceBookLabel(dup: DuplicateBookMatch, sourceId: string): string {
   const candidate = dup.sourceCandidates?.find((row) => row.sourceBookId === sourceId)
   const title = candidate?.title?.trim()
   if (title) return title
-  return `Source record ID #${sourceId}`
+  return t('migration.duplicates.sourceRecordId', { id: sourceId })
 }
 
 function sourceBookSecondary(dup: DuplicateBookMatch, sourceId: string): string | null {
   const candidate = dup.sourceCandidates?.find((row) => row.sourceBookId === sourceId)
   const author = candidate?.author?.trim()
-  if (author) return `by ${author} (ID: ${sourceId})`
+  if (author) return t('migration.duplicates.byAuthor', { author, id: sourceId })
   const filePath = candidate?.filePath?.trim()
-  if (filePath) return `${filePath} (ID: ${sourceId})`
-  return `Booklore source ID: ${sourceId}`
+  if (filePath) return t('migration.duplicates.byFilePath', { filePath, id: sourceId })
+  return t('migration.duplicates.bookloreSourceId', { id: sourceId })
 }
 
 function recommendedSourceBookId(dup: DuplicateBookMatch): string | null {
@@ -404,7 +419,7 @@ function isRecommendedSourceBook(dup: DuplicateBookMatch, sourceId: string): boo
 }
 
 function targetBookLabel(targetBookId: number): string {
-  return duplicateTargetBookLabels.value.get(targetBookId) ?? `Library book #${targetBookId}`
+  return duplicateTargetBookLabels.value.get(targetBookId) ?? t('migration.duplicates.libraryBookId', { id: targetBookId })
 }
 
 function pruneDuplicateResolutions() {
@@ -444,11 +459,11 @@ async function loadDuplicateTargetBookLabels() {
     missingTargetIds.map(async (targetBookId) => {
       try {
         const response = await api(`/api/v1/books/${targetBookId}`)
-        if (!response.ok) return [targetBookId, `Library book #${targetBookId}`] as const
+        if (!response.ok) return [targetBookId, t('migration.duplicates.libraryBookId', { id: targetBookId })] as const
         const payload = asRecord(await response.json())
-        return [targetBookId, asString(payload.title) ?? `Library book #${targetBookId}`] as const
+        return [targetBookId, asString(payload.title) ?? t('migration.duplicates.libraryBookId', { id: targetBookId })] as const
       } catch {
-        return [targetBookId, `Library book #${targetBookId}`] as const
+        return [targetBookId, t('migration.duplicates.libraryBookId', { id: targetBookId })] as const
       }
     }),
   )
@@ -507,7 +522,7 @@ const migrationProgress = computed(() => {
   if (!currentRun || currentRun.state !== 'running') return null
 
   const currentStage = currentRun.currentStage ?? 'init'
-  if (currentStage === 'completed') return { percent: 100, label: 'Completed' }
+  if (currentStage === 'completed') return { percent: 100, label: t('migration.badge.completed') }
 
   const stageIdx = STAGE_NAMES.indexOf(currentStage as (typeof STAGE_NAMES)[number])
   const completedStages = stageIdx >= 0 ? stageIdx : 0
@@ -515,10 +530,10 @@ const migrationProgress = computed(() => {
   const percent = Math.min(Math.round(completedStages * stageWeight + stageWeight * 0.5), 99)
 
   const stageLabels: Record<string, string> = {
-    init: 'Initializing',
-    shared_overlays: 'Importing metadata',
-    book_covers: 'Importing covers',
-    user_state: 'Importing user data',
+    init: t('migration.stages.init'),
+    shared_overlays: t('migration.stages.sharedOverlays'),
+    book_covers: t('migration.stages.bookCovers'),
+    user_state: t('migration.stages.userState'),
   }
 
   return { percent, label: stageLabels[currentStage] ?? currentStage }
@@ -593,7 +608,7 @@ async function initialize() {
     await Promise.all([loadSupportedTypes(), loadTargetUsers(), loadTargetLibraryFolders()])
     await refreshWorkflowState()
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to initialize migration settings'))
+    toast.error(getErrorMessage(error, t('migration.toast.initFailed')))
   } finally {
     loading.value = false
   }
@@ -604,7 +619,7 @@ async function loadSupportedTypes() {
     supportedTypes.value = await listSupportedSourceTypes()
   } catch (error) {
     supportedTypes.value = []
-    toast.error(getErrorMessage(error, 'Failed to load supported migration source types'))
+    toast.error(getErrorMessage(error, t('migration.toast.loadSupportedTypesFailed')))
   }
 }
 
@@ -614,7 +629,7 @@ async function loadTargetUsers() {
     targetUsers.value = await listTargetUsers()
   } catch (error) {
     targetUsers.value = []
-    toast.error(getErrorMessage(error, 'Failed to load target users'))
+    toast.error(getErrorMessage(error, t('migration.toast.loadTargetUsersFailed')))
   } finally {
     busy.loadingTargetUsers = false
   }
@@ -625,7 +640,7 @@ async function loadTargetLibraryFolders() {
     targetLibraryFolders.value = await listTargetLibraryFolders()
   } catch (error) {
     targetLibraryFolders.value = []
-    toast.error(getErrorMessage(error, 'Failed to load target library folders'))
+    toast.error(getErrorMessage(error, t('migration.toast.loadTargetFoldersFailed')))
   }
 }
 
@@ -705,11 +720,11 @@ async function hydrateUserMappingsFromSuggestions(showSuccessToast: boolean) {
       targetUserId: savedMappings.get(row.sourceUserId) ?? row.suggestedTargetUserId ?? fallbackSingleTargetUserId,
     }))
     if (showSuccessToast) {
-      if (userMappings.value.length === 0) toast.warning('No source users were returned')
-      else toast.success('User mapping suggestions loaded')
+      if (userMappings.value.length === 0) toast.warning(t('migration.toast.noSourceUsers'))
+      else toast.success(t('migration.toast.suggestionsLoaded'))
     }
   } catch (error) {
-    if (showSuccessToast) toast.error(getErrorMessage(error, 'Failed to load user mapping suggestions'))
+    if (showSuccessToast) toast.error(getErrorMessage(error, t('migration.toast.loadSuggestionsFailed')))
   } finally {
     busy.loadingSuggestions = false
   }
@@ -741,7 +756,7 @@ function extractMediaPathWarnings(result: Record<string, unknown>): string[] {
 
 async function onTestSource() {
   if (!hasValidSourceDraft()) {
-    toast.error('Host, user, database, and source name are required')
+    toast.error(t('migration.toast.sourceFieldsRequired'))
     return
   }
   busy.testingSource = true
@@ -752,15 +767,17 @@ async function onTestSource() {
     if (result.ok === true) {
       if (warnings.length > 0) {
         const mediaPathWarning = warnings.find((warning) => /mediarootpath/i.test(warning))
-        const highlightedWarning = mediaPathWarning ?? warnings[0] ?? 'Connection test passed with warnings'
+        const highlightedWarning = mediaPathWarning ?? warnings[0] ?? t('migration.toast.connectionPassedWithWarnings')
         toast.warning(
-          warnings.length === 1 ? highlightedWarning : `Connection test passed with ${warnings.length} warning(s). First: ${highlightedWarning}`,
+          warnings.length === 1
+            ? highlightedWarning
+            : t('migration.toast.connectionPassedWithWarningCount', { count: warnings.length, warning: highlightedWarning }),
         )
       } else {
-        toast.success('Connection test passed')
+        toast.success(t('migration.toast.connectionPassed'))
       }
     } else {
-      toast.warning(`Connection ok, but ${missing} required table(s) are missing`)
+      toast.warning(t('migration.toast.connectionMissingTables', { count: missing }))
     }
   } catch (error) {
     toast.error(friendlyConnectionError(error))
@@ -771,24 +788,24 @@ async function onTestSource() {
 
 async function onTestMediaPath() {
   if (hasActiveRun.value) {
-    toast.error('Cannot test media path while a run is active')
+    toast.error(t('migration.toast.cannotTestMediaWhileRunning'))
     return
   }
   if (!hasValidSourceDraft()) {
-    toast.error('Host, user, database, and source name are required')
+    toast.error(t('migration.toast.sourceFieldsRequired'))
     return
   }
   const mediaRootPath = sourceDraft.mediaRootPath.trim()
   if (!mediaRootPath) {
     mediaPathTestState.value = 'fail'
-    const message = 'Media Root Path is required for cover import.'
+    const message = t('migration.toast.mediaPathRequired')
     mediaPathTestMessage.value = message
     toast.error(message)
     return
   }
   if (!mediaRootPath.startsWith('/')) {
     mediaPathTestState.value = 'fail'
-    const message = 'Use an absolute path (for example: /books).'
+    const message = t('migration.toast.mediaPathAbsolute')
     mediaPathTestMessage.value = message
     toast.error(message)
     return
@@ -800,16 +817,16 @@ async function onTestMediaPath() {
     const mediaWarnings = extractMediaPathWarnings(result)
     if (result.ok === true && mediaWarnings.length === 0) {
       mediaPathTestState.value = 'pass'
-      mediaPathTestMessage.value = 'Media path verified.'
-      toast.success('Media path is valid and readable')
+      mediaPathTestMessage.value = t('migration.toast.mediaPathVerified')
+      toast.success(t('migration.toast.mediaPathValid'))
     } else if (mediaWarnings.length > 0) {
       mediaPathTestState.value = 'fail'
-      const message = mediaWarnings[0] ?? 'Media path validation failed.'
+      const message = mediaWarnings[0] ?? t('migration.toast.mediaPathValidationFailed')
       mediaPathTestMessage.value = message
       toast.warning(message)
     } else {
       mediaPathTestState.value = 'fail'
-      const message = 'Connection test failed before media path validation could complete.'
+      const message = t('migration.toast.connectionFailedBeforeMedia')
       mediaPathTestMessage.value = message
       toast.warning(message)
     }
@@ -825,11 +842,11 @@ async function onTestMediaPath() {
 
 async function onSaveAndValidate() {
   if (hasActiveRun.value) {
-    toast.error('Cannot modify source while a run is active')
+    toast.error(t('migration.toast.cannotModifySourceWhileRunning'))
     return
   }
   if (!hasValidSourceDraft()) {
-    toast.error('Host, user, database, and source name are required')
+    toast.error(t('migration.toast.sourceFieldsRequired'))
     return
   }
   busy.savingSource = true
@@ -842,10 +859,10 @@ async function onSaveAndValidate() {
       const warnings = Array.isArray(result.warnings) ? (result.warnings as unknown[]).filter((w): w is string => typeof w === 'string') : []
       await refreshWorkflowState()
       await autoLoadPathPrefixes()
-      toast.success(warnings.length > 0 ? `Source saved and validated with ${warnings.length} warning(s)` : 'Source saved and validated')
+      toast.success(warnings.length > 0 ? t('migration.toast.sourceSavedWithWarnings', { count: warnings.length }) : t('migration.toast.sourceSaved'))
     }
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to save or validate source'))
+    toast.error(getErrorMessage(error, t('migration.toast.saveSourceFailed')))
   } finally {
     busy.savingSource = false
   }
@@ -901,21 +918,21 @@ function cleanedUserMappings() {
 
 async function onSaveMappings() {
   if (hasActiveRun.value) {
-    toast.error('Cannot save mappings while a run is active')
+    toast.error(t('migration.toast.cannotSaveMappingsWhileRunning'))
     return
   }
   const currentSource = source.value
   if (!currentSource) {
-    toast.error('Save source first')
+    toast.error(t('migration.toast.saveSourceFirst'))
     return
   }
   const mappings = cleanedUserMappings()
   if (mappings.length === 0) {
-    toast.error('Map at least one source user to a target user')
+    toast.error(t('migration.toast.mapAtLeastOneUser'))
     return
   }
   if (mappings.length !== userMappings.value.length) {
-    toast.error('Map every source user before saving')
+    toast.error(t('migration.toast.mapEveryUser'))
     return
   }
 
@@ -926,7 +943,7 @@ async function onSaveMappings() {
       try {
         pathValidation.value = await validatePathMappings(currentSource.id, { pathMappings: cleanedPaths, sampleLimit: 10 })
       } catch (pathError) {
-        toast.warning(getErrorMessage(pathError, 'Path validation failed, but profile will still be saved'))
+        toast.warning(getErrorMessage(pathError, t('migration.toast.pathValidationFailedButSaved')))
       }
     }
     await createProfile({
@@ -943,9 +960,9 @@ async function onSaveMappings() {
       },
     })
     await refreshWorkflowState()
-    toast.success('Mappings saved')
+    toast.success(t('migration.toast.mappingsSaved'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to save mappings'))
+    toast.error(getErrorMessage(error, t('migration.toast.saveMappingsFailed')))
   } finally {
     busy.savingProfile = false
   }
@@ -953,12 +970,12 @@ async function onSaveMappings() {
 
 async function onRunDryRun() {
   if (hasActiveRun.value) {
-    toast.error('Cannot run dry-run while a run is active')
+    toast.error(t('migration.toast.cannotDryRunWhileRunning'))
     return
   }
   const currentProfile = profile.value
   if (!currentProfile) {
-    toast.error('Save mappings first')
+    toast.error(t('migration.toast.saveMappingsFirst'))
     return
   }
   busy.dryRun = true
@@ -967,9 +984,9 @@ async function onRunDryRun() {
     await refreshWorkflowState()
     const matched = artifact.summary?.matchedBooks ?? 0
     const unresolved = artifact.summary?.unresolvedBooks ?? 0
-    toast.success(`Dry-run completed: ${matched} matched, ${unresolved} unresolved`)
+    toast.success(t('migration.toast.dryRunCompleted', { matched, unresolved }))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Dry-run failed'))
+    toast.error(getErrorMessage(error, t('migration.toast.dryRunFailed')))
   } finally {
     busy.dryRun = false
   }
@@ -986,7 +1003,7 @@ async function onResolveDuplicates() {
   if (matches.length === 0) return
   const unresolved = matches.filter((m) => !duplicateResolutions.value.has(m.targetBookId))
   if (unresolved.length > 0) {
-    toast.error(`Select a source book for all ${unresolved.length} duplicate groups`)
+    toast.error(t('migration.toast.selectSourceForDuplicates', { count: unresolved.length }))
     return
   }
 
@@ -996,9 +1013,9 @@ async function onResolveDuplicates() {
     await resolveDuplicateMatches(currentPlan.id, resolutions)
     duplicateResolutions.value = new Map()
     await refreshWorkflowState()
-    toast.success('Duplicate matches resolved')
+    toast.success(t('migration.toast.duplicatesResolved'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to resolve duplicates'))
+    toast.error(getErrorMessage(error, t('migration.toast.resolveDuplicatesFailed')))
   } finally {
     busy.resolvingDuplicates = false
   }
@@ -1008,12 +1025,12 @@ const confirmingMigrationStart = ref(false)
 
 async function onStartMigration() {
   if (!preflight.value.ready) {
-    toast.error(preflight.value.issues[0] ?? 'Migration preflight not ready')
+    toast.error(preflight.value.issues[0] ?? t('migration.toast.preflightNotReady'))
     return
   }
   const currentPlan = plan.value
   if (!currentPlan) {
-    toast.error('Run dry-run first')
+    toast.error(t('migration.toast.runDryRunFirst'))
     return
   }
   if (!confirmingMigrationStart.value) {
@@ -1027,9 +1044,9 @@ async function onStartMigration() {
     await startLiveRun({ planArtifactId: currentPlan.id })
     await refreshWorkflowState()
     await refreshRunProgress()
-    toast.success('Migration run started')
+    toast.success(t('migration.toast.runStarted'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to start migration'))
+    toast.error(getErrorMessage(error, t('migration.toast.startFailed')))
   } finally {
     busy.startingRun = false
   }
@@ -1046,9 +1063,9 @@ async function onCancelRun() {
   try {
     await cancelRun(currentRun.id)
     await refreshWorkflowState()
-    toast.success('Migration run cancelled')
+    toast.success(t('migration.toast.runCancelled'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to cancel migration'))
+    toast.error(getErrorMessage(error, t('migration.toast.cancelFailed')))
   } finally {
     busy.cancellingRun = false
   }
@@ -1061,9 +1078,9 @@ async function onRetryRun() {
   try {
     await retryRun(currentRun.id)
     await refreshWorkflowState()
-    toast.success('Migration run retried - resuming from last completed stage')
+    toast.success(t('migration.toast.runRetried'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to retry migration'))
+    toast.error(getErrorMessage(error, t('migration.toast.retryFailed')))
   } finally {
     busy.retryingRun = false
   }
@@ -1077,7 +1094,7 @@ async function refreshRunProgress() {
     runProgress.value = await getRunProgress(currentRun.id)
     if (runProgress.value.run.state !== 'running') await refreshWorkflowState()
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to load run progress'))
+    toast.error(getErrorMessage(error, t('migration.toast.loadProgressFailed')))
   } finally {
     busy.loadingProgress = false
   }
@@ -1086,15 +1103,15 @@ async function refreshRunProgress() {
 async function onRefreshReport() {
   const currentRun = run.value
   if (!currentRun) {
-    toast.error('Start migration first')
+    toast.error(t('migration.toast.startMigrationFirst'))
     return
   }
   busy.loadingReport = true
   try {
     runReport.value = await getRunReport(currentRun.id)
-    toast.success('Run report refreshed')
+    toast.success(t('migration.toast.reportRefreshed'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to load run report'))
+    toast.error(getErrorMessage(error, t('migration.toast.loadReportFailed')))
   } finally {
     busy.loadingReport = false
   }
@@ -1114,16 +1131,16 @@ function onTogglePassword() {
 async function exportReport(format: 'json' | 'csv') {
   const currentRun = run.value
   if (!currentRun) {
-    toast.error('Start migration first')
+    toast.error(t('migration.toast.startMigrationFirst'))
     return
   }
   busy.exporting = true
   try {
     const exported = await exportRunReport(currentRun.id, format)
     downloadTextFile(exported.fileName, exported.content, exported.contentType)
-    toast.success(`Report exported as ${format.toUpperCase()}`)
+    toast.success(t('migration.toast.reportExported', { format: format.toUpperCase() }))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to export migration report'))
+    toast.error(getErrorMessage(error, t('migration.toast.exportFailed')))
   } finally {
     busy.exporting = false
   }
@@ -1154,24 +1171,24 @@ function formatDuration(ms: number): string {
 }
 
 function friendlyUnresolvedReason(reason: string | null): string {
-  if (reason === 'no_title_author_match') return 'No matching book found by title or author'
-  if (reason === 'no_file_path_match') return 'File path did not match any book in this library'
-  if (reason === 'no_file_hash_match') return 'File hash did not match any book in this library'
-  if (reason === 'no_isbn_match') return 'ISBN did not match any book in this library'
-  if (reason === 'insufficient_source_data') return 'Not enough metadata to attempt matching'
-  if (reason === 'ambiguous_isbn_match') return 'Multiple books matched the same ISBN'
-  if (reason === 'ambiguous_file_hash_match') return 'Multiple books matched the same file hash'
-  if (reason === 'ambiguous_file_path_match') return 'Multiple books matched the same file path'
-  if (reason === 'ambiguous_title_author_match') return 'Multiple books matched the same title and author'
-  return reason ?? 'Could not determine reason'
+  if (reason === 'no_title_author_match') return t('migration.unresolvedReason.noTitleAuthorMatch')
+  if (reason === 'no_file_path_match') return t('migration.unresolvedReason.noFilePathMatch')
+  if (reason === 'no_file_hash_match') return t('migration.unresolvedReason.noFileHashMatch')
+  if (reason === 'no_isbn_match') return t('migration.unresolvedReason.noIsbnMatch')
+  if (reason === 'insufficient_source_data') return t('migration.unresolvedReason.insufficientSourceData')
+  if (reason === 'ambiguous_isbn_match') return t('migration.unresolvedReason.ambiguousIsbnMatch')
+  if (reason === 'ambiguous_file_hash_match') return t('migration.unresolvedReason.ambiguousFileHashMatch')
+  if (reason === 'ambiguous_file_path_match') return t('migration.unresolvedReason.ambiguousFilePathMatch')
+  if (reason === 'ambiguous_title_author_match') return t('migration.unresolvedReason.ambiguousTitleAuthorMatch')
+  return reason ?? t('migration.unresolvedReason.unknown')
 }
 
 function friendlyMatchStrategy(strategy: string | null): string {
-  if (strategy === 'isbn') return 'Matched by ISBN'
-  if (strategy === 'file_hash') return 'Matched by file hash'
-  if (strategy === 'path_mapping') return 'Matched by mapped file path'
-  if (strategy === 'title_author') return 'Matched by title and author'
-  return strategy ?? 'Match strategy unavailable'
+  if (strategy === 'isbn') return t('migration.matchStrategy.isbn')
+  if (strategy === 'file_hash') return t('migration.matchStrategy.fileHash')
+  if (strategy === 'path_mapping') return t('migration.matchStrategy.pathMapping')
+  if (strategy === 'title_author') return t('migration.matchStrategy.titleAuthor')
+  return strategy ?? t('migration.matchStrategy.unavailable')
 }
 
 function describeUserPreviewCounts(counts: {
@@ -1182,7 +1199,14 @@ function describeUserPreviewCounts(counts: {
   annotations: number
   shelves: number
 }): string {
-  return `${counts.statuses} statuses, ${counts.fileProgress} progress entries, ${counts.readingSessions ?? 0} reading sessions, ${counts.bookmarks} bookmarks, ${counts.annotations} annotations, ${counts.shelves} collection entries`
+  return t('migration.report.userPreviewCounts', {
+    statuses: counts.statuses,
+    progress: counts.fileProgress,
+    sessions: counts.readingSessions ?? 0,
+    bookmarks: counts.bookmarks,
+    annotations: counts.annotations,
+    collections: counts.shelves,
+  })
 }
 
 function extractPlanUnresolvedBooks(planPayload: unknown): ReportUnresolvedBook[] {
@@ -1200,11 +1224,11 @@ function extractPlanUnresolvedBooks(planPayload: unknown): ReportUnresolvedBook[
 
 function friendlyConnectionError(error: unknown): string {
   const msg = error instanceof Error ? error.message : String(error)
-  if (/ECONNREFUSED|ENOTFOUND|connect ETIMEDOUT/i.test(msg)) return 'Could not reach the database server. Check the host and port.'
-  if (/Access denied|authentication failed/i.test(msg)) return 'Authentication failed. Check the username and password.'
-  if (/Unknown database/i.test(msg)) return 'Database not found. Check the database name.'
-  if (/ETIMEDOUT|timeout/i.test(msg)) return 'Connection timed out. Check host and firewall settings.'
-  return msg || 'Connection test failed'
+  if (/ECONNREFUSED|ENOTFOUND|connect ETIMEDOUT/i.test(msg)) return t('migration.connectionError.unreachable')
+  if (/Access denied|authentication failed/i.test(msg)) return t('migration.connectionError.authFailed')
+  if (/Unknown database/i.test(msg)) return t('migration.connectionError.databaseNotFound')
+  if (/ETIMEDOUT|timeout/i.test(msg)) return t('migration.connectionError.timeout')
+  return msg || t('migration.connectionError.generic')
 }
 
 function runStateClass(state: string) {
@@ -1274,18 +1298,19 @@ interface SourceTypeCompatibility {
   note: string
 }
 
-const SOURCE_TYPE_COMPATIBILITY: Record<string, SourceTypeCompatibility> = {
-  booklore: {
-    testedVersions: ['v2.2.2'],
-    note: 'Later versions are likely compatible but have not been verified. Run a dry-run first to confirm before committing data.',
-  },
-  grimmory: {
-    testedVersions: ['v3.0.3'],
-    note: 'Later versions are likely compatible but have not been verified. Run a dry-run first to confirm before committing data.',
-  },
-}
-
-const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => SOURCE_TYPE_COMPATIBILITY[sourceDraft.type] ?? null)
+const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => {
+  const compatibility: Record<string, SourceTypeCompatibility> = {
+    booklore: {
+      testedVersions: ['v2.2.2'],
+      note: t('migration.source.compatibility.note'),
+    },
+    grimmory: {
+      testedVersions: ['v3.0.3'],
+      note: t('migration.source.compatibility.note'),
+    },
+  }
+  return compatibility[sourceDraft.type] ?? null
+})
 </script>
 
 <template>
@@ -1313,7 +1338,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
           <!-- Sidebar (desktop only) -->
           <nav class="hidden md:flex flex-col w-52 shrink-0 bg-muted/40 border-r border-border">
             <div class="px-4 pt-5 pb-4 border-b border-border flex items-center justify-between shrink-0">
-              <span class="font-semibold text-foreground font-serif truncate">Booklore Import</span>
+              <span class="font-semibold text-foreground font-serif truncate">{{ t('migration.sidebarTitle') }}</span>
               <button
                 class="flex items-center justify-center w-6 h-6 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0 ml-1"
                 @click="handleClose"
@@ -1376,21 +1401,26 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                 <div v-if="currentStep === 0" class="space-y-3">
                   <div class="grid gap-2 md:grid-cols-2">
                     <label class="block">
-                      <span class="settings-hint">Source Type</span>
+                      <span class="settings-hint">{{ t('migration.source.fields.type') }}</span>
                       <select v-model="sourceDraft.type" class="select-field mt-1 w-full" :disabled="hasActiveRun">
                         <option v-for="type in supportedTypes" :key="type" :value="type">{{ type }}</option>
                       </select>
                     </label>
                     <label class="block">
-                      <span class="settings-hint">Source Name</span>
-                      <input v-model="sourceDraft.name" class="input-field mt-1 w-full" placeholder="Booklore Import" :disabled="hasActiveRun" />
+                      <span class="settings-hint">{{ t('migration.source.fields.name') }}</span>
+                      <input
+                        v-model="sourceDraft.name"
+                        class="input-field mt-1 w-full"
+                        :placeholder="t('migration.sidebarTitle')"
+                        :disabled="hasActiveRun"
+                      />
                     </label>
                     <label class="block">
-                      <span class="settings-hint">Host</span>
+                      <span class="settings-hint">{{ t('migration.source.fields.host') }}</span>
                       <input v-model="sourceDraft.host" class="input-field mt-1 w-full" placeholder="127.0.0.1" :disabled="hasActiveRun" />
                     </label>
                     <label class="block">
-                      <span class="settings-hint">Port</span>
+                      <span class="settings-hint">{{ t('migration.source.fields.port') }}</span>
                       <input
                         v-model.number="sourceDraft.port"
                         class="input-field mt-1 w-full"
@@ -1401,17 +1431,17 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                       />
                     </label>
                     <label class="block">
-                      <span class="settings-hint">User</span>
+                      <span class="settings-hint">{{ t('migration.source.fields.user') }}</span>
                       <input v-model="sourceDraft.user" class="input-field mt-1 w-full" placeholder="booklore" :disabled="hasActiveRun" />
                     </label>
                     <label class="block">
-                      <span class="settings-hint">Password</span>
+                      <span class="settings-hint">{{ t('migration.source.fields.password') }}</span>
                       <div class="relative mt-1">
                         <input
                           v-model="sourceDraft.password"
                           class="input-field w-full pr-9"
                           :type="showPassword ? 'text' : 'password'"
-                          :placeholder="source ? 'Saved - leave unchanged' : 'No password set'"
+                          :placeholder="source ? t('migration.source.fields.passwordSaved') : t('migration.source.fields.passwordNotSet')"
                           :disabled="hasActiveRun"
                         />
                         <button
@@ -1426,11 +1456,11 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                       </div>
                     </label>
                     <label class="block">
-                      <span class="settings-hint">Database</span>
+                      <span class="settings-hint">{{ t('migration.source.fields.database') }}</span>
                       <input v-model="sourceDraft.database" class="input-field mt-1 w-full" placeholder="booklore" :disabled="hasActiveRun" />
                     </label>
                     <label class="block">
-                      <span class="settings-hint">Media Root Path</span>
+                      <span class="settings-hint">{{ t('migration.source.fields.mediaRootPath') }}</span>
                       <div class="mt-1 flex items-center gap-2">
                         <input
                           v-model="sourceDraft.mediaRootPath"
@@ -1453,7 +1483,13 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                         >
                           <Loader2 v-if="busy.testingMediaPath" class="size-3.5 animate-spin" />
                           <span v-else>
-                            {{ mediaPathTestState === 'pass' ? 'Path OK' : mediaPathTestState === 'fail' ? 'Path Issue' : 'Test Path' }}
+                            {{
+                              mediaPathTestState === 'pass'
+                                ? t('migration.source.mediaPath.buttonOk')
+                                : mediaPathTestState === 'fail'
+                                  ? t('migration.source.mediaPath.buttonIssue')
+                                  : t('migration.source.mediaPath.buttonTest')
+                            }}
                           </span>
                         </button>
                       </div>
@@ -1469,15 +1505,15 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                     <div class="flex items-center">
                       <label class="flex h-9 cursor-pointer items-center gap-2">
                         <input v-model="sourceDraft.ssl" type="checkbox" class="size-4 rounded border-border" :disabled="hasActiveRun" />
-                        <span class="settings-hint">Use TLS/SSL</span>
+                        <span class="settings-hint">{{ t('migration.source.fields.ssl') }}</span>
                       </label>
                     </div>
                   </div>
 
                   <div v-if="sourceTypeCompatibility" class="rounded border border-border bg-muted/40 px-3.5 py-3 text-xs space-y-1">
-                    <p class="font-medium text-foreground">Tested compatibility</p>
+                    <p class="font-medium text-foreground">{{ t('migration.source.compatibility.title') }}</p>
                     <p class="text-muted-foreground">
-                      Verified against:
+                      {{ t('migration.source.compatibility.verifiedAgainst') }}
                       <span class="font-mono font-medium text-foreground">{{ sourceTypeCompatibility.testedVersions.join(', ') }}</span>
                     </p>
                     <p class="text-muted-foreground">{{ sourceTypeCompatibility.note }}</p>
@@ -1486,11 +1522,11 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                   <div class="flex flex-wrap gap-2">
                     <button class="settings-btn-outline" :disabled="busy.testingSource || hasActiveRun" @click="onTestSource">
                       <Loader2 v-if="busy.testingSource" class="size-3.5 animate-spin" />
-                      Test Connection
+                      {{ t('migration.source.testConnection') }}
                     </button>
                     <button class="settings-btn-primary" :disabled="busy.savingSource || hasActiveRun" @click="onSaveAndValidate">
                       <Loader2 v-if="busy.savingSource" class="size-3.5 animate-spin" />
-                      Save &amp; Validate
+                      {{ t('migration.source.saveAndValidate') }}
                     </button>
                   </div>
 
@@ -1498,15 +1534,21 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                     v-if="sourceValidationWarnings.length > 0"
                     class="rounded border border-amber-500/20 bg-amber-500/10 p-3 text-xs text-amber-700 space-y-1"
                   >
-                    <p class="font-medium">Source validated with warnings</p>
+                    <p class="font-medium">{{ t('migration.source.validatedWithWarnings') }}</p>
                     <p v-for="warn in sourceValidationWarnings" :key="warn">{{ warn }}</p>
                   </div>
 
                   <div v-if="sourceCapabilities" class="rounded border border-border bg-muted/40 p-3 text-xs space-y-2">
-                    <p class="font-medium text-foreground">Last validation snapshot</p>
-                    <p class="text-muted-foreground">Source version: {{ sourceCapabilities.sourceVersion ?? 'Unknown' }}</p>
+                    <p class="font-medium text-foreground">{{ t('migration.source.snapshot.title') }}</p>
+                    <p class="text-muted-foreground">
+                      {{
+                        t('migration.source.snapshot.sourceVersion', {
+                          version: sourceCapabilities.sourceVersion ?? t('migration.source.snapshot.unknown'),
+                        })
+                      }}
+                    </p>
                     <p v-if="sourceCapabilities.missingTables.length > 0" class="text-amber-600">
-                      Missing required tables: {{ sourceCapabilities.missingTables.join(', ') }}
+                      {{ t('migration.source.snapshot.missingTables', { tables: sourceCapabilities.missingTables.join(', ') }) }}
                     </p>
                     <div v-if="sourceRowCounts.length > 0" class="grid gap-1 text-muted-foreground sm:grid-cols-2">
                       <p v-for="[key, count] in sourceRowCounts" :key="key">{{ formatSourceCountLabel(key) }}: {{ count }}</p>
@@ -1517,7 +1559,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                 <!-- Step 1: User & Path Mapping -->
                 <div v-else-if="currentStep === 1" class="space-y-5">
                   <div class="flex items-center gap-2">
-                    <p class="text-xs text-muted-foreground">User suggestions load automatically after source validation.</p>
+                    <p class="text-xs text-muted-foreground">{{ t('migration.mappings.suggestionsAutoLoad') }}</p>
                     <button
                       v-if="source"
                       class="text-xs text-primary underline-offset-2 hover:underline disabled:opacity-50"
@@ -1525,7 +1567,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                       @click="onReloadSuggestions"
                     >
                       <Loader2 v-if="busy.loadingSuggestions || busy.loadingTargetUsers" class="size-3 animate-spin inline" />
-                      Refresh
+                      {{ t('migration.mappings.refresh') }}
                     </button>
                   </div>
 
@@ -1533,8 +1575,8 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                     <table class="w-full text-sm">
                       <thead class="bg-muted/40 text-left">
                         <tr>
-                          <th class="px-3 py-2 font-medium">Source User</th>
-                          <th class="px-3 py-2 font-medium">Target User</th>
+                          <th class="px-3 py-2 font-medium">{{ t('migration.mappings.sourceUser') }}</th>
+                          <th class="px-3 py-2 font-medium">{{ t('migration.mappings.targetUser') }}</th>
                         </tr>
                       </thead>
                       <tbody>
@@ -1548,23 +1590,24 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                           </td>
                         </tr>
                         <tr v-if="userMappings.length === 0" class="border-t border-border">
-                          <td colspan="2" class="px-3 py-4 text-sm text-muted-foreground">No source users loaded yet.</td>
+                          <td colspan="2" class="px-3 py-4 text-sm text-muted-foreground">{{ t('migration.mappings.noSourceUsersLoaded') }}</td>
                         </tr>
                       </tbody>
                     </table>
                   </div>
                   <p v-if="!busy.loadingTargetUsers && targetUsers.length === 0" class="text-xs text-amber-600">
-                    No active target users found. Create or re-enable a BookOrbit user before mapping.
+                    {{ t('migration.mappings.noActiveTargetUsers') }}
                   </p>
 
                   <div class="space-y-2">
                     <div class="flex items-center justify-between">
-                      <p class="settings-hint">Path Prefix Mappings</p>
-                      <button class="settings-btn-outline" :disabled="hasActiveRun" @click="addPathMapping">Add Mapping</button>
+                      <p class="settings-hint">{{ t('migration.mappings.pathPrefixMappings') }}</p>
+                      <button class="settings-btn-outline" :disabled="hasActiveRun" @click="addPathMapping">
+                        {{ t('migration.mappings.addMapping') }}
+                      </button>
                     </div>
                     <p class="text-xs text-muted-foreground">
-                      Path mappings translate source file paths to target paths so books can be matched by file location. Books are also matched by
-                      ISBN, file hash, and title/author regardless of path mappings.
+                      {{ t('migration.mappings.pathMappingsExplanation') }}
                     </p>
                     <div
                       v-for="(row, index) in pathMappings"
@@ -1573,36 +1616,43 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                     >
                       <select v-model="row.sourcePrefix" class="select-field w-full min-w-0" :disabled="hasActiveRun">
                         <option value="">
-                          {{ sourcePathPrefixes.length === 0 ? 'No prefixes found - validate source first' : 'Select source prefix...' }}
+                          {{ sourcePathPrefixes.length === 0 ? t('migration.mappings.noPrefixesFound') : t('migration.mappings.selectSourcePrefix') }}
                         </option>
                         <option v-for="prefix in sourcePathPrefixes" :key="prefix" :value="prefix">{{ prefix }}</option>
                       </select>
                       <select v-model="row.targetPrefix" class="select-field w-full min-w-0" :disabled="hasActiveRun">
-                        <option value="">Select target folder...</option>
+                        <option value="">{{ t('migration.mappings.selectTargetFolder') }}</option>
                         <option v-for="folder in targetLibraryFolders" :key="folder.path" :value="folder.path">
                           {{ folder.libraryName }} - {{ folder.path }}
                         </option>
                       </select>
-                      <button class="settings-btn-outline" :disabled="hasActiveRun" @click="removePathMapping(index)">Remove</button>
+                      <button class="settings-btn-outline" :disabled="hasActiveRun" @click="removePathMapping(index)">
+                        {{ t('migration.mappings.remove') }}
+                      </button>
                     </div>
                   </div>
 
                   <div v-if="pathValidation" class="rounded border border-border bg-muted/40 p-3 text-xs space-y-1">
-                    <p class="font-medium text-foreground">Path validation</p>
+                    <p class="font-medium text-foreground">{{ t('migration.mappings.pathValidation.title') }}</p>
                     <p class="text-muted-foreground">
-                      {{ pathValidation.summary.mappedByPrefix }} of {{ pathValidation.summary.booksWithFilePath }} source books have a mapped path
+                      {{
+                        t('migration.mappings.pathValidation.mappedSummary', {
+                          mapped: pathValidation.summary.mappedByPrefix,
+                          total: pathValidation.summary.booksWithFilePath,
+                        })
+                      }}
                     </p>
                     <p v-if="pathValidation.summary.unmatchedTargetPaths > 0" class="text-amber-600">
-                      {{ pathValidation.summary.unmatchedTargetPaths }} mapped paths not found on disk
+                      {{ t('migration.mappings.pathValidation.unmatched', { count: pathValidation.summary.unmatchedTargetPaths }) }}
                     </p>
                     <p v-else-if="pathValidation.summary.matchedTargetPaths > 0" class="text-emerald-600">
-                      All {{ pathValidation.summary.matchedTargetPaths }} mapped paths found on disk
+                      {{ t('migration.mappings.pathValidation.allMatched', { count: pathValidation.summary.matchedTargetPaths }) }}
                     </p>
                   </div>
 
                   <button class="settings-btn-primary" :disabled="busy.savingProfile || source == null || hasActiveRun" @click="onSaveMappings">
                     <Loader2 v-if="busy.savingProfile" class="size-3.5 animate-spin" />
-                    Save Mappings
+                    {{ t('migration.mappings.saveMappings') }}
                   </button>
                 </div>
 
@@ -1610,33 +1660,33 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                 <div v-else-if="currentStep === 2" class="space-y-5">
                   <button class="settings-btn-primary" :disabled="busy.dryRun || profile == null || hasActiveRun" @click="onRunDryRun">
                     <Loader2 v-if="busy.dryRun" class="size-3.5 animate-spin" />
-                    Run Dry-Run
+                    {{ t('migration.dryRun.run') }}
                   </button>
 
                   <div v-if="plan" class="rounded border border-border bg-muted/30 p-3 space-y-2 text-sm">
                     <p>
-                      Matched: <span class="font-medium">{{ plan.summary?.matchedBooks ?? 0 }}</span> · Unresolved:
-                      <span class="font-medium">{{ plan.summary?.unresolvedBooks ?? 0 }}</span> · Duplicates:
+                      {{ t('migration.dryRun.matched') }} <span class="font-medium">{{ plan.summary?.matchedBooks ?? 0 }}</span> ·
+                      {{ t('migration.dryRun.unresolved') }}
+                      <span class="font-medium">{{ plan.summary?.unresolvedBooks ?? 0 }}</span> · {{ t('migration.dryRun.duplicates') }}
                       <span class="font-medium" :class="(plan.summary?.duplicateBookMatches ?? 0) > 0 ? 'text-red-600' : ''">
                         {{ plan.summary?.duplicateBookMatches ?? 0 }}
                       </span>
                     </p>
                     <div v-if="unresolvedSummary.length > 0" class="space-y-1 text-xs text-muted-foreground">
-                      <p class="font-medium text-foreground">Unresolved summary</p>
+                      <p class="font-medium text-foreground">{{ t('migration.dryRun.unresolvedSummary') }}</p>
                       <p v-for="[reason, count] in unresolvedSummary" :key="reason">{{ friendlyUnresolvedReason(reason) }}: {{ count }}</p>
                     </div>
 
                     <div v-if="duplicateMatches.length > 0" class="space-y-3 border-t border-border pt-3">
                       <div class="space-y-1">
-                        <p class="font-medium text-red-600">Resolve duplicate target matches</p>
+                        <p class="font-medium text-red-600">{{ t('migration.duplicates.title') }}</p>
                         <p class="text-xs text-muted-foreground">
-                          For each target book, choose one source book to keep. Recommended choices are preselected when there is a single strongest
-                          match.
+                          {{ t('migration.duplicates.explanation') }}
                         </p>
                         <p class="text-xs text-muted-foreground">
-                          Remaining groups:
+                          {{ t('migration.duplicates.remainingGroups') }}
                           <span class="font-medium text-foreground">{{ duplicateGroupsRemaining }}</span>
-                          of {{ duplicateMatches.length }}
+                          {{ t('migration.duplicates.ofCount', { total: duplicateMatches.length }) }}
                         </p>
                       </div>
                       <div class="space-y-2">
@@ -1646,7 +1696,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                           class="rounded border border-border bg-background p-3 space-y-1.5"
                         >
                           <p class="text-xs font-medium text-foreground">{{ targetBookLabel(dup.targetBookId) }}</p>
-                          <p class="text-[11px] text-muted-foreground">Target book #{{ dup.targetBookId }}</p>
+                          <p class="text-[11px] text-muted-foreground">{{ t('migration.duplicates.targetBookId', { id: dup.targetBookId }) }}</p>
                           <label
                             v-for="sourceId in dup.sourceBookIds"
                             :key="sourceId"
@@ -1671,7 +1721,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                                 v-if="isRecommendedSourceBook(dup, sourceId)"
                                 class="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-700"
                               >
-                                Recommended
+                                {{ t('migration.duplicates.recommended') }}
                               </span>
                             </div>
                             <span class="text-muted-foreground text-[11px] whitespace-nowrap">{{
@@ -1686,7 +1736,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                         @click="onResolveDuplicates"
                       >
                         <Loader2 v-if="busy.resolvingDuplicates" class="size-3.5 animate-spin" />
-                        Resolve {{ duplicateMatches.length }} duplicate{{ duplicateMatches.length === 1 ? '' : 's' }}
+                        {{ t('migration.duplicates.resolveButton', { count: duplicateMatches.length }, duplicateMatches.length) }}
                       </button>
                     </div>
                   </div>
@@ -1695,50 +1745,52 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                 <!-- Step 3: Run Migration -->
                 <div v-else-if="currentStep === 3" class="space-y-5">
                   <div class="rounded border border-border bg-muted/20 p-3 text-xs space-y-1.5">
-                    <p class="font-medium text-foreground">Preflight checks</p>
-                    <p v-if="preflight.ready" class="text-emerald-600">All checks passed - ready to migrate</p>
+                    <p class="font-medium text-foreground">{{ t('migration.preflight.title') }}</p>
+                    <p v-if="preflight.ready" class="text-emerald-600">{{ t('migration.preflight.allPassed') }}</p>
                     <template v-else>
                       <div v-if="preflight.sourceValidated" class="flex items-center gap-1.5 text-emerald-600">
-                        <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />Source validated
+                        <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />{{ t('migration.preflight.sourceValidated') }}
                       </div>
                       <div v-else class="flex items-center gap-1.5 text-muted-foreground">
                         <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />
-                        {{ !source ? 'Save and validate source connection' : 'Validate source connection' }}
+                        {{ !source ? t('migration.preflight.saveAndValidateSource') : t('migration.preflight.validateSourceConnection') }}
                       </div>
                       <div v-if="profile" class="flex items-center gap-1.5 text-emerald-600">
-                        <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />Mappings saved
+                        <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />{{ t('migration.preflight.mappingsSaved') }}
                       </div>
                       <div v-else class="flex items-center gap-1.5 text-muted-foreground">
-                        <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />Save user and path mappings
+                        <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />{{ t('migration.preflight.saveUserAndPathMappings') }}
                       </div>
                       <div v-if="profile && preflight.pathMappingsValidated" class="flex items-center gap-1.5 text-emerald-600">
-                        <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />Path mappings validated
+                        <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />{{ t('migration.preflight.pathMappingsValidated') }}
                       </div>
                       <div v-else-if="profile" class="flex items-center gap-1.5 text-muted-foreground">
-                        <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />Save path mappings to validate them
+                        <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />{{
+                          t('migration.preflight.savePathMappingsToValidate')
+                        }}
                       </div>
                       <div v-if="preflight.dryRunFresh" class="flex items-center gap-1.5 text-emerald-600">
-                        <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />Dry-run is up to date
+                        <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />{{ t('migration.preflight.dryRunUpToDate') }}
                       </div>
                       <div v-else class="flex items-center gap-1.5 text-muted-foreground">
-                        <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />Run a fresh dry-run
+                        <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />{{ t('migration.preflight.runFreshDryRun') }}
                       </div>
                     </template>
                   </div>
 
                   <div class="flex flex-wrap gap-2">
                     <template v-if="confirmingMigrationStart">
-                      <span class="text-xs text-amber-600 self-center">This will start the live migration. Are you sure?</span>
+                      <span class="text-xs text-amber-600 self-center">{{ t('migration.run.confirmPrompt') }}</span>
                       <button class="settings-btn-primary" :disabled="busy.startingRun" @click="onStartMigration">
                         <Loader2 v-if="busy.startingRun" class="size-3.5 animate-spin" />
-                        Confirm Start
+                        {{ t('migration.run.confirmStart') }}
                       </button>
-                      <button class="settings-btn-outline" @click="onCancelMigrationStart">Cancel</button>
+                      <button class="settings-btn-outline" @click="onCancelMigrationStart">{{ t('common.cancel') }}</button>
                     </template>
                     <template v-else>
                       <button class="settings-btn-primary" :disabled="busy.startingRun || !preflight.ready" @click="onStartMigration">
                         <Loader2 v-if="busy.startingRun" class="size-3.5 animate-spin" />
-                        Start Migration
+                        {{ t('migration.run.startMigration') }}
                       </button>
                     </template>
                     <button
@@ -1748,11 +1800,11 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                       @click="onCancelRun"
                     >
                       <Loader2 v-if="busy.cancellingRun" class="size-3.5 animate-spin" />
-                      Cancel Run
+                      {{ t('migration.run.cancelRun') }}
                     </button>
                     <button class="settings-btn-outline" :disabled="busy.loadingProgress || run == null" @click="refreshRunProgress">
                       <Loader2 v-if="busy.loadingProgress" class="size-3.5 animate-spin" />
-                      Refresh Status
+                      {{ t('migration.run.refreshStatus') }}
                     </button>
                   </div>
 
@@ -1760,8 +1812,8 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                     v-if="pollingError"
                     class="rounded border border-amber-500/20 bg-amber-500/10 px-3 py-2 flex items-center gap-2 text-xs text-amber-700"
                   >
-                    <span>Status polling stopped due to an error.</span>
-                    <button class="underline font-medium" @click="onRetryPolling">Retry</button>
+                    <span>{{ t('migration.run.pollingStopped') }}</span>
+                    <button class="underline font-medium" @click="onRetryPolling">{{ t('migration.run.retry') }}</button>
                   </div>
 
                   <div v-if="run" class="rounded border border-border bg-muted/30 px-4 py-3.5 flex items-center gap-3 text-xs">
@@ -1769,14 +1821,14 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                     <span class="text-muted-foreground">
                       {{
                         run.state === 'running'
-                          ? `Stage: ${run.currentStage ?? 'initializing'}`
+                          ? t('migration.run.stage', { stage: run.currentStage ?? t('migration.run.initializing') })
                           : run.endedAt
-                            ? `Ended ${new Date(run.endedAt).toLocaleString()}`
+                            ? t('migration.run.ended', { time: new Date(run.endedAt).toLocaleString() })
                             : ''
                       }}
                     </span>
                     <button v-if="run.state !== 'running'" class="text-xs text-primary underline-offset-2 hover:underline ml-auto" @click="goNext">
-                      View Report
+                      {{ t('migration.footer.viewReport') }}
                     </button>
                   </div>
 
@@ -1796,113 +1848,119 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
 
                 <!-- Step 4: Migration Report -->
                 <div v-else-if="currentStep === 4" class="space-y-5">
-                  <p v-if="!run" class="text-sm text-muted-foreground">No migration run yet. Complete the steps above to start.</p>
+                  <p v-if="!run" class="text-sm text-muted-foreground">{{ t('migration.report.noRunYet') }}</p>
 
                   <template v-else>
                     <div class="flex flex-wrap items-start justify-between gap-3">
                       <div class="space-y-0.5">
                         <p class="flex items-center gap-2 text-sm font-medium">
-                          Run #{{ run.id }}
+                          {{ t('migration.report.runNumber', { id: run.id }) }}
                           <span class="inline-flex rounded-full border px-2 py-0.5 text-xs" :class="runStateClass(run.state)">{{ run.state }}</span>
                         </p>
                         <p class="text-xs text-muted-foreground">
-                          {{ run.startedAt ? new Date(run.startedAt).toLocaleString() : 'Not started' }}
+                          {{ run.startedAt ? new Date(run.startedAt).toLocaleString() : t('migration.report.notStarted') }}
                           <template v-if="reportData.durationMs != null"> &middot; {{ formatDuration(reportData.durationMs) }}</template>
                         </p>
                       </div>
                       <div class="flex flex-wrap gap-2">
                         <button class="settings-btn-outline" :disabled="busy.loadingReport" @click="onRefreshReport">
                           <Loader2 v-if="busy.loadingReport" class="size-3.5 animate-spin" />
-                          {{ runReport ? 'Reload Report' : 'Load Full Report' }}
+                          {{ runReport ? t('migration.report.reloadReport') : t('migration.report.loadFullReport') }}
                         </button>
-                        <button class="settings-btn-outline" :disabled="busy.exporting" @click="onExportJson">Export JSON</button>
-                        <button class="settings-btn-outline" :disabled="busy.exporting" @click="onExportCsv">Export CSV</button>
+                        <button class="settings-btn-outline" :disabled="busy.exporting" @click="onExportJson">
+                          {{ t('migration.report.exportJson') }}
+                        </button>
+                        <button class="settings-btn-outline" :disabled="busy.exporting" @click="onExportCsv">
+                          {{ t('migration.report.exportCsv') }}
+                        </button>
                       </div>
                     </div>
 
                     <div v-if="run.errorMessage" class="rounded border border-red-500/20 bg-red-500/10 p-3 text-xs text-red-700 space-y-2">
                       <div class="space-y-0.5">
-                        <p class="font-medium">Migration failed</p>
+                        <p class="font-medium">{{ t('migration.report.migrationFailed') }}</p>
                         <p>{{ run.errorMessage }}</p>
                       </div>
                       <button v-if="run.state === 'failed'" class="settings-btn-outline text-xs" :disabled="busy.retryingRun" @click="onRetryRun">
                         <Loader2 v-if="busy.retryingRun" class="size-3.5 animate-spin" />
-                        Retry from last completed stage
+                        {{ t('migration.report.retryFromLastStage') }}
                       </button>
                     </div>
 
                     <template v-if="runReport || runProgress">
                       <div class="grid gap-3 sm:grid-cols-2">
                         <div class="rounded border border-border p-3 space-y-2">
-                          <p class="text-sm font-semibold">Books</p>
+                          <p class="text-sm font-semibold">{{ t('migration.report.booksSection') }}</p>
                           <div class="space-y-1.5 text-xs">
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Metadata overlays applied</span
+                              <span class="text-muted-foreground">{{ t('migration.report.metadataOverlays') }}</span
                               ><span class="font-medium">{{ reportData.bookMetadata?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Author mappings replaced</span
+                              <span class="text-muted-foreground">{{ t('migration.report.authorMappings') }}</span
                               ><span class="font-medium">{{ reportData.bookAuthors?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Narrator mappings replaced</span
+                              <span class="text-muted-foreground">{{ t('migration.report.narratorMappings') }}</span
                               ><span class="font-medium">{{ reportData.bookNarrators?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Genre mappings replaced</span
+                              <span class="text-muted-foreground">{{ t('migration.report.genreMappings') }}</span
                               ><span class="font-medium">{{ reportData.bookGenres?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Tag mappings replaced</span
+                              <span class="text-muted-foreground">{{ t('migration.report.tagMappings') }}</span
                               ><span class="font-medium">{{ reportData.bookTags?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between" :class="reportData.coversSkippedAll ? 'text-amber-600' : ''">
-                              <span>Covers imported</span><span class="font-medium">{{ reportData.bookCovers?.imported ?? 0 }}</span>
+                              <span>{{ t('migration.report.coversImported') }}</span
+                              ><span class="font-medium">{{ reportData.bookCovers?.imported ?? 0 }}</span>
                             </div>
                             <p v-if="reportData.coversSkippedAll" class="text-amber-600 leading-tight">
-                              Cover import skipped - media root path not configured
+                              {{ t('migration.report.coverImportSkipped') }}
                             </p>
                             <div v-if="reportData.unresolvedBooks.length > 0" class="flex justify-between text-amber-600">
-                              <span>Could not match</span><span class="font-medium">{{ reportData.unresolvedBooks.length }}</span>
+                              <span>{{ t('migration.report.couldNotMatch') }}</span
+                              ><span class="font-medium">{{ reportData.unresolvedBooks.length }}</span>
                             </div>
                           </div>
                         </div>
                         <div class="rounded border border-border p-3 space-y-2">
-                          <p class="text-sm font-semibold">User Data</p>
+                          <p class="text-sm font-semibold">{{ t('migration.report.userDataSection') }}</p>
                           <div class="space-y-1.5 text-xs">
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Reading statuses</span
+                              <span class="text-muted-foreground">{{ t('migration.report.readingStatuses') }}</span
                               ><span class="font-medium">{{ reportData.userBookStatus?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Reading progress entries</span
+                              <span class="text-muted-foreground">{{ t('migration.report.readingProgressEntries') }}</span
                               ><span class="font-medium">{{ reportData.readingProgress?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Audiobook progress entries</span
+                              <span class="text-muted-foreground">{{ t('migration.report.audiobookProgressEntries') }}</span
                               ><span class="font-medium">{{ reportData.audiobookProgress?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Reading sessions</span
+                              <span class="text-muted-foreground">{{ t('migration.report.readingSessions') }}</span
                               ><span class="font-medium">{{ reportData.readingSessions?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Bookmarks</span
+                              <span class="text-muted-foreground">{{ t('migration.report.bookmarks') }}</span
                               ><span class="font-medium">{{ reportData.bookmarks?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Annotations</span
+                              <span class="text-muted-foreground">{{ t('migration.report.annotations') }}</span
                               ><span class="font-medium">{{ reportData.annotations?.imported ?? 0 }}</span>
                             </div>
                             <div class="flex justify-between">
-                              <span class="text-muted-foreground">Collection entries</span
+                              <span class="text-muted-foreground">{{ t('migration.report.collectionEntries') }}</span
                               ><span class="font-medium">{{ reportData.collections?.imported ?? 0 }}</span>
                             </div>
                           </div>
                         </div>
                       </div>
                       <p v-if="!runReport && (run.state === 'completed' || run.state === 'failed')" class="text-xs text-muted-foreground">
-                        Click "Load Full Report" to include the dry-run match summary in the exported report.
+                        {{ t('migration.report.loadFullReportHint') }}
                       </p>
                     </template>
 
@@ -1911,13 +1969,13 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                         v-if="run.state === 'completed' && reportData.unresolvedBooks.length === 0 && reportData.coverFailureCount === 0"
                         class="rounded border border-emerald-500/20 bg-emerald-500/5 p-3 text-xs text-emerald-700"
                       >
-                        Migration completed with no unresolved books or failures.
+                        {{ t('migration.report.completedNoIssues') }}
                       </div>
                       <div v-if="reportData.matchedBooks.length > 0" class="space-y-2">
                         <div>
-                          <p class="text-sm font-semibold">Matched books ({{ reportData.matchedBooks.length }})</p>
+                          <p class="text-sm font-semibold">{{ t('migration.report.matchedBooks', { count: reportData.matchedBooks.length }) }}</p>
                           <p class="text-xs text-muted-foreground mt-0.5">
-                            These dry-run matches were used to decide which library books received imported data.
+                            {{ t('migration.report.matchedBooksExplanation') }}
                           </p>
                         </div>
                         <div class="space-y-1.5 max-h-56 overflow-y-auto">
@@ -1926,19 +1984,24 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                             :key="`${book.sourceBookId}-${book.targetBookId}`"
                             class="rounded border border-border px-3 py-2 text-xs"
                           >
-                            <p class="font-medium text-foreground">{{ book.sourceTitle || `Source book ${book.sourceBookId}` }}</p>
+                            <p class="font-medium text-foreground">
+                              {{ book.sourceTitle || t('migration.report.sourceBook', { id: book.sourceBookId }) }}
+                            </p>
                             <p v-if="book.sourceAuthor" class="text-muted-foreground mt-0.5">{{ book.sourceAuthor }}</p>
                             <p class="text-muted-foreground mt-0.5">
-                              {{ friendlyMatchStrategy(book.strategy) }} - {{ book.targetTitle || `Library book ${book.targetBookId}` }}
+                              {{ friendlyMatchStrategy(book.strategy) }} -
+                              {{ book.targetTitle || t('migration.report.libraryBook', { id: book.targetBookId }) }}
                             </p>
                           </div>
                         </div>
                       </div>
                       <div v-if="reportData.unresolvedBooks.length > 0" class="space-y-2">
                         <div>
-                          <p class="text-sm font-semibold text-amber-600">Unresolved books ({{ reportData.unresolvedBooks.length }})</p>
+                          <p class="text-sm font-semibold text-amber-600">
+                            {{ t('migration.report.unresolvedBooks', { count: reportData.unresolvedBooks.length }) }}
+                          </p>
                           <p class="text-xs text-muted-foreground mt-0.5">
-                            These books exist in the source but could not be matched to any book in your library.
+                            {{ t('migration.report.unresolvedBooksExplanation') }}
                           </p>
                         </div>
                         <div class="space-y-1.5 max-h-48 overflow-y-auto">
@@ -1947,7 +2010,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                             :key="book.sourceBookId"
                             class="rounded border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs"
                           >
-                            <p class="font-medium text-foreground">{{ book.title || `Source book ${book.sourceBookId}` }}</p>
+                            <p class="font-medium text-foreground">{{ book.title || t('migration.report.sourceBook', { id: book.sourceBookId }) }}</p>
                             <p v-if="book.author" class="text-muted-foreground mt-0.5">{{ book.author }}</p>
                             <p class="text-muted-foreground mt-0.5">{{ friendlyUnresolvedReason(book.reason) }}</p>
                           </div>
@@ -1955,9 +2018,9 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                       </div>
                       <div v-if="reportData.userPreview.length > 0" class="space-y-2">
                         <div>
-                          <p class="text-sm font-semibold">Mapped users ({{ reportData.userPreview.length }})</p>
+                          <p class="text-sm font-semibold">{{ t('migration.report.mappedUsers', { count: reportData.userPreview.length }) }}</p>
                           <p class="text-xs text-muted-foreground mt-0.5">
-                            Per-user totals come from the dry-run preview cached with the migration plan.
+                            {{ t('migration.report.mappedUsersExplanation') }}
                           </p>
                         </div>
                         <div class="space-y-1.5">
@@ -1975,7 +2038,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                         v-if="reportData.coverFailureCount > 0"
                         class="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-700"
                       >
-                        {{ reportData.coverFailureCount }} cover import(s) failed. Detailed failure rows are not stored.
+                        {{ t('migration.report.coverFailures', { count: reportData.coverFailureCount }) }}
                       </div>
                     </template>
                   </template>
@@ -1993,7 +2056,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                   >
                     <X v-if="currentStep === 0" :size="14" />
                     <ChevronLeft v-else :size="14" />
-                    {{ currentStep === 0 ? 'Cancel' : 'Back' }}
+                    {{ currentStep === 0 ? t('common.cancel') : t('common.back') }}
                   </button>
                   <button
                     v-if="canResetSetup"
@@ -2003,11 +2066,13 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                   >
                     <Loader2 v-if="resettingSource" class="size-3.5 animate-spin" />
                     <RotateCcw v-else :size="14" />
-                    Reset Setup
+                    {{ t('migration.footer.resetSetup') }}
                   </button>
                 </div>
 
-                <span class="text-xs text-muted-foreground hidden md:block">Step {{ currentStep + 1 }} of 5</span>
+                <span class="text-xs text-muted-foreground hidden md:block">{{
+                  t('migration.footer.stepOf', { current: currentStep + 1, total: 5 })
+                }}</span>
 
                 <button
                   v-if="currentStep < 4"
@@ -2022,7 +2087,7 @@ const sourceTypeCompatibility = computed<SourceTypeCompatibility | null>(() => S
                   class="flex items-center gap-1.5 px-4 py-2 rounded-md border border-border text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                   @click="goToSetup"
                 >
-                  Back to Setup
+                  {{ t('migration.footer.backToSetup') }}
                 </button>
               </div>
             </div>

--- a/client/src/features/migration/components/MigrationStepper.vue
+++ b/client/src/features/migration/components/MigrationStepper.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Check, AlertCircle, Loader2 } from '@lucide/vue'
 
 export interface StepDefinition {
@@ -14,6 +15,8 @@ defineProps<{
 const emit = defineEmits<{
   stepClick: [index: number]
 }>()
+
+const { t } = useI18n()
 
 function handleStepClick(index: number) {
   emit('stepClick', index)
@@ -52,10 +55,14 @@ function handleStepClick(index: number) {
           <span class="text-xs font-medium leading-snug" :class="i === activeIndex ? 'text-primary' : 'text-foreground/80'">
             {{ step.label }}
           </span>
-          <span v-if="step.status === 'done' && i !== activeIndex" class="text-[10px] text-emerald-600 mt-0.5 leading-none">Done</span>
-          <span v-else-if="step.status === 'saved' && i !== activeIndex" class="text-[10px] text-amber-600 mt-0.5 leading-none">Saved</span>
-          <span v-else-if="step.status === 'running'" class="text-[10px] text-sky-600 mt-0.5 leading-none">Running</span>
-          <span v-else-if="step.status === 'failed'" class="text-[10px] text-red-600 mt-0.5 leading-none">Failed</span>
+          <span v-if="step.status === 'done' && i !== activeIndex" class="text-[10px] text-emerald-600 mt-0.5 leading-none">{{
+            t('migration.status.done')
+          }}</span>
+          <span v-else-if="step.status === 'saved' && i !== activeIndex" class="text-[10px] text-amber-600 mt-0.5 leading-none">{{
+            t('migration.status.saved')
+          }}</span>
+          <span v-else-if="step.status === 'running'" class="text-[10px] text-sky-600 mt-0.5 leading-none">{{ t('migration.status.running') }}</span>
+          <span v-else-if="step.status === 'failed'" class="text-[10px] text-red-600 mt-0.5 leading-none">{{ t('migration.status.failed') }}</span>
         </span>
       </button>
       <div v-if="i < steps.length - 1" class="ml-[1.375rem] w-px h-3 bg-border shrink-0" />

--- a/client/src/features/migration/components/SearchableUserSelect.vue
+++ b/client/src/features/migration/components/SearchableUserSelect.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import {
   ComboboxAnchor,
   ComboboxContent,
@@ -30,6 +31,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update:modelValue': [value: number | null]
 }>()
+
+const { t } = useI18n()
 
 const searchTerm = ref('')
 
@@ -69,7 +72,7 @@ function displayValue(value: unknown): string {
       <ComboboxInput
         v-model="searchTerm"
         :display-value="displayValue"
-        :placeholder="placeholder ?? 'Select user'"
+        :placeholder="placeholder ?? t('migration.userSelect.placeholder')"
         class="h-9 w-full bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground/70 disabled:opacity-50"
       />
       <ComboboxTrigger class="shrink-0 px-2 text-muted-foreground">
@@ -84,7 +87,7 @@ function displayValue(value: unknown): string {
         class="z-[90] max-h-60 w-[var(--reka-combobox-trigger-width)] overflow-hidden rounded-md border border-border bg-popover shadow-md"
       >
         <ComboboxViewport class="p-1">
-          <ComboboxEmpty class="px-3 py-2 text-sm text-muted-foreground"> No users found </ComboboxEmpty>
+          <ComboboxEmpty class="px-3 py-2 text-sm text-muted-foreground"> {{ t('migration.userSelect.noUsersFound') }} </ComboboxEmpty>
           <ComboboxItem
             v-for="user in filteredUsers"
             :key="user.id"

--- a/client/src/features/notifications/components/NotificationPreferences.vue
+++ b/client/src/features/notifications/components/NotificationPreferences.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { Save } from '@lucide/vue'
 import { NOTIFICATION_CATEGORIES, NOTIFICATION_CATEGORY_LABELS, type NotificationCategory, type NotificationPreferences } from '@bookorbit/types'
@@ -9,6 +10,8 @@ import { api } from '@/lib/api'
 import SettingsPageHeader from '@/features/settings/SettingsPageHeader.vue'
 
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
+const { t } = useI18n()
 
 const { user, me } = useAuth()
 const { popupEnabled, setPopupEnabled, loadPrefs } = useWhatsNew()
@@ -23,7 +26,7 @@ async function handleWhatsNewToggle() {
   try {
     await setPopupEnabled(!popupEnabled.value)
   } catch {
-    toast.error('Failed to save preference')
+    toast.error(t('notifications.preferences.savePreferenceFailed'))
   }
 }
 
@@ -74,15 +77,15 @@ async function handleSave() {
     if (!res.ok) {
       const payload = (await res.json().catch(() => null)) as { message?: string | string[] } | null
       const message = Array.isArray(payload?.message)
-        ? (payload.message[0] ?? 'Failed to save preferences')
-        : (payload?.message ?? 'Failed to save preferences')
+        ? (payload.message[0] ?? t('notifications.preferences.saveFailed'))
+        : (payload?.message ?? t('notifications.preferences.saveFailed'))
       toast.error(message)
       return
     }
 
     await me()
     loadFromUser()
-    toast.success('Notification preferences saved')
+    toast.success(t('notifications.preferences.saved'))
   } finally {
     saving.value = false
   }
@@ -93,15 +96,15 @@ async function handleSave() {
   <SettingsPageHeader
     v-if="!props.embedded"
     class="hidden md:flex"
-    title="Notifications"
-    subtitle="Choose which notification categories you want to receive."
+    :title="t('notifications.preferences.title')"
+    :subtitle="t('notifications.preferences.subtitle')"
   />
   <div v-if="!props.embedded" class="md:hidden px-1">
-    <h1 class="text-xl font-semibold tracking-tight text-foreground">Notifications</h1>
+    <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('notifications.preferences.title') }}</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
     >
-      Choose which notification categories you want to receive.
+      {{ t('notifications.preferences.subtitle') }}
     </p>
   </div>
 
@@ -131,18 +134,18 @@ async function handleSave() {
       <div class="flex items-center gap-2 pt-2 border-t border-border">
         <button class="settings-btn-primary" :disabled="!hasChanges || saving" @click="handleSave">
           <Save :size="14" />
-          {{ saving ? 'Saving...' : 'Save' }}
+          {{ saving ? t('notifications.preferences.saving') : t('common.save') }}
         </button>
-        <span v-if="hasChanges" class="text-xs text-muted-foreground">Unsaved changes</span>
+        <span v-if="hasChanges" class="text-xs text-muted-foreground">{{ t('notifications.preferences.unsavedChanges') }}</span>
       </div>
     </section>
 
     <section class="rounded-lg border border-border bg-card p-4 md:p-5 shadow-xs">
       <div class="flex items-center justify-between gap-4 py-1.5">
         <div class="min-w-0">
-          <p class="text-sm text-foreground">Show "What's New" after updates</p>
+          <p class="text-sm text-foreground">{{ t('notifications.preferences.whatsNewToggle') }}</p>
           <p class="text-xs text-muted-foreground">
-            A popup highlighting new features after the app updates. The archive stays available either way.
+            {{ t('notifications.preferences.whatsNewToggleHint') }}
           </p>
         </div>
         <button

--- a/client/src/features/notifications/components/NotificationSheet.vue
+++ b/client/src/features/notifications/components/NotificationSheet.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Bell, BellOff, CheckCheck, Trash2 } from '@lucide/vue'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
@@ -7,6 +8,8 @@ import { useNotifications } from '../composables/useNotifications'
 import NotificationItemVue from './NotificationItem.vue'
 
 defineProps<{ iconRadiusClass: string }>()
+
+const { t } = useI18n()
 
 const { notifications, unreadCount, loading, hasMore, fetchNotifications, markAsRead, markAllAsRead, dismiss, clearAll } = useNotifications()
 
@@ -60,15 +63,15 @@ function handleLoadMore() {
 
     <SheetContent side="right" class="w-[90vw] sm:max-w-md p-0 flex flex-col gap-0">
       <SheetHeader class="flex flex-row items-center justify-between border-b px-4 py-3 h-14 shrink-0 space-y-0">
-        <SheetTitle class="text-sm font-semibold text-foreground">Notifications</SheetTitle>
+        <SheetTitle class="text-sm font-semibold text-foreground">{{ t('notifications.title') }}</SheetTitle>
         <div class="flex items-center gap-1 pr-8">
           <Button v-if="unreadCount > 0" variant="ghost" size="sm" class="h-7 gap-1.5 text-xs text-muted-foreground" @click="handleMarkAllRead">
             <CheckCheck :size="14" />
-            Mark all read
+            {{ t('notifications.markAllRead') }}
           </Button>
           <Button v-if="notifications.length > 0" variant="ghost" size="sm" class="h-7 gap-1.5 text-xs text-muted-foreground" @click="handleClearAll">
             <Trash2 :size="14" />
-            Clear
+            {{ t('notifications.clear') }}
           </Button>
         </div>
       </SheetHeader>
@@ -76,7 +79,7 @@ function handleLoadMore() {
       <div class="flex-1 overflow-y-auto min-h-0">
         <div v-if="notifications.length === 0 && !loading" class="flex flex-col items-center justify-center py-20 text-muted-foreground">
           <BellOff :size="32" class="mb-4 opacity-20" />
-          <p class="text-sm">No notifications yet</p>
+          <p class="text-sm">{{ t('notifications.empty') }}</p>
         </div>
 
         <div v-else class="flex flex-col gap-1.5 px-2 py-2">
@@ -89,7 +92,7 @@ function handleLoadMore() {
 
         <div v-if="hasMore && !loading" class="p-4">
           <Button variant="ghost" size="sm" class="w-full text-xs text-muted-foreground border border-dashed" @click="handleLoadMore">
-            Load more notifications
+            {{ t('notifications.loadMore') }}
           </Button>
         </div>
       </div>

--- a/client/src/features/reader/ReaderView.vue
+++ b/client/src/features/reader/ReaderView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { toast } from 'vue-sonner'
 import { useFoliate, type RelocateDetail } from './epub/composables/useFoliate'
@@ -36,6 +37,8 @@ import type { FoliateLocationContext, FoliateRenderer } from './epub/composables
 import type { EpubReaderSettings } from '@bookorbit/types'
 import { cfiRangesOverlap } from './epub/utils'
 import { getFormatGroup } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const route = useRoute()
 const router = useRouter()
@@ -310,14 +313,14 @@ onMounted(async () => {
     try {
       await goTo(deepLinkCfi)
     } catch {
-      toast.error('Could not open the linked highlight position')
+      toast.error(t('reader.toast.linkedHighlightError'))
     }
   }
 
   if (hadProgress) {
     const pct = Math.round(progress.percentage.value)
-    const label = chapterTitle.value || `Chapter ${sectionIndex.value + 1}`
-    toast.info(`Resumed at ${pct}% - ${label}`, { duration: 2500 })
+    const label = chapterTitle.value || t('reader.chapterNumber', { number: sectionIndex.value + 1 })
+    toast.info(t('reader.toast.resumed', { pct, label }), { duration: 2500 })
   }
 })
 
@@ -614,13 +617,13 @@ watch(
       <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-10 bg-background">
         <div class="flex flex-col items-center gap-3">
           <div class="w-8 h-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
-          <p class="text-sm text-muted-foreground">Loading book…</p>
+          <p class="text-sm text-muted-foreground">{{ t('reader.loadingBook') }}</p>
         </div>
       </div>
 
       <div v-if="error && !loading" class="absolute inset-0 flex items-center justify-center z-10 p-8 bg-background">
         <div class="text-center max-w-sm">
-          <p class="text-sm font-medium mb-2 text-foreground">Failed to load book</p>
+          <p class="text-sm font-medium mb-2 text-foreground">{{ t('reader.failedToLoadBook') }}</p>
           <p class="text-xs text-muted-foreground">{{ error }}</p>
         </div>
       </div>

--- a/client/src/features/reader/audiobook/AudiobookReaderView.vue
+++ b/client/src/features/reader/audiobook/AudiobookReaderView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch, type WatchStopHandle } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import {
   Bookmark,
@@ -32,6 +33,8 @@ import { useAudioQueue } from './composables/useAudioQueue'
 import { useAudioSettings } from './composables/useAudioSettings'
 import { useAudioBookmarks, type AudioBookmark } from './composables/useAudioBookmarks'
 import { useReadingSession } from '../shared/composables/useReadingSession'
+
+const { t } = useI18n()
 
 const props = defineProps<{ bookId: number; fileId: number; peekMode?: boolean }>()
 const route = useRoute()
@@ -226,11 +229,11 @@ onUnmounted(() => {
 })
 
 const displayTitle = computed(() => {
-  if (!detail.value) return 'Untitled'
+  if (!detail.value) return t('reader.audiobook.untitled')
   if (detail.value.title) return detail.value.title
   const currentFile = audioFiles.value[currentFileIndex.value]
   if (currentFile?.filename) return currentFile.filename
-  return detail.value.folderPath.split('/').pop() || 'Untitled'
+  return detail.value.folderPath.split('/').pop() || t('reader.audiobook.untitled')
 })
 
 const coverSeed = computed(() => detail.value?.title ?? detail.value?.folderPath.split('/').pop() ?? String(props.bookId))
@@ -463,11 +466,11 @@ let sleepChapterStartMs: number | null = null
 let sleepTimerInterval: ReturnType<typeof setInterval> | null = null
 
 const sleepTimerDisplay = computed(() => {
-  if (sleepAtChapterEnd.value) return 'Ch.'
-  const t = sleepTimerRemaining.value
-  if (t <= 0) return null
-  const m = Math.floor(t / 60)
-  const s = t % 60
+  if (sleepAtChapterEnd.value) return t('reader.audiobook.chapterAbbrev')
+  const secs = sleepTimerRemaining.value
+  if (secs <= 0) return null
+  const m = Math.floor(secs / 60)
+  const s = secs % 60
   return m > 0 ? `${m}m` : `${s}s`
 })
 
@@ -728,7 +731,7 @@ onMounted(async () => {
     }
   } catch (e) {
     if (!mounted) return
-    error.value = e instanceof Error ? e.message : 'Failed to load audiobook'
+    error.value = e instanceof Error ? e.message : t('reader.audiobook.loadError')
     loading.value = false
     return
   }
@@ -736,7 +739,7 @@ onMounted(async () => {
   loading.value = false
 
   if (!audioFiles.value.length) {
-    error.value = 'No audio files found for this book.'
+    error.value = t('reader.audiobook.noAudioFiles')
     return
   }
 
@@ -773,16 +776,16 @@ onMounted(async () => {
     <div v-if="loading" class="relative z-10 flex h-full items-center justify-center">
       <div class="flex flex-col items-center gap-3">
         <div class="w-8 h-8 rounded-full border-2 border-white/40 border-t-white animate-spin" />
-        <p class="text-sm text-white/60">Loading audiobook...</p>
+        <p class="text-sm text-white/60">{{ t('reader.audiobook.loading') }}</p>
       </div>
     </div>
 
     <!-- Error state -->
     <div v-else-if="error" class="relative z-10 flex h-full items-center justify-center p-8">
       <div class="text-center max-w-sm">
-        <p class="text-sm font-medium text-white mb-2">Failed to load audiobook</p>
+        <p class="text-sm font-medium text-white mb-2">{{ t('reader.audiobook.loadError') }}</p>
         <p class="text-xs text-white/50 mb-4">{{ error }}</p>
-        <button class="text-sm text-white/80 underline" @click="router.back">Go back</button>
+        <button class="text-sm text-white/80 underline" @click="router.back">{{ t('reader.header.goBack') }}</button>
       </div>
     </div>
 
@@ -801,9 +804,9 @@ onMounted(async () => {
             </p>
           </div>
           <div v-if="props.peekMode" class="flex h-8 items-center gap-1 rounded-md border border-white/20 bg-white/10 px-1.5 text-white">
-            <span class="hidden text-[11px] font-medium sm:inline">Peeking</span>
+            <span class="hidden text-[11px] font-medium sm:inline">{{ t('reader.peek.badge') }}</span>
             <button class="h-6 rounded-sm bg-white px-2 text-[11px] font-semibold text-black hover:bg-white/90" @click="startTrackedReading">
-              Start reading
+              {{ t('reader.peek.startReading') }}
             </button>
           </div>
           <!-- Bookmark toggle -->
@@ -986,7 +989,7 @@ onMounted(async () => {
                 <ChevronUp v-if="showSpeedPicker" class="w-3 h-3 text-white/55" />
                 <ChevronDown v-else class="w-3 h-3 text-white/55" />
               </span>
-              <span class="text-[10px] font-medium tracking-wide">Speed</span>
+              <span class="text-[10px] font-medium tracking-wide">{{ t('reader.audiobook.speed') }}</span>
             </button>
 
             <!-- Chapters / Bookmarks -->
@@ -995,7 +998,7 @@ onMounted(async () => {
               @click="showChapters = !showChapters"
             >
               <BookOpen class="w-5 h-5" />
-              <span class="text-[10px] font-medium tracking-wide">Chapters</span>
+              <span class="text-[10px] font-medium tracking-wide">{{ t('reader.audiobook.chapters') }}</span>
             </button>
 
             <!-- Volume mute toggle -->
@@ -1007,7 +1010,9 @@ onMounted(async () => {
               <VolumeX v-if="settings.volume.value === 0" class="w-5 h-5" />
               <Volume1 v-else-if="settings.volume.value < 0.5" class="w-5 h-5" />
               <Volume2 v-else class="w-5 h-5" />
-              <span class="text-[10px] font-medium tracking-wide">{{ settings.volume.value === 0 ? 'Muted' : 'Volume' }}</span>
+              <span class="text-[10px] font-medium tracking-wide">{{
+                settings.volume.value === 0 ? t('reader.audiobook.muted') : t('reader.audiobook.volume')
+              }}</span>
             </button>
 
             <!-- Sleep timer -->
@@ -1020,7 +1025,7 @@ onMounted(async () => {
               >
                 <Moon class="w-5 h-5" />
                 <span class="text-[10px] font-medium tracking-wide">
-                  {{ sleepTimerDisplay ? sleepTimerDisplay : 'Sleep' }}
+                  {{ sleepTimerDisplay ? sleepTimerDisplay : t('reader.audiobook.sleep') }}
                 </span>
               </button>
             </div>
@@ -1032,7 +1037,7 @@ onMounted(async () => {
       <Transition name="fade">
         <div v-if="showSleepTimer" class="absolute inset-0 z-30" @click="showSleepTimer = false">
           <div class="absolute bg-black/85 backdrop-blur-xl border border-white/10 rounded-2xl p-3 shadow-2xl" :style="sleepPopoverStyle" @click.stop>
-            <p class="text-[10px] font-semibold text-white/50 uppercase tracking-widest px-2 mb-2">Sleep timer</p>
+            <p class="text-[10px] font-semibold text-white/50 uppercase tracking-widest px-2 mb-2">{{ t('reader.audiobook.sleepTimer') }}</p>
             <div class="flex flex-col gap-0.5">
               <button
                 v-for="mins in [15, 30, 45, 60]"
@@ -1040,16 +1045,16 @@ onMounted(async () => {
                 class="text-sm text-left px-3 py-2 rounded-lg transition-colors hover:bg-white/10 text-white"
                 @click="setSleepTimer(mins)"
               >
-                {{ mins }} minutes
+                {{ t('reader.audiobook.minutes', { count: mins }) }}
               </button>
               <button
                 class="text-sm text-left px-3 py-2 rounded-lg transition-colors text-white"
                 :class="detail?.audioMetadata?.chapters?.length ? 'hover:bg-white/10' : 'opacity-40 cursor-not-allowed'"
                 :disabled="!detail?.audioMetadata?.chapters?.length"
-                :title="!detail?.audioMetadata?.chapters?.length ? 'No chapters available' : undefined"
+                :title="!detail?.audioMetadata?.chapters?.length ? t('reader.audiobook.noChaptersAvailable') : undefined"
                 @click="setEndOfChapterSleep"
               >
-                End of chapter
+                {{ t('reader.audiobook.endOfChapter') }}
               </button>
               <template v-if="sleepTimerActive">
                 <div class="border-t border-white/10 my-1" />
@@ -1058,14 +1063,14 @@ onMounted(async () => {
                   class="text-sm text-left px-3 py-2 rounded-lg transition-colors hover:bg-white/10 text-white/70 w-full"
                   @click="extendSleepTimer"
                 >
-                  + 15 minutes
+                  {{ t('reader.audiobook.extend15') }}
                 </button>
                 <button
                   class="text-sm text-left px-3 py-2 rounded-lg transition-colors hover:bg-white/10 text-red-400 w-full"
                   @click="cancelSleepTimer"
                 >
-                  Cancel
-                  <span v-if="sleepTimerDisplay && !sleepAtChapterEnd">({{ sleepTimerDisplay }} left)</span>
+                  {{ t('common.cancel') }}
+                  <span v-if="sleepTimerDisplay && !sleepAtChapterEnd">{{ t('reader.audiobook.timeLeft', { time: sleepTimerDisplay }) }}</span>
                 </button>
               </template>
             </div>
@@ -1077,7 +1082,7 @@ onMounted(async () => {
       <Transition name="fade">
         <div v-if="showSpeedPicker" class="absolute inset-0 z-30" @click="showSpeedPicker = false">
           <div class="absolute bg-black/85 backdrop-blur-xl border border-white/10 rounded-2xl p-3 shadow-2xl" :style="speedPopoverStyle" @click.stop>
-            <p class="text-[10px] font-semibold text-white/50 uppercase tracking-widest px-2 mb-2">Playback speed</p>
+            <p class="text-[10px] font-semibold text-white/50 uppercase tracking-widest px-2 mb-2">{{ t('reader.audiobook.playbackSpeed') }}</p>
             <!-- Fine-grained stepper -->
             <div class="flex items-center justify-between px-2 mb-2 gap-2">
               <button
@@ -1132,14 +1137,14 @@ onMounted(async () => {
                 :class="chaptersTab === 'chapters' ? 'bg-primary/25 text-primary' : 'text-white/50 hover:text-white/80 hover:bg-white/10'"
                 @click="chaptersTab = 'chapters'"
               >
-                Chapters
+                {{ t('reader.audiobook.chapters') }}
               </button>
               <button
                 class="px-3 py-1.5 rounded-full text-xs font-semibold transition-colors"
                 :class="chaptersTab === 'bookmarks' ? 'bg-primary/25 text-primary' : 'text-white/50 hover:text-white/80 hover:bg-white/10'"
                 @click="chaptersTab = 'bookmarks'"
               >
-                Bookmarks
+                {{ t('reader.audiobook.bookmarks') }}
               </button>
             </div>
             <button class="p-1.5 hover:bg-white/10 rounded-full transition-colors" @click="showChapters = false">
@@ -1164,7 +1169,7 @@ onMounted(async () => {
                 </span>
               </button>
             </div>
-            <p v-else class="text-sm text-white/45 px-5 py-6 text-center">No chapters available.</p>
+            <p v-else class="text-sm text-white/45 px-5 py-6 text-center">{{ t('reader.audiobook.noChapters') }}</p>
           </div>
 
           <!-- Bookmarks list -->
@@ -1188,8 +1193,8 @@ onMounted(async () => {
               </div>
             </div>
             <div v-else class="px-5 py-8 text-center">
-              <p class="text-sm text-white/45 mb-3">No bookmarks yet.</p>
-              <p class="text-xs text-white/30">Tap the bookmark icon at the top to save your current position.</p>
+              <p class="text-sm text-white/45 mb-3">{{ t('reader.audiobook.noBookmarks') }}</p>
+              <p class="text-xs text-white/30">{{ t('reader.audiobook.noBookmarksHint') }}</p>
             </div>
           </div>
         </div>
@@ -1207,13 +1212,13 @@ onMounted(async () => {
           class="absolute inset-x-0 bottom-0 z-30 mx-auto bg-black/80 backdrop-blur-2xl rounded-t-2xl border-t border-white/10 shadow-2xl p-5 md:max-w-lg md:mb-6 md:rounded-2xl md:border"
         >
           <div class="flex items-center justify-between mb-5">
-            <p class="font-semibold text-sm">Player settings</p>
+            <p class="font-semibold text-sm">{{ t('reader.audiobook.playerSettings') }}</p>
             <button class="p-1.5 hover:bg-white/10 rounded-full transition-colors" @click="showSettings = false">
               <X class="w-4 h-4" />
             </button>
           </div>
           <div class="mb-4">
-            <p class="text-[10px] font-semibold text-white/45 uppercase tracking-widest mb-2.5">Skip back</p>
+            <p class="text-[10px] font-semibold text-white/45 uppercase tracking-widest mb-2.5">{{ t('reader.audiobook.skipBack') }}</p>
             <div class="flex gap-2">
               <button
                 v-for="secs in [5, 10, 15, 30]"
@@ -1227,7 +1232,7 @@ onMounted(async () => {
             </div>
           </div>
           <div class="mb-4">
-            <p class="text-[10px] font-semibold text-white/45 uppercase tracking-widest mb-2.5">Skip forward</p>
+            <p class="text-[10px] font-semibold text-white/45 uppercase tracking-widest mb-2.5">{{ t('reader.audiobook.skipForward') }}</p>
             <div class="flex gap-2">
               <button
                 v-for="secs in [10, 15, 30, 60]"
@@ -1241,7 +1246,7 @@ onMounted(async () => {
             </div>
           </div>
           <div>
-            <p class="text-[10px] font-semibold text-white/45 uppercase tracking-widest mb-2.5">Volume</p>
+            <p class="text-[10px] font-semibold text-white/45 uppercase tracking-widest mb-2.5">{{ t('reader.audiobook.volume') }}</p>
             <div class="flex items-center gap-3">
               <VolumeX v-if="settings.volume.value === 0" class="w-4 h-4 text-white/55 shrink-0" />
               <Volume1 v-else-if="settings.volume.value < 0.5" class="w-4 h-4 text-white/55 shrink-0" />

--- a/client/src/features/reader/cbz/CbzReaderView.vue
+++ b/client/src/features/reader/cbz/CbzReaderView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { type Component, computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import {
   AlignJustify,
@@ -36,6 +37,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 
 const TWO_PAGE_BREAKPOINT = 900
+
+const { t } = useI18n()
 
 const props = defineProps<{ bookId: number; fileId: number; peekMode?: boolean }>()
 const route = useRoute()
@@ -91,38 +94,38 @@ watch(showSettings, (open) => {
 })
 
 // ── Settings options ───────────────────────────────────────────────────────────
-const FIT_OPTIONS: { value: FitMode; label: string; icon: Component }[] = [
-  { value: 'fit-page', label: 'Page Fit', icon: Maximize },
-  { value: 'fit-width', label: 'Page Width', icon: ArrowLeftRight },
-  { value: 'fit-height', label: 'Page Height', icon: ArrowDownUp },
-  { value: 'actual', label: 'Actual Size', icon: ImageIcon },
-]
-const VIEW_OPTIONS: { value: ViewMode; label: string; icon: Component }[] = [
-  { value: 'single', label: 'Single', icon: BookOpen },
-  { value: 'two-page', label: 'Two-page', icon: LayoutGrid },
-]
-const SCROLL_OPTIONS: { value: ScrollMode; label: string; icon: Component }[] = [
-  { value: 'paginated', label: 'Paged', icon: ScanLine },
-  { value: 'infinite', label: 'Infinite', icon: Layers },
-  { value: 'long-strip', label: 'No gaps', icon: AlignJustify },
-]
-const DIRECTION_OPTIONS: { value: Direction; label: string; icon: Component }[] = [
-  { value: 'ltr', label: 'L to R', icon: ArrowRight },
-  { value: 'rtl', label: 'R to L', icon: ArrowLeft },
-]
-const SPREAD_ALIGNMENT_OPTIONS: { value: SpreadAlignment; label: string; icon: Component }[] = [
-  { value: 'normal', label: 'Normal', icon: LayoutGrid },
-  { value: 'shifted', label: 'Shifted', icon: BookOpen },
-]
-const WIDE_PAGE_OPTIONS: { value: WidePageSingletonMode; label: string; icon: Component }[] = [
-  { value: 'auto', label: 'Auto', icon: ImageIcon },
-  { value: 'disable', label: 'In spreads', icon: LayoutGrid },
-]
-const BG_OPTIONS: { value: BgColor; label: string; icon: Component }[] = [
-  { value: 'black', label: 'Black', icon: Moon },
-  { value: 'gray', label: 'Gray', icon: Circle },
-  { value: 'white', label: 'White', icon: Sun },
-]
+const FIT_OPTIONS = computed<{ value: FitMode; label: string; icon: Component }[]>(() => [
+  { value: 'fit-page', label: t('reader.cbz.fit.page'), icon: Maximize },
+  { value: 'fit-width', label: t('reader.cbz.fit.width'), icon: ArrowLeftRight },
+  { value: 'fit-height', label: t('reader.cbz.fit.height'), icon: ArrowDownUp },
+  { value: 'actual', label: t('reader.cbz.fit.actual'), icon: ImageIcon },
+])
+const VIEW_OPTIONS = computed<{ value: ViewMode; label: string; icon: Component }[]>(() => [
+  { value: 'single', label: t('reader.cbz.view.single'), icon: BookOpen },
+  { value: 'two-page', label: t('reader.cbz.view.twoPage'), icon: LayoutGrid },
+])
+const SCROLL_OPTIONS = computed<{ value: ScrollMode; label: string; icon: Component }[]>(() => [
+  { value: 'paginated', label: t('reader.cbz.scroll.paged'), icon: ScanLine },
+  { value: 'infinite', label: t('reader.cbz.scroll.infinite'), icon: Layers },
+  { value: 'long-strip', label: t('reader.cbz.scroll.noGaps'), icon: AlignJustify },
+])
+const DIRECTION_OPTIONS = computed<{ value: Direction; label: string; icon: Component }[]>(() => [
+  { value: 'ltr', label: t('reader.cbz.direction.ltr'), icon: ArrowRight },
+  { value: 'rtl', label: t('reader.cbz.direction.rtl'), icon: ArrowLeft },
+])
+const SPREAD_ALIGNMENT_OPTIONS = computed<{ value: SpreadAlignment; label: string; icon: Component }[]>(() => [
+  { value: 'normal', label: t('reader.cbz.spreadAlignment.normal'), icon: LayoutGrid },
+  { value: 'shifted', label: t('reader.cbz.spreadAlignment.shifted'), icon: BookOpen },
+])
+const WIDE_PAGE_OPTIONS = computed<{ value: WidePageSingletonMode; label: string; icon: Component }[]>(() => [
+  { value: 'auto', label: t('reader.cbz.widePage.auto'), icon: ImageIcon },
+  { value: 'disable', label: t('reader.cbz.widePage.inSpreads'), icon: LayoutGrid },
+])
+const BG_OPTIONS = computed<{ value: BgColor; label: string; icon: Component }[]>(() => [
+  { value: 'black', label: t('reader.cbz.bg.black'), icon: Moon },
+  { value: 'gray', label: t('reader.cbz.bg.gray'), icon: Circle },
+  { value: 'white', label: t('reader.cbz.bg.white'), icon: Sun },
+])
 
 function onSettingsContentScroll() {
   if (!settingsContentRef.value) return
@@ -188,7 +191,7 @@ function resetBookViewSettings() {
 }
 
 function confirmResetBookViewSettings() {
-  if (!confirm('Reset view settings for this book to your global defaults?')) return
+  if (!confirm(t('reader.cbz.resetConfirm'))) return
   resetBookViewSettings()
 }
 
@@ -614,12 +617,12 @@ onUnmounted(() => {
           <span class="text-xs text-muted-foreground tabular-nums">{{ pageLabel }}</span>
         </div>
         <div v-if="props.peekMode" class="flex h-7 items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 text-primary">
-          <span class="hidden text-[11px] font-medium sm:inline">Peeking</span>
+          <span class="hidden text-[11px] font-medium sm:inline">{{ t('reader.peek.badge') }}</span>
           <button
             class="h-5 rounded-sm bg-primary px-1.5 text-[10px] font-semibold text-primary-foreground hover:bg-primary/90"
             @click="startTrackedReading"
           >
-            Start reading
+            {{ t('reader.peek.startReading') }}
           </button>
         </div>
         <DropdownMenu v-model:open="showSettings">
@@ -652,7 +655,7 @@ onUnmounted(() => {
                     @click.stop="setSettingsTab('view')"
                   >
                     <ImageIcon :size="13" />
-                    <span class="truncate whitespace-nowrap">View</span>
+                    <span class="truncate whitespace-nowrap">{{ t('reader.cbz.tabs.view') }}</span>
                   </button>
                   <button
                     class="flex h-8.5 min-w-0 items-center justify-center gap-1.5 rounded-lg px-2 text-[12px] font-medium leading-none transition-colors"
@@ -664,7 +667,7 @@ onUnmounted(() => {
                     @click.stop="setSettingsTab('reading')"
                   >
                     <ScanLine :size="13" />
-                    <span class="truncate whitespace-nowrap">Reading</span>
+                    <span class="truncate whitespace-nowrap">{{ t('reader.cbz.tabs.reading') }}</span>
                   </button>
                   <button
                     class="flex h-8.5 min-w-0 items-center justify-center gap-1.5 rounded-lg px-2 text-[12px] font-medium leading-none transition-colors"
@@ -676,7 +679,7 @@ onUnmounted(() => {
                     @click.stop="setSettingsTab('layout')"
                   >
                     <LayoutGrid :size="13" />
-                    <span class="truncate whitespace-nowrap">Layout</span>
+                    <span class="truncate whitespace-nowrap">{{ t('reader.cbz.tabs.layout') }}</span>
                   </button>
                 </div>
               </div>
@@ -685,7 +688,7 @@ onUnmounted(() => {
                 <template v-if="settingsTab === 'view'">
                   <div class="space-y-6">
                     <div>
-                      <p class="mb-2 text-[13px] font-medium text-foreground/90">Fit mode</p>
+                      <p class="mb-2 text-[13px] font-medium text-foreground/90">{{ t('reader.cbz.fitMode') }}</p>
                       <div class="grid grid-cols-2 gap-1 rounded-lg bg-muted/55 p-1">
                         <button
                           v-for="opt in FIT_OPTIONS"
@@ -707,7 +710,7 @@ onUnmounted(() => {
                     <div class="h-px bg-border/70" />
 
                     <div>
-                      <p class="mb-2 text-[13px] font-medium text-foreground/90">Background</p>
+                      <p class="mb-2 text-[13px] font-medium text-foreground/90">{{ t('reader.cbz.background') }}</p>
                       <div class="grid grid-cols-3 gap-1 rounded-lg bg-muted/55 p-1">
                         <button
                           v-for="opt in BG_OPTIONS"
@@ -731,7 +734,7 @@ onUnmounted(() => {
                 <template v-else-if="settingsTab === 'reading'">
                   <div class="space-y-6">
                     <div>
-                      <p class="mb-2 text-[13px] font-medium text-foreground/90">Scroll mode</p>
+                      <p class="mb-2 text-[13px] font-medium text-foreground/90">{{ t('reader.cbz.scrollMode') }}</p>
                       <div class="grid grid-cols-3 gap-1 rounded-lg bg-muted/55 p-1">
                         <button
                           v-for="opt in SCROLL_OPTIONS"
@@ -748,13 +751,13 @@ onUnmounted(() => {
                           <span class="truncate whitespace-nowrap">{{ opt.label }}</span>
                         </button>
                       </div>
-                      <p class="mt-1.5 text-[11px] leading-tight text-muted-foreground">Use "No gaps" for webtoons and vertical strips.</p>
+                      <p class="mt-1.5 text-[11px] leading-tight text-muted-foreground">{{ t('reader.cbz.scrollModeHint') }}</p>
                     </div>
 
                     <div class="h-px bg-border/70" />
 
                     <div>
-                      <p class="mb-2 text-[13px] font-medium text-foreground/90">Reading direction</p>
+                      <p class="mb-2 text-[13px] font-medium text-foreground/90">{{ t('reader.cbz.readingDirection') }}</p>
                       <div class="grid grid-cols-2 gap-1 rounded-lg bg-muted/55 p-1">
                         <button
                           v-for="opt in DIRECTION_OPTIONS"
@@ -779,13 +782,13 @@ onUnmounted(() => {
                   <div class="space-y-6">
                     <div>
                       <div class="mb-2 flex items-center justify-between">
-                        <p class="text-[13px] font-medium text-foreground/90">Page view</p>
+                        <p class="text-[13px] font-medium text-foreground/90">{{ t('reader.cbz.pageView') }}</p>
                         <span
                           v-if="showAutoFallbackBadge"
                           class="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] text-muted-foreground"
                         >
                           <Info :size="11" />
-                          Auto-fallback
+                          {{ t('reader.cbz.autoFallback') }}
                         </span>
                       </div>
                       <div class="grid grid-cols-2 gap-1 rounded-lg bg-muted/55 p-1">
@@ -809,7 +812,7 @@ onUnmounted(() => {
                     <div class="h-px bg-border/70" />
 
                     <div v-if="showSpreadAlignmentControl">
-                      <p class="mb-2 text-[13px] font-medium text-foreground/90">Spread alignment</p>
+                      <p class="mb-2 text-[13px] font-medium text-foreground/90">{{ t('reader.cbz.spreadAlignmentLabel') }}</p>
                       <div class="grid grid-cols-2 gap-1 rounded-lg bg-muted/55 p-1">
                         <button
                           v-for="opt in SPREAD_ALIGNMENT_OPTIONS"
@@ -829,12 +832,14 @@ onUnmounted(() => {
                     </div>
 
                     <div v-else-if="showSpreadAlignmentHint" class="rounded-lg border border-border/70 bg-muted/35 px-3 py-2">
-                      <p class="text-xs leading-tight text-muted-foreground">Spread alignment is unavailable in auto-fallback mode.</p>
-                      <button class="mt-1 text-xs text-primary hover:underline" @click.stop="focusForceTwoPageFromHint">Focus two-page toggle</button>
+                      <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.cbz.spreadAlignmentHint') }}</p>
+                      <button class="mt-1 text-xs text-primary hover:underline" @click.stop="focusForceTwoPageFromHint">
+                        {{ t('reader.cbz.focusTwoPageToggle') }}
+                      </button>
                     </div>
 
                     <div>
-                      <p class="mb-2 text-[13px] font-medium text-foreground/90">Force two-page</p>
+                      <p class="mb-2 text-[13px] font-medium text-foreground/90">{{ t('reader.cbz.forceTwoPage') }}</p>
                       <div class="grid grid-cols-2 gap-1 rounded-lg bg-muted/55 p-1">
                         <button
                           ref="forceTwoPageToggleButton"
@@ -847,7 +852,7 @@ onUnmounted(() => {
                           ]"
                           @click.stop="setForceTwoPage(false)"
                         >
-                          Off
+                          {{ t('reader.cbz.off') }}
                         </button>
                         <button
                           class="flex h-[2.125rem] min-w-0 items-center justify-center rounded-lg px-2.5 text-[12px] font-medium leading-none transition-colors"
@@ -858,13 +863,13 @@ onUnmounted(() => {
                           "
                           @click.stop="setForceTwoPage(true)"
                         >
-                          On
+                          {{ t('reader.cbz.on') }}
                         </button>
                       </div>
                     </div>
 
                     <div>
-                      <p class="mb-2 text-[13px] font-medium text-foreground/90">Wide pages</p>
+                      <p class="mb-2 text-[13px] font-medium text-foreground/90">{{ t('reader.cbz.widePages') }}</p>
                       <div class="grid grid-cols-2 gap-1 rounded-lg bg-muted/55 p-1">
                         <button
                           v-for="opt in WIDE_PAGE_OPTIONS"
@@ -889,7 +894,7 @@ onUnmounted(() => {
                       class="w-full rounded-lg border border-destructive/40 px-3 py-2 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10"
                       @click.stop="confirmResetBookViewSettings"
                     >
-                      Reset book view settings
+                      {{ t('reader.cbz.resetBookViewSettings') }}
                     </button>
                   </div>
                 </template>
@@ -974,7 +979,7 @@ onUnmounted(() => {
             <TooltipTrigger as-child>
               <button class="viewer-btn" @click="goToPage(0)"><ChevronsLeft :size="16" /></button>
             </TooltipTrigger>
-            <TooltipContent>First page</TooltipContent>
+            <TooltipContent>{{ t('reader.cbz.firstPage') }}</TooltipContent>
           </Tooltip>
         </div>
         <button class="viewer-btn" :disabled="!canGoPrev" @click="prevPage"><ChevronLeft :size="16" /></button>
@@ -1004,7 +1009,7 @@ onUnmounted(() => {
             <TooltipTrigger as-child>
               <button class="viewer-btn" @click="goToPage(pageCount - 1)"><ChevronsRight :size="16" /></button>
             </TooltipTrigger>
-            <TooltipContent>Last page</TooltipContent>
+            <TooltipContent>{{ t('reader.cbz.lastPage') }}</TooltipContent>
           </Tooltip>
         </div>
       </div>
@@ -1018,7 +1023,7 @@ onUnmounted(() => {
     <div v-if="loading" class="absolute inset-0 flex items-center justify-center z-50 bg-background">
       <div class="flex flex-col items-center gap-3">
         <div class="w-8 h-8 rounded-full border-2 border-primary border-t-transparent animate-spin" />
-        <p class="text-sm text-muted-foreground">Loading…</p>
+        <p class="text-sm text-muted-foreground">{{ t('common.loading') }}</p>
       </div>
     </div>
 

--- a/client/src/features/reader/epub/components/DictionaryPopover.vue
+++ b/client/src/features/reader/epub/components/DictionaryPopover.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Volume2, RefreshCw } from '@lucide/vue'
 import type { DictionaryResult } from '@bookorbit/types'
 import { useDictionary } from '../composables/useDictionary'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   word: string
@@ -129,15 +132,15 @@ watch([loading, result, notFound, hasError], async () => {
         <!-- Not found -->
         <div v-else-if="notFound" class="p-3">
           <p class="text-sm font-medium text-foreground mb-0.5">{{ word }}</p>
-          <p class="text-xs text-muted-foreground">No definition found</p>
+          <p class="text-xs text-muted-foreground">{{ t('reader.dictionary.noDefinition') }}</p>
         </div>
 
         <!-- Error -->
         <div v-else-if="hasError" class="p-3">
-          <p class="text-sm text-destructive mb-2">Could not load definition</p>
+          <p class="text-sm text-destructive mb-2">{{ t('reader.dictionary.loadError') }}</p>
           <button class="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors" @click="handleRetry">
             <RefreshCw :size="12" />
-            Retry
+            {{ t('reader.retry') }}
           </button>
         </div>
 

--- a/client/src/features/reader/epub/components/KeyboardShortcutsModal.vue
+++ b/client/src/features/reader/epub/components/KeyboardShortcutsModal.vue
@@ -1,38 +1,41 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Keyboard, X } from '@lucide/vue'
+
+const { t } = useI18n()
 
 const emit = defineEmits<{
   close: []
 }>()
 
-const shortcutGroups = [
+const shortcutGroups = computed(() => [
   {
-    title: 'Panels',
+    title: t('reader.shortcuts.groups.panels'),
     shortcuts: [
-      { key: 't', description: 'Toggle table of contents' },
-      { key: 's', description: 'Toggle search' },
-      { key: '?', description: 'Show/hide this help' },
-      { key: 'Esc', description: 'Close panel' },
+      { key: 't', description: t('reader.shortcuts.toggleToc') },
+      { key: 's', description: t('reader.shortcuts.toggleSearch') },
+      { key: '?', description: t('reader.shortcuts.toggleHelp') },
+      { key: 'Esc', description: t('reader.shortcuts.closePanel') },
     ],
   },
   {
-    title: 'Reading',
+    title: t('reader.shortcuts.groups.reading'),
     shortcuts: [
-      { key: '← →', description: 'Previous/next page' },
-      { key: 'Home', description: 'Go to start of book' },
-      { key: 'End', description: 'Go to end of book' },
+      { key: '← →', description: t('reader.shortcuts.prevNextPage') },
+      { key: 'Home', description: t('reader.shortcuts.goToStart') },
+      { key: 'End', description: t('reader.shortcuts.goToEnd') },
     ],
   },
   {
-    title: 'Actions',
+    title: t('reader.shortcuts.groups.actions'),
     shortcuts: [
-      { key: 'b', description: 'Toggle bookmark' },
-      { key: 'f', description: 'Toggle fullscreen' },
-      { key: 'm', description: 'Cycle footer info mode' },
+      { key: 'b', description: t('reader.shortcuts.toggleBookmark') },
+      { key: 'f', description: t('reader.shortcuts.toggleFullscreen') },
+      { key: 'm', description: t('reader.shortcuts.cycleFooterMode') },
     ],
   },
-]
+])
 
 function onKeyDown(e: KeyboardEvent) {
   if (e.key === 'Escape') {
@@ -58,7 +61,7 @@ onUnmounted(() => document.removeEventListener('keydown', onKeyDown, true))
       <div class="flex items-center justify-between border-b border-border/80 bg-gradient-to-br from-muted/75 via-card to-muted/40 px-4 py-3">
         <div class="inline-flex items-center gap-2">
           <Keyboard :size="14" class="text-primary" />
-          <h2 class="text-sm font-semibold text-foreground">Keyboard Shortcuts</h2>
+          <h2 class="text-sm font-semibold text-foreground">{{ t('reader.shortcuts.title') }}</h2>
         </div>
 
         <button class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground" @click="emit('close')">

--- a/client/src/features/reader/epub/components/NoteDialog.vue
+++ b/client/src/features/reader/epub/components/NoteDialog.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
 defineProps<{ selectedText: string; modelValue: string }>()
 const emit = defineEmits<{ save: [note: string]; cancel: []; 'update:modelValue': [value: string] }>()
 </script>
@@ -7,25 +11,25 @@ const emit = defineEmits<{ save: [note: string]; cancel: []; 'update:modelValue'
   <Teleport to="body">
     <div class="fixed inset-0 z-[70] flex items-center justify-center p-4 bg-black/50" @click.self="emit('cancel')">
       <div class="bg-card text-card-foreground rounded-lg shadow-2xl p-4 w-full max-w-sm flex flex-col gap-3">
-        <p class="text-sm font-medium">Add note</p>
+        <p class="text-sm font-medium">{{ t('reader.note.title') }}</p>
         <p class="text-xs text-muted-foreground line-clamp-2 italic">"{{ selectedText }}"</p>
         <textarea
           :value="modelValue"
           @input="$emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
           class="w-full rounded-lg border border-border bg-background text-foreground text-sm p-2 resize-none focus:outline-none focus:ring-1 focus:ring-primary"
           rows="4"
-          placeholder="Write your note…"
+          :placeholder="t('reader.note.placeholder')"
           autofocus
         />
         <div class="flex gap-2 justify-end">
           <button class="px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:bg-muted transition-colors" @click="emit('cancel')">
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="px-3 py-1.5 rounded-lg text-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
             @click="emit('save', modelValue)"
           >
-            Save
+            {{ t('common.save') }}
           </button>
         </div>
       </div>

--- a/client/src/features/reader/epub/components/ReaderFooter.vue
+++ b/client/src/features/reader/epub/components/ReaderFooter.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronLeft, ChevronRight, ChevronsUpDown } from '@lucide/vue'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   fraction: number
@@ -74,11 +77,17 @@ function handleGoToBlur() {
   >
     <Tooltip>
       <TooltipTrigger as-child>
-        <button type="button" aria-label="Previous section" class="viewer-btn" :disabled="sectionIndex === 0" @click="emit('prevSection')">
+        <button
+          type="button"
+          :aria-label="t('reader.footer.previousSection')"
+          class="viewer-btn"
+          :disabled="sectionIndex === 0"
+          @click="emit('prevSection')"
+        >
           <ChevronLeft :size="18" />
         </button>
       </TooltipTrigger>
-      <TooltipContent>Previous section</TooltipContent>
+      <TooltipContent>{{ t('reader.footer.previousSection') }}</TooltipContent>
     </Tooltip>
 
     <div class="relative flex-1 flex items-center h-6">
@@ -120,7 +129,7 @@ function handleGoToBlur() {
         ref="goToInputRef"
         v-model="goToValue"
         type="text"
-        placeholder="45 or p123"
+        :placeholder="t('reader.footer.goToPlaceholder')"
         class="w-24 h-8 text-sm tabular-nums text-center bg-muted border border-border rounded px-2 py-1 text-foreground outline-none focus:ring-1 focus:ring-primary"
         @keydown.enter="handleGoToSubmit"
         @keydown="handleGoToKeydown"
@@ -132,16 +141,16 @@ function handleGoToBlur() {
         <TooltipTrigger as-child>
           <button
             type="button"
-            aria-label="Jump to location"
+            :aria-label="t('reader.footer.jumpToLocation')"
             class="h-8 px-2 rounded-md border border-transparent hover:border-border text-xs tabular-nums shrink-0 min-w-18 text-center text-muted-foreground hover:text-foreground transition-colors inline-flex items-center justify-center gap-1"
             @click="handlePercentageClick"
           >
-            <span class="text-[11px] uppercase tracking-wide">Go</span>
+            <span class="text-[11px] uppercase tracking-wide">{{ t('reader.footer.go') }}</span>
             <span>{{ Math.round(fraction * 100) }}%</span>
             <ChevronsUpDown :size="12" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Jump to % or page (e.g. 45 or p123)</TooltipContent>
+        <TooltipContent>{{ t('reader.footer.jumpTooltip') }}</TooltipContent>
       </Tooltip>
     </template>
 
@@ -149,7 +158,7 @@ function handleGoToBlur() {
       <TooltipTrigger as-child>
         <button
           type="button"
-          aria-label="Next section"
+          :aria-label="t('reader.footer.nextSection')"
           class="viewer-btn"
           :disabled="totalSections > 0 && sectionIndex >= totalSections - 1"
           @click="emit('nextSection')"
@@ -157,7 +166,7 @@ function handleGoToBlur() {
           <ChevronRight :size="18" />
         </button>
       </TooltipTrigger>
-      <TooltipContent>Next section</TooltipContent>
+      <TooltipContent>{{ t('reader.footer.nextSection') }}</TooltipContent>
     </Tooltip>
   </footer>
 </template>

--- a/client/src/features/reader/epub/components/ReaderHeader.vue
+++ b/client/src/features/reader/epub/components/ReaderHeader.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import {
   ArrowLeft,
   BookOpen,
@@ -16,6 +17,8 @@ import {
 } from '@lucide/vue'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   chapterTitle: string
@@ -54,9 +57,9 @@ function getFooterModeIcon(mode: 0 | 1 | 2) {
 }
 
 function getFooterModeTooltip(mode: 0 | 1 | 2): string {
-  if (mode === 0) return 'Footer info: page + progress'
-  if (mode === 1) return 'Footer info: reading session + time left'
-  return 'Footer info: chapter + chapter time left'
+  if (mode === 0) return t('reader.header.footerMode.pageProgress')
+  if (mode === 1) return t('reader.header.footerMode.sessionTimeLeft')
+  return t('reader.header.footerMode.chapterTimeLeft')
 }
 
 onMounted(() => document.addEventListener('fullscreenchange', onFullscreenChange))
@@ -71,32 +74,37 @@ onUnmounted(() => document.removeEventListener('fullscreenchange', onFullscreenC
     <div class="flex items-center gap-1 shrink-0">
       <Tooltip>
         <TooltipTrigger as-child>
-          <button class="viewer-btn" aria-label="Go back" @click="emit('back')">
+          <button class="viewer-btn" :aria-label="t('reader.header.goBack')" @click="emit('back')">
             <ArrowLeft :size="18" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Go back</TooltipContent>
+        <TooltipContent>{{ t('reader.header.goBack') }}</TooltipContent>
       </Tooltip>
 
       <div class="viewer-sep" />
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button class="viewer-btn" aria-label="Table of contents" @click="emit('toggleSidebar')">
+          <button class="viewer-btn" :aria-label="t('reader.header.tableOfContents')" @click="emit('toggleSidebar')">
             <BookOpen :size="18" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Table of contents</TooltipContent>
+        <TooltipContent>{{ t('reader.header.tableOfContents') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button class="viewer-btn" :class="isBookmarked ? '!text-primary' : ''" aria-label="Toggle bookmark" @click="emit('toggleBookmark')">
+          <button
+            class="viewer-btn"
+            :class="isBookmarked ? '!text-primary' : ''"
+            :aria-label="t('reader.header.toggleBookmark')"
+            @click="emit('toggleBookmark')"
+          >
             <BookmarkCheck v-if="isBookmarked" :size="18" />
             <Bookmark v-else :size="18" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Toggle bookmark</TooltipContent>
+        <TooltipContent>{{ t('reader.header.toggleBookmark') }}</TooltipContent>
       </Tooltip>
     </div>
 
@@ -108,27 +116,27 @@ onUnmounted(() => document.removeEventListener('fullscreenchange', onFullscreenC
     <!-- Right button group -->
     <div class="flex items-center gap-1 shrink-0 ml-auto">
       <div v-if="props.peekMode" class="flex h-7 items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 text-primary">
-        <span class="hidden text-[11px] font-medium sm:inline">Peeking</span>
+        <span class="hidden text-[11px] font-medium sm:inline">{{ t('reader.peek.badge') }}</span>
         <button
           class="h-5 rounded-sm bg-primary px-1.5 text-[10px] font-semibold text-primary-foreground transition-colors hover:bg-primary/90 sm:h-6 sm:px-2 sm:text-[11px]"
           @click="emit('startReading')"
         >
-          Start reading
+          {{ t('reader.peek.startReading') }}
         </button>
       </div>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button class="viewer-btn" aria-label="Search" @click="emit('toggleSearch')">
+          <button class="viewer-btn" :aria-label="t('common.search')" @click="emit('toggleSearch')">
             <Search :size="18" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Search</TooltipContent>
+        <TooltipContent>{{ t('common.search') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button class="viewer-btn hidden sm:flex" aria-label="Cycle footer info mode" @click="emit('cycleFooterMode')">
+          <button class="viewer-btn hidden sm:flex" :aria-label="t('reader.header.cycleFooterMode')" @click="emit('cycleFooterMode')">
             <component :is="getFooterModeIcon(props.footerMode)" :size="16" />
           </button>
         </TooltipTrigger>
@@ -137,30 +145,35 @@ onUnmounted(() => document.removeEventListener('fullscreenchange', onFullscreenC
 
       <Tooltip>
         <TooltipTrigger as-child>
-          <button class="viewer-btn hidden sm:flex" aria-label="Keyboard shortcuts" @click="emit('toggleHelp')">
+          <button class="viewer-btn hidden sm:flex" :aria-label="t('reader.shortcuts.title')" @click="emit('toggleHelp')">
             <CircleHelp :size="18" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Keyboard shortcuts (?)</TooltipContent>
+        <TooltipContent>{{ t('reader.header.keyboardShortcutsHint') }}</TooltipContent>
       </Tooltip>
 
       <Tooltip>
         <TooltipTrigger as-child>
           <button
             class="viewer-btn hidden sm:flex"
-            :aria-label="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'"
+            :aria-label="isFullscreen ? t('reader.header.exitFullscreen') : t('reader.header.enterFullscreen')"
             @click="emit('toggleFullscreen')"
           >
             <Minimize v-if="isFullscreen" :size="18" />
             <Maximize v-else :size="18" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>{{ isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen' }}</TooltipContent>
+        <TooltipContent>{{ isFullscreen ? t('reader.header.exitFullscreen') : t('reader.header.enterFullscreen') }}</TooltipContent>
       </Tooltip>
 
       <DropdownMenu :open="props.settingsOpen" @update:open="onSettingsOpenChange">
         <DropdownMenuTrigger as-child>
-          <button class="viewer-btn" :class="props.settingsOpen ? '!bg-muted !text-foreground' : ''" title="Settings" aria-label="Reader settings">
+          <button
+            class="viewer-btn"
+            :class="props.settingsOpen ? '!bg-muted !text-foreground' : ''"
+            :title="t('reader.settings.title')"
+            :aria-label="t('reader.settings.ariaLabel')"
+          >
             <Settings :size="18" />
           </button>
         </DropdownMenuTrigger>

--- a/client/src/features/reader/epub/components/ReaderSearchPanel.vue
+++ b/client/src/features/reader/epub/components/ReaderSearchPanel.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { computed, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronRight, Loader2, Search, X } from '@lucide/vue'
 import type { SearchResult } from '../composables/useSearch'
 import { MIN_SEARCH_QUERY_LENGTH } from '../composables/useSearch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   results: SearchResult[]
@@ -67,13 +70,13 @@ function onClear() {
               <ChevronRight :size="18" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Close</TooltipContent>
+          <TooltipContent>{{ t('common.close') }}</TooltipContent>
         </Tooltip>
         <Search :size="15" class="text-muted-foreground shrink-0" />
         <input
           v-model="inputValue"
           type="text"
-          placeholder="Search in book (min 2 chars)..."
+          :placeholder="t('reader.search.placeholder', { min: MIN_SEARCH_QUERY_LENGTH })"
           class="flex-1 min-w-0 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
           autofocus
         />
@@ -89,18 +92,18 @@ function onClear() {
       <div class="flex-1 overflow-y-auto">
         <div v-if="isSearching" class="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
           <Loader2 :size="16" class="animate-spin" />
-          Searching…
+          {{ t('reader.search.searching') }}
         </div>
 
         <div v-else-if="isTooShort" class="px-4 py-8 text-center text-sm text-muted-foreground">
-          Type at least {{ MIN_SEARCH_QUERY_LENGTH }} characters
+          {{ t('reader.search.tooShort', { min: MIN_SEARCH_QUERY_LENGTH }) }}
         </div>
 
         <div v-else-if="trimmedInputValue && !isSearching && results.length === 0" class="px-4 py-8 text-center text-sm text-muted-foreground">
-          No results found
+          {{ t('reader.search.noResults') }}
         </div>
 
-        <div v-else-if="!trimmedInputValue" class="px-4 py-8 text-center text-sm text-muted-foreground">Type to search</div>
+        <div v-else-if="!trimmedInputValue" class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('reader.search.prompt') }}</div>
 
         <ul v-else class="divide-y divide-border">
           <li
@@ -121,7 +124,7 @@ function onClear() {
         </ul>
 
         <p v-if="results.length > 0 && !isSearching" class="px-4 py-2 text-xs text-muted-foreground text-center border-t border-border">
-          {{ results.length }} result{{ results.length !== 1 ? 's' : '' }}
+          {{ t('reader.search.resultCount', { count: results.length }, results.length) }}
         </p>
       </div>
     </div>

--- a/client/src/features/reader/epub/components/ReaderSettingsPanel.vue
+++ b/client/src/features/reader/epub/components/ReaderSettingsPanel.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { BookOpen, LayoutGrid, Moon, Palette, ScrollText, Sun, Type } from '@lucide/vue'
 import type { ReaderState } from '../composables/useReaderState'
 import type { useCustomFonts } from '../composables/useCustomFonts'
 import { themes } from '../constants/themes'
 import { BUILTIN_READER_FONT_OPTIONS } from '@/features/reader/shared/constants/font-options'
 import { formatFontFamilyLabel } from '@/features/reader/shared/lib/font-display'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   state: ReaderState
@@ -28,13 +31,13 @@ const scrollMemory = ref<Record<Tab, number>>({
   layout: 0,
 })
 
-const allTabs: { id: Tab; icon: typeof Palette; label: string }[] = [
-  { id: 'appearance', icon: Palette, label: 'Appearance' },
-  { id: 'text', icon: Type, label: 'Text' },
-  { id: 'layout', icon: LayoutGrid, label: 'Layout' },
-]
+const allTabs = computed<{ id: Tab; icon: typeof Palette; label: string }[]>(() => [
+  { id: 'appearance', icon: Palette, label: t('reader.settings.tabs.appearance') },
+  { id: 'text', icon: Type, label: t('reader.settings.tabs.text') },
+  { id: 'layout', icon: LayoutGrid, label: t('reader.settings.tabs.layout') },
+])
 
-const tabs = computed(() => (props.isFixedLayout ? allTabs.filter((tab) => tab.id !== 'text') : allTabs))
+const tabs = computed(() => (props.isFixedLayout ? allTabs.value.filter((tab) => tab.id !== 'text') : allTabs.value))
 
 const stepperButtonClass = 'size-8 rounded-lg border border-border text-lg font-light text-foreground transition-colors hover:bg-muted'
 const stepperGroupClass = 'flex min-w-[11rem] items-center justify-end gap-2'
@@ -167,7 +170,7 @@ function setFixedLayoutSpreadNone() {
       <template v-if="activeTab === 'appearance'">
         <div class="space-y-6">
           <div>
-            <p class="mb-2 text-[13px] font-medium text-foreground/90">Mode</p>
+            <p class="mb-2 text-[13px] font-medium text-foreground/90">{{ t('reader.settings.appearance.mode') }}</p>
             <div class="grid grid-cols-2 gap-1 rounded-lg bg-muted/55 p-1">
               <button
                 class="flex h-[2.125rem] items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium transition-colors"
@@ -179,7 +182,7 @@ function setFixedLayoutSpreadNone() {
                 @click="emit('update', { isDark: false })"
               >
                 <Sun :size="15" />
-                <span>Light</span>
+                <span>{{ t('reader.settings.appearance.light') }}</span>
               </button>
               <button
                 class="flex h-[2.125rem] items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium transition-colors"
@@ -191,7 +194,7 @@ function setFixedLayoutSpreadNone() {
                 @click="emit('update', { isDark: true })"
               >
                 <Moon :size="15" />
-                <span>Dark</span>
+                <span>{{ t('reader.settings.appearance.dark') }}</span>
               </button>
             </div>
           </div>
@@ -199,7 +202,7 @@ function setFixedLayoutSpreadNone() {
           <div class="h-px bg-border/70" />
 
           <div>
-            <p class="mb-2 text-[13px] font-medium text-foreground/90">Color theme</p>
+            <p class="mb-2 text-[13px] font-medium text-foreground/90">{{ t('reader.settings.appearance.colorTheme') }}</p>
             <div class="grid grid-cols-6 gap-2">
               <button
                 v-for="theme in themes"
@@ -225,8 +228,8 @@ function setFixedLayoutSpreadNone() {
         <div class="space-y-6">
           <div class="flex items-center justify-between gap-4">
             <div class="space-y-1 pr-3">
-              <p class="text-sm font-medium leading-tight">Font size</p>
-              <p class="text-xs leading-tight text-muted-foreground">Range: 10-32px</p>
+              <p class="text-sm font-medium leading-tight">{{ t('reader.settings.text.fontSize') }}</p>
+              <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.text.fontSizeRange') }}</p>
             </div>
             <div :class="stepperGroupClass">
               <button :class="stepperButtonClass" @click="step('fontSize', -1, 10, 32)">−</button>
@@ -237,8 +240,8 @@ function setFixedLayoutSpreadNone() {
 
           <div class="flex items-center justify-between gap-4">
             <div class="space-y-1 pr-3">
-              <p class="text-sm font-medium leading-tight">Line height</p>
-              <p class="text-xs leading-tight text-muted-foreground">Range: 0.8-3.0</p>
+              <p class="text-sm font-medium leading-tight">{{ t('reader.settings.text.lineHeight') }}</p>
+              <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.text.lineHeightRange') }}</p>
             </div>
             <div :class="stepperGroupClass">
               <button :class="stepperButtonClass" @click="step('lineHeight', -0.1, 0.8, 3, 1)">−</button>
@@ -251,11 +254,11 @@ function setFixedLayoutSpreadNone() {
 
           <div class="space-y-3">
             <div class="space-y-1">
-              <p class="text-sm font-medium leading-tight">Font family</p>
-              <p class="text-xs leading-tight text-muted-foreground">Choose built-in or uploaded fonts for body text.</p>
+              <p class="text-sm font-medium leading-tight">{{ t('reader.settings.text.fontFamily') }}</p>
+              <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.text.fontFamilyDescription') }}</p>
             </div>
             <div class="space-y-2">
-              <p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Built-in</p>
+              <p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{{ t('reader.settings.text.builtIn') }}</p>
               <div class="flex flex-wrap gap-2">
                 <button
                   v-for="font in BUILTIN_READER_FONT_OPTIONS"
@@ -277,7 +280,7 @@ function setFixedLayoutSpreadNone() {
             <template v-if="customFonts && customFonts.families.value.length > 0">
               <div class="h-px bg-border/70" />
               <div class="space-y-2">
-                <p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Your fonts</p>
+                <p class="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{{ t('reader.settings.text.yourFonts') }}</p>
                 <div class="flex flex-wrap gap-2">
                   <button
                     v-for="family in customFonts.families.value"
@@ -305,8 +308,8 @@ function setFixedLayoutSpreadNone() {
           <template v-if="isFixedLayout">
             <div class="space-y-3">
               <div class="space-y-1">
-                <p class="text-sm font-medium leading-tight">Page spreads</p>
-                <p class="text-xs leading-tight text-muted-foreground">Choose how this image-based EPUB pairs pages.</p>
+                <p class="text-sm font-medium leading-tight">{{ t('reader.settings.layout.pageSpreads') }}</p>
+                <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.layout.pageSpreadsDescription') }}</p>
               </div>
               <div class="grid grid-cols-2 gap-1 rounded-lg bg-muted/55 p-1">
                 <button
@@ -319,7 +322,7 @@ function setFixedLayoutSpreadNone() {
                   @click="setFixedLayoutSpreadAuto"
                 >
                   <LayoutGrid :size="15" />
-                  <span>Book default</span>
+                  <span>{{ t('reader.settings.layout.bookDefault') }}</span>
                 </button>
                 <button
                   class="flex h-[2.125rem] items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium transition-colors"
@@ -331,7 +334,7 @@ function setFixedLayoutSpreadNone() {
                   @click="setFixedLayoutSpreadNone"
                 >
                   <BookOpen :size="15" />
-                  <span>Single page</span>
+                  <span>{{ t('reader.settings.layout.singlePage') }}</span>
                 </button>
               </div>
             </div>
@@ -340,8 +343,8 @@ function setFixedLayoutSpreadNone() {
           <template v-else>
             <div class="space-y-3">
               <div class="space-y-1">
-                <p class="text-sm font-medium leading-tight">Reading flow</p>
-                <p class="text-xs leading-tight text-muted-foreground">Switch between paged and continuous scrolling.</p>
+                <p class="text-sm font-medium leading-tight">{{ t('reader.settings.layout.readingFlow') }}</p>
+                <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.layout.readingFlowDescription') }}</p>
               </div>
               <div class="grid grid-cols-2 gap-1 rounded-lg bg-muted/55 p-1">
                 <button
@@ -354,7 +357,7 @@ function setFixedLayoutSpreadNone() {
                   @click="emit('update', { flow: 'paginated' })"
                 >
                   <BookOpen :size="15" />
-                  <span>Paginated</span>
+                  <span>{{ t('reader.settings.layout.paginated') }}</span>
                 </button>
                 <button
                   class="flex h-[2.125rem] items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium transition-colors"
@@ -366,7 +369,7 @@ function setFixedLayoutSpreadNone() {
                   @click="emit('update', { flow: 'scrolled' })"
                 >
                   <ScrollText :size="15" />
-                  <span>Scrolled</span>
+                  <span>{{ t('reader.settings.layout.scrolled') }}</span>
                 </button>
               </div>
             </div>
@@ -376,8 +379,8 @@ function setFixedLayoutSpreadNone() {
             <div class="space-y-4">
               <div class="flex items-center justify-between gap-4">
                 <div class="space-y-1 pr-3">
-                  <p class="text-sm font-medium leading-tight">Text columns</p>
-                  <p class="text-xs leading-tight text-muted-foreground">Range: 1-10</p>
+                  <p class="text-sm font-medium leading-tight">{{ t('reader.settings.layout.textColumns') }}</p>
+                  <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.layout.textColumnsRange') }}</p>
                 </div>
                 <div :class="stepperGroupClass">
                   <button :class="stepperButtonClass" @click="step('maxColumnCount', -1, 1, 10)">−</button>
@@ -388,8 +391,8 @@ function setFixedLayoutSpreadNone() {
 
               <div class="flex items-center justify-between gap-4">
                 <div class="space-y-1 pr-3">
-                  <p class="text-sm font-medium leading-tight">Column gap</p>
-                  <p class="text-xs leading-tight text-muted-foreground">Range: 0-50%</p>
+                  <p class="text-sm font-medium leading-tight">{{ t('reader.settings.layout.columnGap') }}</p>
+                  <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.layout.columnGapRange') }}</p>
                 </div>
                 <div :class="stepperGroupClass">
                   <button :class="stepperButtonClass" @click="step('gap', -0.01, 0, 0.5, 2)">−</button>
@@ -400,8 +403,8 @@ function setFixedLayoutSpreadNone() {
 
               <div class="flex items-center justify-between gap-4">
                 <div class="space-y-1 pr-3">
-                  <p class="text-sm font-medium leading-tight">Max width</p>
-                  <p class="text-xs leading-tight text-muted-foreground">Range: 400-1600</p>
+                  <p class="text-sm font-medium leading-tight">{{ t('reader.settings.layout.maxWidth') }}</p>
+                  <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.layout.maxWidthRange') }}</p>
                 </div>
                 <div :class="stepperGroupClass">
                   <button :class="stepperButtonClass" @click="step('maxInlineSize', -40, 400, 1600)">−</button>
@@ -416,8 +419,8 @@ function setFixedLayoutSpreadNone() {
             <div class="space-y-4">
               <div class="flex items-center justify-between gap-4">
                 <div class="space-y-1 pr-3">
-                  <p class="text-sm font-medium leading-tight">Justify text</p>
-                  <p class="text-xs leading-tight text-muted-foreground">Enable full-width paragraph alignment.</p>
+                  <p class="text-sm font-medium leading-tight">{{ t('reader.settings.layout.justifyText') }}</p>
+                  <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.layout.justifyTextDescription') }}</p>
                 </div>
                 <button
                   class="relative h-6 w-11 shrink-0 rounded-full transition-colors"
@@ -433,8 +436,8 @@ function setFixedLayoutSpreadNone() {
 
               <div class="flex items-center justify-between gap-4">
                 <div class="space-y-1 pr-3">
-                  <p class="text-sm font-medium leading-tight">Hyphenation</p>
-                  <p class="text-xs leading-tight text-muted-foreground">Enable automatic word-break hyphenation.</p>
+                  <p class="text-sm font-medium leading-tight">{{ t('reader.settings.layout.hyphenation') }}</p>
+                  <p class="text-xs leading-tight text-muted-foreground">{{ t('reader.settings.layout.hyphenationDescription') }}</p>
                 </div>
                 <button
                   class="relative h-6 w-11 shrink-0 rounded-full transition-colors"

--- a/client/src/features/reader/epub/components/ReaderSidebar.vue
+++ b/client/src/features/reader/epub/components/ReaderSidebar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Bookmark, BookOpen, Highlighter, Trash2, TriangleAlert } from '@lucide/vue'
 import { ANNOTATION_COLOR_FILTER_OPTIONS } from '@bookorbit/types'
 import type { TocItem } from '../composables/useToc'
@@ -7,6 +8,8 @@ import type { Bookmark as BookmarkType } from '../composables/useBookmarks'
 import type { Annotation } from '../composables/useAnnotations'
 import { stripFragment, findNearestCfi, formatCfiLocation, formatDate, getCfiSortKey } from '../utils'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   chapters: TocItem[]
@@ -48,7 +51,7 @@ const HIGHLIGHT_COLOR_META = Object.fromEntries(ANNOTATION_COLOR_FILTER_OPTIONS.
 
 function getHighlightColorLabel(color: string): string {
   const normalized = color.trim().toUpperCase()
-  return HIGHLIGHT_COLOR_META[normalized]?.label ?? `Custom (${normalized})`
+  return HIGHLIGHT_COLOR_META[normalized]?.label ?? t('reader.sidebar.customColor', { color: normalized })
 }
 
 const highlightColorOptions = computed(() =>
@@ -110,7 +113,7 @@ watch(
 )
 
 function getLocationLabel(cfi: string | null | undefined): string {
-  return formatCfiLocation(cfi) ?? 'Location unavailable'
+  return formatCfiLocation(cfi) ?? t('reader.sidebar.locationUnavailable')
 }
 
 function getContextChapter(item: { cfi: string | null | undefined; chapterTitle?: string | null }): string | null {
@@ -208,9 +211,9 @@ function deleteAnnotation(id: number) {
       <div class="flex items-stretch border-b border-border shrink-0">
         <button
           v-for="tab in [
-            { id: 'chapters', icon: BookOpen, label: 'Chapters' },
-            { id: 'bookmarks', icon: Bookmark, label: 'Bookmarks' },
-            { id: 'highlights', icon: Highlighter, label: 'Highlights' },
+            { id: 'chapters', icon: BookOpen, label: t('reader.sidebar.tabs.chapters') },
+            { id: 'bookmarks', icon: Bookmark, label: t('reader.sidebar.tabs.bookmarks') },
+            { id: 'highlights', icon: Highlighter, label: t('reader.sidebar.tabs.highlights') },
           ] as const"
           :key="tab.id"
           class="flex-1 flex items-center justify-center gap-1 py-2.5 text-[13px] relative transition-colors"
@@ -233,17 +236,17 @@ function deleteAnnotation(id: number) {
             @navigate="emit('navigateChapter', $event)"
             @toggleExpand="emit('toggleExpand', $event)"
           />
-          <div v-if="chapters.length === 0" class="px-4 py-8 text-center text-sm text-muted-foreground">No chapters found</div>
+          <div v-if="chapters.length === 0" class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('reader.sidebar.noChapters') }}</div>
         </template>
 
         <template v-if="activeTab === 'bookmarks'">
-          <div v-if="bookmarks.length === 0" class="px-4 py-8 text-center text-sm text-muted-foreground">No bookmarks yet</div>
+          <div v-if="bookmarks.length === 0" class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('reader.sidebar.noBookmarks') }}</div>
           <template v-else>
             <div class="sticky top-0 z-10 border-b border-border/70 bg-card/95 backdrop-blur px-3 py-3 space-y-2">
               <input
                 v-model="bookmarkQuery"
                 type="text"
-                placeholder="Search bookmarks..."
+                :placeholder="t('reader.sidebar.searchBookmarks')"
                 class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm outline-none focus:border-primary"
               />
               <div class="flex items-center gap-2">
@@ -251,9 +254,9 @@ function deleteAnnotation(id: number) {
                   v-model="bookmarkSort"
                   class="h-8 flex-1 rounded-md border border-border bg-background px-2 text-xs text-muted-foreground outline-none focus:border-primary"
                 >
-                  <option value="location">Reading order</option>
-                  <option value="newest">Newest first</option>
-                  <option value="oldest">Oldest first</option>
+                  <option value="location">{{ t('reader.sidebar.sort.readingOrder') }}</option>
+                  <option value="newest">{{ t('reader.sidebar.sort.newest') }}</option>
+                  <option value="oldest">{{ t('reader.sidebar.sort.oldest') }}</option>
                 </select>
                 <span class="text-[11px] text-muted-foreground tabular-nums">{{ filteredAndSortedBookmarks.length }}</span>
               </div>
@@ -269,7 +272,7 @@ function deleteAnnotation(id: number) {
                 <button type="button" class="flex flex-1 min-w-0 items-start gap-2.5 text-left cursor-pointer" @click="navigateBookmark(bm.cfi)">
                   <Bookmark :size="14" class="mt-0.5 shrink-0 text-muted-foreground" />
                   <div class="flex-1 min-w-0">
-                    <p class="text-[13px] font-medium leading-snug truncate">{{ bm.title || 'Bookmark' }}</p>
+                    <p class="text-[13px] font-medium leading-snug truncate">{{ bm.title || t('reader.sidebar.bookmarkFallback') }}</p>
                     <p class="text-[11px] text-muted-foreground mt-0.5">{{ getBookmarkContextLine(bm) }}</p>
                     <p class="text-[11px] text-muted-foreground mt-0.5">{{ formatDate(bm.createdAt) }}</p>
                   </div>
@@ -284,22 +287,24 @@ function deleteAnnotation(id: number) {
                       <Trash2 :size="13" />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent>Delete bookmark</TooltipContent>
+                  <TooltipContent>{{ t('reader.sidebar.deleteBookmark') }}</TooltipContent>
                 </Tooltip>
               </li>
             </ul>
-            <div v-else class="px-4 py-8 text-center text-sm text-muted-foreground">No bookmarks match your filters</div>
+            <div v-else class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('reader.sidebar.noBookmarksMatch') }}</div>
           </template>
         </template>
 
         <template v-if="activeTab === 'highlights'">
-          <div v-if="annotations.length === 0" class="px-4 py-8 text-center text-sm text-muted-foreground">No highlights yet</div>
+          <div v-if="annotations.length === 0" class="px-4 py-8 text-center text-sm text-muted-foreground">
+            {{ t('reader.sidebar.noHighlights') }}
+          </div>
           <template v-else>
             <div class="sticky top-0 z-10 border-b border-border/70 bg-card/95 backdrop-blur px-3 py-3 space-y-2">
               <input
                 v-model="highlightQuery"
                 type="text"
-                placeholder="Search highlights..."
+                :placeholder="t('reader.sidebar.searchHighlights')"
                 class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm outline-none focus:border-primary"
               />
               <div class="grid grid-cols-2 gap-2">
@@ -307,28 +312,28 @@ function deleteAnnotation(id: number) {
                   v-model="highlightSort"
                   class="h-8 rounded-md border border-border bg-background px-2 text-xs text-muted-foreground outline-none focus:border-primary"
                 >
-                  <option value="location">Reading order</option>
-                  <option value="newest">Newest first</option>
-                  <option value="oldest">Oldest first</option>
+                  <option value="location">{{ t('reader.sidebar.sort.readingOrder') }}</option>
+                  <option value="newest">{{ t('reader.sidebar.sort.newest') }}</option>
+                  <option value="oldest">{{ t('reader.sidebar.sort.oldest') }}</option>
                 </select>
                 <select
                   v-model="highlightColorFilter"
                   class="h-8 rounded-md border border-border bg-background px-2 text-xs text-muted-foreground outline-none focus:border-primary"
                 >
-                  <option value="all">All colors</option>
+                  <option value="all">{{ t('reader.sidebar.allColors') }}</option>
                   <option v-for="color in highlightColorOptions" :key="color.hex" :value="color.hex">{{ color.label }}</option>
                 </select>
                 <select
                   v-model="highlightChapterFilter"
                   class="col-span-2 h-8 rounded-md border border-border bg-background px-2 text-xs text-muted-foreground outline-none focus:border-primary"
                 >
-                  <option value="all">All chapters</option>
+                  <option value="all">{{ t('reader.sidebar.allChapters') }}</option>
                   <option v-for="chapter in highlightChapterOptions" :key="chapter" :value="chapter">{{ chapter }}</option>
                 </select>
               </div>
               <label class="flex items-center gap-2 text-xs text-muted-foreground">
                 <input v-model="highlightNotesOnly" type="checkbox" class="h-3.5 w-3.5 rounded border-border accent-primary" />
-                Notes only
+                {{ t('reader.sidebar.notesOnly') }}
                 <span class="ml-auto tabular-nums">{{ filteredAndSortedHighlights.length }}</span>
               </label>
             </div>
@@ -351,7 +356,7 @@ function deleteAnnotation(id: number) {
                           <TooltipTrigger as-child>
                             <TriangleAlert :size="11" class="shrink-0 text-amber-500" />
                           </TooltipTrigger>
-                          <TooltipContent>Synced from device; exact position unavailable, jumps to the chapter</TooltipContent>
+                          <TooltipContent>{{ t('reader.sidebar.approximatePosition') }}</TooltipContent>
                         </Tooltip>
                         <span>{{ getHighlightContextLine(ann) }}</span>
                       </p>
@@ -369,12 +374,12 @@ function deleteAnnotation(id: number) {
                         <Trash2 :size="13" />
                       </button>
                     </TooltipTrigger>
-                    <TooltipContent>Delete highlight</TooltipContent>
+                    <TooltipContent>{{ t('reader.sidebar.deleteHighlight') }}</TooltipContent>
                   </Tooltip>
                 </div>
               </li>
             </ul>
-            <div v-else class="px-4 py-8 text-center text-sm text-muted-foreground">No highlights match your filters</div>
+            <div v-else class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('reader.sidebar.noHighlightsMatch') }}</div>
           </template>
         </template>
       </div>

--- a/client/src/features/reader/epub/components/SelectionPopup.vue
+++ b/client/src/features/reader/epub/components/SelectionPopup.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { BookA, Check, Copy, FileText, Highlighter, Languages, Search, Trash2 } from '@lucide/vue'
 import { ANNOTATION_HIGHLIGHT_COLORS } from '@bookorbit/types'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { copyToClipboard } from '@/lib/clipboard'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   visible: boolean
@@ -92,7 +95,7 @@ async function onCopy() {
                   <Copy v-else :size="15" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{{ copied ? 'Copied!' : 'Copy' }}</TooltipContent>
+              <TooltipContent>{{ copied ? t('reader.selection.copied') : t('reader.selection.copy') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip>
@@ -105,7 +108,7 @@ async function onCopy() {
                   <Highlighter :size="15" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Highlight</TooltipContent>
+              <TooltipContent>{{ t('reader.selection.highlight') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip>
@@ -117,7 +120,7 @@ async function onCopy() {
                   <Search :size="15" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Search</TooltipContent>
+              <TooltipContent>{{ t('common.search') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip>
@@ -129,7 +132,7 @@ async function onCopy() {
                   <Languages :size="15" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Translate</TooltipContent>
+              <TooltipContent>{{ t('reader.selection.translate') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip>
@@ -141,7 +144,7 @@ async function onCopy() {
                   <BookA :size="15" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Define</TooltipContent>
+              <TooltipContent>{{ t('reader.selection.define') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip>
@@ -153,7 +156,7 @@ async function onCopy() {
                   <FileText :size="15" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Add note</TooltipContent>
+              <TooltipContent>{{ t('reader.note.title') }}</TooltipContent>
             </Tooltip>
 
             <Tooltip v-if="overlappingAnnotationId !== null">
@@ -165,7 +168,7 @@ async function onCopy() {
                   <Trash2 :size="15" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Delete annotation</TooltipContent>
+              <TooltipContent>{{ t('reader.selection.deleteAnnotation') }}</TooltipContent>
             </Tooltip>
           </div>
 
@@ -199,7 +202,7 @@ async function onCopy() {
                 class="flex-1 ml-1 px-2 py-0.5 rounded text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
                 @click="applyHighlight(selectedColor, selectedStyle)"
               >
-                Apply
+                {{ t('reader.selection.apply') }}
               </button>
             </div>
           </div>

--- a/client/src/features/reader/epub/components/TranslationPanel.vue
+++ b/client/src/features/reader/epub/components/TranslationPanel.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Copy, RefreshCw } from '@lucide/vue'
 import type { SupportedLanguage, TranslationResult } from '../services/translation.types'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   originalText: string
@@ -29,7 +32,7 @@ function handleLangChange(event: Event) {
   <div class="p-4 flex flex-col gap-3 min-w-0">
     <!-- Original text -->
     <div>
-      <p class="text-[10px] font-medium uppercase tracking-wide text-muted-foreground mb-1">Original</p>
+      <p class="text-[10px] font-medium uppercase tracking-wide text-muted-foreground mb-1">{{ t('reader.translation.original') }}</p>
       <div class="max-h-20 overflow-y-auto">
         <p class="text-sm text-foreground/70 leading-relaxed break-words">{{ originalText }}</p>
       </div>
@@ -39,18 +42,18 @@ function handleLangChange(event: Event) {
 
     <!-- Translation area -->
     <div>
-      <p class="text-[10px] font-medium uppercase tracking-wide text-muted-foreground mb-1">Translation</p>
+      <p class="text-[10px] font-medium uppercase tracking-wide text-muted-foreground mb-1">{{ t('reader.translation.translation') }}</p>
 
       <div v-if="loading" class="flex items-center gap-2 py-2">
         <div class="w-4 h-4 rounded-full border-2 border-primary border-t-transparent animate-spin shrink-0" />
-        <span class="text-sm text-muted-foreground">Translating...</span>
+        <span class="text-sm text-muted-foreground">{{ t('reader.translation.translating') }}</span>
       </div>
 
       <div v-else-if="error" class="py-2">
         <p class="text-sm text-destructive mb-2">{{ error }}</p>
         <button class="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors" @click="emit('retry')">
           <RefreshCw :size="12" />
-          Retry
+          {{ t('reader.retry') }}
         </button>
       </div>
 
@@ -59,7 +62,7 @@ function handleLangChange(event: Event) {
       </div>
 
       <div v-else class="py-2">
-        <p class="text-sm text-muted-foreground italic">No translation yet</p>
+        <p class="text-sm text-muted-foreground italic">{{ t('reader.translation.noTranslation') }}</p>
       </div>
     </div>
 
@@ -75,13 +78,13 @@ function handleLangChange(event: Event) {
       </select>
 
       <span v-if="result" class="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-medium bg-secondary text-secondary-foreground whitespace-nowrap">
-        via {{ result.provider }}
+        {{ t('reader.translation.viaProvider', { provider: result.provider }) }}
       </span>
 
       <button
         v-if="result"
         class="shrink-0 flex items-center justify-center w-7 h-7 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-        title="Copy translation"
+        :title="t('reader.translation.copyTranslation')"
         @click="emit('copy')"
       >
         <Copy :size="14" />

--- a/client/src/features/reader/epub/components/__tests__/ReaderHeader.spec.ts
+++ b/client/src/features/reader/epub/components/__tests__/ReaderHeader.spec.ts
@@ -37,7 +37,7 @@ describe('ReaderHeader', () => {
     await wrapper.get('button[aria-label="Toggle bookmark"]').trigger('click')
     await wrapper.get('button[aria-label="Search"]').trigger('click')
     await wrapper.get('button[aria-label="Cycle footer info mode"]').trigger('click')
-    await wrapper.get('button[aria-label="Keyboard shortcuts"]').trigger('click')
+    await wrapper.get('button[aria-label="Keyboard Shortcuts"]').trigger('click')
     await wrapper.get('button[aria-label="Enter fullscreen"]').trigger('click')
 
     expect(wrapper.emitted('back')?.length).toBe(1)

--- a/client/src/features/reader/pdf-v4/PdfV4ReaderView.vue
+++ b/client/src/features/reader/pdf-v4/PdfV4ReaderView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { PDFViewer, ScrollPlugin, ScrollStrategy, SpreadMode, ZoomMode } from '@embedpdf/vue-pdf-viewer'
 import type { PDFViewerConfig, PluginRegistry, ScrollCapability, EmbedPdfContainer } from '@embedpdf/vue-pdf-viewer'
@@ -11,6 +12,8 @@ import { useThemeStore, ACCENT_OPTIONS } from '@/stores/theme'
 import type { PdfReaderSettings } from '@bookorbit/types'
 import { getIsDark, lookupAccentHex } from './pdf-viewer-utils'
 import { ArrowLeft } from '@lucide/vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{ bookId: number; fileId: number; peekMode?: boolean }>()
 const route = useRoute()
@@ -197,7 +200,7 @@ onUnmounted(() => {
       <button
         class="pointer-events-auto flex h-12 w-12 items-center justify-center rounded-full bg-background/95 text-foreground shadow-lg border border-border backdrop-blur-md transition-transform hover:scale-105 active:scale-95"
         @click="router.back()"
-        aria-label="Go back"
+        :aria-label="t('reader.header.goBack')"
       >
         <ArrowLeft :size="22" />
       </button>
@@ -205,12 +208,12 @@ onUnmounted(() => {
 
     <div v-if="props.peekMode" class="pointer-events-none absolute left-0 right-0 top-3 z-50 flex justify-center">
       <div class="pointer-events-auto flex h-8 items-center gap-2 rounded-md border border-primary/30 bg-background/95 px-2 text-primary shadow-sm">
-        <span class="text-xs font-medium">Peeking</span>
+        <span class="text-xs font-medium">{{ t('reader.peek.badge') }}</span>
         <button
           class="h-6 rounded-sm bg-primary px-2 text-[11px] font-semibold text-primary-foreground hover:bg-primary/90"
           @click="startTrackedReading"
         >
-          Start reading
+          {{ t('reader.peek.startReading') }}
         </button>
       </div>
     </div>

--- a/client/src/features/scanner/components/ScanProgressBar.vue
+++ b/client/src/features/scanner/components/ScanProgressBar.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { ScanProgressEvent } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   progress: ScanProgressEvent | undefined
@@ -15,8 +18,8 @@ const pct = computed(() => {
 const label = computed(() => {
   if (!props.progress) return ''
   const p = props.progress
-  const parts = [`${p.processed.toLocaleString()}/${p.total.toLocaleString()} files`]
-  if (p.added > 0) parts.push(`${p.added} ${p.added === 1 ? 'book' : 'books'} found`)
+  const parts = [t('scanner.filesProgress', { processed: p.processed.toLocaleString(), total: p.total.toLocaleString() })]
+  if (p.added > 0) parts.push(t('scanner.booksFound', { count: p.added }, p.added))
   return parts.join(' · ')
 })
 </script>

--- a/client/src/features/series/components/SeriesCompletionBar.vue
+++ b/client/src/features/series/components/SeriesCompletionBar.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   readCount: number
@@ -28,6 +31,8 @@ const fillClass = computed(() => (props.flush ? 'rounded-none' : 'rounded-full')
     <div class="w-full overflow-hidden" :class="trackClass">
       <div class="h-full transition-all duration-300" :class="[barColorClass, fillClass]" :style="{ width: `${percentage}%` }" />
     </div>
-    <p v-if="!compact" class="mt-1 text-xs text-muted-foreground">{{ readCount }} of {{ totalCount }} read ({{ percentage }}%)</p>
+    <p v-if="!compact" class="mt-1 text-xs text-muted-foreground">
+      {{ t('series.completion.readOfTotal', { read: readCount, total: totalCount, percentage }) }}
+    </p>
   </div>
 </template>

--- a/client/src/features/series/components/SeriesFilters.vue
+++ b/client/src/features/series/components/SeriesFilters.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import type { CompletionStatus } from '../types/series'
+
+const { t } = useI18n()
 
 defineProps<{
   libraryId: number | null
@@ -39,21 +42,21 @@ function onCompletionChange(event: Event) {
 <template>
   <section :class="embedded ? 'rounded-md border border-border bg-card p-3' : 'mb-4 rounded-md border border-border bg-card p-3'">
     <div v-if="!embedded" class="mb-3 flex items-center justify-between">
-      <span class="text-xs font-medium text-muted-foreground">Series Filters</span>
+      <span class="text-xs font-medium text-muted-foreground">{{ t('series.filters.title') }}</span>
       <div class="flex items-center gap-2">
         <button
           v-if="(activeCount ?? 0) > 0"
           class="h-7 rounded-md border border-input px-2.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           @click="onClear"
         >
-          Clear all
+          {{ t('series.filters.clearAll') }}
         </button>
         <button
           v-if="closable"
           class="h-7 rounded-md border border-input px-2.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           @click="onClose"
         >
-          Close
+          {{ t('common.close') }}
         </button>
       </div>
     </div>
@@ -64,7 +67,7 @@ function onCompletionChange(event: Event) {
         class="h-9 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60"
         @change="onLibraryChange"
       >
-        <option value="">All Libraries</option>
+        <option value="">{{ t('series.filters.allLibraries') }}</option>
         <option v-for="library in libraries" :key="library.id" :value="library.id">{{ library.name }}</option>
       </select>
 
@@ -73,10 +76,10 @@ function onCompletionChange(event: Event) {
         class="h-9 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60"
         @change="onCompletionChange"
       >
-        <option value="">All completion</option>
-        <option value="not_started">Not started</option>
-        <option value="in_progress">In progress</option>
-        <option value="complete">Complete</option>
+        <option value="">{{ t('series.filters.allCompletion') }}</option>
+        <option value="not_started">{{ t('series.filters.notStarted') }}</option>
+        <option value="in_progress">{{ t('series.filters.inProgress') }}</option>
+        <option value="complete">{{ t('series.filters.complete') }}</option>
       </select>
     </div>
   </section>

--- a/client/src/features/series/components/SeriesGapBanner.vue
+++ b/client/src/features/series/components/SeriesGapBanner.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { AlertCircle } from '@lucide/vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   gaps: number[]
@@ -12,6 +15,8 @@ const gapsLabel = computed(() => props.gaps.map((g) => `#${g}`).join(', '))
 <template>
   <div v-if="gaps.length > 0" class="flex items-start gap-2 rounded-md border border-border bg-muted/50 px-3 py-2">
     <AlertCircle :size="16" class="mt-0.5 shrink-0 text-muted-foreground" />
-    <p class="text-xs text-muted-foreground"><span class="font-medium">Possible gaps:</span> {{ gapsLabel }}</p>
+    <p class="text-xs text-muted-foreground">
+      <span class="font-medium">{{ t('series.gaps.label') }}</span> {{ gapsLabel }}
+    </p>
   </div>
 </template>

--- a/client/src/features/series/views/SeriesDetailView.vue
+++ b/client/src/features/series/views/SeriesDetailView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { ChevronLeft, Pencil } from '@lucide/vue'
 import { toast } from 'vue-sonner'
@@ -39,6 +40,7 @@ import {
   shouldPersistCoverRatio,
 } from '../lib/cover-scale'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const mainRef = ref<HTMLElement | null>(null)
@@ -71,8 +73,8 @@ const {
 } = useSeriesDetail(seriesId)
 
 const pageTitle = computed(() => {
-  if (seriesInfo.value?.name) return `Series · ${seriesInfo.value.name}`
-  return seriesId.value != null ? `Series #${seriesId.value}` : 'Series'
+  if (seriesInfo.value?.name) return t('series.detail.pageTitleNamed', { name: seriesInfo.value.name })
+  return seriesId.value != null ? t('series.detail.pageTitleWithId', { id: seriesId.value }) : t('series.detail.pageTitle')
 })
 usePageTitle(pageTitle)
 
@@ -333,7 +335,7 @@ async function loadLeadBookPreview(preserveCurrent = false) {
     }
   } catch (err) {
     if (token !== leadBookRequestToken) return
-    leadBookError.value = err instanceof Error ? err.message : 'Failed to load lead book details'
+    leadBookError.value = err instanceof Error ? err.message : t('series.detail.leadBookLoadError')
   } finally {
     if (token === leadBookRequestToken) loadingLeadBook.value = false
   }
@@ -351,7 +353,7 @@ async function editSeriesMetadata() {
   if (!canEditMetadata.value || openingSeriesEditor.value || loadingBooks.value) return
 
   if (books.value.length === 0) {
-    toast.error('This series has no books to edit.')
+    toast.error(t('series.detail.noBooksToEdit'))
     return
   }
 
@@ -364,13 +366,13 @@ async function editSeriesMetadata() {
     }
 
     if (booksError.value || hasMore.value) {
-      toast.error(booksError.value ?? 'Failed to load the full series for editing.')
+      toast.error(booksError.value ?? t('series.detail.loadFullSeriesError'))
       return
     }
 
     const ids = books.value.map((book) => book.id)
     if (ids.length === 0) {
-      toast.error('This series has no books to edit.')
+      toast.error(t('series.detail.noBooksToEdit'))
       return
     }
 
@@ -450,12 +452,12 @@ defineOptions({ name: 'SeriesDetailView' })
       <div class="mb-4">
         <button class="flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground" @click="goBack">
           <ChevronLeft :size="16" />
-          Back
+          {{ t('common.back') }}
         </button>
       </div>
 
       <div v-if="notFound">
-        <EntityNotFound entity="Series" />
+        <EntityNotFound :entity="t('series.detail.entityName')" />
       </div>
 
       <template v-else>
@@ -519,10 +521,10 @@ defineOptions({ name: 'SeriesDetailView' })
                 <div class="min-w-0">
                   <h1 class="text-xl font-bold text-foreground">{{ seriesInfo.name }}</h1>
                   <div class="mt-2 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-                    <span>{{ seriesInfo.bookCount }} {{ seriesInfo.bookCount === 1 ? 'book' : 'books' }}</span>
+                    <span>{{ t('series.detail.bookCount', { count: seriesInfo.bookCount }, seriesInfo.bookCount) }}</span>
                     <span v-if="visibleSeriesAuthors.length > 0">
-                      by {{ visibleSeriesAuthors.join(', ') }}
-                      <span v-if="hiddenSeriesAuthorsCount > 0"> +{{ hiddenSeriesAuthorsCount }} more</span>
+                      {{ t('series.detail.byAuthors', { authors: visibleSeriesAuthors.join(', ') }) }}
+                      <span v-if="hiddenSeriesAuthorsCount > 0"> {{ t('series.detail.moreAuthors', { count: hiddenSeriesAuthorsCount }) }}</span>
                     </span>
                   </div>
                 </div>
@@ -534,7 +536,7 @@ defineOptions({ name: 'SeriesDetailView' })
                   @click="editSeriesMetadata"
                 >
                   <Pencil :size="14" />
-                  {{ openingSeriesEditor ? 'Preparing editor...' : 'Edit Metadata' }}
+                  {{ openingSeriesEditor ? t('series.detail.preparingEditor') : t('series.detail.editMetadata') }}
                 </button>
               </div>
 
@@ -543,9 +545,9 @@ defineOptions({ name: 'SeriesDetailView' })
 
               <div class="mt-4 border-t border-border/60 pt-4">
                 <div class="mb-2">
-                  <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/90">First in Series</p>
+                  <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/90">{{ t('series.detail.firstInSeries') }}</p>
                   <p v-if="leadBook" class="mt-1 text-base font-semibold leading-tight text-foreground">
-                    {{ leadBook.title ?? 'Untitled' }}
+                    {{ leadBook.title ?? t('series.detail.untitled') }}
                     <span v-if="leadBook.seriesIndex != null" class="text-muted-foreground">#{{ leadBook.seriesIndex }}</span>
                   </p>
                   <p v-if="leadMetaItems.length > 0" class="mt-1 text-[11px] text-muted-foreground">
@@ -553,7 +555,7 @@ defineOptions({ name: 'SeriesDetailView' })
                   </p>
                 </div>
 
-                <div v-if="loadingLeadBook && !leadBook" class="text-sm text-muted-foreground">Loading first book preview...</div>
+                <div v-if="loadingLeadBook && !leadBook" class="text-sm text-muted-foreground">{{ t('series.detail.loadingFirstBook') }}</div>
                 <div v-else-if="leadBookError" class="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
                   {{ leadBookError }}
                 </div>
@@ -572,12 +574,12 @@ defineOptions({ name: 'SeriesDetailView' })
                       class="whitespace-nowrap text-xs font-medium text-foreground/75 transition-colors hover:text-foreground"
                       @click="toggleLeadGenresExpanded"
                     >
-                      {{ leadGenresExpanded ? 'Show less' : `+${hiddenLeadGenres} more` }}
+                      {{ leadGenresExpanded ? t('series.detail.showLess') : t('series.detail.moreGenres', { count: hiddenLeadGenres }) }}
                     </button>
                   </div>
 
                   <div>
-                    <p class="mb-2 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">Synopsis</p>
+                    <p class="mb-2 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">{{ t('series.detail.synopsis') }}</p>
                     <div v-if="leadBook.description">
                       <div
                         class="text-sm leading-relaxed text-foreground/85"
@@ -589,14 +591,14 @@ defineOptions({ name: 'SeriesDetailView' })
                         class="mt-2 text-xs text-muted-foreground transition-colors hover:text-foreground"
                         @click="toggleLeadDescriptionExpanded"
                       >
-                        {{ leadDescriptionExpanded ? 'Show less' : 'Show more' }}
+                        {{ leadDescriptionExpanded ? t('series.detail.showLess') : t('series.detail.showMore') }}
                       </button>
                     </div>
-                    <p v-else class="text-sm italic text-muted-foreground">No description available.</p>
+                    <p v-else class="text-sm italic text-muted-foreground">{{ t('series.detail.noDescription') }}</p>
                   </div>
-                  <p v-if="loadingLeadBook" class="text-xs text-muted-foreground">Updating preview...</p>
+                  <p v-if="loadingLeadBook" class="text-xs text-muted-foreground">{{ t('series.detail.updatingPreview') }}</p>
                 </div>
-                <div v-else class="text-sm text-muted-foreground">No books available to preview.</div>
+                <div v-else class="text-sm text-muted-foreground">{{ t('series.detail.noBooksToPreview') }}</div>
               </div>
             </div>
           </div>
@@ -604,7 +606,7 @@ defineOptions({ name: 'SeriesDetailView' })
 
         <!-- Loading state -->
         <div v-if="loadingBooks && !seriesInfo" class="mb-4 rounded-lg border border-border/70 bg-card/60 p-4 text-sm text-muted-foreground">
-          Loading series...
+          {{ t('series.detail.loadingSeries') }}
         </div>
 
         <!-- Books section -->
@@ -613,23 +615,25 @@ defineOptions({ name: 'SeriesDetailView' })
             class="sticky top-0 z-20 -mx-3 mb-3 border-b border-border/60 bg-card/92 px-3 pb-3 pt-1 backdrop-blur supports-backdrop-filter:bg-card/78"
           >
             <div class="flex flex-col gap-2 md:flex-row md:items-center" :class="groupByMedia ? 'md:justify-end' : 'md:justify-between'">
-              <h2 v-if="!groupByMedia" data-testid="series-books-section-heading" class="text-sm font-semibold text-foreground">Books</h2>
+              <h2 v-if="!groupByMedia" data-testid="series-books-section-heading" class="text-sm font-semibold text-foreground">
+                {{ t('series.detail.booksHeading') }}
+              </h2>
               <div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
                 <select
                   v-model="sort"
                   class="h-8 w-full min-w-0 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60 sm:w-auto"
                 >
-                  <option value="seriesIndex">Series Order</option>
-                  <option value="title">Title</option>
-                  <option value="addedAt">Recently Added</option>
+                  <option value="seriesIndex">{{ t('series.detail.sort.seriesOrder') }}</option>
+                  <option value="title">{{ t('series.detail.sort.title') }}</option>
+                  <option value="addedAt">{{ t('series.detail.sort.recentlyAdded') }}</option>
                 </select>
 
                 <select
                   v-model="order"
                   class="h-8 w-full min-w-0 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60 sm:w-auto"
                 >
-                  <option value="asc">Ascending</option>
-                  <option value="desc">Descending</option>
+                  <option value="asc">{{ t('series.detail.order.ascending') }}</option>
+                  <option value="desc">{{ t('series.detail.order.descending') }}</option>
                 </select>
 
                 <select
@@ -637,15 +641,15 @@ defineOptions({ name: 'SeriesDetailView' })
                   class="h-8 w-full min-w-0 rounded-md border border-input bg-background px-2.5 text-sm outline-none transition-colors focus:border-primary/60 sm:w-auto"
                   @change="onLibraryFilterChange"
                 >
-                  <option value="">All Libraries</option>
+                  <option value="">{{ t('series.detail.allLibraries') }}</option>
                   <option v-for="library in libraries" :key="library.id" :value="library.id">{{ library.name }}</option>
                 </select>
 
                 <div class="flex h-8 w-full items-center justify-between gap-2 rounded-md border border-input px-2.5 text-sm sm:w-auto">
-                  <span class="whitespace-nowrap text-muted-foreground">Group by media</span>
+                  <span class="whitespace-nowrap text-muted-foreground">{{ t('series.detail.groupByMedia') }}</span>
                   <ToggleSwitch
                     :model-value="groupByMedia"
-                    aria-label="Group by media"
+                    :aria-label="t('series.detail.groupByMedia')"
                     data-testid="series-group-by-media-toggle"
                     @update:model-value="handleGroupByMediaUpdate"
                   />
@@ -655,8 +659,8 @@ defineOptions({ name: 'SeriesDetailView' })
           </div>
 
           <div v-if="!loadingBooks && books.length === 0" class="flex flex-col items-center justify-center gap-2 py-16 text-center">
-            <p class="text-sm font-medium text-foreground">No books found in this series</p>
-            <p class="text-xs text-muted-foreground">Try selecting another library.</p>
+            <p class="text-sm font-medium text-foreground">{{ t('series.detail.noBooksFound') }}</p>
+            <p class="text-xs text-muted-foreground">{{ t('series.detail.trySelectingLibrary') }}</p>
           </div>
 
           <template v-if="books.length > 0">
@@ -691,9 +695,9 @@ defineOptions({ name: 'SeriesDetailView' })
           </template>
 
           <div ref="sentinel" class="mt-4 flex h-8 items-center justify-center">
-            <span v-if="loadingBooks" class="text-xs text-muted-foreground">Loading...</span>
+            <span v-if="loadingBooks" class="text-xs text-muted-foreground">{{ t('common.loading') }}</span>
             <span v-else-if="!hasMore && books.length > 0" class="text-xs text-muted-foreground">
-              All {{ total.toLocaleString() }} books loaded
+              {{ t('series.detail.allBooksLoaded', { count: total.toLocaleString() }) }}
             </span>
           </div>
         </section>

--- a/client/src/features/series/views/SeriesView.vue
+++ b/client/src/features/series/views/SeriesView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { ArrowUpDown, Filter, Search, SlidersHorizontal, X } from '@lucide/vue'
 
@@ -14,6 +15,7 @@ import SeriesFilters from '../components/SeriesFilters.vue'
 import { useSeriesList } from '../composables/useSeriesList'
 import type { CompletionStatus, SeriesListSort, SortDirection } from '../types/series'
 
+const { t } = useI18n()
 const router = useRouter()
 const route = useRoute()
 const mainRef = ref<HTMLElement | null>(null)
@@ -46,15 +48,15 @@ const seriesGridGap = ref(Math.max(storage.get(SERIES_GRID_GAP_STORAGE_KEY, 20),
 let observer: IntersectionObserver | null = null
 let searchTimer: ReturnType<typeof setTimeout> | null = null
 
-const SORT_LABELS: Record<SeriesListSort, string> = {
-  name: 'Name',
-  bookCount: 'Book Count',
-  lastAddedAt: 'Recent Additions',
-  readProgress: 'Reading Progress',
-}
+const sortLabels = computed<Record<SeriesListSort, string>>(() => ({
+  name: t('series.list.sort.name'),
+  bookCount: t('series.list.sort.bookCount'),
+  lastAddedAt: t('series.list.sort.recentAdditions'),
+  readProgress: t('series.list.sort.readingProgress'),
+}))
 
 const isDefaultSort = computed(() => sort.value === 'name' && order.value === 'asc')
-const sortSummary = computed(() => `${SORT_LABELS[sort.value]} ${order.value === 'asc' ? '↑' : '↓'}`)
+const sortSummary = computed(() => `${sortLabels.value[sort.value]} ${order.value === 'asc' ? '↑' : '↓'}`)
 
 const activeFilterCount = computed(() => {
   let count = 0
@@ -262,7 +264,7 @@ defineOptions({ name: 'SeriesView' })
 <template>
   <section class="flex h-full flex-col">
     <ViewHeader
-      title="Series"
+      :title="t('series.list.title')"
       icon="Library"
       fallback-icon="Library"
       :total="total"
@@ -285,7 +287,7 @@ defineOptions({ name: 'SeriesView' })
           <input
             v-model="q"
             type="search"
-            placeholder="Search series or author"
+            :placeholder="t('series.list.searchPlaceholder')"
             class="series-search-input h-full w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/85"
           />
           <button v-if="q.trim()" class="ml-1 text-muted-foreground/85 transition-colors hover:text-foreground" @click="clearSearchQuery">
@@ -308,11 +310,11 @@ defineOptions({ name: 'SeriesView' })
               >
                 <ArrowUpDown :size="13" />
                 <span class="hidden lg:inline">{{ sortSummary }}</span>
-                <span class="lg:hidden">Sort</span>
+                <span class="lg:hidden">{{ t('series.list.sortButton') }}</span>
               </button>
             </PopoverTrigger>
             <PopoverContent align="start" class="w-56 p-2">
-              <div class="mb-2 px-1 text-xs font-medium text-muted-foreground">Sort by</div>
+              <div class="mb-2 px-1 text-xs font-medium text-muted-foreground">{{ t('series.list.sortBy') }}</div>
               <div class="flex flex-col gap-0.5">
                 <button
                   v-for="field in ['name', 'bookCount', 'lastAddedAt', 'readProgress'] as const"
@@ -321,7 +323,7 @@ defineOptions({ name: 'SeriesView' })
                   :class="sort === field ? 'text-foreground font-medium' : 'text-muted-foreground'"
                   @click="setSortField(field)"
                 >
-                  {{ SORT_LABELS[field] }}
+                  {{ sortLabels[field] }}
                   <span v-if="sort === field" class="text-xs text-primary">{{ order === 'asc' ? '↑' : '↓' }}</span>
                 </button>
               </div>
@@ -334,7 +336,7 @@ defineOptions({ name: 'SeriesView' })
                   :class="order === dir ? 'bg-muted text-foreground font-medium' : 'text-muted-foreground'"
                   @click="setSortOrder(dir)"
                 >
-                  {{ dir === 'asc' ? 'Ascending' : 'Descending' }}
+                  {{ dir === 'asc' ? t('series.list.ascending') : t('series.list.descending') }}
                 </button>
               </div>
             </PopoverContent>
@@ -360,7 +362,7 @@ defineOptions({ name: 'SeriesView' })
           @click="toggleFiltersOpen"
         >
           <Filter :size="13" />
-          <span>Filters</span>
+          <span>{{ t('series.list.filters') }}</span>
           <span v-if="activeFilterCount > 0" class="text-xs font-semibold">({{ activeFilterCount }})</span>
         </button>
 
@@ -370,7 +372,7 @@ defineOptions({ name: 'SeriesView' })
           @click="clearFilters"
         >
           <X :size="13" />
-          Clear
+          {{ t('series.list.clear') }}
         </button>
 
         <button
@@ -401,7 +403,7 @@ defineOptions({ name: 'SeriesView' })
           ref="mobileSearchInput"
           v-model="q"
           type="search"
-          placeholder="Search series or author"
+          :placeholder="t('series.list.searchPlaceholder')"
           class="mobile-search-input h-9 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground/85"
         />
         <button v-if="q.trim()" class="text-muted-foreground/85 hover:text-foreground" @click="clearSearchQuery">
@@ -417,7 +419,7 @@ defineOptions({ name: 'SeriesView' })
             @change="onMobileSortChange"
           >
             <option v-for="field in ['name', 'bookCount', 'lastAddedAt', 'readProgress'] as const" :key="field" :value="field">
-              {{ SORT_LABELS[field] }}
+              {{ sortLabels[field] }}
             </option>
           </select>
           <ArrowUpDown :size="13" class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground/85" />
@@ -432,7 +434,7 @@ defineOptions({ name: 'SeriesView' })
           "
           @click="setSortOrder(order === 'asc' ? 'desc' : 'asc')"
         >
-          {{ order === 'asc' ? 'Asc' : 'Desc' }}
+          {{ order === 'asc' ? t('series.list.ascShort') : t('series.list.descShort') }}
         </button>
 
         <button
@@ -440,7 +442,7 @@ defineOptions({ name: 'SeriesView' })
           class="h-8 rounded-md px-2 text-sm text-muted-foreground transition-colors hover:text-destructive"
           @click="clearFilters"
         >
-          Clear
+          {{ t('series.list.clear') }}
         </button>
       </div>
 
@@ -497,8 +499,8 @@ defineOptions({ name: 'SeriesView' })
 
       <!-- Empty state -->
       <div v-if="initialLoadComplete && items.length === 0 && !loading" class="mt-12 text-center text-sm text-muted-foreground">
-        <p v-if="activeFilterCount > 0">No series match your filters.</p>
-        <p v-else>No series found in your libraries.</p>
+        <p v-if="activeFilterCount > 0">{{ t('series.list.noMatch') }}</p>
+        <p v-else>{{ t('series.list.empty') }}</p>
       </div>
 
       <!-- Error state -->

--- a/client/src/features/settings/AccountAllSettings.vue
+++ b/client/src/features/settings/AccountAllSettings.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import AccountSettings from './AccountSettings.vue'
 import NotificationPreferences from '@/features/notifications/components/NotificationPreferences.vue'
 import ContentRestrictionsSettings from './ContentRestrictionsSettings.vue'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 import SettingsPageHeader from './SettingsPageHeader.vue'
-import { ACCOUNT_TAB_INFO, ACCOUNT_TABS, normalizeAccountTab, type AccountTab as Tab } from './lib/account-tabs'
+import { ACCOUNT_TABS, normalizeAccountTab, type AccountTab as Tab } from './lib/account-tabs'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { isDemoRestrictedAccount } = usePermissions()
@@ -16,7 +18,7 @@ const availableTabs = computed(() =>
   ACCOUNT_TABS.filter((id) => {
     if (id === 'notifications') return !isDemoRestrictedAccount.value
     return true
-  }).map((id) => ({ id, label: ACCOUNT_TAB_INFO[id].navLabel })),
+  }).map((id) => ({ id, label: t(`settings.account.tabs.${id}`) })),
 )
 
 function resolveTab(raw: unknown): Tab {
@@ -52,7 +54,7 @@ function selectTab(tab: Tab) {
 </script>
 
 <template>
-  <SettingsPageHeader title="Account" subtitle="Manage your profile and notification preferences." />
+  <SettingsPageHeader :title="t('settings.account.title')" :subtitle="t('settings.account.subtitleAll')" />
 
   <div
     class="flex gap-1 mb-5 md:mb-6 border-b border-border overflow-x-auto md:overflow-visible md:static sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 snap-x"

--- a/client/src/features/settings/AccountSettings.vue
+++ b/client/src/features/settings/AccountSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { OidcProviderPublic, UserSettings } from '@bookorbit/types'
 import { ChevronDown, ChevronUp, Clock, KeyRound, Link, LinkIcon, MapPin, Save, Trash2, Upload } from '@lucide/vue'
 import { toast } from 'vue-sonner'
@@ -16,6 +17,7 @@ import { useOnboardingTour } from '@/features/onboarding/composables/useOnboardi
 
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
 
+const { t } = useI18n()
 const { user, me } = useAuth()
 const { isDemoRestrictedAccount } = usePermissions()
 const { open: openChangePassword } = useChangePasswordDialog()
@@ -30,7 +32,7 @@ const removeAvatarConfirmOpen = ref(false)
 const profileCardOpen = ref(true)
 const avatarCardOpen = ref(false)
 const isMobile = useMediaQuery('(max-width: 767px)')
-const DEMO_RESTRICTED_ACCOUNT_MESSAGE = 'Demo-restricted account cannot edit account settings'
+const DEMO_RESTRICTED_ACCOUNT_MESSAGE = t('settings.account.demoRestricted.cannotEdit')
 
 const formName = ref('')
 const formTimezone = ref('UTC')
@@ -64,8 +66,8 @@ const profileChanged = computed(() => {
 })
 const saveFeedback = computed(() => {
   if (profileError.value) return profileError.value
-  if (profileChanged.value) return 'Unsaved changes'
-  if (profileState.value === 'saved') return 'All changes saved'
+  if (profileChanged.value) return t('settings.account.feedback.unsavedChanges')
+  if (profileState.value === 'saved') return t('settings.account.feedback.allSaved')
   return ''
 })
 const accountEditBlocked = computed(() => isDemoRestrictedAccount.value)
@@ -93,9 +95,9 @@ async function onFileSelected(event: Event) {
 
   try {
     await uploadAvatar(file)
-    toast.success('Profile picture updated')
+    toast.success(t('settings.account.avatar.updated'))
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to upload profile picture'
+    const message = error instanceof Error ? error.message : t('settings.account.avatar.uploadFailed')
     toast.error(message)
   }
 }
@@ -108,9 +110,9 @@ async function onRemoveAvatar() {
   removeAvatarConfirmOpen.value = false
   try {
     await removeAvatar()
-    toast.success('Profile picture removed')
+    toast.success(t('settings.account.avatar.removed'))
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to remove profile picture'
+    const message = error instanceof Error ? error.message : t('settings.account.avatar.removeFailed')
     toast.error(message)
   }
 }
@@ -121,7 +123,7 @@ async function saveProfile() {
   profileError.value = null
   const trimmedName = formName.value.trim()
   if (!trimmedName) {
-    profileError.value = 'Name is required'
+    profileError.value = t('settings.account.profile.nameRequired')
     toast.error(profileError.value)
     return
   }
@@ -139,8 +141,8 @@ async function saveProfile() {
     if (!res.ok) {
       const payload = (await res.json().catch(() => null)) as { message?: string | string[] } | null
       const message = Array.isArray(payload?.message)
-        ? (payload.message[0] ?? 'Failed to update profile')
-        : (payload?.message ?? 'Failed to update profile')
+        ? (payload.message[0] ?? t('settings.account.profile.updateFailed'))
+        : (payload?.message ?? t('settings.account.profile.updateFailed'))
       profileError.value = message
       toast.error(message)
       return
@@ -148,7 +150,7 @@ async function saveProfile() {
 
     await me()
     profileState.value = 'saved'
-    toast.success('Profile updated')
+    toast.success(t('settings.account.profile.updated'))
   } finally {
     savingProfile.value = false
   }
@@ -166,13 +168,13 @@ async function saveTimezone() {
     if (!res.ok) {
       const payload = (await res.json().catch(() => null)) as { message?: string | string[] } | null
       const message = Array.isArray(payload?.message)
-        ? (payload.message[0] ?? 'Failed to save preferences')
-        : (payload?.message ?? 'Failed to save preferences')
+        ? (payload.message[0] ?? t('settings.account.preferences.saveFailed'))
+        : (payload?.message ?? t('settings.account.preferences.saveFailed'))
       toast.error(message)
       return
     }
     await me()
-    toast.success('Preferences saved')
+    toast.success(t('settings.account.preferences.saved'))
   } finally {
     savingTimezone.value = false
   }
@@ -238,7 +240,7 @@ async function initiateOidcLink(provider: OidcProviderPublic) {
     const stateRes = await api(`/api/v1/auth/oidc/${provider.slug}/link-state`, { method: 'POST' })
     if (!stateRes.ok) {
       const err = await stateRes.json().catch(() => ({}))
-      throw new Error(((err as Record<string, unknown>).message as string) ?? 'Failed to generate link state')
+      throw new Error(((err as Record<string, unknown>).message as string) ?? t('settings.account.connectedAccounts.linkStateFailed'))
     }
     const { state, authorizationEndpoint, clientId, scopes } = await stateRes.json()
     const nonce = crypto.randomUUID()
@@ -257,7 +259,7 @@ async function initiateOidcLink(provider: OidcProviderPublic) {
     sessionStorage.setItem('oidc_link_pending', '1')
     window.location.href = `${authorizationEndpoint}?${params.toString()}`
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to start OIDC link')
+    toast.error(err instanceof Error ? err.message : t('settings.account.connectedAccounts.startLinkFailed'))
     linkingSlug.value = null
   }
 }
@@ -274,15 +276,15 @@ async function confirmUnlink() {
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      throw new Error(((err as Record<string, unknown>).message as string) ?? 'Failed to unlink')
+      throw new Error(((err as Record<string, unknown>).message as string) ?? t('settings.account.connectedAccounts.unlinkFailed'))
     }
     linkedIdentities.value = linkedIdentities.value.filter((i) => i.providerId !== unlinkTarget.value!.providerId)
     unlinkDialogOpen.value = false
     unlinkPassword.value = ''
     unlinkTarget.value = null
-    toast.success('Identity unlinked')
+    toast.success(t('settings.account.connectedAccounts.unlinked'))
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to unlink identity')
+    toast.error(err instanceof Error ? err.message : t('settings.account.connectedAccounts.unlinkIdentityFailed'))
   } finally {
     unlinking.value = false
   }
@@ -303,13 +305,13 @@ function closeUnlinkDialog() {
 </script>
 
 <template>
-  <SettingsPageHeader v-if="!props.embedded" class="hidden md:flex" title="Account" subtitle="Manage your personal profile settings." />
+  <SettingsPageHeader v-if="!props.embedded" class="hidden md:flex" :title="t('settings.account.title')" :subtitle="t('settings.account.subtitle')" />
   <div v-if="!props.embedded" class="md:hidden px-1">
-    <h1 class="text-xl font-semibold tracking-tight text-foreground">Account</h1>
+    <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('settings.account.title') }}</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
     >
-      Manage your personal profile settings.
+      {{ t('settings.account.subtitle') }}
     </p>
   </div>
 
@@ -317,7 +319,7 @@ function closeUnlinkDialog() {
     <section class="rounded-lg border border-border bg-card p-4 md:p-5 space-y-4 mb-4 shadow-xs">
       <button class="md:hidden w-full flex items-center justify-between gap-2 text-left" @click="profileCardOpen = !profileCardOpen">
         <div>
-          <p class="text-sm font-semibold text-foreground">Profile & Security</p>
+          <p class="text-sm font-semibold text-foreground">{{ t('settings.account.profile.securityHeading') }}</p>
           <p class="text-xs text-muted-foreground truncate max-w-[17rem]">@{{ user?.username ?? '' }}</p>
         </div>
         <ChevronUp v-if="profileCardOpen" :size="16" class="text-muted-foreground shrink-0" />
@@ -329,11 +331,11 @@ function closeUnlinkDialog() {
           v-if="accountEditBlocked"
           class="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400"
         >
-          Demo-restricted account: editing profile, password, avatar, and linked identities is disabled.
+          {{ t('settings.account.demoRestricted.notice') }}
         </p>
         <div class="grid gap-4 sm:grid-cols-2">
           <div class="space-y-1.5 sm:col-span-2">
-            <label class="settings-label">Username</label>
+            <label class="settings-label">{{ t('settings.account.profile.username') }}</label>
             <input
               :value="user?.username ?? ''"
               type="text"
@@ -342,7 +344,7 @@ function closeUnlinkDialog() {
             />
           </div>
           <div class="space-y-1.5">
-            <label class="settings-label">Full name</label>
+            <label class="settings-label">{{ t('settings.account.profile.fullName') }}</label>
             <input
               v-model="formName"
               type="text"
@@ -355,21 +357,21 @@ function closeUnlinkDialog() {
             />
           </div>
           <div class="space-y-1.5">
-            <label class="settings-label">Email</label>
+            <label class="settings-label">{{ t('settings.account.profile.email') }}</label>
             <input
               :value="user?.email ?? ''"
               type="email"
               readonly
               class="w-full rounded-md border border-input bg-muted/50 px-3 py-2 text-sm text-muted-foreground truncate"
             />
-            <p class="text-xs text-muted-foreground">Contact an administrator to change your email address.</p>
+            <p class="text-xs text-muted-foreground">{{ t('settings.account.profile.emailHint') }}</p>
           </div>
         </div>
 
         <div class="hidden md:flex flex-wrap items-center gap-2">
           <button class="settings-btn-primary" :disabled="!profileChanged || profileBusy || accountEditBlocked" @click="saveProfile">
             <Save :size="14" />
-            {{ savingProfile ? 'Saving...' : 'Save profile' }}
+            {{ savingProfile ? t('settings.account.profile.saving') : t('settings.account.profile.save') }}
           </button>
           <button
             v-if="canChangePassword"
@@ -378,11 +380,17 @@ function closeUnlinkDialog() {
             @click="openChangePassword()"
           >
             <KeyRound :size="14" />
-            Change password
+            {{ t('settings.account.profile.changePassword') }}
           </button>
           <span class="text-xs text-muted-foreground">
-            Account type:
-            {{ user?.provisioningMethod === 'oidc' ? 'OIDC / SSO' : user?.provisioningMethod === 'shared' ? 'Shared' : 'Local' }}
+            {{ t('settings.account.profile.accountType') }}
+            {{
+              user?.provisioningMethod === 'oidc'
+                ? t('settings.account.profile.accountTypeOidc')
+                : user?.provisioningMethod === 'shared'
+                  ? t('settings.account.profile.accountTypeShared')
+                  : t('settings.account.profile.accountTypeLocal')
+            }}
           </span>
         </div>
 
@@ -394,11 +402,17 @@ function closeUnlinkDialog() {
             @click="openChangePassword()"
           >
             <KeyRound :size="14" />
-            Change password
+            {{ t('settings.account.profile.changePassword') }}
           </button>
           <span class="text-xs text-muted-foreground">
-            Account type:
-            {{ user?.provisioningMethod === 'oidc' ? 'OIDC / SSO' : user?.provisioningMethod === 'shared' ? 'Shared' : 'Local' }}
+            {{ t('settings.account.profile.accountType') }}
+            {{
+              user?.provisioningMethod === 'oidc'
+                ? t('settings.account.profile.accountTypeOidc')
+                : user?.provisioningMethod === 'shared'
+                  ? t('settings.account.profile.accountTypeShared')
+                  : t('settings.account.profile.accountTypeLocal')
+            }}
           </span>
         </div>
         <p v-if="profileError" class="text-xs text-destructive">{{ profileError }}</p>
@@ -409,13 +423,13 @@ function closeUnlinkDialog() {
       <div class="flex items-center gap-2">
         <Clock class="h-4 w-4 text-muted-foreground shrink-0" />
         <div>
-          <p class="text-sm font-semibold text-foreground">Reading Preferences</p>
-          <p class="text-xs text-muted-foreground mt-0.5">Timezone is used for time-sensitive achievements like Early Bird and All-nighter.</p>
+          <p class="text-sm font-semibold text-foreground">{{ t('settings.account.readingPreferences.title') }}</p>
+          <p class="text-xs text-muted-foreground mt-0.5">{{ t('settings.account.readingPreferences.timezoneHint') }}</p>
         </div>
       </div>
       <div class="grid gap-4 sm:grid-cols-2">
         <div class="space-y-1.5">
-          <label class="settings-label">Timezone</label>
+          <label class="settings-label">{{ t('settings.account.readingPreferences.timezone') }}</label>
           <select
             v-model="formTimezone"
             class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
@@ -426,15 +440,15 @@ function closeUnlinkDialog() {
       </div>
       <button class="settings-btn-primary" :disabled="!timezoneChanged || savingTimezone" @click="saveTimezone">
         <Save :size="14" />
-        {{ savingTimezone ? 'Saving...' : 'Save preferences' }}
+        {{ savingTimezone ? t('settings.account.profile.saving') : t('settings.account.readingPreferences.save') }}
       </button>
     </section>
 
     <section class="rounded-lg border border-border bg-card p-4 md:p-5 space-y-4 shadow-xs">
       <button class="md:hidden w-full flex items-center justify-between gap-2 text-left" @click="avatarCardOpen = !avatarCardOpen">
         <div>
-          <p class="text-sm font-semibold text-foreground">Profile Picture</p>
-          <p class="text-xs text-muted-foreground truncate max-w-[17rem]">{{ user?.name ?? 'Unknown user' }}</p>
+          <p class="text-sm font-semibold text-foreground">{{ t('settings.account.avatar.title') }}</p>
+          <p class="text-xs text-muted-foreground truncate max-w-[17rem]">{{ user?.name ?? t('settings.account.avatar.unknownUser') }}</p>
         </div>
         <ChevronUp v-if="avatarCardOpen" :size="16" class="text-muted-foreground shrink-0" />
         <ChevronDown v-else :size="16" class="text-muted-foreground shrink-0" />
@@ -444,9 +458,11 @@ function closeUnlinkDialog() {
         <div class="flex items-center gap-4">
           <UserAvatar :name="user?.name ?? null" :avatar-url="user?.avatarUrl ?? null" size-class="h-20 w-20" text-class="text-xl font-semibold" />
           <div class="min-w-0">
-            <p class="text-sm font-medium text-foreground truncate">{{ user?.name ?? 'Unknown user' }}</p>
+            <p class="text-sm font-medium text-foreground truncate">{{ user?.name ?? t('settings.account.avatar.unknownUser') }}</p>
             <p class="text-xs text-muted-foreground truncate">{{ user?.username ?? '' }}</p>
-            <p class="mt-1 text-xs text-muted-foreground">PNG/JPEG/WEBP up to {{ Math.floor(MAX_PROFILE_AVATAR_BYTES / 1024 / 1024) }} MB</p>
+            <p class="mt-1 text-xs text-muted-foreground">
+              {{ t('settings.account.avatar.formatHint', { size: Math.floor(MAX_PROFILE_AVATAR_BYTES / 1024 / 1024) }) }}
+            </p>
           </div>
         </div>
 
@@ -455,7 +471,13 @@ function closeUnlinkDialog() {
 
           <button class="settings-btn-primary" :disabled="profileBusy || accountEditBlocked" @click="triggerFileDialog">
             <Upload :size="14" />
-            {{ uploading ? 'Uploading...' : hasAvatar ? 'Replace picture' : 'Upload picture' }}
+            {{
+              uploading
+                ? t('settings.account.avatar.uploading')
+                : hasAvatar
+                  ? t('settings.account.avatar.replace')
+                  : t('settings.account.avatar.upload')
+            }}
           </button>
 
           <button
@@ -464,7 +486,7 @@ function closeUnlinkDialog() {
             @click="removeAvatarConfirmOpen = true"
           >
             <Trash2 :size="14" />
-            {{ removing ? 'Removing...' : 'Remove picture' }}
+            {{ removing ? t('settings.account.avatar.removing') : t('settings.account.avatar.remove') }}
           </button>
         </div>
       </div>
@@ -478,7 +500,7 @@ function closeUnlinkDialog() {
           @click="saveProfile"
         >
           <Save :size="14" />
-          {{ savingProfile ? 'Saving...' : 'Save profile' }}
+          {{ savingProfile ? t('settings.account.profile.saving') : t('settings.account.profile.save') }}
         </button>
       </div>
       <p v-if="saveFeedback" class="mt-1.5 text-xs" :class="profileError ? 'text-destructive' : 'text-muted-foreground'">
@@ -492,7 +514,7 @@ function closeUnlinkDialog() {
     <section class="rounded-lg border border-border bg-card p-4 md:p-5 space-y-3 shadow-xs">
       <div class="flex items-center gap-2">
         <LinkIcon class="h-4 w-4 text-muted-foreground shrink-0" />
-        <h2 class="text-sm font-semibold text-foreground">Connected Accounts</h2>
+        <h2 class="text-sm font-semibold text-foreground">{{ t('settings.account.connectedAccounts.title') }}</h2>
       </div>
 
       <!-- Linked identities -->
@@ -513,14 +535,14 @@ function closeUnlinkDialog() {
             class="shrink-0 rounded-md border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             @click="openUnlinkDialog(identity)"
           >
-            Unlink
+            {{ t('settings.account.connectedAccounts.unlink') }}
           </button>
         </div>
       </div>
 
       <!-- Link new provider -->
       <div v-if="availableForLinking().length > 0" class="space-y-2">
-        <p class="text-xs text-muted-foreground">Link additional providers:</p>
+        <p class="text-xs text-muted-foreground">{{ t('settings.account.connectedAccounts.linkAdditional') }}</p>
         <div class="flex flex-wrap gap-2">
           <button
             v-for="provider in availableForLinking()"
@@ -532,13 +554,17 @@ function closeUnlinkDialog() {
           >
             <img v-if="provider.iconUrl" :src="provider.iconUrl" alt="" class="h-3 w-3 shrink-0 object-contain" />
             <Link class="h-3 w-3" />
-            {{ linkingSlug === provider.slug ? 'Redirecting...' : `Link ${provider.displayName}` }}
+            {{
+              linkingSlug === provider.slug
+                ? t('settings.account.connectedAccounts.redirecting')
+                : t('settings.account.connectedAccounts.linkProvider', { provider: provider.displayName })
+            }}
           </button>
         </div>
       </div>
 
       <p v-if="linkedIdentities.length === 0 && availableForLinking().length === 0" class="text-sm text-muted-foreground">
-        No OIDC providers are configured. Ask an administrator to set up SSO.
+        {{ t('settings.account.connectedAccounts.noneConfigured') }}
       </p>
     </section>
   </div>
@@ -550,21 +576,21 @@ function closeUnlinkDialog() {
   >
     <button class="absolute inset-0 bg-black/45" @click="removeAvatarConfirmOpen = false" />
     <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-      <p class="text-base font-semibold text-foreground">Remove profile picture?</p>
-      <p class="mt-1 text-sm text-muted-foreground">Your avatar will be removed and replaced with initials.</p>
+      <p class="text-base font-semibold text-foreground">{{ t('settings.account.avatar.removeConfirm.title') }}</p>
+      <p class="mt-1 text-sm text-muted-foreground">{{ t('settings.account.avatar.removeConfirm.description') }}</p>
       <div class="mt-4 flex items-center justify-end gap-2">
         <button
           class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
           @click="removeAvatarConfirmOpen = false"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           :disabled="accountEditBlocked"
           class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 disabled:cursor-not-allowed"
           @click="onRemoveAvatar"
         >
-          Remove
+          {{ t('settings.account.avatar.removeConfirm.confirm') }}
         </button>
       </div>
     </div>
@@ -577,11 +603,11 @@ function closeUnlinkDialog() {
         <div class="flex items-center gap-2">
           <MapPin class="h-4 w-4 text-muted-foreground shrink-0" />
           <div>
-            <p class="text-sm font-semibold text-foreground">Guided Tour</p>
-            <p class="text-xs text-muted-foreground mt-0.5">Replay the walkthrough that highlights key features of the app.</p>
+            <p class="text-sm font-semibold text-foreground">{{ t('settings.account.tour.title') }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('settings.account.tour.description') }}</p>
           </div>
         </div>
-        <button class="settings-btn-outline shrink-0" @click="resetTour">Take the tour again</button>
+        <button class="settings-btn-outline shrink-0" @click="resetTour">{{ t('settings.account.tour.action') }}</button>
       </div>
     </section>
   </div>
@@ -590,25 +616,27 @@ function closeUnlinkDialog() {
   <div v-if="unlinkDialogOpen" class="fixed inset-0 z-[70] flex items-end justify-center md:items-center md:px-4" @click.self="closeUnlinkDialog">
     <button class="absolute inset-0 bg-black/45" @click="closeUnlinkDialog" />
     <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-      <p class="text-base font-semibold text-foreground">Unlink {{ unlinkTarget?.providerName ?? 'OIDC' }} identity?</p>
-      <p class="mt-1 text-sm text-muted-foreground">Enter your password to confirm. You will no longer be able to sign in with this provider.</p>
+      <p class="text-base font-semibold text-foreground">
+        {{ t('settings.account.connectedAccounts.unlinkDialog.title', { provider: unlinkTarget?.providerName ?? 'OIDC' }) }}
+      </p>
+      <p class="mt-1 text-sm text-muted-foreground">{{ t('settings.account.connectedAccounts.unlinkDialog.description') }}</p>
       <input
         v-model="unlinkPassword"
         type="password"
-        placeholder="Current password"
+        :placeholder="t('settings.account.connectedAccounts.unlinkDialog.currentPassword')"
         autocomplete="current-password"
         class="input-field mt-3 w-full"
       />
       <div class="mt-4 flex items-center justify-end gap-2">
         <button class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors" @click="closeUnlinkDialog">
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           :disabled="unlinking || !unlinkPassword || accountEditBlocked"
           class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
           @click="confirmUnlink"
         >
-          {{ unlinking ? 'Unlinking...' : 'Unlink' }}
+          {{ unlinking ? t('settings.account.connectedAccounts.unlinking') : t('settings.account.connectedAccounts.unlink') }}
         </button>
       </div>
     </div>

--- a/client/src/features/settings/AdminAllSettings.vue
+++ b/client/src/features/settings/AdminAllSettings.vue
@@ -18,7 +18,7 @@ const availableTabs = computed(() =>
   ADMIN_TABS.filter((id) => {
     const perm = ADMIN_TAB_INFO[id].permission
     return isSuperuser.value || (perm !== null && userPermissions.value.includes(perm))
-  }).map((id) => ({ id, label: ADMIN_TAB_INFO[id].navLabel })),
+  }).map((id) => ({ id, label: t(`settings.admin.tabs.${id}`) })),
 )
 
 function resolveTab(raw: unknown): Tab {

--- a/client/src/features/settings/AdminAllSettings.vue
+++ b/client/src/features/settings/AdminAllSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import SettingsPageHeader from './SettingsPageHeader.vue'
 import UsersPage from '@/features/admin/UsersPage.vue'
@@ -8,6 +9,7 @@ import MagicLinksSettings from './MagicLinksSettings.vue'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 import { ADMIN_TAB_INFO, ADMIN_TABS, normalizeAdminTab, type AdminTab as Tab } from './lib/admin-tabs'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { isSuperuser, userPermissions } = usePermissions()
@@ -59,7 +61,7 @@ function selectTab(tab: Tab) {
 </script>
 
 <template>
-  <SettingsPageHeader title="Admin" subtitle="Manage users and authentication settings." />
+  <SettingsPageHeader :title="t('settings.admin.title')" :subtitle="t('settings.admin.subtitle')" />
 
   <div
     :class="[

--- a/client/src/features/settings/AppearanceBehaviorSettings.vue
+++ b/client/src/features/settings/AppearanceBehaviorSettings.vue
@@ -1,9 +1,21 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { BookOpen, BookText } from '@lucide/vue'
+import { LOCALE_LABELS, SUPPORTED_LOCALES, type Locale } from '@bookorbit/types'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import { useDisplaySettings, type BookThumbnailClickAction } from '@/composables/useDisplaySettings'
 import { useSeriesCollapsePreference } from '@/features/book/composables/useSeriesCollapsePreference'
+import { useLocaleStore } from '@/stores/locale'
+
+const { t } = useI18n()
+const localeStore = useLocaleStore()
+
+const LANGUAGE_OPTIONS: { id: Locale; label: string }[] = SUPPORTED_LOCALES.map((id) => ({ id, label: LOCALE_LABELS[id] }))
+
+async function setLanguage(next: Locale) {
+  await localeStore.setLocale(next)
+}
 
 const { smartScopeFilterExpanded, thumbnailClickAction } = useDisplaySettings()
 const { prefs, setPreference } = useSeriesCollapsePreference()
@@ -26,6 +38,34 @@ function setThumbnailClickAction(action: BookThumbnailClickAction) {
 
 <template>
   <div>
+    <p class="settings-group-label">{{ t('settings.appearance.language.title') }}</p>
+    <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs mb-6">
+      <div class="flex flex-col gap-3 px-4 py-3.5 md:flex-row md:items-center md:justify-between md:px-5 md:py-4 bg-card">
+        <div class="min-w-0">
+          <p class="settings-label">{{ t('settings.appearance.language.label') }}</p>
+          <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:whitespace-normal md:overflow-visible">
+            {{ t('settings.appearance.language.description') }}
+          </p>
+        </div>
+        <div
+          class="grid w-full gap-1 rounded-lg border border-border bg-muted/50 p-1 sm:w-auto"
+          :style="{ gridTemplateColumns: `repeat(${LANGUAGE_OPTIONS.length}, minmax(0, 1fr))` }"
+          data-testid="language-control"
+        >
+          <button
+            v-for="opt in LANGUAGE_OPTIONS"
+            :key="opt.id"
+            class="min-w-0 rounded-md px-3 py-1.5 text-center text-xs font-medium transition-colors"
+            :class="localeStore.locale === opt.id ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
+            :data-testid="`language-option-${opt.id}`"
+            @click="setLanguage(opt.id)"
+          >
+            <span class="block truncate">{{ opt.label }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
     <p class="settings-group-label">Library Behavior</p>
     <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
       <div class="flex flex-col gap-3 px-4 py-3.5 md:flex-row md:items-center md:justify-between md:px-5 md:py-4 bg-card">

--- a/client/src/features/settings/AppearanceBehaviorSettings.vue
+++ b/client/src/features/settings/AppearanceBehaviorSettings.vue
@@ -23,8 +23,18 @@ const { prefs, setPreference } = useSeriesCollapsePreference()
 const globalCollapseEnabled = computed(() => prefs.value?.global ?? false)
 
 const THUMBNAIL_CLICK_OPTIONS: { id: BookThumbnailClickAction; label: string; hint: string; icon: typeof BookOpen }[] = [
-  { id: 'reader', label: 'Read first', hint: 'Open the reader when a readable file exists', icon: BookOpen },
-  { id: 'details', label: 'Open details', hint: 'Go to the book details page from grid and list thumbnails', icon: BookText },
+  {
+    id: 'reader',
+    label: t('settings.appearance.behavior.thumbnailClicks.readFirst'),
+    hint: t('settings.appearance.behavior.thumbnailClicks.readFirstHint'),
+    icon: BookOpen,
+  },
+  {
+    id: 'details',
+    label: t('settings.appearance.behavior.thumbnailClicks.openDetails'),
+    hint: t('settings.appearance.behavior.thumbnailClicks.openDetailsHint'),
+    icon: BookText,
+  },
 ]
 
 async function handleGlobalCollapseToggle(value: boolean) {
@@ -66,13 +76,13 @@ function setThumbnailClickAction(action: BookThumbnailClickAction) {
       </div>
     </div>
 
-    <p class="settings-group-label">Library Behavior</p>
+    <p class="settings-group-label">{{ t('settings.appearance.behavior.title') }}</p>
     <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
       <div class="flex flex-col gap-3 px-4 py-3.5 md:flex-row md:items-center md:justify-between md:px-5 md:py-4 bg-card">
         <div class="min-w-0">
-          <p class="settings-label">Thumbnail clicks</p>
+          <p class="settings-label">{{ t('settings.appearance.behavior.thumbnailClicks.label') }}</p>
           <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:whitespace-normal md:overflow-visible">
-            Choose what happens when opening a book from grid and list views
+            {{ t('settings.appearance.behavior.thumbnailClicks.hint') }}
           </p>
         </div>
         <div
@@ -96,18 +106,18 @@ function setThumbnailClickAction(action: BookThumbnailClickAction) {
       </div>
       <div class="flex items-center justify-between gap-3 px-4 py-3 md:px-5 md:py-3.5 bg-card">
         <div class="min-w-0">
-          <p class="settings-label">Show filter preview by default</p>
+          <p class="settings-label">{{ t('settings.appearance.behavior.filterPreview.label') }}</p>
           <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:whitespace-normal md:overflow-visible">
-            Expand the active filter and sort summary when opening a smartScope
+            {{ t('settings.appearance.behavior.filterPreview.hint') }}
           </p>
         </div>
         <ToggleSwitch v-model="smartScopeFilterExpanded" />
       </div>
       <div class="flex items-center justify-between gap-3 px-4 py-3 md:px-5 md:py-3.5 bg-card">
         <div class="min-w-0">
-          <p class="settings-label">Collapse series by default</p>
+          <p class="settings-label">{{ t('settings.appearance.behavior.collapseSeries.label') }}</p>
           <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:whitespace-normal md:overflow-visible">
-            Group books in the same series into a single card in library and collection views
+            {{ t('settings.appearance.behavior.collapseSeries.hint') }}
           </p>
         </div>
         <ToggleSwitch :model-value="globalCollapseEnabled" @update:model-value="handleGlobalCollapseToggle" />

--- a/client/src/features/settings/AppearanceBookCoverSettings.vue
+++ b/client/src/features/settings/AppearanceBookCoverSettings.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Image } from '@lucide/vue'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import {
@@ -9,32 +10,62 @@ import {
   type CardOverlayKey,
 } from '@/composables/useDisplaySettings'
 
+const { t } = useI18n()
+
 const { cardOverlays, bookSpineOverlay, showSpineOnComics, bookShadowStrength, bookCoverDisplayMode } = useDisplaySettings()
 
 const OVERLAY_OPTIONS: { key: CardOverlayKey; label: string; hint: string }[] = [
-  { key: 'progress-bar', label: 'Progress bar', hint: 'Thin colored line along the bottom edge' },
-  { key: 'format', label: 'File format', hint: 'Color-coded EPUB, PDF, CBZ badge at bottom-right' },
-  { key: 'rating', label: 'Rating', hint: 'Star rating indicator at bottom-left' },
-  { key: 'read-status', label: 'Read status', hint: 'Color icon showing the current reading status at top-left' },
-  { key: 'series-position', label: 'Series number', hint: 'Badge showing the book position in its series at top-right (e.g. #3, #1.5)' },
-  { key: 'lock-status', label: 'Lock status', hint: 'Metadata lock icon at top-right - orange when locked, green when unlocked' },
+  {
+    key: 'progress-bar',
+    label: t('settings.appearance.bookCovers.overlays.progressBar.label'),
+    hint: t('settings.appearance.bookCovers.overlays.progressBar.hint'),
+  },
+  { key: 'format', label: t('settings.appearance.bookCovers.overlays.format.label'), hint: t('settings.appearance.bookCovers.overlays.format.hint') },
+  { key: 'rating', label: t('settings.appearance.bookCovers.overlays.rating.label'), hint: t('settings.appearance.bookCovers.overlays.rating.hint') },
+  {
+    key: 'read-status',
+    label: t('settings.appearance.bookCovers.overlays.readStatus.label'),
+    hint: t('settings.appearance.bookCovers.overlays.readStatus.hint'),
+  },
+  {
+    key: 'series-position',
+    label: t('settings.appearance.bookCovers.overlays.seriesPosition.label'),
+    hint: t('settings.appearance.bookCovers.overlays.seriesPosition.hint'),
+  },
+  {
+    key: 'lock-status',
+    label: t('settings.appearance.bookCovers.overlays.lockStatus.label'),
+    hint: t('settings.appearance.bookCovers.overlays.lockStatus.hint'),
+  },
 ]
 
 const BOOK_SPINE_OPTIONS: { id: BookSpineOverlay; label: string; hint: string }[] = [
-  { id: 'off', label: 'Off', hint: 'No spine/gloss effect on covers' },
-  { id: 'subtle', label: 'Subtle', hint: 'Light spine and sheen, closer to the default look' },
-  { id: 'strong', label: 'Strong', hint: 'More pronounced spine and gloss treatment' },
+  { id: 'off', label: t('settings.appearance.bookCovers.spine.off.label'), hint: t('settings.appearance.bookCovers.spine.off.hint') },
+  { id: 'subtle', label: t('settings.appearance.bookCovers.spine.subtle.label'), hint: t('settings.appearance.bookCovers.spine.subtle.hint') },
+  { id: 'strong', label: t('settings.appearance.bookCovers.spine.strong.label'), hint: t('settings.appearance.bookCovers.spine.strong.hint') },
 ]
 
 const BOOK_SHADOW_OPTIONS: { id: BookShadowStrength; label: string; hint: string }[] = [
-  { id: 'default', label: 'Default', hint: 'Current elevation and depth' },
-  { id: 'strong', label: 'Strong', hint: 'Heavier shelf-like drop shadow under covers' },
+  { id: 'default', label: t('settings.appearance.bookCovers.shadow.default.label'), hint: t('settings.appearance.bookCovers.shadow.default.hint') },
+  { id: 'strong', label: t('settings.appearance.bookCovers.shadow.strong.label'), hint: t('settings.appearance.bookCovers.shadow.strong.hint') },
 ]
 
 const BOOK_COVER_DISPLAY_OPTIONS: { id: BookCoverDisplayMode; label: string; hint: string }[] = [
-  { id: 'blurred-fit', label: 'Blurred fit', hint: 'Show the full cover with a blurred fill behind it' },
-  { id: 'fill-crop', label: 'Fill card', hint: 'Fill the entire slot by cropping edges when aspect ratios differ' },
-  { id: 'natural-bottom', label: 'Natural bottom', hint: 'Keep the original cover ratio and anchor the cover to the bottom' },
+  {
+    id: 'blurred-fit',
+    label: t('settings.appearance.bookCovers.displayMode.blurredFit.label'),
+    hint: t('settings.appearance.bookCovers.displayMode.blurredFit.hint'),
+  },
+  {
+    id: 'fill-crop',
+    label: t('settings.appearance.bookCovers.displayMode.fillCrop.label'),
+    hint: t('settings.appearance.bookCovers.displayMode.fillCrop.hint'),
+  },
+  {
+    id: 'natural-bottom',
+    label: t('settings.appearance.bookCovers.displayMode.naturalBottom.label'),
+    hint: t('settings.appearance.bookCovers.displayMode.naturalBottom.hint'),
+  },
 ]
 
 function toggleOverlay(key: CardOverlayKey) {
@@ -58,12 +89,12 @@ function setBookCoverDisplayMode(mode: BookCoverDisplayMode) {
 
 <template>
   <div>
-    <p class="settings-group-label">Book Covers</p>
+    <p class="settings-group-label">{{ t('settings.appearance.bookCovers.title') }}</p>
     <div class="border border-border rounded-lg overflow-hidden divide-y divide-border mb-4 shadow-xs">
       <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
         <div>
-          <p class="settings-label">Cover display mode</p>
-          <p class="settings-hint">Controls how real covers fit inside book slots when aspect ratios differ</p>
+          <p class="settings-label">{{ t('settings.appearance.bookCovers.displayMode.title') }}</p>
+          <p class="settings-hint">{{ t('settings.appearance.bookCovers.displayMode.hint') }}</p>
         </div>
         <div class="mt-3 grid gap-2 md:grid-cols-3">
           <button
@@ -87,8 +118,8 @@ function setBookCoverDisplayMode(mode: BookCoverDisplayMode) {
       </div>
       <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
         <div>
-          <p class="settings-label">Book spine overlay</p>
-          <p class="settings-hint">Adds a stylized spine and gloss effect to cover cards</p>
+          <p class="settings-label">{{ t('settings.appearance.bookCovers.spine.title') }}</p>
+          <p class="settings-hint">{{ t('settings.appearance.bookCovers.spine.hint') }}</p>
         </div>
         <div class="mt-3 grid gap-2 sm:grid-cols-3">
           <button
@@ -109,17 +140,17 @@ function setBookCoverDisplayMode(mode: BookCoverDisplayMode) {
       </div>
       <div class="flex items-center justify-between gap-3 px-4 py-3.5 md:px-5 md:py-4 bg-card">
         <div class="min-w-0">
-          <p class="settings-label">Show spine on comics</p>
+          <p class="settings-label">{{ t('settings.appearance.bookCovers.showSpineOnComics.label') }}</p>
           <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:whitespace-normal md:overflow-visible">
-            Apply the spine and gloss effect to comic covers (cbz, cbr, cb7)
+            {{ t('settings.appearance.bookCovers.showSpineOnComics.hint') }}
           </p>
         </div>
         <ToggleSwitch v-model="showSpineOnComics" />
       </div>
       <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
         <div>
-          <p class="settings-label">Cover shadow strength</p>
-          <p class="settings-hint">Controls depth under covers across grid, list, table, and dashboard thumbnails</p>
+          <p class="settings-label">{{ t('settings.appearance.bookCovers.shadow.title') }}</p>
+          <p class="settings-hint">{{ t('settings.appearance.bookCovers.shadow.hint') }}</p>
         </div>
         <div class="mt-3 flex items-center gap-1 p-1 rounded-lg border border-border bg-muted/50 self-start">
           <button
@@ -137,8 +168,8 @@ function setBookCoverDisplayMode(mode: BookCoverDisplayMode) {
 
     <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
       <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
-        <p class="settings-label">Card overlays</p>
-        <p class="settings-hint">Choose metadata shown directly on book cover cards</p>
+        <p class="settings-label">{{ t('settings.appearance.bookCovers.overlays.title') }}</p>
+        <p class="settings-hint">{{ t('settings.appearance.bookCovers.overlays.hint') }}</p>
       </div>
       <div v-for="opt in OVERLAY_OPTIONS" :key="opt.key" class="flex items-center justify-between gap-3 px-4 py-3 md:px-5 md:py-3.5 bg-card">
         <div class="min-w-0">

--- a/client/src/features/settings/AppearanceIconsSettings.vue
+++ b/client/src/features/settings/AppearanceIconsSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronLeft, ChevronRight, Image, Loader2, Pencil, RotateCw, Search, Trash2, Upload, UploadCloud, X } from '@lucide/vue'
 import {
   CUSTOM_ICON_DEFAULT_PAGE_SIZE,
@@ -17,6 +18,7 @@ import { usePermissions } from '@/features/auth/composables/usePermissions'
 import { useCustomIcons } from '@/features/custom-icons/composables/useCustomIcons'
 import IconUploadDialog from '@/features/custom-icons/components/IconUploadDialog.vue'
 
+const { t } = useI18n()
 const { hasPermission } = usePermissions()
 const { fetchIconPage, fetchIconUsage, updateCustomIcon, replaceCustomIconSvg, deleteCustomIcon, bulkDeleteCustomIcons } = useCustomIcons()
 
@@ -88,7 +90,7 @@ async function loadPage() {
     items.value = result.items
     total.value = result.total
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load icons'
+    error.value = err instanceof Error ? err.message : t('settings.appearance.icons.errors.load')
   } finally {
     loading.value = false
   }
@@ -213,10 +215,10 @@ async function saveEdit(icon: CustomIcon) {
   try {
     await updateCustomIcon(icon.slug, { name })
     cancelEdit()
-    toast.success('Icon saved')
+    toast.success(t('settings.appearance.icons.toasts.saved'))
     await loadPage()
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to save icon')
+    toast.error(err instanceof Error ? err.message : t('settings.appearance.icons.errors.save'))
   } finally {
     savingSlug.value = null
   }
@@ -236,16 +238,16 @@ async function handleReplaceInput(event: Event) {
   if (!file || !slug) return
   try {
     await replaceCustomIconSvg(slug, file)
-    toast.success('Icon updated')
+    toast.success(t('settings.appearance.icons.toasts.updated'))
     await loadPage()
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to replace icon')
+    toast.error(err instanceof Error ? err.message : t('settings.appearance.icons.errors.replace'))
   }
 }
 
 async function removeIcon(icon: CustomIcon) {
   if (deletingSlug.value) return
-  if (!window.confirm(`Delete "${icon.name}"? Existing uses will fall back to their default icon.`)) return
+  if (!window.confirm(t('settings.appearance.icons.confirm.deleteOne', { name: icon.name }))) return
   deletingSlug.value = icon.slug
   try {
     await deleteCustomIcon(icon.slug)
@@ -253,10 +255,10 @@ async function removeIcon(icon: CustomIcon) {
     const next = new Set(selected.value)
     next.delete(icon.slug)
     selected.value = next
-    toast.success('Icon deleted')
+    toast.success(t('settings.appearance.icons.toasts.deleted'))
     await loadPage()
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to delete icon')
+    toast.error(err instanceof Error ? err.message : t('settings.appearance.icons.errors.delete'))
   } finally {
     deletingSlug.value = null
   }
@@ -265,17 +267,18 @@ async function removeIcon(icon: CustomIcon) {
 async function deleteSelected() {
   if (bulkDeleting.value || selected.value.size === 0) return
   const slugs = [...selected.value]
-  if (!window.confirm(`Delete ${slugs.length} icon${slugs.length === 1 ? '' : 's'}? Existing uses will fall back to their default icon.`)) return
+  if (!window.confirm(t('settings.appearance.icons.confirm.deleteMany', { count: slugs.length }, slugs.length))) return
   bulkDeleting.value = true
   try {
     const result = await bulkDeleteCustomIcons(slugs)
     clearSelection()
     expandedSlug.value = null
-    if (result.failed.length > 0) toast.warning(`Deleted ${result.deleted.length}, ${result.failed.length} failed`)
-    else toast.success(`Deleted ${result.deleted.length} icon${result.deleted.length === 1 ? '' : 's'}`)
+    if (result.failed.length > 0)
+      toast.warning(t('settings.appearance.icons.toasts.bulkDeletePartial', { deleted: result.deleted.length, failed: result.failed.length }))
+    else toast.success(t('settings.appearance.icons.toasts.bulkDeleted', { count: result.deleted.length }, result.deleted.length))
     await loadPage()
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to delete icons')
+    toast.error(err instanceof Error ? err.message : t('settings.appearance.icons.errors.bulkDelete'))
   } finally {
     bulkDeleting.value = false
   }
@@ -287,9 +290,9 @@ function handleUploaded() {
 
 function usageSummary(usage: CustomIconUsage): string {
   const parts: string[] = []
-  if (usage.libraries) parts.push(`${usage.libraries} librar${usage.libraries === 1 ? 'y' : 'ies'}`)
-  if (usage.collections) parts.push(`${usage.collections} collection${usage.collections === 1 ? '' : 's'}`)
-  if (usage.smartScopes) parts.push(`${usage.smartScopes} smart scope${usage.smartScopes === 1 ? '' : 's'}`)
+  if (usage.libraries) parts.push(t('settings.appearance.icons.usage.libraries', { count: usage.libraries }, usage.libraries))
+  if (usage.collections) parts.push(t('settings.appearance.icons.usage.collections', { count: usage.collections }, usage.collections))
+  if (usage.smartScopes) parts.push(t('settings.appearance.icons.usage.smartScopes', { count: usage.smartScopes }, usage.smartScopes))
   return parts.join(', ')
 }
 </script>
@@ -303,11 +306,11 @@ function usageSummary(usage: CustomIconUsage): string {
       <div class="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
         <Button v-if="canManageIcons" type="button" class="h-9 gap-2 self-start sm:self-auto" @click="openUpload">
           <UploadCloud :size="15" />
-          Upload icons
+          {{ t('settings.appearance.icons.uploadIcons') }}
         </Button>
         <div class="sm:text-right">
-          <p class="settings-group-label mb-0">Custom Icons</p>
-          <p class="text-xs text-muted-foreground">{{ total }} icon{{ total === 1 ? '' : 's' }} uploaded</p>
+          <p class="settings-group-label mb-0">{{ t('settings.appearance.icons.title') }}</p>
+          <p class="text-xs text-muted-foreground">{{ t('settings.appearance.icons.uploadedCount', { count: total }, total) }}</p>
         </div>
       </div>
 
@@ -317,7 +320,7 @@ function usageSummary(usage: CustomIconUsage): string {
           <input
             v-model="query"
             type="text"
-            placeholder="Search icons"
+            :placeholder="t('settings.appearance.icons.searchPlaceholder')"
             class="w-full min-w-0 bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
           />
           <button v-if="query" type="button" class="shrink-0 text-muted-foreground hover:text-foreground" @click="clearQuery">
@@ -333,7 +336,7 @@ function usageSummary(usage: CustomIconUsage): string {
               :class="sort === 'newest' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setSort('newest')"
             >
-              Newest
+              {{ t('settings.appearance.icons.sort.newest') }}
             </button>
             <button
               type="button"
@@ -341,7 +344,7 @@ function usageSummary(usage: CustomIconUsage): string {
               :class="sort === 'name' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setSort('name')"
             >
-              Name
+              {{ t('settings.appearance.icons.sort.name') }}
             </button>
           </div>
           <Button type="button" variant="outline" size="icon" class="h-9 w-9 shrink-0" :disabled="loading" @click="refresh">
@@ -354,13 +357,13 @@ function usageSummary(usage: CustomIconUsage): string {
         v-if="canManageIcons && selectedCount > 0"
         class="flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm"
       >
-        <span class="font-medium text-foreground">{{ selectedCount }} selected</span>
+        <span class="font-medium text-foreground">{{ t('settings.appearance.icons.selectedCount', { count: selectedCount }) }}</span>
         <div class="flex items-center gap-2">
-          <Button type="button" variant="ghost" size="sm" class="h-8" @click="clearSelection">Clear</Button>
+          <Button type="button" variant="ghost" size="sm" class="h-8" @click="clearSelection">{{ t('settings.appearance.icons.clear') }}</Button>
           <Button type="button" variant="destructive" size="sm" class="h-8 gap-1.5" :disabled="bulkDeleting" @click="deleteSelected">
             <Loader2 v-if="bulkDeleting" :size="14" class="animate-spin" />
             <Trash2 v-else :size="14" />
-            Delete selected
+            {{ t('settings.appearance.icons.deleteSelected') }}
           </Button>
         </div>
       </div>
@@ -374,12 +377,14 @@ function usageSummary(usage: CustomIconUsage): string {
         class="rounded-lg border border-border bg-card px-4 py-10 text-center text-sm text-muted-foreground"
       >
         <Loader2 :size="20" class="mx-auto mb-2 animate-spin" />
-        Loading icons...
+        {{ t('settings.appearance.icons.loading') }}
       </div>
 
       <div v-else-if="items.length === 0" class="rounded-lg border border-border bg-card px-4 py-10 text-center">
         <Image :size="22" class="mx-auto mb-2 text-muted-foreground" />
-        <p class="text-sm text-muted-foreground">{{ query ? 'No icons match your search.' : 'No custom icons uploaded yet.' }}</p>
+        <p class="text-sm text-muted-foreground">
+          {{ query ? t('settings.appearance.icons.emptySearch') : t('settings.appearance.icons.emptyNoIcons') }}
+        </p>
       </div>
 
       <div v-else>
@@ -428,7 +433,7 @@ function usageSummary(usage: CustomIconUsage): string {
                         <input
                           v-model="editingName"
                           :maxlength="CUSTOM_ICON_NAME_MAX_LENGTH"
-                          placeholder="Name"
+                          :placeholder="t('settings.appearance.icons.namePlaceholder')"
                           class="h-8 w-full rounded-md border border-input bg-background px-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                         />
                       </div>
@@ -436,13 +441,13 @@ function usageSummary(usage: CustomIconUsage): string {
                     <template v-else>
                       <p class="truncate text-sm font-semibold text-foreground">{{ expandedIcon.name }}</p>
                       <p class="mt-1 text-xs text-muted-foreground">
-                        <span v-if="usageLoading === expandedIcon.slug">Checking usage...</span>
+                        <span v-if="usageLoading === expandedIcon.slug">{{ t('settings.appearance.icons.checkingUsage') }}</span>
                         <template v-else-if="expandedUsage">
                           <template v-if="expandedUsage.total > 0">
-                            Used by {{ expandedUsage.total }}
+                            {{ t('settings.appearance.icons.usedBy', { count: expandedUsage.total }) }}
                             <span class="text-muted-foreground/70">({{ usageSummary(expandedUsage) }})</span>
                           </template>
-                          <template v-else>Not used yet</template>
+                          <template v-else>{{ t('settings.appearance.icons.notUsedYet') }}</template>
                         </template>
                       </p>
                     </template>
@@ -461,18 +466,18 @@ function usageSummary(usage: CustomIconUsage): string {
                   <template v-if="editingSlug === expandedIcon.slug">
                     <Button type="button" size="sm" class="h-8" :disabled="savingSlug === expandedIcon.slug" @click="saveEdit(expandedIcon)">
                       <Loader2 v-if="savingSlug === expandedIcon.slug" :size="14" class="animate-spin" />
-                      Save
+                      {{ t('common.save') }}
                     </Button>
-                    <Button type="button" variant="outline" size="sm" class="h-8" @click="cancelEdit">Cancel</Button>
+                    <Button type="button" variant="outline" size="sm" class="h-8" @click="cancelEdit">{{ t('common.cancel') }}</Button>
                   </template>
                   <template v-else>
                     <Button type="button" variant="outline" size="sm" class="h-8 gap-1.5" @click="startEdit(expandedIcon)">
                       <Pencil :size="14" />
-                      Rename
+                      {{ t('settings.appearance.icons.rename') }}
                     </Button>
                     <Button type="button" variant="outline" size="sm" class="h-8 gap-1.5" @click="openReplaceFilePicker(expandedIcon)">
                       <Upload :size="14" />
-                      Replace
+                      {{ t('settings.appearance.icons.replace') }}
                     </Button>
                     <Button
                       type="button"
@@ -484,7 +489,7 @@ function usageSummary(usage: CustomIconUsage): string {
                     >
                       <Loader2 v-if="deletingSlug === expandedIcon.slug" :size="14" class="animate-spin" />
                       <Trash2 v-else :size="14" />
-                      Delete
+                      {{ t('common.delete') }}
                     </Button>
                   </template>
                 </div>

--- a/client/src/features/settings/AppearanceLayoutSettings.vue
+++ b/client/src/features/settings/AppearanceLayoutSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Circle, Square } from '@lucide/vue'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import {
@@ -10,6 +11,8 @@ import {
   type GridCardLabelField,
   type SeriesCardCoverMode,
 } from '@/composables/useDisplaySettings'
+
+const { t } = useI18n()
 
 const {
   portraitCoverSize,
@@ -54,11 +57,11 @@ function setOffMode() {
 }
 
 const LABEL_FIELD_OPTIONS: { value: GridCardLabelField; label: string }[] = [
-  { value: 'hidden', label: 'Hidden' },
-  { value: 'book-title', label: 'Book title' },
-  { value: 'series-title', label: 'Series title' },
-  { value: 'series-title-position', label: 'Series title + position' },
-  { value: 'author', label: 'Author' },
+  { value: 'hidden', label: t('settings.appearance.layout.labelField.hidden') },
+  { value: 'book-title', label: t('settings.appearance.layout.labelField.bookTitle') },
+  { value: 'series-title', label: t('settings.appearance.layout.labelField.seriesTitle') },
+  { value: 'series-title-position', label: t('settings.appearance.layout.labelField.seriesTitlePosition') },
+  { value: 'author', label: t('settings.appearance.layout.labelField.author') },
 ]
 
 function handlePrimaryLabelChange(event: Event) {
@@ -93,13 +96,13 @@ function handleAuthorCoverSizeInput(event: Event) {
 <template>
   <div class="space-y-6">
     <div>
-      <p class="settings-group-label">Library Grid Layout</p>
+      <p class="settings-group-label">{{ t('settings.appearance.layout.gridLayout.title') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Cover size behavior</p>
-            <p class="settings-hint">Control whether portrait/square sizes and grid spacing are shared across all views or kept per-view</p>
-            <p v-if="!syncModeEnabled" class="settings-hint mt-1">Per-view mode: adjust cover size and spacing from each view's Display panel.</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.coverSizeBehavior.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.layout.coverSizeBehavior.hint') }}</p>
+            <p v-if="!syncModeEnabled" class="settings-hint mt-1">{{ t('settings.appearance.layout.coverSizeBehavior.perViewHint') }}</p>
           </div>
           <div class="flex items-center gap-1 p-1 rounded-lg border border-border bg-muted/50 self-start">
             <button
@@ -107,14 +110,14 @@ function handleAuthorCoverSizeInput(event: Event) {
               :class="coverSizeScope === 'synced' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setCoverSizeScope('synced')"
             >
-              Sync all views
+              {{ t('settings.appearance.layout.coverSizeBehavior.syncAll') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
               :class="coverSizeScope === 'per-view' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setCoverSizeScope('per-view')"
             >
-              Per-view sizes
+              {{ t('settings.appearance.layout.coverSizeBehavior.perView') }}
             </button>
           </div>
         </div>
@@ -124,12 +127,12 @@ function handleAuthorCoverSizeInput(event: Event) {
           :class="{ 'opacity-60': !syncModeEnabled }"
         >
           <div>
-            <p class="settings-label">Portrait cover size</p>
-            <p class="settings-hint">Used for portrait libraries and views</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.portraitCoverSize.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.layout.portraitCoverSize.hint') }}</p>
           </div>
           <div class="w-full md:w-72">
             <div class="mb-1.5 flex items-center justify-between gap-3">
-              <span class="text-xs text-muted-foreground">Cover size</span>
+              <span class="text-xs text-muted-foreground">{{ t('settings.appearance.layout.coverSize') }}</span>
               <span class="text-xs font-medium tabular-nums text-foreground">{{ portraitCoverSize }}px</span>
             </div>
             <input
@@ -150,12 +153,12 @@ function handleAuthorCoverSizeInput(event: Event) {
           :class="{ 'opacity-60': !syncModeEnabled }"
         >
           <div>
-            <p class="settings-label">Square cover size</p>
-            <p class="settings-hint">Used for square libraries and views</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.squareCoverSize.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.layout.squareCoverSize.hint') }}</p>
           </div>
           <div class="w-full md:w-72">
             <div class="mb-1.5 flex items-center justify-between gap-3">
-              <span class="text-xs text-muted-foreground">Cover size</span>
+              <span class="text-xs text-muted-foreground">{{ t('settings.appearance.layout.coverSize') }}</span>
               <span class="text-xs font-medium tabular-nums text-foreground">{{ squareCoverSize }}px</span>
             </div>
             <input
@@ -176,12 +179,12 @@ function handleAuthorCoverSizeInput(event: Event) {
           :class="{ 'opacity-60': !syncModeEnabled }"
         >
           <div>
-            <p class="settings-label">Portrait grid spacing</p>
-            <p class="settings-hint">Gap between portrait covers</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.portraitGridSpacing.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.layout.portraitGridSpacing.hint') }}</p>
           </div>
           <div class="w-full md:w-72">
             <div class="mb-1.5 flex items-center justify-between gap-3">
-              <span class="text-xs text-muted-foreground">Grid spacing</span>
+              <span class="text-xs text-muted-foreground">{{ t('settings.appearance.layout.gridSpacing') }}</span>
               <span class="text-xs font-medium tabular-nums text-foreground">{{ portraitGridGap }}px</span>
             </div>
             <input
@@ -202,12 +205,12 @@ function handleAuthorCoverSizeInput(event: Event) {
           :class="{ 'opacity-60': !syncModeEnabled }"
         >
           <div>
-            <p class="settings-label">Square grid spacing</p>
-            <p class="settings-hint">Gap between square covers</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.squareGridSpacing.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.layout.squareGridSpacing.hint') }}</p>
           </div>
           <div class="w-full md:w-72">
             <div class="mb-1.5 flex items-center justify-between gap-3">
-              <span class="text-xs text-muted-foreground">Grid spacing</span>
+              <span class="text-xs text-muted-foreground">{{ t('settings.appearance.layout.gridSpacing') }}</span>
               <span class="text-xs font-medium tabular-nums text-foreground">{{ squareGridGap }}px</span>
             </div>
             <input
@@ -225,8 +228,8 @@ function handleAuthorCoverSizeInput(event: Event) {
 
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Card info mode</p>
-            <p class="settings-hint">Where to show book title and author on grid cards</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.cardInfoMode.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.layout.cardInfoMode.hint') }}</p>
           </div>
           <div class="flex items-center gap-1 p-1 rounded-lg border border-border bg-muted/50 self-start">
             <button
@@ -234,21 +237,21 @@ function handleAuthorCoverSizeInput(event: Event) {
               :class="cardInfoMode === 'hover-overlay' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setHoverOverlayMode"
             >
-              On hover
+              {{ t('settings.appearance.layout.cardInfoMode.onHover') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
               :class="cardInfoMode === 'below-cover' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setBelowCoverMode"
             >
-              Below cover
+              {{ t('settings.appearance.layout.cardInfoMode.belowCover') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
               :class="cardInfoMode === 'off' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setOffMode"
             >
-              Off
+              {{ t('settings.appearance.layout.cardInfoMode.off') }}
             </button>
           </div>
         </div>
@@ -257,8 +260,8 @@ function handleAuthorCoverSizeInput(event: Event) {
           <div v-if="showLabelFields" class="divide-y divide-border">
             <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
               <div>
-                <p class="settings-label">Primary card label</p>
-                <p class="settings-hint">Text shown below each book cover (first line)</p>
+                <p class="settings-label">{{ t('settings.appearance.layout.primaryCardLabel.label') }}</p>
+                <p class="settings-hint">{{ t('settings.appearance.layout.primaryCardLabel.hint') }}</p>
               </div>
               <select
                 :value="gridCardPrimaryLabel"
@@ -271,8 +274,8 @@ function handleAuthorCoverSizeInput(event: Event) {
 
             <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
               <div>
-                <p class="settings-label">Secondary card label</p>
-                <p class="settings-hint">Additional text below the primary label (second line)</p>
+                <p class="settings-label">{{ t('settings.appearance.layout.secondaryCardLabel.label') }}</p>
+                <p class="settings-hint">{{ t('settings.appearance.layout.secondaryCardLabel.hint') }}</p>
               </div>
               <select
                 :value="gridCardSecondaryLabel"
@@ -288,12 +291,12 @@ function handleAuthorCoverSizeInput(event: Event) {
     </div>
 
     <div>
-      <p class="settings-group-label">Series Display</p>
+      <p class="settings-group-label">{{ t('settings.appearance.layout.seriesDisplay.title') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Collapsed series cover</p>
-            <p class="settings-hint">Choose which cover to show when series are collapsed in the book grid</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.seriesDisplay.collapsedCover.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.layout.seriesDisplay.collapsedCover.hint') }}</p>
           </div>
           <div class="flex items-center gap-1 p-1 rounded-lg border border-border bg-muted/50 self-start">
             <button
@@ -301,14 +304,14 @@ function handleAuthorCoverSizeInput(event: Event) {
               :class="seriesCardCoverMode === 'stack' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setSeriesCardCoverMode('stack')"
             >
-              Stack
+              {{ t('settings.appearance.layout.seriesDisplay.stack') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
               :class="seriesCardCoverMode === 'mosaic' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setSeriesCardCoverMode('mosaic')"
             >
-              Mosaic
+              {{ t('settings.appearance.layout.seriesDisplay.mosaic') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
@@ -317,7 +320,7 @@ function handleAuthorCoverSizeInput(event: Event) {
               "
               @click="setSeriesCardCoverMode('first-volume')"
             >
-              First
+              {{ t('settings.appearance.layout.seriesDisplay.first') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
@@ -326,7 +329,7 @@ function handleAuthorCoverSizeInput(event: Event) {
               "
               @click="setSeriesCardCoverMode('latest-volume')"
             >
-              Latest
+              {{ t('settings.appearance.layout.seriesDisplay.latest') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
@@ -335,7 +338,7 @@ function handleAuthorCoverSizeInput(event: Event) {
               "
               @click="setSeriesCardCoverMode('first-unread')"
             >
-              First Unread
+              {{ t('settings.appearance.layout.seriesDisplay.firstUnread') }}
             </button>
           </div>
         </div>
@@ -343,16 +346,16 @@ function handleAuthorCoverSizeInput(event: Event) {
     </div>
 
     <div>
-      <p class="settings-group-label">Author Grid</p>
+      <p class="settings-group-label">{{ t('settings.appearance.layout.authorGrid.title') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Cover size</p>
-            <p class="settings-hint">Width of author covers in the grid</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.authorGrid.coverSize.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.layout.authorGrid.coverSize.hint') }}</p>
           </div>
           <div class="w-full md:w-72">
             <div class="mb-1.5 flex items-center justify-between gap-3">
-              <span class="text-xs text-muted-foreground">Cover size</span>
+              <span class="text-xs text-muted-foreground">{{ t('settings.appearance.layout.coverSize') }}</span>
               <span class="text-xs font-medium tabular-nums text-foreground">{{ authorCoverSize }}px</span>
             </div>
             <input
@@ -369,8 +372,8 @@ function handleAuthorCoverSizeInput(event: Event) {
 
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Cover shape</p>
-            <p class="settings-hint">Shape of author covers in the grid</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.authorGrid.coverShape.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.layout.authorGrid.coverShape.hint') }}</p>
           </div>
           <div class="flex items-center gap-1 p-1 rounded-lg border border-border bg-muted/50 self-start">
             <button
@@ -378,14 +381,14 @@ function handleAuthorCoverSizeInput(event: Event) {
               :class="authorCoverShape === 'circle' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setAuthorCoverShape('circle')"
             >
-              <Circle :size="12" /> Circle
+              <Circle :size="12" /> {{ t('settings.appearance.layout.authorGrid.circle') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
               :class="authorCoverShape === 'square' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="setAuthorCoverShape('square')"
             >
-              <Square :size="12" /> Square
+              <Square :size="12" /> {{ t('settings.appearance.layout.authorGrid.square') }}
             </button>
           </div>
         </div>
@@ -393,13 +396,13 @@ function handleAuthorCoverSizeInput(event: Event) {
     </div>
 
     <div>
-      <p class="settings-group-label">List and Table Views</p>
+      <p class="settings-group-label">{{ t('settings.appearance.layout.listTableViews.title') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div class="flex items-center justify-between gap-3 px-4 py-3 md:px-5 md:py-3.5 bg-card">
           <div class="min-w-0">
-            <p class="settings-label">Zebra striping</p>
+            <p class="settings-label">{{ t('settings.appearance.layout.zebraStriping.label') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:whitespace-normal md:overflow-visible">
-              Alternate row background colors for easier scanning
+              {{ t('settings.appearance.layout.zebraStriping.hint') }}
             </p>
           </div>
           <ToggleSwitch v-model="tableZebraStriping" />

--- a/client/src/features/settings/AppearancePreferenceStorage.vue
+++ b/client/src/features/settings/AppearancePreferenceStorage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { Cloud, Monitor } from '@lucide/vue'
 import { getDisplayPreferencesSnapshot } from '@/composables/useDisplaySettings'
@@ -10,6 +11,7 @@ import { usePermissions } from '@/features/auth/composables/usePermissions'
 import { api } from '@/lib/api'
 import { useThemeStore } from '@/stores/theme'
 
+const { t } = useI18n()
 const themeStore = useThemeStore()
 const { user } = useAuth()
 const { isDemoRestrictedAccount } = usePermissions()
@@ -20,7 +22,7 @@ async function handleSetStorageMode(sync: boolean) {
   if (!user.value || syncEnabled.value === sync) return
 
   if (isDemoRestrictedAccount.value) {
-    toast.error('Demo-restricted account cannot change theme storage mode')
+    toast.error(t('settings.appearance.storage.errors.demoRestricted'))
     return
   }
 
@@ -32,7 +34,7 @@ async function handleSetStorageMode(sync: boolean) {
     })
 
     if (!res.ok) {
-      toast.error('Failed to update storage mode')
+      toast.error(t('settings.appearance.storage.errors.update'))
       return
     }
 
@@ -69,9 +71,9 @@ async function handleSetStorageMode(sync: boolean) {
       }
     }
 
-    toast.success(sync ? 'Preferences will now be synced' : 'Preferences will stay on this device')
+    toast.success(sync ? t('settings.appearance.storage.toasts.synced') : t('settings.appearance.storage.toasts.local'))
   } catch {
-    toast.error('An error occurred while updating storage mode')
+    toast.error(t('settings.appearance.storage.errors.generic'))
   }
 }
 
@@ -86,7 +88,7 @@ async function handleAccountMode() {
 
 <template>
   <div>
-    <p class="settings-group-label">Where to save appearance preferences</p>
+    <p class="settings-group-label">{{ t('settings.appearance.storage.title') }}</p>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
       <div
         class="flex items-start gap-4 px-4 py-3.5 md:px-5 md:py-4 rounded-lg border-2 cursor-pointer transition-colors"
@@ -101,13 +103,13 @@ async function handleAccountMode() {
         </div>
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 mb-1">
-            <span class="settings-label">This device only</span>
+            <span class="settings-label">{{ t('settings.appearance.storage.device.title') }}</span>
             <span v-if="!syncEnabled" class="text-xs font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-primary/15 text-primary">
-              Active
+              {{ t('settings.appearance.storage.active') }}
             </span>
           </div>
           <span class="block text-xs text-muted-foreground leading-relaxed">
-            Preferences stay in your browser. Best if you want a different look on different devices.
+            {{ t('settings.appearance.storage.device.description') }}
           </span>
         </div>
       </div>
@@ -128,19 +130,19 @@ async function handleAccountMode() {
         </div>
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2 mb-1">
-            <span class="settings-label">My account</span>
+            <span class="settings-label">{{ t('settings.appearance.storage.account.title') }}</span>
             <span v-if="syncEnabled" class="text-xs font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-primary/15 text-primary">
-              Active
+              {{ t('settings.appearance.storage.active') }}
             </span>
             <span
               v-if="isDemoRestrictedAccount"
               class="text-xs font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
             >
-              Not available
+              {{ t('settings.appearance.storage.notAvailable') }}
             </span>
           </div>
           <span class="block text-xs text-muted-foreground leading-relaxed">
-            Preferences are saved to your account. Best if you want the same appearance on every device.
+            {{ t('settings.appearance.storage.account.description') }}
           </span>
         </div>
       </div>

--- a/client/src/features/settings/AppearanceSettings.vue
+++ b/client/src/features/settings/AppearanceSettings.vue
@@ -9,7 +9,7 @@ import AppearanceIconsSettings from './AppearanceIconsSettings.vue'
 import AppearanceLayoutSettings from './AppearanceLayoutSettings.vue'
 import AppearanceThemeSettings from './AppearanceThemeSettings.vue'
 import SettingsPageHeader from './SettingsPageHeader.vue'
-import { APPEARANCE_TAB_LABELS, APPEARANCE_TABS, normalizeAppearanceTab, type AppearanceTab as Tab } from './lib/appearance-tabs'
+import { APPEARANCE_TABS, normalizeAppearanceTab, type AppearanceTab as Tab } from './lib/appearance-tabs'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -17,7 +17,7 @@ const router = useRouter()
 const themeStore = useThemeStore()
 
 const activeTab = ref<Tab>(normalizeAppearanceTab(route.query.tab))
-const tabs: { id: Tab; label: string }[] = APPEARANCE_TABS.map((id) => ({ id, label: APPEARANCE_TAB_LABELS[id] }))
+const tabs = computed(() => APPEARANCE_TABS.map((id) => ({ id, label: t(`settings.appearance.tabs.${id}`) })))
 
 const accentLabel = computed(() => [...ACCENT_VIVID, ...ACCENT_PASTEL].find((opt) => opt.id === themeStore.accent)?.label ?? themeStore.accent)
 const backgroundLabel = computed(() => BACKGROUND_OPTIONS.find((opt) => opt.id === themeStore.background)?.label ?? themeStore.background)

--- a/client/src/features/settings/AppearanceSettings.vue
+++ b/client/src/features/settings/AppearanceSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { ACCENT_PASTEL, ACCENT_VIVID, BACKGROUND_OPTIONS, useThemeStore } from '@/stores/theme'
 import AppearanceBehaviorSettings from './AppearanceBehaviorSettings.vue'
@@ -10,6 +11,7 @@ import AppearanceThemeSettings from './AppearanceThemeSettings.vue'
 import SettingsPageHeader from './SettingsPageHeader.vue'
 import { APPEARANCE_TAB_LABELS, APPEARANCE_TABS, normalizeAppearanceTab, type AppearanceTab as Tab } from './lib/appearance-tabs'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const themeStore = useThemeStore()
@@ -44,12 +46,18 @@ function selectTab(tab: Tab) {
 </script>
 
 <template>
-  <SettingsPageHeader title="Display" subtitle="Control themes, covers, layout, and how your library is presented." />
+  <SettingsPageHeader :title="t('settings.appearance.pageTitle')" :subtitle="t('settings.appearance.pageSubtitle')" />
   <div
     class="md:hidden sticky top-0 z-20 -mx-4 mb-4 px-4 py-2 border-y border-border/70 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/75"
   >
     <p class="text-[11px] font-medium text-muted-foreground overflow-hidden text-ellipsis whitespace-nowrap">
-      Theme: {{ themeStore.theme === 'dark' ? 'Dark' : 'Light' }} • Accent: {{ accentLabel }} • Background: {{ backgroundLabel }}
+      {{
+        t('settings.appearance.mobileSummary', {
+          theme: themeStore.theme === 'dark' ? t('settings.appearance.themeMode.dark') : t('settings.appearance.themeMode.light'),
+          accent: accentLabel,
+          background: backgroundLabel,
+        })
+      }}
     </p>
   </div>
 

--- a/client/src/features/settings/AppearanceThemeSettings.vue
+++ b/client/src/features/settings/AppearanceThemeSettings.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { Moon, Sun } from '@lucide/vue'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { ACCENT_PASTEL, ACCENT_VIVID, BACKGROUND_OPTIONS, RADIUS_OPTIONS, useThemeStore } from '@/stores/theme'
 import AppearancePreferenceStorage from './AppearancePreferenceStorage.vue'
 
+const { t } = useI18n()
 const themeStore = useThemeStore()
 
 const BACKGROUND_GROUPS: { label: string; ids: string[] }[] = [
-  { label: 'Fundamental', ids: ['none', 'dots', 'cross', 'terminal', 'millimeter'] },
-  { label: 'Structural', ids: ['blueprint', 'brushed', 'scanlines', 'vinyl', 'carbon', 'perforated'] },
-  { label: 'Ambient', ids: ['aurora', 'horizon', 'glow', 'mesh', 'elevation'] },
-  { label: 'Refractive', ids: ['prism', 'spectrum', 'spectrum-x', 'spectrum-plus', 'eclipse'] },
+  { label: t('settings.appearance.theme.backgroundGroups.fundamental'), ids: ['none', 'dots', 'cross', 'terminal', 'millimeter'] },
+  { label: t('settings.appearance.theme.backgroundGroups.structural'), ids: ['blueprint', 'brushed', 'scanlines', 'vinyl', 'carbon', 'perforated'] },
+  { label: t('settings.appearance.theme.backgroundGroups.ambient'), ids: ['aurora', 'horizon', 'glow', 'mesh', 'elevation'] },
+  { label: t('settings.appearance.theme.backgroundGroups.refractive'), ids: ['prism', 'spectrum', 'spectrum-x', 'spectrum-plus', 'eclipse'] },
 ]
 
 function handleLightTheme() {
@@ -35,12 +37,12 @@ function handleBrightnessInput(event: Event) {
     <AppearancePreferenceStorage />
 
     <div>
-      <p class="settings-group-label">Theme</p>
+      <p class="settings-group-label">{{ t('settings.appearance.theme.title') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Color scheme</p>
-            <p class="settings-hint">Light or dark interface</p>
+            <p class="settings-label">{{ t('settings.appearance.theme.colorScheme.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.theme.colorScheme.hint') }}</p>
           </div>
           <div class="flex items-center gap-1 p-1 rounded-lg border border-border bg-muted/50 self-start">
             <button
@@ -48,21 +50,21 @@ function handleBrightnessInput(event: Event) {
               :class="themeStore.theme === 'light' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="handleLightTheme"
             >
-              <Sun :size="12" /> Light
+              <Sun :size="12" /> {{ t('settings.appearance.themeMode.light') }}
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
               :class="themeStore.theme === 'dark' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="handleDarkTheme"
             >
-              <Moon :size="12" /> Dark
+              <Moon :size="12" /> {{ t('settings.appearance.themeMode.dark') }}
             </button>
           </div>
         </div>
 
         <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
-          <p class="settings-label mb-0.5">Accent color</p>
-          <p class="text-xs text-muted-foreground mb-3">Controls highlights and interactive elements</p>
+          <p class="settings-label mb-0.5">{{ t('settings.appearance.theme.accentColor.label') }}</p>
+          <p class="text-xs text-muted-foreground mb-3">{{ t('settings.appearance.theme.accentColor.hint') }}</p>
           <div class="space-y-2">
             <div class="flex items-center gap-1.5 flex-wrap">
               <Tooltip v-for="opt in ACCENT_VIVID" :key="opt.id">
@@ -103,8 +105,8 @@ function handleBrightnessInput(event: Event) {
 
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Corner radius</p>
-            <p class="settings-hint">Roundness of cards and UI elements</p>
+            <p class="settings-label">{{ t('settings.appearance.theme.cornerRadius.label') }}</p>
+            <p class="settings-hint">{{ t('settings.appearance.theme.cornerRadius.hint') }}</p>
           </div>
           <div class="flex items-center gap-1.5 self-start">
             <button
@@ -127,7 +129,7 @@ function handleBrightnessInput(event: Event) {
         <div v-if="themeStore.theme === 'dark'" class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
             <div class="flex items-center justify-between gap-3 mb-0.5">
-              <p class="settings-label">Surface brightness</p>
+              <p class="settings-label">{{ t('settings.appearance.theme.surfaceBrightness.label') }}</p>
               <div class="flex items-center gap-2">
                 <span class="settings-value md:hidden">{{ themeStore.brightness }}%</span>
                 <button
@@ -135,11 +137,11 @@ function handleBrightnessInput(event: Event) {
                   class="text-xs text-muted-foreground hover:text-foreground transition-colors"
                   @click="resetBrightness"
                 >
-                  Reset
+                  {{ t('settings.appearance.theme.surfaceBrightness.reset') }}
                 </button>
               </div>
             </div>
-            <p class="settings-hint">Lighten dark mode surfaces</p>
+            <p class="settings-hint">{{ t('settings.appearance.theme.surfaceBrightness.hint') }}</p>
             <div>
               <span class="settings-value hidden md:inline">{{ themeStore.brightness }}%</span>
             </div>
@@ -158,13 +160,13 @@ function handleBrightnessInput(event: Event) {
     </div>
 
     <div>
-      <p class="settings-group-label">Library Background</p>
+      <p class="settings-group-label">{{ t('settings.appearance.theme.libraryBackground.title') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
             <div>
-              <p class="settings-label">Background pattern</p>
-              <p class="settings-hint">Pattern shown behind the book grid</p>
+              <p class="settings-label">{{ t('settings.appearance.theme.libraryBackground.pattern.label') }}</p>
+              <p class="settings-hint">{{ t('settings.appearance.theme.libraryBackground.pattern.hint') }}</p>
             </div>
           </div>
           <div class="space-y-5 md:space-y-6">

--- a/client/src/features/settings/AudioSettings.vue
+++ b/client/src/features/settings/AudioSettings.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { AudioReaderSettings } from '@bookorbit/types'
 import { useReaderDefaultSettings } from '@/features/reader/shared/composables/useReaderSettings'
 import SettingsPageHeader from './SettingsPageHeader.vue'
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -22,13 +25,9 @@ onMounted(load)
   <div
     class="[&_.settings-hint]:overflow-hidden [&_.settings-hint]:text-ellipsis [&_.settings-hint]:whitespace-nowrap md:[&_.settings-hint]:overflow-visible md:[&_.settings-hint]:whitespace-normal"
   >
-    <SettingsPageHeader
-      v-if="!props.embedded"
-      title="Audiobook Player"
-      subtitle="Default settings applied when playing M4B, MP3, and other audio formats."
-    >
+    <SettingsPageHeader v-if="!props.embedded" :title="t('settings.reader.audio.title')" :subtitle="t('settings.reader.audio.subtitle')">
       <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-        Reset to defaults
+        {{ t('settings.reader.resetToDefaults') }}
       </button>
     </SettingsPageHeader>
     <template v-else>
@@ -36,26 +35,26 @@ onMounted(load)
         class="md:hidden sticky top-11 z-10 -mx-4 mb-4 px-4 py-2 border-y border-border/70 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/75"
       >
         <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-          Reset to defaults
+          {{ t('settings.reader.resetToDefaults') }}
         </button>
       </div>
       <div class="hidden md:flex justify-end mb-4">
         <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-          Reset to defaults
+          {{ t('settings.reader.resetToDefaults') }}
         </button>
       </div>
     </template>
 
     <!-- Playback -->
     <div class="mb-6">
-      <p class="settings-group-label">Playback</p>
+      <p class="settings-group-label">{{ t('settings.reader.audio.playback') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border">
         <!-- Playback speed -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Default playback speed</p>
+            <p class="settings-label">{{ t('settings.reader.audio.playbackSpeed') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Speed multiplier applied when opening a new audiobook
+              {{ t('settings.reader.audio.playbackSpeedHint') }}
             </p>
           </div>
           <div class="flex flex-wrap gap-2 self-start md:self-auto md:justify-end">
@@ -79,11 +78,11 @@ onMounted(load)
         <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
             <div class="flex items-center justify-between gap-3">
-              <p class="settings-label">Default volume</p>
+              <p class="settings-label">{{ t('settings.reader.audio.volume') }}</p>
               <span class="settings-value">{{ Math.round(effective.volume * 100) }}%</span>
             </div>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Initial volume level (0 to 100%)
+              {{ t('settings.reader.audio.volumeHint') }}
             </p>
           </div>
           <input
@@ -101,14 +100,14 @@ onMounted(load)
 
     <!-- Skip controls -->
     <div class="mb-6">
-      <p class="settings-group-label">Skip controls</p>
+      <p class="settings-group-label">{{ t('settings.reader.audio.skipControls') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border">
         <!-- Skip back -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Skip back duration</p>
+            <p class="settings-label">{{ t('settings.reader.audio.skipBack') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Seconds rewound on skip-back press
+              {{ t('settings.reader.audio.skipBackHint') }}
             </p>
           </div>
           <div class="flex flex-wrap gap-2 self-start md:self-auto md:justify-end">
@@ -131,9 +130,9 @@ onMounted(load)
         <!-- Skip forward -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Skip forward duration</p>
+            <p class="settings-label">{{ t('settings.reader.audio.skipForward') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Seconds advanced on skip-forward press
+              {{ t('settings.reader.audio.skipForwardHint') }}
             </p>
           </div>
           <div class="flex flex-wrap gap-2 self-start md:self-auto md:justify-end">

--- a/client/src/features/settings/AuthorEnrichmentSettings.vue
+++ b/client/src/features/settings/AuthorEnrichmentSettings.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { RefreshCw, Save } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import type { AuthorAutoEnrichmentConfig } from '@bookorbit/types'
 import { api } from '@/lib/api'
 import { useAuthorEligibleCountPreview } from './composables/useAuthorEligibleCountPreview'
+
+const { t } = useI18n()
 
 const DEFAULT_CONFIG: AuthorAutoEnrichmentConfig = {
   enabled: false,
@@ -40,12 +43,12 @@ async function saveConfig() {
     })
     if (res.ok) {
       config.value = await res.json()
-      toast.success('Author enrichment settings saved')
+      toast.success(t('settings.admin.authorEnrichment.saved'))
     } else {
-      toast.error('Failed to save author enrichment settings')
+      toast.error(t('settings.admin.authorEnrichment.saveFailed'))
     }
   } catch {
-    toast.error('Failed to save author enrichment settings')
+    toast.error(t('settings.admin.authorEnrichment.saveFailed'))
   } finally {
     saving.value = false
   }
@@ -75,9 +78,9 @@ async function runAuthorBackfill() {
     const res = await api('/api/v1/authors/enrichment/backfill', { method: 'POST' })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const { queued } = await res.json()
-    if (queued === 0) toast.info('No eligible authors found')
+    if (queued === 0) toast.info(t('settings.admin.authorEnrichment.noEligibleAuthors'))
   } catch {
-    toast.error('Failed to queue author backfill')
+    toast.error(t('settings.admin.authorEnrichment.queueFailed'))
   } finally {
     authorBackfillRunning.value = false
   }
@@ -90,9 +93,9 @@ async function runAuthorBackfillAll() {
     const res = await api('/api/v1/authors/enrichment/backfill-all', { method: 'POST' })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const { queued } = await res.json()
-    if (queued === 0) toast.info('No authors to enrich')
+    if (queued === 0) toast.info(t('settings.admin.authorEnrichment.noAuthorsToEnrich'))
   } catch {
-    toast.error('Failed to queue author backfill')
+    toast.error(t('settings.admin.authorEnrichment.queueFailed'))
   } finally {
     authorBackfillAllRunning.value = false
   }
@@ -100,58 +103,58 @@ async function runAuthorBackfillAll() {
 </script>
 
 <template>
-  <p class="settings-group-label">Configuration</p>
+  <p class="settings-group-label">{{ t('settings.admin.authorEnrichment.configuration') }}</p>
   <div
     class="md:hidden sticky top-11 z-10 -mx-4 mb-4 px-4 py-2 border-y border-border/70 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/75"
   >
     <div class="flex items-center gap-2 flex-wrap">
       <button class="settings-btn-primary flex-1 justify-center" :disabled="saving" @click="saveConfig">
         <Save class="size-3.5" />
-        {{ saving ? 'Saving...' : 'Save' }}
+        {{ saving ? t('settings.admin.authorEnrichment.saving') : t('common.save') }}
       </button>
       <button class="settings-btn-outline" :disabled="authorBackfillRunning" @click="runAuthorBackfill">
         <RefreshCw :size="13" :class="authorBackfillRunning ? 'animate-spin' : ''" />
-        {{ authorBackfillRunning ? 'Running...' : 'Run eligible' }}
+        {{ authorBackfillRunning ? t('settings.admin.authorEnrichment.running') : t('settings.admin.authorEnrichment.runEligibleShort') }}
       </button>
       <button class="settings-btn-outline" :disabled="authorBackfillAllRunning" @click="runAuthorBackfillAll">
         <RefreshCw :size="13" :class="authorBackfillAllRunning ? 'animate-spin' : ''" />
-        {{ authorBackfillAllRunning ? 'Running...' : 'Run all' }}
+        {{ authorBackfillAllRunning ? t('settings.admin.authorEnrichment.running') : t('settings.admin.authorEnrichment.runAllShort') }}
       </button>
     </div>
   </div>
   <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
     <div class="px-4 py-3.5 md:px-5 md:py-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6 bg-card">
       <div>
-        <p class="settings-label">Enable auto author enrichment</p>
-        <p class="settings-hint">Automatically fetch author biographies and profile photos when books are added or updated.</p>
+        <p class="settings-label">{{ t('settings.admin.authorEnrichment.enableTitle') }}</p>
+        <p class="settings-hint">{{ t('settings.admin.authorEnrichment.enableHint') }}</p>
       </div>
       <ToggleSwitch class="self-start" :model-value="config.enabled" :disabled="saving" @update:model-value="toggleEnabled" />
     </div>
 
     <div class="px-4 py-3.5 md:px-5 md:py-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6 bg-card">
       <div>
-        <p class="settings-label">Update strategy</p>
-        <p class="settings-hint">What to do when an author already has a biography or photo.</p>
+        <p class="settings-label">{{ t('settings.admin.authorEnrichment.updateStrategyTitle') }}</p>
+        <p class="settings-hint">{{ t('settings.admin.authorEnrichment.updateStrategyHint') }}</p>
       </div>
       <select class="select-field w-full md:w-64" :value="config.writeMode" :disabled="saving" @change="onWriteModeChange">
-        <option value="missing_only">Only fill missing data (recommended)</option>
-        <option value="always_refetch">Always refresh existing data</option>
+        <option value="missing_only">{{ t('settings.admin.authorEnrichment.writeModeMissingOnly') }}</option>
+        <option value="always_refetch">{{ t('settings.admin.authorEnrichment.writeModeAlwaysRefetch') }}</option>
       </select>
     </div>
 
     <template v-if="config.enabled">
       <div class="px-4 py-3.5 md:px-5 md:py-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between md:gap-6 bg-card">
         <div>
-          <p class="settings-label">Trigger on import</p>
-          <p class="settings-hint">Queue authors for enrichment when books are first added to a library.</p>
+          <p class="settings-label">{{ t('settings.admin.authorEnrichment.triggerOnImportTitle') }}</p>
+          <p class="settings-hint">{{ t('settings.admin.authorEnrichment.triggerOnImportHint') }}</p>
         </div>
         <ToggleSwitch class="self-start" :model-value="config.triggerOnImport" :disabled="saving" @update:model-value="toggleTriggerOnImport" />
       </div>
     </template>
 
     <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
-      <p class="settings-label mb-1">Eligibility conditions</p>
-      <p class="settings-hint mb-3">An author is eligible if it matches any enabled condition.</p>
+      <p class="settings-label mb-1">{{ t('settings.admin.authorEnrichment.eligibilityTitle') }}</p>
+      <p class="settings-hint mb-3">{{ t('settings.admin.authorEnrichment.eligibilityHint') }}</p>
       <div class="flex flex-col gap-4">
         <label class="flex items-center gap-3 cursor-pointer select-none">
           <input
@@ -162,8 +165,8 @@ async function runAuthorBackfillAll() {
             @change="toggleCondition('neverEnriched')"
           />
           <div>
-            <span class="text-sm font-medium">Never enriched</span>
-            <p class="text-xs text-muted-foreground">Enrich authors that have never had a successful enrichment.</p>
+            <span class="text-sm font-medium">{{ t('settings.admin.authorEnrichment.neverEnrichedTitle') }}</span>
+            <p class="text-xs text-muted-foreground">{{ t('settings.admin.authorEnrichment.neverEnrichedHint') }}</p>
           </div>
         </label>
         <label class="flex items-center gap-3 cursor-pointer select-none">
@@ -175,8 +178,8 @@ async function runAuthorBackfillAll() {
             @change="toggleCondition('missingBio')"
           />
           <div>
-            <span class="text-sm font-medium">Missing bio</span>
-            <p class="text-xs text-muted-foreground">Enrich if the author has no biography.</p>
+            <span class="text-sm font-medium">{{ t('settings.admin.authorEnrichment.missingBioTitle') }}</span>
+            <p class="text-xs text-muted-foreground">{{ t('settings.admin.authorEnrichment.missingBioHint') }}</p>
           </div>
         </label>
         <label class="flex items-center gap-3 cursor-pointer select-none">
@@ -188,8 +191,8 @@ async function runAuthorBackfillAll() {
             @change="toggleCondition('missingPhoto')"
           />
           <div>
-            <span class="text-sm font-medium">Missing photo</span>
-            <p class="text-xs text-muted-foreground">Enrich if the author has no profile photo.</p>
+            <span class="text-sm font-medium">{{ t('settings.admin.authorEnrichment.missingPhotoTitle') }}</span>
+            <p class="text-xs text-muted-foreground">{{ t('settings.admin.authorEnrichment.missingPhotoHint') }}</p>
           </div>
         </label>
       </div>
@@ -198,20 +201,20 @@ async function runAuthorBackfillAll() {
     <div class="hidden md:flex items-center gap-3 px-5 py-4 bg-card">
       <button class="settings-btn-primary" :disabled="saving" @click="saveConfig">
         <Save class="size-3.5" />
-        {{ saving ? 'Saving...' : 'Save' }}
+        {{ saving ? t('settings.admin.authorEnrichment.saving') : t('common.save') }}
       </button>
       <div class="w-px h-4 bg-border shrink-0" />
       <button class="settings-btn-outline" :disabled="authorBackfillRunning" @click="runAuthorBackfill">
         <RefreshCw :size="13" :class="authorBackfillRunning ? 'animate-spin' : ''" />
-        {{ authorBackfillRunning ? 'Running...' : 'Run for eligible authors' }}
+        {{ authorBackfillRunning ? t('settings.admin.authorEnrichment.running') : t('settings.admin.authorEnrichment.runForEligibleAuthors') }}
       </button>
       <span v-if="eligibleCount !== null" class="text-xs text-muted-foreground">
-        {{ countLoading ? '...' : `~${eligibleCount} eligible` }}
+        {{ countLoading ? '...' : t('settings.admin.authorEnrichment.eligibleCount', { count: eligibleCount }) }}
       </span>
       <div class="w-px h-4 bg-border shrink-0" />
       <button class="settings-btn-outline" :disabled="authorBackfillAllRunning" @click="runAuthorBackfillAll">
         <RefreshCw :size="13" :class="authorBackfillAllRunning ? 'animate-spin' : ''" />
-        {{ authorBackfillAllRunning ? 'Running...' : 'Run for all authors' }}
+        {{ authorBackfillAllRunning ? t('settings.admin.authorEnrichment.running') : t('settings.admin.authorEnrichment.runForAllAuthors') }}
       </button>
     </div>
   </div>

--- a/client/src/features/settings/BookDockSettings.vue
+++ b/client/src/features/settings/BookDockSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Loader2 } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import type { BookDockAutoFinalizeMetadataMode } from '@bookorbit/types'
@@ -9,6 +10,7 @@ import { api } from '@/lib/api'
 import { useLibraries } from '@/features/library/composables/useLibraries'
 import { useAppInfo } from './composables/useAppInfo'
 
+const { t } = useI18n()
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
 const autoFetch = ref(true)
 const autoFinalizeEnabled = ref(false)
@@ -54,7 +56,7 @@ async function saveSetting(key: string, value: string) {
     body: JSON.stringify({ value }),
   })
   if (!res.ok) {
-    toast.error('Failed to save setting')
+    toast.error(t('settings.reader.bookDock.saveSettingFailed'))
   }
 }
 
@@ -70,9 +72,9 @@ async function toggle() {
     })
     if (res.ok) {
       autoFetch.value = newVal
-      toast.success(newVal ? 'Auto-fetch enabled' : 'Auto-fetch disabled')
+      toast.success(newVal ? t('settings.reader.bookDock.autoFetchEnabled') : t('settings.reader.bookDock.autoFetchDisabled'))
     } else {
-      toast.error('Failed to update setting')
+      toast.error(t('settings.reader.bookDock.updateSettingFailed'))
     }
   } finally {
     saving.value = false
@@ -91,9 +93,9 @@ async function toggleAutoFinalize() {
     })
     if (res.ok) {
       autoFinalizeEnabled.value = newVal
-      toast.success(newVal ? 'Auto-finalize enabled' : 'Auto-finalize disabled')
+      toast.success(newVal ? t('settings.reader.bookDock.autoFinalizeEnabled') : t('settings.reader.bookDock.autoFinalizeDisabled'))
     } else {
-      toast.error('Failed to update setting')
+      toast.error(t('settings.reader.bookDock.updateSettingFailed'))
     }
   } finally {
     saving.value = false
@@ -109,26 +111,26 @@ async function onLibraryChange(event: Event) {
     saveSetting('book_dock_auto_finalize_library_id', String(id)),
     saveSetting('book_dock_auto_finalize_folder_id', String(autoFinalizeFolderId.value ?? '')),
   ])
-  toast.success('Destination library updated')
+  toast.success(t('settings.reader.bookDock.destinationLibraryUpdated'))
 }
 
 async function onFolderChange(event: Event) {
   autoFinalizeFolderId.value = Number((event.target as HTMLSelectElement).value)
   await saveSetting('book_dock_auto_finalize_folder_id', String(autoFinalizeFolderId.value))
-  toast.success('Destination folder updated')
+  toast.success(t('settings.reader.bookDock.destinationFolderUpdated'))
 }
 
 async function onThresholdChange() {
   if (!isThresholdApplicable.value) return
   await saveSetting('book_dock_auto_finalize_threshold', String(autoFinalizeThreshold.value))
-  toast.success('Confidence threshold updated')
+  toast.success(t('settings.reader.bookDock.confidenceThresholdUpdated'))
 }
 
 async function onMetadataModeChange(event: Event) {
   const value = (event.target as HTMLSelectElement).value as BookDockAutoFinalizeMetadataMode
   autoFinalizeMetadataMode.value = value
   await saveSetting('book_dock_auto_finalize_metadata_mode', value)
-  toast.success('Metadata mode updated')
+  toast.success(t('settings.reader.bookDock.metadataModeUpdated'))
 }
 </script>
 
@@ -136,15 +138,15 @@ async function onMetadataModeChange(event: Event) {
   <SettingsPageHeader
     v-if="!props.embedded"
     class="hidden md:flex"
-    title="Book Dock"
-    subtitle="Configure how files are processed when they enter Book Dock."
+    :title="t('settings.reader.bookDock.title')"
+    :subtitle="t('settings.reader.bookDock.subtitle')"
   />
   <div v-if="!props.embedded" class="md:hidden px-1">
-    <h1 class="text-xl font-semibold tracking-tight text-foreground">Book Dock</h1>
+    <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('settings.reader.bookDock.title') }}</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
     >
-      Configure how files are processed when they enter Book Dock.
+      {{ t('settings.reader.bookDock.subtitle') }}
     </p>
   </div>
 
@@ -154,13 +156,12 @@ async function onMetadataModeChange(event: Event) {
 
   <div v-else class="mt-5 md:mt-0 space-y-6">
     <div>
-      <p class="settings-group-label">Drop folder</p>
+      <p class="settings-group-label">{{ t('settings.reader.bookDock.dropFolder') }}</p>
       <div class="mt-4 border border-border rounded-lg overflow-hidden shadow-xs">
         <div class="px-4 py-3.5 bg-card md:px-5 md:py-4">
-          <p class="settings-label">Container path</p>
+          <p class="settings-label">{{ t('settings.reader.bookDock.containerPath') }}</p>
           <p class="settings-hint mb-2">
-            Copy or move book files into this folder and they will be automatically picked up and processed by Book Dock. Subdirectories are
-            supported.
+            {{ t('settings.reader.bookDock.containerPathHint') }}
           </p>
           <code
             v-if="bookDockPath"
@@ -169,20 +170,22 @@ async function onMetadataModeChange(event: Event) {
             >{{ bookDockPath }}</code
           >
           <p class="settings-hint mt-2">
-            To change this path, set <code class="text-xs font-mono">BOOK_DOCK_PATH</code> in your <code class="text-xs font-mono">.env</code> file.
+            {{ t('settings.reader.bookDock.changePathPrefix') }} <code class="text-xs font-mono">BOOK_DOCK_PATH</code>
+            {{ t('settings.reader.bookDock.changePathMiddle') }} <code class="text-xs font-mono">.env</code>
+            {{ t('settings.reader.bookDock.changePathSuffix') }}
           </p>
         </div>
       </div>
     </div>
 
-    <p class="settings-group-label">Metadata</p>
+    <p class="settings-group-label">{{ t('settings.reader.bookDock.metadata') }}</p>
 
     <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
       <div class="flex flex-col gap-3 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:px-5 md:py-4">
         <div class="min-w-0">
-          <p class="settings-label">Auto-fetch metadata from providers</p>
+          <p class="settings-label">{{ t('settings.reader.bookDock.autoFetch') }}</p>
           <p class="settings-hint">
-            Automatically fetch metadata from configured providers (Google Books, iTunes, Open Library, etc.) after a file is added to Book Dock.
+            {{ t('settings.reader.bookDock.autoFetchHint') }}
           </p>
         </div>
         <ToggleSwitch :model-value="autoFetch" :disabled="saving" class="self-start md:self-auto md:ml-4" @update:model-value="() => toggle()" />
@@ -190,12 +193,12 @@ async function onMetadataModeChange(event: Event) {
     </div>
 
     <div class="mt-6 space-y-4">
-      <p class="settings-group-label">Auto-finalize</p>
+      <p class="settings-group-label">{{ t('settings.reader.bookDock.autoFinalize') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div class="flex flex-col gap-3 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:px-5 md:py-4">
           <div class="min-w-0">
-            <p class="settings-label">Enable auto-finalize</p>
-            <p class="settings-hint">Files with a metadata confidence score at or above the threshold will be finalized automatically.</p>
+            <p class="settings-label">{{ t('settings.reader.bookDock.enableAutoFinalize') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.bookDock.enableAutoFinalizeHint') }}</p>
           </div>
           <ToggleSwitch
             :model-value="autoFinalizeEnabled"
@@ -208,8 +211,8 @@ async function onMetadataModeChange(event: Event) {
         <div v-if="autoFinalizeEnabled" class="px-4 py-3.5 bg-card space-y-4 md:px-5 md:py-4">
           <label class="block">
             <span class="text-xs font-medium text-muted-foreground">
-              Confidence threshold: {{ autoFinalizeThreshold }}%
-              <span v-if="!isThresholdApplicable"> (ignored in Embedded only mode)</span>
+              {{ t('settings.reader.bookDock.confidenceThreshold', { value: autoFinalizeThreshold }) }}
+              <span v-if="!isThresholdApplicable"> {{ t('settings.reader.bookDock.thresholdIgnored') }}</span>
             </span>
             <input
               v-model.number="autoFinalizeThreshold"
@@ -228,26 +231,26 @@ async function onMetadataModeChange(event: Event) {
           </label>
 
           <label class="block">
-            <span class="text-xs font-medium text-muted-foreground">Destination library</span>
+            <span class="text-xs font-medium text-muted-foreground">{{ t('settings.reader.bookDock.destinationLibrary') }}</span>
             <select class="select-field mt-1 w-full" :value="autoFinalizeLibraryId ?? ''" @change="onLibraryChange">
-              <option value="" disabled>Select a library...</option>
+              <option value="" disabled>{{ t('settings.reader.bookDock.selectLibrary') }}</option>
               <option v-for="lib in libraries" :key="lib.id" :value="lib.id">{{ lib.name }}</option>
             </select>
           </label>
 
           <label class="block">
-            <span class="text-xs font-medium text-muted-foreground">Metadata mode</span>
+            <span class="text-xs font-medium text-muted-foreground">{{ t('settings.reader.bookDock.metadataMode') }}</span>
             <select class="select-field mt-1 w-full" :value="autoFinalizeMetadataMode" @change="onMetadataModeChange">
-              <option value="safe_merge">Safe merge (recommended)</option>
-              <option value="fetched_only">Fetched only</option>
-              <option value="embedded_only">Embedded only</option>
+              <option value="safe_merge">{{ t('settings.reader.bookDock.metadataModeSafeMerge') }}</option>
+              <option value="fetched_only">{{ t('settings.reader.bookDock.metadataModeFetchedOnly') }}</option>
+              <option value="embedded_only">{{ t('settings.reader.bookDock.metadataModeEmbeddedOnly') }}</option>
             </select>
           </label>
 
           <label class="block">
-            <span class="text-xs font-medium text-muted-foreground">Destination folder</span>
+            <span class="text-xs font-medium text-muted-foreground">{{ t('settings.reader.bookDock.destinationFolder') }}</span>
             <select class="select-field mt-1 w-full" :value="autoFinalizeFolderId ?? ''" @change="onFolderChange">
-              <option value="" disabled>Select a folder...</option>
+              <option value="" disabled>{{ t('settings.reader.bookDock.selectFolder') }}</option>
               <option v-for="folder in autoFinalizeFolders" :key="folder.id" :value="folder.id">{{ folder.path }}</option>
             </select>
           </label>

--- a/client/src/features/settings/ComicsSettings.vue
+++ b/client/src/features/settings/ComicsSettings.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { CbxReaderSettings } from '@bookorbit/types'
 import { useReaderDefaultSettings } from '@/features/reader/shared/composables/useReaderSettings'
 import SettingsPageHeader from './SettingsPageHeader.vue'
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -22,9 +25,9 @@ onMounted(load)
   <div
     class="[&_.settings-hint]:overflow-hidden [&_.settings-hint]:text-ellipsis [&_.settings-hint]:whitespace-nowrap md:[&_.settings-hint]:overflow-visible md:[&_.settings-hint]:whitespace-normal"
   >
-    <SettingsPageHeader v-if="!props.embedded" title="Comics Reader" subtitle="Default settings applied when opening CBZ, CBR, and CB7 files.">
+    <SettingsPageHeader v-if="!props.embedded" :title="t('settings.reader.comics.title')" :subtitle="t('settings.reader.comics.subtitle')">
       <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-        Reset to defaults
+        {{ t('settings.reader.resetToDefaults') }}
       </button>
     </SettingsPageHeader>
     <template v-else>
@@ -32,26 +35,26 @@ onMounted(load)
         class="md:hidden sticky top-11 z-10 -mx-4 mb-4 px-4 py-2 border-y border-border/70 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/75"
       >
         <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-          Reset to defaults
+          {{ t('settings.reader.resetToDefaults') }}
         </button>
       </div>
       <div class="hidden md:flex justify-end mb-4">
         <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-          Reset to defaults
+          {{ t('settings.reader.resetToDefaults') }}
         </button>
       </div>
     </template>
 
     <!-- View -->
     <div class="mb-6">
-      <p class="settings-group-label">View</p>
+      <p class="settings-group-label">{{ t('settings.reader.comics.view') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border">
         <!-- Scroll mode -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Reading mode</p>
+            <p class="settings-label">{{ t('settings.reader.comics.readingMode') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              How pages are navigated - use "Infinite (no gaps)" for webtoons
+              {{ t('settings.reader.comics.readingModeHint') }}
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
@@ -62,14 +65,14 @@ onMounted(load)
               "
               @click="update({ scrollMode: 'paginated' })"
             >
-              Paginated
+              {{ t('settings.reader.comics.paginated') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
               :class="effective.scrollMode === 'infinite' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ scrollMode: 'infinite' })"
             >
-              Infinite (spaced)
+              {{ t('settings.reader.comics.infiniteSpaced') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
@@ -78,7 +81,7 @@ onMounted(load)
               "
               @click="update({ scrollMode: 'long-strip' })"
             >
-              Infinite (no gaps)
+              {{ t('settings.reader.comics.infiniteNoGaps') }}
             </button>
           </div>
         </div>
@@ -86,9 +89,9 @@ onMounted(load)
         <!-- View mode -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Page view</p>
+            <p class="settings-label">{{ t('settings.reader.comics.pageView') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Show one or two pages side by side
+              {{ t('settings.reader.comics.pageViewHint') }}
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
@@ -97,14 +100,14 @@ onMounted(load)
               :class="effective.viewMode === 'single' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ viewMode: 'single' })"
             >
-              Single
+              {{ t('settings.reader.comics.single') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
               :class="effective.viewMode === 'two-page' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ viewMode: 'two-page' })"
             >
-              Two-page
+              {{ t('settings.reader.comics.twoPage') }}
             </button>
           </div>
         </div>
@@ -112,18 +115,18 @@ onMounted(load)
         <!-- Fit mode -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Fit mode</p>
+            <p class="settings-label">{{ t('settings.reader.comics.fitMode') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              How pages are scaled to fit the screen
+              {{ t('settings.reader.comics.fitModeHint') }}
             </p>
           </div>
           <div class="flex flex-wrap gap-2 self-start md:self-auto md:justify-end">
             <button
               v-for="opt in [
-                { id: 'fit-page' as const, label: 'Page' },
-                { id: 'fit-width' as const, label: 'Width' },
-                { id: 'fit-height' as const, label: 'Height' },
-                { id: 'actual' as const, label: 'Actual' },
+                { id: 'fit-page' as const, label: t('settings.reader.comics.fitPage') },
+                { id: 'fit-width' as const, label: t('settings.reader.comics.fitWidth') },
+                { id: 'fit-height' as const, label: t('settings.reader.comics.fitHeight') },
+                { id: 'actual' as const, label: t('settings.reader.comics.fitActual') },
               ]"
               :key="opt.id"
               class="h-8 md:h-7 px-3 text-xs border-2 transition-colors font-medium rounded-md"
@@ -142,9 +145,9 @@ onMounted(load)
         <!-- Reading direction -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Reading direction</p>
+            <p class="settings-label">{{ t('settings.reader.comics.readingDirection') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Left-to-right for western comics; right-to-left for manga
+              {{ t('settings.reader.comics.readingDirectionHint') }}
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
@@ -153,14 +156,14 @@ onMounted(load)
               :class="effective.direction === 'ltr' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ direction: 'ltr' })"
             >
-              L to R
+              {{ t('settings.reader.comics.ltr') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
               :class="effective.direction === 'rtl' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ direction: 'rtl' })"
             >
-              R to L
+              {{ t('settings.reader.comics.rtl') }}
             </button>
           </div>
         </div>
@@ -168,9 +171,9 @@ onMounted(load)
         <!-- Spread alignment -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Spread alignment</p>
+            <p class="settings-label">{{ t('settings.reader.comics.spreadAlignment') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Shift pairing by one page after the cover for off-by-one scans
+              {{ t('settings.reader.comics.spreadAlignmentHint') }}
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
@@ -181,7 +184,7 @@ onMounted(load)
               "
               @click="update({ spreadAlignment: 'normal' })"
             >
-              Normal
+              {{ t('settings.reader.comics.alignmentNormal') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
@@ -190,7 +193,7 @@ onMounted(load)
               "
               @click="update({ spreadAlignment: 'shifted' })"
             >
-              Shifted
+              {{ t('settings.reader.comics.alignmentShifted') }}
             </button>
           </div>
         </div>
@@ -198,9 +201,9 @@ onMounted(load)
         <!-- Wide page handling -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Wide-page handling</p>
+            <p class="settings-label">{{ t('settings.reader.comics.widePageHandling') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Auto shows wide scans alone in two-page paginated mode
+              {{ t('settings.reader.comics.widePageHandlingHint') }}
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
@@ -211,7 +214,7 @@ onMounted(load)
               "
               @click="update({ widePageSingletonMode: 'auto' })"
             >
-              Auto
+              {{ t('settings.reader.comics.widePageAuto') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
@@ -222,7 +225,7 @@ onMounted(load)
               "
               @click="update({ widePageSingletonMode: 'disable' })"
             >
-              Disable
+              {{ t('settings.reader.comics.widePageDisable') }}
             </button>
           </div>
         </div>
@@ -230,9 +233,9 @@ onMounted(load)
         <!-- Force two-page -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Force two-page on small screens</p>
+            <p class="settings-label">{{ t('settings.reader.comics.forceTwoPage') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Bypass mobile auto-fallback when paginated two-page mode is selected
+              {{ t('settings.reader.comics.forceTwoPageHint') }}
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
@@ -241,14 +244,14 @@ onMounted(load)
               :class="!effective.forceTwoPage ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ forceTwoPage: false })"
             >
-              Off
+              {{ t('settings.reader.comics.off') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
               :class="effective.forceTwoPage ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ forceTwoPage: true })"
             >
-              On
+              {{ t('settings.reader.comics.on') }}
             </button>
           </div>
         </div>
@@ -257,22 +260,22 @@ onMounted(load)
 
     <!-- Display -->
     <div class="mb-6">
-      <p class="settings-group-label">Display</p>
+      <p class="settings-group-label">{{ t('settings.reader.comics.display') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border">
         <!-- Background color -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Background color</p>
+            <p class="settings-label">{{ t('settings.reader.comics.backgroundColor') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Canvas color behind pages
+              {{ t('settings.reader.comics.backgroundColorHint') }}
             </p>
           </div>
           <div class="flex flex-wrap gap-2 self-start">
             <button
               v-for="opt in [
-                { id: 'black' as const, label: 'Black' },
-                { id: 'gray' as const, label: 'Gray' },
-                { id: 'white' as const, label: 'White' },
+                { id: 'black' as const, label: t('settings.reader.comics.bgBlack') },
+                { id: 'gray' as const, label: t('settings.reader.comics.bgGray') },
+                { id: 'white' as const, label: t('settings.reader.comics.bgWhite') },
               ]"
               :key="opt.id"
               class="h-8 md:h-7 px-3 text-xs border-2 transition-colors font-medium rounded-md"

--- a/client/src/features/settings/ContentRestrictionsSettings.vue
+++ b/client/src/features/settings/ContentRestrictionsSettings.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ShieldAlert } from '@lucide/vue'
 import { api } from '@/lib/api'
 import type { ContentFilterRulesWithNames } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const filters = ref<ContentFilterRulesWithNames | null>(null)
 const loading = ref(true)
@@ -20,7 +23,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div v-if="loading" class="text-sm text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="text-sm text-muted-foreground">{{ t('common.loading') }}</div>
 
   <template v-else-if="filters">
     <div
@@ -28,21 +31,21 @@ onMounted(async () => {
       class="rounded-lg border border-border bg-muted/30 px-5 py-8 text-center"
     >
       <ShieldAlert :size="32" class="mx-auto mb-3 text-muted-foreground/60" />
-      <p class="text-sm font-medium text-foreground">No content restrictions</p>
-      <p class="mt-1 text-xs text-muted-foreground">Your account has full access to all content within your assigned libraries.</p>
+      <p class="text-sm font-medium text-foreground">{{ t('settings.account.restrictions.none.title') }}</p>
+      <p class="mt-1 text-xs text-muted-foreground">{{ t('settings.account.restrictions.none.description') }}</p>
     </div>
 
     <div v-else class="space-y-5">
       <div class="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 flex gap-3">
         <ShieldAlert :size="18" class="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
         <p class="text-sm text-amber-700 dark:text-amber-300">
-          Your account has content restrictions applied by an administrator. Some books may not be visible to you.
+          {{ t('settings.account.restrictions.banner') }}
         </p>
       </div>
 
       <div v-if="filters.includeTags?.length" class="space-y-2">
-        <p class="text-sm font-medium text-foreground">Allowed tags</p>
-        <p class="text-xs text-muted-foreground">Only books that have at least one of these tags are shown to you.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.account.restrictions.allowedTags.title') }}</p>
+        <p class="text-xs text-muted-foreground">{{ t('settings.account.restrictions.allowedTags.description') }}</p>
         <div class="flex flex-wrap gap-2">
           <span
             v-for="tag in filters.includeTags"
@@ -55,8 +58,8 @@ onMounted(async () => {
       </div>
 
       <div v-if="filters.excludeTags?.length" class="space-y-2">
-        <p class="text-sm font-medium text-foreground">Blocked tags</p>
-        <p class="text-xs text-muted-foreground">Books with any of these tags are hidden from you.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.account.restrictions.blockedTags.title') }}</p>
+        <p class="text-xs text-muted-foreground">{{ t('settings.account.restrictions.blockedTags.description') }}</p>
         <div class="flex flex-wrap gap-2">
           <span
             v-for="tag in filters.excludeTags"
@@ -69,8 +72,8 @@ onMounted(async () => {
       </div>
 
       <div v-if="filters.includeGenres?.length" class="space-y-2">
-        <p class="text-sm font-medium text-foreground">Allowed genres</p>
-        <p class="text-xs text-muted-foreground">Only books that have at least one of these genres are shown to you.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.account.restrictions.allowedGenres.title') }}</p>
+        <p class="text-xs text-muted-foreground">{{ t('settings.account.restrictions.allowedGenres.description') }}</p>
         <div class="flex flex-wrap gap-2">
           <span
             v-for="genre in filters.includeGenres"
@@ -83,8 +86,8 @@ onMounted(async () => {
       </div>
 
       <div v-if="filters.excludeGenres?.length" class="space-y-2">
-        <p class="text-sm font-medium text-foreground">Blocked genres</p>
-        <p class="text-xs text-muted-foreground">Books with any of these genres are hidden from you.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.account.restrictions.blockedGenres.title') }}</p>
+        <p class="text-xs text-muted-foreground">{{ t('settings.account.restrictions.blockedGenres.description') }}</p>
         <div class="flex flex-wrap gap-2">
           <span
             v-for="genre in filters.excludeGenres"

--- a/client/src/features/settings/EbookSettings.vue
+++ b/client/src/features/settings/EbookSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { EpubReaderSettings } from '@bookorbit/types'
 import { fontCssFamilyGroupName } from '@bookorbit/types'
 import { useReaderDefaultSettings } from '@/features/reader/shared/composables/useReaderSettings'
@@ -19,6 +20,8 @@ const props = withDefaults(
     embedded: false,
   },
 )
+
+const { t } = useI18n()
 
 const { effective, load, update, reset } = useReaderDefaultSettings<EpubReaderSettings>('epub')
 
@@ -84,9 +87,9 @@ function setFixedLayoutSpreadNone() {
   <div
     class="[&_.settings-hint]:overflow-hidden [&_.settings-hint]:text-ellipsis [&_.settings-hint]:whitespace-nowrap md:[&_.settings-hint]:overflow-visible md:[&_.settings-hint]:whitespace-normal"
   >
-    <SettingsPageHeader v-if="!props.embedded" title="eBook Reader" subtitle="Default settings applied when opening EPUB, MOBI, FB2, and TXT files.">
+    <SettingsPageHeader v-if="!props.embedded" :title="t('settings.reader.ebook.title')" :subtitle="t('settings.reader.ebook.subtitle')">
       <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-        Reset to defaults
+        {{ t('settings.reader.resetToDefaults') }}
       </button>
     </SettingsPageHeader>
     <template v-else>
@@ -94,25 +97,25 @@ function setFixedLayoutSpreadNone() {
         class="md:hidden sticky top-11 z-10 -mx-4 mb-4 px-4 py-2 border-y border-border/70 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/75"
       >
         <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-          Reset to defaults
+          {{ t('settings.reader.resetToDefaults') }}
         </button>
       </div>
       <div class="hidden md:flex justify-end mb-4">
         <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-          Reset to defaults
+          {{ t('settings.reader.resetToDefaults') }}
         </button>
       </div>
     </template>
 
     <!-- Formatting source -->
     <div class="mb-6">
-      <p class="settings-group-label">New Books</p>
+      <p class="settings-group-label">{{ t('settings.reader.ebook.newBooks') }}</p>
       <div class="border border-border rounded-lg overflow-hidden bg-card">
         <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between px-4 py-3.5 md:px-5 md:py-4">
           <div>
-            <p class="settings-label">Apply my settings to new books</p>
+            <p class="settings-label">{{ t('settings.reader.ebook.applySettings') }}</p>
             <p class="settings-hint">
-              When off, new books open with the publisher's own fonts and layout. Your settings only apply once you change something in-reader.
+              {{ t('settings.reader.ebook.applySettingsHint') }}
             </p>
           </div>
           <ToggleSwitch
@@ -126,13 +129,13 @@ function setFixedLayoutSpreadNone() {
 
     <!-- Layout -->
     <div class="mb-6">
-      <p class="settings-group-label">Layout</p>
+      <p class="settings-group-label">{{ t('settings.reader.ebook.layout') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border">
         <!-- Flow -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Reading flow</p>
-            <p class="settings-hint">Paginated flips pages; scrolled flows continuously</p>
+            <p class="settings-label">{{ t('settings.reader.ebook.readingFlow') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.readingFlowHint') }}</p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
             <button
@@ -140,14 +143,14 @@ function setFixedLayoutSpreadNone() {
               :class="effective.flow === 'paginated' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ flow: 'paginated' })"
             >
-              Paginated
+              {{ t('settings.reader.ebook.paginated') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
               :class="effective.flow === 'scrolled' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ flow: 'scrolled' })"
             >
-              Scrolled
+              {{ t('settings.reader.ebook.scrolled') }}
             </button>
           </div>
         </div>
@@ -155,8 +158,8 @@ function setFixedLayoutSpreadNone() {
         <!-- Fixed-layout spread -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Fixed-layout page spreads</p>
-            <p class="settings-hint">Default for manga, comics, and image-based EPUBs</p>
+            <p class="settings-label">{{ t('settings.reader.ebook.fixedLayoutSpread') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.fixedLayoutSpreadHint') }}</p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
             <button
@@ -166,7 +169,7 @@ function setFixedLayoutSpreadNone() {
               "
               @click="setFixedLayoutSpreadAuto"
             >
-              Book default
+              {{ t('settings.reader.ebook.bookDefault') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
@@ -175,7 +178,7 @@ function setFixedLayoutSpreadNone() {
               "
               @click="setFixedLayoutSpreadNone"
             >
-              Single page
+              {{ t('settings.reader.ebook.singlePage') }}
             </button>
           </div>
         </div>
@@ -184,10 +187,10 @@ function setFixedLayoutSpreadNone() {
         <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
             <div class="flex items-center justify-between gap-3">
-              <p class="settings-label">Columns</p>
+              <p class="settings-label">{{ t('settings.reader.ebook.columns') }}</p>
               <span class="settings-value">{{ effective.maxColumnCount }}</span>
             </div>
-            <p class="settings-hint">Number of text columns per page</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.columnsHint') }}</p>
           </div>
           <input
             type="range"
@@ -204,13 +207,13 @@ function setFixedLayoutSpreadNone() {
 
     <!-- Theme -->
     <div class="mb-6">
-      <p class="settings-group-label">Theme</p>
+      <p class="settings-group-label">{{ t('settings.reader.ebook.theme') }}</p>
       <div class="border border-border rounded-lg overflow-hidden bg-card px-4 py-3.5 md:px-5 md:py-4">
         <!-- Dark mode toggle -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between mb-4">
           <div>
-            <p class="settings-label">Dark mode</p>
-            <p class="settings-hint">Use the dark variant of the selected theme</p>
+            <p class="settings-label">{{ t('settings.reader.ebook.darkMode') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.darkModeHint') }}</p>
           </div>
           <ToggleSwitch class="self-start" :model-value="effective.isDark" @update:model-value="update({ isDark: $event })" />
         </div>
@@ -275,23 +278,23 @@ function setFixedLayoutSpreadNone() {
 
     <!-- Typography -->
     <div class="mb-6">
-      <p class="settings-group-label">Typography</p>
+      <p class="settings-group-label">{{ t('settings.reader.ebook.typography') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border">
         <!-- Font family -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Font</p>
-            <p class="settings-hint">Typeface used for body text</p>
+            <p class="settings-label">{{ t('settings.reader.ebook.font') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.fontHint') }}</p>
           </div>
           <select
             class="text-xs border border-border rounded-md px-2 py-2 md:py-1.5 bg-card text-foreground focus:outline-none focus:ring-1 focus:ring-primary self-start min-w-40"
             :value="effective.fontFamily ?? ''"
             @change="update({ fontFamily: ($event.target as HTMLSelectElement).value || null })"
           >
-            <optgroup label="Built-in fonts">
+            <optgroup :label="t('settings.reader.ebook.builtInFonts')">
               <option v-for="f in BUILTIN_READER_FONT_OPTIONS" :key="String(f.value)" :value="f.value ?? ''">{{ f.label }}</option>
             </optgroup>
-            <optgroup v-if="customFontOptions.length > 0" label="Your Fonts">
+            <optgroup v-if="customFontOptions.length > 0" :label="t('settings.reader.ebook.yourFonts')">
               <option v-for="f in customFontOptions" :key="f.id" :value="f.id">{{ f.label }}</option>
             </optgroup>
           </select>
@@ -301,10 +304,10 @@ function setFixedLayoutSpreadNone() {
         <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
             <div class="flex items-center justify-between gap-3">
-              <p class="settings-label">Font size</p>
+              <p class="settings-label">{{ t('settings.reader.ebook.fontSize') }}</p>
               <span class="settings-value">{{ effective.fontSize }}px</span>
             </div>
-            <p class="settings-hint">Base text size in pixels</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.fontSizeHint') }}</p>
           </div>
           <input
             type="range"
@@ -321,10 +324,10 @@ function setFixedLayoutSpreadNone() {
         <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
             <div class="flex items-center justify-between gap-3">
-              <p class="settings-label">Line height</p>
+              <p class="settings-label">{{ t('settings.reader.ebook.lineHeight') }}</p>
               <span class="settings-value">{{ effective.lineHeight.toFixed(1) }}</span>
             </div>
-            <p class="settings-hint">Vertical spacing between lines</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.lineHeightHint') }}</p>
           </div>
           <input
             type="range"
@@ -340,8 +343,8 @@ function setFixedLayoutSpreadNone() {
         <!-- Justify -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Justify text</p>
-            <p class="settings-hint">Align text to both margins</p>
+            <p class="settings-label">{{ t('settings.reader.ebook.justify') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.justifyHint') }}</p>
           </div>
           <ToggleSwitch class="self-start" :model-value="effective.justify" @update:model-value="update({ justify: $event })" />
         </div>
@@ -349,8 +352,8 @@ function setFixedLayoutSpreadNone() {
         <!-- Hyphenation -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Hyphenation</p>
-            <p class="settings-hint">Automatically break long words with hyphens</p>
+            <p class="settings-label">{{ t('settings.reader.ebook.hyphenation') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.hyphenationHint') }}</p>
           </div>
           <ToggleSwitch class="self-start" :model-value="effective.hyphenate" @update:model-value="update({ hyphenate: $event })" />
         </div>
@@ -359,16 +362,16 @@ function setFixedLayoutSpreadNone() {
 
     <!-- Advanced -->
     <div class="mb-6">
-      <p class="settings-group-label">Advanced</p>
+      <p class="settings-group-label">{{ t('settings.reader.ebook.advanced') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border">
         <!-- Max inline size -->
         <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
             <div class="flex items-center justify-between gap-3">
-              <p class="settings-label">Max content width</p>
+              <p class="settings-label">{{ t('settings.reader.ebook.maxContentWidth') }}</p>
               <span class="settings-value">{{ effective.maxInlineSize }}px</span>
             </div>
-            <p class="settings-hint">Maximum width of the text area in pixels</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.maxContentWidthHint') }}</p>
           </div>
           <input
             type="range"
@@ -385,10 +388,10 @@ function setFixedLayoutSpreadNone() {
         <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
             <div class="flex items-center justify-between gap-3">
-              <p class="settings-label">Column gap</p>
+              <p class="settings-label">{{ t('settings.reader.ebook.columnGap') }}</p>
               <span class="settings-value">{{ Math.round(effective.gap * 100) }}%</span>
             </div>
-            <p class="settings-hint">Horizontal padding on each side of the text area</p>
+            <p class="settings-hint">{{ t('settings.reader.ebook.columnGapHint') }}</p>
           </div>
           <input
             type="range"

--- a/client/src/features/settings/FileNamingSettings.vue
+++ b/client/src/features/settings/FileNamingSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Check, ChevronDown, ChevronUp, ClipboardCopy, Info, Loader2, RotateCcw, Save } from '@lucide/vue'
 import {
   DEFAULT_DOWNLOAD_PATTERN,
@@ -17,6 +18,7 @@ import SettingsPageHeader from './SettingsPageHeader.vue'
 import { copyToClipboard } from '@/lib/clipboard'
 import AppIcon from '@/components/AppIcon.vue'
 
+const { t } = useI18n()
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
 
 const {
@@ -70,123 +72,123 @@ let globalPreviewTimer: ReturnType<typeof setTimeout> | null = null
 let folderPreviewTimer: ReturnType<typeof setTimeout> | null = null
 let downloadPreviewTimer: ReturnType<typeof setTimeout> | null = null
 
-const MODIFIERS = [
-  { key: ':first', description: 'First value only' },
-  { key: ':sort', description: 'Last, First format' },
-  { key: ':initial', description: 'First letter only' },
+const MODIFIERS = computed(() => [
+  { key: ':first', description: t('settings.reader.fileNaming.modFirst') },
+  { key: ':sort', description: t('settings.reader.fileNaming.modSort') },
+  { key: ':initial', description: t('settings.reader.fileNaming.modInitial') },
   { key: ':upper', description: 'UPPERCASE' },
   { key: ':lower', description: 'lowercase' },
-]
+])
 
-const EXAMPLES = [
+const EXAMPLES = computed(() => [
   {
-    label: 'Calibre-style default',
+    label: t('settings.reader.fileNaming.exCalibre'),
     pattern: '{authors}/{title}< ({year})>',
     cases: [
-      { label: 'with year', result: 'William Gibson/Neuromancer (1984).epub' },
-      { label: 'no year', result: 'William Gibson/Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseWithYear'), result: 'William Gibson/Neuromancer (1984).epub' },
+      { label: t('settings.reader.fileNaming.caseNoYear'), result: 'William Gibson/Neuromancer.epub' },
     ],
   },
   {
-    label: 'Series reader',
+    label: t('settings.reader.fileNaming.exSeriesReader'),
     pattern: '{authors:first}/<{series}/><{seriesIndex}. >{title}',
     cases: [
-      { label: 'in series', result: 'William Gibson/Sprawl/01. Neuromancer.epub' },
-      { label: 'standalone', result: 'William Gibson/Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseInSeries'), result: 'William Gibson/Sprawl/01. Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseStandalone'), result: 'William Gibson/Neuromancer.epub' },
     ],
   },
   {
-    label: 'Clean download filename',
+    label: t('settings.reader.fileNaming.exCleanDownload'),
     pattern: '{authors:first} - {title}< ({year})>',
     cases: [
-      { label: 'with year', result: 'William Gibson - Neuromancer (1984).epub' },
-      { label: 'no year', result: 'William Gibson - Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseWithYear'), result: 'William Gibson - Neuromancer (1984).epub' },
+      { label: t('settings.reader.fileNaming.caseNoYear'), result: 'William Gibson - Neuromancer.epub' },
     ],
   },
   {
-    label: 'Alphabetical grouping with series',
+    label: t('settings.reader.fileNaming.exAlphabetical'),
     pattern: '{authors:initial}/{authors:sort}/<{series}/><{seriesIndex}. >{title}',
     cases: [
-      { label: 'in series', result: 'G/Gibson, William/Sprawl/01. Neuromancer.epub' },
-      { label: 'standalone', result: 'G/Gibson, William/Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseInSeries'), result: 'G/Gibson, William/Sprawl/01. Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseStandalone'), result: 'G/Gibson, William/Neuromancer.epub' },
     ],
   },
   {
-    label: 'Series or Standalone fallback',
+    label: t('settings.reader.fileNaming.exSeriesFallback'),
     pattern: '<{series}|Standalone>/<{seriesIndex}. >{title}',
     cases: [
-      { label: 'in series', result: 'Sprawl/01. Neuromancer.epub' },
-      { label: 'no series', result: 'Standalone/Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseInSeries'), result: 'Sprawl/01. Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseNoSeries'), result: 'Standalone/Neuromancer.epub' },
     ],
   },
   {
-    label: 'Download with optional subtitle',
+    label: t('settings.reader.fileNaming.exOptionalSubtitle'),
     pattern: '{authors:first} - {title}< - {subtitle}>< ({year})>',
     cases: [
-      { label: 'full', result: 'Andrew Hunt - The Pragmatic Programmer - From Journeyman to Master (1999).epub' },
-      { label: 'minimal', result: 'Andrew Hunt - The Pragmatic Programmer.epub' },
+      { label: t('settings.reader.fileNaming.caseFull'), result: 'Andrew Hunt - The Pragmatic Programmer - From Journeyman to Master (1999).epub' },
+      { label: t('settings.reader.fileNaming.caseMinimal'), result: 'Andrew Hunt - The Pragmatic Programmer.epub' },
     ],
   },
   {
-    label: 'Multilingual library',
+    label: t('settings.reader.fileNaming.exMultilingual'),
     pattern: '<{language:upper}/>{authors}/{title}',
     cases: [
-      { label: 'with language', result: 'EN/William Gibson/Neuromancer.epub' },
-      { label: 'no language', result: 'William Gibson/Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseWithLanguage'), result: 'EN/William Gibson/Neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseNoLanguage'), result: 'William Gibson/Neuromancer.epub' },
     ],
   },
   {
-    label: 'Publisher-organized',
+    label: t('settings.reader.fileNaming.exPublisher'),
     pattern: '<{publisher}/>{authors:first}/{title}',
     cases: [
-      { label: 'with publisher', result: "O'Reilly/Andrew Hunt/The Pragmatic Programmer.epub" },
-      { label: 'no publisher', result: 'Andrew Hunt/The Pragmatic Programmer.epub' },
+      { label: t('settings.reader.fileNaming.caseWithPublisher'), result: "O'Reilly/Andrew Hunt/The Pragmatic Programmer.epub" },
+      { label: t('settings.reader.fileNaming.caseNoPublisher'), result: 'Andrew Hunt/The Pragmatic Programmer.epub' },
     ],
   },
   {
-    label: 'Stacked optional folders',
+    label: t('settings.reader.fileNaming.exStacked'),
     pattern: '<{language:upper}/><{publisher}|Unknown Publisher>/{authors:first}/{title}',
     cases: [
-      { label: 'all set', result: "EN/O'Reilly/Andrew Hunt/The Pragmatic Programmer.epub" },
-      { label: 'no language', result: "O'Reilly/Andrew Hunt/The Pragmatic Programmer.epub" },
-      { label: 'no publisher', result: 'Unknown Publisher/Andrew Hunt/The Pragmatic Programmer.epub' },
+      { label: t('settings.reader.fileNaming.caseAllSet'), result: "EN/O'Reilly/Andrew Hunt/The Pragmatic Programmer.epub" },
+      { label: t('settings.reader.fileNaming.caseNoLanguage'), result: "O'Reilly/Andrew Hunt/The Pragmatic Programmer.epub" },
+      { label: t('settings.reader.fileNaming.caseNoPublisher'), result: 'Unknown Publisher/Andrew Hunt/The Pragmatic Programmer.epub' },
     ],
   },
   {
-    label: 'Folder-drop with sort name',
+    label: t('settings.reader.fileNaming.exFolderDrop'),
     pattern: '{authors:initial}/{authors:sort}/<{series}/>',
     cases: [
-      { label: 'in series', result: 'G/Gibson, William/Sprawl/neuromancer.epub' },
-      { label: 'standalone', result: 'G/Gibson, William/neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseInSeries'), result: 'G/Gibson, William/Sprawl/neuromancer.epub' },
+      { label: t('settings.reader.fileNaming.caseStandalone'), result: 'G/Gibson, William/neuromancer.epub' },
     ],
   },
-]
+])
 
 async function copyToken(token: string) {
   const value = `{${token}}`
   const copied = await copyToClipboard(value)
   if (copied) {
-    toast.success(`${value} copied to clipboard`)
+    toast.success(t('settings.reader.fileNaming.copiedToClipboard', { value }))
   } else {
-    toast.error('Failed to copy token')
+    toast.error(t('settings.reader.fileNaming.copyTokenFailed'))
   }
 }
 
 async function copyPattern(pattern: string) {
   const copied = await copyToClipboard(pattern)
   if (copied) {
-    toast.success('Pattern copied to clipboard')
+    toast.success(t('settings.reader.fileNaming.patternCopied'))
   } else {
-    toast.error('Failed to copy pattern')
+    toast.error(t('settings.reader.fileNaming.copyPatternFailed'))
   }
 }
 
 async function copyText(text: string, label: string) {
   const copied = await copyToClipboard(text)
   if (copied) {
-    toast.success(`${label} copied to clipboard`)
+    toast.success(t('settings.reader.fileNaming.labelCopied', { label }))
   } else {
-    toast.error(`Failed to copy ${label.toLowerCase()}`)
+    toast.error(t('settings.reader.fileNaming.copyLabelFailed', { label: label.toLowerCase() }))
   }
 }
 
@@ -263,23 +265,30 @@ onUnmounted(() => {
     <SettingsPageHeader
       v-if="!props.embedded"
       class="hidden md:flex"
-      title="File Naming"
-      subtitle="Control how files are organized on disk when uploaded and how they are named when downloaded using placeholder tokens."
+      :title="t('settings.reader.fileNaming.title')"
+      :subtitle="t('settings.reader.fileNaming.subtitle')"
     />
     <div v-if="!props.embedded" class="md:hidden px-1">
-      <h1 class="text-xl font-semibold tracking-tight text-foreground">File Naming</h1>
+      <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('settings.reader.fileNaming.title') }}</h1>
       <p
         class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
       >
-        Control how files are organized on disk when uploaded and how they are named when downloaded using placeholder tokens.
+        {{ t('settings.reader.fileNaming.subtitle') }}
       </p>
     </div>
 
     <div class="md:hidden border border-border/60 bg-card rounded-lg p-3 space-y-3">
       <div class="space-y-1.5 pt-1 pb-4 border-border/60">
         <div class="flex items-center justify-between gap-2">
-          <p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">File as Book preview</p>
-          <button class="text-xs text-primary hover:underline" @click="copyText(uploadPreviewValue, 'File as Book preview')">Copy</button>
+          <p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            {{ t('settings.reader.fileNaming.fileAsBookPreview') }}
+          </p>
+          <button
+            class="text-xs text-primary hover:underline"
+            @click="copyText(uploadPreviewValue, t('settings.reader.fileNaming.fileAsBookPreview'))"
+          >
+            {{ t('settings.reader.fileNaming.copy') }}
+          </button>
         </div>
         <div class="rounded-md border border-border bg-background px-2.5 py-2 font-mono text-xs overflow-x-auto whitespace-nowrap">
           {{ uploadPreviewValue }}
@@ -287,8 +296,15 @@ onUnmounted(() => {
       </div>
       <div class="space-y-1.5 pt-1 pb-4 border-border/60">
         <div class="flex items-center justify-between gap-2">
-          <p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Folder as Book preview</p>
-          <button class="text-xs text-primary hover:underline" @click="copyText(folderPreviewValue, 'Folder as Book preview')">Copy</button>
+          <p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            {{ t('settings.reader.fileNaming.folderAsBookPreview') }}
+          </p>
+          <button
+            class="text-xs text-primary hover:underline"
+            @click="copyText(folderPreviewValue, t('settings.reader.fileNaming.folderAsBookPreview'))"
+          >
+            {{ t('settings.reader.fileNaming.copy') }}
+          </button>
         </div>
         <div class="rounded-md border border-border bg-background px-2.5 py-2 font-mono text-xs overflow-x-auto whitespace-nowrap">
           {{ folderPreviewValue }}
@@ -296,8 +312,15 @@ onUnmounted(() => {
       </div>
       <div class="space-y-1.5">
         <div class="flex items-center justify-between gap-2">
-          <p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Download preview</p>
-          <button class="text-xs text-primary hover:underline" @click="copyText(downloadPreviewValue, 'Download preview')">Copy</button>
+          <p class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            {{ t('settings.reader.fileNaming.downloadPreview') }}
+          </p>
+          <button
+            class="text-xs text-primary hover:underline"
+            @click="copyText(downloadPreviewValue, t('settings.reader.fileNaming.downloadPreview'))"
+          >
+            {{ t('settings.reader.fileNaming.copy') }}
+          </button>
         </div>
         <div class="rounded-md border border-border bg-background px-2.5 py-2 font-mono text-xs overflow-x-auto whitespace-nowrap">
           {{ downloadPreviewValue }}
@@ -307,15 +330,14 @@ onUnmounted(() => {
 
     <!-- Global Patterns -->
     <section class="space-y-4">
-      <p class="settings-group-label">Global Defaults</p>
+      <p class="settings-group-label">{{ t('settings.reader.fileNaming.globalDefaults') }}</p>
       <div class="border border-border rounded-lg bg-card overflow-hidden divide-y divide-border shadow-xs">
         <div class="px-4 py-4 md:px-6 md:py-5">
           <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
             <div class="w-full lg:max-w-md">
-              <p class="settings-label">Cross-platform path sanitization</p>
+              <p class="settings-label">{{ t('settings.reader.fileNaming.crossPlatform') }}</p>
               <p class="settings-hint">
-                Make generated file and folder names safe on Windows by replacing invalid characters and reserved names, and removing trailing dots
-                and spaces. Disable only for Linux-only setups that intentionally keep those characters.
+                {{ t('settings.reader.fileNaming.crossPlatformHint') }}
               </p>
             </div>
             <div class="flex items-center gap-3 w-full lg:w-auto">
@@ -330,7 +352,7 @@ onUnmounted(() => {
               >
                 <Loader2 v-if="savingCrossPlatformSanitization" :size="14" class="animate-spin" />
                 <Save v-else :size="14" />
-                <span>Save</span>
+                <span>{{ t('common.save') }}</span>
               </button>
             </div>
           </div>
@@ -340,8 +362,8 @@ onUnmounted(() => {
         <div class="px-4 py-4 md:px-6 md:py-5 space-y-4">
           <div class="flex flex-col lg:flex-row lg:items-start justify-between gap-4">
             <div class="w-full lg:max-w-md">
-              <p class="settings-label">File as Book default</p>
-              <p class="settings-hint">Upload pattern for libraries using File as Book mode. Each file is one book.</p>
+              <p class="settings-label">{{ t('settings.reader.fileNaming.fileAsBookDefault') }}</p>
+              <p class="settings-hint">{{ t('settings.reader.fileNaming.fileAsBookDefaultHint') }}</p>
             </div>
             <div class="flex flex-col gap-4 w-full lg:flex-row lg:items-center lg:w-auto">
               <div class="relative flex-1 lg:w-120 xl:w-140">
@@ -363,13 +385,15 @@ onUnmounted(() => {
               >
                 <Loader2 v-if="savingGlobal" :size="14" class="animate-spin" />
                 <Save v-else :size="14" />
-                <span>Save</span>
+                <span>{{ t('common.save') }}</span>
               </button>
             </div>
           </div>
 
           <div class="hidden md:flex items-center gap-2.5 px-3 py-2 rounded-lg bg-muted/40 border border-border/50 font-mono text-xs">
-            <span class="text-muted-foreground shrink-0 uppercase tracking-wider font-semibold text-[10px]">Preview:</span>
+            <span class="text-muted-foreground shrink-0 uppercase tracking-wider font-semibold text-[10px]">{{
+              t('settings.reader.fileNaming.previewLabel')
+            }}</span>
             <span class="text-foreground truncate">{{ uploadPreviewValue }}</span>
           </div>
         </div>
@@ -378,8 +402,8 @@ onUnmounted(() => {
         <div class="px-4 py-4 md:px-6 md:py-5 space-y-4">
           <div class="flex flex-col lg:flex-row lg:items-start justify-between gap-4">
             <div class="w-full lg:max-w-md">
-              <p class="settings-label">Folder as Book default</p>
-              <p class="settings-hint">Upload pattern for libraries using Folder as Book mode. Each book must be in its own folder.</p>
+              <p class="settings-label">{{ t('settings.reader.fileNaming.folderAsBookDefault') }}</p>
+              <p class="settings-hint">{{ t('settings.reader.fileNaming.folderAsBookDefaultHint') }}</p>
             </div>
             <div class="flex flex-col gap-4 w-full lg:flex-row lg:items-center lg:w-auto">
               <div class="relative flex-1 lg:w-120 xl:w-140">
@@ -401,13 +425,15 @@ onUnmounted(() => {
               >
                 <Loader2 v-if="savingFolder" :size="14" class="animate-spin" />
                 <Save v-else :size="14" />
-                <span>Save</span>
+                <span>{{ t('common.save') }}</span>
               </button>
             </div>
           </div>
 
           <div class="hidden md:flex items-center gap-2.5 px-3 py-2 rounded-lg bg-muted/40 border border-border/50 font-mono text-xs">
-            <span class="text-muted-foreground shrink-0 uppercase tracking-wider font-semibold text-[10px]">Preview:</span>
+            <span class="text-muted-foreground shrink-0 uppercase tracking-wider font-semibold text-[10px]">{{
+              t('settings.reader.fileNaming.previewLabel')
+            }}</span>
             <span class="text-foreground truncate">{{ folderPreviewValue }}</span>
           </div>
         </div>
@@ -416,8 +442,8 @@ onUnmounted(() => {
         <div class="px-4 py-4 md:px-6 md:py-5 space-y-4">
           <div class="flex flex-col lg:flex-row lg:items-start justify-between gap-4">
             <div class="w-full lg:max-w-md">
-              <p class="settings-label">Download Pattern</p>
-              <p class="settings-hint">Suggested filenames for single-file downloads and files inside export ZIPs.</p>
+              <p class="settings-label">{{ t('settings.reader.fileNaming.downloadPattern') }}</p>
+              <p class="settings-hint">{{ t('settings.reader.fileNaming.downloadPatternHint') }}</p>
             </div>
             <div class="flex flex-col gap-4 w-full lg:flex-row lg:items-center lg:w-auto">
               <div class="relative flex-1 lg:w-120 xl:w-140">
@@ -439,13 +465,15 @@ onUnmounted(() => {
               >
                 <Loader2 v-if="savingDownload" :size="14" class="animate-spin" />
                 <Save v-else :size="14" />
-                <span>Save</span>
+                <span>{{ t('common.save') }}</span>
               </button>
             </div>
           </div>
 
           <div class="hidden md:flex items-center gap-2.5 px-3 py-2 rounded-lg bg-muted/40 border border-border/50 font-mono text-xs">
-            <span class="text-muted-foreground shrink-0 uppercase tracking-wider font-semibold text-[10px]">Preview:</span>
+            <span class="text-muted-foreground shrink-0 uppercase tracking-wider font-semibold text-[10px]">{{
+              t('settings.reader.fileNaming.previewLabel')
+            }}</span>
             <span class="text-foreground truncate">{{ downloadPreviewValue }}</span>
           </div>
         </div>
@@ -454,10 +482,10 @@ onUnmounted(() => {
 
     <!-- Library Overrides -->
     <section class="space-y-4">
-      <p class="settings-group-label">Library Overrides</p>
+      <p class="settings-group-label">{{ t('settings.reader.fileNaming.libraryOverrides') }}</p>
       <div class="border border-border rounded-lg bg-card overflow-hidden divide-y divide-border shadow-xs">
         <div v-if="libraries.length === 0" class="px-4 py-8 md:px-6 md:py-10 text-center text-sm text-muted-foreground italic">
-          No libraries configured. Create one in Library settings to set custom naming patterns.
+          {{ t('settings.reader.fileNaming.noLibraries') }}
         </div>
 
         <div v-for="lib in libraries" :key="lib.id" class="px-4 py-4 md:px-6 md:py-5 space-y-3">
@@ -470,9 +498,11 @@ onUnmounted(() => {
                 <div class="flex items-center gap-2 flex-wrap">
                   <span class="settings-label truncate">{{ lib.name }}</span>
                   <Badge v-if="lib.fileNamingPattern" variant="secondary" class="h-4.5 px-1.5 text-[10px] font-bold uppercase tracking-tight">
-                    Custom
+                    {{ t('settings.reader.fileNaming.badgeCustom') }}
                   </Badge>
-                  <Badge v-else variant="outline" class="h-4.5 px-1.5 text-[10px] font-bold uppercase tracking-tight opacity-60"> Default </Badge>
+                  <Badge v-else variant="outline" class="h-4.5 px-1.5 text-[10px] font-bold uppercase tracking-tight opacity-60">
+                    {{ t('settings.reader.fileNaming.badgeDefault') }}
+                  </Badge>
                   <Badge
                     variant="outline"
                     class="h-4.5 px-1.5 text-[10px] font-bold uppercase tracking-tight"
@@ -480,7 +510,11 @@ onUnmounted(() => {
                       lib.organizationMode === 'book_per_folder' ? 'text-blue-500 border-blue-500/40' : 'text-emerald-500 border-emerald-500/40'
                     "
                   >
-                    {{ lib.organizationMode === 'book_per_folder' ? 'Folder as Book' : 'File as Book' }}
+                    {{
+                      lib.organizationMode === 'book_per_folder'
+                        ? t('settings.reader.fileNaming.orgFolderAsBook')
+                        : t('settings.reader.fileNaming.orgFileAsBook')
+                    }}
                   </Badge>
                 </div>
               </div>
@@ -514,13 +548,15 @@ onUnmounted(() => {
                     <RotateCcw :size="13" />
                   </button>
                 </TooltipTrigger>
-                <TooltipContent>Reset to default</TooltipContent>
+                <TooltipContent>{{ t('settings.reader.fileNaming.resetToDefault') }}</TooltipContent>
               </Tooltip>
             </div>
           </div>
 
           <div class="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-muted/40 border border-border/50 text-xs">
-            <span class="text-muted-foreground shrink-0 uppercase tracking-wider font-semibold text-[10px]">Preview:</span>
+            <span class="text-muted-foreground shrink-0 uppercase tracking-wider font-semibold text-[10px]">{{
+              t('settings.reader.fileNaming.previewLabel')
+            }}</span>
             <div class="overflow-x-auto min-w-0 font-mono">
               <span class="text-foreground whitespace-nowrap">{{ getEffectivePreview(lib) }}</span>
             </div>
@@ -531,7 +567,7 @@ onUnmounted(() => {
 
     <!-- Placeholder Reference -->
     <section class="space-y-4">
-      <p class="settings-group-label">Pattern Reference</p>
+      <p class="settings-group-label">{{ t('settings.reader.fileNaming.patternReference') }}</p>
 
       <!-- Reference accordion -->
       <div class="border border-border rounded-lg bg-card shadow-xs overflow-hidden">
@@ -541,8 +577,8 @@ onUnmounted(() => {
         >
           <div class="flex items-center gap-2.5">
             <Info :size="16" class="text-primary shrink-0" />
-            <span class="text-sm font-medium text-foreground">Placeholder Reference</span>
-            <span class="hidden sm:inline text-xs text-muted-foreground">- guide for creating custom naming patterns</span>
+            <span class="text-sm font-medium text-foreground">{{ t('settings.reader.fileNaming.placeholderReference') }}</span>
+            <span class="hidden sm:inline text-xs text-muted-foreground">{{ t('settings.reader.fileNaming.placeholderReferenceHint') }}</span>
           </div>
           <ChevronUp v-if="referenceOpen" :size="16" class="text-muted-foreground shrink-0" />
           <ChevronDown v-else :size="16" class="text-muted-foreground shrink-0" />
@@ -553,29 +589,29 @@ onUnmounted(() => {
           <div class="p-5 space-y-3">
             <button class="w-full flex items-center justify-between gap-2 text-left" @click="tokenHelpOpen = !tokenHelpOpen">
               <div>
-                <p class="text-xs font-semibold text-foreground uppercase tracking-wider">Tokens</p>
-                <p class="text-[11px] text-muted-foreground">Copy placeholders quickly</p>
+                <p class="text-xs font-semibold text-foreground uppercase tracking-wider">{{ t('settings.reader.fileNaming.tokens') }}</p>
+                <p class="text-[11px] text-muted-foreground">{{ t('settings.reader.fileNaming.tokensHint') }}</p>
               </div>
               <ChevronUp v-if="tokenHelpOpen" :size="15" class="text-muted-foreground shrink-0" />
               <ChevronDown v-else :size="15" class="text-muted-foreground shrink-0" />
             </button>
             <div v-if="tokenHelpOpen" class="space-y-3">
-              <p class="text-xs text-muted-foreground leading-relaxed">Click any token to copy it to your clipboard.</p>
+              <p class="text-xs text-muted-foreground leading-relaxed">{{ t('settings.reader.fileNaming.clickTokenHint') }}</p>
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
-                <Tooltip v-for="t in PATTERN_TOKENS" :key="t.token">
+                <Tooltip v-for="tok in PATTERN_TOKENS" :key="tok.token">
                   <TooltipTrigger as-child>
                     <button
                       class="group flex items-center justify-between gap-3 px-3 py-2 rounded-lg border border-border bg-background text-left hover:border-primary/40 hover:bg-primary/5 transition-colors"
-                      @click="copyToken(t.token)"
+                      @click="copyToken(tok.token)"
                     >
                       <div class="min-w-0">
-                        <code class="text-xs font-mono font-semibold text-primary">{{ '{' + t.token + '}' }}</code>
-                        <p class="text-[11px] text-muted-foreground leading-tight mt-0.5">{{ t.description }}</p>
+                        <code class="text-xs font-mono font-semibold text-primary">{{ '{' + tok.token + '}' }}</code>
+                        <p class="text-[11px] text-muted-foreground leading-tight mt-0.5">{{ tok.description }}</p>
                       </div>
                       <ClipboardCopy :size="13" class="shrink-0 text-muted-foreground/60 group-hover:text-primary/60 transition-colors" />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent>Copy {{ '{' + t.token + '}' }}</TooltipContent>
+                  <TooltipContent>{{ t('settings.reader.fileNaming.copyValue', { value: '{' + tok.token + '}' }) }}</TooltipContent>
                 </Tooltip>
               </div>
             </div>
@@ -585,15 +621,15 @@ onUnmounted(() => {
           <div class="p-5 space-y-3">
             <button class="w-full flex items-center justify-between gap-2 text-left" @click="modifierHelpOpen = !modifierHelpOpen">
               <div>
-                <p class="text-xs font-semibold text-foreground uppercase tracking-wider">Modifiers</p>
-                <p class="text-[11px] text-muted-foreground">Transform token values</p>
+                <p class="text-xs font-semibold text-foreground uppercase tracking-wider">{{ t('settings.reader.fileNaming.modifiers') }}</p>
+                <p class="text-[11px] text-muted-foreground">{{ t('settings.reader.fileNaming.modifiersHint') }}</p>
               </div>
               <ChevronUp v-if="modifierHelpOpen" :size="15" class="text-muted-foreground shrink-0" />
               <ChevronDown v-else :size="15" class="text-muted-foreground shrink-0" />
             </button>
             <div v-if="modifierHelpOpen" class="space-y-3">
               <p class="text-xs text-muted-foreground leading-relaxed">
-                Append a modifier inside a token to transform its value:
+                {{ t('settings.reader.fileNaming.modifiersExplain') }}
                 <code class="bg-muted px-1.5 py-0.5 rounded font-mono text-foreground text-[11px]">{authors:first}</code>
               </p>
               <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
@@ -609,8 +645,9 @@ onUnmounted(() => {
               <div class="flex items-start gap-3 px-4 py-3 rounded-lg bg-primary/5 border border-primary/10">
                 <code class="text-sm font-mono text-primary shrink-0 mt-0.5">/</code>
                 <p class="text-xs text-muted-foreground leading-relaxed">
-                  End a pattern with <code class="bg-primary/10 text-primary px-1 py-0.5 rounded font-mono text-[11px]">/</code> to specify a folder
-                  only. The original filename will be preserved inside it.
+                  {{ t('settings.reader.fileNaming.folderOnlyPrefix') }}
+                  <code class="bg-primary/10 text-primary px-1 py-0.5 rounded font-mono text-[11px]">/</code>
+                  {{ t('settings.reader.fileNaming.folderOnlySuffix') }}
                 </p>
               </div>
             </div>
@@ -620,16 +657,18 @@ onUnmounted(() => {
           <div class="p-5 space-y-3">
             <button class="w-full flex items-center justify-between gap-2 text-left" @click="conditionalHelpOpen = !conditionalHelpOpen">
               <div>
-                <p class="text-xs font-semibold text-foreground uppercase tracking-wider">Conditional Logic</p>
-                <p class="text-[11px] text-muted-foreground">Optional segments and fallbacks</p>
+                <p class="text-xs font-semibold text-foreground uppercase tracking-wider">{{ t('settings.reader.fileNaming.conditionalLogic') }}</p>
+                <p class="text-[11px] text-muted-foreground">{{ t('settings.reader.fileNaming.conditionalLogicHint') }}</p>
               </div>
               <ChevronUp v-if="conditionalHelpOpen" :size="15" class="text-muted-foreground shrink-0" />
               <ChevronDown v-else :size="15" class="text-muted-foreground shrink-0" />
             </button>
             <p v-if="conditionalHelpOpen" class="text-xs text-muted-foreground leading-relaxed">
-              Wrap in <code class="bg-muted px-1 py-0.5 rounded font-mono text-foreground text-[11px]">&lt;...&gt;</code> to skip a segment when its
-              token is empty. Use <code class="bg-muted px-1 py-0.5 rounded font-mono text-foreground text-[11px]">|fallback</code> for a default
-              value.
+              {{ t('settings.reader.fileNaming.conditionalPart1') }}
+              <code class="bg-muted px-1 py-0.5 rounded font-mono text-foreground text-[11px]">&lt;...&gt;</code>
+              {{ t('settings.reader.fileNaming.conditionalPart2') }}
+              <code class="bg-muted px-1 py-0.5 rounded font-mono text-foreground text-[11px]">|fallback</code>
+              {{ t('settings.reader.fileNaming.conditionalPart3') }}
             </p>
           </div>
         </div>
@@ -638,13 +677,13 @@ onUnmounted(() => {
 
     <!-- Examples -->
     <section class="space-y-4">
-      <p class="settings-group-label">Examples</p>
+      <p class="settings-group-label">{{ t('settings.reader.fileNaming.examples') }}</p>
       <div class="border border-border rounded-lg bg-card shadow-xs overflow-hidden">
         <div class="p-5 space-y-3">
           <button class="w-full flex items-center justify-between gap-2 text-left" @click="examplesOpen = !examplesOpen">
             <div>
-              <p class="text-sm font-medium text-foreground">Pattern Examples</p>
-              <p class="text-xs text-muted-foreground">Ready-made patterns for common library styles</p>
+              <p class="text-sm font-medium text-foreground">{{ t('settings.reader.fileNaming.patternExamples') }}</p>
+              <p class="text-xs text-muted-foreground">{{ t('settings.reader.fileNaming.patternExamplesHint') }}</p>
             </div>
             <ChevronUp v-if="examplesOpen" :size="15" class="text-muted-foreground shrink-0" />
             <ChevronDown v-else :size="15" class="text-muted-foreground shrink-0" />
@@ -665,10 +704,10 @@ onUnmounted(() => {
                       @click="copyPattern(ex.pattern)"
                     >
                       <ClipboardCopy :size="12" />
-                      Copy
+                      {{ t('settings.reader.fileNaming.copy') }}
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent>Copy pattern to clipboard</TooltipContent>
+                  <TooltipContent>{{ t('settings.reader.fileNaming.copyPatternTooltip') }}</TooltipContent>
                 </Tooltip>
               </div>
               <div class="px-4 py-3 space-y-2">

--- a/client/src/features/settings/FontsSettings.vue
+++ b/client/src/features/settings/FontsSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { Pencil, Trash2, Upload, X, Check, ChevronDown, ChevronRight } from '@lucide/vue'
 import { MAX_FONTS_PER_USER } from '@bookorbit/types'
@@ -8,17 +9,19 @@ import { useCustomFonts } from '@/features/reader/epub/composables/useCustomFont
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 import SettingsPageHeader from './SettingsPageHeader.vue'
 
-const WEIGHT_LABELS: Record<number, string> = {
-  100: 'Thin',
-  200: 'Extra Light',
-  300: 'Light',
-  400: 'Regular',
-  500: 'Medium',
-  600: 'Semi Bold',
-  700: 'Bold',
-  800: 'Extra Bold',
-  900: 'Black',
-}
+const { t } = useI18n()
+
+const WEIGHT_LABELS = computed<Record<number, string>>(() => ({
+  100: t('settings.reader.fonts.weightThin'),
+  200: t('settings.reader.fonts.weightExtraLight'),
+  300: t('settings.reader.fonts.weightLight'),
+  400: t('settings.reader.fonts.weightRegular'),
+  500: t('settings.reader.fonts.weightMedium'),
+  600: t('settings.reader.fonts.weightSemiBold'),
+  700: t('settings.reader.fonts.weightBold'),
+  800: t('settings.reader.fonts.weightExtraBold'),
+  900: t('settings.reader.fonts.weightBlack'),
+}))
 
 const customFonts = useCustomFonts()
 const { fonts, families, loading, uploading, fetchFonts, uploadFont, updateFont } = customFonts
@@ -93,10 +96,10 @@ async function saveEditFamily() {
   const results = await Promise.allSettled(variantsToUpdate.map((f) => updateFont(f.id, { familyName: newName })))
   const failed = results.some((r) => r.status === 'rejected' || r.value === null)
   if (failed) {
-    toast.error('Failed to rename font family')
+    toast.error(t('settings.reader.fonts.renameFamilyFailed'))
     await fetchFonts()
   } else {
-    toast.success(`Renamed to "${newName}"`)
+    toast.success(t('settings.reader.fonts.renamedTo', { name: newName }))
   }
 }
 
@@ -122,7 +125,7 @@ async function saveEditVariant() {
     style: editingVariantStyle.value,
   })
   if (!result) {
-    toast.error('Failed to update font variant')
+    toast.error(t('settings.reader.fonts.updateVariantFailed'))
     await fetchFonts()
   }
 }
@@ -140,11 +143,11 @@ async function deleteVariant(font: UserFont) {
     const success = await customFonts.deleteFont(font.id)
     if (!success) {
       fonts.value = snapshot
-      toast.error('Failed to delete font')
+      toast.error(t('settings.reader.fonts.deleteFontFailed'))
     }
   } catch {
     fonts.value = snapshot
-    toast.error('Failed to delete font')
+    toast.error(t('settings.reader.fonts.deleteFontFailed'))
   }
 }
 
@@ -158,7 +161,7 @@ async function deleteFamily(familyName: string) {
   const failed = results.some((r) => r.status === 'rejected' || (r.status === 'fulfilled' && !r.value))
   if (failed) {
     await fetchFonts()
-    toast.error('Failed to delete font family')
+    toast.error(t('settings.reader.fonts.deleteFamilyFailed'))
   }
 }
 
@@ -187,16 +190,16 @@ function handleFileInput(event: Event) {
 
 async function processFiles(files: File[]) {
   if (isDemoRestrictedAccount.value) {
-    toast.error('Demo-restricted account cannot manage fonts')
+    toast.error(t('settings.reader.fonts.demoCannotManage'))
     return
   }
   uploadErrors.value = []
   for (const file of files) {
     try {
       await uploadFont(file)
-      toast.success(`"${file.name}" added`)
+      toast.success(t('settings.reader.fonts.fileAdded', { name: file.name }))
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Upload failed'
+      const message = err instanceof Error ? err.message : t('settings.reader.fonts.uploadFailed')
       uploadErrors.value = [...uploadErrors.value, `${file.name}: ${message}`]
     }
   }
@@ -215,11 +218,11 @@ function formatBytes(bytes: number): string {
 
 <template>
   <div>
-    <SettingsPageHeader title="Fonts" subtitle="Upload custom fonts for use in the eBook reader." />
+    <SettingsPageHeader :title="t('settings.reader.fonts.title')" :subtitle="t('settings.reader.fonts.subtitle')" />
 
     <!-- Upload zone -->
     <div class="mb-6">
-      <p class="settings-group-label">Upload Fonts</p>
+      <p class="settings-group-label">{{ t('settings.reader.fonts.uploadFonts') }}</p>
       <label
         class="relative flex flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed px-6 py-8 text-center transition-colors"
         :class="[
@@ -239,12 +242,15 @@ function formatBytes(bytes: number): string {
         </div>
         <div>
           <p class="text-sm font-medium text-foreground">
-            <span v-if="isDemoRestrictedAccount">Not available for demo accounts</span>
-            <span v-else-if="uploading">Uploading...</span>
-            <span v-else-if="isDragging">Drop files here</span>
-            <span v-else>Drag font files here, or <span class="text-primary underline underline-offset-2">browse</span></span>
+            <span v-if="isDemoRestrictedAccount">{{ t('settings.reader.fonts.notAvailableDemo') }}</span>
+            <span v-else-if="uploading">{{ t('settings.reader.fonts.uploading') }}</span>
+            <span v-else-if="isDragging">{{ t('settings.reader.fonts.dropFilesHere') }}</span>
+            <span v-else
+              >{{ t('settings.reader.fonts.dragFontsPrefix') }}
+              <span class="text-primary underline underline-offset-2">{{ t('settings.reader.fonts.browse') }}</span></span
+            >
           </p>
-          <p class="mt-1 text-xs text-muted-foreground">TTF, OTF, WOFF, WOFF2 - max 10 MB each</p>
+          <p class="mt-1 text-xs text-muted-foreground">{{ t('settings.reader.fonts.fileTypesHint') }}</p>
         </div>
         <input
           type="file"
@@ -274,12 +280,14 @@ function formatBytes(bytes: number): string {
     <!-- Font list -->
     <div>
       <div class="flex items-center justify-between mb-2">
-        <p class="settings-group-label mb-0">Your Fonts</p>
-        <span class="text-xs text-muted-foreground">{{ fonts.length }} / {{ MAX_FONTS_PER_USER }} used</span>
+        <p class="settings-group-label mb-0">{{ t('settings.reader.fonts.yourFonts') }}</p>
+        <span class="text-xs text-muted-foreground">{{
+          t('settings.reader.fonts.fontsUsed', { count: fonts.length, max: MAX_FONTS_PER_USER })
+        }}</span>
       </div>
 
       <div v-if="loading" class="flex items-center justify-center py-10 text-muted-foreground">
-        <span class="text-sm">Loading...</span>
+        <span class="text-sm">{{ t('common.loading') }}</span>
       </div>
 
       <div
@@ -290,8 +298,8 @@ function formatBytes(bytes: number): string {
           <Upload :size="22" />
         </div>
         <div>
-          <p class="text-sm font-medium text-foreground">No fonts uploaded yet</p>
-          <p class="text-xs text-muted-foreground mt-1">Drag a font file above to get started.</p>
+          <p class="text-sm font-medium text-foreground">{{ t('settings.reader.fonts.noFontsYet') }}</p>
+          <p class="text-xs text-muted-foreground mt-1">{{ t('settings.reader.fonts.noFontsHint') }}</p>
         </div>
       </div>
 
@@ -323,15 +331,15 @@ function formatBytes(bytes: number): string {
               @click.stop
             />
 
-            <span class="shrink-0 text-xs text-muted-foreground"
-              >{{ family.variants.length }} {{ family.variants.length === 1 ? 'file' : 'files' }}</span
-            >
+            <span class="shrink-0 text-xs text-muted-foreground">{{
+              t('settings.reader.fonts.fileCount', { count: family.variants.length }, family.variants.length)
+            }}</span>
 
             <div class="flex items-center gap-1 shrink-0">
               <button
                 v-if="editingFamilyName !== family.name && !isDemoRestrictedAccount"
                 class="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                title="Rename family"
+                :title="t('settings.reader.fonts.renameFamily')"
                 @click.stop="startEditFamily(family.name)"
               >
                 <Pencil :size="13" />
@@ -339,7 +347,7 @@ function formatBytes(bytes: number): string {
               <button
                 v-if="editingFamilyName === family.name"
                 class="flex h-7 w-7 items-center justify-center rounded-md text-primary transition-colors hover:bg-primary/10"
-                title="Save"
+                :title="t('common.save')"
                 @click.stop="saveEditFamily"
               >
                 <Check :size="13" />
@@ -347,7 +355,7 @@ function formatBytes(bytes: number): string {
               <button
                 v-if="!isDemoRestrictedAccount"
                 class="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                title="Delete family"
+                :title="t('settings.reader.fonts.deleteFamily')"
                 @click.stop="deleteFamily(family.name)"
               >
                 <Trash2 :size="13" />
@@ -360,7 +368,7 @@ function formatBytes(bytes: number): string {
             class="px-4 pb-3 -mt-1 text-sm text-muted-foreground/90 truncate"
             :style="{ fontFamily: `'${family.cssFamilyName}', sans-serif`, fontSize: '16px' }"
           >
-            The quick brown fox jumps over the lazy dog
+            {{ t('settings.reader.fonts.pangram') }}
           </div>
 
           <!-- Variant rows (expanded) -->
@@ -381,14 +389,15 @@ function formatBytes(bytes: number): string {
                       class="h-7 rounded border border-border bg-background px-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
                       @keydown="handleVariantEditKeydown"
                     >
-                      <option value="normal">Normal</option>
-                      <option value="italic">Italic</option>
+                      <option value="normal">{{ t('settings.reader.fonts.styleNormal') }}</option>
+                      <option value="italic">{{ t('settings.reader.fonts.styleItalic') }}</option>
                     </select>
                   </div>
                 </template>
                 <template v-else>
                   <span class="text-xs text-foreground">
-                    {{ WEIGHT_LABELS[variant.weight] ?? variant.weight }} {{ variant.style === 'italic' ? '· Italic' : '' }}
+                    {{ WEIGHT_LABELS[variant.weight] ?? variant.weight }}
+                    {{ variant.style === 'italic' ? '· ' + t('settings.reader.fonts.styleItalic') : '' }}
                   </span>
                   <span class="ml-2 text-xs text-muted-foreground uppercase">{{ variant.format }}</span>
                   <span class="ml-2 text-xs text-muted-foreground">{{ formatBytes(variant.fileSize) }}</span>
@@ -399,7 +408,7 @@ function formatBytes(bytes: number): string {
                 <button
                   v-if="editingVariantId !== variant.id && !isDemoRestrictedAccount"
                   class="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                  title="Edit weight/style"
+                  :title="t('settings.reader.fonts.editVariant')"
                   @click="startEditVariant(variant)"
                 >
                   <Pencil :size="12" />
@@ -407,7 +416,7 @@ function formatBytes(bytes: number): string {
                 <button
                   v-if="editingVariantId === variant.id"
                   class="flex h-6 w-6 items-center justify-center rounded text-primary transition-colors hover:bg-primary/10"
-                  title="Save"
+                  :title="t('common.save')"
                   @click="saveEditVariant"
                 >
                   <Check :size="12" />
@@ -415,7 +424,7 @@ function formatBytes(bytes: number): string {
                 <button
                   v-if="editingVariantId === variant.id"
                   class="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted"
-                  title="Cancel"
+                  :title="t('common.cancel')"
                   @click="cancelEdits"
                 >
                   <X :size="12" />
@@ -423,7 +432,7 @@ function formatBytes(bytes: number): string {
                 <button
                   v-if="editingVariantId !== variant.id && !isDemoRestrictedAccount"
                   class="flex h-6 w-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-                  title="Delete variant"
+                  :title="t('settings.reader.fonts.deleteVariant')"
                   @click="deleteVariant(variant)"
                 >
                   <Trash2 :size="12" />

--- a/client/src/features/settings/KoboSettings.vue
+++ b/client/src/features/settings/KoboSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Plus, Trash2, Copy, Check, Pencil, X, Tablet } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
@@ -9,6 +10,7 @@ import { useKoboDevices } from '@/features/kobo/composables/useKoboDevices'
 import { useKoboSettings } from '@/features/kobo/composables/useKoboSettings'
 import type { KoboDevice } from '@bookorbit/types'
 
+const { t } = useI18n()
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
 
 const { devices, fetchDevices, createDevice, renameDevice, revokeDevice } = useKoboDevices()
@@ -54,17 +56,17 @@ function applySettingsToLocal() {
 }
 
 function formatLastSeen(date: string | null): string {
-  if (!date) return 'Never'
+  if (!date) return t('settings.reader.kobo.never')
   const d = new Date(date)
   const now = new Date()
   const diffMs = now.getTime() - d.getTime()
   const diffMins = Math.floor(diffMs / 60000)
-  if (diffMins < 1) return 'Just now'
-  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffMins < 1) return t('settings.reader.kobo.justNow')
+  if (diffMins < 60) return t('settings.reader.kobo.minutesAgo', { count: diffMins })
   const diffHours = Math.floor(diffMins / 60)
-  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffHours < 24) return t('settings.reader.kobo.hoursAgo', { count: diffHours })
   const diffDays = Math.floor(diffHours / 24)
-  return `${diffDays}d ago`
+  return t('settings.reader.kobo.daysAgo', { count: diffDays })
 }
 
 onMounted(async () => {
@@ -72,7 +74,7 @@ onMounted(async () => {
     await Promise.all([fetchDevices(), fetchSettings()])
     applySettingsToLocal()
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Failed to load'
+    error.value = e instanceof Error ? e.message : t('settings.reader.kobo.loadFailed')
   } finally {
     loading.value = false
   }
@@ -96,10 +98,10 @@ async function submitCreate() {
     newDeviceSyncUrl.value = `${window.location.origin}/api/v1/kobo/${device.token}`
     showCreateForm.value = false
     newDeviceName.value = ''
-    toast.success(`Device "${device.name}" registered`)
+    toast.success(t('settings.reader.kobo.deviceRegistered', { name: device.name }))
   } catch (e) {
-    createError.value = e instanceof Error ? e.message : 'Failed to create device'
-    toast.error(createError.value ?? 'Failed to create device')
+    createError.value = e instanceof Error ? e.message : t('settings.reader.kobo.createDeviceFailed')
+    toast.error(createError.value ?? t('settings.reader.kobo.createDeviceFailed'))
   } finally {
     creating.value = false
   }
@@ -120,9 +122,9 @@ async function copyToken() {
   if (!newDeviceSyncUrl.value) return
   const copied = await copyToClipboard(newDeviceSyncUrl.value)
   if (copied) {
-    toast.success('Sync URL copied to clipboard')
+    toast.success(t('settings.reader.kobo.syncUrlCopied'))
   } else {
-    toast.error('Failed to copy sync URL')
+    toast.error(t('settings.reader.kobo.syncUrlCopyFailed'))
   }
 }
 
@@ -141,29 +143,29 @@ async function submitRename(device: KoboDevice) {
   renaming.value = true
   try {
     await renameDevice(device.id, renameValue.value.trim())
-    toast.success('Device renamed')
+    toast.success(t('settings.reader.kobo.deviceRenamed'))
     renamingId.value = null
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to rename device')
+    toast.error(e instanceof Error ? e.message : t('settings.reader.kobo.renameDeviceFailed'))
   } finally {
     renaming.value = false
   }
 }
 
 async function revoke(device: KoboDevice) {
-  if (!confirm(`Revoke access for "${device.name}"? The device will not be able to sync until re-paired.`)) return
+  if (!confirm(t('settings.reader.kobo.revokeConfirm', { name: device.name }))) return
   try {
     await revokeDevice(device.id)
-    toast.success(`Access revoked for "${device.name}"`)
+    toast.success(t('settings.reader.kobo.accessRevoked', { name: device.name }))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to revoke access')
+    toast.error(e instanceof Error ? e.message : t('settings.reader.kobo.revokeFailed'))
   }
 }
 
 async function saveSettings() {
   if (readingThreshold.value >= finishedThreshold.value) {
-    settingsError.value = 'Reading threshold must be less than finished threshold'
-    toast.error(settingsError.value ?? 'Failed to save settings')
+    settingsError.value = t('settings.reader.kobo.thresholdOrderError')
+    toast.error(settingsError.value ?? t('settings.reader.kobo.saveSettingsFailed'))
     return
   }
   savingSettings.value = true
@@ -179,10 +181,10 @@ async function saveSettings() {
       syncBookOrbitAnnotationsToKobo: syncBookOrbitAnnotationsToKobo.value,
     })
     applySettingsToLocal()
-    toast.success('Kobo sync settings saved')
+    toast.success(t('settings.reader.kobo.settingsSaved'))
   } catch (e) {
-    settingsError.value = e instanceof Error ? e.message : 'Failed to save'
-    toast.error(settingsError.value ?? 'Failed to save settings')
+    settingsError.value = e instanceof Error ? e.message : t('settings.reader.kobo.saveFailed')
+    toast.error(settingsError.value ?? t('settings.reader.kobo.saveSettingsFailed'))
   } finally {
     savingSettings.value = false
   }
@@ -190,9 +192,9 @@ async function saveSettings() {
 </script>
 
 <template>
-  <SettingsPageHeader v-if="!props.embedded" title="Kobo Sync" subtitle="Pair your Kobo device to sync your library." />
+  <SettingsPageHeader v-if="!props.embedded" :title="t('settings.reader.kobo.title')" :subtitle="t('settings.reader.kobo.subtitle')" />
 
-  <div v-if="loading" class="text-sm text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="text-sm text-muted-foreground">{{ t('common.loading') }}</div>
   <div v-else-if="error" class="text-sm text-destructive">{{ error }}</div>
   <template v-else>
     <!-- New device token display -->
@@ -203,8 +205,8 @@ async function saveSettings() {
             <Check :size="13" stroke-width="3" />
           </div>
           <div>
-            <p class="settings-label leading-none mb-0.5">Device paired successfully</p>
-            <p class="settings-hint">You're ready to set up your Kobo. Follow the instructions below.</p>
+            <p class="settings-label leading-none mb-0.5">{{ t('settings.reader.kobo.devicePaired') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.kobo.devicePairedHint') }}</p>
           </div>
         </div>
         <button @click="dismissToken()" class="text-muted-foreground hover:text-foreground transition-colors p-1 shrink-0">
@@ -214,7 +216,7 @@ async function saveSettings() {
 
       <div class="space-y-4">
         <div class="bg-background rounded-lg border border-border p-4">
-          <p class="text-xs font-bold text-muted-foreground uppercase tracking-widest mb-2.5">Sync URL</p>
+          <p class="text-xs font-bold text-muted-foreground uppercase tracking-widest mb-2.5">{{ t('settings.reader.kobo.syncUrl') }}</p>
           <div class="flex items-center gap-2 px-3 py-2.5 rounded-md border border-border bg-muted/30">
             <Tablet :size="14" class="text-muted-foreground shrink-0" />
             <span class="flex-1 text-sm text-foreground font-mono select-all truncate min-w-0">{{ newDeviceSyncUrl }}</span>
@@ -223,7 +225,7 @@ async function saveSettings() {
               @click="copyToken()"
             >
               <Copy :size="12" />
-              Copy
+              {{ t('settings.reader.kobo.copy') }}
             </button>
           </div>
         </div>
@@ -231,7 +233,7 @@ async function saveSettings() {
           class="flex items-center gap-2 text-xs font-medium text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 rounded-md border border-amber-200 dark:border-amber-900/50"
         >
           <X :size="14" class="shrink-0" />
-          This URL will not be shown again. Keep it private.
+          {{ t('settings.reader.kobo.urlNotShownAgain') }}
         </div>
       </div>
     </div>
@@ -239,25 +241,31 @@ async function saveSettings() {
     <!-- Devices -->
     <div class="mb-8">
       <div class="flex items-center justify-between mb-3">
-        <p class="settings-group-label mb-0">Registered Devices</p>
+        <p class="settings-group-label mb-0">{{ t('settings.reader.kobo.registeredDevices') }}</p>
         <button v-if="!showCreateForm" class="settings-btn-primary" @click="showCreateForm = true">
           <Plus :size="12" />
-          Add device
+          {{ t('settings.reader.kobo.addDevice') }}
         </button>
       </div>
 
       <!-- Create form -->
       <div v-if="showCreateForm" class="border border-border rounded-lg p-5 bg-card mb-4 space-y-4 shadow-xs">
         <div>
-          <label class="settings-label block mb-1.5">Device name</label>
-          <input v-model="newDeviceName" type="text" placeholder="e.g. My Kobo Libra" autofocus class="input-field w-full" />
+          <label class="settings-label block mb-1.5">{{ t('settings.reader.kobo.deviceName') }}</label>
+          <input
+            v-model="newDeviceName"
+            type="text"
+            :placeholder="t('settings.reader.kobo.deviceNamePlaceholder')"
+            autofocus
+            class="input-field w-full"
+          />
         </div>
         <div v-if="createError" class="text-xs text-destructive">{{ createError }}</div>
         <div class="flex items-center gap-2 pt-1">
           <button class="settings-btn-primary" :disabled="creating || !newDeviceName.trim()" @click="submitCreate()">
-            {{ creating ? 'Creating...' : 'Create device' }}
+            {{ creating ? t('settings.reader.kobo.creating') : t('settings.reader.kobo.createDevice') }}
           </button>
-          <button class="settings-btn-outline" @click="cancelCreate()">Cancel</button>
+          <button class="settings-btn-outline" @click="cancelCreate()">{{ t('common.cancel') }}</button>
         </div>
       </div>
 
@@ -265,15 +273,17 @@ async function saveSettings() {
         <div class="w-10 h-10 rounded-full bg-muted flex items-center justify-center mx-auto mb-3">
           <Tablet :size="18" class="text-muted-foreground/70" />
         </div>
-        <p class="text-sm font-medium text-foreground">No devices yet</p>
-        <p class="text-xs text-muted-foreground mt-1 max-w-[240px] mx-auto">Add a device to start syncing your books to your Kobo.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.reader.kobo.noDevicesYet') }}</p>
+        <p class="text-xs text-muted-foreground mt-1 max-w-[240px] mx-auto">{{ t('settings.reader.kobo.noDevicesHint') }}</p>
       </div>
 
       <div v-else-if="devices.length > 0" class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div v-for="device in devices" :key="device.id" class="px-5 py-4 bg-card transition-colors hover:bg-muted/30">
           <div v-if="renamingId === device.id" class="flex items-center gap-2">
             <input v-model="renameValue" type="text" class="flex-1 input-field" @keydown.enter="submitRename(device)" @keydown.esc="cancelRename()" />
-            <button class="settings-btn-primary" :disabled="renaming || !renameValue.trim()" @click="submitRename(device)">Save</button>
+            <button class="settings-btn-primary" :disabled="renaming || !renameValue.trim()" @click="submitRename(device)">
+              {{ t('common.save') }}
+            </button>
             <button class="settings-btn-outline h-9 w-9 p-0 flex items-center justify-center" @click="cancelRename()">
               <X :size="14" />
             </button>
@@ -284,20 +294,20 @@ async function saveSettings() {
             </div>
             <div class="flex-1 min-w-0">
               <p class="settings-label truncate leading-none mb-1.5">{{ device.name }}</p>
-              <p class="settings-hint leading-none">Last sync: {{ formatLastSeen(device.lastSeenAt) }}</p>
+              <p class="settings-hint leading-none">{{ t('settings.reader.kobo.lastSync', { time: formatLastSeen(device.lastSeenAt) }) }}</p>
             </div>
             <div class="flex items-center gap-1">
               <button
                 class="w-8 h-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                 @click="startRename(device)"
-                title="Rename device"
+                :title="t('settings.reader.kobo.renameDevice')"
               >
                 <Pencil :size="14" />
               </button>
               <button
                 class="w-8 h-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
                 @click="revoke(device)"
-                title="Revoke access"
+                :title="t('settings.reader.kobo.revokeAccess')"
               >
                 <Trash2 :size="14" />
               </button>
@@ -309,13 +319,13 @@ async function saveSettings() {
 
     <!-- Sync settings -->
     <div class="mb-8">
-      <p class="settings-group-label">Sync Preferences</p>
+      <p class="settings-group-label">{{ t('settings.reader.kobo.syncPreferences') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div class="flex items-center justify-between px-5 py-4 bg-card">
           <div class="pr-8">
-            <p class="settings-label">Two-way progress sync</p>
+            <p class="settings-label">{{ t('settings.reader.kobo.twoWaySync') }}</p>
             <p class="settings-hint">
-              Sync reading position between BookOrbit and Kobo. Requires KEPUB delivery for precise locations and reliable page restore.
+              {{ t('settings.reader.kobo.twoWaySyncHint') }}
             </p>
           </div>
           <ToggleSwitch v-model="twoWayProgressSync" />
@@ -323,10 +333,9 @@ async function saveSettings() {
 
         <div class="flex items-center justify-between px-5 py-4 bg-card">
           <div class="pr-8">
-            <p class="settings-label">Sync BookOrbit highlights to Kobo</p>
+            <p class="settings-label">{{ t('settings.reader.kobo.syncHighlights') }}</p>
             <p class="settings-hint">
-              Send highlights made in BookOrbit or KOReader to your Kobo. Kobo highlights are imported into BookOrbit even when this is off. Linked
-              annotations sync edits and deletes both ways. Requires KEPUB delivery; the book on Kobo must be the KEPUB downloaded from BookOrbit.
+              {{ t('settings.reader.kobo.syncHighlightsHint') }}
             </p>
           </div>
           <ToggleSwitch v-model="syncBookOrbitAnnotationsToKobo" />
@@ -334,10 +343,9 @@ async function saveSettings() {
 
         <div class="flex items-center justify-between px-5 py-4 bg-card">
           <div class="pr-8">
-            <p class="settings-label">Convert to KEPUB</p>
+            <p class="settings-label">{{ t('settings.reader.kobo.convertKepub') }}</p>
             <p class="settings-hint">
-              Send eligible EPUBs as KEPUB. This stays on when progress sync or BookOrbit-to-Kobo highlights are enabled. On the next Kobo sync,
-              affected books are offered again as KEPUB downloads; remove any old EPUB copy if Kobo keeps opening it.
+              {{ t('settings.reader.kobo.convertKepubHint') }}
             </p>
           </div>
           <ToggleSwitch v-model="convertToKepub" :disabled="twoWayProgressSync || syncBookOrbitAnnotationsToKobo" />
@@ -345,55 +353,59 @@ async function saveSettings() {
 
         <div v-if="convertToKepub" class="flex items-center justify-between px-5 py-4 bg-card">
           <div class="pr-8">
-            <p class="settings-label">Force hyphenation</p>
-            <p class="settings-hint">Ensures consistent text justification. This will regenerate cached KEPUBs.</p>
+            <p class="settings-label">{{ t('settings.reader.kobo.forceHyphenation') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.kobo.forceHyphenationHint') }}</p>
           </div>
           <ToggleSwitch v-model="forceEnableHyphenation" />
         </div>
 
         <div class="px-5 py-5 bg-card space-y-5">
           <div>
-            <p class="settings-label mb-1">Progress Thresholds</p>
-            <p class="settings-hint">Define when Kobo reading progress updates your library status.</p>
+            <p class="settings-label mb-1">{{ t('settings.reader.kobo.progressThresholds') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.kobo.progressThresholdsHint') }}</p>
           </div>
 
           <div class="grid sm:grid-cols-2 gap-6">
             <div class="space-y-2">
               <div class="flex items-center justify-between">
-                <label class="text-[12px] font-bold text-muted-foreground uppercase tracking-widest">Mark as Reading</label>
+                <label class="text-[12px] font-bold text-muted-foreground uppercase tracking-widest">{{
+                  t('settings.reader.kobo.markAsReading')
+                }}</label>
                 <span class="text-xs font-mono text-primary font-bold">{{ readingThreshold }}%</span>
               </div>
               <input v-model.number="readingThreshold" type="range" min="0.5" max="10" step="0.5" class="w-full accent-primary cursor-pointer" />
-              <p class="text-[12px] text-muted-foreground leading-tight">Minimum percentage to move a book to "Reading".</p>
+              <p class="text-[12px] text-muted-foreground leading-tight">{{ t('settings.reader.kobo.markAsReadingHint') }}</p>
             </div>
             <div class="space-y-2">
               <div class="flex items-center justify-between">
-                <label class="text-[12px] font-bold text-muted-foreground uppercase tracking-widest">Mark as Finished</label>
+                <label class="text-[12px] font-bold text-muted-foreground uppercase tracking-widest">{{
+                  t('settings.reader.kobo.markAsFinished')
+                }}</label>
                 <span class="text-xs font-mono text-primary font-bold">{{ finishedThreshold }}%</span>
               </div>
               <input v-model.number="finishedThreshold" type="range" min="75" max="100" step="1" class="w-full accent-primary cursor-pointer" />
-              <p class="text-[12px] text-muted-foreground leading-tight">Percentage threshold to mark a book as "Finished".</p>
+              <p class="text-[12px] text-muted-foreground leading-tight">{{ t('settings.reader.kobo.markAsFinishedHint') }}</p>
             </div>
           </div>
 
           <div>
             <div class="flex items-center justify-between mb-2">
-              <label class="text-[12px] font-bold text-muted-foreground uppercase tracking-widest">KEPUB conversion limit</label>
+              <label class="text-[12px] font-bold text-muted-foreground uppercase tracking-widest">{{ t('settings.reader.kobo.kepubLimit') }}</label>
               <span class="text-xs font-mono text-primary font-bold">{{ kepubConversionLimitMb }} MB</span>
             </div>
             <input v-model.number="kepubConversionLimitMb" type="range" min="1" max="500" step="5" class="w-full accent-primary cursor-pointer" />
             <p class="text-[12px] text-muted-foreground mt-2">
-              Books above this limit are sent as regular EPUBs, so BookOrbit will not sync their reader position back to Kobo.
+              {{ t('settings.reader.kobo.kepubLimitHint') }}
             </p>
           </div>
         </div>
 
         <div class="px-5 py-4 bg-muted/30 flex items-center justify-between">
           <div v-if="settingsError" class="text-xs text-destructive font-medium flex items-center gap-1.5"><X :size="14" /> {{ settingsError }}</div>
-          <div v-else class="text-[12px] text-muted-foreground italic">Changes must be saved to take effect.</div>
+          <div v-else class="text-[12px] text-muted-foreground italic">{{ t('settings.reader.kobo.changesMustBeSaved') }}</div>
 
           <button class="settings-btn-primary" :disabled="savingSettings" @click="saveSettings()">
-            {{ savingSettings ? 'Saving...' : 'Save Sync Settings' }}
+            {{ savingSettings ? t('settings.reader.kobo.saving') : t('settings.reader.kobo.saveSyncSettings') }}
           </button>
         </div>
       </div>

--- a/client/src/features/settings/KoreaderSettings.vue
+++ b/client/src/features/settings/KoreaderSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import {
   AlertTriangle,
   BookOpen,
@@ -23,6 +24,7 @@ import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import { copyToClipboard } from '@/lib/clipboard'
 import { useKoreaderSync } from '@/features/koreader/composables/useKoreaderSync'
 
+const { t } = useI18n()
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
 
 const {
@@ -71,7 +73,11 @@ const pluginTotals = computed(
 )
 const latestPluginVersion = computed(() => syncStatus.value?.latestPluginVersion ?? null)
 const pluginUpdateAvailable = computed(() => syncStatus.value?.pluginUpdateAvailable ?? false)
-const latestPluginLabel = computed(() => (latestPluginVersion.value ? `Latest plugin: v${latestPluginVersion.value}` : 'Latest plugin unavailable'))
+const latestPluginLabel = computed(() =>
+  latestPluginVersion.value
+    ? t('settings.reader.koreader.latestPlugin', { version: latestPluginVersion.value })
+    : t('settings.reader.koreader.latestPluginUnavailable'),
+)
 const pendingDeletes = computed(() => pluginTotals.value.pendingDeletes)
 const failedPositions = computed(() => pluginTotals.value.failedPositions)
 const hasPluginActivity = computed(
@@ -87,32 +93,28 @@ const hasPluginActivity = computed(
 const createDisabled = computed(() => creating.value || !newUsername.value || newPassword.value.length < 6)
 
 function formatLastSync(dateStr: string | null): string {
-  if (!dateStr) return 'Never'
+  if (!dateStr) return t('settings.reader.koreader.never')
   const d = new Date(dateStr)
   const now = new Date()
   const diffMs = now.getTime() - d.getTime()
   const diffMins = Math.floor(diffMs / 60000)
-  if (diffMins < 1) return 'Just now'
-  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffMins < 1) return t('settings.reader.koreader.justNow')
+  if (diffMins < 60) return t('settings.reader.koreader.minutesAgo', { count: diffMins })
   const diffHours = Math.floor(diffMins / 60)
-  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffHours < 24) return t('settings.reader.koreader.hoursAgo', { count: diffHours })
   const diffDays = Math.floor(diffHours / 24)
-  return `${diffDays}d ago`
+  return t('settings.reader.koreader.daysAgo', { count: diffDays })
 }
 
 function formatDate(dateStr: string | null | undefined): string {
-  if (!dateStr) return 'Unknown'
+  if (!dateStr) return t('settings.reader.koreader.unknown')
   return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(dateStr))
 }
 
-function formatCount(value: number, singular: string, plural = `${singular}s`): string {
-  return `${value} ${value === 1 ? singular : plural}`
-}
-
 function pluginUpdateText(updateAvailable: boolean | null): string {
-  if (updateAvailable === true) return 'Update available'
-  if (updateAvailable === false) return 'Up to date'
-  return 'Version unknown'
+  if (updateAvailable === true) return t('settings.reader.koreader.updateAvailable')
+  if (updateAvailable === false) return t('settings.reader.koreader.upToDate')
+  return t('settings.reader.koreader.versionUnknown')
 }
 
 function pluginUpdateClass(updateAvailable: boolean | null): string {
@@ -125,7 +127,7 @@ onMounted(async () => {
   try {
     await fetchSyncStatus()
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Failed to load KOReader settings'
+    error.value = e instanceof Error ? e.message : t('settings.reader.koreader.loadFailed')
   }
 })
 
@@ -137,9 +139,9 @@ async function handleCreate() {
     helpOpen.value = false
     newUsername.value = ''
     newPassword.value = ''
-    toast.success('KOReader sync credentials created')
+    toast.success(t('settings.reader.koreader.credentialsCreated'))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to create credentials')
+    toast.error(e instanceof Error ? e.message : t('settings.reader.koreader.createCredentialsFailed'))
   } finally {
     creating.value = false
   }
@@ -172,9 +174,9 @@ function handleToggleHelp() {
 async function handleToggleSync(newValue: boolean) {
   try {
     await updateCredentials({ syncEnabled: newValue })
-    toast.success(`KOReader sync ${newValue ? 'enabled' : 'disabled'}`)
+    toast.success(newValue ? t('settings.reader.koreader.syncEnabled') : t('settings.reader.koreader.syncDisabled'))
   } catch {
-    toast.error('Failed to toggle sync')
+    toast.error(t('settings.reader.koreader.toggleSyncFailed'))
   }
 }
 
@@ -182,21 +184,21 @@ async function handleDelete() {
   try {
     await deleteCredentials()
     deleteConfirmOpen.value = false
-    toast.success('KOReader credentials deleted')
+    toast.success(t('settings.reader.koreader.credentialsDeleted'))
   } catch {
-    toast.error('Failed to delete credentials')
+    toast.error(t('settings.reader.koreader.deleteCredentialsFailed'))
   }
 }
 
 async function handleCopyUrl() {
   const copied = await copyToClipboard(syncUrl.value)
   if (!copied) {
-    toast.error('Failed to copy sync URL')
+    toast.error(t('settings.reader.koreader.syncUrlCopyFailed'))
     return
   }
 
   urlCopied.value = true
-  toast.success('Sync URL copied to clipboard')
+  toast.success(t('settings.reader.koreader.syncUrlCopied'))
   if (urlCopiedTimer) clearTimeout(urlCopiedTimer)
   urlCopiedTimer = setTimeout(() => {
     urlCopied.value = false
@@ -207,9 +209,9 @@ async function handleCopyUrl() {
 async function handleRefresh() {
   try {
     await fetchSyncStatus()
-    toast.success('Sync status refreshed')
+    toast.success(t('settings.reader.koreader.statusRefreshed'))
   } catch {
-    toast.error('Failed to refresh')
+    toast.error(t('settings.reader.koreader.refreshFailed'))
   }
 }
 
@@ -219,9 +221,9 @@ async function handleDownloadPlugin() {
   downloadingPlugin.value = true
   try {
     await downloadPluginPackage()
-    toast.success('Plugin downloaded. Copy bookorbit.koplugin from the zip to koreader/plugins/ on your device.')
+    toast.success(t('settings.reader.koreader.pluginDownloaded'))
   } catch (e) {
-    toast.error(e instanceof Error ? e.message : 'Failed to download the plugin')
+    toast.error(e instanceof Error ? e.message : t('settings.reader.koreader.pluginDownloadFailed'))
   } finally {
     downloadingPlugin.value = false
   }
@@ -232,20 +234,20 @@ async function handleDownloadPlugin() {
   <SettingsPageHeader
     v-if="!props.embedded"
     class="hidden md:flex"
-    title="KOReader Sync"
-    subtitle="Browse your BookOrbit catalog in KOReader and sync progress, reading activity, highlights, and annotation changes."
+    :title="t('settings.reader.koreader.title')"
+    :subtitle="t('settings.reader.koreader.subtitle')"
   />
   <div v-if="!props.embedded" class="md:hidden px-1">
-    <h1 class="text-xl font-semibold tracking-tight text-foreground">KOReader Sync</h1>
+    <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('settings.reader.koreader.title') }}</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
     >
-      Browse your BookOrbit catalog in KOReader and sync progress, reading activity, highlights, and annotation changes.
+      {{ t('settings.reader.koreader.subtitle') }}
     </p>
   </div>
 
   <div v-if="loading" class="mt-5 md:mt-0 border border-border rounded-lg px-5 py-8 bg-card text-sm text-muted-foreground shadow-xs">
-    Loading KOReader settings...
+    {{ t('settings.reader.koreader.loadingSettings') }}
   </div>
   <div v-else-if="error" class="border border-destructive/30 rounded-lg px-5 py-4 bg-card text-sm text-destructive shadow-xs">{{ error }}</div>
   <template v-else>
@@ -254,31 +256,36 @@ async function handleDownloadPlugin() {
         <div class="w-10 h-10 rounded-lg bg-muted flex items-center justify-center mx-auto mb-3">
           <BookOpen :size="18" class="text-muted-foreground/80" />
         </div>
-        <p class="text-sm font-medium text-foreground">KOReader sync is not configured</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.reader.koreader.notConfigured') }}</p>
         <p class="text-xs text-muted-foreground mt-1 mb-4 max-w-sm mx-auto">
-          Create one set of sync credentials, then use them with the BookOrbit KOReader plugin for browsing, downloads, progress, reading events,
-          highlights, and deletes.
+          {{ t('settings.reader.koreader.notConfiguredHint') }}
         </p>
         <button class="settings-btn-primary mx-auto min-h-10 justify-center" @click="handleShowSetupForm">
           <User :size="13" />
-          Create credentials
+          {{ t('settings.reader.koreader.createCredentials') }}
         </button>
       </div>
 
       <div v-else class="border border-border rounded-lg p-4 md:p-5 bg-card space-y-4 shadow-xs">
-        <p class="text-sm font-medium text-foreground">Create KOReader Sync Credentials</p>
-        <p class="text-xs text-muted-foreground">These credentials authenticate your KOReader devices with BookOrbit.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.reader.koreader.createFormTitle') }}</p>
+        <p class="text-xs text-muted-foreground">{{ t('settings.reader.koreader.createFormHint') }}</p>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Username</label>
-          <input v-model="newUsername" type="text" placeholder="e.g. myreader" class="input-field w-full" autocomplete="off" />
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('settings.reader.koreader.username') }}</label>
+          <input
+            v-model="newUsername"
+            type="text"
+            :placeholder="t('settings.reader.koreader.usernamePlaceholder')"
+            class="input-field w-full"
+            autocomplete="off"
+          />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Password</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('settings.reader.koreader.password') }}</label>
           <div class="relative">
             <input
               v-model="newPassword"
               :type="showPassword ? 'text' : 'password'"
-              placeholder="Min 6 characters"
+              :placeholder="t('settings.reader.koreader.passwordPlaceholder')"
               class="input-field w-full pr-10"
               autocomplete="new-password"
             />
@@ -290,20 +297,20 @@ async function handleDownloadPlugin() {
         </div>
         <div class="hidden md:flex items-center gap-2 pt-1">
           <button class="settings-btn-primary" :disabled="createDisabled" @click="handleCreate">
-            {{ creating ? 'Creating...' : 'Create' }}
+            {{ creating ? t('settings.reader.koreader.creating') : t('settings.reader.koreader.create') }}
           </button>
-          <button class="settings-btn-outline" @click="handleCancelSetup">Cancel</button>
+          <button class="settings-btn-outline" @click="handleCancelSetup">{{ t('common.cancel') }}</button>
         </div>
         <div class="md:hidden sticky bottom-2 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
           <div class="flex items-center gap-2">
             <button class="settings-btn-primary flex-1 min-h-10 justify-center" :disabled="createDisabled" @click="handleCreate">
-              {{ creating ? 'Creating...' : 'Create' }}
+              {{ creating ? t('settings.reader.koreader.creating') : t('settings.reader.koreader.create') }}
             </button>
             <button
               class="rounded-md border border-border px-3 min-h-10 text-sm text-foreground hover:bg-muted transition-colors"
               @click="handleCancelSetup"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
           </div>
         </div>
@@ -313,41 +320,41 @@ async function handleDownloadPlugin() {
     <template v-else>
       <div class="mb-8">
         <div class="flex items-center justify-between mb-3">
-          <p class="settings-group-label mb-0">KOReader Status</p>
+          <p class="settings-group-label mb-0">{{ t('settings.reader.koreader.status') }}</p>
           <button class="settings-btn-outline" @click="handleRefresh">
             <RefreshCw :size="12" />
-            Refresh
+            {{ t('settings.reader.koreader.refresh') }}
           </button>
         </div>
         <div class="border border-border rounded-lg overflow-hidden shadow-xs divide-y divide-border">
           <div class="flex flex-col gap-3 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:px-5 md:py-4">
             <div class="min-w-0">
-              <p class="settings-label">Progress sync</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.progressSync') }}</p>
               <p class="settings-hint">
-                Allow KOReader devices to sync progress, reading activity, highlights, and annotation deletes with BookOrbit.
+                {{ t('settings.reader.koreader.progressSyncHint') }}
               </p>
             </div>
             <ToggleSwitch :model-value="credentials?.syncEnabled ?? false" class="self-start md:self-auto" @update:model-value="handleToggleSync" />
           </div>
           <div class="grid gap-3 px-4 py-4 bg-card md:grid-cols-2 lg:grid-cols-5 md:px-5">
             <div class="min-w-0">
-              <p class="settings-label">Username</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.username') }}</p>
               <p class="settings-hint font-mono truncate">{{ credentials?.username }}</p>
             </div>
             <div>
-              <p class="settings-label">Last sync</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.lastSync') }}</p>
               <p class="settings-hint">{{ formatLastSync(syncStatus?.lastSyncAt ?? null) }}</p>
             </div>
             <div>
-              <p class="settings-label">Synced books</p>
-              <p class="settings-hint">{{ formatCount(totalSyncedBooks, 'book') }}</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.syncedBooks') }}</p>
+              <p class="settings-hint">{{ t('settings.reader.koreader.bookCount', { count: totalSyncedBooks }, totalSyncedBooks) }}</p>
             </div>
             <div>
-              <p class="settings-label">Devices</p>
-              <p class="settings-hint">{{ formatCount(deviceCount, 'device') }}</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.devices') }}</p>
+              <p class="settings-hint">{{ t('settings.reader.koreader.deviceCount', { count: deviceCount }, deviceCount) }}</p>
             </div>
             <div>
-              <p class="settings-label">Credentials created</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.credentialsCreatedLabel') }}</p>
               <p class="settings-hint">{{ formatDate(credentials?.createdAt) }}</p>
             </div>
           </div>
@@ -355,57 +362,57 @@ async function handleDownloadPlugin() {
       </div>
 
       <div class="mb-8">
-        <p class="settings-group-label">Setup</p>
+        <p class="settings-group-label">{{ t('settings.reader.koreader.setup') }}</p>
         <div class="border border-border rounded-lg overflow-hidden shadow-xs divide-y divide-border">
           <div class="px-4 py-4 bg-card md:px-5">
             <div class="mb-2 flex items-center gap-2">
               <BookOpen :size="14" class="text-muted-foreground shrink-0" />
-              <p class="settings-label">Plugin server URL</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.pluginServerUrl') }}</p>
             </div>
             <div class="flex flex-col gap-2 md:flex-row md:items-center">
               <input :value="syncUrl" readonly class="input-field flex-1 min-w-0 font-mono text-xs md:text-sm" />
               <button class="settings-btn-outline w-full min-h-10 justify-center md:w-auto md:min-h-0" @click="handleCopyUrl">
                 <Check v-if="urlCopied" :size="12" />
                 <Copy v-else :size="12" />
-                {{ urlCopied ? 'Copied' : 'Copy URL' }}
+                {{ urlCopied ? t('settings.reader.koreader.copied') : t('settings.reader.koreader.copyUrl') }}
               </button>
             </div>
           </div>
           <div class="flex flex-col gap-3 px-4 py-4 bg-card md:flex-row md:items-center md:justify-between md:px-5">
             <div class="min-w-0">
               <div class="flex flex-wrap items-center gap-2">
-                <p class="settings-label">Preconfigured BookOrbit plugin</p>
+                <p class="settings-label">{{ t('settings.reader.koreader.preconfiguredPlugin') }}</p>
                 <span
                   v-if="pluginUpdateAvailable"
                   class="rounded-md border border-primary/40 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
                 >
-                  Update available
+                  {{ t('settings.reader.koreader.updateAvailable') }}
                 </span>
               </div>
               <p class="settings-hint">
-                Download a zip with the server URL and your sync login already configured. The plugin includes catalog browsing and sync. Copy the
-                folder to
-                <span class="font-mono text-foreground/70">koreader/plugins/</span> and restart KOReader.
+                {{ t('settings.reader.koreader.preconfiguredPluginHintPrefix') }}
+                <span class="font-mono text-foreground/70">koreader/plugins/</span>
+                {{ t('settings.reader.koreader.preconfiguredPluginHintSuffix') }}
               </p>
-              <p class="settings-hint mt-1">{{ latestPluginLabel }}. Device updates run from the BookOrbit menu in KOReader.</p>
+              <p class="settings-hint mt-1">{{ t('settings.reader.koreader.latestPluginNote', { label: latestPluginLabel }) }}</p>
             </div>
             <button class="settings-btn-primary self-start md:self-auto" :disabled="downloadingPlugin" @click="handleDownloadPlugin">
               <Download :size="12" />
-              {{ downloadingPlugin ? 'Preparing...' : 'Download Plugin' }}
+              {{ downloadingPlugin ? t('settings.reader.koreader.preparing') : t('settings.reader.koreader.downloadPlugin') }}
             </button>
           </div>
         </div>
       </div>
 
       <div class="mb-8">
-        <p class="settings-group-label">Devices</p>
+        <p class="settings-group-label">{{ t('settings.reader.koreader.devices') }}</p>
         <div v-if="deviceCount === 0" class="border border-border rounded-lg px-5 py-8 bg-card text-center shadow-xs">
           <div class="w-10 h-10 rounded-lg bg-muted flex items-center justify-center mx-auto mb-3">
             <Smartphone :size="18" class="text-muted-foreground/80" />
           </div>
-          <p class="text-sm font-medium text-foreground">No devices have synced yet</p>
+          <p class="text-sm font-medium text-foreground">{{ t('settings.reader.koreader.noDevicesSynced') }}</p>
           <p class="text-xs text-muted-foreground mt-1 max-w-sm mx-auto">
-            Install the BookOrbit plugin for full sync, or configure KOReader's stock progress sync for progress-only updates.
+            {{ t('settings.reader.koreader.noDevicesSyncedHint') }}
           </p>
         </div>
         <div v-else class="border border-border rounded-lg overflow-hidden shadow-xs divide-y divide-border">
@@ -418,10 +425,11 @@ async function handleDownloadPlugin() {
                 <p class="settings-label truncate">{{ device.device }}</p>
                 <div class="mt-1 grid gap-1 text-xs text-muted-foreground sm:grid-cols-2">
                   <p class="min-w-0">
-                    Last sync: <span class="text-foreground/80">{{ formatLastSync(device.lastSyncAt) }}</span>
+                    {{ t('settings.reader.koreader.lastSyncLabel') }} <span class="text-foreground/80">{{ formatLastSync(device.lastSyncAt) }}</span>
                   </p>
                   <p class="min-w-0 truncate">
-                    Last book: <span class="text-foreground/80">{{ device.lastBookTitle ?? 'None yet' }}</span>
+                    {{ t('settings.reader.koreader.lastBookLabel') }}
+                    <span class="text-foreground/80">{{ device.lastBookTitle ?? t('settings.reader.koreader.noneYet') }}</span>
                   </p>
                 </div>
               </div>
@@ -431,10 +439,10 @@ async function handleDownloadPlugin() {
       </div>
 
       <div class="mb-8">
-        <p class="settings-group-label">Plugin Activity</p>
+        <p class="settings-group-label">{{ t('settings.reader.koreader.pluginActivity') }}</p>
         <div class="border border-border rounded-lg overflow-hidden shadow-xs divide-y divide-border">
           <div v-if="!hasPluginActivity" class="px-4 py-5 bg-card text-sm text-muted-foreground md:px-5">
-            No plugin activity has been reported yet.
+            {{ t('settings.reader.koreader.noPluginActivity') }}
           </div>
           <div v-for="sweep in sweeps" :key="sweep.deviceId" class="px-4 py-4 bg-card md:px-5">
             <div class="flex items-start gap-3">
@@ -452,70 +460,71 @@ async function handleDownloadPlugin() {
                   </span>
                 </div>
                 <p class="settings-hint mt-1">
-                  Last full sync: {{ formatLastSync(sweep.lastSweepAt) }}
-                  <span v-if="sweep.updateAvailable === true && sweep.latestPluginVersion"> - latest plugin v{{ sweep.latestPluginVersion }}</span>
+                  {{ t('settings.reader.koreader.lastFullSync', { time: formatLastSync(sweep.lastSweepAt) }) }}
+                  <span v-if="sweep.updateAvailable === true && sweep.latestPluginVersion">
+                    {{ t('settings.reader.koreader.latestPluginSuffix', { version: sweep.latestPluginVersion }) }}</span
+                  >
                 </p>
               </div>
             </div>
             <div class="mt-4 grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
               <div class="rounded-md border border-border bg-background px-3 py-2">
                 <p class="font-medium text-foreground">{{ sweep.lastSweepBooksMatched }}</p>
-                <p>Matched books</p>
+                <p>{{ t('settings.reader.koreader.matchedBooks') }}</p>
               </div>
               <div class="rounded-md border border-border bg-background px-3 py-2">
                 <p class="font-medium text-foreground">{{ sweep.lastSweepPageStats }}</p>
-                <p>Reading events</p>
+                <p>{{ t('settings.reader.koreader.readingEvents') }}</p>
               </div>
               <div class="rounded-md border border-border bg-background px-3 py-2">
                 <p class="font-medium text-foreground">{{ sweep.lastSweepAnnotations }}</p>
-                <p>Highlights</p>
+                <p>{{ t('settings.reader.koreader.highlights') }}</p>
               </div>
             </div>
           </div>
           <div v-if="hasPluginActivity" class="px-4 py-4 bg-card md:px-5">
             <div class="flex items-center gap-2 mb-3">
               <Library :size="14" class="text-muted-foreground shrink-0" />
-              <p class="settings-label">Synced totals</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.syncedTotals') }}</p>
             </div>
             <div class="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
               <div class="rounded-md border border-border bg-background px-3 py-2">
                 <p class="font-medium text-foreground">{{ pluginTotals.matchedBooks }}</p>
-                <p>Matched books</p>
+                <p>{{ t('settings.reader.koreader.matchedBooks') }}</p>
               </div>
               <div class="rounded-md border border-border bg-background px-3 py-2">
                 <p class="font-medium text-foreground">{{ pluginTotals.pageStatEvents }}</p>
-                <p>Reading events</p>
+                <p>{{ t('settings.reader.koreader.readingEvents') }}</p>
               </div>
               <div class="rounded-md border border-border bg-background px-3 py-2">
                 <p class="font-medium text-foreground">{{ pluginTotals.annotations }}</p>
-                <p>Highlights</p>
+                <p>{{ t('settings.reader.koreader.highlights') }}</p>
               </div>
               <div class="rounded-md border border-border bg-background px-3 py-2">
                 <p class="font-medium text-foreground">{{ pluginTotals.trashedAnnotations }}</p>
-                <p>Trashed highlights</p>
+                <p>{{ t('settings.reader.koreader.trashedHighlights') }}</p>
               </div>
             </div>
             <div v-if="pendingDeletes > 0" class="mt-3 flex gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-foreground">
               <AlertTriangle :size="14" class="mt-0.5 shrink-0 text-muted-foreground" />
-              <p>{{ formatCount(pendingDeletes, 'deleted highlight') }} awaiting KOReader plugin acknowledgement.</p>
+              <p>{{ t('settings.reader.koreader.pendingDeletes', { count: pendingDeletes }, pendingDeletes) }}</p>
             </div>
             <div v-if="failedPositions > 0" class="mt-3 flex gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-foreground">
               <AlertTriangle :size="14" class="mt-0.5 shrink-0 text-muted-foreground" />
-              <p>{{ formatCount(failedPositions, 'highlight position') }} need attention.</p>
+              <p>{{ t('settings.reader.koreader.failedPositions', { count: failedPositions }, failedPositions) }}</p>
             </div>
           </div>
         </div>
       </div>
 
       <div class="mb-8">
-        <p class="settings-group-label">Setup Guide</p>
+        <p class="settings-group-label">{{ t('settings.reader.koreader.setupGuide') }}</p>
         <div class="border border-border rounded-lg bg-card shadow-xs">
           <button class="w-full flex items-center justify-between gap-2 px-4 py-4 text-left md:px-5" @click="handleToggleHelp">
             <div class="flex-1 min-w-0">
-              <p class="settings-label">KOReader setup steps</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.setupSteps') }}</p>
               <p class="settings-hint">
-                Use the BookOrbit plugin for catalog browsing, downloads, progress, reading events, and highlights. Use the stock plugin for progress
-                only.
+                {{ t('settings.reader.koreader.setupStepsHint') }}
               </p>
             </div>
             <ChevronUp v-if="helpOpen" :size="14" class="text-muted-foreground shrink-0" />
@@ -523,30 +532,39 @@ async function handleDownloadPlugin() {
           </button>
           <div v-if="helpOpen" class="border-t border-border px-4 py-4 space-y-4 text-xs text-muted-foreground md:px-5">
             <div>
-              <p class="font-medium text-foreground/80 mb-2">BookOrbit plugin</p>
+              <p class="font-medium text-foreground/80 mb-2">{{ t('settings.reader.koreader.pluginGuideTitle') }}</p>
               <ol class="list-decimal list-inside space-y-2 pl-1">
-                <li>Download the preconfigured plugin above.</li>
+                <li>{{ t('settings.reader.koreader.pluginStep1') }}</li>
                 <li>
-                  Unzip it and copy <span class="font-mono text-foreground/70">bookorbit.koplugin</span> to
-                  <span class="font-mono text-foreground/70">koreader/plugins/</span> on your device.
+                  {{ t('settings.reader.koreader.pluginStep2Prefix') }}
+                  <span class="font-mono text-foreground/70">bookorbit.koplugin</span>
+                  {{ t('settings.reader.koreader.pluginStep2Middle') }}
+                  <span class="font-mono text-foreground/70">koreader/plugins/</span>
+                  {{ t('settings.reader.koreader.pluginStep2Suffix') }}
                 </li>
-                <li>Restart KOReader. The server and login are configured automatically.</li>
-                <li>Open <span class="font-mono text-foreground/70">Browse BookOrbit</span> to search, download, and link books to sync.</li>
+                <li>{{ t('settings.reader.koreader.pluginStep3') }}</li>
+                <li>
+                  {{ t('settings.reader.koreader.pluginStep4Prefix') }}
+                  <span class="font-mono text-foreground/70">Browse BookOrbit</span>
+                  {{ t('settings.reader.koreader.pluginStep4Suffix') }}
+                </li>
               </ol>
             </div>
             <div>
-              <p class="font-medium text-foreground/80 mb-2">Stock progress sync plugin</p>
+              <p class="font-medium text-foreground/80 mb-2">{{ t('settings.reader.koreader.stockGuideTitle') }}</p>
               <ol class="list-decimal list-inside space-y-2 pl-1">
-                <li>On your KOReader device, go to <span class="font-mono text-foreground/70">Tools &gt; Progress sync</span>.</li>
-                <li>Set the custom sync server to the URL shown above.</li>
-                <li>Enter the username and password you created, then tap Login.</li>
+                <li>
+                  {{ t('settings.reader.koreader.stockStep1Prefix') }}
+                  <span class="font-mono text-foreground/70">Tools &gt; Progress sync</span>{{ t('settings.reader.koreader.stockStep1Suffix') }}
+                </li>
+                <li>{{ t('settings.reader.koreader.stockStep2') }}</li>
+                <li>{{ t('settings.reader.koreader.stockStep3') }}</li>
               </ol>
             </div>
             <div class="flex gap-2 rounded-md border border-border bg-muted/40 px-3 py-2">
               <Calendar :size="14" class="mt-0.5 shrink-0 text-muted-foreground" />
               <p>
-                BookOrbit saves KOReader-compatible EPUB locations from the web reader. Restore should land close to the same position, though exact
-                line placement can vary by reader and EPUB layout.
+                {{ t('settings.reader.koreader.locationNote') }}
               </p>
             </div>
           </div>
@@ -554,19 +572,19 @@ async function handleDownloadPlugin() {
       </div>
 
       <div class="mb-6">
-        <p class="settings-group-label">Danger Zone</p>
+        <p class="settings-group-label">{{ t('settings.reader.koreader.dangerZone') }}</p>
         <div class="border border-destructive/30 rounded-lg overflow-hidden shadow-xs">
           <div class="flex flex-col gap-3 px-4 py-4 bg-card md:flex-row md:items-center md:justify-between md:px-5">
             <div class="min-w-0">
-              <p class="settings-label">Delete KOReader credentials</p>
-              <p class="settings-hint">Remove sync credentials and disconnect all devices. Progress data will be retained.</p>
+              <p class="settings-label">{{ t('settings.reader.koreader.deleteCredentials') }}</p>
+              <p class="settings-hint">{{ t('settings.reader.koreader.deleteCredentialsHint') }}</p>
             </div>
             <button
               class="self-start md:self-auto flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors shrink-0"
               @click="handleOpenDeleteConfirm"
             >
               <Trash2 :size="12" />
-              Delete
+              {{ t('common.delete') }}
             </button>
           </div>
         </div>
@@ -580,22 +598,22 @@ async function handleDownloadPlugin() {
     >
       <button class="absolute inset-0 bg-black/45" @click="handleCloseDeleteConfirm" />
       <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Delete KOReader credentials?</p>
+        <p class="text-base font-semibold text-foreground">{{ t('settings.reader.koreader.deleteConfirmTitle') }}</p>
         <p class="mt-1 text-sm text-muted-foreground">
-          This will remove your sync credentials and disconnect all KOReader devices. Existing progress data will be kept.
+          {{ t('settings.reader.koreader.deleteConfirmBody') }}
         </p>
         <div class="mt-4 flex items-center justify-end gap-2">
           <button
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="handleCloseDeleteConfirm"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
             @click="handleDelete"
           >
-            Delete
+            {{ t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/settings/LibrariesSettings.vue
+++ b/client/src/features/settings/LibrariesSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import {
   FolderOpen,
@@ -32,6 +33,7 @@ import { parseCronToHuman } from '@/features/library/utils/cron'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 import AppIcon from '@/components/AppIcon.vue'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { hasPermission } = usePermissions()
@@ -67,13 +69,13 @@ async function confirmSyncFiles() {
   fileSyncingMap.value[lib.id] = true
   try {
     await syncAllFiles(lib.id)
-    toast.success(`Metadata synced to files for "${lib.name}"`)
+    toast.success(t('settings.admin.libraries.metadataSynced', { name: lib.name }))
   } catch (e) {
     const msg = e instanceof Error ? e.message : ''
     if (msg.includes('400')) {
-      toast.error('Metadata file write is not enabled for this library. Enable it in the library settings.')
+      toast.error(t('settings.admin.libraries.fileWriteNotEnabled'))
     } else {
-      toast.error(`File sync failed for "${lib.name}"`)
+      toast.error(t('settings.admin.libraries.fileSyncFailed', { name: lib.name }))
     }
   } finally {
     fileSyncingMap.value[lib.id] = false
@@ -120,22 +122,22 @@ async function scan(lib: LibraryType) {
   try {
     const res = await api(`/api/v1/scanner/libraries/${lib.id}/scan`, { method: 'POST' })
     if (res.ok) {
-      toast.success(`Scan started for "${lib.name}"`)
+      toast.success(t('settings.admin.libraries.scanStarted', { name: lib.name }))
       subscribeLibrary(lib.id)
     } else {
-      toast.error(`Failed to start scan for "${lib.name}"`)
+      toast.error(t('settings.admin.libraries.scanStartFailed', { name: lib.name }))
     }
   } catch {
-    toast.error(`Failed to start scan for "${lib.name}"`)
+    toast.error(t('settings.admin.libraries.scanStartFailed', { name: lib.name }))
   }
 }
 
 async function refreshCovers(lib: LibraryType) {
   try {
     const res = await api(`/api/v1/scanner/libraries/${lib.id}/refresh-covers`, { method: 'POST' })
-    if (!res.ok) toast.error(`Failed to refresh covers for "${lib.name}"`)
+    if (!res.ok) toast.error(t('settings.admin.libraries.refreshCoversFailed', { name: lib.name }))
   } catch {
-    toast.error(`Failed to refresh covers for "${lib.name}"`)
+    toast.error(t('settings.admin.libraries.refreshCoversFailed', { name: lib.name }))
   }
 }
 
@@ -145,13 +147,13 @@ async function scanAll() {
     const results = await Promise.all(libraries.value.map((lib) => api(`/api/v1/scanner/libraries/${lib.id}/scan`, { method: 'POST' })))
     const failed = results.filter((r) => !r.ok).length
     if (failed === 0) {
-      toast.success('Scan started for all libraries')
+      toast.success(t('settings.admin.libraries.scanStartedAll'))
       subscribeAll()
     } else {
-      toast.error(`${failed} librar${failed === 1 ? 'y' : 'ies'} failed to start`)
+      toast.error(t('settings.admin.libraries.librariesFailedToStart', { count: failed }, failed))
     }
   } catch {
-    toast.error('Failed to start scans')
+    toast.error(t('settings.admin.libraries.scansStartFailed'))
   } finally {
     scanningAll.value = false
   }
@@ -178,10 +180,10 @@ async function onSaved(library: LibraryType) {
   editingLibrary.value = null
   subscribeLibrary(library.id)
   if (isNew) {
-    toast.success(`Library "${library.name}" created`)
+    toast.success(t('settings.admin.libraries.libraryCreated', { name: library.name }))
     await handleLibraryCreated(library)
   } else {
-    toast.success(`Library "${library.name}" updated`)
+    toast.success(t('settings.admin.libraries.libraryUpdated', { name: library.name }))
     await refreshLibraries()
   }
   loadAllStats()
@@ -200,7 +202,7 @@ async function confirmDelete() {
   try {
     const res = await api(`/api/v1/libraries/${deletedId}`, { method: 'DELETE' })
     if (res.ok) {
-      toast.success(`"${deletedName}" deleted`)
+      toast.success(t('settings.admin.libraries.libraryDeleted', { name: deletedName }))
       deletingLibrary.value = null
       await refreshLibraries()
       loadAllStats()
@@ -213,10 +215,10 @@ async function confirmDelete() {
         }
       }
     } else {
-      toast.error('Failed to delete library')
+      toast.error(t('settings.admin.libraries.deleteFailed'))
     }
   } catch {
-    toast.error('Failed to delete library')
+    toast.error(t('settings.admin.libraries.deleteFailed'))
   } finally {
     deleting.value = false
   }
@@ -234,12 +236,13 @@ function scanProgressLabel(libraryId: number): string {
   const p = getProgress(libraryId)
   if (!p) return ''
   if (p.status === 'running') {
-    if (p.total === 0) return 'Scanning...'
+    if (p.total === 0) return t('settings.admin.libraries.scanning')
     const pct = Math.floor((p.processed / p.total) * 100)
-    return `Scanning ${pct}% (${p.processed}/${p.total})`
+    return t('settings.admin.libraries.scanningProgress', { pct, processed: p.processed, total: p.total })
   }
-  if (p.status === 'completed') return `Done - ${p.added} added, ${p.updated} updated`
-  if (p.status === 'failed') return p.errorMessage ? `Failed: ${p.errorMessage}` : 'Scan failed'
+  if (p.status === 'completed') return t('settings.admin.libraries.scanDone', { added: p.added, updated: p.updated })
+  if (p.status === 'failed')
+    return p.errorMessage ? t('settings.admin.libraries.scanFailedWithError', { error: p.errorMessage }) : t('settings.admin.libraries.scanFailed')
   return ''
 }
 
@@ -248,18 +251,18 @@ function coverRefreshLabel(libraryId: number): string {
   if (!p) return ''
   if (p.status === 'running') {
     const pct = p.total > 0 ? Math.floor((p.processed / p.total) * 100) : 0
-    return `Refreshing covers ${pct}% (${p.processed}/${p.total})`
+    return t('settings.admin.libraries.refreshingCovers', { pct, processed: p.processed, total: p.total })
   }
-  if (p.status === 'completed') return `Covers refreshed (${p.total} processed)`
+  if (p.status === 'completed') return t('settings.admin.libraries.coversRefreshed', { count: p.total })
   return ''
 }
 </script>
 
 <template>
   <div class="md:hidden mb-3">
-    <h2 class="settings-title">Libraries</h2>
+    <h2 class="settings-title">{{ t('settings.admin.libraries.title') }}</h2>
     <p class="settings-subtitle overflow-hidden" style="display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2">
-      Manage your media libraries and trigger content scans.
+      {{ t('settings.admin.libraries.subtitle') }}
     </p>
   </div>
   <div
@@ -268,23 +271,23 @@ function coverRefreshLabel(libraryId: number): string {
     <div class="grid grid-cols-2 gap-2">
       <button class="settings-btn-outline w-full justify-center" :disabled="scanningAll || libraries.length === 0" @click="scanAll">
         <RefreshCw :size="14" :class="scanningAll ? 'animate-spin' : ''" />
-        {{ scanningAll ? 'Scanning...' : 'Scan All' }}
+        {{ scanningAll ? t('settings.admin.libraries.scanning') : t('settings.admin.libraries.scanAll') }}
       </button>
       <button class="settings-btn-primary w-full justify-center" @click="openCreate">
         <Plus :size="14" />
-        Add Library
+        {{ t('settings.admin.libraries.addLibrary') }}
       </button>
     </div>
   </div>
 
-  <SettingsPageHeader title="Libraries" subtitle="Manage your media libraries and trigger content scans." class="hidden md:flex">
+  <SettingsPageHeader :title="t('settings.admin.libraries.title')" :subtitle="t('settings.admin.libraries.subtitle')" class="hidden md:flex">
     <button class="settings-btn-outline" :disabled="scanningAll || libraries.length === 0" @click="scanAll">
       <RefreshCw :size="14" :class="scanningAll ? 'animate-spin' : ''" />
-      {{ scanningAll ? 'Scanning...' : 'Scan All' }}
+      {{ scanningAll ? t('settings.admin.libraries.scanning') : t('settings.admin.libraries.scanAll') }}
     </button>
     <button class="settings-btn-primary" @click="openCreate">
       <Plus :size="14" />
-      Add Library
+      {{ t('settings.admin.libraries.addLibrary') }}
     </button>
   </SettingsPageHeader>
 
@@ -314,10 +317,16 @@ function coverRefreshLabel(libraryId: number): string {
                 <!-- Col 1 -->
                 <span v-if="stats[lib.id]" class="flex items-center gap-1 text-xs text-muted-foreground min-w-0">
                   <BookOpen :size="11" class="shrink-0" />
-                  <span class="truncate">{{ stats[lib.id]?.totalBooks }} book{{ stats[lib.id]?.totalBooks === 1 ? '' : 's' }}</span>
+                  <span class="truncate">{{
+                    t('settings.admin.libraries.bookCount', { count: stats[lib.id]?.totalBooks ?? 0 }, stats[lib.id]?.totalBooks ?? 0)
+                  }}</span>
                 </span>
                 <span v-else class="text-xs text-muted-foreground truncate min-w-0">
-                  Added {{ new Date(lib.createdAt).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }) }}
+                  {{
+                    t('settings.admin.libraries.addedDate', {
+                      date: new Date(lib.createdAt).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' }),
+                    })
+                  }}
                 </span>
 
                 <span
@@ -332,14 +341,16 @@ function coverRefreshLabel(libraryId: number): string {
                 <!-- Col 2 -->
                 <span class="flex items-center gap-1 text-xs text-muted-foreground min-w-0">
                   <component :is="lib.organizationMode === 'book_per_file' ? FileText : Folder" :size="11" class="shrink-0" />
-                  <span class="truncate">{{ lib.organizationMode === 'book_per_file' ? 'File mode' : 'Folder mode' }}</span>
+                  <span class="truncate">{{
+                    lib.organizationMode === 'book_per_file' ? t('settings.admin.libraries.fileMode') : t('settings.admin.libraries.folderMode')
+                  }}</span>
                 </span>
 
                 <Tooltip v-if="lib.folders.length > 0">
                   <TooltipTrigger as-child>
                     <span class="flex items-center gap-1 text-xs text-muted-foreground cursor-default min-w-0">
                       <FolderOpen :size="11" class="shrink-0" />
-                      <span class="truncate">{{ lib.folders.length }} {{ lib.folders.length === 1 ? 'folder' : 'folders' }}</span>
+                      <span class="truncate">{{ t('settings.admin.libraries.folderCount', { count: lib.folders.length }, lib.folders.length) }}</span>
                     </span>
                   </TooltipTrigger>
                   <TooltipContent class="max-w-xs">
@@ -353,7 +364,7 @@ function coverRefreshLabel(libraryId: number): string {
                 <!-- Col 3 -->
                 <span v-if="lib.watch" class="flex items-center gap-1 text-xs font-medium text-primary/80 min-w-0">
                   <Eye :size="11" class="shrink-0" />
-                  <span class="truncate">Watching</span>
+                  <span class="truncate">{{ t('settings.admin.libraries.watching') }}</span>
                 </span>
                 <span v-else class="min-w-0"></span>
 
@@ -370,13 +381,13 @@ function coverRefreshLabel(libraryId: number): string {
                 <!-- Col 4 -->
                 <span v-if="lib.fileWriteEnabled" class="flex items-center gap-1 text-xs text-muted-foreground min-w-0">
                   <FileEdit :size="11" class="shrink-0" />
-                  <span class="truncate">File write</span>
+                  <span class="truncate">{{ t('settings.admin.libraries.fileWrite') }}</span>
                 </span>
                 <span v-else class="min-w-0"></span>
 
                 <span v-if="lib.fileRenameEnabled" class="flex items-center gap-1 text-xs text-muted-foreground min-w-0">
                   <Pencil :size="11" class="shrink-0" />
-                  <span class="truncate">File rename</span>
+                  <span class="truncate">{{ t('settings.admin.libraries.fileRename') }}</span>
                 </span>
                 <span v-else class="min-w-0"></span>
               </div>
@@ -386,7 +397,7 @@ function coverRefreshLabel(libraryId: number): string {
             <div class="flex items-center gap-2 shrink-0">
               <button class="settings-btn-outline" :disabled="isScanning(lib.id)" @click="scan(lib)">
                 <RefreshCw :size="14" :class="isScanning(lib.id) ? 'animate-spin' : ''" />
-                {{ isScanning(lib.id) ? 'Scanning...' : 'Scan' }}
+                {{ isScanning(lib.id) ? t('settings.admin.libraries.scanning') : t('settings.admin.libraries.scan') }}
               </button>
 
               <DropdownMenu>
@@ -400,20 +411,20 @@ function coverRefreshLabel(libraryId: number): string {
                 <DropdownMenuContent align="end" class="w-52">
                   <DropdownMenuItem @click="openEdit(lib)">
                     <Pencil />
-                    Edit library
+                    {{ t('settings.admin.libraries.editLibrary') }}
                   </DropdownMenuItem>
                   <DropdownMenuItem :disabled="isRefreshingCovers(lib.id)" @click="refreshCovers(lib)">
                     <Images :class="isRefreshingCovers(lib.id) ? 'animate-pulse' : ''" />
-                    Refresh covers
+                    {{ t('settings.admin.libraries.refreshCovers') }}
                   </DropdownMenuItem>
                   <DropdownMenuItem :disabled="!!fileSyncingMap[lib.id] || !lib.fileWriteEnabled" @click="promptSyncFiles(lib)">
                     <FileEdit :class="fileSyncingMap[lib.id] ? 'animate-pulse' : ''" />
-                    <span class="flex-1">Sync metadata to files</span>
+                    <span class="flex-1">{{ t('settings.admin.libraries.syncMetadataToFiles') }}</span>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem variant="destructive" @click="openDelete(lib)">
                     <Trash2 />
-                    Delete library
+                    {{ t('settings.admin.libraries.deleteLibrary') }}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -474,11 +485,11 @@ function coverRefreshLabel(libraryId: number): string {
         <div class="flex h-12 w-12 items-center justify-center rounded-lg bg-muted mx-auto mb-4">
           <FolderOpen :size="22" class="text-muted-foreground/80" />
         </div>
-        <p class="text-sm font-medium text-foreground mb-1">No libraries yet</p>
-        <p class="text-sm text-muted-foreground mb-5">Add a library to start organizing your books.</p>
+        <p class="text-sm font-medium text-foreground mb-1">{{ t('settings.admin.libraries.emptyTitle') }}</p>
+        <p class="text-sm text-muted-foreground mb-5">{{ t('settings.admin.libraries.emptyHint') }}</p>
         <button class="settings-btn-primary" @click="openCreate">
           <Plus :size="14" />
-          Add your first library
+          {{ t('settings.admin.libraries.addFirstLibrary') }}
         </button>
       </div>
     </div>
@@ -490,11 +501,13 @@ function coverRefreshLabel(libraryId: number): string {
   <!-- Delete confirmation dialog -->
   <div v-if="deletingLibrary" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
     <div class="bg-card border border-border rounded-lg shadow-xl w-full max-w-sm p-6">
-      <h3 class="text-base font-semibold text-foreground mb-1">Delete "{{ deletingLibrary.name }}"?</h3>
+      <h3 class="text-base font-semibold text-foreground mb-1">
+        {{ t('settings.admin.libraries.deleteConfirmTitle', { name: deletingLibrary.name }) }}
+      </h3>
       <p class="text-sm text-muted-foreground mb-4">
-        This will permanently remove all books, metadata, reading progress, bookmarks, and annotations in this library. This cannot be undone.
+        {{ t('settings.admin.libraries.deleteConfirmBody') }}
       </p>
-      <p class="text-sm text-foreground mb-2">Type the library name to confirm:</p>
+      <p class="text-sm text-foreground mb-2">{{ t('settings.admin.libraries.deleteConfirmTypeName') }}</p>
       <input
         v-model="deleteConfirmName"
         type="text"
@@ -508,14 +521,14 @@ function coverRefreshLabel(libraryId: number): string {
           class="px-4 py-2 text-sm font-medium rounded-md border border-border hover:bg-muted transition-colors text-muted-foreground"
           @click="deletingLibrary = null"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           class="px-4 py-2 text-sm font-medium rounded-md bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity disabled:opacity-50"
           :disabled="deleteConfirmName !== deletingLibrary.name || deleting"
           @click="confirmDelete"
         >
-          {{ deleting ? 'Deleting...' : 'Delete Library' }}
+          {{ deleting ? t('settings.admin.libraries.deleting') : t('settings.admin.libraries.deleteLibraryButton') }}
         </button>
       </div>
     </div>
@@ -524,24 +537,24 @@ function coverRefreshLabel(libraryId: number): string {
   <!-- Sync confirmation dialog -->
   <div v-if="confirmSyncLibrary" class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
     <div class="bg-card border border-border rounded-lg shadow-xl w-full max-w-sm p-6">
-      <h3 class="text-base font-semibold text-foreground mb-1">Sync metadata to files?</h3>
+      <h3 class="text-base font-semibold text-foreground mb-1">{{ t('settings.admin.libraries.syncConfirmTitle') }}</h3>
       <p class="text-sm text-muted-foreground mb-4">
-        This will overwrite the metadata inside every supported file in
+        {{ t('settings.admin.libraries.syncConfirmBodyPrefix') }}
         <span class="font-medium text-foreground">{{ confirmSyncLibrary.name }}</span>
-        directly on disk. This cannot be undone.
+        {{ t('settings.admin.libraries.syncConfirmBodySuffix') }}
       </p>
       <div class="flex justify-end gap-2">
         <button
           class="px-4 py-2 text-sm font-medium rounded-md border border-border hover:bg-muted transition-colors text-muted-foreground"
           @click="confirmSyncLibrary = null"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           class="px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity"
           @click="confirmSyncFiles"
         >
-          Sync files
+          {{ t('settings.admin.libraries.syncFiles') }}
         </button>
       </div>
     </div>

--- a/client/src/features/settings/MagicLinksSettings.vue
+++ b/client/src/features/settings/MagicLinksSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Plus, Trash2, Copy, Check, Link, Pause, Play } from '@lucide/vue'
 import { api } from '@/lib/api'
 import { copyToClipboard } from '@/lib/clipboard'
@@ -13,6 +14,8 @@ const props = withDefaults(defineProps<{ withHeader?: boolean; withEmbeddedCreat
 })
 
 defineExpose({ openCreateForm })
+
+const { t } = useI18n()
 
 interface SharedUser {
   id: number
@@ -78,7 +81,7 @@ async function handleCreate() {
     })
     showCreateForm.value = false
   } catch (e) {
-    createError.value = e instanceof Error ? e.message : 'Failed to create'
+    createError.value = e instanceof Error ? e.message : t('settings.magicLinks.errors.create')
   } finally {
     creating.value = false
   }
@@ -91,7 +94,7 @@ function getMagicUrl(rawToken: string): string {
 async function copyMagicUrl(tokenId: number, rawToken: string) {
   const copied = await copyToClipboard(getMagicUrl(rawToken))
   if (!copied) {
-    error.value = 'Failed to copy magic link'
+    error.value = t('settings.magicLinks.errors.copy')
     return
   }
 
@@ -108,7 +111,7 @@ async function handleToggleActive(id: number, currentIsActive: boolean) {
   try {
     await setActive(id, !currentIsActive)
   } catch {
-    error.value = 'Failed to update magic link'
+    error.value = t('settings.magicLinks.errors.update')
   }
 }
 
@@ -119,7 +122,7 @@ async function handleRevoke() {
     await revokeToken(revokeConfirmId.value)
     revokeConfirmId.value = null
   } catch {
-    error.value = 'Failed to revoke'
+    error.value = t('settings.magicLinks.errors.revoke')
   } finally {
     revoking.value = false
   }
@@ -138,73 +141,73 @@ function isExpired(expiresAt: string | null | undefined): boolean {
 
 <template>
   <template v-if="props.withHeader">
-    <SettingsPageHeader class="hidden md:flex" title="Magic Links" subtitle="Create shareable login links for shared accounts.">
+    <SettingsPageHeader class="hidden md:flex" :title="t('settings.magicLinks.title')" :subtitle="t('settings.magicLinks.subtitle')">
       <button class="settings-btn-primary" :disabled="sharedUsers.length === 0" @click="openCreateForm">
         <Plus :size="14" />
-        Create link
+        {{ t('settings.magicLinks.createLink') }}
       </button>
     </SettingsPageHeader>
     <div class="md:hidden px-1">
-      <h1 class="text-xl font-semibold tracking-tight text-foreground">Magic Links</h1>
+      <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('settings.magicLinks.title') }}</h1>
       <p
         class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
       >
-        Create shareable login links for shared accounts.
+        {{ t('settings.magicLinks.subtitle') }}
       </p>
     </div>
     <div class="md:hidden sticky top-11 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2 mt-4 mb-3">
       <button class="settings-btn-primary w-full min-h-10 justify-center" :disabled="sharedUsers.length === 0" @click="openCreateForm">
         <Plus :size="14" />
-        Create link
+        {{ t('settings.magicLinks.createLink') }}
       </button>
     </div>
   </template>
   <div v-else-if="props.withEmbeddedCreateAction" class="mb-4 flex items-center justify-end md:mb-5">
     <button class="settings-btn-primary w-full justify-center md:w-auto" :disabled="sharedUsers.length === 0" @click="openCreateForm">
       <Plus :size="14" />
-      Create link
+      {{ t('settings.magicLinks.createLink') }}
     </button>
   </div>
 
   <p v-if="sharedUsers.length === 0 && !loading" class="text-sm text-muted-foreground mb-4">
-    No shared accounts found. Create a shared account from the Users page first.
+    {{ t('settings.magicLinks.noSharedAccounts') }}
   </p>
 
   <div v-if="error" class="mb-4 text-sm text-destructive">{{ error }}</div>
-  <div v-if="loading" class="text-sm text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="text-sm text-muted-foreground">{{ t('common.loading') }}</div>
 
   <!-- Create form modal -->
   <div v-if="showCreateForm" class="fixed inset-0 z-[70] flex items-end justify-center md:items-center md:px-4" @click.self="showCreateForm = false">
     <button class="absolute inset-0 bg-black/45" @click="showCreateForm = false" />
     <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-      <p class="text-base font-semibold text-foreground">Create magic link</p>
-      <p class="mt-1 text-sm text-muted-foreground">Generate a shareable login URL for a shared account.</p>
+      <p class="text-base font-semibold text-foreground">{{ t('settings.magicLinks.createDialog.title') }}</p>
+      <p class="mt-1 text-sm text-muted-foreground">{{ t('settings.magicLinks.createDialog.description') }}</p>
 
       <div class="mt-4 space-y-3">
         <div>
-          <label class="block text-sm font-medium text-foreground mb-1">Shared account</label>
+          <label class="block text-sm font-medium text-foreground mb-1">{{ t('settings.magicLinks.createDialog.sharedAccount') }}</label>
           <select
             v-model="createUserId"
             class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           >
-            <option :value="null" disabled>Select a shared account</option>
+            <option :value="null" disabled>{{ t('settings.magicLinks.createDialog.selectAccount') }}</option>
             <option v-for="u in sharedUsers" :key="u.id" :value="u.id">{{ u.name }} (@{{ u.username }})</option>
           </select>
         </div>
         <div>
-          <label class="block text-sm font-medium text-foreground mb-1">Label</label>
+          <label class="block text-sm font-medium text-foreground mb-1">{{ t('settings.magicLinks.createDialog.label') }}</label>
           <input
             v-model="createLabel"
             type="text"
             maxlength="100"
-            placeholder="e.g. Demo link for conference"
+            :placeholder="t('settings.magicLinks.createDialog.labelPlaceholder')"
             class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
         <div>
           <label class="block text-sm font-medium text-foreground mb-1">
-            Expires at
-            <span class="text-muted-foreground font-normal">(optional)</span>
+            {{ t('settings.magicLinks.createDialog.expiresAt') }}
+            <span class="text-muted-foreground font-normal">{{ t('settings.magicLinks.createDialog.optional') }}</span>
           </label>
           <input
             v-model="createExpiresAt"
@@ -221,14 +224,14 @@ function isExpired(expiresAt: string | null | undefined): boolean {
           class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
           @click="showCreateForm = false"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           class="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
           :disabled="creating || !createUserId || !createLabel.trim()"
           @click="handleCreate"
         >
-          {{ creating ? 'Creating...' : 'Create' }}
+          {{ creating ? t('settings.magicLinks.createDialog.creating') : t('settings.magicLinks.createDialog.create') }}
         </button>
       </div>
     </div>
@@ -236,17 +239,17 @@ function isExpired(expiresAt: string | null | undefined): boolean {
 
   <!-- Active tokens -->
   <div v-if="!loading && activeTokens.length > 0" class="space-y-3">
-    <h2 class="text-sm font-medium text-muted-foreground">Active links</h2>
+    <h2 class="text-sm font-medium text-muted-foreground">{{ t('settings.magicLinks.activeLinks') }}</h2>
     <div class="hidden md:block rounded-lg border border-border overflow-hidden shadow-xs">
       <table class="w-full text-sm">
         <thead class="bg-muted/50">
           <tr>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Label</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Account</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Created by</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Expires</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Uses</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Last used</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.label') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.account') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.createdBy') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.expires') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.uses') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.lastUsed') }}</th>
             <th class="px-4 py-3" />
           </tr>
         </thead>
@@ -260,17 +263,17 @@ function isExpired(expiresAt: string | null | undefined): boolean {
                   v-if="!token.isActive"
                   class="inline-flex items-center rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400"
                 >
-                  Paused
+                  {{ t('settings.magicLinks.paused') }}
                 </span>
               </div>
             </td>
             <td class="px-4 py-3 text-muted-foreground font-mono text-xs">@{{ token.username }}</td>
-            <td class="px-4 py-3 text-muted-foreground text-xs">{{ token.createdByUsername ?? 'Deleted user' }}</td>
+            <td class="px-4 py-3 text-muted-foreground text-xs">{{ token.createdByUsername ?? t('settings.magicLinks.deletedUser') }}</td>
             <td class="px-4 py-3">
               <span v-if="token.expiresAt" class="text-xs" :class="isExpired(token.expiresAt) ? 'text-destructive' : 'text-muted-foreground'">
-                {{ isExpired(token.expiresAt) ? 'Expired ' : '' }}{{ formatDate(token.expiresAt) }}
+                {{ isExpired(token.expiresAt) ? t('settings.magicLinks.expiredPrefix') : '' }}{{ formatDate(token.expiresAt) }}
               </span>
-              <span v-else class="text-xs text-muted-foreground">Never</span>
+              <span v-else class="text-xs text-muted-foreground">{{ t('settings.magicLinks.never') }}</span>
             </td>
             <td class="px-4 py-3 text-muted-foreground text-xs">{{ token.useCount }}</td>
             <td class="px-4 py-3 text-muted-foreground text-xs">{{ formatDate(token.lastUsedAt) }}</td>
@@ -287,7 +290,7 @@ function isExpired(expiresAt: string | null | undefined): boolean {
                       <Copy v-else :size="14" />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent>{{ copiedId === token.id ? 'Copied!' : 'Copy link' }}</TooltipContent>
+                  <TooltipContent>{{ copiedId === token.id ? t('settings.magicLinks.copied') : t('settings.magicLinks.copyLink') }}</TooltipContent>
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger as-child>
@@ -299,7 +302,7 @@ function isExpired(expiresAt: string | null | undefined): boolean {
                       <Play v-else :size="14" />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent>{{ token.isActive ? 'Pause' : 'Resume' }}</TooltipContent>
+                  <TooltipContent>{{ token.isActive ? t('settings.magicLinks.pause') : t('settings.magicLinks.resume') }}</TooltipContent>
                 </Tooltip>
                 <Tooltip>
                   <TooltipTrigger as-child>
@@ -310,7 +313,7 @@ function isExpired(expiresAt: string | null | undefined): boolean {
                       <Trash2 :size="14" />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent>Revoke</TooltipContent>
+                  <TooltipContent>{{ t('settings.magicLinks.revoke') }}</TooltipContent>
                 </Tooltip>
               </div>
             </td>
@@ -336,7 +339,7 @@ function isExpired(expiresAt: string | null | undefined): boolean {
                 v-if="!token.isActive"
                 class="inline-flex items-center rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400"
               >
-                Paused
+                {{ t('settings.magicLinks.paused') }}
               </span>
             </div>
             <p class="mt-1 text-xs text-muted-foreground">@{{ token.username }}</p>
@@ -366,11 +369,15 @@ function isExpired(expiresAt: string | null | undefined): boolean {
           </div>
         </div>
         <div class="mt-2 flex items-center gap-4 text-xs text-muted-foreground">
-          <span>{{ token.useCount }} uses</span>
+          <span>{{ t('settings.magicLinks.usesCount', { count: token.useCount }) }}</span>
           <span v-if="token.expiresAt" :class="isExpired(token.expiresAt) ? 'text-destructive' : ''">
-            {{ isExpired(token.expiresAt) ? 'Expired' : `Expires ${formatDate(token.expiresAt)}` }}
+            {{
+              isExpired(token.expiresAt)
+                ? t('settings.magicLinks.expired')
+                : t('settings.magicLinks.expiresOn', { date: formatDate(token.expiresAt) })
+            }}
           </span>
-          <span v-else>No expiry</span>
+          <span v-else>{{ t('settings.magicLinks.noExpiry') }}</span>
         </div>
       </div>
     </div>
@@ -378,16 +385,16 @@ function isExpired(expiresAt: string | null | undefined): boolean {
 
   <!-- Inactive tokens (revoked or expired) -->
   <div v-if="!loading && inactiveTokens.length > 0" class="mt-6 space-y-3">
-    <h2 class="text-sm font-medium text-muted-foreground">Inactive links</h2>
+    <h2 class="text-sm font-medium text-muted-foreground">{{ t('settings.magicLinks.inactiveLinks') }}</h2>
     <div class="hidden md:block rounded-lg border border-border overflow-hidden shadow-xs opacity-60">
       <table class="w-full text-sm">
         <thead class="bg-muted/50">
           <tr>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Label</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Account</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Created</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
-            <th class="px-4 py-3 text-left font-medium text-muted-foreground">Total uses</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.label') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.account') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.created') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.status') }}</th>
+            <th class="px-4 py-3 text-left font-medium text-muted-foreground">{{ t('settings.magicLinks.columns.totalUses') }}</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-border">
@@ -396,7 +403,11 @@ function isExpired(expiresAt: string | null | undefined): boolean {
             <td class="px-4 py-3 text-muted-foreground font-mono text-xs">@{{ token.username }}</td>
             <td class="px-4 py-3 text-muted-foreground text-xs">{{ formatDate(token.createdAt) }}</td>
             <td class="px-4 py-3 text-muted-foreground text-xs">
-              {{ token.revokedAt ? `Revoked ${formatDate(token.revokedAt)}` : `Expired ${formatDate(token.expiresAt)}` }}
+              {{
+                token.revokedAt
+                  ? t('settings.magicLinks.revokedOn', { date: formatDate(token.revokedAt) })
+                  : t('settings.magicLinks.expiredOn', { date: formatDate(token.expiresAt) })
+              }}
             </td>
             <td class="px-4 py-3 text-muted-foreground text-xs">{{ token.useCount }}</td>
           </tr>
@@ -407,16 +418,20 @@ function isExpired(expiresAt: string | null | undefined): boolean {
     <div class="md:hidden space-y-3 opacity-60">
       <div v-for="token in inactiveTokens" :key="token.id" class="rounded-lg border border-border bg-card px-4 py-3.5 shadow-xs">
         <p class="text-sm text-muted-foreground line-through">{{ token.label }}</p>
-        <p class="mt-1 text-xs text-muted-foreground">@{{ token.username }} - {{ token.useCount }} uses</p>
+        <p class="mt-1 text-xs text-muted-foreground">@{{ token.username }} - {{ t('settings.magicLinks.usesCount', { count: token.useCount }) }}</p>
         <p class="mt-0.5 text-xs text-muted-foreground">
-          {{ token.revokedAt ? `Revoked ${formatDate(token.revokedAt)}` : `Expired ${formatDate(token.expiresAt)}` }}
+          {{
+            token.revokedAt
+              ? t('settings.magicLinks.revokedOn', { date: formatDate(token.revokedAt) })
+              : t('settings.magicLinks.expiredOn', { date: formatDate(token.expiresAt) })
+          }}
         </p>
       </div>
     </div>
   </div>
 
   <p v-if="!loading && tokens.length === 0 && sharedUsers.length > 0" class="text-sm text-muted-foreground mt-4">
-    No magic links created yet. Click "Create link" to generate a shareable login URL.
+    {{ t('settings.magicLinks.emptyState', { action: t('settings.magicLinks.createLink') }) }}
   </p>
 
   <!-- Revoke confirmation modal -->
@@ -427,23 +442,23 @@ function isExpired(expiresAt: string | null | undefined): boolean {
   >
     <button class="absolute inset-0 bg-black/45" @click="revokeConfirmId = null" />
     <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-      <p class="text-base font-semibold text-foreground">Revoke magic link?</p>
+      <p class="text-base font-semibold text-foreground">{{ t('settings.magicLinks.revokeDialog.title') }}</p>
       <p class="mt-1 text-sm text-muted-foreground">
-        This will immediately invalidate the link and terminate all active sessions for the linked account.
+        {{ t('settings.magicLinks.revokeDialog.description') }}
       </p>
       <div class="mt-4 flex items-center justify-end gap-2">
         <button
           class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
           @click="revokeConfirmId = null"
         >
-          Cancel
+          {{ t('common.cancel') }}
         </button>
         <button
           class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 transition-colors"
           :disabled="revoking"
           @click="handleRevoke"
         >
-          {{ revoking ? 'Revoking...' : 'Revoke' }}
+          {{ revoking ? t('settings.magicLinks.revoking') : t('settings.magicLinks.revoke') }}
         </button>
       </div>
     </div>

--- a/client/src/features/settings/MaintenanceSettings.vue
+++ b/client/src/features/settings/MaintenanceSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Check, RefreshCw, Sparkles, ArrowUpFromLine, CheckCircle2, AlertCircle, Loader2, Bell, Award } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
@@ -8,6 +9,8 @@ import MigrationModal from '@/features/migration/components/MigrationModal.vue'
 import { api } from '@/lib/api'
 import { getWorkflowState, type MigrationWorkflowState } from '@/features/migration/lib/migration-api'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
+
+const { t } = useI18n()
 
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
 
@@ -82,12 +85,12 @@ async function toggleUpdateCheck(newVal: boolean) {
     })
     if (res.ok) {
       updateCheckEnabled.value = newVal
-      toast.success(`Update checks ${newVal ? 'enabled' : 'disabled'}`)
+      toast.success(newVal ? t('settings.admin.maintenance.updateChecksEnabled') : t('settings.admin.maintenance.updateChecksDisabled'))
     } else {
-      toast.error('Failed to update setting')
+      toast.error(t('settings.admin.maintenance.updateSettingFailed'))
     }
   } catch {
-    toast.error('Failed to update setting')
+    toast.error(t('settings.admin.maintenance.updateSettingFailed'))
   } finally {
     updateCheckLoading.value = false
   }
@@ -102,10 +105,12 @@ async function rebuildEmbeddings() {
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const data: { queued: number } = await res.json()
     queued.value = data.queued
-    toast.success(`${data.queued} books queued for embedding`)
+    toast.success(t('settings.admin.maintenance.booksQueuedForEmbedding', { count: data.queued }, data.queued))
   } catch (e) {
-    embeddingError.value = e instanceof Error ? e.message : 'Failed'
-    toast.error(`Failed to rebuild embeddings: ${embeddingError.value ?? 'Unknown error'}`)
+    embeddingError.value = e instanceof Error ? e.message : t('settings.admin.maintenance.failed')
+    toast.error(
+      t('settings.admin.maintenance.rebuildEmbeddingsFailed', { error: embeddingError.value ?? t('settings.admin.maintenance.unknownError') }),
+    )
   } finally {
     running.value = false
   }
@@ -114,7 +119,7 @@ async function rebuildEmbeddings() {
 async function runAchievementBackfill() {
   if (!isSuperuser.value || achievementBackfillRunning.value) return
 
-  if (!confirm('Run achievement backfill for all achievements across all users? This may take a while.')) return
+  if (!confirm(t('settings.admin.maintenance.achievementBackfillConfirm'))) return
 
   achievementBackfillRunning.value = true
   achievementBackfillError.value = null
@@ -128,10 +133,10 @@ async function runAchievementBackfill() {
 
     const result: { usersProcessed: number; awardsGranted: number } = await res.json()
     achievementBackfillResult.value = result
-    toast.success(`Achievement backfill complete: ${result.awardsGranted} awards granted`)
+    toast.success(t('settings.admin.maintenance.achievementBackfillComplete', { count: result.awardsGranted }))
   } catch (e) {
-    achievementBackfillError.value = e instanceof Error ? e.message : 'Failed to run backfill'
-    toast.error(`Failed to run achievement backfill: ${achievementBackfillError.value}`)
+    achievementBackfillError.value = e instanceof Error ? e.message : t('settings.admin.maintenance.backfillRunFailed')
+    toast.error(t('settings.admin.maintenance.achievementBackfillFailed', { error: achievementBackfillError.value }))
   } finally {
     achievementBackfillRunning.value = false
   }
@@ -148,22 +153,22 @@ function formatDate(iso: string | null | undefined): string {
   <SettingsPageHeader
     v-if="!props.embedded"
     class="hidden md:flex"
-    title="Maintenance"
-    subtitle="Manage background tasks, system indices, and maintenance operations."
+    :title="t('settings.admin.maintenance.title')"
+    :subtitle="t('settings.admin.maintenance.subtitle')"
   />
   <div v-if="!props.embedded" class="md:hidden px-1">
-    <h1 class="text-xl font-semibold tracking-tight text-foreground">Maintenance</h1>
+    <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('settings.admin.maintenance.title') }}</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
     >
-      Manage background tasks, system indices, and maintenance operations.
+      {{ t('settings.admin.maintenance.subtitle') }}
     </p>
   </div>
 
   <div class="mt-5 md:mt-0 space-y-6">
     <!-- Booklore Import -->
     <div>
-      <p class="settings-group-label">Import</p>
+      <p class="settings-group-label">{{ t('settings.admin.maintenance.importGroup') }}</p>
       <div class="border border-border rounded-lg bg-card px-4 py-4 md:px-5 md:py-5 shadow-xs">
         <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between md:gap-6">
           <div class="flex items-start gap-3">
@@ -192,31 +197,37 @@ function formatDate(iso: string | null | undefined): string {
 
             <div class="min-w-0">
               <p class="settings-label">
-                <template v-if="migrationCardState === 'none' || migrationCardState === 'loading'">Import from Booklore</template>
-                <template v-else-if="migrationCardState === 'configured'">Booklore import configured</template>
-                <template v-else-if="migrationCardState === 'running'">Migration running</template>
-                <template v-else-if="migrationCardState === 'completed'">Migration completed</template>
-                <template v-else-if="migrationCardState === 'failed'">Migration failed</template>
+                <template v-if="migrationCardState === 'none' || migrationCardState === 'loading'">{{
+                  t('settings.admin.maintenance.importFromBooklore')
+                }}</template>
+                <template v-else-if="migrationCardState === 'configured'">{{ t('settings.admin.maintenance.bookloreImportConfigured') }}</template>
+                <template v-else-if="migrationCardState === 'running'">{{ t('settings.admin.maintenance.migrationRunning') }}</template>
+                <template v-else-if="migrationCardState === 'completed'">{{ t('settings.admin.maintenance.migrationCompleted') }}</template>
+                <template v-else-if="migrationCardState === 'failed'">{{ t('settings.admin.maintenance.migrationFailed') }}</template>
               </p>
 
               <p
                 class="settings-hint leading-relaxed max-w-sm mt-0.5 md:[display:block] overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
               >
                 <template v-if="migrationCardState === 'none' || migrationCardState === 'loading'">
-                  One-time import of books, metadata, and reading progress from a previous Booklore installation.
+                  {{ t('settings.admin.maintenance.importDescription') }}
                 </template>
                 <template v-else-if="migrationCardState === 'configured'">
-                  Source: {{ migrationSource!.name }}. No migration run yet - continue setup to run the import.
+                  {{ t('settings.admin.maintenance.configuredDescription', { name: migrationSource!.name }) }}
                 </template>
                 <template v-else-if="migrationCardState === 'running'">
-                  Stage: {{ migrationRun!.currentStage ?? 'initializing' }} - started
-                  {{ migrationRun!.startedAt ? formatDate(migrationRun!.startedAt) : 'recently' }}
+                  {{
+                    t('settings.admin.maintenance.runningDescription', {
+                      stage: migrationRun!.currentStage ?? t('settings.admin.maintenance.stageInitializing'),
+                      started: migrationRun!.startedAt ? formatDate(migrationRun!.startedAt) : t('settings.admin.maintenance.recently'),
+                    })
+                  }}
                 </template>
                 <template v-else-if="migrationCardState === 'completed'">
-                  From {{ migrationSource!.name }} - completed {{ formatDate(migrationRun!.endedAt) }}
+                  {{ t('settings.admin.maintenance.completedDescription', { name: migrationSource!.name, date: formatDate(migrationRun!.endedAt) }) }}
                 </template>
                 <template v-else-if="migrationCardState === 'failed'">
-                  {{ migrationRun!.errorMessage ?? 'An error occurred during migration.' }}
+                  {{ migrationRun!.errorMessage ?? t('settings.admin.maintenance.migrationErrorGeneric') }}
                 </template>
               </p>
             </div>
@@ -230,10 +241,10 @@ function formatDate(iso: string | null | undefined): string {
           >
             <template v-if="migrationCardState === 'none'">
               <ArrowUpFromLine :size="13" />
-              Get Started
+              {{ t('settings.admin.maintenance.getStarted') }}
             </template>
-            <template v-else-if="migrationCardState === 'configured'">Continue Setup</template>
-            <template v-else>View Details</template>
+            <template v-else-if="migrationCardState === 'configured'">{{ t('settings.admin.maintenance.continueSetup') }}</template>
+            <template v-else>{{ t('settings.admin.maintenance.viewDetails') }}</template>
           </button>
         </div>
       </div>
@@ -241,7 +252,7 @@ function formatDate(iso: string | null | undefined): string {
 
     <!-- Recommendations -->
     <div>
-      <p class="settings-group-label">Recommendations</p>
+      <p class="settings-group-label">{{ t('settings.admin.maintenance.recommendationsGroup') }}</p>
       <div class="border border-border rounded-lg bg-card px-4 py-4 md:px-5 md:py-5 shadow-xs">
         <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between md:gap-6">
           <div class="flex items-start gap-3">
@@ -249,22 +260,22 @@ function formatDate(iso: string | null | undefined): string {
               <Sparkles :size="16" class="text-primary" />
             </div>
             <div class="min-w-0">
-              <p class="settings-label">Refresh recommendation index</p>
+              <p class="settings-label">{{ t('settings.admin.maintenance.refreshRecommendationIndex') }}</p>
               <p
                 class="settings-hint leading-relaxed max-w-sm md:[display:block] overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
               >
-                Update the recommendations engine with your latest library changes. This process runs in the background.
+                {{ t('settings.admin.maintenance.refreshRecommendationHint') }}
               </p>
               <p v-if="queued !== null" class="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400 mt-2">
                 <Check :size="12" />
-                {{ queued }} books queued for processing
+                {{ t('settings.admin.maintenance.booksQueuedForProcessing', { count: queued }, queued) }}
               </p>
               <p v-if="embeddingError" class="text-xs text-destructive mt-2">{{ embeddingError }}</p>
             </div>
           </div>
           <button class="settings-btn-outline self-start md:w-auto md:shrink-0" :disabled="running" @click="rebuildEmbeddings">
             <RefreshCw :size="13" :class="running ? 'animate-spin' : ''" />
-            {{ running ? 'Running...' : 'Run' }}
+            {{ running ? t('settings.admin.maintenance.running') : t('settings.admin.maintenance.run') }}
           </button>
         </div>
       </div>
@@ -272,7 +283,7 @@ function formatDate(iso: string | null | undefined): string {
 
     <!-- Achievements -->
     <div v-if="isSuperuser">
-      <p class="settings-group-label">Achievements</p>
+      <p class="settings-group-label">{{ t('settings.admin.maintenance.achievementsGroup') }}</p>
       <div class="border border-border rounded-lg bg-card px-4 py-4 md:px-5 md:py-5 shadow-xs">
         <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between md:gap-6">
           <div class="flex items-start gap-3 min-w-0">
@@ -281,15 +292,20 @@ function formatDate(iso: string | null | undefined): string {
             </div>
 
             <div class="min-w-0 flex-1">
-              <p class="settings-label">Backfill achievements</p>
+              <p class="settings-label">{{ t('settings.admin.maintenance.backfillAchievements') }}</p>
               <p
                 class="settings-hint leading-relaxed max-w-sm md:[display:block] overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
               >
-                Re-evaluate achievements across all users.
+                {{ t('settings.admin.maintenance.backfillAchievementsHint') }}
               </p>
 
               <p v-if="achievementBackfillResult" class="mt-2 text-xs text-green-600 dark:text-green-400">
-                Processed {{ achievementBackfillResult.usersProcessed }} users; granted {{ achievementBackfillResult.awardsGranted }} awards.
+                {{
+                  t('settings.admin.maintenance.backfillResult', {
+                    users: achievementBackfillResult.usersProcessed,
+                    awards: achievementBackfillResult.awardsGranted,
+                  })
+                }}
               </p>
               <p v-if="achievementBackfillError" class="mt-2 text-xs text-destructive">{{ achievementBackfillError }}</p>
             </div>
@@ -301,7 +317,7 @@ function formatDate(iso: string | null | undefined): string {
             @click="runAchievementBackfill"
           >
             <RefreshCw :size="13" :class="achievementBackfillRunning ? 'animate-spin' : ''" />
-            {{ achievementBackfillRunning ? 'Running...' : 'Run Backfill' }}
+            {{ achievementBackfillRunning ? t('settings.admin.maintenance.running') : t('settings.admin.maintenance.runBackfill') }}
           </button>
         </div>
       </div>
@@ -309,7 +325,7 @@ function formatDate(iso: string | null | undefined): string {
 
     <!-- Update checks -->
     <div>
-      <p class="settings-group-label">Updates</p>
+      <p class="settings-group-label">{{ t('settings.admin.maintenance.updatesGroup') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="flex items-start gap-3">
@@ -317,9 +333,9 @@ function formatDate(iso: string | null | undefined): string {
               <Bell :size="16" class="text-primary" />
             </div>
             <div class="min-w-0">
-              <p class="settings-label">Check for updates</p>
+              <p class="settings-label">{{ t('settings.admin.maintenance.checkForUpdates') }}</p>
               <p class="settings-hint">
-                Automatically check GitHub for a new release on startup and show an indicator in the sidebar when one is available.
+                {{ t('settings.admin.maintenance.checkForUpdatesHint') }}
               </p>
             </div>
           </div>

--- a/client/src/features/settings/MetadataAllSettings.vue
+++ b/client/src/features/settings/MetadataAllSettings.vue
@@ -10,7 +10,7 @@ import MetadataScoreWeightsSettings from './MetadataScoreWeightsSettings.vue'
 import BookMetadataFetchSettings from './metadata-auto-fetch/BookMetadataFetchSettings.vue'
 import AuthorEnrichmentSettings from './AuthorEnrichmentSettings.vue'
 import SettingsPageHeader from './SettingsPageHeader.vue'
-import { METADATA_TAB_INFO, METADATA_TABS, normalizeMetadataTab, type MetadataTab as Tab } from './lib/metadata-tabs'
+import { METADATA_TABS, normalizeMetadataTab, type MetadataTab as Tab } from './lib/metadata-tabs'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 
 const { t } = useI18n()
@@ -28,9 +28,9 @@ function canAccessTab(tab: Tab): boolean {
 const tabs = computed(() =>
   METADATA_TABS.filter(canAccessTab).map((id) => ({
     id,
-    navLabel: METADATA_TAB_INFO[id].navLabel,
-    titleLabel: METADATA_TAB_INFO[id].titleLabel,
-    subtitle: METADATA_TAB_INFO[id].subtitle,
+    navLabel: t(`settings.metadata.tabs.${id}`),
+    titleLabel: t(`settings.metadata.tabTitles.${id}`),
+    subtitle: t(`settings.metadata.tabSubtitles.${id}`),
   })),
 )
 
@@ -55,7 +55,10 @@ watch(
   },
 )
 
-const activeTabInfo = computed(() => METADATA_TAB_INFO[activeTab.value])
+const activeTabInfo = computed(() => ({
+  titleLabel: t(`settings.metadata.tabTitles.${activeTab.value}`),
+  subtitle: t(`settings.metadata.tabSubtitles.${activeTab.value}`),
+}))
 const hasAccessibleTabs = computed(() => tabs.value.length > 0)
 
 const tabWidths: Record<Tab, string> = {

--- a/client/src/features/settings/MetadataAllSettings.vue
+++ b/client/src/features/settings/MetadataAllSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import MetadataPreferencesSettings from './metadata-preferences/MetadataPreferencesSettings.vue'
 import MetadataFieldRulesSettings from './metadata-preferences/MetadataFieldRulesSettings.vue'
@@ -12,6 +13,7 @@ import SettingsPageHeader from './SettingsPageHeader.vue'
 import { METADATA_TAB_INFO, METADATA_TABS, normalizeMetadataTab, type MetadataTab as Tab } from './lib/metadata-tabs'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { hasPermission } = usePermissions()
@@ -75,16 +77,16 @@ function selectTab(tab: Tab) {
 <template>
   <div class="metadata-mobile-hints">
     <div class="md:hidden mb-3">
-      <h2 class="settings-title">{{ hasAccessibleTabs ? activeTabInfo.titleLabel : 'Metadata' }}</h2>
+      <h2 class="settings-title">{{ hasAccessibleTabs ? activeTabInfo.titleLabel : t('settings.metadata.title') }}</h2>
       <p class="settings-subtitle overflow-hidden" style="display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 2">
-        {{ hasAccessibleTabs ? activeTabInfo.subtitle : 'You do not have permission to manage metadata settings.' }}
+        {{ hasAccessibleTabs ? activeTabInfo.subtitle : t('settings.metadata.noPermission') }}
       </p>
     </div>
     <div v-if="hasAccessibleTabs" class="hidden md:block">
       <SettingsPageHeader :title="activeTabInfo.titleLabel" :subtitle="activeTabInfo.subtitle" />
     </div>
     <div v-else class="hidden md:block">
-      <SettingsPageHeader title="Metadata" subtitle="You do not have permission to manage metadata settings." />
+      <SettingsPageHeader :title="t('settings.metadata.title')" :subtitle="t('settings.metadata.noPermission')" />
     </div>
 
     <div
@@ -119,7 +121,7 @@ function selectTab(tab: Tab) {
       <AuthorEnrichmentSettings v-else-if="activeTab === 'authors'" />
     </div>
     <div v-else class="max-w-3xl rounded-lg border border-border bg-card px-4 py-5 text-sm text-muted-foreground">
-      You do not have permission to manage metadata settings.
+      {{ t('settings.metadata.noPermission') }}
     </div>
   </div>
 </template>

--- a/client/src/features/settings/MetadataScoreWeightsSettings.vue
+++ b/client/src/features/settings/MetadataScoreWeightsSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, reactive, ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { RefreshCw, Save, RotateCcw } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import type { MetadataScoreWeights, MetadataScoreField } from '@bookorbit/types'
@@ -7,6 +8,7 @@ import { DEFAULT_METADATA_SCORE_WEIGHTS, METADATA_SCORE_FIELDS, METADATA_SCORE_G
 import { api } from '@/lib/api'
 import { useMetadataScoreWeights } from '@/features/metadata-score/composables/useMetadataScoreWeights'
 
+const { t } = useI18n()
 const { resetFetchCache } = useMetadataScoreWeights()
 
 const weights = reactive<MetadataScoreWeights>({ ...DEFAULT_METADATA_SCORE_WEIGHTS })
@@ -55,12 +57,12 @@ async function saveWeights() {
     })
     if (res.ok) {
       resetFetchCache()
-      toast.success('Score weights saved. Recalculating library scores...')
+      toast.success(t('settings.admin.scoreWeights.savedRecalculating'))
     } else {
-      toast.error('Failed to save score weights')
+      toast.error(t('settings.admin.scoreWeights.saveFailed'))
     }
   } catch {
-    toast.error('Failed to save score weights')
+    toast.error(t('settings.admin.scoreWeights.saveFailed'))
   } finally {
     saving.value = false
   }
@@ -72,12 +74,12 @@ async function recalculateAll() {
   try {
     const res = await api('/api/v1/metadata-score/recalculate', { method: 'POST' })
     if (res.ok) {
-      toast.success('Score recalculation started in the background')
+      toast.success(t('settings.admin.scoreWeights.recalcStarted'))
     } else {
-      toast.error('Recalculation failed')
+      toast.error(t('settings.admin.scoreWeights.recalcFailed'))
     }
   } catch {
-    toast.error('Recalculation failed')
+    toast.error(t('settings.admin.scoreWeights.recalcFailed'))
   } finally {
     recalculating.value = false
   }
@@ -95,7 +97,7 @@ function handleResetClick() {
   resetConfirmTimer = null
   resetConfirming.value = false
   Object.assign(weights, DEFAULT_METADATA_SCORE_WEIGHTS)
-  toast.success('Weights reset to defaults. Save to apply.')
+  toast.success(t('settings.admin.scoreWeights.resetToDefaults'))
 }
 </script>
 
@@ -103,9 +105,9 @@ function handleResetClick() {
   <div class="mb-4">
     <div class="md:flex md:items-start md:justify-between md:gap-4">
       <div>
-        <p class="settings-group-label !mb-0">Score Weights</p>
+        <p class="settings-group-label !mb-0">{{ t('settings.admin.scoreWeights.groupLabel') }}</p>
         <p class="settings-hint mt-0.5">
-          Assign a weight to each field. Total weight:
+          {{ t('settings.admin.scoreWeights.assignHintPrefix') }}
           <span class="font-medium text-foreground">{{ totalWeight }}</span
           >.
         </p>
@@ -118,15 +120,15 @@ function handleResetClick() {
           @click="handleResetClick"
         >
           <RotateCcw class="size-3.5" />
-          {{ resetConfirming ? 'Are you sure?' : 'Reset to defaults' }}
+          {{ resetConfirming ? t('settings.admin.scoreWeights.areYouSure') : t('settings.admin.scoreWeights.resetToDefaultsButton') }}
         </button>
         <button type="button" class="settings-btn-outline" :disabled="recalculating" @click="recalculateAll">
           <RefreshCw class="size-3.5" :class="{ 'animate-spin': recalculating }" />
-          Recalculate all
+          {{ t('settings.admin.scoreWeights.recalculateAll') }}
         </button>
         <button type="button" class="settings-btn-primary" :disabled="saving" @click="saveWeights">
           <Save class="size-3.5" />
-          Save
+          {{ t('common.save') }}
         </button>
       </div>
     </div>
@@ -142,15 +144,15 @@ function handleResetClick() {
         @click="handleResetClick"
       >
         <RotateCcw class="size-3.5" />
-        {{ resetConfirming ? 'Confirm reset' : 'Reset' }}
+        {{ resetConfirming ? t('settings.admin.scoreWeights.confirmReset') : t('settings.admin.scoreWeights.reset') }}
       </button>
       <button type="button" class="settings-btn-outline" :disabled="recalculating" @click="recalculateAll">
         <RefreshCw class="size-3.5" :class="{ 'animate-spin': recalculating }" />
-        Recalculate
+        {{ t('settings.admin.scoreWeights.recalculate') }}
       </button>
       <button type="button" class="settings-btn-primary flex-1 justify-center" :disabled="saving" @click="saveWeights">
         <Save class="size-3.5" />
-        Save
+        {{ t('common.save') }}
       </button>
     </div>
   </div>
@@ -159,7 +161,7 @@ function handleResetClick() {
     <div v-for="group in groups" :key="group.group" class="px-5 py-4 bg-card">
       <div class="flex items-center justify-between mb-3">
         <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wide">{{ group.label }}</p>
-        <span class="text-xs text-muted-foreground">subtotal: {{ groupTotal(group) }}</span>
+        <span class="text-xs text-muted-foreground">{{ t('settings.admin.scoreWeights.subtotal', { count: groupTotal(group) }) }}</span>
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-2.5">
         <div v-for="entry in group.fields" :key="entry.field" class="flex items-start md:items-center gap-2">

--- a/client/src/features/settings/MigrationSettings.vue
+++ b/client/src/features/settings/MigrationSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Eye, EyeOff, Loader2 } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import SettingsPageHeader from './SettingsPageHeader.vue'
@@ -39,6 +40,8 @@ import {
 } from '@/features/migration/lib/migration-api'
 import { useMigrationPolling } from '@/features/migration/composables/useMigrationPolling'
 import { useMigrationProgress } from '@/features/migration/composables/useMigrationProgress'
+
+const { t } = useI18n()
 
 const { subscribeRun, unsubscribeRun, getProgress: getSocketProgress, progressMap: socketProgressMap } = useMigrationProgress()
 
@@ -129,18 +132,18 @@ const mediaRootPathHint = computed(() => {
   if (!path) {
     return {
       className: 'text-amber-600',
-      text: 'Required for migrating book covers.',
+      text: t('settings.admin.migration.mediaPathRequired'),
     }
   }
   if (!path.startsWith('/')) {
     return {
       className: 'text-amber-600',
-      text: 'Use an absolute path (for example: /books). Relative paths are not supported.',
+      text: t('settings.admin.migration.mediaPathAbsolute'),
     }
   }
   return {
     className: 'text-muted-foreground',
-    text: 'Cover import path configured. Use Test Connection to verify access and Booklore images folder structure.',
+    text: t('settings.admin.migration.mediaPathConfigured'),
   }
 })
 
@@ -160,15 +163,15 @@ const preflight = computed(() => {
     dryRunFresh = currentPlan.profileId === currentProfile.id && planCreated >= profileUpdated && planCreated >= sourceValidatedAt
   }
 
-  if (!currentSource) issues.push('Save source connection settings')
-  else if (!sourceValidated) issues.push('Validate source connection')
-  if (!currentProfile) issues.push('Save user and path mappings')
-  else if (!pathMappingsValidated) issues.push('Save path mappings to validate them')
-  if (!dryRunFresh) issues.push('Run a fresh dry-run')
+  if (!currentSource) issues.push(t('settings.admin.migration.issueSaveSource'))
+  else if (!sourceValidated) issues.push(t('settings.admin.migration.issueValidateSource'))
+  if (!currentProfile) issues.push(t('settings.admin.migration.issueSaveMappings'))
+  else if (!pathMappingsValidated) issues.push(t('settings.admin.migration.issueSavePathMappings'))
+  if (!dryRunFresh) issues.push(t('settings.admin.migration.issueFreshDryRun'))
   else if ((currentPlan?.summary?.duplicateBookMatches ?? 0) > 0 || currentPlan?.summary?.status === 'blocked') {
-    issues.push('Resolve duplicate target book matches in the dry-run')
+    issues.push(t('settings.admin.migration.issueResolveDuplicates'))
   }
-  if (hasActiveRun.value) issues.push('Wait for active run to finish')
+  if (hasActiveRun.value) issues.push(t('settings.admin.migration.issueWaitActiveRun'))
 
   return { sourceValidated, pathMappingsValidated, dryRunFresh, ready: issues.length === 0, issues }
 })
@@ -192,11 +195,14 @@ const stepStatus = computed(() => {
 const stepperSteps = computed<StepDefinition[]>(() => {
   const s = stepStatus.value
   return [
-    { label: 'Source Connection', status: s.source === 'done' ? 'done' : s.source === 'saved' ? 'saved' : 'pending' },
-    { label: 'User & Path Mapping', status: s.mappings },
-    { label: 'Dry-Run', status: s.dryRun },
-    { label: 'Run Migration', status: s.migration },
-    { label: 'Report', status: run.value ? 'done' : 'pending' },
+    {
+      label: t('settings.admin.migration.stepSourceConnection'),
+      status: s.source === 'done' ? 'done' : s.source === 'saved' ? 'saved' : 'pending',
+    },
+    { label: t('settings.admin.migration.stepUserPathMapping'), status: s.mappings },
+    { label: t('settings.admin.migration.stepDryRun'), status: s.dryRun },
+    { label: t('settings.admin.migration.stepRunMigration'), status: s.migration },
+    { label: t('settings.admin.migration.stepReport'), status: run.value ? 'done' : 'pending' },
   ]
 })
 
@@ -254,33 +260,49 @@ function goToSetup() {
   currentStep.value = 0
 }
 
-const stepTitles = ['Source Connection', 'User & Path Mapping', 'Dry Run', 'Run Migration', 'Migration Report']
-const stepSubtitles = [
-  'Configure the database connection to your source Booklore instance.',
-  'Map source users to target users and translate file paths.',
-  'Preview what will be imported before running the live migration.',
-  'Start the live import and monitor its progress.',
-  'Review what was imported and export a detailed report.',
-]
-const continueLabels = ['Continue to Mappings', 'Continue to Dry Run', 'Continue to Migration', 'View Report', '']
+const stepTitles = computed(() => [
+  t('settings.admin.migration.stepSourceConnection'),
+  t('settings.admin.migration.stepUserPathMapping'),
+  t('settings.admin.migration.stepDryRunTitle'),
+  t('settings.admin.migration.stepRunMigration'),
+  t('settings.admin.migration.stepReportTitle'),
+])
+const stepSubtitles = computed(() => [
+  t('settings.admin.migration.subtitleSource'),
+  t('settings.admin.migration.subtitleMappings'),
+  t('settings.admin.migration.subtitleDryRun'),
+  t('settings.admin.migration.subtitleRun'),
+  t('settings.admin.migration.subtitleReport'),
+])
+const continueLabels = computed(() => [
+  t('settings.admin.migration.continueToMappings'),
+  t('settings.admin.migration.continueToDryRun'),
+  t('settings.admin.migration.continueToMigration'),
+  t('settings.admin.migration.viewReport'),
+  '',
+])
 
-const currentStepTitle = computed(() => stepTitles[currentStep.value] ?? '')
-const currentStepSubtitle = computed(() => stepSubtitles[currentStep.value] ?? '')
-const continueLabel = computed(() => continueLabels[currentStep.value] ?? '')
+const currentStepTitle = computed(() => stepTitles.value[currentStep.value] ?? '')
+const currentStepSubtitle = computed(() => stepSubtitles.value[currentStep.value] ?? '')
+const continueLabel = computed(() => continueLabels.value[currentStep.value] ?? '')
 
 const currentStepBadge = computed((): { label: string; cls: string } | null => {
   const s = stepStatus.value
   const n = currentStep.value
   if (n === 0) {
-    if (s.source === 'done') return { label: 'Validated', cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
-    if (s.source === 'saved') return { label: 'Saved', cls: 'text-amber-700 bg-amber-500/10 border-amber-500/20' }
+    if (s.source === 'done')
+      return { label: t('settings.admin.migration.badgeValidated'), cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
+    if (s.source === 'saved') return { label: t('settings.admin.migration.badgeSaved'), cls: 'text-amber-700 bg-amber-500/10 border-amber-500/20' }
   }
-  if (n === 1 && s.mappings === 'done') return { label: 'Saved', cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
-  if (n === 2 && s.dryRun === 'done') return { label: 'Up to date', cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
+  if (n === 1 && s.mappings === 'done')
+    return { label: t('settings.admin.migration.badgeSaved'), cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
+  if (n === 2 && s.dryRun === 'done')
+    return { label: t('settings.admin.migration.badgeUpToDate'), cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
   if (n === 3) {
-    if (s.migration === 'done') return { label: 'Completed', cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
-    if (s.migration === 'running') return { label: 'Running', cls: 'text-sky-700 bg-sky-500/10 border-sky-500/20' }
-    if (s.migration === 'failed') return { label: 'Failed', cls: 'text-red-700 bg-red-500/10 border-red-500/20' }
+    if (s.migration === 'done')
+      return { label: t('settings.admin.migration.badgeCompleted'), cls: 'text-emerald-700 bg-emerald-500/10 border-emerald-500/20' }
+    if (s.migration === 'running') return { label: t('settings.admin.migration.badgeRunning'), cls: 'text-sky-700 bg-sky-500/10 border-sky-500/20' }
+    if (s.migration === 'failed') return { label: t('settings.admin.migration.badgeFailed'), cls: 'text-red-700 bg-red-500/10 border-red-500/20' }
   }
   return null
 })
@@ -332,16 +354,16 @@ function sourceBookLabel(dup: DuplicateBookMatch, sourceId: string): string {
   const candidate = dup.sourceCandidates?.find((row) => row.sourceBookId === sourceId)
   const title = candidate?.title?.trim()
   if (title) return title
-  return `Source record ID #${sourceId}`
+  return t('settings.admin.migration.sourceRecordId', { id: sourceId })
 }
 
 function sourceBookSecondary(dup: DuplicateBookMatch, sourceId: string): string | null {
   const candidate = dup.sourceCandidates?.find((row) => row.sourceBookId === sourceId)
   const author = candidate?.author?.trim()
-  if (author) return `by ${author} (ID: ${sourceId})`
+  if (author) return t('settings.admin.migration.byAuthorWithId', { author, id: sourceId })
   const filePath = candidate?.filePath?.trim()
-  if (filePath) return `${filePath} (ID: ${sourceId})`
-  return `Booklore source ID: ${sourceId}`
+  if (filePath) return t('settings.admin.migration.filePathWithId', { path: filePath, id: sourceId })
+  return t('settings.admin.migration.bookloreSourceId', { id: sourceId })
 }
 
 function recommendedSourceBookId(dup: DuplicateBookMatch): string | null {
@@ -371,7 +393,7 @@ function isRecommendedSourceBook(dup: DuplicateBookMatch, sourceId: string): boo
 }
 
 function targetBookLabel(targetBookId: number): string {
-  return duplicateTargetBookLabels.value.get(targetBookId) ?? `Library book #${targetBookId}`
+  return duplicateTargetBookLabels.value.get(targetBookId) ?? t('settings.admin.migration.libraryBookNum', { id: targetBookId })
 }
 
 function pruneDuplicateResolutions() {
@@ -411,11 +433,11 @@ async function loadDuplicateTargetBookLabels() {
     missingTargetIds.map(async (targetBookId) => {
       try {
         const response = await api(`/api/v1/books/${targetBookId}`)
-        if (!response.ok) return [targetBookId, `Library book #${targetBookId}`] as const
+        if (!response.ok) return [targetBookId, t('settings.admin.migration.libraryBookNum', { id: targetBookId })] as const
         const payload = asRecord(await response.json())
-        return [targetBookId, asString(payload.title) ?? `Library book #${targetBookId}`] as const
+        return [targetBookId, asString(payload.title) ?? t('settings.admin.migration.libraryBookNum', { id: targetBookId })] as const
       } catch {
-        return [targetBookId, `Library book #${targetBookId}`] as const
+        return [targetBookId, t('settings.admin.migration.libraryBookNum', { id: targetBookId })] as const
       }
     }),
   )
@@ -473,7 +495,7 @@ const migrationProgress = computed(() => {
   if (!currentRun || currentRun.state !== 'running') return null
 
   const currentStage = currentRun.currentStage ?? 'init'
-  if (currentStage === 'completed') return { percent: 100, label: 'Completed' }
+  if (currentStage === 'completed') return { percent: 100, label: t('settings.admin.migration.stageCompleted') }
 
   const stageIdx = STAGE_NAMES.indexOf(currentStage as (typeof STAGE_NAMES)[number])
   const completedStages = stageIdx >= 0 ? stageIdx : 0
@@ -481,10 +503,10 @@ const migrationProgress = computed(() => {
   const percent = Math.min(Math.round(completedStages * stageWeight + stageWeight * 0.5), 99)
 
   const stageLabels: Record<string, string> = {
-    init: 'Initializing',
-    shared_overlays: 'Importing metadata',
-    book_covers: 'Importing covers',
-    user_state: 'Importing user data',
+    init: t('settings.admin.migration.stageInit'),
+    shared_overlays: t('settings.admin.migration.stageSharedOverlays'),
+    book_covers: t('settings.admin.migration.stageBookCovers'),
+    user_state: t('settings.admin.migration.stageUserState'),
   }
 
   return { percent, label: stageLabels[currentStage] ?? currentStage }
@@ -549,7 +571,7 @@ async function initialize() {
     await Promise.all([loadSupportedTypes(), loadTargetUsers(), loadTargetLibraryFolders()])
     await refreshWorkflowState()
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to initialize migration settings'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorInitialize')))
   } finally {
     loading.value = false
   }
@@ -560,7 +582,7 @@ async function loadSupportedTypes() {
     supportedTypes.value = await listSupportedSourceTypes()
   } catch (error) {
     supportedTypes.value = []
-    toast.error(getErrorMessage(error, 'Failed to load supported migration source types'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorLoadSourceTypes')))
   }
 }
 
@@ -570,7 +592,7 @@ async function loadTargetUsers() {
     targetUsers.value = await listTargetUsers()
   } catch (error) {
     targetUsers.value = []
-    toast.error(getErrorMessage(error, 'Failed to load target users'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorLoadTargetUsers')))
   } finally {
     busy.loadingTargetUsers = false
   }
@@ -581,7 +603,7 @@ async function loadTargetLibraryFolders() {
     targetLibraryFolders.value = await listTargetLibraryFolders()
   } catch (error) {
     targetLibraryFolders.value = []
-    toast.error(getErrorMessage(error, 'Failed to load target library folders'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorLoadLibraryFolders')))
   }
 }
 
@@ -653,14 +675,14 @@ async function hydrateUserMappingsFromSuggestions(showSuccessToast: boolean) {
 
     if (showSuccessToast) {
       if (userMappings.value.length === 0) {
-        toast.warning('No source users were returned')
+        toast.warning(t('settings.admin.migration.noSourceUsersReturned'))
       } else {
-        toast.success('User mapping suggestions loaded')
+        toast.success(t('settings.admin.migration.userMappingSuggestionsLoaded'))
       }
     }
   } catch (error) {
     if (showSuccessToast) {
-      toast.error(getErrorMessage(error, 'Failed to load user mapping suggestions'))
+      toast.error(getErrorMessage(error, t('settings.admin.migration.errorLoadSuggestions')))
     }
   } finally {
     busy.loadingSuggestions = false
@@ -693,7 +715,7 @@ function extractMediaPathWarnings(result: Record<string, unknown>): string[] {
 
 async function onTestSource() {
   if (!hasValidSourceDraft()) {
-    toast.error('Host, user, database, and source name are required')
+    toast.error(t('settings.admin.migration.requiredFields'))
     return
   }
 
@@ -705,15 +727,17 @@ async function onTestSource() {
     if (result.ok === true) {
       if (warnings.length > 0) {
         const mediaPathWarning = warnings.find((warning) => /mediarootpath/i.test(warning))
-        const highlightedWarning = mediaPathWarning ?? warnings[0] ?? 'Connection test passed with warnings'
+        const highlightedWarning = mediaPathWarning ?? warnings[0] ?? t('settings.admin.migration.connectionTestPassedWithWarnings')
         toast.warning(
-          warnings.length === 1 ? highlightedWarning : `Connection test passed with ${warnings.length} warning(s). First: ${highlightedWarning}`,
+          warnings.length === 1
+            ? highlightedWarning
+            : t('settings.admin.migration.connectionTestPassedWithCount', { count: warnings.length, first: highlightedWarning }),
         )
       } else {
-        toast.success('Connection test passed')
+        toast.success(t('settings.admin.migration.connectionTestPassed'))
       }
     } else {
-      toast.warning(`Connection ok, but ${missing} required table(s) are missing`)
+      toast.warning(t('settings.admin.migration.connectionOkMissingTables', { count: missing }))
     }
   } catch (error) {
     toast.error(friendlyConnectionError(error))
@@ -724,24 +748,24 @@ async function onTestSource() {
 
 async function onTestMediaPath() {
   if (hasActiveRun.value) {
-    toast.error('Cannot test media path while a run is active')
+    toast.error(t('settings.admin.migration.cannotTestMediaPathActiveRun'))
     return
   }
   if (!hasValidSourceDraft()) {
-    toast.error('Host, user, database, and source name are required')
+    toast.error(t('settings.admin.migration.requiredFields'))
     return
   }
   const mediaRootPath = sourceDraft.mediaRootPath.trim()
   if (!mediaRootPath) {
     mediaPathTestState.value = 'fail'
-    const message = 'Media Root Path is required for cover import.'
+    const message = t('settings.admin.migration.mediaRootPathRequiredCover')
     mediaPathTestMessage.value = message
     toast.error(message)
     return
   }
   if (!mediaRootPath.startsWith('/')) {
     mediaPathTestState.value = 'fail'
-    const message = 'Use an absolute path (for example: /books).'
+    const message = t('settings.admin.migration.useAbsolutePath')
     mediaPathTestMessage.value = message
     toast.error(message)
     return
@@ -753,16 +777,16 @@ async function onTestMediaPath() {
     const mediaWarnings = extractMediaPathWarnings(result)
     if (result.ok === true && mediaWarnings.length === 0) {
       mediaPathTestState.value = 'pass'
-      mediaPathTestMessage.value = 'Media path verified.'
-      toast.success('Media path is valid and readable')
+      mediaPathTestMessage.value = t('settings.admin.migration.mediaPathVerified')
+      toast.success(t('settings.admin.migration.mediaPathValidReadable'))
     } else if (mediaWarnings.length > 0) {
       mediaPathTestState.value = 'fail'
-      const message = mediaWarnings[0] ?? 'Media path validation failed.'
+      const message = mediaWarnings[0] ?? t('settings.admin.migration.mediaPathValidationFailed')
       mediaPathTestMessage.value = message
       toast.warning(message)
     } else {
       mediaPathTestState.value = 'fail'
-      const message = 'Connection test failed before media path validation could complete.'
+      const message = t('settings.admin.migration.connectionFailedBeforeMediaPath')
       mediaPathTestMessage.value = message
       toast.warning(message)
     }
@@ -778,11 +802,11 @@ async function onTestMediaPath() {
 
 async function onSaveAndValidate() {
   if (hasActiveRun.value) {
-    toast.error('Cannot modify source while a run is active')
+    toast.error(t('settings.admin.migration.cannotModifySourceActiveRun'))
     return
   }
   if (!hasValidSourceDraft()) {
-    toast.error('Host, user, database, and source name are required')
+    toast.error(t('settings.admin.migration.requiredFields'))
     return
   }
 
@@ -801,10 +825,14 @@ async function onSaveAndValidate() {
       const warnings = Array.isArray(result.warnings) ? (result.warnings as unknown[]).filter((w): w is string => typeof w === 'string') : []
       await refreshWorkflowState()
       await autoLoadPathPrefixes()
-      toast.success(warnings.length > 0 ? `Source saved and validated with ${warnings.length} warning(s)` : 'Source saved and validated')
+      toast.success(
+        warnings.length > 0
+          ? t('settings.admin.migration.sourceSavedValidatedWarnings', { count: warnings.length })
+          : t('settings.admin.migration.sourceSavedValidated'),
+      )
     }
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to save or validate source'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorSaveValidateSource')))
   } finally {
     busy.savingSource = false
   }
@@ -854,22 +882,22 @@ function cleanedUserMappings() {
 
 async function onSaveMappings() {
   if (hasActiveRun.value) {
-    toast.error('Cannot save mappings while a run is active')
+    toast.error(t('settings.admin.migration.cannotSaveMappingsActiveRun'))
     return
   }
   const currentSource = source.value
   if (!currentSource) {
-    toast.error('Save source first')
+    toast.error(t('settings.admin.migration.saveSourceFirst'))
     return
   }
 
   const mappings = cleanedUserMappings()
   if (mappings.length === 0) {
-    toast.error('Map at least one source user to a target user')
+    toast.error(t('settings.admin.migration.mapAtLeastOneUser'))
     return
   }
   if (mappings.length !== userMappings.value.length) {
-    toast.error('Map every source user before saving')
+    toast.error(t('settings.admin.migration.mapEveryUser'))
     return
   }
 
@@ -880,7 +908,7 @@ async function onSaveMappings() {
       try {
         pathValidation.value = await validatePathMappings(currentSource.id, { pathMappings: cleanedPaths, sampleLimit: 10 })
       } catch (pathError) {
-        toast.warning(getErrorMessage(pathError, 'Path validation failed, but profile will still be saved'))
+        toast.warning(getErrorMessage(pathError, t('settings.admin.migration.pathValidationFailedProfileSaved')))
       }
     }
 
@@ -898,9 +926,9 @@ async function onSaveMappings() {
       },
     })
     await refreshWorkflowState()
-    toast.success('Mappings saved')
+    toast.success(t('settings.admin.migration.mappingsSaved'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to save mappings'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorSaveMappings')))
   } finally {
     busy.savingProfile = false
   }
@@ -908,12 +936,12 @@ async function onSaveMappings() {
 
 async function onRunDryRun() {
   if (hasActiveRun.value) {
-    toast.error('Cannot run dry-run while a run is active')
+    toast.error(t('settings.admin.migration.cannotRunDryRunActiveRun'))
     return
   }
   const currentProfile = profile.value
   if (!currentProfile) {
-    toast.error('Save mappings first')
+    toast.error(t('settings.admin.migration.saveMappingsFirst'))
     return
   }
 
@@ -923,9 +951,9 @@ async function onRunDryRun() {
     await refreshWorkflowState()
     const matched = artifact.summary?.matchedBooks ?? 0
     const unresolved = artifact.summary?.unresolvedBooks ?? 0
-    toast.success(`Dry-run completed: ${matched} matched, ${unresolved} unresolved`)
+    toast.success(t('settings.admin.migration.dryRunCompleted', { matched, unresolved }))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Dry-run failed'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.dryRunFailed')))
   } finally {
     busy.dryRun = false
   }
@@ -944,7 +972,7 @@ async function onResolveDuplicates() {
 
   const unresolved = matches.filter((m) => !duplicateResolutions.value.has(m.targetBookId))
   if (unresolved.length > 0) {
-    toast.error(`Select a source book for all ${unresolved.length} duplicate groups`)
+    toast.error(t('settings.admin.migration.selectSourceForAllGroups', { count: unresolved.length }))
     return
   }
 
@@ -957,9 +985,9 @@ async function onResolveDuplicates() {
     await resolveDuplicateMatches(currentPlan.id, resolutions)
     duplicateResolutions.value = new Map()
     await refreshWorkflowState()
-    toast.success('Duplicate matches resolved')
+    toast.success(t('settings.admin.migration.duplicatesResolved'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to resolve duplicates'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorResolveDuplicates')))
   } finally {
     busy.resolvingDuplicates = false
   }
@@ -969,12 +997,12 @@ const confirmingMigrationStart = ref(false)
 
 async function onStartMigration() {
   if (!preflight.value.ready) {
-    toast.error(preflight.value.issues[0] ?? 'Migration preflight not ready')
+    toast.error(preflight.value.issues[0] ?? t('settings.admin.migration.preflightNotReady'))
     return
   }
   const currentPlan = plan.value
   if (!currentPlan) {
-    toast.error('Run dry-run first')
+    toast.error(t('settings.admin.migration.runDryRunFirst'))
     return
   }
 
@@ -989,9 +1017,9 @@ async function onStartMigration() {
     await startLiveRun({ planArtifactId: currentPlan.id })
     await refreshWorkflowState()
     await refreshRunProgress()
-    toast.success('Migration run started')
+    toast.success(t('settings.admin.migration.runStarted'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to start migration'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorStartMigration')))
   } finally {
     busy.startingRun = false
   }
@@ -1008,9 +1036,9 @@ async function onCancelRun() {
   try {
     await cancelRun(currentRun.id)
     await refreshWorkflowState()
-    toast.success('Migration run cancelled')
+    toast.success(t('settings.admin.migration.runCancelled'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to cancel migration'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorCancelMigration')))
   } finally {
     busy.cancellingRun = false
   }
@@ -1023,9 +1051,9 @@ async function onRetryRun() {
   try {
     await retryRun(currentRun.id)
     await refreshWorkflowState()
-    toast.success('Migration run retried - resuming from last completed stage')
+    toast.success(t('settings.admin.migration.runRetried'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to retry migration'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorRetryMigration')))
   } finally {
     busy.retryingRun = false
   }
@@ -1042,7 +1070,7 @@ async function refreshRunProgress() {
       await refreshWorkflowState()
     }
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to load run progress'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorLoadRunProgress')))
   } finally {
     busy.loadingProgress = false
   }
@@ -1051,16 +1079,16 @@ async function refreshRunProgress() {
 async function onRefreshReport() {
   const currentRun = run.value
   if (!currentRun) {
-    toast.error('Start migration first')
+    toast.error(t('settings.admin.migration.startMigrationFirst'))
     return
   }
 
   busy.loadingReport = true
   try {
     runReport.value = await getRunReport(currentRun.id)
-    toast.success('Run report refreshed')
+    toast.success(t('settings.admin.migration.reportRefreshed'))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to load run report'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorLoadReport')))
   } finally {
     busy.loadingReport = false
   }
@@ -1081,7 +1109,7 @@ function onTogglePassword() {
 async function exportReport(format: 'json' | 'csv') {
   const currentRun = run.value
   if (!currentRun) {
-    toast.error('Start migration first')
+    toast.error(t('settings.admin.migration.startMigrationFirst'))
     return
   }
 
@@ -1089,9 +1117,9 @@ async function exportReport(format: 'json' | 'csv') {
   try {
     const exported = await exportRunReport(currentRun.id, format)
     downloadTextFile(exported.fileName, exported.content, exported.contentType)
-    toast.success(`Report exported as ${format.toUpperCase()}`)
+    toast.success(t('settings.admin.migration.reportExported', { format: format.toUpperCase() }))
   } catch (error) {
-    toast.error(getErrorMessage(error, 'Failed to export migration report'))
+    toast.error(getErrorMessage(error, t('settings.admin.migration.errorExportReport')))
   } finally {
     busy.exporting = false
   }
@@ -1122,24 +1150,24 @@ function formatDuration(ms: number): string {
 }
 
 function friendlyUnresolvedReason(reason: string | null): string {
-  if (reason === 'no_title_author_match') return 'No matching book found by title or author'
-  if (reason === 'no_file_path_match') return 'File path did not match any book in this library'
-  if (reason === 'no_file_hash_match') return 'File hash did not match any book in this library'
-  if (reason === 'no_isbn_match') return 'ISBN did not match any book in this library'
-  if (reason === 'insufficient_source_data') return 'Not enough metadata to attempt matching'
-  if (reason === 'ambiguous_isbn_match') return 'Multiple books matched the same ISBN'
-  if (reason === 'ambiguous_file_hash_match') return 'Multiple books matched the same file hash'
-  if (reason === 'ambiguous_file_path_match') return 'Multiple books matched the same file path'
-  if (reason === 'ambiguous_title_author_match') return 'Multiple books matched the same title and author'
-  return reason ?? 'Could not determine reason'
+  if (reason === 'no_title_author_match') return t('settings.admin.migration.reasonNoTitleAuthorMatch')
+  if (reason === 'no_file_path_match') return t('settings.admin.migration.reasonNoFilePathMatch')
+  if (reason === 'no_file_hash_match') return t('settings.admin.migration.reasonNoFileHashMatch')
+  if (reason === 'no_isbn_match') return t('settings.admin.migration.reasonNoIsbnMatch')
+  if (reason === 'insufficient_source_data') return t('settings.admin.migration.reasonInsufficientSourceData')
+  if (reason === 'ambiguous_isbn_match') return t('settings.admin.migration.reasonAmbiguousIsbnMatch')
+  if (reason === 'ambiguous_file_hash_match') return t('settings.admin.migration.reasonAmbiguousFileHashMatch')
+  if (reason === 'ambiguous_file_path_match') return t('settings.admin.migration.reasonAmbiguousFilePathMatch')
+  if (reason === 'ambiguous_title_author_match') return t('settings.admin.migration.reasonAmbiguousTitleAuthorMatch')
+  return reason ?? t('settings.admin.migration.reasonUnknown')
 }
 
 function friendlyMatchStrategy(strategy: string | null): string {
-  if (strategy === 'isbn') return 'Matched by ISBN'
-  if (strategy === 'file_hash') return 'Matched by file hash'
-  if (strategy === 'path_mapping') return 'Matched by mapped file path'
-  if (strategy === 'title_author') return 'Matched by title and author'
-  return strategy ?? 'Match strategy unavailable'
+  if (strategy === 'isbn') return t('settings.admin.migration.strategyIsbn')
+  if (strategy === 'file_hash') return t('settings.admin.migration.strategyFileHash')
+  if (strategy === 'path_mapping') return t('settings.admin.migration.strategyPathMapping')
+  if (strategy === 'title_author') return t('settings.admin.migration.strategyTitleAuthor')
+  return strategy ?? t('settings.admin.migration.strategyUnavailable')
 }
 
 function describeUserPreviewCounts(counts: {
@@ -1149,7 +1177,13 @@ function describeUserPreviewCounts(counts: {
   annotations: number
   shelves: number
 }): string {
-  return `${counts.statuses} statuses, ${counts.fileProgress} progress entries, ${counts.bookmarks} bookmarks, ${counts.annotations} annotations, ${counts.shelves} collection entries`
+  return t('settings.admin.migration.userPreviewCounts', {
+    statuses: counts.statuses,
+    progress: counts.fileProgress,
+    bookmarks: counts.bookmarks,
+    annotations: counts.annotations,
+    collections: counts.shelves,
+  })
 }
 
 function extractPlanUnresolvedBooks(planPayload: unknown): ReportUnresolvedBook[] {
@@ -1173,11 +1207,11 @@ function extractPlanUnresolvedBooks(planPayload: unknown): ReportUnresolvedBook[
 
 function friendlyConnectionError(error: unknown): string {
   const msg = error instanceof Error ? error.message : String(error)
-  if (/ECONNREFUSED|ENOTFOUND|connect ETIMEDOUT/i.test(msg)) return 'Could not reach the database server. Check the host and port.'
-  if (/Access denied|authentication failed/i.test(msg)) return 'Authentication failed. Check the username and password.'
-  if (/Unknown database/i.test(msg)) return 'Database not found. Check the database name.'
-  if (/ETIMEDOUT|timeout/i.test(msg)) return 'Connection timed out. Check host and firewall settings.'
-  return msg || 'Connection test failed'
+  if (/ECONNREFUSED|ENOTFOUND|connect ETIMEDOUT/i.test(msg)) return t('settings.admin.migration.connErrorUnreachable')
+  if (/Access denied|authentication failed/i.test(msg)) return t('settings.admin.migration.connErrorAuth')
+  if (/Unknown database/i.test(msg)) return t('settings.admin.migration.connErrorUnknownDatabase')
+  if (/ETIMEDOUT|timeout/i.test(msg)) return t('settings.admin.migration.connErrorTimeout')
+  return msg || t('settings.admin.migration.connErrorGeneric')
 }
 
 function runStateClass(state: string) {
@@ -1244,10 +1278,7 @@ function formatSourceCountLabel(key: string) {
 </script>
 
 <template>
-  <SettingsPageHeader
-    title="Migration"
-    subtitle="One-time Booklore import: connect source, map users, dry-run, start migration, and export a report."
-  />
+  <SettingsPageHeader :title="t('settings.admin.migration.title')" :subtitle="t('settings.admin.migration.subtitle')" />
 
   <div v-if="loading" class="flex items-center justify-center py-16">
     <Loader2 class="size-5 animate-spin text-muted-foreground" />
@@ -1256,7 +1287,7 @@ function formatSourceCountLabel(key: string) {
   <div v-else class="flex gap-10 items-start">
     <!-- Sidebar stepper (desktop) -->
     <aside class="hidden lg:block w-44 shrink-0 pt-1">
-      <p class="settings-group-label mb-2">Progress</p>
+      <p class="settings-group-label mb-2">{{ t('settings.admin.migration.progress') }}</p>
       <MigrationStepper :steps="stepperSteps" :active-index="currentStep" @step-click="onStepClick" />
     </aside>
 
@@ -1294,35 +1325,37 @@ function formatSourceCountLabel(key: string) {
           <div v-if="currentStep === 0" class="space-y-3">
             <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
               <label class="block">
-                <span class="settings-hint">Source Type</span>
+                <span class="settings-hint">{{ t('settings.admin.migration.sourceType') }}</span>
                 <select v-model="sourceDraft.type" class="select-field mt-1 w-full" :disabled="hasActiveRun">
                   <option v-for="type in supportedTypes" :key="type" :value="type">{{ type }}</option>
                 </select>
               </label>
               <label class="block">
-                <span class="settings-hint">Source Name</span>
+                <span class="settings-hint">{{ t('settings.admin.migration.sourceName') }}</span>
                 <input v-model="sourceDraft.name" class="input-field mt-1 w-full" placeholder="Booklore Import" :disabled="hasActiveRun" />
               </label>
               <label class="block">
-                <span class="settings-hint">Host</span>
+                <span class="settings-hint">{{ t('settings.admin.migration.host') }}</span>
                 <input v-model="sourceDraft.host" class="input-field mt-1 w-full" placeholder="127.0.0.1" :disabled="hasActiveRun" />
               </label>
               <label class="block">
-                <span class="settings-hint">Port</span>
+                <span class="settings-hint">{{ t('settings.admin.migration.port') }}</span>
                 <input v-model.number="sourceDraft.port" class="input-field mt-1 w-full" type="number" min="1" max="65535" :disabled="hasActiveRun" />
               </label>
               <label class="block">
-                <span class="settings-hint">User</span>
+                <span class="settings-hint">{{ t('settings.admin.migration.user') }}</span>
                 <input v-model="sourceDraft.user" class="input-field mt-1 w-full" placeholder="booklore" :disabled="hasActiveRun" />
               </label>
               <label class="block">
-                <span class="settings-hint">Password</span>
+                <span class="settings-hint">{{ t('settings.admin.migration.password') }}</span>
                 <div class="relative mt-1">
                   <input
                     v-model="sourceDraft.password"
                     class="input-field w-full pr-9"
                     :type="showPassword ? 'text' : 'password'"
-                    :placeholder="source ? 'Saved - leave unchanged' : 'No password set'"
+                    :placeholder="
+                      source ? t('settings.admin.migration.passwordSavedPlaceholder') : t('settings.admin.migration.passwordEmptyPlaceholder')
+                    "
                     :disabled="hasActiveRun"
                   />
                   <button
@@ -1337,11 +1370,11 @@ function formatSourceCountLabel(key: string) {
                 </div>
               </label>
               <label class="block">
-                <span class="settings-hint">Database</span>
+                <span class="settings-hint">{{ t('settings.admin.migration.database') }}</span>
                 <input v-model="sourceDraft.database" class="input-field mt-1 w-full" placeholder="booklore" :disabled="hasActiveRun" />
               </label>
               <label class="block md:col-span-2 xl:col-span-2">
-                <span class="settings-hint">Media Root Path</span>
+                <span class="settings-hint">{{ t('settings.admin.migration.mediaRootPath') }}</span>
                 <div class="mt-1 flex items-center gap-2">
                   <input v-model="sourceDraft.mediaRootPath" class="input-field w-full" placeholder="/data/booklore/media" :disabled="hasActiveRun" />
                   <button
@@ -1359,7 +1392,13 @@ function formatSourceCountLabel(key: string) {
                   >
                     <Loader2 v-if="busy.testingMediaPath" class="size-3.5 animate-spin" />
                     <span v-else>
-                      {{ mediaPathTestState === 'pass' ? 'Path OK' : mediaPathTestState === 'fail' ? 'Path Issue' : 'Test Path' }}
+                      {{
+                        mediaPathTestState === 'pass'
+                          ? t('settings.admin.migration.pathOk')
+                          : mediaPathTestState === 'fail'
+                            ? t('settings.admin.migration.pathIssue')
+                            : t('settings.admin.migration.testPath')
+                      }}
                     </span>
                   </button>
                 </div>
@@ -1371,7 +1410,7 @@ function formatSourceCountLabel(key: string) {
               <div class="flex items-center">
                 <label class="flex h-9 cursor-pointer items-center gap-2">
                   <input v-model="sourceDraft.ssl" type="checkbox" class="size-4 rounded border-border" :disabled="hasActiveRun" />
-                  <span class="settings-hint">Use TLS/SSL</span>
+                  <span class="settings-hint">{{ t('settings.admin.migration.useTls') }}</span>
                 </label>
               </div>
             </div>
@@ -1379,11 +1418,11 @@ function formatSourceCountLabel(key: string) {
             <div class="flex flex-wrap gap-2">
               <button class="settings-btn-outline" :disabled="busy.testingSource || hasActiveRun" @click="onTestSource">
                 <Loader2 v-if="busy.testingSource" class="size-3.5 animate-spin" />
-                Test Connection
+                {{ t('settings.admin.migration.testConnection') }}
               </button>
               <button class="settings-btn-primary" :disabled="busy.savingSource || hasActiveRun" @click="onSaveAndValidate">
                 <Loader2 v-if="busy.savingSource" class="size-3.5 animate-spin" />
-                Save &amp; Validate
+                {{ t('settings.admin.migration.saveAndValidate') }}
               </button>
             </div>
 
@@ -1391,15 +1430,19 @@ function formatSourceCountLabel(key: string) {
               v-if="sourceValidationWarnings.length > 0"
               class="rounded border border-amber-500/20 bg-amber-500/10 p-3 text-xs text-amber-700 space-y-1"
             >
-              <p class="font-medium">Source validated with warnings</p>
+              <p class="font-medium">{{ t('settings.admin.migration.sourceValidatedWithWarnings') }}</p>
               <p v-for="warn in sourceValidationWarnings" :key="warn">{{ warn }}</p>
             </div>
 
             <div v-if="sourceCapabilities" class="rounded border border-border bg-muted/40 p-3 text-xs space-y-2">
-              <p class="font-medium text-foreground">Last validation snapshot</p>
-              <p class="text-muted-foreground">Source version: {{ sourceCapabilities.sourceVersion ?? 'Unknown' }}</p>
+              <p class="font-medium text-foreground">{{ t('settings.admin.migration.lastValidationSnapshot') }}</p>
+              <p class="text-muted-foreground">
+                {{
+                  t('settings.admin.migration.sourceVersion', { version: sourceCapabilities.sourceVersion ?? t('settings.admin.migration.unknown') })
+                }}
+              </p>
               <p v-if="sourceCapabilities.missingTables.length > 0" class="text-amber-600">
-                Missing required tables: {{ sourceCapabilities.missingTables.join(', ') }}
+                {{ t('settings.admin.migration.missingRequiredTables', { tables: sourceCapabilities.missingTables.join(', ') }) }}
               </p>
               <div v-if="sourceRowCounts.length > 0" class="grid gap-1 text-muted-foreground sm:grid-cols-2 xl:grid-cols-3">
                 <p v-for="[key, count] in sourceRowCounts" :key="key">{{ formatSourceCountLabel(key) }}: {{ count }}</p>
@@ -1410,7 +1453,7 @@ function formatSourceCountLabel(key: string) {
           <!-- Step 1: User & Path Mapping -->
           <div v-else-if="currentStep === 1" class="space-y-5">
             <div class="flex items-center gap-2">
-              <p class="text-xs text-muted-foreground">User suggestions load automatically after source validation.</p>
+              <p class="text-xs text-muted-foreground">{{ t('settings.admin.migration.suggestionsAutoLoad') }}</p>
               <button
                 v-if="source"
                 class="text-xs text-primary underline-offset-2 hover:underline disabled:opacity-50"
@@ -1418,7 +1461,7 @@ function formatSourceCountLabel(key: string) {
                 @click="onReloadSuggestions"
               >
                 <Loader2 v-if="busy.loadingSuggestions || busy.loadingTargetUsers" class="size-3 animate-spin inline" />
-                Refresh
+                {{ t('settings.admin.migration.refresh') }}
               </button>
             </div>
 
@@ -1426,8 +1469,8 @@ function formatSourceCountLabel(key: string) {
               <table class="w-full text-sm">
                 <thead class="bg-muted/40 text-left">
                   <tr>
-                    <th class="px-3 py-2 font-medium">Source User</th>
-                    <th class="px-3 py-2 font-medium">Target User</th>
+                    <th class="px-3 py-2 font-medium">{{ t('settings.admin.migration.sourceUser') }}</th>
+                    <th class="px-3 py-2 font-medium">{{ t('settings.admin.migration.targetUser') }}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1441,63 +1484,74 @@ function formatSourceCountLabel(key: string) {
                     </td>
                   </tr>
                   <tr v-if="userMappings.length === 0" class="border-t border-border">
-                    <td colspan="2" class="px-3 py-4 text-sm text-muted-foreground">No source users loaded yet.</td>
+                    <td colspan="2" class="px-3 py-4 text-sm text-muted-foreground">{{ t('settings.admin.migration.noSourceUsersLoaded') }}</td>
                   </tr>
                 </tbody>
               </table>
             </div>
             <p v-if="!busy.loadingTargetUsers && targetUsers.length === 0" class="text-xs text-amber-600">
-              No active target users found. Create or re-enable a BookOrbit user before mapping.
+              {{ t('settings.admin.migration.noActiveTargetUsers') }}
             </p>
 
             <div class="space-y-2">
               <div class="flex items-center justify-between">
-                <p class="settings-hint">Path Prefix Mappings</p>
-                <button class="settings-btn-outline" :disabled="hasActiveRun" @click="addPathMapping">Add Mapping</button>
+                <p class="settings-hint">{{ t('settings.admin.migration.pathPrefixMappings') }}</p>
+                <button class="settings-btn-outline" :disabled="hasActiveRun" @click="addPathMapping">
+                  {{ t('settings.admin.migration.addMapping') }}
+                </button>
               </div>
               <p class="text-xs text-muted-foreground">
-                Path mappings translate source file paths to target paths so books can be matched by file location. For example, if your Booklore
-                library stored files under <code class="font-mono">/books/Large</code> and the same files now live under
-                <code class="font-mono">/srv/bookorbit/books/Large</code>, add that mapping here. Books are also matched by ISBN, file hash, and
-                title/author regardless of path mappings - path mapping is only one of four strategies and does not limit which source books are
-                included in the migration.
+                {{ t('settings.admin.migration.pathMappingsHelp1') }} <code class="font-mono">/books/Large</code>
+                {{ t('settings.admin.migration.pathMappingsHelp2') }} <code class="font-mono">/srv/bookorbit/books/Large</code
+                >{{ t('settings.admin.migration.pathMappingsHelp3') }}
               </p>
 
               <div v-for="(row, index) in pathMappings" :key="index" class="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-center">
                 <select v-model="row.sourcePrefix" class="select-field w-full min-w-0" :disabled="hasActiveRun">
                   <option value="">
-                    {{ sourcePathPrefixes.length === 0 ? 'No prefixes found - validate source first' : 'Select source prefix...' }}
+                    {{
+                      sourcePathPrefixes.length === 0
+                        ? t('settings.admin.migration.noPrefixesFound')
+                        : t('settings.admin.migration.selectSourcePrefix')
+                    }}
                   </option>
                   <option v-for="prefix in sourcePathPrefixes" :key="prefix" :value="prefix">{{ prefix }}</option>
                 </select>
 
                 <select v-model="row.targetPrefix" class="select-field w-full min-w-0" :disabled="hasActiveRun">
-                  <option value="">Select target folder...</option>
+                  <option value="">{{ t('settings.admin.migration.selectTargetFolder') }}</option>
                   <option v-for="folder in targetLibraryFolders" :key="folder.path" :value="folder.path">
                     {{ folder.libraryName }} - {{ folder.path }}
                   </option>
                 </select>
 
-                <button class="settings-btn-outline" :disabled="hasActiveRun" @click="removePathMapping(index)">Remove</button>
+                <button class="settings-btn-outline" :disabled="hasActiveRun" @click="removePathMapping(index)">
+                  {{ t('settings.admin.migration.remove') }}
+                </button>
               </div>
             </div>
 
             <div v-if="pathValidation" class="rounded border border-border bg-muted/40 p-3 text-xs space-y-1">
-              <p class="font-medium text-foreground">Path validation</p>
+              <p class="font-medium text-foreground">{{ t('settings.admin.migration.pathValidation') }}</p>
               <p class="text-muted-foreground">
-                {{ pathValidation.summary.mappedByPrefix }} of {{ pathValidation.summary.booksWithFilePath }} source books have a mapped path
+                {{
+                  t('settings.admin.migration.pathValidationMapped', {
+                    mapped: pathValidation.summary.mappedByPrefix,
+                    total: pathValidation.summary.booksWithFilePath,
+                  })
+                }}
               </p>
               <p v-if="pathValidation.summary.unmatchedTargetPaths > 0" class="text-amber-600">
-                {{ pathValidation.summary.unmatchedTargetPaths }} mapped paths not found on disk - those books will fall back to ISBN / title matching
+                {{ t('settings.admin.migration.pathValidationUnmatched', { count: pathValidation.summary.unmatchedTargetPaths }) }}
               </p>
               <p v-else-if="pathValidation.summary.matchedTargetPaths > 0" class="text-emerald-600">
-                All {{ pathValidation.summary.matchedTargetPaths }} mapped paths found on disk
+                {{ t('settings.admin.migration.pathValidationAllMatched', { count: pathValidation.summary.matchedTargetPaths }) }}
               </p>
             </div>
 
             <button class="settings-btn-primary" :disabled="busy.savingProfile || source == null || hasActiveRun" @click="onSaveMappings">
               <Loader2 v-if="busy.savingProfile" class="size-3.5 animate-spin" />
-              Save Mappings
+              {{ t('settings.admin.migration.saveMappings') }}
             </button>
           </div>
 
@@ -1505,38 +1559,39 @@ function formatSourceCountLabel(key: string) {
           <div v-else-if="currentStep === 2" class="space-y-5">
             <button class="settings-btn-primary" :disabled="busy.dryRun || profile == null || hasActiveRun" @click="onRunDryRun">
               <Loader2 v-if="busy.dryRun" class="size-3.5 animate-spin" />
-              Run Dry-Run
+              {{ t('settings.admin.migration.runDryRun') }}
             </button>
 
             <div v-if="plan" class="rounded border border-border bg-muted/30 p-3 space-y-2 text-sm">
               <p>
-                Matched: <span class="font-medium">{{ plan.summary?.matchedBooks ?? 0 }}</span> · Unresolved:
-                <span class="font-medium">{{ plan.summary?.unresolvedBooks ?? 0 }}</span> · Duplicate matches:
+                {{ t('settings.admin.migration.matched') }} <span class="font-medium">{{ plan.summary?.matchedBooks ?? 0 }}</span> ·
+                {{ t('settings.admin.migration.unresolved') }}
+                <span class="font-medium">{{ plan.summary?.unresolvedBooks ?? 0 }}</span> · {{ t('settings.admin.migration.duplicateMatches') }}
                 <span class="font-medium" :class="(plan.summary?.duplicateBookMatches ?? 0) > 0 ? 'text-red-600' : ''">
                   {{ plan.summary?.duplicateBookMatches ?? 0 }}
                 </span>
               </p>
               <div v-if="unresolvedSummary.length > 0" class="space-y-1 text-xs text-muted-foreground">
-                <p class="font-medium text-foreground">Unresolved summary</p>
+                <p class="font-medium text-foreground">{{ t('settings.admin.migration.unresolvedSummary') }}</p>
                 <p v-for="[reason, count] in unresolvedSummary" :key="reason">{{ friendlyUnresolvedReason(reason) }}: {{ count }}</p>
               </div>
 
               <div v-if="duplicateMatches.length > 0" class="space-y-3 border-t border-border pt-3">
                 <div class="space-y-1">
-                  <p class="font-medium text-red-600">Resolve duplicate target matches</p>
+                  <p class="font-medium text-red-600">{{ t('settings.admin.migration.resolveDuplicateMatches') }}</p>
                   <p class="text-xs text-muted-foreground">
-                    For each target book, choose one source book to keep. Recommended choices are preselected when there is a single strongest match.
+                    {{ t('settings.admin.migration.resolveDuplicateHint') }}
                   </p>
                   <p class="text-xs text-muted-foreground">
-                    Remaining groups:
+                    {{ t('settings.admin.migration.remainingGroups') }}
                     <span class="font-medium text-foreground">{{ duplicateGroupsRemaining }}</span>
-                    of {{ duplicateMatches.length }}
+                    {{ t('settings.admin.migration.ofCount', { count: duplicateMatches.length }) }}
                   </p>
                 </div>
                 <div class="space-y-3">
                   <div v-for="dup in duplicateMatches" :key="dup.targetBookId" class="rounded border border-border bg-background p-3 space-y-2">
                     <p class="text-xs font-medium text-foreground">{{ targetBookLabel(dup.targetBookId) }}</p>
-                    <p class="text-[11px] text-muted-foreground">Target book #{{ dup.targetBookId }}</p>
+                    <p class="text-[11px] text-muted-foreground">{{ t('settings.admin.migration.targetBookNum', { id: dup.targetBookId }) }}</p>
                     <div class="space-y-1">
                       <label
                         v-for="sourceId in dup.sourceBookIds"
@@ -1562,7 +1617,7 @@ function formatSourceCountLabel(key: string) {
                             v-if="isRecommendedSourceBook(dup, sourceId)"
                             class="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-700"
                           >
-                            Recommended
+                            {{ t('settings.admin.migration.recommended') }}
                           </span>
                         </div>
                         <span class="text-muted-foreground text-[11px] whitespace-nowrap">{{
@@ -1578,7 +1633,7 @@ function formatSourceCountLabel(key: string) {
                   @click="onResolveDuplicates"
                 >
                   <Loader2 v-if="busy.resolvingDuplicates" class="size-3.5 animate-spin" />
-                  Resolve {{ duplicateMatches.length }} duplicate{{ duplicateMatches.length === 1 ? '' : 's' }}
+                  {{ t('settings.admin.migration.resolveDuplicatesButton', { count: duplicateMatches.length }, duplicateMatches.length) }}
                 </button>
               </div>
             </div>
@@ -1587,66 +1642,66 @@ function formatSourceCountLabel(key: string) {
           <!-- Step 3: Run Migration -->
           <div v-else-if="currentStep === 3" class="space-y-5">
             <div class="rounded border border-border bg-muted/20 p-3 text-xs space-y-1.5">
-              <p class="font-medium text-foreground">Preflight checks</p>
-              <p v-if="preflight.ready" class="text-emerald-600">All checks passed - ready to migrate</p>
+              <p class="font-medium text-foreground">{{ t('settings.admin.migration.preflightChecks') }}</p>
+              <p v-if="preflight.ready" class="text-emerald-600">{{ t('settings.admin.migration.allChecksPassed') }}</p>
               <template v-else>
                 <div v-if="preflight.sourceValidated" class="flex items-center gap-1.5 text-emerald-600">
                   <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />
-                  Source validated
+                  {{ t('settings.admin.migration.checkSourceValidated') }}
                 </div>
                 <div v-else class="flex items-center gap-1.5 text-muted-foreground">
                   <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />
-                  {{ !source ? 'Save and validate source connection' : 'Validate source connection' }}
+                  {{ !source ? t('settings.admin.migration.checkSaveValidateSource') : t('settings.admin.migration.checkValidateSource') }}
                 </div>
                 <div v-if="profile" class="flex items-center gap-1.5 text-emerald-600">
                   <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />
-                  Mappings saved
+                  {{ t('settings.admin.migration.checkMappingsSaved') }}
                 </div>
                 <div v-else class="flex items-center gap-1.5 text-muted-foreground">
                   <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />
-                  Save user and path mappings
+                  {{ t('settings.admin.migration.checkSaveMappings') }}
                 </div>
                 <div v-if="profile && preflight.pathMappingsValidated" class="flex items-center gap-1.5 text-emerald-600">
                   <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />
-                  Path mappings validated
+                  {{ t('settings.admin.migration.checkPathMappingsValidated') }}
                 </div>
                 <div v-else-if="profile" class="flex items-center gap-1.5 text-muted-foreground">
                   <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />
-                  Save path mappings to validate them
+                  {{ t('settings.admin.migration.checkSavePathMappings') }}
                 </div>
                 <div v-if="preflight.dryRunFresh" class="flex items-center gap-1.5 text-emerald-600">
                   <span class="size-1.5 rounded-full bg-emerald-500 flex-none" />
-                  Dry-run is up to date
+                  {{ t('settings.admin.migration.checkDryRunUpToDate') }}
                 </div>
                 <div v-else class="flex items-center gap-1.5 text-muted-foreground">
                   <span class="size-1.5 rounded-full bg-muted-foreground/40 flex-none" />
-                  Run a fresh dry-run
+                  {{ t('settings.admin.migration.checkFreshDryRun') }}
                 </div>
               </template>
             </div>
 
             <div class="flex flex-wrap gap-2">
               <template v-if="confirmingMigrationStart">
-                <span class="text-xs text-amber-600 self-center">This will start the live migration. Are you sure?</span>
+                <span class="text-xs text-amber-600 self-center">{{ t('settings.admin.migration.startConfirmPrompt') }}</span>
                 <button class="settings-btn-primary" :disabled="busy.startingRun" @click="onStartMigration">
                   <Loader2 v-if="busy.startingRun" class="size-3.5 animate-spin" />
-                  Confirm Start
+                  {{ t('settings.admin.migration.confirmStart') }}
                 </button>
-                <button class="settings-btn-outline" @click="onCancelMigrationStart">Cancel</button>
+                <button class="settings-btn-outline" @click="onCancelMigrationStart">{{ t('common.cancel') }}</button>
               </template>
               <template v-else>
                 <button class="settings-btn-primary" :disabled="busy.startingRun || !preflight.ready" @click="onStartMigration">
                   <Loader2 v-if="busy.startingRun" class="size-3.5 animate-spin" />
-                  Start Migration
+                  {{ t('settings.admin.migration.startMigration') }}
                 </button>
               </template>
               <button v-if="run?.state === 'running'" class="settings-btn-outline text-red-600" :disabled="busy.cancellingRun" @click="onCancelRun">
                 <Loader2 v-if="busy.cancellingRun" class="size-3.5 animate-spin" />
-                Cancel Run
+                {{ t('settings.admin.migration.cancelRun') }}
               </button>
               <button class="settings-btn-outline" :disabled="busy.loadingProgress || run == null" @click="refreshRunProgress">
                 <Loader2 v-if="busy.loadingProgress" class="size-3.5 animate-spin" />
-                Refresh Status
+                {{ t('settings.admin.migration.refreshStatus') }}
               </button>
             </div>
 
@@ -1654,8 +1709,8 @@ function formatSourceCountLabel(key: string) {
               v-if="pollingError"
               class="rounded border border-amber-500/20 bg-amber-500/10 px-3 py-2 flex items-center gap-2 text-xs text-amber-700"
             >
-              <span>Status polling stopped due to an error.</span>
-              <button class="underline font-medium" @click="onRetryPolling">Retry</button>
+              <span>{{ t('settings.admin.migration.statusPollingStopped') }}</span>
+              <button class="underline font-medium" @click="onRetryPolling">{{ t('settings.admin.migration.retry') }}</button>
             </div>
 
             <div v-if="run" class="rounded border border-border bg-muted/30 px-4 py-3.5 flex items-center gap-3 text-xs">
@@ -1663,14 +1718,14 @@ function formatSourceCountLabel(key: string) {
               <span class="text-muted-foreground">
                 {{
                   run.state === 'running'
-                    ? `Stage: ${run.currentStage ?? 'initializing'}`
+                    ? t('settings.admin.migration.stageLabel', { stage: run.currentStage ?? t('settings.admin.migration.stageInitializing') })
                     : run.endedAt
-                      ? `Ended ${new Date(run.endedAt).toLocaleString()}`
+                      ? t('settings.admin.migration.endedLabel', { date: new Date(run.endedAt).toLocaleString() })
                       : ''
                 }}
               </span>
               <button v-if="run.state !== 'running'" class="text-xs text-primary underline-offset-2 hover:underline ml-auto" @click="goNext">
-                View Report
+                {{ t('settings.admin.migration.viewReport') }}
               </button>
             </div>
 
@@ -1690,40 +1745,44 @@ function formatSourceCountLabel(key: string) {
 
           <!-- Step 4: Migration Report -->
           <div v-else-if="currentStep === 4" class="space-y-5">
-            <p v-if="!run" class="text-sm text-muted-foreground">No migration run yet. Complete the steps above to start.</p>
+            <p v-if="!run" class="text-sm text-muted-foreground">{{ t('settings.admin.migration.noRunYet') }}</p>
 
             <template v-else>
               <!-- Run header -->
               <div class="flex flex-wrap items-start justify-between gap-3">
                 <div class="space-y-0.5">
                   <p class="flex items-center gap-2 text-sm font-medium">
-                    Run #{{ run.id }}
+                    {{ t('settings.admin.migration.runNum', { id: run.id }) }}
                     <span class="inline-flex rounded-full border px-2 py-0.5 text-xs" :class="runStateClass(run.state)">{{ run.state }}</span>
                   </p>
                   <p class="text-xs text-muted-foreground">
-                    {{ run.startedAt ? new Date(run.startedAt).toLocaleString() : 'Not started' }}
+                    {{ run.startedAt ? new Date(run.startedAt).toLocaleString() : t('settings.admin.migration.notStarted') }}
                     <template v-if="reportData.durationMs != null"> &middot; {{ formatDuration(reportData.durationMs) }}</template>
                   </p>
                 </div>
                 <div class="flex flex-wrap gap-2">
                   <button class="settings-btn-outline" :disabled="busy.loadingReport" @click="onRefreshReport">
                     <Loader2 v-if="busy.loadingReport" class="size-3.5 animate-spin" />
-                    {{ runReport ? 'Reload Report' : 'Load Full Report' }}
+                    {{ runReport ? t('settings.admin.migration.reloadReport') : t('settings.admin.migration.loadFullReport') }}
                   </button>
-                  <button class="settings-btn-outline" :disabled="busy.exporting" @click="onExportJson">Export JSON</button>
-                  <button class="settings-btn-outline" :disabled="busy.exporting" @click="onExportCsv">Export CSV</button>
+                  <button class="settings-btn-outline" :disabled="busy.exporting" @click="onExportJson">
+                    {{ t('settings.admin.migration.exportJson') }}
+                  </button>
+                  <button class="settings-btn-outline" :disabled="busy.exporting" @click="onExportCsv">
+                    {{ t('settings.admin.migration.exportCsv') }}
+                  </button>
                 </div>
               </div>
 
               <!-- Error (if failed) -->
               <div v-if="run.errorMessage" class="rounded border border-red-500/20 bg-red-500/10 p-3 text-xs text-red-700 space-y-2">
                 <div class="space-y-0.5">
-                  <p class="font-medium">Migration failed</p>
+                  <p class="font-medium">{{ t('settings.admin.migration.migrationFailed') }}</p>
                   <p>{{ run.errorMessage }}</p>
                 </div>
                 <button v-if="run.state === 'failed'" class="settings-btn-outline text-xs" :disabled="busy.retryingRun" @click="onRetryRun">
                   <Loader2 v-if="busy.retryingRun" class="size-3.5 animate-spin" />
-                  Retry from last completed stage
+                  {{ t('settings.admin.migration.retryFromLastStage') }}
                 </button>
               </div>
 
@@ -1732,37 +1791,37 @@ function formatSourceCountLabel(key: string) {
                 <div class="grid gap-3 sm:grid-cols-2">
                   <!-- Books card -->
                   <div class="rounded border border-border p-3 space-y-2">
-                    <p class="text-sm font-semibold">Books</p>
+                    <p class="text-sm font-semibold">{{ t('settings.admin.migration.booksCard') }}</p>
                     <div class="space-y-1.5 text-xs">
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Metadata overlays applied</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.metadataOverlaysApplied') }}</span>
                         <span class="font-medium">{{ reportData.bookMetadata?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Author mappings replaced</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.authorMappingsReplaced') }}</span>
                         <span class="font-medium">{{ reportData.bookAuthors?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Narrator mappings replaced</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.narratorMappingsReplaced') }}</span>
                         <span class="font-medium">{{ reportData.bookNarrators?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Genre mappings replaced</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.genreMappingsReplaced') }}</span>
                         <span class="font-medium">{{ reportData.bookGenres?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Tag mappings replaced</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.tagMappingsReplaced') }}</span>
                         <span class="font-medium">{{ reportData.bookTags?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between" :class="reportData.coversSkippedAll ? 'text-amber-600' : ''">
-                        <span>Covers imported</span>
+                        <span>{{ t('settings.admin.migration.coversImported') }}</span>
                         <span class="font-medium">{{ reportData.bookCovers?.imported ?? 0 }}</span>
                       </div>
                       <p v-if="reportData.coversSkippedAll" class="text-amber-600 leading-tight">
-                        Cover import was skipped - media root path is not configured on the source
+                        {{ t('settings.admin.migration.coverImportSkipped') }}
                       </p>
                       <div v-if="reportData.unresolvedBooks.length > 0" class="flex justify-between text-amber-600">
-                        <span>Could not match</span>
+                        <span>{{ t('settings.admin.migration.couldNotMatch') }}</span>
                         <span class="font-medium">{{ reportData.unresolvedBooks.length }}</span>
                       </div>
                     </div>
@@ -1770,30 +1829,30 @@ function formatSourceCountLabel(key: string) {
 
                   <!-- User data card -->
                   <div class="rounded border border-border p-3 space-y-2">
-                    <p class="text-sm font-semibold">User Data</p>
+                    <p class="text-sm font-semibold">{{ t('settings.admin.migration.userDataCard') }}</p>
                     <div class="space-y-1.5 text-xs">
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Reading statuses</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.readingStatuses') }}</span>
                         <span class="font-medium">{{ reportData.userBookStatus?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Reading progress entries</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.readingProgressEntries') }}</span>
                         <span class="font-medium">{{ reportData.readingProgress?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Audiobook progress entries</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.audiobookProgressEntries') }}</span>
                         <span class="font-medium">{{ reportData.audiobookProgress?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Bookmarks</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.bookmarksLabel') }}</span>
                         <span class="font-medium">{{ reportData.bookmarks?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Annotations</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.annotationsLabel') }}</span>
                         <span class="font-medium">{{ reportData.annotations?.imported ?? 0 }}</span>
                       </div>
                       <div class="flex justify-between">
-                        <span class="text-muted-foreground">Collection entries</span>
+                        <span class="text-muted-foreground">{{ t('settings.admin.migration.collectionEntries') }}</span>
                         <span class="font-medium">{{ reportData.collections?.imported ?? 0 }}</span>
                       </div>
                     </div>
@@ -1801,7 +1860,7 @@ function formatSourceCountLabel(key: string) {
                 </div>
 
                 <p v-if="!runReport && (run.state === 'completed' || run.state === 'failed')" class="text-xs text-muted-foreground">
-                  Click "Load Full Report" to include the dry-run match summary in the exported report.
+                  {{ t('settings.admin.migration.loadFullReportHint') }}
                 </p>
               </template>
 
@@ -1811,14 +1870,16 @@ function formatSourceCountLabel(key: string) {
                   v-if="run.state === 'completed' && reportData.unresolvedBooks.length === 0 && reportData.coverFailureCount === 0"
                   class="rounded border border-emerald-500/20 bg-emerald-500/5 p-3 text-xs text-emerald-700"
                 >
-                  Migration completed with no unresolved books or failures.
+                  {{ t('settings.admin.migration.completedNoIssues') }}
                 </div>
 
                 <div v-if="reportData.matchedBooks.length > 0" class="space-y-2">
                   <div>
-                    <p class="text-sm font-semibold">Matched books ({{ reportData.matchedBooks.length }})</p>
+                    <p class="text-sm font-semibold">
+                      {{ t('settings.admin.migration.matchedBooksHeading', { count: reportData.matchedBooks.length }) }}
+                    </p>
                     <p class="text-xs text-muted-foreground mt-0.5">
-                      These dry-run matches were used to decide which library books received imported data.
+                      {{ t('settings.admin.migration.matchedBooksHint') }}
                     </p>
                   </div>
                   <div class="space-y-1.5 max-h-56 overflow-y-auto">
@@ -1827,10 +1888,13 @@ function formatSourceCountLabel(key: string) {
                       :key="`${book.sourceBookId}-${book.targetBookId}`"
                       class="rounded border border-border px-3 py-2 text-xs"
                     >
-                      <p class="font-medium text-foreground">{{ book.sourceTitle || `Source book ${book.sourceBookId}` }}</p>
+                      <p class="font-medium text-foreground">
+                        {{ book.sourceTitle || t('settings.admin.migration.sourceBookFallback', { id: book.sourceBookId }) }}
+                      </p>
                       <p v-if="book.sourceAuthor" class="text-muted-foreground mt-0.5">{{ book.sourceAuthor }}</p>
                       <p class="text-muted-foreground mt-0.5">
-                        {{ friendlyMatchStrategy(book.strategy) }} - {{ book.targetTitle || `Library book ${book.targetBookId}` }}
+                        {{ friendlyMatchStrategy(book.strategy) }} -
+                        {{ book.targetTitle || t('settings.admin.migration.libraryBookFallback', { id: book.targetBookId }) }}
                       </p>
                     </div>
                   </div>
@@ -1838,9 +1902,11 @@ function formatSourceCountLabel(key: string) {
 
                 <div v-if="reportData.unresolvedBooks.length > 0" class="space-y-2">
                   <div>
-                    <p class="text-sm font-semibold text-amber-600">Unresolved books ({{ reportData.unresolvedBooks.length }})</p>
+                    <p class="text-sm font-semibold text-amber-600">
+                      {{ t('settings.admin.migration.unresolvedBooksHeading', { count: reportData.unresolvedBooks.length }) }}
+                    </p>
                     <p class="text-xs text-muted-foreground mt-0.5">
-                      These books exist in the source but could not be matched to any book in your library.
+                      {{ t('settings.admin.migration.unresolvedBooksHint') }}
                     </p>
                   </div>
                   <div class="space-y-1.5 max-h-64 overflow-y-auto">
@@ -1849,7 +1915,9 @@ function formatSourceCountLabel(key: string) {
                       :key="book.sourceBookId"
                       class="rounded border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs"
                     >
-                      <p class="font-medium text-foreground">{{ book.title || `Source book ${book.sourceBookId}` }}</p>
+                      <p class="font-medium text-foreground">
+                        {{ book.title || t('settings.admin.migration.sourceBookFallback', { id: book.sourceBookId }) }}
+                      </p>
                       <p v-if="book.author" class="text-muted-foreground mt-0.5">{{ book.author }}</p>
                       <p class="text-muted-foreground mt-0.5">{{ friendlyUnresolvedReason(book.reason) }}</p>
                     </div>
@@ -1858,8 +1926,10 @@ function formatSourceCountLabel(key: string) {
 
                 <div v-if="reportData.userPreview.length > 0" class="space-y-2">
                   <div>
-                    <p class="text-sm font-semibold">Mapped users ({{ reportData.userPreview.length }})</p>
-                    <p class="text-xs text-muted-foreground mt-0.5">Per-user totals come from the dry-run preview cached with the migration plan.</p>
+                    <p class="text-sm font-semibold">
+                      {{ t('settings.admin.migration.mappedUsersHeading', { count: reportData.userPreview.length }) }}
+                    </p>
+                    <p class="text-xs text-muted-foreground mt-0.5">{{ t('settings.admin.migration.mappedUsersHint') }}</p>
                   </div>
                   <div class="space-y-1.5">
                     <div
@@ -1874,7 +1944,7 @@ function formatSourceCountLabel(key: string) {
                 </div>
 
                 <div v-if="reportData.coverFailureCount > 0" class="rounded border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-700">
-                  {{ reportData.coverFailureCount }} cover import(s) failed. Detailed failure rows are not stored.
+                  {{ t('settings.admin.migration.coverImportsFailed', { count: reportData.coverFailureCount }) }}
                 </div>
               </template>
             </template>
@@ -1883,10 +1953,10 @@ function formatSourceCountLabel(key: string) {
 
         <!-- Card footer -->
         <div class="px-6 py-4 border-t border-border bg-muted/30 flex items-center justify-between">
-          <button v-if="currentStep > 0" class="settings-btn-outline" @click="goPrev">Back</button>
+          <button v-if="currentStep > 0" class="settings-btn-outline" @click="goPrev">{{ t('common.back') }}</button>
           <div v-else />
           <button v-if="currentStep < 4" class="settings-btn-primary" @click="goNext">{{ continueLabel }}</button>
-          <button v-else class="settings-btn-outline" @click="goToSetup">Back to Setup</button>
+          <button v-else class="settings-btn-outline" @click="goToSetup">{{ t('settings.admin.migration.backToSetup') }}</button>
         </div>
       </div>
     </div>

--- a/client/src/features/settings/OidcSettings.vue
+++ b/client/src/features/settings/OidcSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { api } from '@/lib/api'
 import { generatePkce } from '@/features/auth/composables/useOidc'
 import { toast } from 'vue-sonner'
@@ -9,6 +10,8 @@ import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import SettingsPageHeader from './SettingsPageHeader.vue'
 
 const props = withDefaults(defineProps<{ embedded?: boolean }>(), { embedded: false })
+
+const { t } = useI18n()
 
 interface ProviderSummary {
   id: number
@@ -144,14 +147,14 @@ async function startEdit(slug: string) {
       api(`/api/v1/app-settings/oidc/providers/${slug}`),
       api(`/api/v1/app-settings/oidc/providers/${slug}/group-mappings`),
     ])
-    if (!providerRes.ok) throw new Error('Failed to load provider')
+    if (!providerRes.ok) throw new Error(t('settings.oidc.errors.loadProvider'))
     const data = await providerRes.json()
     Object.assign(form, data)
     form.clientSecret = ''
     if (mappingsRes.ok) groupMappings.value = await mappingsRes.json()
     viewMode.value = 'edit'
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to load provider')
+    toast.error(err instanceof Error ? err.message : t('settings.oidc.errors.loadProvider'))
   } finally {
     loading.value = false
   }
@@ -186,9 +189,9 @@ async function saveProvider() {
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        throw new Error(((err as Record<string, unknown>).message as string) ?? 'Failed to create provider')
+        throw new Error(((err as Record<string, unknown>).message as string) ?? t('settings.oidc.errors.createProvider'))
       }
-      toast.success('Provider created')
+      toast.success(t('settings.oidc.toasts.providerCreated'))
       backToList()
     } else {
       const body: Record<string, unknown> = {
@@ -210,12 +213,12 @@ async function saveProvider() {
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        throw new Error(((err as Record<string, unknown>).message as string) ?? 'Failed to save')
+        throw new Error(((err as Record<string, unknown>).message as string) ?? t('settings.oidc.errors.save'))
       }
-      toast.success('Provider saved')
+      toast.success(t('settings.oidc.toasts.providerSaved'))
     }
   } catch (err) {
-    saveError.value = err instanceof Error ? err.message : 'Failed to save'
+    saveError.value = err instanceof Error ? err.message : t('settings.oidc.errors.save')
     toast.error(saveError.value)
   } finally {
     saving.value = false
@@ -229,12 +232,12 @@ async function deleteProvider() {
     const res = await api(`/api/v1/app-settings/oidc/providers/${editingSlug.value}`, { method: 'DELETE' })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      throw new Error(((err as Record<string, unknown>).message as string) ?? 'Failed to delete')
+      throw new Error(((err as Record<string, unknown>).message as string) ?? t('settings.oidc.errors.delete'))
     }
-    toast.success('Provider deleted')
+    toast.success(t('settings.oidc.toasts.providerDeleted'))
     backToList()
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to delete provider')
+    toast.error(err instanceof Error ? err.message : t('settings.oidc.errors.deleteProvider'))
   } finally {
     deleting.value = false
   }
@@ -249,7 +252,7 @@ async function testConnection() {
     const res = await api(`/api/v1/app-settings/oidc/providers/${slug}/test?issuerUri=${encodeURIComponent(form.issuerUri)}`, { method: 'POST' })
     testResult.value = await res.json()
   } catch {
-    testResult.value = { success: false, error: 'Request failed' }
+    testResult.value = { success: false, error: t('settings.oidc.errors.requestFailed') }
   } finally {
     testing.value = false
   }
@@ -261,7 +264,7 @@ async function previewOidcClaims() {
   previewClaims.value = null
   try {
     const stateRes = await api(`/api/v1/auth/oidc/${editingSlug.value}/preview-state`, { method: 'POST' })
-    if (!stateRes.ok) throw new Error('Failed to generate preview state')
+    if (!stateRes.ok) throw new Error(t('settings.oidc.errors.previewState'))
     const { state, authorizationEndpoint } = await stateRes.json()
     const nonce = crypto.randomUUID()
     const { codeVerifier, codeChallenge } = await generatePkce()
@@ -280,7 +283,7 @@ async function previewOidcClaims() {
     sessionStorage.setItem('oidc_preview_pending', editingSlug.value)
     window.location.href = `${authorizationEndpoint}?${params.toString()}`
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to start preview')
+    toast.error(err instanceof Error ? err.message : t('settings.oidc.errors.startPreview'))
     previewing.value = false
   }
 }
@@ -309,14 +312,14 @@ async function addGroupMapping() {
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      throw new Error(((err as Record<string, unknown>).message as string) ?? 'Failed to add mapping')
+      throw new Error(((err as Record<string, unknown>).message as string) ?? t('settings.oidc.errors.addMapping'))
     }
     const created: GroupMapping = await res.json()
     groupMappings.value.push(created)
     newMapping.oidcGroupClaim = ''
-    toast.success('Group mapping added')
+    toast.success(t('settings.oidc.toasts.mappingAdded'))
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Failed to add mapping')
+    toast.error(err instanceof Error ? err.message : t('settings.oidc.errors.addMapping'))
   } finally {
     addingMapping.value = false
   }
@@ -326,11 +329,11 @@ async function deleteGroupMapping(id: number) {
   if (!editingSlug.value) return
   try {
     const res = await api(`/api/v1/app-settings/oidc/providers/${editingSlug.value}/group-mappings/${id}`, { method: 'DELETE' })
-    if (!res.ok) throw new Error('Failed to delete')
+    if (!res.ok) throw new Error(t('settings.oidc.errors.delete'))
     groupMappings.value = groupMappings.value.filter((m) => m.id !== id)
-    toast.success('Group mapping removed')
+    toast.success(t('settings.oidc.toasts.mappingRemoved'))
   } catch {
-    toast.error('Failed to remove group mapping')
+    toast.error(t('settings.oidc.errors.removeMapping'))
   }
 }
 </script>
@@ -338,30 +341,25 @@ async function deleteGroupMapping(id: number) {
 <template>
   <!-- List view -->
   <template v-if="viewMode === 'list'">
-    <SettingsPageHeader
-      v-if="!props.embedded"
-      class="hidden md:flex"
-      title="OIDC / SSO"
-      subtitle="Manage OpenID Connect providers for single sign-on."
-    />
+    <SettingsPageHeader v-if="!props.embedded" class="hidden md:flex" :title="t('settings.oidc.title')" :subtitle="t('settings.oidc.subtitle')" />
     <div v-if="!props.embedded" class="md:hidden px-1">
-      <h1 class="text-xl font-semibold tracking-tight text-foreground">OIDC / SSO</h1>
+      <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('settings.oidc.title') }}</h1>
       <p
         class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
       >
-        Manage OpenID Connect providers for single sign-on.
+        {{ t('settings.oidc.subtitle') }}
       </p>
     </div>
 
-    <div v-if="loading" class="mt-5 md:mt-0 text-sm text-muted-foreground">Loading...</div>
+    <div v-if="loading" class="mt-5 md:mt-0 text-sm text-muted-foreground">{{ t('common.loading') }}</div>
 
     <div v-else class="mt-5 md:mt-0 space-y-4">
       <div>
         <div class="flex items-center justify-between mb-3">
-          <p class="settings-group-label mb-0">Providers</p>
+          <p class="settings-group-label mb-0">{{ t('settings.oidc.providers') }}</p>
           <button type="button" class="settings-btn-primary" @click="startCreate">
             <Plus :size="12" />
-            Add Provider
+            {{ t('settings.oidc.addProvider') }}
           </button>
         </div>
         <div class="border border-border rounded-lg overflow-hidden shadow-xs">
@@ -387,7 +385,7 @@ async function deleteGroupMapping(id: number) {
                 class="shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium"
                 :class="provider.enabled ? 'bg-green-500/10 text-green-600' : 'bg-muted text-muted-foreground'"
               >
-                {{ provider.enabled ? 'Enabled' : 'Disabled' }}
+                {{ provider.enabled ? t('settings.oidc.enabled') : t('settings.oidc.disabled') }}
               </span>
             </button>
           </div>
@@ -395,8 +393,8 @@ async function deleteGroupMapping(id: number) {
             <div class="w-10 h-10 rounded-full bg-muted flex items-center justify-center mx-auto mb-3">
               <ShieldCheck :size="18" class="text-muted-foreground/70" />
             </div>
-            <p class="text-sm font-medium text-foreground">No providers yet</p>
-            <p class="text-xs text-muted-foreground mt-1 max-w-[240px] mx-auto">Add an OIDC provider to enable single sign-on for your users.</p>
+            <p class="text-sm font-medium text-foreground">{{ t('settings.oidc.empty.title') }}</p>
+            <p class="text-xs text-muted-foreground mt-1 max-w-[240px] mx-auto">{{ t('settings.oidc.empty.description') }}</p>
           </div>
         </div>
       </div>
@@ -416,31 +414,35 @@ async function deleteGroupMapping(id: number) {
         <img :src="form.iconUrl" alt="" class="h-7 w-7 object-contain" />
       </div>
       <div>
-        <h2 class="text-lg font-semibold text-foreground">{{ viewMode === 'create' ? 'Add Provider' : form.displayName || 'Edit Provider' }}</h2>
-        <p class="text-sm text-muted-foreground">{{ viewMode === 'create' ? 'Configure a new OIDC provider.' : `Editing ${editingSlug}` }}</p>
+        <h2 class="text-lg font-semibold text-foreground">
+          {{ viewMode === 'create' ? t('settings.oidc.addProvider') : form.displayName || t('settings.oidc.editProvider') }}
+        </h2>
+        <p class="text-sm text-muted-foreground">
+          {{ viewMode === 'create' ? t('settings.oidc.configureNew') : t('settings.oidc.editing', { slug: editingSlug }) }}
+        </p>
       </div>
     </div>
     <div class="md:hidden px-1 mb-4">
       <button type="button" class="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-2" @click="backToList">
         <ArrowLeft class="w-4 h-4" />
-        Back
+        {{ t('common.back') }}
       </button>
       <h1 class="text-xl font-semibold tracking-tight text-foreground">
-        {{ viewMode === 'create' ? 'Add Provider' : form.displayName || 'Edit Provider' }}
+        {{ viewMode === 'create' ? t('settings.oidc.addProvider') : form.displayName || t('settings.oidc.editProvider') }}
       </h1>
     </div>
 
-    <div v-if="loading" class="text-sm text-muted-foreground">Loading...</div>
+    <div v-if="loading" class="text-sm text-muted-foreground">{{ t('common.loading') }}</div>
 
     <form v-else class="space-y-6" @submit.prevent="saveProvider">
       <!-- Status -->
       <div>
-        <p class="settings-group-label">Status</p>
+        <p class="settings-group-label">{{ t('settings.oidc.form.status') }}</p>
         <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
           <div class="flex flex-col gap-3 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:px-5 md:py-4">
             <div class="min-w-0">
-              <p class="settings-label">Enable provider</p>
-              <p class="settings-hint">Show this provider on the login page.</p>
+              <p class="settings-label">{{ t('settings.oidc.form.enableProvider') }}</p>
+              <p class="settings-hint">{{ t('settings.oidc.form.enableProviderHint') }}</p>
             </div>
             <ToggleSwitch v-model="form.enabled" class="self-start md:self-auto" />
           </div>
@@ -449,32 +451,37 @@ async function deleteGroupMapping(id: number) {
 
       <!-- Identity -->
       <div>
-        <p class="settings-group-label">Provider Identity</p>
+        <p class="settings-group-label">{{ t('settings.oidc.form.identity') }}</p>
         <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
           <div
             v-if="viewMode === 'create'"
             class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4"
           >
             <div class="min-w-0 md:shrink-0">
-              <p class="settings-label">Slug</p>
-              <p class="settings-hint">Unique identifier (lowercase, hyphens). Cannot be changed later.</p>
+              <p class="settings-label">{{ t('settings.oidc.form.slug') }}</p>
+              <p class="settings-hint">{{ t('settings.oidc.form.slugHint') }}</p>
             </div>
             <input v-model="form.slug" type="text" placeholder="keycloak" pattern="[a-z0-9]+(?:-[a-z0-9]+)*" class="input-field w-full md:w-72" />
           </div>
           <div class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4">
             <div class="min-w-0 md:shrink-0">
-              <p class="settings-label">Display Name</p>
-              <p class="settings-hint">Shown on the login button.</p>
+              <p class="settings-label">{{ t('settings.oidc.form.displayName') }}</p>
+              <p class="settings-hint">{{ t('settings.oidc.form.displayNameHint') }}</p>
             </div>
             <input v-model="form.displayName" type="text" placeholder="Keycloak" class="input-field w-full md:w-72" />
           </div>
           <div class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4">
             <div class="min-w-0 md:shrink-0">
-              <p class="settings-label">Icon URL</p>
-              <p class="settings-hint">Optional logo shown next to the login button.</p>
+              <p class="settings-label">{{ t('settings.oidc.form.iconUrl') }}</p>
+              <p class="settings-hint">{{ t('settings.oidc.form.iconUrlHint') }}</p>
             </div>
             <div class="flex w-full items-center gap-2 md:w-72">
-              <img v-if="form.iconUrl" :src="form.iconUrl" alt="icon preview" class="h-5 w-5 shrink-0 rounded object-contain" />
+              <img
+                v-if="form.iconUrl"
+                :src="form.iconUrl"
+                :alt="t('settings.oidc.form.iconPreviewAlt')"
+                class="h-5 w-5 shrink-0 rounded object-contain"
+              />
               <input v-model="form.iconUrl" type="url" placeholder="https://example.com/logo.svg" class="input-field min-w-0 flex-1" />
             </div>
           </div>
@@ -483,12 +490,12 @@ async function deleteGroupMapping(id: number) {
 
       <!-- Connection -->
       <div>
-        <p class="settings-group-label">Connection</p>
+        <p class="settings-group-label">{{ t('settings.oidc.form.connection') }}</p>
         <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
           <div class="flex flex-col gap-3 px-4 py-3.5 bg-card md:flex-row md:items-start md:justify-between md:gap-8 md:px-5 md:py-4">
             <div class="min-w-0 md:shrink-0 md:pt-0.5">
-              <p class="settings-label">Issuer URI</p>
-              <p class="settings-hint">The provider's base URL.</p>
+              <p class="settings-label">{{ t('settings.oidc.form.issuerUri') }}</p>
+              <p class="settings-hint">{{ t('settings.oidc.form.issuerUriHint') }}</p>
             </div>
             <div class="flex w-full flex-col items-start gap-2 md:w-auto md:items-end">
               <div class="flex w-full flex-col gap-2 md:w-auto md:flex-row md:items-center">
@@ -499,7 +506,7 @@ async function deleteGroupMapping(id: number) {
                   class="w-full rounded-md border border-input bg-background px-3 py-2 text-xs font-medium hover:bg-muted disabled:opacity-50 transition-colors shrink-0 focus:outline-none focus:ring-2 focus:ring-primary/50 md:w-auto md:py-1.5"
                   @click="testConnection"
                 >
-                  {{ testing ? 'Testing...' : 'Test' }}
+                  {{ testing ? t('settings.oidc.form.testing') : t('settings.oidc.form.test') }}
                 </button>
               </div>
               <div
@@ -510,14 +517,18 @@ async function deleteGroupMapping(id: number) {
                 "
               >
                 <div class="flex items-center justify-between gap-2">
-                  <span>{{ testResult.success ? `Connected - ${testResult.issuer ?? ''}` : (testResult.error ?? 'Connection failed') }}</span>
+                  <span>{{
+                    testResult.success
+                      ? t('settings.oidc.test.connected', { issuer: testResult.issuer ?? '' })
+                      : (testResult.error ?? t('settings.oidc.test.connectionFailed'))
+                  }}</span>
                   <button
                     v-if="testResult.success"
                     type="button"
                     class="shrink-0 underline underline-offset-2 opacity-70 hover:opacity-100"
                     @click="toggleTestDetails"
                   >
-                    {{ showTestDetails ? 'Hide' : 'Details' }}
+                    {{ showTestDetails ? t('settings.oidc.test.hide') : t('settings.oidc.test.details') }}
                   </button>
                 </div>
                 <div v-if="testResult.success && showTestDetails" class="mt-2 space-y-0.5 border-t border-green-500/20 pt-2 font-mono text-[10px]">
@@ -526,27 +537,30 @@ async function deleteGroupMapping(id: number) {
                   <div v-if="testResult.jwksUri">jwks: {{ testResult.jwksUri }}</div>
                   <div v-if="testResult.codeChallengeMethodsSupported?.length">pkce: {{ testResult.codeChallengeMethodsSupported.join(', ') }}</div>
                   <div v-if="testResult.supportedScopes?.length">scopes: {{ testResult.supportedScopes.join(', ') }}</div>
-                  <div>backchannel logout: {{ testResult.backchannelLogoutSupported ? 'supported' : 'not supported' }}</div>
+                  <div>
+                    backchannel logout:
+                    {{ testResult.backchannelLogoutSupported ? t('settings.oidc.test.supported') : t('settings.oidc.test.notSupported') }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4">
-            <p class="settings-label md:shrink-0">Client ID</p>
+            <p class="settings-label md:shrink-0">{{ t('settings.oidc.form.clientId') }}</p>
             <input v-model="form.clientId" type="text" class="input-field w-full md:w-72" />
           </div>
           <div class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4">
-            <p class="settings-label md:shrink-0">Client Secret</p>
+            <p class="settings-label md:shrink-0">{{ t('settings.oidc.form.clientSecret') }}</p>
             <input
               v-model="form.clientSecret"
               type="password"
-              :placeholder="viewMode === 'edit' ? 'Leave blank to keep existing' : ''"
+              :placeholder="viewMode === 'edit' ? t('settings.oidc.form.clientSecretPlaceholder') : ''"
               autocomplete="new-password"
               class="input-field w-full md:w-72"
             />
           </div>
           <div class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4">
-            <p class="settings-label md:shrink-0">Scopes</p>
+            <p class="settings-label md:shrink-0">{{ t('settings.oidc.form.scopes') }}</p>
             <input v-model="form.scopes" type="text" class="input-field w-full md:w-72" />
           </div>
         </div>
@@ -555,7 +569,7 @@ async function deleteGroupMapping(id: number) {
       <!-- Claim mapping -->
       <div>
         <div class="flex items-center justify-between">
-          <p class="settings-group-label">Claim Mapping</p>
+          <p class="settings-group-label">{{ t('settings.oidc.form.claimMapping') }}</p>
           <button
             v-if="viewMode === 'edit' && form.enabled && form.clientId && form.issuerUri"
             type="button"
@@ -563,34 +577,34 @@ async function deleteGroupMapping(id: number) {
             class="text-xs font-medium text-primary underline-offset-2 hover:underline disabled:opacity-50"
             @click="previewOidcClaims"
           >
-            {{ previewing ? 'Redirecting...' : 'Preview claims' }}
+            {{ previewing ? t('settings.oidc.form.redirecting') : t('settings.oidc.form.previewClaims') }}
           </button>
         </div>
         <div v-if="previewClaims" class="mb-3 rounded-md border border-border bg-card p-3 text-xs">
-          <p class="font-medium text-foreground mb-1.5">Mapped claims</p>
+          <p class="font-medium text-foreground mb-1.5">{{ t('settings.oidc.form.mappedClaims') }}</p>
           <pre class="text-muted-foreground overflow-auto rounded bg-muted/40 p-2 text-[11px]">{{
             JSON.stringify(previewClaims.mapped, null, 2)
           }}</pre>
-          <p class="mt-2 font-medium text-foreground mb-1.5">Raw claims</p>
+          <p class="mt-2 font-medium text-foreground mb-1.5">{{ t('settings.oidc.form.rawClaims') }}</p>
           <pre class="text-muted-foreground overflow-auto rounded bg-muted/40 p-2 text-[11px] max-h-40">{{
             JSON.stringify(previewClaims.raw, null, 2)
           }}</pre>
         </div>
         <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
           <div class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4">
-            <p class="settings-label md:shrink-0">Username claim</p>
+            <p class="settings-label md:shrink-0">{{ t('settings.oidc.form.usernameClaim') }}</p>
             <input v-model="form.claimMapping.username" type="text" class="input-field w-full md:w-72" />
           </div>
           <div class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4">
-            <p class="settings-label md:shrink-0">Name claim</p>
+            <p class="settings-label md:shrink-0">{{ t('settings.oidc.form.nameClaim') }}</p>
             <input v-model="form.claimMapping.name" type="text" class="input-field w-full md:w-72" />
           </div>
           <div class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4">
-            <p class="settings-label md:shrink-0">Email claim</p>
+            <p class="settings-label md:shrink-0">{{ t('settings.oidc.form.emailClaim') }}</p>
             <input v-model="form.claimMapping.email" type="text" class="input-field w-full md:w-72" />
           </div>
           <div class="flex flex-col gap-2 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:gap-8 md:px-5 md:py-4">
-            <p class="settings-label md:shrink-0">Groups claim</p>
+            <p class="settings-label md:shrink-0">{{ t('settings.oidc.form.groupsClaim') }}</p>
             <input v-model="form.claimMapping.groups" type="text" class="input-field w-full md:w-72" />
           </div>
         </div>
@@ -598,26 +612,26 @@ async function deleteGroupMapping(id: number) {
 
       <!-- Auto-provisioning -->
       <div>
-        <p class="settings-group-label">Auto-Provisioning</p>
+        <p class="settings-group-label">{{ t('settings.oidc.form.autoProvisioning') }}</p>
         <div class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
           <div class="flex flex-col gap-3 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:px-5 md:py-4">
             <div class="min-w-0">
-              <p class="settings-label">Auto-provision users</p>
-              <p class="settings-hint">Create accounts on first OIDC login if user does not exist.</p>
+              <p class="settings-label">{{ t('settings.oidc.form.autoProvisionUsers') }}</p>
+              <p class="settings-hint">{{ t('settings.oidc.form.autoProvisionUsersHint') }}</p>
             </div>
             <ToggleSwitch v-model="form.autoProvision.enabled" class="self-start md:self-auto" />
           </div>
           <div class="flex flex-col gap-3 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:px-5 md:py-4">
             <div class="min-w-0">
-              <p class="settings-label">Allow local account linking</p>
-              <p class="settings-hint">Link OIDC identity to an existing local account by username match.</p>
+              <p class="settings-label">{{ t('settings.oidc.form.allowLocalLinking') }}</p>
+              <p class="settings-hint">{{ t('settings.oidc.form.allowLocalLinkingHint') }}</p>
             </div>
             <ToggleSwitch v-model="form.autoProvision.allowLocalLinking" class="self-start md:self-auto" />
           </div>
           <div class="px-4 py-3.5 bg-card md:px-5 md:py-4">
             <div class="mb-3">
-              <p class="settings-label">Default permissions</p>
-              <p class="settings-hint">Permissions granted to new users on first OIDC login.</p>
+              <p class="settings-label">{{ t('settings.oidc.form.defaultPermissions') }}</p>
+              <p class="settings-hint">{{ t('settings.oidc.form.defaultPermissionsHint') }}</p>
             </div>
             <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
               <label v-for="perm in ALL_PERMISSIONS" :key="perm" class="flex items-center gap-2.5 cursor-pointer select-none">
@@ -636,15 +650,19 @@ async function deleteGroupMapping(id: number) {
 
       <!-- Group Mappings (only in edit mode) -->
       <div v-if="viewMode === 'edit'">
-        <p class="settings-group-label">Group Mappings</p>
-        <p class="mb-3 text-xs text-muted-foreground">Map OIDC group claims to BookOrbit permissions. Synced on every login.</p>
+        <p class="settings-group-label">{{ t('settings.oidc.groupMappings.title') }}</p>
+        <p class="mb-3 text-xs text-muted-foreground">{{ t('settings.oidc.groupMappings.description') }}</p>
         <div class="border border-border rounded-lg overflow-hidden bg-card shadow-xs">
           <div v-if="groupMappings.length > 0" class="divide-y divide-border">
             <div v-for="mapping in groupMappings" :key="mapping.id" class="flex items-center justify-between gap-3 px-4 py-3 md:px-5">
               <div class="min-w-0 flex-1">
                 <p class="text-sm font-medium text-foreground truncate">{{ mapping.oidcGroupClaim }}</p>
                 <p class="text-xs text-muted-foreground">
-                  {{ mapping.permissionName ? (PERMISSION_LABELS[mapping.permissionName as Permission] ?? mapping.permissionName) : 'No permission' }}
+                  {{
+                    mapping.permissionName
+                      ? (PERMISSION_LABELS[mapping.permissionName as Permission] ?? mapping.permissionName)
+                      : t('settings.oidc.groupMappings.noPermission')
+                  }}
                 </p>
               </div>
               <button
@@ -656,15 +674,15 @@ async function deleteGroupMapping(id: number) {
               </button>
             </div>
           </div>
-          <div v-else class="px-4 py-4 text-sm text-muted-foreground md:px-5">No group mappings configured.</div>
+          <div v-else class="px-4 py-4 text-sm text-muted-foreground md:px-5">{{ t('settings.oidc.groupMappings.empty') }}</div>
 
           <div class="border-t border-border px-4 py-3.5 md:px-5 md:py-4">
-            <p class="settings-label mb-2">Add mapping</p>
+            <p class="settings-label mb-2">{{ t('settings.oidc.groupMappings.addMapping') }}</p>
             <div class="flex flex-col gap-2 sm:flex-row">
               <input
                 v-model="newMapping.oidcGroupClaim"
                 type="text"
-                placeholder="OIDC group claim (e.g. admins)"
+                :placeholder="t('settings.oidc.groupMappings.claimPlaceholder')"
                 class="input-field flex-1 min-w-0"
               />
               <select v-model="newMapping.permissionName" class="input-field sm:w-52 shrink-0">
@@ -678,7 +696,7 @@ async function deleteGroupMapping(id: number) {
                 class="settings-btn-primary shrink-0 disabled:opacity-50"
                 @click="addGroupMapping"
               >
-                {{ addingMapping ? 'Adding...' : 'Add' }}
+                {{ addingMapping ? t('settings.oidc.groupMappings.adding') : t('settings.oidc.groupMappings.add') }}
               </button>
             </div>
           </div>
@@ -688,7 +706,13 @@ async function deleteGroupMapping(id: number) {
       <!-- Save + Delete -->
       <div class="hidden md:flex items-center gap-3">
         <button type="submit" :disabled="saving" class="settings-btn-primary">
-          {{ saving ? 'Saving...' : viewMode === 'create' ? 'Create Provider' : 'Save Changes' }}
+          {{
+            saving
+              ? t('settings.oidc.form.saving')
+              : viewMode === 'create'
+                ? t('settings.oidc.form.createProvider')
+                : t('settings.oidc.form.saveChanges')
+          }}
         </button>
         <button
           v-if="viewMode === 'edit'"
@@ -697,14 +721,20 @@ async function deleteGroupMapping(id: number) {
           class="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:opacity-50 transition-colors"
           @click="deleteProvider"
         >
-          {{ deleting ? 'Deleting...' : 'Delete Provider' }}
+          {{ deleting ? t('settings.oidc.form.deleting') : t('settings.oidc.form.deleteProvider') }}
         </button>
         <p v-if="saveError" class="text-sm text-destructive">{{ saveError }}</p>
       </div>
       <div class="md:hidden sticky bottom-2 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
         <div class="flex items-center gap-2">
           <button type="submit" :disabled="saving" class="settings-btn-primary w-full min-h-10 justify-center">
-            {{ saving ? 'Saving...' : viewMode === 'create' ? 'Create Provider' : 'Save Changes' }}
+            {{
+              saving
+                ? t('settings.oidc.form.saving')
+                : viewMode === 'create'
+                  ? t('settings.oidc.form.createProvider')
+                  : t('settings.oidc.form.saveChanges')
+            }}
           </button>
           <button
             v-if="viewMode === 'edit'"

--- a/client/src/features/settings/OpdsSettings.vue
+++ b/client/src/features/settings/OpdsSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Plus, Trash2, Copy, Rss, ChevronDown, ChevronUp } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
@@ -10,6 +11,7 @@ import { usePermissions } from '@/features/auth/composables/usePermissions'
 import type { OpdsUser, OpdsSortOrder } from '@bookorbit/types'
 import { useMediaQuery } from '@vueuse/core'
 
+const { t } = useI18n()
 const { hasPermission } = usePermissions()
 const canManageSettings = computed(() => hasPermission('manage_app_settings'))
 
@@ -31,18 +33,18 @@ const isMobile = useMediaQuery('(max-width: 767px)')
 
 const opdsUrl = computed(() => `${window.location.origin}/api/v1/opds`)
 
-const sortOrderOptions: { label: string; value: OpdsSortOrder }[] = [
-  { label: 'Recently Added', value: 'recent' },
-  { label: 'Title (A-Z)', value: 'title_asc' },
-  { label: 'Title (Z-A)', value: 'title_desc' },
-  { label: 'Author (A-Z)', value: 'author_asc' },
-  { label: 'Author (Z-A)', value: 'author_desc' },
-  { label: 'Series (A-Z)', value: 'series_asc' },
-  { label: 'Series (Z-A)', value: 'series_desc' },
-]
+const sortOrderOptions = computed<{ label: string; value: OpdsSortOrder }[]>(() => [
+  { label: t('settings.reader.opds.sortRecent'), value: 'recent' },
+  { label: t('settings.reader.opds.sortTitleAsc'), value: 'title_asc' },
+  { label: t('settings.reader.opds.sortTitleDesc'), value: 'title_desc' },
+  { label: t('settings.reader.opds.sortAuthorAsc'), value: 'author_asc' },
+  { label: t('settings.reader.opds.sortAuthorDesc'), value: 'author_desc' },
+  { label: t('settings.reader.opds.sortSeriesAsc'), value: 'series_asc' },
+  { label: t('settings.reader.opds.sortSeriesDesc'), value: 'series_desc' },
+])
 
 function sortOrderLabel(value: OpdsSortOrder): string {
-  return sortOrderOptions.find((o) => o.value === value)?.label ?? value
+  return sortOrderOptions.value.find((o) => o.value === value)?.label ?? value
 }
 
 onMounted(async () => {
@@ -57,7 +59,7 @@ onMounted(async () => {
       opdsUsers.value = await usersRes.json()
     }
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Failed to load'
+    error.value = e instanceof Error ? e.message : t('settings.reader.opds.loadFailed')
   } finally {
     loading.value = false
   }
@@ -73,21 +75,21 @@ async function toggleOpds() {
     })
     if (res.ok) {
       opdsEnabled.value = newVal
-      toast.success(`OPDS server ${newVal ? 'enabled' : 'disabled'}`)
+      toast.success(newVal ? t('settings.reader.opds.serverEnabled') : t('settings.reader.opds.serverDisabled'))
     } else {
-      toast.error('Failed to update OPDS settings')
+      toast.error(t('settings.reader.opds.updateSettingsFailed'))
     }
   } catch {
-    toast.error('Failed to update OPDS settings')
+    toast.error(t('settings.reader.opds.updateSettingsFailed'))
   }
 }
 
 async function copyUrl() {
   const copied = await copyToClipboard(opdsUrl.value)
   if (copied) {
-    toast.success('OPDS URL copied to clipboard')
+    toast.success(t('settings.reader.opds.urlCopied'))
   } else {
-    toast.error('Failed to copy OPDS URL')
+    toast.error(t('settings.reader.opds.urlCopyFailed'))
   }
 }
 
@@ -102,8 +104,8 @@ async function createUser() {
     })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
-      createError.value = data.message ?? 'Failed to create OPDS user'
-      toast.error(createError.value ?? 'Failed to create OPDS user')
+      createError.value = data.message ?? t('settings.reader.opds.createUserFailed')
+      toast.error(createError.value ?? t('settings.reader.opds.createUserFailed'))
       return
     }
     const user = await res.json()
@@ -112,9 +114,9 @@ async function createUser() {
     createUsername.value = ''
     createPassword.value = ''
     createSortOrder.value = 'recent'
-    toast.success(`OPDS user "${user.username}" created`)
+    toast.success(t('settings.reader.opds.userCreated', { username: user.username }))
   } catch {
-    toast.error('Failed to create OPDS user')
+    toast.error(t('settings.reader.opds.createUserFailed'))
   } finally {
     creating.value = false
   }
@@ -131,12 +133,12 @@ async function updateSortOrder(user: OpdsUser, sortOrder: OpdsSortOrder) {
       const updated = await res.json()
       const idx = opdsUsers.value.findIndex((u) => u.id === user.id)
       if (idx >= 0) opdsUsers.value[idx] = updated
-      toast.success(`Sort order updated for "${user.username}"`)
+      toast.success(t('settings.reader.opds.sortOrderUpdated', { username: user.username }))
     } else {
-      toast.error('Failed to update sort order')
+      toast.error(t('settings.reader.opds.updateSortFailed'))
     }
   } catch {
-    toast.error('Failed to update sort order')
+    toast.error(t('settings.reader.opds.updateSortFailed'))
   }
 }
 
@@ -150,12 +152,12 @@ async function deleteUser(user: OpdsUser) {
     const res = await api(`/api/v1/opds-users/${user.id}`, { method: 'DELETE' })
     if (res.ok) {
       opdsUsers.value = opdsUsers.value.filter((u) => u.id !== user.id)
-      toast.success(`OPDS user "${user.username}" deleted`)
+      toast.success(t('settings.reader.opds.userDeleted', { username: user.username }))
     } else {
-      toast.error('Failed to delete OPDS user')
+      toast.error(t('settings.reader.opds.deleteUserFailed'))
     }
   } catch {
-    toast.error('Failed to delete OPDS user')
+    toast.error(t('settings.reader.opds.deleteUserFailed'))
   }
 }
 
@@ -183,9 +185,9 @@ function userDetailsOpen(id: number) {
 async function copyValue(value: string, label: string) {
   const copied = await copyToClipboard(value)
   if (copied) {
-    toast.success(`${label} copied`)
+    toast.success(t('settings.reader.opds.labelCopied', { label }))
   } else {
-    toast.error(`Failed to copy ${label.toLowerCase()}`)
+    toast.error(t('settings.reader.opds.copyLabelFailed', { label: label.toLowerCase() }))
   }
 }
 
@@ -199,31 +201,27 @@ watch(
 </script>
 
 <template>
-  <SettingsPageHeader
-    class="hidden md:flex"
-    title="OPDS"
-    subtitle="Connect OPDS-compatible reading apps like KOReader or Thorium Reader to your library."
-  />
+  <SettingsPageHeader class="hidden md:flex" :title="t('settings.reader.opds.title')" :subtitle="t('settings.reader.opds.subtitle')" />
   <div class="md:hidden px-1">
-    <h1 class="text-xl font-semibold tracking-tight text-foreground">OPDS</h1>
+    <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('settings.reader.opds.title') }}</h1>
     <p
       class="mt-1 text-sm text-muted-foreground leading-5 overflow-hidden text-ellipsis [display:-webkit-box] [-webkit-line-clamp:2] [-webkit-box-orient:vertical]"
     >
-      Connect OPDS-compatible reading apps like KOReader or Thorium Reader to your library.
+      {{ t('settings.reader.opds.subtitle') }}
     </p>
   </div>
 
-  <div v-if="loading" class="mt-5 md:mt-0 text-sm text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="mt-5 md:mt-0 text-sm text-muted-foreground">{{ t('common.loading') }}</div>
   <div v-else-if="error" class="text-sm text-destructive">{{ error }}</div>
   <template v-else>
     <!-- Server Toggle -->
     <div v-if="canManageSettings" class="mb-6">
-      <p class="settings-group-label">Server</p>
+      <p class="settings-group-label">{{ t('settings.reader.opds.server') }}</p>
       <div class="border border-border rounded-lg overflow-hidden shadow-xs">
         <div class="flex flex-col gap-3 px-4 py-3.5 bg-card md:flex-row md:items-center md:justify-between md:px-5 md:py-4">
           <div class="min-w-0">
-            <p class="settings-label">OPDS Catalog Server</p>
-            <p class="settings-hint">Allow OPDS clients to browse and download books</p>
+            <p class="settings-label">{{ t('settings.reader.opds.catalogServer') }}</p>
+            <p class="settings-hint">{{ t('settings.reader.opds.catalogServerHint') }}</p>
           </div>
           <ToggleSwitch :model-value="opdsEnabled" class="self-start md:self-auto" @update:model-value="toggleOpds()" />
         </div>
@@ -232,7 +230,7 @@ watch(
 
     <!-- Endpoint URL -->
     <div v-if="opdsEnabled" class="mb-6">
-      <p class="settings-group-label">Endpoint</p>
+      <p class="settings-group-label">{{ t('settings.reader.opds.endpoint') }}</p>
       <div class="border border-border rounded-lg overflow-hidden shadow-xs">
         <div class="flex flex-col md:flex-row md:items-center gap-2 px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <Rss :size="14" class="text-muted-foreground shrink-0" />
@@ -242,7 +240,7 @@ watch(
             @click="copyUrl()"
           >
             <Copy :size="12" />
-            Copy
+            {{ t('settings.reader.opds.copy') }}
           </button>
         </div>
       </div>
@@ -251,18 +249,18 @@ watch(
     <!-- OPDS Users -->
     <div v-if="opdsEnabled" class="mb-6">
       <div class="hidden md:flex items-center justify-between mb-3">
-        <p class="settings-group-label mb-0">OPDS Accounts</p>
+        <p class="settings-group-label mb-0">{{ t('settings.reader.opds.accounts') }}</p>
         <button
           v-if="!showCreateForm"
           class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
           @click="showCreateForm = true"
         >
           <Plus :size="12" />
-          Add
+          {{ t('settings.reader.opds.add') }}
         </button>
       </div>
       <div class="md:hidden flex items-center justify-between mb-2">
-        <p class="settings-group-label mb-0">OPDS Accounts</p>
+        <p class="settings-group-label mb-0">{{ t('settings.reader.opds.accounts') }}</p>
       </div>
       <div v-if="!showCreateForm" class="md:hidden sticky top-0 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2 mb-3">
         <button
@@ -270,22 +268,22 @@ watch(
           @click="showCreateForm = true"
         >
           <Plus :size="13" />
-          Add account
+          {{ t('settings.reader.opds.addAccount') }}
         </button>
       </div>
 
       <!-- Create form -->
       <div v-if="showCreateForm" class="border border-border rounded-lg p-4 md:p-5 bg-card mb-4 space-y-4 shadow-xs">
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Username</label>
-          <input v-model="createUsername" type="text" placeholder="e.g. koreader" class="input-field w-full" />
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('settings.reader.opds.username') }}</label>
+          <input v-model="createUsername" type="text" :placeholder="t('settings.reader.opds.usernamePlaceholder')" class="input-field w-full" />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Password</label>
-          <input v-model="createPassword" type="password" placeholder="Min 8 characters" class="input-field w-full" />
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('settings.reader.opds.password') }}</label>
+          <input v-model="createPassword" type="password" :placeholder="t('settings.reader.opds.passwordPlaceholder')" class="input-field w-full" />
         </div>
         <div>
-          <label class="block text-xs font-medium text-muted-foreground mb-1.5">Default Sort</label>
+          <label class="block text-xs font-medium text-muted-foreground mb-1.5">{{ t('settings.reader.opds.defaultSort') }}</label>
           <select v-model="createSortOrder" class="select-field w-full">
             <option v-for="opt in sortOrderOptions" :key="opt.value" :value="opt.value">{{ opt.label }}</option>
           </select>
@@ -297,13 +295,13 @@ watch(
             :disabled="creating || !createUsername || !createPassword"
             @click="createUser()"
           >
-            {{ creating ? 'Creating...' : 'Create' }}
+            {{ creating ? t('settings.reader.opds.creating') : t('settings.reader.opds.create') }}
           </button>
           <button
             class="px-4 py-2 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-muted transition-colors"
             @click="cancelCreate()"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
         </div>
         <div class="md:hidden sticky bottom-2 z-20 border border-border/60 bg-card/95 backdrop-blur rounded-lg px-3 py-2">
@@ -313,13 +311,13 @@ watch(
               :disabled="creating || !createUsername || !createPassword"
               @click="createUser()"
             >
-              {{ creating ? 'Creating...' : 'Create' }}
+              {{ creating ? t('settings.reader.opds.creating') : t('settings.reader.opds.create') }}
             </button>
             <button
               class="rounded-md border border-border px-3 min-h-10 text-sm text-foreground hover:bg-muted transition-colors"
               @click="cancelCreate()"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
           </div>
         </div>
@@ -327,7 +325,7 @@ watch(
 
       <!-- Users list -->
       <div v-if="opdsUsers.length === 0 && !showCreateForm" class="border border-border rounded-lg px-5 py-8 bg-card text-center shadow-xs">
-        <p class="text-sm text-muted-foreground">No OPDS accounts yet. Create one to start using OPDS clients.</p>
+        <p class="text-sm text-muted-foreground">{{ t('settings.reader.opds.noAccounts') }}</p>
       </div>
       <div v-else-if="opdsUsers.length > 0" class="border border-border rounded-lg overflow-hidden divide-y divide-border shadow-xs">
         <div v-for="user in opdsUsers" :key="user.id" class="px-4 py-3.5 bg-card space-y-3 md:flex md:items-center md:gap-3 md:space-y-0 md:px-5">
@@ -352,19 +350,21 @@ watch(
           </div>
           <div class="md:hidden flex items-center gap-3 text-xs">
             <button class="text-primary hover:underline" @click="toggleUserDetails(user.id)">
-              {{ userDetailsOpen(user.id) ? 'Hide details' : 'Show details' }}
+              {{ userDetailsOpen(user.id) ? t('settings.reader.opds.hideDetails') : t('settings.reader.opds.showDetails') }}
             </button>
-            <button class="text-muted-foreground hover:text-foreground" @click="copyValue(user.username, 'Username')">Copy username</button>
-            <button class="text-destructive hover:underline" @click="requestDeleteUser(user)">Delete</button>
+            <button class="text-muted-foreground hover:text-foreground" @click="copyValue(user.username, t('settings.reader.opds.usernameLabel'))">
+              {{ t('settings.reader.opds.copyUsername') }}
+            </button>
+            <button class="text-destructive hover:underline" @click="requestDeleteUser(user)">{{ t('common.delete') }}</button>
           </div>
           <div
             v-if="userDetailsOpen(user.id)"
             class="md:hidden rounded-md border border-border bg-background px-3 py-2 text-xs text-muted-foreground"
           >
             <div class="grid grid-cols-[4.5rem_1fr] gap-y-1.5 gap-x-2">
-              <span class="text-muted-foreground/80">Username</span>
+              <span class="text-muted-foreground/80">{{ t('settings.reader.opds.usernameLabel') }}</span>
               <span class="font-mono text-foreground/90 break-all">{{ user.username }}</span>
-              <span class="text-muted-foreground/80">Sort</span>
+              <span class="text-muted-foreground/80">{{ t('settings.reader.opds.sortLabel') }}</span>
               <span class="text-foreground/90">{{ sortOrderLabel(user.sortOrder) }}</span>
             </div>
           </div>
@@ -374,12 +374,12 @@ watch(
 
     <div v-if="opdsEnabled" class="border border-border rounded-lg bg-card/50 shadow-xs">
       <button class="w-full flex items-center justify-between gap-2 p-4 text-left" @click="helpOpen = !helpOpen">
-        <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">OPDS Notes</p>
+        <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">{{ t('settings.reader.opds.notes') }}</p>
         <ChevronUp v-if="helpOpen" :size="14" class="text-muted-foreground" />
         <ChevronDown v-else :size="14" class="text-muted-foreground" />
       </button>
       <p v-if="helpOpen" class="px-4 pb-4 text-xs text-muted-foreground">
-        Use OPDS accounts in reader apps. Keep credentials private and rotate passwords if shared accidentally.
+        {{ t('settings.reader.opds.notesBody') }}
       </p>
     </div>
 
@@ -390,20 +390,20 @@ watch(
     >
       <button class="absolute inset-0 bg-black/45" @click="deleteConfirmUser = null" />
       <div class="relative w-full rounded-t-lg border border-border bg-card p-4 shadow-xl md:max-w-md md:rounded-lg md:p-5">
-        <p class="text-base font-semibold text-foreground">Delete OPDS account?</p>
-        <p class="mt-1 text-sm text-muted-foreground">Delete "{{ deleteConfirmUser.username }}". This action cannot be undone.</p>
+        <p class="text-base font-semibold text-foreground">{{ t('settings.reader.opds.deleteConfirmTitle') }}</p>
+        <p class="mt-1 text-sm text-muted-foreground">{{ t('settings.reader.opds.deleteConfirmBody', { username: deleteConfirmUser.username }) }}</p>
         <div class="mt-4 flex items-center justify-end gap-2">
           <button
             class="rounded-md border border-border px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors"
             @click="deleteConfirmUser = null"
           >
-            Cancel
+            {{ t('common.cancel') }}
           </button>
           <button
             class="rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
             @click="confirmDeleteUser"
           >
-            Delete
+            {{ t('common.delete') }}
           </button>
         </div>
       </div>

--- a/client/src/features/settings/PdfSettings.vue
+++ b/client/src/features/settings/PdfSettings.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { PdfReaderSettings } from '@bookorbit/types'
 import { useReaderDefaultSettings } from '@/features/reader/shared/composables/useReaderSettings'
 import SettingsPageHeader from './SettingsPageHeader.vue'
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -24,9 +27,9 @@ const showZoom = computed(() => effective.value.zoomMode === 'custom')
   <div
     class="[&_.settings-hint]:overflow-hidden [&_.settings-hint]:text-ellipsis [&_.settings-hint]:whitespace-nowrap md:[&_.settings-hint]:overflow-visible md:[&_.settings-hint]:whitespace-normal"
   >
-    <SettingsPageHeader v-if="!props.embedded" title="PDF Reader" subtitle="Default settings applied when opening PDF files.">
+    <SettingsPageHeader v-if="!props.embedded" :title="t('settings.reader.pdf.title')" :subtitle="t('settings.reader.pdf.subtitle')">
       <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-        Reset to defaults
+        {{ t('settings.reader.resetToDefaults') }}
       </button>
     </SettingsPageHeader>
     <template v-else>
@@ -34,26 +37,26 @@ const showZoom = computed(() => effective.value.zoomMode === 'custom')
         class="md:hidden sticky top-11 z-10 -mx-4 mb-4 px-4 py-2 border-y border-border/70 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/75"
       >
         <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-          Reset to defaults
+          {{ t('settings.reader.resetToDefaults') }}
         </button>
       </div>
       <div class="hidden md:flex justify-end mb-4">
         <button class="text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2" @click="reset()">
-          Reset to defaults
+          {{ t('settings.reader.resetToDefaults') }}
         </button>
       </div>
     </template>
 
     <!-- Layout -->
     <div class="mb-6">
-      <p class="settings-group-label">Layout</p>
+      <p class="settings-group-label">{{ t('settings.reader.pdf.layout') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border">
         <!-- Scroll mode -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Scroll mode</p>
+            <p class="settings-label">{{ t('settings.reader.pdf.scrollMode') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Page flips one at a time; continuous scrolls through all pages
+              {{ t('settings.reader.pdf.scrollModeHint') }}
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
@@ -62,14 +65,14 @@ const showZoom = computed(() => effective.value.zoomMode === 'custom')
               :class="effective.scrollMode === 'page' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ scrollMode: 'page' })"
             >
-              Page
+              {{ t('settings.reader.pdf.page') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
               :class="effective.scrollMode === 'vertical' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ scrollMode: 'vertical' })"
             >
-              Scrolled
+              {{ t('settings.reader.pdf.scrolled') }}
             </button>
           </div>
         </div>
@@ -77,9 +80,9 @@ const showZoom = computed(() => effective.value.zoomMode === 'custom')
         <!-- Page spread -->
         <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div>
-            <p class="settings-label">Page spread</p>
+            <p class="settings-label">{{ t('settings.reader.pdf.pageSpread') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Which page number starts on the right in two-page view
+              {{ t('settings.reader.pdf.pageSpreadHint') }}
             </p>
           </div>
           <div class="flex flex-wrap items-center gap-1.5 p-1 rounded-lg border border-border bg-muted/50 self-start">
@@ -88,21 +91,21 @@ const showZoom = computed(() => effective.value.zoomMode === 'custom')
               :class="effective.spread === 'none' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ spread: 'none' })"
             >
-              None
+              {{ t('settings.reader.pdf.spreadNone') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
               :class="effective.spread === 'odd' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ spread: 'odd' })"
             >
-              Odd
+              {{ t('settings.reader.pdf.spreadOdd') }}
             </button>
             <button
               class="h-8 px-3 rounded-md text-xs font-medium transition-colors"
               :class="effective.spread === 'even' ? 'bg-background shadow-xs text-foreground' : 'text-muted-foreground hover:text-foreground'"
               @click="update({ spread: 'even' })"
             >
-              Even
+              {{ t('settings.reader.pdf.spreadEven') }}
             </button>
           </div>
         </div>
@@ -111,22 +114,22 @@ const showZoom = computed(() => effective.value.zoomMode === 'custom')
 
     <!-- Zoom -->
     <div class="mb-6">
-      <p class="settings-group-label">Zoom</p>
+      <p class="settings-group-label">{{ t('settings.reader.pdf.zoom') }}</p>
       <div class="border border-border rounded-lg overflow-hidden divide-y divide-border">
         <!-- Zoom mode -->
         <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
-            <p class="settings-label">Default fit</p>
+            <p class="settings-label">{{ t('settings.reader.pdf.defaultFit') }}</p>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              How pages are scaled when a PDF is opened
+              {{ t('settings.reader.pdf.defaultFitHint') }}
             </p>
           </div>
           <div class="flex flex-wrap gap-2">
             <button
               v-for="opt in [
-                { id: 'fit-page' as const, label: 'Fit Page' },
-                { id: 'fit-width' as const, label: 'Fit Width' },
-                { id: 'custom' as const, label: 'Custom' },
+                { id: 'fit-page' as const, label: t('settings.reader.pdf.fitPage') },
+                { id: 'fit-width' as const, label: t('settings.reader.pdf.fitWidth') },
+                { id: 'custom' as const, label: t('settings.reader.pdf.custom') },
               ]"
               :key="opt.id"
               class="h-8 px-3 text-xs border-2 transition-colors font-medium rounded-md"
@@ -146,11 +149,11 @@ const showZoom = computed(() => effective.value.zoomMode === 'custom')
         <div v-if="showZoom" class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
           <div class="mb-3">
             <div class="flex items-center justify-between gap-3">
-              <p class="settings-label">Zoom level</p>
+              <p class="settings-label">{{ t('settings.reader.pdf.zoomLevel') }}</p>
               <span class="settings-value">{{ Math.round(effective.customScale * 100) }}%</span>
             </div>
             <p class="settings-hint overflow-hidden text-ellipsis whitespace-nowrap md:overflow-visible md:whitespace-normal">
-              Scale factor for custom zoom mode
+              {{ t('settings.reader.pdf.zoomLevelHint') }}
             </p>
           </div>
           <input

--- a/client/src/features/settings/ReaderAllSettings.vue
+++ b/client/src/features/settings/ReaderAllSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import SettingsPageHeader from './SettingsPageHeader.vue'
 import ReaderSettings from './ReaderSettings.vue'
@@ -10,6 +11,7 @@ import AudioSettings from './AudioSettings.vue'
 import FontsSettings from './FontsSettings.vue'
 import { READER_TAB_LABELS, READER_TABS, normalizeReaderTab, type ReaderTab as Tab } from './lib/reader-tabs'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 
@@ -37,7 +39,7 @@ function selectTab(tab: Tab) {
 </script>
 
 <template>
-  <SettingsPageHeader title="Reader" subtitle="Configure defaults for all reading modes in one place." />
+  <SettingsPageHeader :title="t('settings.reader.all.title')" :subtitle="t('settings.reader.all.subtitle')" />
 
   <div
     class="flex gap-1 mb-5 md:mb-6 border-b border-border overflow-x-auto md:overflow-visible md:static sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 snap-x"

--- a/client/src/features/settings/ReaderAllSettings.vue
+++ b/client/src/features/settings/ReaderAllSettings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import SettingsPageHeader from './SettingsPageHeader.vue'
@@ -9,7 +9,7 @@ import PdfSettings from './PdfSettings.vue'
 import ComicsSettings from './ComicsSettings.vue'
 import AudioSettings from './AudioSettings.vue'
 import FontsSettings from './FontsSettings.vue'
-import { READER_TAB_LABELS, READER_TABS, normalizeReaderTab, type ReaderTab as Tab } from './lib/reader-tabs'
+import { READER_TABS, normalizeReaderTab, type ReaderTab as Tab } from './lib/reader-tabs'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -28,9 +28,11 @@ watch(
   },
 )
 
-const tabs: { id: Tab; label: string }[] = READER_TABS.slice()
-  .sort((a, b) => (a === 'general' ? 1 : b === 'general' ? -1 : 0))
-  .map((id) => ({ id, label: READER_TAB_LABELS[id] }))
+const tabs = computed(() =>
+  READER_TABS.slice()
+    .sort((a, b) => (a === 'general' ? 1 : b === 'general' ? -1 : 0))
+    .map((id) => ({ id, label: t(`settings.reader.tabs.${id}`) })),
+)
 
 function selectTab(tab: Tab) {
   activeTab.value = tab

--- a/client/src/features/settings/ReaderSettings.vue
+++ b/client/src/features/settings/ReaderSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Monitor, Cloud } from '@lucide/vue'
 import { toast } from 'vue-sonner'
 import { api } from '@/lib/api'
@@ -16,6 +17,7 @@ const props = withDefaults(
   },
 )
 
+const { t } = useI18n()
 const { user } = useAuth()
 const { isDemoRestrictedAccount } = usePermissions()
 
@@ -24,7 +26,7 @@ const syncEnabled = computed(() => !isDemoRestrictedAccount.value && (user.value
 async function setStorageMode(sync: boolean) {
   if (!user.value || syncEnabled.value === sync) return
   if (isDemoRestrictedAccount.value) {
-    toast.error('Demo-restricted account cannot change reader storage mode')
+    toast.error(t('settings.reader.general.demoCannotChangeStorage'))
     return
   }
   try {
@@ -35,12 +37,12 @@ async function setStorageMode(sync: boolean) {
     })
     if (res.ok) {
       user.value = { ...user.value, settings: { ...user.value.settings, syncReaderPreferences: sync } }
-      toast.success(sync ? 'Preferences will now be synced' : 'Preferences will stay on this device')
+      toast.success(sync ? t('settings.reader.general.preferencesSynced') : t('settings.reader.general.preferencesLocal'))
     } else {
-      toast.error('Failed to update storage mode')
+      toast.error(t('settings.reader.general.storageUpdateFailed'))
     }
   } catch {
-    toast.error('An error occurred while updating storage mode')
+    toast.error(t('settings.reader.general.storageUpdateError'))
   }
 }
 </script>
@@ -49,11 +51,11 @@ async function setStorageMode(sync: boolean) {
   <div
     class="[&_.settings-hint]:overflow-hidden [&_.settings-hint]:text-ellipsis [&_.settings-hint]:whitespace-nowrap md:[&_.settings-hint]:overflow-visible md:[&_.settings-hint]:whitespace-normal"
   >
-    <SettingsPageHeader v-if="!props.embedded" title="Reading" subtitle="General behavior that applies across all reader types." />
+    <SettingsPageHeader v-if="!props.embedded" :title="t('settings.reader.general.title')" :subtitle="t('settings.reader.general.subtitle')" />
 
     <!-- Preference storage -->
     <div class="mt-5 mb-2">
-      <p class="settings-group-label">Where to save reader preferences</p>
+      <p class="settings-group-label">{{ t('settings.reader.general.storageLabel') }}</p>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <!-- This device only -->
         <div
@@ -69,13 +71,13 @@ async function setStorageMode(sync: boolean) {
           </div>
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2 mb-1">
-              <span class="settings-label">This device only</span>
+              <span class="settings-label">{{ t('settings.reader.general.deviceOnly') }}</span>
               <span v-if="!syncEnabled" class="text-xs font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-primary/15 text-primary">
-                Active
+                {{ t('settings.reader.general.active') }}
               </span>
             </div>
             <span class="block text-xs text-muted-foreground leading-relaxed">
-              Preferences stay in your browser. Best if you always read on this device, or want different settings per device.
+              {{ t('settings.reader.general.deviceOnlyHint') }}
             </span>
           </div>
         </div>
@@ -97,19 +99,19 @@ async function setStorageMode(sync: boolean) {
           </div>
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2 mb-1">
-              <span class="settings-label">My account</span>
+              <span class="settings-label">{{ t('settings.reader.general.myAccount') }}</span>
               <span v-if="syncEnabled" class="text-xs font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-primary/15 text-primary">
-                Active
+                {{ t('settings.reader.general.active') }}
               </span>
               <span
                 v-if="isDemoRestrictedAccount"
                 class="text-xs font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground"
               >
-                Not available
+                {{ t('settings.reader.general.notAvailable') }}
               </span>
             </div>
             <span class="block text-xs text-muted-foreground leading-relaxed">
-              Preferences are saved to your account. Best if you log in from multiple devices and want a consistent experience everywhere.
+              {{ t('settings.reader.general.myAccountHint') }}
             </span>
           </div>
         </div>

--- a/client/src/features/settings/SettingsHeader.vue
+++ b/client/src/features/settings/SettingsHeader.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { Permission } from '@bookorbit/types'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { isSuperuser, userPermissions } = usePermissions()
@@ -24,45 +26,45 @@ const sections = computed<Section[]>(() => {
   const result: Section[] = []
 
   if (su || perms.includes('manage_libraries')) {
-    result.push({ label: 'Libraries', routeName: 'settings-libraries' })
+    result.push({ label: t('settings.common.nav.libraries'), routeName: 'settings-libraries' })
   }
 
-  result.push({ label: 'Display', routeName: 'settings-appearance' })
-  result.push({ label: 'Reader', routeName: 'settings-reader-general' })
+  result.push({ label: t('settings.common.nav.display'), routeName: 'settings-appearance' })
+  result.push({ label: t('settings.common.nav.reader'), routeName: 'settings-reader-general' })
 
   if (su || perms.includes('manage_metadata_config') || perms.includes('manage_libraries')) {
-    result.push({ label: 'Metadata', routeName: 'settings-admin-metadata' })
+    result.push({ label: t('settings.common.nav.metadata'), routeName: 'settings-admin-metadata' })
   }
 
   if (su || perms.includes('email_send') || perms.includes('manage_email')) {
-    result.push({ label: 'Email', routeName: 'settings-email' })
+    result.push({ label: t('settings.common.nav.email'), routeName: 'settings-email' })
   }
 
   if (su || perms.includes('opds_access')) {
-    result.push({ label: 'OPDS', routeName: 'settings-opds' })
+    result.push({ label: t('settings.common.nav.opds'), routeName: 'settings-opds' })
   }
 
   if (su || perms.includes(Permission.KoboSync)) {
-    result.push({ label: 'Kobo', routeName: 'settings-kobo' })
+    result.push({ label: t('settings.common.nav.kobo'), routeName: 'settings-kobo' })
   }
 
   if (su || perms.includes(Permission.KoreaderSync)) {
-    result.push({ label: 'KOReader', routeName: 'settings-koreader' })
+    result.push({ label: t('settings.common.nav.koreader'), routeName: 'settings-koreader' })
   }
 
   if (su || perms.includes(Permission.HardcoverSync)) {
-    result.push({ label: 'Hardcover', routeName: 'settings-hardcover' })
+    result.push({ label: t('settings.common.nav.hardcover'), routeName: 'settings-hardcover' })
   }
 
   if (su || perms.includes('manage_users') || perms.includes('manage_app_settings')) {
-    result.push({ label: 'Admin', routeName: 'settings-admin' })
+    result.push({ label: t('settings.common.nav.admin'), routeName: 'settings-admin' })
   }
 
   if (su || perms.includes('manage_app_settings') || perms.includes('book_dock_access')) {
-    result.push({ label: 'System', routeName: 'settings-system' })
+    result.push({ label: t('settings.common.nav.system'), routeName: 'settings-system' })
   }
 
-  result.push({ label: 'Account', routeName: 'settings-account' })
+  result.push({ label: t('settings.common.nav.account'), routeName: 'settings-account' })
 
   return result
 })

--- a/client/src/features/settings/SystemAllSettings.vue
+++ b/client/src/features/settings/SystemAllSettings.vue
@@ -20,7 +20,7 @@ const availableTabs = computed(() =>
     const perm = SYSTEM_TAB_INFO[id].permission
     if (id === 'audit-log') return isSuperuser.value
     return isSuperuser.value || (perm !== null && userPermissions.value.includes(perm))
-  }).map((id) => ({ id, label: SYSTEM_TAB_INFO[id].navLabel })),
+  }).map((id) => ({ id, label: t(`settings.system.tabs.${id}`) })),
 )
 
 function resolveTab(raw: unknown): Tab {

--- a/client/src/features/settings/SystemAllSettings.vue
+++ b/client/src/features/settings/SystemAllSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import SettingsPageHeader from './SettingsPageHeader.vue'
 import FileNamingSettings from './FileNamingSettings.vue'
@@ -9,6 +10,7 @@ import AuditLogPage from '@/features/audit/AuditLogPage.vue'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 import { SYSTEM_TAB_INFO, SYSTEM_TABS, normalizeSystemTab, type SystemTab as Tab } from './lib/system-tabs'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { isSuperuser, userPermissions } = usePermissions()
@@ -62,7 +64,7 @@ function selectTab(tab: Tab) {
 </script>
 
 <template>
-  <SettingsPageHeader title="System" subtitle="File organization, ingestion, and maintenance settings." />
+  <SettingsPageHeader :title="t('settings.admin.system.title')" :subtitle="t('settings.admin.system.subtitle')" />
 
   <div
     :class="[

--- a/client/src/features/settings/__tests__/AppearanceSettings.spec.ts
+++ b/client/src/features/settings/__tests__/AppearanceSettings.spec.ts
@@ -115,6 +115,10 @@ vi.mock('@/stores/theme', () => ({
   useThemeStore: () => themeStore,
 }))
 
+vi.mock('@/stores/locale', () => ({
+  useLocaleStore: () => ({ locale: ref('en'), setLocale: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined) }),
+}))
+
 vi.mock('@/composables/useDisplaySettings', () => ({
   getDisplayPreferencesSnapshot: () => displaySnapshot,
   useDisplaySettings: () => displayRefs,

--- a/client/src/features/settings/__tests__/account-tabs.spec.ts
+++ b/client/src/features/settings/__tests__/account-tabs.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { ACCOUNT_TABS, ACCOUNT_TAB_INFO, normalizeAccountTab } from '../lib/account-tabs'
+import { ACCOUNT_TABS, normalizeAccountTab } from '../lib/account-tabs'
 
 describe('account-tabs', () => {
   describe('ACCOUNT_TABS', () => {
@@ -9,41 +9,6 @@ describe('account-tabs', () => {
 
     it('has length 3', () => {
       expect(ACCOUNT_TABS.length).toBe(3)
-    })
-  })
-
-  describe('ACCOUNT_TAB_INFO', () => {
-    it('has an entry for every tab', () => {
-      for (const tab of ACCOUNT_TABS) {
-        expect(ACCOUNT_TAB_INFO[tab]).toBeDefined()
-      }
-    })
-
-    it('every entry has navLabel, titleLabel, and subtitle', () => {
-      for (const tab of ACCOUNT_TABS) {
-        const info = ACCOUNT_TAB_INFO[tab]
-        expect(typeof info.navLabel).toBe('string')
-        expect(info.navLabel.length).toBeGreaterThan(0)
-        expect(typeof info.titleLabel).toBe('string')
-        expect(info.titleLabel.length).toBeGreaterThan(0)
-        expect(typeof info.subtitle).toBe('string')
-        expect(info.subtitle.length).toBeGreaterThan(0)
-      }
-    })
-
-    it('profile entry has correct labels', () => {
-      expect(ACCOUNT_TAB_INFO.profile.navLabel).toBe('Profile')
-      expect(ACCOUNT_TAB_INFO.profile.titleLabel).toBe('Account')
-    })
-
-    it('notifications entry has correct labels', () => {
-      expect(ACCOUNT_TAB_INFO.notifications.navLabel).toBe('Notifications')
-      expect(ACCOUNT_TAB_INFO.notifications.titleLabel).toBe('Notifications')
-    })
-
-    it('restrictions entry has correct labels', () => {
-      expect(ACCOUNT_TAB_INFO.restrictions.navLabel).toBe('Restrictions')
-      expect(ACCOUNT_TAB_INFO.restrictions.titleLabel).toBe('Content Restrictions')
     })
   })
 

--- a/client/src/features/settings/__tests__/admin-tabs.spec.ts
+++ b/client/src/features/settings/__tests__/admin-tabs.spec.ts
@@ -19,15 +19,9 @@ describe('admin-tabs', () => {
       }
     })
 
-    it('every entry has navLabel, titleLabel, subtitle, and permission', () => {
+    it('every entry has a permission', () => {
       for (const tab of ADMIN_TABS) {
         const info = ADMIN_TAB_INFO[tab]
-        expect(typeof info.navLabel).toBe('string')
-        expect(info.navLabel.length).toBeGreaterThan(0)
-        expect(typeof info.titleLabel).toBe('string')
-        expect(info.titleLabel.length).toBeGreaterThan(0)
-        expect(typeof info.subtitle).toBe('string')
-        expect(info.subtitle.length).toBeGreaterThan(0)
         expect(info.permission === null || typeof info.permission === 'string').toBe(true)
       }
     })
@@ -42,21 +36,6 @@ describe('admin-tabs', () => {
 
     it('magic-links entry is superuser-only', () => {
       expect(ADMIN_TAB_INFO['magic-links'].permission).toBeNull()
-    })
-
-    it('users entry has correct labels', () => {
-      expect(ADMIN_TAB_INFO.users.navLabel).toBe('Users')
-      expect(ADMIN_TAB_INFO.users.titleLabel).toBe('Users')
-    })
-
-    it('magic-links entry has correct labels', () => {
-      expect(ADMIN_TAB_INFO['magic-links'].navLabel).toBe('Magic Links')
-      expect(ADMIN_TAB_INFO['magic-links'].titleLabel).toBe('Magic Links')
-    })
-
-    it('oidc entry has correct labels', () => {
-      expect(ADMIN_TAB_INFO.oidc.navLabel).toBe('OIDC / SSO')
-      expect(ADMIN_TAB_INFO.oidc.titleLabel).toBe('OIDC / SSO')
     })
   })
 

--- a/client/src/features/settings/__tests__/system-tabs.spec.ts
+++ b/client/src/features/settings/__tests__/system-tabs.spec.ts
@@ -19,15 +19,9 @@ describe('system-tabs', () => {
       }
     })
 
-    it('every entry has navLabel, titleLabel, subtitle, and permission', () => {
+    it('every entry has a permission', () => {
       for (const tab of SYSTEM_TABS) {
         const info = SYSTEM_TAB_INFO[tab]
-        expect(typeof info.navLabel).toBe('string')
-        expect(info.navLabel.length).toBeGreaterThan(0)
-        expect(typeof info.titleLabel).toBe('string')
-        expect(info.titleLabel.length).toBeGreaterThan(0)
-        expect(typeof info.subtitle).toBe('string')
-        expect(info.subtitle.length).toBeGreaterThan(0)
         expect(info.permission === null || typeof info.permission === 'string').toBe(true)
       }
     })
@@ -46,22 +40,6 @@ describe('system-tabs', () => {
 
     it('audit-log has null permission (superuser only)', () => {
       expect(SYSTEM_TAB_INFO['audit-log'].permission).toBeNull()
-    })
-
-    it('file-naming has correct nav label', () => {
-      expect(SYSTEM_TAB_INFO['file-naming'].navLabel).toBe('File Naming')
-    })
-
-    it('book-dock has correct nav label', () => {
-      expect(SYSTEM_TAB_INFO['book-dock'].navLabel).toBe('Book Dock')
-    })
-
-    it('maintenance has correct nav label', () => {
-      expect(SYSTEM_TAB_INFO.maintenance.navLabel).toBe('Maintenance')
-    })
-
-    it('audit-log has correct nav label', () => {
-      expect(SYSTEM_TAB_INFO['audit-log'].navLabel).toBe('Audit Log')
     })
   })
 

--- a/client/src/features/settings/lib/__tests__/appearance-tabs.spec.ts
+++ b/client/src/features/settings/lib/__tests__/appearance-tabs.spec.ts
@@ -1,16 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { APPEARANCE_TAB_LABELS, APPEARANCE_TAB_TITLE_LABELS, APPEARANCE_TABS, normalizeAppearanceTab } from '../appearance-tabs'
+import { APPEARANCE_TABS, normalizeAppearanceTab } from '../appearance-tabs'
 
 describe('appearance-tabs', () => {
   it('keeps the public tab order stable', () => {
     expect(APPEARANCE_TABS).toEqual(['theme', 'book-covers', 'icons', 'layout', 'behavior'])
-  })
-
-  it('has nav and title labels for every tab', () => {
-    for (const tab of APPEARANCE_TABS) {
-      expect(APPEARANCE_TAB_LABELS[tab]).toBeTruthy()
-      expect(APPEARANCE_TAB_TITLE_LABELS[tab]).toBeTruthy()
-    }
   })
 
   it('normalizes invalid values to theme', () => {

--- a/client/src/features/settings/lib/__tests__/metadata-tabs.spec.ts
+++ b/client/src/features/settings/lib/__tests__/metadata-tabs.spec.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { METADATA_TAB_INFO, METADATA_TABS, normalizeMetadataTab } from '../metadata-tabs'
+import { METADATA_TABS, normalizeMetadataTab } from '../metadata-tabs'
 
 describe('metadata tabs', () => {
   it('keeps genre blocklist as the final metadata tab', () => {
     expect(METADATA_TABS).toEqual(['providers', 'field-rules', 'custom-fields', 'score', 'auto-fetch', 'authors', 'genre-blocklist'])
-    expect(METADATA_TAB_INFO['genre-blocklist'].navLabel).toBe('Genre Blocklist')
   })
 
   it('normalizes supported metadata tabs and falls back to providers', () => {

--- a/client/src/features/settings/lib/__tests__/reader-tabs.spec.ts
+++ b/client/src/features/settings/lib/__tests__/reader-tabs.spec.ts
@@ -1,21 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { READER_TABS, READER_TAB_LABELS, READER_TAB_TITLE_LABELS, normalizeReaderTab } from '../reader-tabs'
+import { READER_TABS, normalizeReaderTab } from '../reader-tabs'
 
 describe('reader-tabs', () => {
   it('includes fonts tab in READER_TABS', () => {
     expect(READER_TABS).toContain('fonts')
-  })
-
-  it('has labels for all tabs', () => {
-    for (const tab of READER_TABS) {
-      expect(READER_TAB_LABELS[tab]).toBeTruthy()
-      expect(READER_TAB_TITLE_LABELS[tab]).toBeTruthy()
-    }
-  })
-
-  it('fonts tab has correct labels', () => {
-    expect(READER_TAB_LABELS['fonts']).toBe('Fonts')
-    expect(READER_TAB_TITLE_LABELS['fonts']).toBe('Reader Fonts')
   })
 
   describe('normalizeReaderTab', () => {

--- a/client/src/features/settings/lib/account-tabs.ts
+++ b/client/src/features/settings/lib/account-tabs.ts
@@ -2,30 +2,6 @@ export const ACCOUNT_TABS = ['profile', 'notifications', 'restrictions'] as cons
 
 export type AccountTab = (typeof ACCOUNT_TABS)[number]
 
-type AccountTabInfo = {
-  navLabel: string
-  titleLabel: string
-  subtitle: string
-}
-
-export const ACCOUNT_TAB_INFO: Record<AccountTab, AccountTabInfo> = {
-  profile: {
-    navLabel: 'Profile',
-    titleLabel: 'Account',
-    subtitle: 'Manage your personal profile settings.',
-  },
-  notifications: {
-    navLabel: 'Notifications',
-    titleLabel: 'Notifications',
-    subtitle: 'Choose which notification categories you want to receive.',
-  },
-  restrictions: {
-    navLabel: 'Restrictions',
-    titleLabel: 'Content Restrictions',
-    subtitle: 'View content restrictions applied to your account.',
-  },
-}
-
 export function normalizeAccountTab(value: unknown): AccountTab {
   if (typeof value === 'string' && ACCOUNT_TABS.includes(value as AccountTab)) {
     return value as AccountTab

--- a/client/src/features/settings/lib/admin-tabs.ts
+++ b/client/src/features/settings/lib/admin-tabs.ts
@@ -3,29 +3,17 @@ export const ADMIN_TABS = ['users', 'magic-links', 'oidc'] as const
 export type AdminTab = (typeof ADMIN_TABS)[number]
 
 type AdminTabInfo = {
-  navLabel: string
-  titleLabel: string
-  subtitle: string
   permission: string | null
 }
 
 export const ADMIN_TAB_INFO: Record<AdminTab, AdminTabInfo> = {
   users: {
-    navLabel: 'Users',
-    titleLabel: 'Users',
-    subtitle: 'Manage user accounts and permission assignments.',
     permission: 'manage_users',
   },
   'magic-links': {
-    navLabel: 'Magic Links',
-    titleLabel: 'Magic Links',
-    subtitle: 'Create shareable login links for shared accounts.',
     permission: null,
   },
   oidc: {
-    navLabel: 'OIDC / SSO',
-    titleLabel: 'OIDC / SSO',
-    subtitle: 'Manage OpenID Connect providers for single sign-on.',
     permission: 'manage_app_settings',
   },
 }

--- a/client/src/features/settings/lib/appearance-tabs.ts
+++ b/client/src/features/settings/lib/appearance-tabs.ts
@@ -2,22 +2,6 @@ export const APPEARANCE_TABS = ['theme', 'book-covers', 'icons', 'layout', 'beha
 
 export type AppearanceTab = (typeof APPEARANCE_TABS)[number]
 
-export const APPEARANCE_TAB_LABELS: Record<AppearanceTab, string> = {
-  theme: 'Theme',
-  'book-covers': 'Book Covers',
-  icons: 'Icons',
-  layout: 'Layout',
-  behavior: 'Behavior',
-}
-
-export const APPEARANCE_TAB_TITLE_LABELS: Record<AppearanceTab, string> = {
-  theme: 'Display',
-  'book-covers': 'Book Covers',
-  icons: 'Icons',
-  layout: 'Display Layout',
-  behavior: 'Library Behavior',
-}
-
 export function normalizeAppearanceTab(value: unknown): AppearanceTab {
   if (typeof value === 'string' && APPEARANCE_TABS.includes(value as AppearanceTab)) {
     return value as AppearanceTab

--- a/client/src/features/settings/lib/metadata-tabs.ts
+++ b/client/src/features/settings/lib/metadata-tabs.ts
@@ -2,50 +2,6 @@ export const METADATA_TABS = ['providers', 'field-rules', 'custom-fields', 'scor
 
 export type MetadataTab = (typeof METADATA_TABS)[number]
 
-type MetadataTabInfo = {
-  navLabel: string
-  titleLabel: string
-  subtitle: string
-}
-
-export const METADATA_TAB_INFO: Record<MetadataTab, MetadataTabInfo> = {
-  providers: {
-    navLabel: 'Providers',
-    titleLabel: 'Providers',
-    subtitle: 'Enable external metadata sources and configure their credentials.',
-  },
-  'field-rules': {
-    navLabel: 'Field Rules',
-    titleLabel: 'Field-Level Rules',
-    subtitle: 'Control which provider supplies each metadata field and how values are merged across your libraries.',
-  },
-  'custom-fields': {
-    navLabel: 'Custom Fields',
-    titleLabel: 'Custom Metadata',
-    subtitle: 'Define custom metadata fields and choose which libraries use them.',
-  },
-  'genre-blocklist': {
-    navLabel: 'Genre Blocklist',
-    titleLabel: 'Genre Blocklist',
-    subtitle: 'Prevent unwanted provider genre values from being written to books.',
-  },
-  score: {
-    navLabel: 'Score',
-    titleLabel: 'Confidence Score',
-    subtitle: 'Assign weights to metadata fields to calculate how much to trust fetched results.',
-  },
-  'auto-fetch': {
-    navLabel: 'Books',
-    titleLabel: 'Book Auto-Fetch',
-    subtitle: 'Automatically fetch covers, descriptions, and other details when new books are added to your library.',
-  },
-  authors: {
-    navLabel: 'Authors',
-    titleLabel: 'Author Auto-Fetch',
-    subtitle: 'Automatically fetch biographies and profile photos when new authors appear in your library.',
-  },
-}
-
 export function normalizeMetadataTab(value: unknown): MetadataTab {
   if (typeof value === 'string' && METADATA_TABS.includes(value as MetadataTab)) {
     return value as MetadataTab

--- a/client/src/features/settings/lib/reader-tabs.ts
+++ b/client/src/features/settings/lib/reader-tabs.ts
@@ -2,24 +2,6 @@ export const READER_TABS = ['general', 'ebook', 'pdf', 'comics', 'audio', 'fonts
 
 export type ReaderTab = (typeof READER_TABS)[number]
 
-export const READER_TAB_LABELS: Record<ReaderTab, string> = {
-  general: 'General',
-  ebook: 'eBook',
-  pdf: 'PDF',
-  comics: 'Comics',
-  audio: 'Audiobook',
-  fonts: 'Fonts',
-}
-
-export const READER_TAB_TITLE_LABELS: Record<ReaderTab, string> = {
-  general: 'Reader Settings',
-  ebook: 'eBook Reader',
-  pdf: 'PDF Reader',
-  comics: 'Comics Reader',
-  audio: 'Audiobook Player',
-  fonts: 'Reader Fonts',
-}
-
 export function normalizeReaderTab(value: unknown): ReaderTab {
   if (typeof value === 'string' && READER_TABS.includes(value as ReaderTab)) {
     return value as ReaderTab

--- a/client/src/features/settings/lib/system-tabs.ts
+++ b/client/src/features/settings/lib/system-tabs.ts
@@ -3,35 +3,20 @@ export const SYSTEM_TABS = ['file-naming', 'book-dock', 'maintenance', 'audit-lo
 export type SystemTab = (typeof SYSTEM_TABS)[number]
 
 type SystemTabInfo = {
-  navLabel: string
-  titleLabel: string
-  subtitle: string
   permission: string | null
 }
 
 export const SYSTEM_TAB_INFO: Record<SystemTab, SystemTabInfo> = {
   'file-naming': {
-    navLabel: 'File Naming',
-    titleLabel: 'File Naming',
-    subtitle: 'Control how files are organized on disk when uploaded and how they are named when downloaded using placeholder tokens.',
     permission: 'manage_app_settings',
   },
   'book-dock': {
-    navLabel: 'Book Dock',
-    titleLabel: 'Book Dock',
-    subtitle: 'Configure how files are processed when they enter Book Dock.',
     permission: 'book_dock_access',
   },
   maintenance: {
-    navLabel: 'Maintenance',
-    titleLabel: 'Maintenance',
-    subtitle: 'Manage background tasks, system indices, and maintenance operations.',
     permission: 'manage_app_settings',
   },
   'audit-log': {
-    navLabel: 'Audit Log',
-    titleLabel: 'Audit Log',
-    subtitle: 'A record of admin-significant actions performed across the system.',
     permission: null,
   },
 }

--- a/client/src/features/settings/metadata-auto-fetch/BookMetadataFetchSettings.vue
+++ b/client/src/features/settings/metadata-auto-fetch/BookMetadataFetchSettings.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { BookMetadataFetchConfig } from '@bookorbit/types'
 import { useLibraries } from '@/features/library/composables/useLibraries'
 import { useBookMetadataFetchConfig } from '@/features/book-metadata-fetch/composables/useBookMetadataFetchConfig'
 import GlobalAutoFetchConfig from './components/GlobalAutoFetchConfig.vue'
 import LibraryAutoFetchConfig from './components/LibraryAutoFetchConfig.vue'
 
+const { t } = useI18n()
 const { globalConfig, fetchGlobalConfig } = useBookMetadataFetchConfig()
 const { libraries, fetchLibraries } = useLibraries()
 const loading = ref(true)
@@ -24,14 +26,14 @@ function handleGlobalUpdated(updated: BookMetadataFetchConfig) {
 </script>
 
 <template>
-  <div v-if="loading" class="text-sm text-muted-foreground">Loading...</div>
+  <div v-if="loading" class="text-sm text-muted-foreground">{{ t('common.loading') }}</div>
 
   <template v-else>
-    <p class="settings-group-label">Global Settings</p>
+    <p class="settings-group-label">{{ t('settings.metadata.autoFetch.globalSettings') }}</p>
     <GlobalAutoFetchConfig v-if="globalConfig" :config="globalConfig" @updated="handleGlobalUpdated" />
 
     <template v-if="libraries.length > 0">
-      <p class="settings-group-label mt-8">Per-Library Overrides</p>
+      <p class="settings-group-label mt-8">{{ t('settings.metadata.autoFetch.perLibraryOverrides') }}</p>
       <div class="flex flex-col gap-3">
         <LibraryAutoFetchConfig v-for="lib in libraries" :key="lib.id" :library="lib" :global-config="globalConfig!" />
       </div>

--- a/client/src/features/settings/metadata-auto-fetch/components/ConditionConfigurator.vue
+++ b/client/src/features/settings/metadata-auto-fetch/components/ConditionConfigurator.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import type { BookMetadataFetchConditions, MetadataField } from '@bookorbit/types'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
 import MissingFieldsPicker from './MissingFieldsPicker.vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   modelValue: BookMetadataFetchConditions
@@ -41,8 +44,8 @@ function updateNeverFetched(enabled: boolean) {
         class="mt-0.5 shrink-0"
       />
       <div>
-        <p class="settings-label">Never fetched</p>
-        <p class="settings-hint">Fetch books that have never had a metadata fetch attempt.</p>
+        <p class="settings-label">{{ t('settings.metadata.autoFetch.conditions.neverFetched.label') }}</p>
+        <p class="settings-hint">{{ t('settings.metadata.autoFetch.conditions.neverFetched.hint') }}</p>
       </div>
     </div>
 
@@ -54,10 +57,10 @@ function updateNeverFetched(enabled: boolean) {
         class="mt-0.5 shrink-0"
       />
       <div class="flex-1">
-        <p class="settings-label">Low metadata score</p>
-        <p class="settings-hint">Fetch if the metadata score is below a threshold.</p>
+        <p class="settings-label">{{ t('settings.metadata.autoFetch.conditions.scoreThreshold.label') }}</p>
+        <p class="settings-hint">{{ t('settings.metadata.autoFetch.conditions.scoreThreshold.hint') }}</p>
         <div v-if="modelValue.scoreThreshold.enabled" class="flex items-center gap-2 mt-2">
-          <span class="text-xs text-muted-foreground">Score below</span>
+          <span class="text-xs text-muted-foreground">{{ t('settings.metadata.autoFetch.conditions.scoreThreshold.scoreBelow') }}</span>
           <input
             type="number"
             min="0"
@@ -80,8 +83,8 @@ function updateNeverFetched(enabled: boolean) {
         class="mt-0.5 shrink-0"
       />
       <div class="flex-1">
-        <p class="settings-label">Missing fields</p>
-        <p class="settings-hint">Fetch if any of the selected fields are empty.</p>
+        <p class="settings-label">{{ t('settings.metadata.autoFetch.conditions.missingFields.label') }}</p>
+        <p class="settings-hint">{{ t('settings.metadata.autoFetch.conditions.missingFields.hint') }}</p>
         <MissingFieldsPicker
           v-if="modelValue.missingFields.enabled"
           :model-value="modelValue.missingFields.fields"

--- a/client/src/features/settings/metadata-auto-fetch/components/GlobalAutoFetchConfig.vue
+++ b/client/src/features/settings/metadata-auto-fetch/components/GlobalAutoFetchConfig.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronDown, ChevronUp, Save } from '@lucide/vue'
 import type { BookMetadataFetchConfig } from '@bookorbit/types'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
@@ -10,6 +11,7 @@ import { useBookMetadataFetchStatus } from '@/features/book-metadata-fetch/compo
 import { invalidateEligibleCountPreviews, useEligibleCountPreview } from '@/features/book-metadata-fetch/composables/useEligibleCountPreview'
 import { useMediaQuery } from '@vueuse/core'
 
+const { t } = useI18n()
 const { saveGlobalConfig } = useBookMetadataFetchConfig()
 const { triggerGlobal } = useBookMetadataFetchActions()
 const { status } = useBookMetadataFetchStatus()
@@ -31,21 +33,26 @@ const statusLabel = computed<string | null>(() => {
   if (triggerResult.value) return triggerResult.value
   const remaining = status.value.queued + status.value.processing
   if (remaining > 0) {
-    return status.value.paused ? `${remaining} in queue - paused` : `${remaining} remaining`
+    return status.value.paused
+      ? t('settings.metadata.autoFetch.status.inQueuePaused', { count: remaining })
+      : t('settings.metadata.autoFetch.status.remaining', { count: remaining })
   }
   if (eligibleCount.value !== null) {
-    return countLoading.value ? null : `~${eligibleCount.value} eligible`
+    return countLoading.value ? null : t('settings.metadata.autoFetch.status.eligible', { count: eligibleCount.value })
   }
   return null
 })
 const activeConditionSummary = computed(() => {
   const c = local.value.conditions
   const parts: string[] = []
-  if (c.neverFetched.enabled) parts.push('Never fetched')
-  if (c.scoreThreshold.enabled) parts.push(`Score < ${c.scoreThreshold.threshold}`)
+  if (c.neverFetched.enabled) parts.push(t('settings.metadata.autoFetch.conditions.neverFetched.summary'))
+  if (c.scoreThreshold.enabled)
+    parts.push(t('settings.metadata.autoFetch.conditions.scoreThreshold.summary', { threshold: c.scoreThreshold.threshold }))
   if (c.missingFields.enabled && c.missingFields.fields.length > 0)
-    parts.push(`Missing ${c.missingFields.fields.length} field${c.missingFields.fields.length === 1 ? '' : 's'}`)
-  return parts.length > 0 ? parts.join(' • ') : 'No conditions enabled'
+    parts.push(
+      t('settings.metadata.autoFetch.conditions.missingFields.summary', { count: c.missingFields.fields.length }, c.missingFields.fields.length),
+    )
+  return parts.length > 0 ? parts.join(' • ') : t('settings.metadata.autoFetch.conditions.noneEnabled')
 })
 
 watch(
@@ -78,7 +85,8 @@ async function handleTrigger() {
   triggerResult.value = null
   try {
     const { queued } = await triggerGlobal()
-    triggerResult.value = queued > 0 ? `Queued ${queued} books` : 'No eligible books found'
+    triggerResult.value =
+      queued > 0 ? t('settings.metadata.autoFetch.trigger.queued', { count: queued }, queued) : t('settings.metadata.autoFetch.trigger.noneFound')
     invalidateEligibleCountPreviews()
   } finally {
     triggering.value = false
@@ -91,8 +99,8 @@ async function handleTrigger() {
     <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
       <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
-          <p class="settings-label">Enable auto-fetch</p>
-          <p class="settings-hint">Automatically fetch metadata for eligible books.</p>
+          <p class="settings-label">{{ t('settings.metadata.autoFetch.enable.label') }}</p>
+          <p class="settings-hint">{{ t('settings.metadata.autoFetch.enable.hint') }}</p>
         </div>
         <ToggleSwitch class="self-start" v-model="local.enabled" />
       </div>
@@ -101,8 +109,8 @@ async function handleTrigger() {
     <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
       <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
-          <p class="settings-label">Trigger on import</p>
-          <p class="settings-hint">Queue eligible books when they are first added to a library.</p>
+          <p class="settings-label">{{ t('settings.metadata.autoFetch.triggerOnImport.label') }}</p>
+          <p class="settings-hint">{{ t('settings.metadata.autoFetch.triggerOnImport.hint') }}</p>
         </div>
         <ToggleSwitch class="self-start" v-model="local.triggerOnImport" :disabled="!local.enabled" />
       </div>
@@ -110,11 +118,11 @@ async function handleTrigger() {
 
     <div class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
       <button class="w-full flex items-center justify-between gap-2 text-left" @click="conditionsOpen = !conditionsOpen">
-        <p class="settings-label">Eligibility conditions</p>
+        <p class="settings-label">{{ t('settings.metadata.autoFetch.conditions.title') }}</p>
         <ChevronUp v-if="conditionsOpen" :size="15" class="text-muted-foreground shrink-0" />
         <ChevronDown v-else :size="15" class="text-muted-foreground shrink-0" />
       </button>
-      <p class="settings-hint mt-1 mb-4">A book is eligible if it matches any enabled condition.</p>
+      <p class="settings-hint mt-1 mb-4">{{ t('settings.metadata.autoFetch.conditions.hint') }}</p>
       <p class="text-xs text-muted-foreground mb-3">{{ activeConditionSummary }}</p>
       <ConditionConfigurator v-if="conditionsOpen" v-model="local.conditions" />
     </div>
@@ -123,10 +131,10 @@ async function handleTrigger() {
       <div class="flex items-center gap-2 flex-wrap">
         <button :disabled="saving" class="settings-btn-primary h-9 px-3 justify-center" @click="handleSave">
           <Save class="size-3.5" />
-          {{ saving ? 'Saving...' : 'Save' }}
+          {{ saving ? t('settings.metadata.autoFetch.saving') : t('common.save') }}
         </button>
         <button :disabled="triggering" class="settings-btn-outline h-9 px-3" @click="handleTrigger">
-          {{ triggering ? 'Running...' : 'Run now' }}
+          {{ triggering ? t('settings.metadata.autoFetch.running') : t('settings.metadata.autoFetch.runNow') }}
         </button>
         <span v-if="statusLabel" class="text-xs text-muted-foreground">{{ statusLabel }}</span>
       </div>
@@ -135,11 +143,11 @@ async function handleTrigger() {
     <div class="hidden md:flex items-center gap-3 px-5 py-4 bg-card">
       <button :disabled="saving" class="settings-btn-primary" @click="handleSave">
         <Save class="size-3.5" />
-        {{ saving ? 'Saving...' : 'Save' }}
+        {{ saving ? t('settings.metadata.autoFetch.saving') : t('common.save') }}
       </button>
       <div class="w-px h-4 bg-border shrink-0" />
       <button :disabled="triggering" class="settings-btn-outline" @click="handleTrigger">
-        {{ triggering ? 'Running...' : 'Run for eligible books' }}
+        {{ triggering ? t('settings.metadata.autoFetch.running') : t('settings.metadata.autoFetch.runForEligible') }}
       </button>
       <span v-if="statusLabel" class="text-xs text-muted-foreground">{{ statusLabel }}</span>
     </div>

--- a/client/src/features/settings/metadata-auto-fetch/components/LibraryAutoFetchConfig.vue
+++ b/client/src/features/settings/metadata-auto-fetch/components/LibraryAutoFetchConfig.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronDown, ChevronUp, Save } from '@lucide/vue'
 import type { BookMetadataFetchConfig, BookMetadataFetchLibraryConfig, Library } from '@bookorbit/types'
 import ToggleSwitch from '@/components/ui/ToggleSwitch.vue'
@@ -15,6 +16,7 @@ const props = defineProps<{
   globalConfig: BookMetadataFetchConfig
 }>()
 
+const { t } = useI18n()
 const { fetchLibraryConfig, saveLibraryConfig } = useBookMetadataFetchConfig()
 const { triggerForLibrary } = useBookMetadataFetchActions()
 const { status } = useBookMetadataFetchStatus()
@@ -37,21 +39,26 @@ const statusLabel = computed<string | null>(() => {
   if (triggerResult.value) return triggerResult.value
   const remaining = status.value.queued + status.value.processing
   if (remaining > 0) {
-    return status.value.paused ? `${remaining} in queue - paused` : `${remaining} remaining`
+    return status.value.paused
+      ? t('settings.metadata.autoFetch.status.inQueuePaused', { count: remaining })
+      : t('settings.metadata.autoFetch.status.remaining', { count: remaining })
   }
   if (eligibleCount.value !== null) {
-    return countLoading.value ? null : `~${eligibleCount.value} eligible`
+    return countLoading.value ? null : t('settings.metadata.autoFetch.status.eligible', { count: eligibleCount.value })
   }
   return null
 })
 const activeConditionSummary = computed(() => {
   const c = displayConfig.value.conditions
   const parts: string[] = []
-  if (c.neverFetched.enabled) parts.push('Never fetched')
-  if (c.scoreThreshold.enabled) parts.push(`Score < ${c.scoreThreshold.threshold}`)
+  if (c.neverFetched.enabled) parts.push(t('settings.metadata.autoFetch.conditions.neverFetched.summary'))
+  if (c.scoreThreshold.enabled)
+    parts.push(t('settings.metadata.autoFetch.conditions.scoreThreshold.summary', { threshold: c.scoreThreshold.threshold }))
   if (c.missingFields.enabled && c.missingFields.fields.length > 0)
-    parts.push(`Missing ${c.missingFields.fields.length} field${c.missingFields.fields.length === 1 ? '' : 's'}`)
-  return parts.length > 0 ? parts.join(' • ') : 'No conditions enabled'
+    parts.push(
+      t('settings.metadata.autoFetch.conditions.missingFields.summary', { count: c.missingFields.fields.length }, c.missingFields.fields.length),
+    )
+  return parts.length > 0 ? parts.join(' • ') : t('settings.metadata.autoFetch.conditions.noneEnabled')
 })
 
 const lastRunLabel = computed(() => {
@@ -62,14 +69,16 @@ const lastRunLabel = computed(() => {
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
   const diffMins = Math.floor(diffMs / (1000 * 60))
   let when: string
-  if (diffMins < 2) when = 'just now'
-  else if (diffMins < 60) when = `${diffMins}m ago`
-  else if (diffHours < 24) when = `${diffHours}h ago`
-  else if (diffDays === 1) when = 'yesterday'
-  else when = `${diffDays} days ago`
+  if (diffMins < 2) when = t('settings.metadata.autoFetch.lastRun.justNow')
+  else if (diffMins < 60) when = t('settings.metadata.autoFetch.lastRun.minutesAgo', { count: diffMins })
+  else if (diffHours < 24) when = t('settings.metadata.autoFetch.lastRun.hoursAgo', { count: diffHours })
+  else if (diffDays === 1) when = t('settings.metadata.autoFetch.lastRun.yesterday')
+  else when = t('settings.metadata.autoFetch.lastRun.daysAgo', { count: diffDays })
   const queued = libraryData.value.lastQueuedCount
-  if (queued === null) return `Last run: ${when}`
-  return queued > 0 ? `Last run: ${when} - queued ${queued} books` : `Last run: ${when} - no eligible books`
+  if (queued === null) return t('settings.metadata.autoFetch.lastRun.label', { when })
+  return queued > 0
+    ? t('settings.metadata.autoFetch.lastRun.labelQueued', { when, count: queued })
+    : t('settings.metadata.autoFetch.lastRun.labelNoneEligible', { when })
 })
 
 onMounted(async () => {
@@ -114,7 +123,8 @@ async function handleTrigger() {
   triggerResult.value = null
   try {
     const { queued } = await triggerForLibrary(props.library.id)
-    triggerResult.value = queued > 0 ? `Queued ${queued} books` : 'No eligible books found'
+    triggerResult.value =
+      queued > 0 ? t('settings.metadata.autoFetch.trigger.queued', { count: queued }, queued) : t('settings.metadata.autoFetch.trigger.noneFound')
     invalidateEligibleCountPreviews()
     if (libraryData.value) {
       libraryData.value.lastRunAt = new Date().toISOString()
@@ -167,27 +177,27 @@ function cloneConfigOnly(config: BookMetadataFetchConfig): BookMetadataFetchConf
         <p class="settings-label">{{ props.library.name }}</p>
         <p v-if="lastRunLabel" class="text-xs text-muted-foreground mt-0.5">{{ lastRunLabel }}</p>
         <p class="text-xs text-muted-foreground mt-1 line-clamp-1">
-          {{ inheriting ? 'Inheriting global defaults' : activeConditionSummary }}
+          {{ inheriting ? t('settings.metadata.autoFetch.library.inheritingGlobal') : activeConditionSummary }}
         </p>
       </div>
       <div class="flex items-center gap-2 self-start">
-        <span class="text-xs text-muted-foreground">Inherit from global</span>
+        <span class="text-xs text-muted-foreground">{{ t('settings.metadata.autoFetch.library.inheritFromGlobal') }}</span>
         <ToggleSwitch :model-value="inheriting" @update:model-value="handleInheritToggle" @click.stop />
         <ChevronUp v-if="cardOpen" :size="15" class="text-muted-foreground md:hidden ml-1" />
         <ChevronDown v-else :size="15" class="text-muted-foreground md:hidden ml-1" />
       </div>
     </button>
 
-    <div v-if="loading && cardOpen" class="px-4 py-3.5 md:px-5 md:py-4 bg-card text-xs text-muted-foreground">Loading...</div>
+    <div v-if="loading && cardOpen" class="px-4 py-3.5 md:px-5 md:py-4 bg-card text-xs text-muted-foreground">{{ t('common.loading') }}</div>
 
     <template v-else-if="cardOpen">
       <div v-if="inheriting" class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
-        <p class="text-xs text-muted-foreground italic">Using global defaults.</p>
+        <p class="text-xs text-muted-foreground italic">{{ t('settings.metadata.autoFetch.library.usingGlobalDefaults') }}</p>
       </div>
 
       <div v-else class="px-4 py-3.5 md:px-5 md:py-4 bg-card">
         <button class="w-full flex items-center justify-between gap-2 text-left" @click="conditionsOpen = !conditionsOpen">
-          <p class="settings-label">Eligibility conditions</p>
+          <p class="settings-label">{{ t('settings.metadata.autoFetch.conditions.title') }}</p>
           <ChevronUp v-if="conditionsOpen" :size="15" class="text-muted-foreground shrink-0" />
           <ChevronDown v-else :size="15" class="text-muted-foreground shrink-0" />
         </button>
@@ -198,10 +208,10 @@ function cloneConfigOnly(config: BookMetadataFetchConfig): BookMetadataFetchConf
       <div class="hidden md:flex items-center gap-2 md:gap-3 flex-wrap px-4 py-3.5 md:px-5 md:py-4 bg-card">
         <button v-if="!inheriting" :disabled="saving" class="settings-btn-primary" @click="handleSave">
           <Save class="size-3.5" />
-          {{ saving ? 'Saving...' : 'Save override' }}
+          {{ saving ? t('settings.metadata.autoFetch.saving') : t('settings.metadata.autoFetch.library.saveOverride') }}
         </button>
         <button :disabled="triggering" class="settings-btn-outline" @click="handleTrigger">
-          {{ triggering ? 'Running...' : 'Run now' }}
+          {{ triggering ? t('settings.metadata.autoFetch.running') : t('settings.metadata.autoFetch.runNow') }}
         </button>
         <span v-if="statusLabel" class="text-xs text-muted-foreground">{{ statusLabel }}</span>
       </div>
@@ -210,10 +220,10 @@ function cloneConfigOnly(config: BookMetadataFetchConfig): BookMetadataFetchConf
         <div class="flex items-center gap-2 flex-wrap">
           <button v-if="!inheriting" :disabled="saving" class="settings-btn-primary h-9 px-3 justify-center" @click="handleSave">
             <Save class="size-3.5" />
-            {{ saving ? 'Saving...' : 'Save override' }}
+            {{ saving ? t('settings.metadata.autoFetch.saving') : t('settings.metadata.autoFetch.library.saveOverride') }}
           </button>
           <button :disabled="triggering" class="settings-btn-outline h-9 px-3" @click="handleTrigger">
-            {{ triggering ? 'Running...' : 'Run now' }}
+            {{ triggering ? t('settings.metadata.autoFetch.running') : t('settings.metadata.autoFetch.runNow') }}
           </button>
           <span v-if="statusLabel" class="text-xs text-muted-foreground">{{ statusLabel }}</span>
         </div>

--- a/client/src/features/settings/metadata-auto-fetch/components/MissingFieldsPicker.vue
+++ b/client/src/features/settings/metadata-auto-fetch/components/MissingFieldsPicker.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import type { MetadataField } from '@bookorbit/types'
 import { ALL_METADATA_FIELDS } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   modelValue: MetadataField[]
@@ -8,23 +11,8 @@ const props = defineProps<{
 }>()
 const emit = defineEmits<{ 'update:modelValue': [MetadataField[]] }>()
 
-const FIELD_LABELS: Record<MetadataField, string> = {
-  title: 'Title',
-  subtitle: 'Subtitle',
-  description: 'Description',
-  cover: 'Cover',
-  authors: 'Authors',
-  publisher: 'Publisher',
-  publishedYear: 'Published year',
-  language: 'Language',
-  pageCount: 'Page count',
-  communityRating: 'Community rating',
-  seriesName: 'Series name',
-  seriesIndex: 'Series index',
-  genres: 'Genres',
-  narrators: 'Narrators',
-  duration: 'Duration',
-  abridged: 'Abridged',
+function fieldLabel(field: MetadataField): string {
+  return t(`settings.metadata.fields.${field}`)
 }
 
 function toggle(field: MetadataField) {
@@ -55,7 +43,7 @@ function toggle(field: MetadataField) {
         props.disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
       ]"
     >
-      {{ FIELD_LABELS[field] }}
+      {{ fieldLabel(field) }}
     </button>
   </div>
 </template>

--- a/client/src/features/settings/metadata-preferences/CustomMetadataSettings.vue
+++ b/client/src/features/settings/metadata-preferences/CustomMetadataSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Archive, ArchiveRestore, ChevronDown, GripVertical, LayoutList, Loader2, Plus, Save, Search, Trash2 } from '@lucide/vue'
 import { VueDraggable } from 'vue-draggable-plus'
 import type { CustomMetadataFieldDefinition, CustomMetadataFieldType } from '@bookorbit/types'
@@ -15,6 +16,7 @@ type Draft = {
   enabledLibraryIds: number[]
 }
 
+const { t } = useI18n()
 const { libraries, fetchLibraries } = useLibraries()
 const {
   loading,
@@ -62,9 +64,9 @@ const canConfirmDelete = computed(() => deleteConfirmInput.value === deleteConfi
 function labelError(label: string, excludeId?: number): string | null {
   const trimmed = label.trim()
   if (!trimmed) return null
-  if (trimmed.length > 255) return 'Label must be 255 characters or fewer'
+  if (trimmed.length > 255) return t('settings.metadata.customFields.labelTooLong')
   const duplicate = activeFields.value.some((field) => field.id !== excludeId && field.label.toLowerCase() === trimmed.toLowerCase())
-  if (duplicate) return 'A field with this label already exists'
+  if (duplicate) return t('settings.metadata.customFields.labelDuplicate')
   return null
 }
 
@@ -104,7 +106,7 @@ function canSave(field: CustomMetadataFieldDefinition): boolean {
 }
 
 function usageLabel(field: CustomMetadataFieldDefinition): string {
-  return field.usageCount === 1 ? 'Used by 1 book' : `Used by ${field.usageCount} books`
+  return t('settings.metadata.customFields.usage', { count: field.usageCount }, field.usageCount)
 }
 
 function toggleCreate() {
@@ -192,8 +194,10 @@ onMounted(() => {
             <Plus :size="15" />
           </div>
           <div class="text-left">
-            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">New Field</span>
-            <p class="settings-hint">Define a custom metadata field and choose which libraries use it.</p>
+            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{
+              t('settings.metadata.customFields.newField.title')
+            }}</span>
+            <p class="settings-hint">{{ t('settings.metadata.customFields.newField.hint') }}</p>
           </div>
         </div>
         <ChevronDown class="h-4 w-4 shrink-0 text-muted-foreground transition-transform" :class="createOpen ? 'rotate-180' : ''" />
@@ -202,18 +206,18 @@ onMounted(() => {
       <div v-if="createOpen" class="p-4 md:p-5 space-y-4 border-t border-border">
         <div class="grid gap-4 md:grid-cols-[minmax(0,1fr)_10rem]">
           <label class="space-y-1.5">
-            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">Label</span>
+            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{ t('settings.metadata.customFields.label') }}</span>
             <input
               v-model="createForm.label"
               class="input-field w-full"
-              placeholder="e.g. Original Title"
+              :placeholder="t('settings.metadata.customFields.labelPlaceholder')"
               :aria-invalid="!!createLabelError"
               @keydown.enter="handleCreate"
             />
             <span v-if="createLabelError" class="text-xs text-destructive">{{ createLabelError }}</span>
           </label>
           <label class="space-y-1.5">
-            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">Type</span>
+            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{ t('settings.metadata.customFields.type') }}</span>
             <select v-model="createForm.type" class="select-field w-full">
               <option v-for="type in CUSTOM_METADATA_FIELD_TYPES" :key="type" :value="type">{{ CUSTOM_FIELD_TYPE_META[type].label }}</option>
             </select>
@@ -230,10 +234,12 @@ onMounted(() => {
             @click="toggleCreatePreview"
           >
             <ChevronDown class="h-3.5 w-3.5 transition-transform" :class="showCreatePreview ? 'rotate-180' : ''" />
-            Preview how this field appears when editing a book
+            {{ t('settings.metadata.customFields.previewToggle') }}
           </button>
           <div v-if="showCreatePreview" class="mt-3 max-w-xs">
-            <span class="text-xs font-medium text-muted-foreground">{{ createForm.label.trim() || 'Untitled field' }}</span>
+            <span class="text-xs font-medium text-muted-foreground">{{
+              createForm.label.trim() || t('settings.metadata.customFields.untitledField')
+            }}</span>
             <CustomFieldPreviewInput class="mt-1" :type="createForm.type" />
           </div>
         </div>
@@ -242,7 +248,7 @@ onMounted(() => {
           <button class="settings-btn-primary" :disabled="!canCreate" @click="handleCreate">
             <Loader2 v-if="creating" :size="14" class="animate-spin" />
             <Plus v-else :size="14" />
-            Add field
+            {{ t('settings.metadata.customFields.addField') }}
           </button>
         </div>
       </div>
@@ -255,8 +261,8 @@ onMounted(() => {
             <LayoutList :size="15" />
           </div>
           <div>
-            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">Fields</span>
-            <p class="settings-hint">Drag to reorder, edit labels, toggle libraries, or archive fields you no longer need.</p>
+            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{ t('settings.metadata.customFields.fields') }}</span>
+            <p class="settings-hint">{{ t('settings.metadata.customFields.fieldsHint') }}</p>
           </div>
         </div>
         <div class="flex items-center gap-2">
@@ -265,9 +271,9 @@ onMounted(() => {
             <input
               v-model="searchQuery"
               type="search"
-              placeholder="Search fields"
+              :placeholder="t('settings.metadata.customFields.searchPlaceholder')"
               class="input-field w-full pl-8 sm:w-48"
-              aria-label="Search custom fields"
+              :aria-label="t('settings.metadata.customFields.searchAriaLabel')"
             />
           </div>
           <Loader2 v-if="loading || reordering" :size="15" class="animate-spin text-muted-foreground shrink-0" />
@@ -275,13 +281,13 @@ onMounted(() => {
       </div>
 
       <div v-if="activeFields.length === 0 && !loading" class="mx-4 my-5 rounded-lg border border-dashed border-border px-4 py-10 text-center">
-        <p class="text-sm font-medium text-foreground">No custom fields yet</p>
-        <p class="mt-1 text-xs text-muted-foreground">Use the form above to define your first custom metadata field.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.metadata.customFields.emptyTitle') }}</p>
+        <p class="mt-1 text-xs text-muted-foreground">{{ t('settings.metadata.customFields.emptyHint') }}</p>
       </div>
 
       <div v-else-if="isSearching && visibleFieldCount === 0" class="mx-4 my-5 rounded-lg border border-dashed border-border px-4 py-10 text-center">
-        <p class="text-sm font-medium text-foreground">No fields match "{{ searchQuery.trim() }}"</p>
-        <p class="mt-1 text-xs text-muted-foreground">Try a different label, key, or type.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.metadata.customFields.noMatchTitle', { query: searchQuery.trim() }) }}</p>
+        <p class="mt-1 text-xs text-muted-foreground">{{ t('settings.metadata.customFields.noMatchHint') }}</p>
       </div>
 
       <VueDraggable
@@ -301,8 +307,8 @@ onMounted(() => {
               type="button"
               class="custom-field-handle mt-7 shrink-0 text-muted-foreground/60 hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed cursor-grab active:cursor-grabbing"
               :disabled="reordering || isSearching"
-              :title="isSearching ? 'Clear search to reorder' : 'Drag to reorder'"
-              aria-label="Drag to reorder field"
+              :title="isSearching ? t('settings.metadata.customFields.clearSearchToReorder') : t('settings.metadata.customFields.dragToReorder')"
+              :aria-label="t('settings.metadata.customFields.dragToReorderField')"
             >
               <GripVertical :size="16" />
             </button>
@@ -310,13 +316,13 @@ onMounted(() => {
               <div class="grid gap-4 sm:grid-cols-[minmax(0,1fr)_9rem]">
                 <label class="space-y-1.5">
                   <span class="flex items-center gap-2 text-xs font-bold text-muted-foreground uppercase tracking-widest">
-                    Label
+                    {{ t('settings.metadata.customFields.label') }}
                     <span
                       v-if="isDirty(field)"
                       class="inline-flex items-center gap-1 normal-case tracking-normal font-medium text-amber-600 dark:text-amber-400"
                     >
                       <span class="h-1.5 w-1.5 rounded-full bg-amber-500" />
-                      Unsaved
+                      {{ t('settings.metadata.customFields.unsaved') }}
                     </span>
                   </span>
                   <input
@@ -328,7 +334,9 @@ onMounted(() => {
                   <span v-if="draftLabelError(field)" class="text-xs text-destructive">{{ draftLabelError(field) }}</span>
                 </label>
                 <div class="space-y-1.5">
-                  <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">Type</span>
+                  <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{
+                    t('settings.metadata.customFields.type')
+                  }}</span>
                   <div class="h-9 flex items-center gap-1.5 px-3 rounded-md border border-border bg-muted/30 text-sm">
                     <component :is="CUSTOM_FIELD_TYPE_META[field.type].icon" :size="14" class="text-muted-foreground" />
                     <span class="text-muted-foreground">{{ CUSTOM_FIELD_TYPE_META[field.type].label }}</span>
@@ -353,7 +361,7 @@ onMounted(() => {
                   <button class="settings-btn-outline" :disabled="!canSave(field)" @click="handleSave(field)">
                     <Loader2 v-if="savingId === field.id" :size="14" class="animate-spin" />
                     <Save v-else :size="14" />
-                    Save
+                    {{ t('common.save') }}
                   </button>
                   <button
                     class="settings-btn-outline text-destructive hover:border-destructive/40 hover:bg-destructive/5"
@@ -362,7 +370,7 @@ onMounted(() => {
                   >
                     <Loader2 v-if="archivingId === field.id" :size="14" class="animate-spin" />
                     <Archive v-else :size="14" />
-                    Archive
+                    {{ t('settings.metadata.customFields.archive') }}
                   </button>
                 </div>
               </div>
@@ -383,9 +391,11 @@ onMounted(() => {
             <Archive :size="15" />
           </div>
           <div class="text-left">
-            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">Archived Fields</span>
+            <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{
+              t('settings.metadata.customFields.archivedFields')
+            }}</span>
             <p class="settings-hint">
-              {{ archivedFields.length }} archived {{ archivedFields.length === 1 ? 'field' : 'fields' }} - restore or permanently delete.
+              {{ t('settings.metadata.customFields.archivedSummary', { count: archivedFields.length }, archivedFields.length) }}
             </p>
           </div>
         </div>
@@ -410,7 +420,7 @@ onMounted(() => {
               </span>
               <span class="text-xs text-muted-foreground">{{ usageLabel(field) }}</span>
               <span class="text-xs text-muted-foreground" :title="formatAbsoluteDateTime(field.archivedAt!)">
-                Archived {{ formatRelativeTime(field.archivedAt!) }}
+                {{ t('settings.metadata.customFields.archivedAt', { when: formatRelativeTime(field.archivedAt!) }) }}
               </span>
             </div>
           </div>
@@ -418,7 +428,7 @@ onMounted(() => {
             <button class="settings-btn-outline" :disabled="restoringId === field.id" @click="handleRestore(field)">
               <Loader2 v-if="restoringId === field.id" :size="14" class="animate-spin" />
               <ArchiveRestore v-else :size="14" />
-              Restore
+              {{ t('settings.metadata.customFields.restore') }}
             </button>
             <button
               class="settings-btn-outline text-destructive hover:border-destructive/40 hover:bg-destructive/5"
@@ -426,7 +436,7 @@ onMounted(() => {
               @click="openDeleteConfirm(field)"
             >
               <Trash2 :size="14" />
-              Delete forever
+              {{ t('settings.metadata.customFields.deleteForever') }}
             </button>
           </div>
         </div>
@@ -442,28 +452,32 @@ onMounted(() => {
             <Trash2 :size="16" />
           </div>
           <div>
-            <p class="text-sm font-semibold text-foreground">Permanently delete field</p>
+            <p class="text-sm font-semibold text-foreground">{{ t('settings.metadata.customFields.deleteDialog.title') }}</p>
             <p class="mt-1 text-xs text-muted-foreground">
-              This will permanently delete <span class="font-medium text-foreground">{{ deleteConfirmField.label }}</span> and remove its stored
-              values from <span class="font-medium text-foreground">{{ usageLabel(deleteConfirmField).toLowerCase() }}</span
-              >. This cannot be undone.
+              {{ t('settings.metadata.customFields.deleteDialog.bodyBefore') }}
+              <span class="font-medium text-foreground">{{ deleteConfirmField.label }}</span>
+              {{ t('settings.metadata.customFields.deleteDialog.bodyMiddle') }}
+              <span class="font-medium text-foreground">{{ usageLabel(deleteConfirmField).toLowerCase() }}</span
+              >{{ t('settings.metadata.customFields.deleteDialog.bodyAfter') }}
             </p>
           </div>
         </div>
         <div class="p-5 space-y-3">
           <label class="space-y-1.5">
             <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">
-              Type <span class="text-foreground normal-case tracking-normal font-semibold">{{ deleteConfirmField.label }}</span> to confirm
+              {{ t('settings.metadata.customFields.deleteDialog.confirmBefore') }}
+              <span class="text-foreground normal-case tracking-normal font-semibold">{{ deleteConfirmField.label }}</span>
+              {{ t('settings.metadata.customFields.deleteDialog.confirmAfter') }}
             </span>
             <input
               v-model="deleteConfirmInput"
               class="input-field w-full"
-              placeholder="Type the field label to confirm"
+              :placeholder="t('settings.metadata.customFields.deleteDialog.confirmPlaceholder')"
               @keydown.enter="confirmDeletePermanently"
             />
           </label>
           <div class="flex justify-end gap-2">
-            <button class="settings-btn-outline" @click="cancelDeleteConfirm">Cancel</button>
+            <button class="settings-btn-outline" @click="cancelDeleteConfirm">{{ t('common.cancel') }}</button>
             <button
               class="settings-btn-outline text-destructive hover:border-destructive/40 hover:bg-destructive/5 disabled:opacity-50"
               :disabled="!canConfirmDelete"
@@ -471,7 +485,7 @@ onMounted(() => {
             >
               <Loader2 v-if="deletingPermanentlyId !== null" :size="14" class="animate-spin" />
               <Trash2 v-else :size="14" />
-              Delete forever
+              {{ t('settings.metadata.customFields.deleteForever') }}
             </button>
           </div>
         </div>

--- a/client/src/features/settings/metadata-preferences/MetadataFieldRulesSettings.vue
+++ b/client/src/features/settings/metadata-preferences/MetadataFieldRulesSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { FieldPreferenceOverrides } from '@bookorbit/types'
 import { Info } from '@lucide/vue'
 import { useLibraries } from '@/features/library/composables/useLibraries'
@@ -8,6 +9,7 @@ import LibraryPreferencePanel from './components/LibraryPreferencePanel.vue'
 import { useProviderConfig } from './composables/useProviderConfig'
 import { useMetadataPreferences } from './composables/useMetadataPreferences'
 
+const { t } = useI18n()
 const { statuses, fetchConfig } = useProviderConfig()
 const {
   globalPrefs,
@@ -54,18 +56,24 @@ async function onResetLibrary(libraryId: number) {
     <div class="p-4 rounded-lg bg-primary/5 border border-primary/10 max-w-6xl shadow-xs">
       <div class="flex items-start gap-3 mb-3">
         <Info :size="18" class="text-primary shrink-0 mt-0.5" />
-        <p class="text-sm font-medium text-foreground">How Field Rules Work</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.metadata.fieldRules.howItWorks.title') }}</p>
       </div>
       <div class="grid sm:grid-cols-2 gap-x-8 gap-y-4 text-xs leading-relaxed text-muted-foreground ml-7">
         <div>
-          <p class="font-semibold text-foreground mb-1">Priority Order</p>
-          <p>Drag providers in the list to reorder them. The top-most provider that returns a result will be the primary source for that field.</p>
+          <p class="font-semibold text-foreground mb-1">{{ t('settings.metadata.fieldRules.howItWorks.priorityOrder.title') }}</p>
+          <p>{{ t('settings.metadata.fieldRules.howItWorks.priorityOrder.body') }}</p>
         </div>
         <div>
-          <p class="font-semibold text-foreground mb-1">Merge Strategy</p>
+          <p class="font-semibold text-foreground mb-1">{{ t('settings.metadata.fieldRules.howItWorks.mergeStrategy.title') }}</p>
           <ul class="space-y-1">
-            <li><span class="text-foreground">Fill missing:</span> Only write if current value is empty.</li>
-            <li><span class="text-foreground">Overwrite:</span> Replace whenever a provider has data.</li>
+            <li>
+              <span class="text-foreground">{{ t('settings.metadata.fieldRules.howItWorks.mergeStrategy.fillMissingTerm') }}</span>
+              {{ t('settings.metadata.fieldRules.howItWorks.mergeStrategy.fillMissingBody') }}
+            </li>
+            <li>
+              <span class="text-foreground">{{ t('settings.metadata.fieldRules.howItWorks.mergeStrategy.overwriteTerm') }}</span>
+              {{ t('settings.metadata.fieldRules.howItWorks.mergeStrategy.overwriteBody') }}
+            </li>
           </ul>
         </div>
       </div>
@@ -82,8 +90,8 @@ async function onResetLibrary(libraryId: number) {
 
     <div v-if="libraries.length" class="space-y-4">
       <div class="px-1">
-        <p class="text-sm font-medium text-foreground">Library Overrides</p>
-        <p class="settings-hint">Expand a library to customize individual fields. Fields not overridden inherit global defaults.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.metadata.fieldRules.libraryOverrides.title') }}</p>
+        <p class="settings-hint">{{ t('settings.metadata.fieldRules.libraryOverrides.hint') }}</p>
       </div>
       <div class="space-y-3">
         <LibraryPreferencePanel

--- a/client/src/features/settings/metadata-preferences/MetadataGenreBlocklistSettings.vue
+++ b/client/src/features/settings/metadata-preferences/MetadataGenreBlocklistSettings.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Ban, Loader2, Plus, Search, Trash2 } from '@lucide/vue'
 import type { MetadataFetchPreferences } from '@bookorbit/types'
 import { useMetadataPreferences } from './composables/useMetadataPreferences'
 
+const { t } = useI18n()
 const { globalPrefs, loadingGlobal, savingGlobal, fetchGlobal, saveGlobal } = useMetadataPreferences()
 
 const draftBlocklist = ref<string[]>([])
@@ -35,8 +37,8 @@ const filteredBlocklist = computed(() => {
   return draftBlocklist.value.filter((genre) => genre.toLowerCase().includes(filterToken.value))
 })
 const visibleCountLabel = computed(() => {
-  if (!filterToken.value) return `${draftBlocklist.value.length} ${draftBlocklist.value.length === 1 ? 'entry' : 'entries'}`
-  return `${filteredBlocklist.value.length} of ${draftBlocklist.value.length}`
+  if (!filterToken.value) return t('settings.metadata.genreBlocklist.entryCount', { count: draftBlocklist.value.length }, draftBlocklist.value.length)
+  return t('settings.metadata.genreBlocklist.filteredCount', { shown: filteredBlocklist.value.length, total: draftBlocklist.value.length })
 })
 
 function normalizeBlocklist(values: readonly string[]): string[] {
@@ -96,7 +98,7 @@ async function removeGenre(genre: string) {
 }
 
 function removeGenreLabel(genre: string): string {
-  return `Remove ${genre}`
+  return t('settings.metadata.genreBlocklist.removeLabel', { genre })
 }
 </script>
 
@@ -108,13 +110,13 @@ function removeGenreLabel(genre: string): string {
           <Ban :size="16" />
         </div>
         <div>
-          <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">Global Genre Exclusions</span>
-          <p class="settings-hint">Exact genre values in this list are stripped from provider results before metadata is written.</p>
+          <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{ t('settings.metadata.genreBlocklist.heading') }}</span>
+          <p class="settings-hint">{{ t('settings.metadata.genreBlocklist.hint') }}</p>
         </div>
       </div>
       <div v-if="savingGlobal" class="inline-flex h-8 items-center gap-2 text-xs font-medium text-muted-foreground">
         <Loader2 :size="14" class="animate-spin" />
-        <span>Saving</span>
+        <span>{{ t('settings.metadata.genreBlocklist.saving') }}</span>
       </div>
     </div>
 
@@ -125,20 +127,20 @@ function removeGenreLabel(genre: string): string {
     <div v-else class="p-4 md:p-5 space-y-5">
       <div class="grid gap-2 md:grid-cols-[1fr_auto]">
         <div>
-          <label for="genre-blocklist-entry" class="sr-only">Genre value</label>
+          <label for="genre-blocklist-entry" class="sr-only">{{ t('settings.metadata.genreBlocklist.genreValueLabel') }}</label>
           <input
             id="genre-blocklist-entry"
             v-model="newGenre"
             class="w-full h-9 rounded-md border border-input bg-background px-3 text-sm outline-none transition-shadow focus:ring-1 focus:ring-ring placeholder:text-muted-foreground"
-            placeholder="Add a genre value, for example Audiobook"
+            :placeholder="t('settings.metadata.genreBlocklist.addPlaceholder')"
             @keydown.enter="addGenre"
           />
-          <p v-if="isDuplicate" class="mt-1.5 text-xs text-destructive">This genre is already blocked.</p>
+          <p v-if="isDuplicate" class="mt-1.5 text-xs text-destructive">{{ t('settings.metadata.genreBlocklist.duplicate') }}</p>
         </div>
         <button class="settings-btn-primary h-9 px-3 justify-center md:min-w-24" type="button" :disabled="!canAdd" @click="addGenre">
           <Loader2 v-if="savingGlobal" :size="14" class="animate-spin" />
           <Plus v-else :size="14" />
-          <span>Add</span>
+          <span>{{ t('settings.metadata.genreBlocklist.add') }}</span>
         </button>
       </div>
 
@@ -149,7 +151,7 @@ function removeGenreLabel(genre: string): string {
           <input
             v-model="filterText"
             class="w-full h-8 rounded-md border border-input bg-background pl-8 pr-3 text-sm outline-none transition-shadow focus:ring-1 focus:ring-ring placeholder:text-muted-foreground"
-            placeholder="Filter blocklist"
+            :placeholder="t('settings.metadata.genreBlocklist.filterPlaceholder')"
           />
         </div>
       </div>
@@ -169,12 +171,12 @@ function removeGenreLabel(genre: string): string {
             </button>
           </div>
         </div>
-        <div v-else class="px-4 py-8 text-center text-sm text-muted-foreground">No blocked genres match the current filter.</div>
+        <div v-else class="px-4 py-8 text-center text-sm text-muted-foreground">{{ t('settings.metadata.genreBlocklist.noFilterMatch') }}</div>
       </div>
 
       <div v-else class="rounded-lg border border-dashed border-border px-4 py-10 text-center">
-        <p class="text-sm font-medium text-foreground">No blocked genres</p>
-        <p class="mt-1 text-xs text-muted-foreground">Add exact values such as Audiobook or Adult to keep them out of fetched metadata.</p>
+        <p class="text-sm font-medium text-foreground">{{ t('settings.metadata.genreBlocklist.emptyTitle') }}</p>
+        <p class="mt-1 text-xs text-muted-foreground">{{ t('settings.metadata.genreBlocklist.emptyHint') }}</p>
       </div>
     </div>
   </div>

--- a/client/src/features/settings/metadata-preferences/components/CustomFieldPreviewInput.vue
+++ b/client/src/features/settings/metadata-preferences/components/CustomFieldPreviewInput.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { CustomMetadataFieldType } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 defineProps<{ type: CustomMetadataFieldType }>()
 
@@ -16,12 +19,14 @@ function toggleBoolean() {
 
 <template>
   <div class="space-y-1">
-    <span class="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-widest">Preview</span>
+    <span class="text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-widest">{{
+      t('settings.metadata.customFields.preview')
+    }}</span>
     <input
       v-if="type === 'text' || type === 'url'"
       v-model="textValue"
       :type="type === 'url' ? 'url' : 'text'"
-      :placeholder="type === 'url' ? 'https://example.com' : 'Sample value'"
+      :placeholder="type === 'url' ? 'https://example.com' : t('settings.metadata.customFields.sampleValue')"
       class="input-field w-full"
     />
     <input v-else-if="type === 'number'" v-model="numberValue" type="number" placeholder="0" class="input-field w-full" />

--- a/client/src/features/settings/metadata-preferences/components/FieldConfigSheet.vue
+++ b/client/src/features/settings/metadata-preferences/components/FieldConfigSheet.vue
@@ -1,28 +1,12 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X, ChevronUp, ChevronDown } from '@lucide/vue'
 import type { FieldPreference, MetadataField, MetadataProviderKey, ProviderStatus } from '@bookorbit/types'
 import MergeStrategyPicker from './MergeStrategyPicker.vue'
 import { providerChipStyle, PROVIDER_SHORT_LABELS } from '@/lib/provider-colors'
 
-const FIELD_LABELS: Record<MetadataField, string> = {
-  title: 'Title',
-  subtitle: 'Subtitle',
-  description: 'Description',
-  cover: 'Cover',
-  authors: 'Authors',
-  publisher: 'Publisher',
-  publishedYear: 'Published year',
-  language: 'Language',
-  pageCount: 'Page count',
-  communityRating: 'Community rating',
-  seriesName: 'Series name',
-  seriesIndex: 'Series index',
-  genres: 'Genres',
-  narrators: 'Narrators',
-  duration: 'Duration',
-  abridged: 'Abridged',
-}
+const { t } = useI18n()
 
 const props = defineProps<{
   field: MetadataField
@@ -85,8 +69,8 @@ const sortedStatuses = computed(() => {
       <div class="relative bg-card border-t border-border rounded-t-2xl max-h-[85vh] flex flex-col z-10">
         <div class="flex items-center justify-between px-4 py-3.5 border-b border-border shrink-0">
           <div>
-            <p class="text-sm font-semibold text-foreground">{{ FIELD_LABELS[field] }}</p>
-            <p class="text-xs text-muted-foreground mt-0.5">Tap providers to assign, use arrows to reorder</p>
+            <p class="text-sm font-semibold text-foreground">{{ t(`settings.metadata.fields.${field}`) }}</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('settings.metadata.fieldRules.sheet.subtitle') }}</p>
           </div>
           <button class="h-8 w-8 flex items-center justify-center rounded-full hover:bg-muted transition-colors" @click="$emit('close')">
             <X :size="16" />
@@ -101,11 +85,13 @@ const sortedStatuses = computed(() => {
               class="h-4 w-4 rounded border-input accent-primary"
               @change="$emit('change', { ...preference, enabled: ($event.target as HTMLInputElement).checked })"
             />
-            <span class="text-sm text-foreground">Enable this field during refresh</span>
+            <span class="text-sm text-foreground">{{ t('settings.metadata.fieldRules.sheet.enableField') }}</span>
           </label>
 
           <div>
-            <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2.5">Providers</p>
+            <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2.5">
+              {{ t('settings.metadata.fieldRules.sheet.providers') }}
+            </p>
             <div class="space-y-1.5">
               <div
                 v-for="status in sortedStatuses"
@@ -124,8 +110,12 @@ const sortedStatuses = computed(() => {
                   <span class="text-xs font-medium px-2 py-0.5 rounded" :style="providerChipStyle(status.key, !isUsable(status))">
                     {{ PROVIDER_SHORT_LABELS[status.key] ?? status.key }}
                   </span>
-                  <span v-if="!status.enabled" class="text-xs text-muted-foreground">disabled</span>
-                  <span v-else-if="!status.configured" class="text-xs text-muted-foreground">not configured</span>
+                  <span v-if="!status.enabled" class="text-xs text-muted-foreground">{{
+                    t('settings.metadata.fieldRules.sheet.statusDisabled')
+                  }}</span>
+                  <span v-else-if="!status.configured" class="text-xs text-muted-foreground">{{
+                    t('settings.metadata.fieldRules.sheet.statusNotConfigured')
+                  }}</span>
                 </div>
                 <div v-if="isAssigned(status.key as MetadataProviderKey)" class="flex items-center gap-1 shrink-0">
                   <span class="text-xs tabular-nums text-muted-foreground w-4 text-center">
@@ -151,7 +141,9 @@ const sortedStatuses = computed(() => {
           </div>
 
           <div>
-            <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2.5">Merge Strategy</p>
+            <p class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2.5">
+              {{ t('settings.metadata.fieldRules.table.mergeStrategy') }}
+            </p>
             <MergeStrategyPicker
               :model-value="preference.mergeStrategy"
               :disabled="!preference.enabled"
@@ -166,7 +158,7 @@ const sortedStatuses = computed(() => {
             class="w-full h-10 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
             @click="$emit('close')"
           >
-            Done
+            {{ t('settings.metadata.fieldRules.sheet.done') }}
           </button>
         </div>
       </div>

--- a/client/src/features/settings/metadata-preferences/components/FieldGroupSection.vue
+++ b/client/src/features/settings/metadata-preferences/components/FieldGroupSection.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronDown, ChevronRight } from '@lucide/vue'
 import type { FieldPreference, MetadataField, ProviderStatus } from '@bookorbit/types'
 import FieldRow from './FieldRow.vue'
+
+const { t } = useI18n()
 
 const props = withDefaults(
   defineProps<{
@@ -29,9 +32,9 @@ const open = ref(props.defaultOpen)
 const summary = computed(() => {
   const enabled = props.fields.filter((field) => props.preferences[field]?.enabled).length
   const overrides = props.overriddenFields ? props.fields.filter((field) => props.overriddenFields?.has(field)).length : 0
-  const base = `${props.fields.length} fields · ${enabled} enabled`
+  const base = t('settings.metadata.fieldRules.groupSummary.base', { fields: props.fields.length, enabled })
   if (!props.overriddenFields) return base
-  return `${base} · ${overrides} overrides`
+  return t('settings.metadata.fieldRules.groupSummary.withOverrides', { base, overrides })
 })
 </script>
 

--- a/client/src/features/settings/metadata-preferences/components/FieldPreferenceTable.vue
+++ b/client/src/features/settings/metadata-preferences/components/FieldPreferenceTable.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useMediaQuery } from '@vueuse/core'
 import type { FieldPreference, MetadataFetchPreferences, MetadataField, ProviderStatus } from '@bookorbit/types'
 import FieldGroupSection from './FieldGroupSection.vue'
 import ProviderReservoir from './ProviderReservoir.vue'
 import { Info } from '@lucide/vue'
+
+const { t } = useI18n()
 
 defineProps<{
   preferences: MetadataFetchPreferences
@@ -17,14 +21,16 @@ const emit = defineEmits<{
   revert: [field: MetadataField]
 }>()
 
-const GROUPS: { label: string; fields: MetadataField[] }[] = [
-  { label: 'Core', fields: ['title', 'subtitle', 'description', 'cover'] },
-  { label: 'Contributors', fields: ['authors'] },
-  { label: 'Publication', fields: ['publisher', 'publishedYear', 'language', 'pageCount', 'communityRating'] },
-  { label: 'Series', fields: ['seriesName', 'seriesIndex'] },
-  { label: 'Classification', fields: ['genres'] },
-  { label: 'Audiobook', fields: ['narrators', 'duration', 'abridged'] },
+const GROUPS: { id: string; label: string; fields: MetadataField[] }[] = [
+  { id: 'core', label: 'Core', fields: ['title', 'subtitle', 'description', 'cover'] },
+  { id: 'contributors', label: 'Contributors', fields: ['authors'] },
+  { id: 'publication', label: 'Publication', fields: ['publisher', 'publishedYear', 'language', 'pageCount', 'communityRating'] },
+  { id: 'series', label: 'Series', fields: ['seriesName', 'seriesIndex'] },
+  { id: 'classification', label: 'Classification', fields: ['genres'] },
+  { id: 'audiobook', label: 'Audiobook', fields: ['narrators', 'duration', 'abridged'] },
 ]
+
+const groups = computed(() => GROUPS.map((group) => ({ ...group, label: t(`settings.metadata.fieldRules.groups.${group.id}`) })))
 
 const isMobile = useMediaQuery('(max-width: 767px)')
 </script>
@@ -36,7 +42,7 @@ const isMobile = useMediaQuery('(max-width: 767px)')
       <div class="flex items-center gap-2.5">
         <Info :size="14" class="text-primary shrink-0" />
         <p class="text-[11px] font-medium text-muted-foreground uppercase tracking-widest leading-none">
-          Drag providers from here onto any field to add them
+          {{ t('settings.metadata.fieldRules.dragProvidersHint') }}
         </p>
       </div>
       <div class="flex items-center">
@@ -46,22 +52,28 @@ const isMobile = useMediaQuery('(max-width: 767px)')
 
     <!-- Table Header (desktop) -->
     <div class="hidden md:flex items-center gap-4 px-5 py-3 bg-muted/10 border-b border-border/60">
-      <div class="w-48 shrink-0 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Field</div>
-      <div class="flex-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Active Providers (ordered by priority)</div>
-      <div class="w-44 shrink-0 text-xs font-semibold text-muted-foreground uppercase tracking-wider">Merge Strategy</div>
+      <div class="w-48 shrink-0 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        {{ t('settings.metadata.fieldRules.table.field') }}
+      </div>
+      <div class="flex-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        {{ t('settings.metadata.fieldRules.table.activeProviders') }}
+      </div>
+      <div class="w-44 shrink-0 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        {{ t('settings.metadata.fieldRules.table.mergeStrategy') }}
+      </div>
       <div
         v-if="overriddenFields !== undefined"
         class="w-16 shrink-0 text-xs font-semibold text-muted-foreground uppercase tracking-wider text-center"
       >
-        Status
+        {{ t('settings.metadata.fieldRules.table.status') }}
       </div>
     </div>
 
     <!-- Content -->
     <div class="divide-y divide-border/60">
       <FieldGroupSection
-        v-for="group in GROUPS"
-        :key="group.label"
+        v-for="group in groups"
+        :key="group.id"
         :label="group.label"
         :fields="group.fields"
         :default-open="!isMobile"

--- a/client/src/features/settings/metadata-preferences/components/FieldRow.vue
+++ b/client/src/features/settings/metadata-preferences/components/FieldRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { AlertTriangle, RotateCcw, Settings2 } from '@lucide/vue'
 import type { FieldPreference, MetadataField, ProviderStatus } from '@bookorbit/types'
 import MergeStrategyPicker from './MergeStrategyPicker.vue'
@@ -7,6 +8,8 @@ import ProviderChipList from './ProviderChipList.vue'
 import FieldConfigSheet from './FieldConfigSheet.vue'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Badge } from '@/components/ui/badge'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   field: MetadataField
@@ -21,26 +24,7 @@ const emit = defineEmits<{
   revert: [field: MetadataField]
 }>()
 
-const FIELD_LABELS: Record<MetadataField, string> = {
-  title: 'Title',
-  subtitle: 'Subtitle',
-  description: 'Description',
-  cover: 'Cover',
-  authors: 'Authors',
-  publisher: 'Publisher',
-  publishedYear: 'Published year',
-  language: 'Language',
-  pageCount: 'Page count',
-  communityRating: 'Community rating',
-  seriesName: 'Series name',
-  seriesIndex: 'Series index',
-  genres: 'Genres',
-  narrators: 'Narrators',
-  duration: 'Duration',
-  abridged: 'Abridged',
-}
-
-const label = computed(() => FIELD_LABELS[props.field] ?? props.field)
+const label = computed(() => t(`settings.metadata.fields.${props.field}`))
 const noProviders = computed(() => props.preference.enabled && props.preference.providers.length === 0)
 const sheetOpen = ref(false)
 
@@ -83,7 +67,7 @@ function onSheetChange(pref: FieldPreference) {
           <TooltipTrigger as-child>
             <AlertTriangle :size="14" class="text-amber-500 animate-pulse shrink-0" />
           </TooltipTrigger>
-          <TooltipContent>Enabled but has no providers</TooltipContent>
+          <TooltipContent>{{ t('settings.metadata.fieldRules.field.noProviders') }}</TooltipContent>
         </Tooltip>
       </div>
     </div>
@@ -99,7 +83,7 @@ function onSheetChange(pref: FieldPreference) {
         />
         <span v-if="noProviders" class="flex items-center gap-1.5 text-xs text-amber-500 font-bold uppercase tracking-tight">
           <AlertTriangle :size="12" />
-          Empty
+          {{ t('settings.metadata.fieldRules.field.empty') }}
         </span>
       </div>
       <button
@@ -108,7 +92,7 @@ function onSheetChange(pref: FieldPreference) {
         @click="sheetOpen = true"
       >
         <Settings2 :size="13" />
-        Config
+        {{ t('settings.metadata.fieldRules.field.config') }}
       </button>
     </div>
 
@@ -126,7 +110,9 @@ function onSheetChange(pref: FieldPreference) {
         <Tooltip v-if="!inherited">
           <TooltipTrigger as-child>
             <div class="flex items-center gap-1">
-              <Badge variant="secondary" class="h-4.5 px-1.5 text-[9px] font-bold uppercase tracking-tight"> Custom </Badge>
+              <Badge variant="secondary" class="h-4.5 px-1.5 text-[9px] font-bold uppercase tracking-tight">
+                {{ t('settings.metadata.fieldRules.field.custom') }}
+              </Badge>
               <button
                 :disabled="saving"
                 class="flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/5 transition-colors disabled:opacity-40"
@@ -136,9 +122,11 @@ function onSheetChange(pref: FieldPreference) {
               </button>
             </div>
           </TooltipTrigger>
-          <TooltipContent>Reset to default</TooltipContent>
+          <TooltipContent>{{ t('settings.metadata.fieldRules.field.resetToDefault') }}</TooltipContent>
         </Tooltip>
-        <Badge v-else variant="outline" class="h-4.5 px-1.5 text-[9px] font-bold uppercase tracking-tight opacity-40"> Default </Badge>
+        <Badge v-else variant="outline" class="h-4.5 px-1.5 text-[9px] font-bold uppercase tracking-tight opacity-40">
+          {{ t('settings.metadata.fieldRules.field.default') }}
+        </Badge>
       </div>
     </div>
 

--- a/client/src/features/settings/metadata-preferences/components/GlobalPreferencePanel.vue
+++ b/client/src/features/settings/metadata-preferences/components/GlobalPreferencePanel.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Loader2, RotateCcw, Save, Settings, Trash2 } from '@lucide/vue'
 import type { FieldPreference, MetadataFetchPreferences, MetadataField, ProviderStatus } from '@bookorbit/types'
 import FieldPreferenceTable from './FieldPreferenceTable.vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   preferences: MetadataFetchPreferences | null
@@ -61,12 +64,12 @@ function toggleSaveProviderIds() {
 
 function handleClearAll() {
   if (!draft.value) return
-  if (!confirm('Remove all active providers from every field? This will be saved immediately and cannot be undone.')) return
+  if (!confirm(t('settings.metadata.fieldRules.global.clearAllConfirm'))) return
   emit('clearAll', draft.value)
 }
 
 function handleResetToDefault() {
-  if (!confirm('Reset all global field rules to system defaults? This will overwrite your current configuration.')) return
+  if (!confirm(t('settings.metadata.fieldRules.global.resetConfirm'))) return
   emit('resetToDefault')
 }
 </script>
@@ -75,8 +78,8 @@ function handleResetToDefault() {
   <div class="border border-border rounded-lg bg-card overflow-hidden shadow-xs">
     <div class="px-4 py-3.5 md:px-5 md:py-4 border-b border-border flex flex-col md:flex-row md:items-center justify-between gap-4 bg-muted/30">
       <div>
-        <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">Global Defaults</span>
-        <p class="settings-hint">Default rules applied to every library. Override per-library below.</p>
+        <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{ t('settings.metadata.fieldRules.global.title') }}</span>
+        <p class="settings-hint">{{ t('settings.metadata.fieldRules.global.hint') }}</p>
       </div>
       <div class="hidden md:flex items-center gap-2 flex-wrap">
         <button
@@ -85,7 +88,7 @@ function handleResetToDefault() {
           @click="handleClearAll"
         >
           <Trash2 :size="13" />
-          <span>Clear All Providers</span>
+          <span>{{ t('settings.metadata.fieldRules.clearAllProviders') }}</span>
         </button>
         <button
           class="settings-btn h-8 px-3 flex items-center gap-1.5 text-xs font-medium text-muted-foreground border border-border rounded-md hover:text-foreground hover:border-border/80 hover:bg-muted/50 transition-colors disabled:opacity-40"
@@ -93,12 +96,12 @@ function handleResetToDefault() {
           @click="handleResetToDefault"
         >
           <RotateCcw :size="13" />
-          <span>Reset to Default</span>
+          <span>{{ t('settings.metadata.fieldRules.resetToDefault') }}</span>
         </button>
         <button class="settings-btn-primary h-8 px-3" :disabled="saving || !draft" @click="save">
           <Loader2 v-if="saving" :size="14" class="animate-spin" />
           <Save v-else :size="14" />
-          <span>Save Defaults</span>
+          <span>{{ t('settings.metadata.fieldRules.global.saveDefaults') }}</span>
         </button>
       </div>
     </div>
@@ -110,7 +113,7 @@ function handleResetToDefault() {
           @click="handleClearAll"
         >
           <Trash2 :size="13" />
-          <span>Clear All</span>
+          <span>{{ t('settings.metadata.fieldRules.clearAll') }}</span>
         </button>
         <button
           class="settings-btn h-8 px-3 flex items-center gap-1.5 text-xs font-medium text-muted-foreground border border-border rounded-md hover:text-foreground hover:border-border/80 hover:bg-muted/50 transition-colors disabled:opacity-40"
@@ -118,12 +121,12 @@ function handleResetToDefault() {
           @click="handleResetToDefault"
         >
           <RotateCcw :size="13" />
-          <span>Reset</span>
+          <span>{{ t('settings.metadata.fieldRules.reset') }}</span>
         </button>
         <button class="settings-btn-primary h-8 px-3 justify-center ml-auto" :disabled="saving || !draft" @click="save">
           <Loader2 v-if="saving" :size="14" class="animate-spin" />
           <Save v-else :size="14" />
-          <span>Save Defaults</span>
+          <span>{{ t('settings.metadata.fieldRules.global.saveDefaults') }}</span>
         </button>
       </div>
     </div>
@@ -135,7 +138,7 @@ function handleResetToDefault() {
       <div class="border-t border-border px-6 py-6 bg-muted/5 space-y-5">
         <div class="flex items-center gap-2">
           <Settings :size="16" class="text-muted-foreground" />
-          <h4 class="settings-group-label !mb-0">Advanced Fetch Behavior</h4>
+          <h4 class="settings-group-label !mb-0">{{ t('settings.metadata.fieldRules.advanced.title') }}</h4>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -153,9 +156,9 @@ function handleResetToDefault() {
                 />
               </div>
               <div class="space-y-1">
-                <span class="text-sm font-medium text-foreground">Combine genres from all selected providers</span>
+                <span class="text-sm font-medium text-foreground">{{ t('settings.metadata.fieldRules.advanced.combineGenres.label') }}</span>
                 <p class="text-xs text-muted-foreground">
-                  Collect and deduplicate genres from every provider assigned to the Genres field, rather than stopping at the first result.
+                  {{ t('settings.metadata.fieldRules.advanced.combineGenres.hint') }}
                 </p>
               </div>
             </label>
@@ -175,10 +178,9 @@ function handleResetToDefault() {
                 />
               </div>
               <div class="space-y-1">
-                <span class="text-sm font-medium text-foreground">Store provider IDs on books</span>
+                <span class="text-sm font-medium text-foreground">{{ t('settings.metadata.fieldRules.advanced.storeProviderIds.label') }}</span>
                 <p class="text-xs text-muted-foreground">
-                  When fetching metadata, save the returned provider IDs (ISBN, ASIN, Goodreads ID, etc.) on the book record for more accurate future
-                  lookups.
+                  {{ t('settings.metadata.fieldRules.advanced.storeProviderIds.hint') }}
                 </p>
               </div>
             </label>

--- a/client/src/features/settings/metadata-preferences/components/LibraryPreferencePanel.vue
+++ b/client/src/features/settings/metadata-preferences/components/LibraryPreferencePanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch, type CSSProperties } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronDown, ChevronRight, Loader2, RotateCcw, Library, Trash2, Save } from '@lucide/vue'
 import type {
   FieldPreference,
@@ -14,6 +15,8 @@ import FieldPreferenceTable from './FieldPreferenceTable.vue'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Badge } from '@/components/ui/badge'
 import { getFormatColor } from '@/features/book/lib/format-colors'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   libraryName: string
@@ -87,7 +90,7 @@ function onRevert(field: MetadataField) {
 
 function onClearAll() {
   if (!draft.value) return
-  if (!confirm(`Remove all active providers from every field in "${props.libraryName}"?`)) return
+  if (!confirm(t('settings.metadata.fieldRules.library.clearAllConfirm', { library: props.libraryName }))) return
   const updatedFields = { ...draft.value.fields }
   const newChanges = new Map(pendingChanges.value)
   for (const field of ALL_METADATA_FIELDS) {
@@ -101,7 +104,7 @@ function onClearAll() {
 
 function onReset() {
   if (!props.libraryPrefs) return
-  if (!confirm(`Reset "${props.libraryName}" to global defaults? All library overrides will be removed.`)) return
+  if (!confirm(t('settings.metadata.fieldRules.library.resetConfirm', { library: props.libraryName }))) return
   emit('reset', props.libraryPrefs.libraryId)
 }
 
@@ -134,22 +137,22 @@ function onSave() {
           <div class="flex items-center gap-3">
             <span class="text-sm font-semibold text-foreground truncate">{{ libraryName }}</span>
             <Badge variant="outline" class="h-4.5 px-1.5 text-[10px] font-bold uppercase tracking-tight">
-              <span class="text-muted-foreground">Primary:</span>
+              <span class="text-muted-foreground">{{ t('settings.metadata.fieldRules.library.primary') }}</span>
               <span class="ml-1" :style="primaryFormatStyle">{{ primaryFormat }}</span>
             </Badge>
             <Badge v-if="overriddenFields.size > 0" variant="secondary" class="h-4.5 px-1.5 text-[10px] font-bold uppercase tracking-tight">
-              {{ overriddenFields.size }} {{ overriddenFields.size === 1 ? 'Override' : 'Overrides' }}
-              <span v-if="isDirty" class="ml-1 opacity-60">(unsaved)</span>
+              {{ t('settings.metadata.fieldRules.library.overrideCount', { count: overriddenFields.size }, overriddenFields.size) }}
+              <span v-if="isDirty" class="ml-1 opacity-60">{{ t('settings.metadata.fieldRules.library.unsavedSuffix') }}</span>
             </Badge>
             <Badge v-else variant="outline" class="h-4.5 px-1.5 text-[10px] font-bold uppercase tracking-tight opacity-60">
-              {{ isDirty ? 'Unsaved changes' : 'Global Defaults' }}
+              {{ isDirty ? t('settings.metadata.fieldRules.library.unsavedChanges') : t('settings.metadata.fieldRules.library.globalDefaults') }}
             </Badge>
           </div>
           <p v-if="!open" class="text-[11px] text-muted-foreground font-mono truncate">
             {{
               hasPersistedOverrides
-                ? `Overriding: ${Array.from(Object.keys(libraryPrefs?.overrides ?? {})).join(', ')}`
-                : 'Inheriting all global metadata rules'
+                ? t('settings.metadata.fieldRules.library.overriding', { fields: Array.from(Object.keys(libraryPrefs?.overrides ?? {})).join(', ') })
+                : t('settings.metadata.fieldRules.library.inheritingAll')
             }}
           </p>
         </div>
@@ -166,7 +169,7 @@ function onSave() {
         <div class="px-5 py-4 border-t border-border flex flex-col md:flex-row md:items-center justify-between gap-4 bg-muted/30">
           <div>
             <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{ libraryName }}</span>
-            <p class="settings-hint">Fields not overridden inherit global defaults.</p>
+            <p class="settings-hint">{{ t('settings.metadata.fieldRules.library.subHint') }}</p>
           </div>
           <div class="flex items-center gap-2 flex-wrap">
             <button
@@ -175,7 +178,7 @@ function onSave() {
               @click="onClearAll"
             >
               <Trash2 :size="13" />
-              <span>Clear All Providers</span>
+              <span>{{ t('settings.metadata.fieldRules.clearAllProviders') }}</span>
             </button>
             <Tooltip>
               <TooltipTrigger as-child>
@@ -185,15 +188,15 @@ function onSave() {
                   @click="onReset"
                 >
                   <RotateCcw :size="13" />
-                  <span>Reset to Default</span>
+                  <span>{{ t('settings.metadata.fieldRules.resetToDefault') }}</span>
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Remove all overrides and inherit global defaults</TooltipContent>
+              <TooltipContent>{{ t('settings.metadata.fieldRules.library.resetTooltip') }}</TooltipContent>
             </Tooltip>
             <button class="settings-btn-primary h-8 px-3" :disabled="saving || !isDirty" @click="onSave">
               <Loader2 v-if="saving" :size="14" class="animate-spin" />
               <Save v-else :size="14" />
-              <span>Save</span>
+              <span>{{ t('common.save') }}</span>
             </button>
           </div>
         </div>

--- a/client/src/features/settings/metadata-preferences/components/LibraryToggleGroup.vue
+++ b/client/src/features/settings/metadata-preferences/components/LibraryToggleGroup.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { Library } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const props = defineProps<{ modelValue: number[]; libraries: Library[] }>()
 const emit = defineEmits<{ 'update:modelValue': [number[]] }>()
@@ -37,17 +40,21 @@ function toggleAll() {
 <template>
   <div class="space-y-2">
     <div class="flex items-center justify-between gap-3">
-      <p class="text-xs font-bold text-muted-foreground uppercase tracking-widest">Enabled Libraries</p>
+      <p class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{ t('settings.metadata.customFields.enabledLibraries') }}</p>
       <div v-if="libraries.length > 0" class="flex items-center gap-2 text-xs">
-        <span class="text-muted-foreground tabular-nums">{{ selectedCount }} of {{ libraries.length }}</span>
-        <button type="button" class="text-primary hover:underline disabled:opacity-40" :disabled="allSelected" @click="selectAll">Select all</button>
+        <span class="text-muted-foreground tabular-nums">{{
+          t('settings.metadata.customFields.countOf', { selected: selectedCount, total: libraries.length })
+        }}</span>
+        <button type="button" class="text-primary hover:underline disabled:opacity-40" :disabled="allSelected" @click="selectAll">
+          {{ t('settings.metadata.customFields.selectAll') }}
+        </button>
         <span class="text-border">|</span>
         <button type="button" class="text-primary hover:underline disabled:opacity-40" :disabled="selectedCount === 0" @click="clearAll">
-          Clear
+          {{ t('settings.metadata.customFields.clear') }}
         </button>
       </div>
     </div>
-    <p v-if="libraries.length === 0" class="text-xs text-muted-foreground italic">No libraries available yet.</p>
+    <p v-if="libraries.length === 0" class="text-xs text-muted-foreground italic">{{ t('settings.metadata.customFields.noLibraries') }}</p>
     <div v-else class="flex flex-wrap gap-2">
       <button
         type="button"
@@ -60,7 +67,7 @@ function toggleAll() {
         "
         @click="toggleAll"
       >
-        All libraries
+        {{ t('settings.metadata.customFields.allLibraries') }}
       </button>
       <button
         v-for="library in libraries"

--- a/client/src/features/settings/metadata-preferences/components/MergeStrategyPicker.vue
+++ b/client/src/features/settings/metadata-preferences/components/MergeStrategyPicker.vue
@@ -1,14 +1,30 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { MergeStrategy } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 defineProps<{ modelValue: MergeStrategy; disabled?: boolean }>()
 defineEmits<{ 'update:modelValue': [value: MergeStrategy] }>()
 
-const options: { value: MergeStrategy; label: string; description: string }[] = [
-  { value: 'fillMissing', label: 'Fill missing', description: 'Only write if field is currently empty' },
-  { value: 'overwriteIfProvided', label: 'Overwrite if provided', description: 'Write if provider returned a value' },
-  { value: 'overwrite', label: 'Always overwrite', description: 'Always replace existing value' },
-]
+const options = computed<{ value: MergeStrategy; label: string; description: string }[]>(() => [
+  {
+    value: 'fillMissing',
+    label: t('settings.metadata.mergeStrategy.fillMissing.label'),
+    description: t('settings.metadata.mergeStrategy.fillMissing.description'),
+  },
+  {
+    value: 'overwriteIfProvided',
+    label: t('settings.metadata.mergeStrategy.overwriteIfProvided.label'),
+    description: t('settings.metadata.mergeStrategy.overwriteIfProvided.description'),
+  },
+  {
+    value: 'overwrite',
+    label: t('settings.metadata.mergeStrategy.overwrite.label'),
+    description: t('settings.metadata.mergeStrategy.overwrite.description'),
+  },
+])
 </script>
 
 <template>

--- a/client/src/features/settings/metadata-preferences/components/ProviderChipList.vue
+++ b/client/src/features/settings/metadata-preferences/components/ProviderChipList.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { VueDraggable } from 'vue-draggable-plus'
 import { GripVertical, X } from '@lucide/vue'
 import type { MetadataProviderKey, ProviderStatus } from '@bookorbit/types'
 import { providerChipStyle, PROVIDER_SHORT_LABELS } from '@/lib/provider-colors'
 import { PROVIDER_DND_GROUP, toProviderDragItems } from '../lib/provider-drag'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   providers: MetadataProviderKey[]
@@ -118,7 +121,7 @@ function removeProvider(index: number) {
     </VueDraggable>
 
     <span v-if="localProviders.length === 0 && !disabled" class="text-xs text-muted-foreground/60 italic h-6 flex items-center px-1">
-      drag a provider here
+      {{ t('settings.metadata.fieldRules.dragProviderHere') }}
     </span>
   </div>
 </template>

--- a/client/src/features/settings/metadata-preferences/components/ProviderConfigPanel.vue
+++ b/client/src/features/settings/metadata-preferences/components/ProviderConfigPanel.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Loader2, Save } from '@lucide/vue'
 import { MetadataProviderKey } from '@bookorbit/types'
 import type { ProviderConfigurations, ProviderConnectionTestResult, ProviderStatus, ProviderThrottleRuntimeState } from '@bookorbit/types'
 import { toast } from 'vue-sonner'
 import { Badge } from '@/components/ui/badge'
 import { stripBearerPrefix } from '../lib/provider-token'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   config: ProviderConfigurations | null
@@ -112,59 +115,72 @@ const rows: RowDef[] = [
   {
     key: 'google',
     label: 'Google Books',
-    hint: "Broad coverage from Google's book index. Google Books now requires an API key before this provider can be enabled.",
+    hint: t('settings.metadata.providers.hints.google'),
     fields: [
       {
         key: 'apiKey',
-        label: 'API Key',
+        label: t('settings.metadata.providers.fields.apiKey'),
         type: 'password',
         placeholder: 'AIza...',
-        helper: 'Google Books API key from Google Cloud.',
+        helper: t('settings.metadata.providers.helpers.googleApiKey'),
         alwaysEditable: true,
       },
     ],
     enableRequirement: {
       isConfigured: (c) => !!c.google.apiKey.trim(),
-      blockedMessage: 'Google Books requires an API key before it can be enabled',
+      blockedMessage: t('settings.metadata.providers.blocked.google'),
     },
   },
   {
     key: 'amazon',
     label: 'Amazon',
-    hint: 'Session cookie is recommended. Paste cookie value only (no "Cookie:").',
+    hint: t('settings.metadata.providers.hints.amazon'),
     fields: [
-      { key: 'domain', label: 'Region', type: 'select', options: AMAZON_DOMAINS, widthClass: 'md:w-[6.75rem] md:min-w-[6.75rem]' },
-      { key: 'cookie', label: 'Cookie', type: 'password', placeholder: 'session-id=...; ubid-main=...; x-main=...' },
+      {
+        key: 'domain',
+        label: t('settings.metadata.providers.fields.region'),
+        type: 'select',
+        options: AMAZON_DOMAINS,
+        widthClass: 'md:w-[6.75rem] md:min-w-[6.75rem]',
+      },
+      {
+        key: 'cookie',
+        label: t('settings.metadata.providers.fields.cookie'),
+        type: 'password',
+        placeholder: 'session-id=...; ubid-main=...; x-main=...',
+      },
     ],
   },
-  { key: 'goodreads', label: 'Goodreads', hint: 'The largest reading community on the web. No setup required.', fields: [] },
+  { key: 'goodreads', label: 'Goodreads', hint: t('settings.metadata.providers.hints.goodreads'), fields: [] },
   {
     key: 'hardcover',
     label: 'Hardcover',
-    hint: 'A modern alternative to Goodreads. Token from hardcover.app/account/api. "Bearer " prefix is optional.',
-    fields: [{ key: 'apiKey', label: 'API Key', type: 'password', placeholder: 'eyJ...', alwaysEditable: true }],
+    hint: t('settings.metadata.providers.hints.hardcover'),
+    fields: [{ key: 'apiKey', label: t('settings.metadata.providers.fields.apiKey'), type: 'password', placeholder: 'eyJ...', alwaysEditable: true }],
     enableRequirement: {
       isConfigured: (c) => !!c.hardcover.apiKey.trim(),
-      blockedMessage: 'Hardcover requires an API key before it can be enabled',
+      blockedMessage: t('settings.metadata.providers.blocked.hardcover'),
       requiresPassingTest: true,
-      missingTestMessage: 'Hardcover token must pass Test before it can be enabled',
+      missingTestMessage: t('settings.metadata.providers.blocked.hardcoverTest'),
     },
   },
-  { key: 'openLibrary', label: 'Open Library', hint: "The Internet Archive's free book catalog. No setup required.", fields: [] },
+  { key: 'openLibrary', label: 'Open Library', hint: t('settings.metadata.providers.hints.openLibrary'), fields: [] },
   {
     key: 'itunes',
     label: 'iTunes',
-    hint: "Apple's digital book catalog. Choose whether to fetch high or standard resolution covers.",
-    fields: [{ key: 'coverResolution', label: 'Cover Resolution', type: 'select', options: ['high', 'standard'] }],
+    hint: t('settings.metadata.providers.hints.itunes'),
+    fields: [
+      { key: 'coverResolution', label: t('settings.metadata.providers.fields.coverResolution'), type: 'select', options: ['high', 'standard'] },
+    ],
   },
   {
     key: 'kobo',
     label: 'Kobo',
-    hint: "Scrapes Kobo's public book pages. Country and language must match Kobo URL paths; bot protection can block requests.",
+    hint: t('settings.metadata.providers.hints.kobo'),
     fields: [
       {
         key: 'country',
-        label: 'Country',
+        label: t('settings.metadata.providers.fields.country'),
         type: 'select',
         options: KOBO_COUNTRIES,
         alwaysEditable: true,
@@ -172,7 +188,7 @@ const rows: RowDef[] = [
       },
       {
         key: 'language',
-        label: 'Language',
+        label: t('settings.metadata.providers.fields.language'),
         type: 'select',
         options: KOBO_LANGUAGES,
         alwaysEditable: true,
@@ -183,35 +199,35 @@ const rows: RowDef[] = [
   {
     key: 'audible',
     label: 'Audible',
-    hint: 'Pulls audiobook metadata from Audible. No additional setup is required.',
-    fields: [{ key: 'domain', label: 'Region', type: 'select', options: AUDIBLE_DOMAINS }],
+    hint: t('settings.metadata.providers.hints.audible'),
+    fields: [{ key: 'domain', label: t('settings.metadata.providers.fields.region'), type: 'select', options: AUDIBLE_DOMAINS }],
   },
-  { key: 'audnexus', label: 'AudNexus', hint: 'Community-driven audiobook metadata. No setup required.', fields: [] },
+  { key: 'audnexus', label: 'AudNexus', hint: t('settings.metadata.providers.hints.audnexus'), fields: [] },
   {
     key: 'comicvine',
     label: 'ComicVine',
-    hint: 'Comic book metadata from ComicVine. A free API key is required from comicvine.gamespot.com.',
-    fields: [{ key: 'apiKey', label: 'API Key', type: 'password', alwaysEditable: true }],
+    hint: t('settings.metadata.providers.hints.comicvine'),
+    fields: [{ key: 'apiKey', label: t('settings.metadata.providers.fields.apiKey'), type: 'password', alwaysEditable: true }],
     enableRequirement: {
       isConfigured: (c) => !!c.comicvine.apiKey.trim(),
-      blockedMessage: 'ComicVine requires an API key before it can be enabled',
+      blockedMessage: t('settings.metadata.providers.blocked.comicvine'),
     },
   },
-  { key: 'ranobedb', label: 'RanobeDB', hint: 'Japanese light novel metadata from RanobeDB. No setup required.', fields: [] },
+  { key: 'ranobedb', label: 'RanobeDB', hint: t('settings.metadata.providers.hints.ranobedb'), fields: [] },
   {
     key: 'lubimyczytac',
     label: 'LubimyCzytac',
-    hint: 'Polish book catalog (lubimyczytac.pl). Scrapes public book pages. No setup required.',
+    hint: t('settings.metadata.providers.hints.lubimyczytac'),
     fields: [],
   },
   {
     key: 'aladin',
     label: 'Aladin',
-    hint: 'Korean book metadata from Aladin (알라딘). A TTB Key from aladin.co.kr is required.',
-    fields: [{ key: 'ttbKey', label: 'TTB Key', type: 'password', placeholder: 'ttb...', alwaysEditable: true }],
+    hint: t('settings.metadata.providers.hints.aladin'),
+    fields: [{ key: 'ttbKey', label: t('settings.metadata.providers.fields.ttbKey'), type: 'password', placeholder: 'ttb...', alwaysEditable: true }],
     enableRequirement: {
       isConfigured: (c) => !!c.aladin.ttbKey.trim(),
-      blockedMessage: 'Aladin requires a TTB Key before it can be enabled',
+      blockedMessage: t('settings.metadata.providers.blocked.aladin'),
     },
   },
 ]
@@ -240,7 +256,7 @@ function isThrottled(key: string): boolean {
 function throttleMessage(key: string): string | null {
   const seconds = throttleSecondsLeft(key)
   if (seconds === null) return null
-  return `Retry in ${formatDuration(seconds)}`
+  return t('settings.metadata.providers.retryIn', { duration: formatDuration(seconds) })
 }
 
 function isTesting(key: string): boolean {
@@ -283,7 +299,7 @@ function enableBlockedMessage(row: RowDef): string | null {
   const req = row.enableRequirement
   if (!req.isConfigured(draft.value)) return req.blockedMessage
   if (req.requiresPassingTest && !hasPassingTestForCurrentInput(row.key as MetadataProviderKey)) {
-    return req.missingTestMessage ?? 'Run Test before enabling'
+    return req.missingTestMessage ?? t('settings.metadata.providers.runTestBeforeEnabling')
   }
   return null
 }
@@ -299,11 +315,11 @@ function isConfiguredBadge(row: RowDef): boolean {
 type BadgeView = { label: string; variant: 'destructive' | 'outline'; class?: string }
 function badgeFor(row: RowDef): BadgeView | null {
   if (!statusFor(row.key)) return null
-  if (!isConfiguredBadge(row)) return { label: 'Setup Required', variant: 'destructive' }
+  if (!isConfiguredBadge(row)) return { label: t('settings.metadata.providers.badge.setupRequired'), variant: 'destructive' }
   if (isThrottled(row.key)) {
-    return { label: 'Throttled', variant: 'outline', class: 'text-amber-600 border-amber-500/30 bg-amber-500/5' }
+    return { label: t('settings.metadata.providers.badge.throttled'), variant: 'outline', class: 'text-amber-600 border-amber-500/30 bg-amber-500/5' }
   }
-  return { label: 'Ready', variant: 'outline', class: 'text-emerald-600 border-emerald-500/30 bg-emerald-500/5' }
+  return { label: t('settings.metadata.providers.badge.ready'), variant: 'outline', class: 'text-emerald-600 border-emerald-500/30 bg-emerald-500/5' }
 }
 
 function formatDuration(totalSeconds: number): string {
@@ -366,12 +382,12 @@ const draftReady = computed(() => draft.value !== null)
   <form class="border border-border rounded-lg bg-card overflow-hidden shadow-xs" @submit.prevent="save">
     <div class="px-4 py-3.5 md:px-5 md:py-4 border-b border-border flex items-center justify-between bg-muted/30">
       <div class="flex items-center gap-2">
-        <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">Available Sources</span>
+        <span class="text-xs font-bold text-muted-foreground uppercase tracking-widest">{{ t('settings.metadata.providers.availableSources') }}</span>
       </div>
       <button type="submit" class="settings-btn-primary h-8 px-3" :disabled="saving || !draftReady">
         <Loader2 v-if="saving" :size="14" class="animate-spin" />
         <Save v-else :size="14" />
-        <span>Save Changes</span>
+        <span>{{ t('settings.metadata.providers.saveChanges') }}</span>
       </button>
     </div>
 
@@ -444,10 +460,10 @@ const draftReady = computed(() => draft.value !== null)
               @click="testProvider(row.key)"
             >
               <Loader2 v-if="isTesting(row.key)" :size="11" class="animate-spin" />
-              <span>{{ isTesting(row.key) ? 'Testing...' : 'Test' }}</span>
+              <span>{{ isTesting(row.key) ? t('settings.metadata.providers.testing') : t('settings.metadata.providers.test') }}</span>
             </button>
             <span v-else />
-            <span class="text-[11px] text-muted-foreground md:hidden">Enabled</span>
+            <span class="text-[11px] text-muted-foreground md:hidden">{{ t('settings.metadata.providers.enabled') }}</span>
             <button
               type="button"
               role="switch"
@@ -469,7 +485,7 @@ const draftReady = computed(() => draft.value !== null)
             {{ testResultFor(row.key)?.message }}
           </p>
           <p v-if="showHardcoverEnableHint(row)" class="text-[10px] text-muted-foreground md:text-right">
-            Run Test with the current token to unlock the enable switch.
+            {{ t('settings.metadata.providers.hardcoverEnableHint') }}
           </p>
         </div>
       </div>

--- a/client/src/features/settings/metadata-preferences/components/ProviderReservoir.vue
+++ b/client/src/features/settings/metadata-preferences/components/ProviderReservoir.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { VueDraggable } from 'vue-draggable-plus'
 import { GripVertical } from '@lucide/vue'
 import type { MetadataProviderKey, ProviderStatus } from '@bookorbit/types'
 import { providerChipStyle, PROVIDER_SHORT_LABELS } from '@/lib/provider-colors'
 import { PROVIDER_DND_GROUP, createProviderDragItem, type ProviderDragItem } from '../lib/provider-drag'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   statuses: ProviderStatus[]
@@ -30,9 +33,9 @@ function cloneProvider(item: ReservoirProviderItem): ProviderDragItem {
 
 function providerTitle(provider: ReservoirProviderItem) {
   const status = props.statuses.find((item) => item.key === provider.key)
-  if (!status?.enabled) return `${provider.label} - disabled`
-  if (!status?.configured) return `${provider.label} - not configured`
-  return `Drag to assign ${provider.label} to a field`
+  if (!status?.enabled) return t('settings.metadata.fieldRules.reservoir.disabled', { provider: provider.label })
+  if (!status?.configured) return t('settings.metadata.fieldRules.reservoir.notConfigured', { provider: provider.label })
+  return t('settings.metadata.fieldRules.reservoir.dragToAssign', { provider: provider.label })
 }
 </script>
 

--- a/client/src/features/smart-scope/components/CreateSmartScopeDialog.vue
+++ b/client/src/features/smart-scope/components/CreateSmartScopeDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { X } from '@lucide/vue'
 import { useSmartScopes } from '@/features/smart-scope/composables/useSmartScopes'
@@ -10,6 +11,7 @@ const emit = defineEmits<{ close: [] }>()
 
 const router = useRouter()
 const { createSmartScope } = useSmartScopes()
+const { t } = useI18n()
 
 const name = ref('')
 const icon = ref('')
@@ -21,11 +23,11 @@ const trimmedIcon = computed(() => icon.value.trim())
 
 async function submit() {
   if (!trimmedName.value) {
-    error.value = 'Name is required'
+    error.value = t('smartScope.dialog.nameRequired')
     return
   }
   if (!trimmedIcon.value) {
-    error.value = 'Choose an icon'
+    error.value = t('smartScope.dialog.iconRequired')
     return
   }
   saving.value = true
@@ -43,7 +45,7 @@ async function submit() {
     emit('close')
     router.push({ name: 'smartScope', params: { id: smartScope.id } })
   } catch {
-    error.value = 'Failed to create smartScope'
+    error.value = t('smartScope.createDialog.createFailed')
   } finally {
     saving.value = false
   }
@@ -56,7 +58,7 @@ async function submit() {
       <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="emit('close')" />
       <div class="relative z-10 w-full max-w-md mx-4 bg-card border border-border rounded-lg shadow-2xl p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-base font-semibold text-foreground">New Smart Scope</h2>
+          <h2 class="text-base font-semibold text-foreground">{{ t('smartScope.createDialog.title') }}</h2>
           <button @click="emit('close')" class="text-muted-foreground hover:text-foreground transition-colors">
             <X :size="18" />
           </button>
@@ -64,24 +66,24 @@ async function submit() {
 
         <form @submit.prevent="submit" class="flex flex-col gap-4">
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground">Name</label>
+            <label class="text-sm font-medium text-foreground">{{ t('smartScope.dialog.name') }}</label>
             <input
               v-model="name"
               type="text"
-              placeholder="e.g. Unread Sci-Fi"
+              :placeholder="t('smartScope.dialog.namePlaceholder')"
               autofocus
               class="h-9 rounded-md border border-input bg-background text-foreground text-sm px-3 focus:outline-none focus:ring-2 focus:ring-primary placeholder:text-muted-foreground"
             />
           </div>
 
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground"> Icon </label>
-            <IconPicker v-model="icon" placeholder="Choose an icon..." />
+            <label class="text-sm font-medium text-foreground">{{ t('smartScope.dialog.icon') }}</label>
+            <IconPicker v-model="icon" :placeholder="t('smartScope.dialog.iconPlaceholder')" />
           </div>
 
           <label class="flex items-center gap-2.5 cursor-pointer select-none">
             <input type="checkbox" v-model="isPublic" class="h-4 w-4 rounded border border-input accent-primary" />
-            <span class="text-sm text-foreground">Visible to all users</span>
+            <span class="text-sm text-foreground">{{ t('smartScope.createDialog.visibleToAll') }}</span>
           </label>
 
           <p v-if="error" class="text-sm text-destructive">{{ error }}</p>
@@ -92,14 +94,14 @@ async function submit() {
               @click="emit('close')"
               class="h-9 px-4 rounded-md border border-input bg-background text-sm text-foreground hover:bg-muted transition-colors"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               type="submit"
               :disabled="!trimmedName || !trimmedIcon || saving"
               class="h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {{ saving ? 'Creating...' : 'Create' }}
+              {{ saving ? t('smartScope.dialog.creating') : t('smartScope.dialog.create') }}
             </button>
           </div>
         </form>

--- a/client/src/features/smart-scope/components/SaveAsSmartScopeDialog.vue
+++ b/client/src/features/smart-scope/components/SaveAsSmartScopeDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { X } from '@lucide/vue'
 import { useSmartScopes } from '@/features/smart-scope/composables/useSmartScopes'
@@ -16,6 +17,7 @@ const emit = defineEmits<{ close: [] }>()
 
 const router = useRouter()
 const { createSmartScope } = useSmartScopes()
+const { t } = useI18n()
 
 const name = ref('')
 const icon = ref('')
@@ -26,11 +28,11 @@ const trimmedIcon = computed(() => icon.value.trim())
 
 async function submit() {
   if (!trimmedName.value) {
-    error.value = 'Name is required'
+    error.value = t('smartScope.dialog.nameRequired')
     return
   }
   if (!trimmedIcon.value) {
-    error.value = 'Choose an icon'
+    error.value = t('smartScope.dialog.iconRequired')
     return
   }
   saving.value = true
@@ -47,7 +49,7 @@ async function submit() {
     emit('close')
     router.push({ name: 'smartScope', params: { id: smartScope.id } })
   } catch {
-    error.value = 'Failed to save smartScope'
+    error.value = t('smartScope.saveAsDialog.saveFailed')
   } finally {
     saving.value = false
   }
@@ -60,7 +62,7 @@ async function submit() {
       <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" @click="emit('close')" />
       <div class="relative z-10 w-full max-w-md mx-4 bg-card border border-border rounded-lg shadow-2xl p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-base font-semibold text-foreground">Save as SmartScope</h2>
+          <h2 class="text-base font-semibold text-foreground">{{ t('smartScope.saveAsDialog.title') }}</h2>
           <button @click="emit('close')" class="text-muted-foreground hover:text-foreground transition-colors">
             <X :size="18" />
           </button>
@@ -68,19 +70,19 @@ async function submit() {
 
         <form @submit.prevent="submit" class="flex flex-col gap-4">
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground">Name</label>
+            <label class="text-sm font-medium text-foreground">{{ t('smartScope.dialog.name') }}</label>
             <input
               v-model="name"
               type="text"
-              placeholder="e.g. Unread Sci-Fi"
+              :placeholder="t('smartScope.dialog.namePlaceholder')"
               autofocus
               class="h-9 rounded-md border border-input bg-background text-foreground text-sm px-3 focus:outline-none focus:ring-2 focus:ring-primary placeholder:text-muted-foreground"
             />
           </div>
 
           <div class="flex flex-col gap-1.5">
-            <label class="text-sm font-medium text-foreground">Icon</label>
-            <IconPicker v-model="icon" placeholder="Choose an icon..." />
+            <label class="text-sm font-medium text-foreground">{{ t('smartScope.dialog.icon') }}</label>
+            <IconPicker v-model="icon" :placeholder="t('smartScope.dialog.iconPlaceholder')" />
           </div>
 
           <p v-if="error" class="text-sm text-destructive">{{ error }}</p>
@@ -91,14 +93,14 @@ async function submit() {
               @click="emit('close')"
               class="h-9 px-4 rounded-md border border-input bg-background text-sm text-foreground hover:bg-muted transition-colors"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               type="submit"
               :disabled="!trimmedName || !trimmedIcon || saving"
               class="h-9 px-4 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {{ saving ? 'Saving...' : 'Save SmartScope' }}
+              {{ saving ? t('smartScope.dialog.saving') : t('smartScope.saveAsDialog.save') }}
             </button>
           </div>
         </form>

--- a/client/src/features/smart-scope/components/SmartScopeEditorPanel.vue
+++ b/client/src/features/smart-scope/components/SmartScopeEditorPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X, Zap } from '@lucide/vue'
 import { api } from '@/lib/api'
 import type { GroupRule, SmartScope, Rule, SortSpec } from '@bookorbit/types'
@@ -8,28 +9,32 @@ import BookFilterBuilder from '@/features/book/components/BookFilterBuilder.vue'
 import BookSortBuilder from '@/features/book/components/BookSortBuilder.vue'
 import IconPicker from '@/components/IconPicker.vue'
 
-const TEMPLATES: { label: string; build: () => GroupRule }[] = [
+const { t } = useI18n()
+
+const TEMPLATES: { id: string; build: () => GroupRule }[] = [
   {
-    label: 'Has Series',
+    id: 'hasSeries',
     build: () => ({ type: 'group', join: 'AND', rules: [{ type: 'rule', field: 'series', operator: 'isNotEmpty' } as Rule] }),
   },
   {
-    label: 'Added Recently',
+    id: 'addedRecently',
     build: () => ({ type: 'group', join: 'AND', rules: [{ type: 'rule', field: 'addedAt', operator: 'withinLast', value: 30 } as Rule] }),
   },
   {
-    label: 'PDF Only',
+    id: 'pdfOnly',
     build: () => ({ type: 'group', join: 'AND', rules: [{ type: 'rule', field: 'format', operator: 'includesAny', value: ['pdf'] } as Rule] }),
   },
   {
-    label: 'No Genres',
+    id: 'noGenres',
     build: () => ({ type: 'group', join: 'AND', rules: [{ type: 'rule', field: 'genre', operator: 'isEmpty' } as Rule] }),
   },
   {
-    label: 'EPUB Only',
+    id: 'epubOnly',
     build: () => ({ type: 'group', join: 'AND', rules: [{ type: 'rule', field: 'format', operator: 'includesAny', value: ['epub'] } as Rule] }),
   },
 ]
+
+const templates = computed(() => TEMPLATES.map((tpl) => ({ ...tpl, label: t(`smartScope.editorPanel.templates.${tpl.id}`) })))
 
 const props = defineProps<{
   open: boolean
@@ -97,8 +102,8 @@ async function fetchPreview() {
   }
 }
 
-function applyTemplate(t: (typeof TEMPLATES)[number]) {
-  draftFilter.value = t.build()
+function applyTemplate(tpl: (typeof TEMPLATES)[number]) {
+  draftFilter.value = tpl.build()
 }
 
 function initFilter() {
@@ -112,11 +117,11 @@ function hasCompleteRules(group: GroupRule | undefined): boolean {
 async function save() {
   if (!props.smartScope) return
   if (!trimmedDraftName.value) {
-    saveError.value = 'Name is required'
+    saveError.value = t('smartScope.dialog.nameRequired')
     return
   }
   if (!trimmedDraftIcon.value) {
-    saveError.value = 'Choose an icon'
+    saveError.value = t('smartScope.dialog.iconRequired')
     return
   }
   saving.value = true
@@ -131,7 +136,7 @@ async function save() {
     emit('saved')
     emit('close')
   } catch {
-    saveError.value = 'Failed to save'
+    saveError.value = t('smartScope.editorPanel.saveFailed')
   } finally {
     saving.value = false
   }
@@ -150,9 +155,9 @@ async function save() {
         <div class="flex items-start gap-4 px-6 py-5 border-b border-border shrink-0">
           <div class="flex-1 min-w-0">
             <h2 class="text-base font-semibold text-foreground leading-tight truncate">
-              {{ draftName || 'Untitled SmartScope' }}
+              {{ draftName || t('smartScope.editorPanel.untitled') }}
             </h2>
-            <p class="text-xs text-muted-foreground mt-0.5">Configure smartScope settings</p>
+            <p class="text-xs text-muted-foreground mt-0.5">{{ t('smartScope.editorPanel.subtitle') }}</p>
           </div>
           <div class="flex items-center gap-2 shrink-0 mt-0.5">
             <span
@@ -160,8 +165,8 @@ async function save() {
               class="flex items-center gap-1 text-xs px-2.5 py-1 rounded-full border font-medium transition-all"
               :class="previewLoading ? 'border-border text-muted-foreground' : 'border-primary/30 bg-primary/8 text-primary'"
             >
-              <span v-if="previewLoading" class="animate-pulse">counting...</span>
-              <template v-else>{{ previewCount?.toLocaleString() }} books</template>
+              <span v-if="previewLoading" class="animate-pulse">{{ t('smartScope.editorPanel.counting') }}</span>
+              <template v-else>{{ t('smartScope.editorPanel.bookCount', { count: previewCount?.toLocaleString() }, previewCount ?? 0) }}</template>
             </span>
             <button
               @click="emit('close')"
@@ -176,47 +181,47 @@ async function save() {
         <div class="flex-1 overflow-y-auto px-6 py-6 flex flex-col gap-5">
           <!-- Identity card -->
           <div class="rounded-lg border border-border bg-background p-5 flex flex-col gap-4">
-            <h3 class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">Identity</h3>
+            <h3 class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">{{ t('smartScope.editorPanel.identity') }}</h3>
             <div class="flex gap-3">
               <div class="flex-1 flex flex-col gap-1.5">
-                <label class="text-xs font-medium text-foreground/70">Name</label>
+                <label class="text-xs font-medium text-foreground/70">{{ t('smartScope.dialog.name') }}</label>
                 <input
                   v-model="draftName"
                   type="text"
-                  placeholder="e.g. Unread Sci-Fi"
+                  :placeholder="t('smartScope.dialog.namePlaceholder')"
                   class="h-10 rounded-lg border border-input bg-card text-foreground text-sm px-3 focus:outline-none focus:ring-2 focus:ring-primary placeholder:text-muted-foreground/60"
                 />
               </div>
               <div class="flex-1 flex flex-col gap-1.5">
-                <label class="text-xs font-medium text-foreground/70">Icon</label>
-                <IconPicker v-model="draftIcon" placeholder="Choose an icon..." />
+                <label class="text-xs font-medium text-foreground/70">{{ t('smartScope.dialog.icon') }}</label>
+                <IconPicker v-model="draftIcon" :placeholder="t('smartScope.dialog.iconPlaceholder')" />
               </div>
             </div>
           </div>
 
           <!-- Filters card -->
           <div class="rounded-lg border border-border bg-background p-5 flex flex-col gap-4">
-            <h3 class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">Filters</h3>
+            <h3 class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">{{ t('smartScope.editorPanel.filters') }}</h3>
 
             <!-- Empty state -->
             <template v-if="!draftFilter">
-              <p class="text-sm text-muted-foreground leading-relaxed">No filters set. All accessible books will be included in this smartScope.</p>
+              <p class="text-sm text-muted-foreground leading-relaxed">{{ t('smartScope.editorPanel.noFilters') }}</p>
               <div class="flex flex-wrap gap-2">
                 <button
-                  v-for="t in TEMPLATES"
-                  :key="t.label"
-                  @click="applyTemplate(t)"
+                  v-for="tpl in templates"
+                  :key="tpl.id"
+                  @click="applyTemplate(tpl)"
                   class="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg border border-dashed border-border bg-muted/30 text-foreground hover:border-primary hover:bg-primary/5 hover:text-primary transition-colors"
                 >
                   <Zap :size="11" class="shrink-0" />
-                  {{ t.label }}
+                  {{ tpl.label }}
                 </button>
               </div>
               <button
                 @click="initFilter"
                 class="self-start flex items-center gap-1.5 h-9 px-4 rounded-lg border border-input bg-card text-sm text-foreground hover:bg-muted transition-colors"
               >
-                Build from scratch
+                {{ t('smartScope.editorPanel.buildFromScratch') }}
               </button>
             </template>
 
@@ -224,14 +229,14 @@ async function save() {
             <template v-else>
               <BookFilterBuilder v-model="draftFilter" preserve-incomplete-root />
               <div class="flex flex-wrap items-center gap-1.5 pt-3 border-t border-border/50">
-                <span class="text-xs text-muted-foreground shrink-0">Replace with template:</span>
+                <span class="text-xs text-muted-foreground shrink-0">{{ t('smartScope.editorPanel.replaceWithTemplate') }}</span>
                 <button
-                  v-for="t in TEMPLATES"
-                  :key="t.label"
-                  @click="applyTemplate(t)"
+                  v-for="tpl in templates"
+                  :key="tpl.id"
+                  @click="applyTemplate(tpl)"
                   class="text-xs px-2.5 py-1 rounded-full border border-dashed border-border text-muted-foreground hover:border-primary hover:text-primary transition-colors"
                 >
-                  {{ t.label }}
+                  {{ tpl.label }}
                 </button>
               </div>
             </template>
@@ -239,7 +244,7 @@ async function save() {
 
           <!-- Sort card -->
           <div class="rounded-lg border border-border bg-background p-5 flex flex-col gap-4">
-            <h3 class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">Default Sort</h3>
+            <h3 class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">{{ t('smartScope.editorPanel.defaultSort') }}</h3>
             <BookSortBuilder v-model="draftSort" />
           </div>
         </div>
@@ -253,14 +258,14 @@ async function save() {
               @click="emit('close')"
               class="h-10 px-5 rounded-lg border border-input bg-card text-sm text-foreground hover:bg-muted transition-colors"
             >
-              Cancel
+              {{ t('common.cancel') }}
             </button>
             <button
               @click="save"
               :disabled="!trimmedDraftName || !trimmedDraftIcon || saving"
               class="h-10 px-6 rounded-lg bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {{ saving ? 'Saving...' : 'Save changes' }}
+              {{ saving ? t('smartScope.dialog.saving') : t('smartScope.editorPanel.saveChanges') }}
             </button>
           </div>
         </div>

--- a/client/src/features/statistics/components/BreakdownSelect.vue
+++ b/client/src/features/statistics/components/BreakdownSelect.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { BREAKDOWN_OPTIONS, type BreakdownDimension } from '../lib/breakdown'
 
+const { t } = useI18n()
 const model = defineModel<BreakdownDimension>({ required: true })
 </script>
 
@@ -8,7 +10,7 @@ const model = defineModel<BreakdownDimension>({ required: true })
   <select
     v-model="model"
     class="border-border bg-background text-foreground rounded-md border px-2 py-1 text-xs"
-    aria-label="Break down by source or format"
+    :aria-label="t('statistics.breakdown.ariaLabel')"
   >
     <option v-for="option in BREAKDOWN_OPTIONS" :key="option.value" :value="option.value">{{ option.label }}</option>
   </select>

--- a/client/src/features/statistics/components/ChartCard.vue
+++ b/client/src/features/statistics/components/ChartCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { AlertCircle, GripVertical } from '@lucide/vue'
 import { Skeleton } from '@/components/ui/skeleton'
 import ChartEmptyState from './ChartEmptyState.vue'
@@ -16,6 +17,8 @@ const props = defineProps<{
   unknownCount?: number
   error?: boolean
 }>()
+
+const { t } = useI18n()
 
 const ICON_HUE_OFFSETS = [0, 45, 90, 135, 180, 225, 270, 315, 337]
 
@@ -53,18 +56,22 @@ const iconStyle = computed(() => {
 
         <div v-else-if="error" class="text-muted-foreground flex h-full flex-col items-center justify-center gap-2">
           <AlertCircle class="size-6" />
-          <p class="text-sm">Failed to load data</p>
+          <p class="text-sm">{{ t('statistics.card.loadError') }}</p>
         </div>
 
         <div v-else-if="empty" class="h-full">
-          <ChartEmptyState :icon="icon" :title="emptyTitle ?? 'No data yet'" :description="emptyDescription ?? 'No data available for this chart'" />
+          <ChartEmptyState
+            :icon="icon"
+            :title="emptyTitle ?? t('statistics.card.emptyTitle')"
+            :description="emptyDescription ?? t('statistics.card.emptyDescription')"
+          />
         </div>
 
         <slot v-else />
       </div>
 
       <p v-if="!loading && !error && unknownCount && unknownCount > 0" class="text-muted-foreground mt-2 text-xs">
-        {{ unknownCount }} {{ unknownCount === 1 ? 'book has' : 'books have' }} no data for this field
+        {{ t('statistics.card.unknownField', { count: unknownCount }, unknownCount) }}
       </p>
     </div>
   </div>

--- a/client/src/features/statistics/components/StatisticsPage.vue
+++ b/client/src/features/statistics/components/StatisticsPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { Check, ChevronDown, GripVertical, Settings2 } from '@lucide/vue'
 import { VueDraggable } from 'vue-draggable-plus'
@@ -31,6 +32,7 @@ const {
   setLibraryFilter,
 } = useStatisticsConfig()
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { libraries, fetchLibraries } = useLibraries()
@@ -82,8 +84,8 @@ const activeOrderedCharts = computed(() => (activeTab.value === 'library' ? orde
 
 const libraryLabel = computed(() => {
   const count = filters.value.libraryIds.length
-  if (count === 0 || count === libraries.value.length) return 'All Libraries'
-  return `${count} of ${libraries.value.length} Libraries`
+  if (count === 0 || count === libraries.value.length) return t('statistics.filter.allLibraries')
+  return t('statistics.filter.librarySelection', { count, total: libraries.value.length })
 })
 
 const isFiltered = computed(() => filters.value.libraryIds.length > 0 && filters.value.libraryIds.length < libraries.value.length)
@@ -147,7 +149,7 @@ function setTab(tab: StatisticsTab) {
           ]"
           @click="setTab('library')"
         >
-          Library Stats
+          {{ t('statistics.tabs.library') }}
         </button>
         <button
           :class="[
@@ -156,7 +158,7 @@ function setTab(tab: StatisticsTab) {
           ]"
           @click="setTab('user')"
         >
-          My Reading
+          {{ t('statistics.tabs.user') }}
         </button>
       </div>
 
@@ -181,7 +183,7 @@ function setTab(tab: StatisticsTab) {
               <div :class="['flex size-4 items-center justify-center rounded border', !isFiltered ? 'border-primary bg-primary' : 'border-border']">
                 <Check v-if="!isFiltered" class="text-primary-foreground size-2.5" />
               </div>
-              All Libraries
+              {{ t('statistics.filter.allLibraries') }}
             </button>
             <div class="border-border my-1 border-t" />
             <button
@@ -208,7 +210,7 @@ function setTab(tab: StatisticsTab) {
           @click="openConfig"
         >
           <Settings2 class="size-3.5" />
-          Configure
+          {{ t('statistics.config.button') }}
         </button>
       </div>
     </div>
@@ -219,12 +221,12 @@ function setTab(tab: StatisticsTab) {
       <SheetContent side="right" class="w-[90dvw] max-w-[90dvw] sm:w-[420px] sm:max-w-[420px]">
         <SheetHeader>
           <div class="flex items-center justify-between pr-8">
-            <SheetTitle>Configure Charts</SheetTitle>
+            <SheetTitle>{{ t('statistics.config.title') }}</SheetTitle>
             <span class="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-xs font-medium tabular-nums">
               {{ activeVisibleCount }} / {{ activeTotalCount }}
             </span>
           </div>
-          <SheetDescription>Drag to reorder, toggle to show or hide.</SheetDescription>
+          <SheetDescription>{{ t('statistics.config.description') }}</SheetDescription>
         </SheetHeader>
 
         <div class="flex-1 overflow-y-auto px-4">
@@ -258,7 +260,7 @@ function setTab(tab: StatisticsTab) {
             class="text-muted-foreground hover:text-foreground w-full rounded-md py-2 text-sm transition-colors hover:bg-transparent"
             @click="handleReset"
           >
-            Reset to defaults
+            {{ t('statistics.config.reset') }}
           </button>
         </SheetFooter>
       </SheetContent>

--- a/client/src/features/statistics/components/StatisticsSummaryCard.vue
+++ b/client/src/features/statistics/components/StatisticsSummaryCard.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { BarChart3, BookCheck, BookOpen, BookText, Building2, CalendarPlus, CalendarRange, Globe, Layers, Tags, Users } from '@lucide/vue'
 
 import { useStatisticsSummary } from '../composables/useStatisticsSummary'
 import { useUserStatisticsSummary } from '../composables/useUserStatisticsSummary'
+
+const { t } = useI18n()
 
 const { data, loading: libraryLoading } = useStatisticsSummary()
 const { data: userData, loading: userLoading } = useUserStatisticsSummary()
@@ -42,19 +45,79 @@ const avgProgress = computed(() => {
 const loading = computed(() => libraryLoading.value || userLoading.value)
 
 const kpis = computed(() => [
-  { icon: BookOpen, label: 'Books', value: data.value ? formatNumber(data.value.totalBooks) : '-', colorIndex: 1 },
-  { icon: Users, label: 'Authors', value: data.value ? formatNumber(data.value.totalAuthors) : '-', colorIndex: 2 },
-  { icon: Layers, label: 'Series', value: data.value ? formatNumber(data.value.totalSeries) : '-', colorIndex: 3 },
-  { icon: Building2, label: 'Publishers', value: data.value ? formatNumber(data.value.totalPublishers) : '-', colorIndex: 4 },
-  { icon: BarChart3, label: 'Storage', value: data.value ? formatBytes(data.value.totalStorageBytes) : '-', colorIndex: 5 },
-  { icon: Tags, label: 'Genres', value: data.value ? formatNumber(data.value.totalGenres) : '-', colorIndex: 6 },
-  { icon: Globe, label: 'Languages', value: data.value ? formatNumber(data.value.totalLanguages) : '-', colorIndex: 7 },
-  { icon: CalendarRange, label: 'Published', value: publicationRange.value, colorIndex: 8 },
-  { icon: CalendarPlus, label: 'This Year', value: data.value ? formatNumber(data.value.booksAddedThisYear) : '-', colorIndex: 9 },
-  { icon: BookText, label: 'Started', value: userData.value ? formatNumber(userData.value.startedBooks) : '-', colorIndex: 1 },
-  { icon: BookOpen, label: 'In Progress', value: userData.value ? formatNumber(userData.value.inProgressBooks) : '-', colorIndex: 2 },
-  { icon: BookCheck, label: 'Completed', value: userData.value ? formatNumber(userData.value.completedBooks) : '-', colorIndex: 3 },
-  { icon: BarChart3, label: 'Avg Progress', value: avgProgress.value, colorIndex: 4 },
+  {
+    icon: BookOpen,
+    key: 'books',
+    label: t('statistics.summary.books'),
+    value: data.value ? formatNumber(data.value.totalBooks) : '-',
+    colorIndex: 1,
+  },
+  {
+    icon: Users,
+    key: 'authors',
+    label: t('statistics.summary.authors'),
+    value: data.value ? formatNumber(data.value.totalAuthors) : '-',
+    colorIndex: 2,
+  },
+  {
+    icon: Layers,
+    key: 'series',
+    label: t('statistics.summary.series'),
+    value: data.value ? formatNumber(data.value.totalSeries) : '-',
+    colorIndex: 3,
+  },
+  {
+    icon: Building2,
+    key: 'publishers',
+    label: t('statistics.summary.publishers'),
+    value: data.value ? formatNumber(data.value.totalPublishers) : '-',
+    colorIndex: 4,
+  },
+  {
+    icon: BarChart3,
+    key: 'storage',
+    label: t('statistics.summary.storage'),
+    value: data.value ? formatBytes(data.value.totalStorageBytes) : '-',
+    colorIndex: 5,
+  },
+  { icon: Tags, key: 'genres', label: t('statistics.summary.genres'), value: data.value ? formatNumber(data.value.totalGenres) : '-', colorIndex: 6 },
+  {
+    icon: Globe,
+    key: 'languages',
+    label: t('statistics.summary.languages'),
+    value: data.value ? formatNumber(data.value.totalLanguages) : '-',
+    colorIndex: 7,
+  },
+  { icon: CalendarRange, key: 'published', label: t('statistics.summary.published'), value: publicationRange.value, colorIndex: 8 },
+  {
+    icon: CalendarPlus,
+    key: 'thisYear',
+    label: t('statistics.summary.thisYear'),
+    value: data.value ? formatNumber(data.value.booksAddedThisYear) : '-',
+    colorIndex: 9,
+  },
+  {
+    icon: BookText,
+    key: 'started',
+    label: t('statistics.summary.started'),
+    value: userData.value ? formatNumber(userData.value.startedBooks) : '-',
+    colorIndex: 1,
+  },
+  {
+    icon: BookOpen,
+    key: 'inProgress',
+    label: t('statistics.summary.inProgress'),
+    value: userData.value ? formatNumber(userData.value.inProgressBooks) : '-',
+    colorIndex: 2,
+  },
+  {
+    icon: BookCheck,
+    key: 'completed',
+    label: t('statistics.summary.completed'),
+    value: userData.value ? formatNumber(userData.value.completedBooks) : '-',
+    colorIndex: 3,
+  },
+  { icon: BarChart3, key: 'avgProgress', label: t('statistics.summary.avgProgress'), value: avgProgress.value, colorIndex: 4 },
 ])
 </script>
 
@@ -67,7 +130,7 @@ const kpis = computed(() => [
       <div class="flex gap-3 overflow-x-auto pb-0.5 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <div
           v-for="(kpi, index) in kpis"
-          :key="kpi.label"
+          :key="kpi.key"
           :class="[
             'border-border/60 bg-background/50 flex shrink-0 items-center gap-3 rounded-lg border px-4 py-2.5 animate-fade-up',
             loading ? 'opacity-60' : '',

--- a/client/src/features/statistics/components/library/AcquisitionLagScatterChart.vue
+++ b/client/src/features/statistics/components/library/AcquisitionLagScatterChart.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { CalendarRange } from '@lucide/vue'
 
 import type { AcquisitionLagPoint } from '@bookorbit/types'
 import { useAcquisitionLagScatter } from '../../composables/useAcquisitionLagScatter'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useAcquisitionLagScatter()
 const option = shallowRef({})
@@ -79,7 +82,7 @@ watchEffect(() => {
 
 <template>
   <ChartCard
-    title="Acquisition Lag"
+    :title="t('statistics.charts.acquisitionLag.title')"
     :icon="CalendarRange"
     :color-index="6"
     :loading

--- a/client/src/features/statistics/components/library/BooksAddedOverTimeChart.vue
+++ b/client/src/features/statistics/components/library/BooksAddedOverTimeChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { shallowRef, watchEffect } from 'vue'
+import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { TrendingUp } from '@lucide/vue'
 
@@ -10,14 +11,16 @@ import ChartCard from '../ChartCard.vue'
 
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 
-const DATE_RANGE_LABELS = {
-  'all-time': 'All Time',
-  'last-5-years': 'Last 5 Years',
-  'last-year': 'Last Year',
-} as const
+const { t } = useI18n()
 
 const { data, loading, error } = useBooksAddedOverTime()
 const { filters, setGranularity, setDateRange } = useStatisticsConfig()
+
+const dateRangeLabels = computed<Record<string, string>>(() => ({
+  'all-time': t('statistics.charts.booksAddedOverTime.allTime'),
+  'last-5-years': t('statistics.charts.booksAddedOverTime.last5Years'),
+  'last-year': t('statistics.charts.booksAddedOverTime.lastYear'),
+}))
 
 const option = shallowRef({})
 
@@ -85,7 +88,7 @@ function handleLastYear() {
 </script>
 
 <template>
-  <ChartCard title="Books Added Over Time" :icon="TrendingUp" :color-index="3" :loading :error :empty="!data.items.length">
+  <ChartCard :title="t('statistics.charts.booksAddedOverTime.title')" :icon="TrendingUp" :color-index="3" :loading :error :empty="!data.items.length">
     <template #controls>
       <div class="flex items-center gap-1">
         <div class="border-border flex rounded-md border text-xs">
@@ -96,7 +99,7 @@ function handleLastYear() {
             ]"
             @click="handleMonthly"
           >
-            Monthly
+            {{ t('statistics.charts.booksAddedOverTime.monthly') }}
           </button>
           <button
             :class="[
@@ -105,20 +108,20 @@ function handleLastYear() {
             ]"
             @click="handleYearly"
           >
-            Yearly
+            {{ t('statistics.charts.booksAddedOverTime.yearly') }}
           </button>
         </div>
 
         <DropdownMenu>
           <DropdownMenuTrigger as-child>
             <button class="border-border text-muted-foreground hover:text-foreground rounded-md border px-2 py-1 text-xs transition-colors">
-              {{ DATE_RANGE_LABELS[filters.booksOverTimeRange] }}
+              {{ dateRangeLabels[filters.booksOverTimeRange] }}
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" class="text-xs">
-            <DropdownMenuItem @click="handleAllTime">All Time</DropdownMenuItem>
-            <DropdownMenuItem @click="handleLast5Years">Last 5 Years</DropdownMenuItem>
-            <DropdownMenuItem @click="handleLastYear">Last Year</DropdownMenuItem>
+            <DropdownMenuItem @click="handleAllTime">{{ t('statistics.charts.booksAddedOverTime.allTime') }}</DropdownMenuItem>
+            <DropdownMenuItem @click="handleLast5Years">{{ t('statistics.charts.booksAddedOverTime.last5Years') }}</DropdownMenuItem>
+            <DropdownMenuItem @click="handleLastYear">{{ t('statistics.charts.booksAddedOverTime.lastYear') }}</DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/client/src/features/statistics/components/library/FormatDistributionChart.vue
+++ b/client/src/features/statistics/components/library/FormatDistributionChart.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { PieChart } from '@lucide/vue'
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 
 import { useFormatDistribution } from '../../composables/useFormatDistribution'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useFormatDistribution()
 const { md } = useBreakpoints(breakpointsTailwind)
@@ -37,7 +40,7 @@ watchEffect(() => {
 
 <template>
   <ChartCard
-    title="Format Distribution"
+    :title="t('statistics.charts.formatDistribution.title')"
     :icon="PieChart"
     :color-index="1"
     :loading

--- a/client/src/features/statistics/components/library/FormatShareOverTimeChart.vue
+++ b/client/src/features/statistics/components/library/FormatShareOverTimeChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { TrendingUp } from '@lucide/vue'
 
@@ -7,6 +8,8 @@ import { useFormatShareOverTime } from '../../composables/useFormatShareOverTime
 import ChartCard from '../ChartCard.vue'
 
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+const { t } = useI18n()
 
 const { data, loading, error } = useFormatShareOverTime()
 const option = shallowRef({})
@@ -83,7 +86,14 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Format Share Over Time" :icon="TrendingUp" :color-index="3" :loading :error :empty="!data.items.length">
+  <ChartCard
+    :title="t('statistics.charts.formatShareOverTime.title')"
+    :icon="TrendingUp"
+    :color-index="3"
+    :loading
+    :error
+    :empty="!data.items.length"
+  >
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>
 </template>

--- a/client/src/features/statistics/components/library/GenreCooccurrenceChart.vue
+++ b/client/src/features/statistics/components/library/GenreCooccurrenceChart.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { computed, shallowRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { GitMerge } from '@lucide/vue'
 import type { ChordDiagramData } from '@bookorbit/types'
 
 import { useGenreCooccurrence } from '../../composables/useGenreCooccurrence'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useGenreCooccurrence()
 const option = shallowRef({})
@@ -50,7 +53,7 @@ watch(
 </script>
 
 <template>
-  <ChartCard title="Genre Co-occurrence" :icon="GitMerge" :color-index="3" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.genreCooccurrence.title')" :icon="GitMerge" :color-index="3" :loading :error :empty="isEmpty">
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>
 </template>

--- a/client/src/features/statistics/components/library/GenreDistributionChart.vue
+++ b/client/src/features/statistics/components/library/GenreDistributionChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Tag } from '@lucide/vue'
 
@@ -9,6 +10,8 @@ import { useGenreDistribution } from '../../composables/useGenreDistribution'
 import ChartCard from '../ChartCard.vue'
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useGenreDistribution()
 
 const total = computed(() => data.value.items.reduce((s, d) => s + d.count, 0))
@@ -71,7 +74,15 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Genre Distribution" :icon="Tag" :color-index="8" :loading :error :empty="!data.items.length" :unknown-count="data.unknownCount">
+  <ChartCard
+    :title="t('statistics.charts.genreDistribution.title')"
+    :icon="Tag"
+    :color-index="8"
+    :loading
+    :error
+    :empty="!data.items.length"
+    :unknown-count="data.unknownCount"
+  >
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>
 </template>

--- a/client/src/features/statistics/components/library/LanguageDistributionChart.vue
+++ b/client/src/features/statistics/components/library/LanguageDistributionChart.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Globe } from '@lucide/vue'
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 
 import { useLanguageDistribution } from '../../composables/useLanguageDistribution'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useLanguageDistribution()
 const { md } = useBreakpoints(breakpointsTailwind)
@@ -43,7 +46,7 @@ watchEffect(() => {
 
 <template>
   <ChartCard
-    title="Language Distribution"
+    :title="t('statistics.charts.languageDistribution.title')"
     :icon="Globe"
     :color-index="2"
     :loading

--- a/client/src/features/statistics/components/library/LargestBooksChart.vue
+++ b/client/src/features/statistics/components/library/LargestBooksChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { HardDrive } from '@lucide/vue'
 
@@ -7,6 +8,8 @@ import { formatBytes } from '@/lib/formatting'
 import { getFormatColor } from '@/features/book/lib/format-colors'
 import { useLargestBooks } from '../../composables/useLargestBooks'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useLargestBooks()
 const option = shallowRef({})
@@ -85,7 +88,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Top 50 Largest Books" :icon="HardDrive" :color-index="2" :loading :error :empty="!data.items.length">
+  <ChartCard :title="t('statistics.charts.largestBooks.title')" :icon="HardDrive" :color-index="2" :loading :error :empty="!data.items.length">
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>
 </template>

--- a/client/src/features/statistics/components/library/LibraryIntegrityGaugeChart.vue
+++ b/client/src/features/statistics/components/library/LibraryIntegrityGaugeChart.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { ShieldCheck } from '@lucide/vue'
 
 import { readCssColor } from '@/lib/echarts'
 import { useLibraryIntegrityGauge } from '../../composables/useLibraryIntegrityGauge'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useLibraryIntegrityGauge()
 const option = shallowRef({})
@@ -96,7 +99,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Library Integrity" :icon="ShieldCheck" :color-index="4" :loading :error :empty="totalBooks === 0">
+  <ChartCard :title="t('statistics.charts.libraryIntegrity.title')" :icon="ShieldCheck" :color-index="4" :loading :error :empty="totalBooks === 0">
     <div class="flex h-full flex-col">
       <VChart :option="option" autoresize style="height: 76%" />
       <div class="mt-0 grid grid-cols-3 gap-2 px-1">

--- a/client/src/features/statistics/components/library/LibraryMetadataCompletenessHeatmapChart.vue
+++ b/client/src/features/statistics/components/library/LibraryMetadataCompletenessHeatmapChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { ListChecks } from '@lucide/vue'
 import { useThemeStore } from '@/stores/theme'
@@ -25,6 +26,8 @@ const FIELD_ORDER = [
 ]
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useLibraryMetadataCompleteness()
 const option = shallowRef({})
 const heatmapPaletteState = computed(() => ({
@@ -109,7 +112,14 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Library Metadata Completeness" :icon="ListChecks" :color-index="7" :loading :error :empty="!data.items.length">
+  <ChartCard
+    :title="t('statistics.charts.libraryMetadataCompleteness.title')"
+    :icon="ListChecks"
+    :color-index="7"
+    :loading
+    :error
+    :empty="!data.items.length"
+  >
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>
 </template>

--- a/client/src/features/statistics/components/library/MetadataCompletenessChart.vue
+++ b/client/src/features/statistics/components/library/MetadataCompletenessChart.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { ListChecks } from '@lucide/vue'
 
 import { useMetadataCompleteness } from '../../composables/useMetadataCompleteness'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useMetadataCompleteness()
 const option = shallowRef({})
@@ -52,7 +55,14 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Metadata Completeness" :icon="ListChecks" :color-index="7" :loading :error :empty="!data.items.length">
+  <ChartCard
+    :title="t('statistics.charts.metadataCompleteness.title')"
+    :icon="ListChecks"
+    :color-index="7"
+    :loading
+    :error
+    :empty="!data.items.length"
+  >
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>
 </template>

--- a/client/src/features/statistics/components/library/MetadataFreshnessGaugeChart.vue
+++ b/client/src/features/statistics/components/library/MetadataFreshnessGaugeChart.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Gauge } from '@lucide/vue'
 
 import { readCssColor } from '@/lib/echarts'
 import { useMetadataFreshnessGauge } from '../../composables/useMetadataFreshnessGauge'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useMetadataFreshnessGauge()
 const option = shallowRef({})
@@ -88,7 +91,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Metadata Freshness" :icon="Gauge" :color-index="2" :loading :error :empty="totalBooks === 0">
+  <ChartCard :title="t('statistics.charts.metadataFreshness.title')" :icon="Gauge" :color-index="2" :loading :error :empty="totalBooks === 0">
     <div class="flex h-full flex-col">
       <VChart :option="option" autoresize style="height: 76%" />
       <div class="mt-0 grid grid-cols-3 gap-2 px-1">

--- a/client/src/features/statistics/components/library/MetadataScoreDistributionChart.vue
+++ b/client/src/features/statistics/components/library/MetadataScoreDistributionChart.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { BarChart3 } from '@lucide/vue'
 
 import { useMetadataScoreDistribution } from '../../composables/useMetadataScoreDistribution'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useMetadataScoreDistribution()
 const option = shallowRef({})
@@ -70,7 +73,7 @@ watchEffect(() => {
 
 <template>
   <ChartCard
-    title="Metadata Score Distribution"
+    :title="t('statistics.charts.metadataScoreDistribution.title')"
     :icon="BarChart3"
     :color-index="2"
     :loading

--- a/client/src/features/statistics/components/library/PageCountDistributionChart.vue
+++ b/client/src/features/statistics/components/library/PageCountDistributionChart.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { BookOpen } from '@lucide/vue'
 
 import { usePageCountDistribution } from '../../composables/usePageCountDistribution'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = usePageCountDistribution()
 const option = shallowRef({})
@@ -51,7 +54,7 @@ watchEffect(() => {
 
 <template>
   <ChartCard
-    title="Page Count Distribution"
+    :title="t('statistics.charts.pageCountDistribution.title')"
     :icon="BookOpen"
     :color-index="1"
     :loading

--- a/client/src/features/statistics/components/library/PublicationDecadeChart.vue
+++ b/client/src/features/statistics/components/library/PublicationDecadeChart.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { CalendarDays } from '@lucide/vue'
 
 import { usePublicationDecade } from '../../composables/usePublicationDecade'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = usePublicationDecade()
 const option = shallowRef({})
@@ -46,7 +49,7 @@ watchEffect(() => {
 
 <template>
   <ChartCard
-    title="Publication Decade"
+    :title="t('statistics.charts.publicationDecade.title')"
     :icon="CalendarDays"
     :color-index="5"
     :loading

--- a/client/src/features/statistics/components/library/PublicationYearTimelineChart.vue
+++ b/client/src/features/statistics/components/library/PublicationYearTimelineChart.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { TrendingUp } from '@lucide/vue'
 
 import { usePublicationYearTimeline } from '../../composables/usePublicationYearTimeline'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = usePublicationYearTimeline()
 const option = shallowRef({})
@@ -202,7 +205,14 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Publication Year Timeline" :icon="TrendingUp" :color-index="4" :loading :error :empty="!data.items.length">
+  <ChartCard
+    :title="t('statistics.charts.publicationYearTimeline.title')"
+    :icon="TrendingUp"
+    :color-index="4"
+    :loading
+    :error
+    :empty="!data.items.length"
+  >
     <div class="flex h-full flex-col">
       <VChart :option autoresize style="flex: 1; min-height: 0" />
       <div v-if="statCards" class="mt-2 grid grid-cols-6 gap-2 md:gap-8 px-1">

--- a/client/src/features/statistics/components/library/StorageByFormatChart.vue
+++ b/client/src/features/statistics/components/library/StorageByFormatChart.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { HardDrive } from '@lucide/vue'
 import { breakpointsTailwind, useBreakpoints } from '@vueuse/core'
 
 import { useStorageByFormat } from '../../composables/useStorageByFormat'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const { data, loading, error } = useStorageByFormat()
 const { md } = useBreakpoints(breakpointsTailwind)
@@ -46,7 +49,7 @@ watchEffect(() => {
 
 <template>
   <ChartCard
-    title="Storage by Format"
+    :title="t('statistics.charts.storageByFormat.title')"
     :icon="HardDrive"
     :color-index="4"
     :loading

--- a/client/src/features/statistics/components/library/TopAuthorsChart.vue
+++ b/client/src/features/statistics/components/library/TopAuthorsChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Users } from '@lucide/vue'
 
@@ -9,6 +10,8 @@ import { useTopAuthors } from '../../composables/useTopAuthors'
 import ChartCard from '../ChartCard.vue'
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useTopAuthors()
 const option = shallowRef({})
 
@@ -123,7 +126,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Top 25 Authors" :icon="Users" :color-index="6" :loading :error :empty="!data.items.length">
+  <ChartCard :title="t('statistics.charts.topAuthors.title')" :icon="Users" :color-index="6" :loading :error :empty="!data.items.length">
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>
 </template>

--- a/client/src/features/statistics/components/library/TopSeriesChart.vue
+++ b/client/src/features/statistics/components/library/TopSeriesChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Layers } from '@lucide/vue'
 
@@ -9,6 +10,8 @@ import { useTopSeries } from '../../composables/useTopSeries'
 import ChartCard from '../ChartCard.vue'
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useTopSeries()
 const option = shallowRef({})
 
@@ -145,7 +148,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Top 50 Series" :icon="Layers" :color-index="8" :loading :error :empty="!data.items.length">
+  <ChartCard :title="t('statistics.charts.topSeries.title')" :icon="Layers" :color-index="8" :loading :error :empty="!data.items.length">
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>
 </template>

--- a/client/src/features/statistics/components/user/BooksCompletedChart.vue
+++ b/client/src/features/statistics/components/user/BooksCompletedChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { BookCheck } from '@lucide/vue'
 
@@ -9,6 +10,8 @@ import ChartEmptyState from '../ChartEmptyState.vue'
 
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 const MIN_COMPLETIONS = 2
+
+const { t } = useI18n()
 
 const { data, loading, error } = useUserBooksCompleted()
 
@@ -72,12 +75,12 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Books Completed" :icon="BookCheck" :color-index="3" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.booksCompleted.title')" :icon="BookCheck" :color-index="3" :loading :error :empty="isEmpty">
     <ChartEmptyState
       v-if="!hasEnoughData"
       :icon="BookCheck"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_COMPLETIONS} completed books for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.booksCompleted.notEnoughData', { count: MIN_COMPLETIONS })"
     />
     <VChart v-else :option autoresize style="height: 100%" />
   </ChartCard>

--- a/client/src/features/statistics/components/user/CompletionLatencyChart.vue
+++ b/client/src/features/statistics/components/user/CompletionLatencyChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Rabbit } from '@lucide/vue'
 
@@ -8,6 +9,8 @@ import ChartCard from '../ChartCard.vue'
 import ChartEmptyState from '../ChartEmptyState.vue'
 
 const MIN_COMPLETIONS = 5
+
+const { t } = useI18n()
 
 const { data, loading, error } = useUserCompletionLatency()
 const option = shallowRef({})
@@ -59,12 +62,12 @@ function metric(value: number | null): string {
 </script>
 
 <template>
-  <ChartCard title="Completion Latency" :icon="Rabbit" :color-index="2" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.completionLatency.title')" :icon="Rabbit" :color-index="2" :loading :error :empty="isEmpty">
     <ChartEmptyState
       v-if="lowConfidence"
       :icon="Rabbit"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_COMPLETIONS} completed books for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.completionLatency.notEnoughData', { count: MIN_COMPLETIONS })"
     />
     <div v-else class="flex h-full flex-col gap-3">
       <div class="text-muted-foreground grid grid-cols-3 gap-2 text-xs">

--- a/client/src/features/statistics/components/user/CompletionTimelineChart.vue
+++ b/client/src/features/statistics/components/user/CompletionTimelineChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { CalendarRange } from '@lucide/vue'
 
@@ -9,6 +10,8 @@ import ChartEmptyState from '../ChartEmptyState.vue'
 
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 const MIN_COMPLETIONS = 3
+
+const { t } = useI18n()
 
 const { data, loading, error } = useUserCompletionTimeline()
 const option = shallowRef({})
@@ -66,12 +69,12 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Completion Timeline" :icon="CalendarRange" :color-index="8" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.completionTimeline.title')" :icon="CalendarRange" :color-index="8" :loading :error :empty="isEmpty">
     <ChartEmptyState
       v-if="lowConfidence"
       :icon="CalendarRange"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_COMPLETIONS} completed books for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.completionTimeline.notEnoughData', { count: MIN_COMPLETIONS })"
     />
     <VChart v-else :option autoresize style="height: 100%" />
   </ChartCard>

--- a/client/src/features/statistics/components/user/FavoriteReadingDaysChart.vue
+++ b/client/src/features/statistics/components/user/FavoriteReadingDaysChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { CalendarDays } from '@lucide/vue'
 import type { ReadingSessionSourceBucket } from '@bookorbit/types'
@@ -16,6 +17,8 @@ const MIN_EVENTS = 14
 const DAYS_WINDOW = 365
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useUserFavoriteReadingDays()
 const option = shallowRef({})
 
@@ -100,15 +103,15 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Favorite Reading Days" :icon="CalendarDays" :color-index="6" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.favoriteReadingDays.title')" :icon="CalendarDays" :color-index="6" :loading :error :empty="isEmpty">
     <template #controls>
       <BreakdownSelect v-model="dimension" />
     </template>
     <ChartEmptyState
       v-if="lowConfidence"
       :icon="CalendarDays"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_EVENTS} reading events for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.favoriteReadingDays.notEnoughData', { count: MIN_EVENTS })"
     />
     <VChart v-else :option autoresize style="height: 100%" />
   </ChartCard>

--- a/client/src/features/statistics/components/user/GenreReadingTimeTreemapChart.vue
+++ b/client/src/features/statistics/components/user/GenreReadingTimeTreemapChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Tag } from '@lucide/vue'
 import { READING_SESSION_SOURCE_BUCKETS, READING_SESSION_SOURCE_BUCKET_LABELS } from '@bookorbit/types'
@@ -13,6 +14,8 @@ import ChartEmptyState from '../ChartEmptyState.vue'
 const MIN_GENRES = 2
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useUserGenreReadingTime()
 
 const totalSeconds = computed(() => data.value.reduce((s, item) => s + item.readingSeconds, 0))
@@ -84,12 +87,12 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Genre Reading Time" :icon="Tag" :color-index="6" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.genreReadingTime.title')" :icon="Tag" :color-index="6" :loading :error :empty="isEmpty">
     <ChartEmptyState
       v-if="!hasEnoughData"
       :icon="Tag"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_GENRES} genres with reading time for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.genreReadingTime.notEnoughData', { count: MIN_GENRES })"
     />
     <VChart v-else :option autoresize style="height: 100%" />
   </ChartCard>

--- a/client/src/features/statistics/components/user/GoalTrajectoryChart.vue
+++ b/client/src/features/statistics/components/user/GoalTrajectoryChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Goal } from '@lucide/vue'
 
@@ -9,6 +10,8 @@ import ChartEmptyState from '../ChartEmptyState.vue'
 
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 const MIN_COMPLETIONS = 2
+
+const { t } = useI18n()
 
 const { data, loading, error } = useUserGoalTrajectory()
 const option = shallowRef({})
@@ -73,18 +76,18 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Pace vs Goal" :icon="Goal" :color-index="9" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.goalTrajectory.title')" :icon="Goal" :color-index="9" :loading :error :empty="isEmpty">
     <ChartEmptyState
       v-if="noCompletionsYet"
       :icon="Goal"
-      title="No completed books yet"
-      description="Complete a book in this period to compare your pace against your yearly goal."
+      :title="t('statistics.charts.goalTrajectory.noCompletedTitle')"
+      :description="t('statistics.charts.goalTrajectory.noCompletedDescription')"
     />
     <ChartEmptyState
       v-else-if="lowConfidence"
       :icon="Goal"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_COMPLETIONS} completed books for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.goalTrajectory.notEnoughData', { count: MIN_COMPLETIONS })"
     />
     <VChart v-else :option autoresize style="height: 100%" />
   </ChartCard>

--- a/client/src/features/statistics/components/user/PeakReadingHoursChart.vue
+++ b/client/src/features/statistics/components/user/PeakReadingHoursChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Clock3 } from '@lucide/vue'
 import type { ReadingSessionSourceBucket } from '@bookorbit/types'
@@ -14,6 +15,8 @@ import ChartEmptyState from '../ChartEmptyState.vue'
 const MIN_EVENTS = 20
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useUserPeakReadingHours()
 const option = shallowRef({})
 const dimension = ref<BreakdownDimension>(DEFAULT_BREAKDOWN_DIMENSION)
@@ -88,15 +91,15 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Peak Reading Hours" :icon="Clock3" :color-index="5" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.peakReadingHours.title')" :icon="Clock3" :color-index="5" :loading :error :empty="isEmpty">
     <template #controls>
       <BreakdownSelect v-model="dimension" />
     </template>
     <ChartEmptyState
       v-if="lowConfidence"
       :icon="Clock3"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_EVENTS} reading events for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.peakReadingHours.notEnoughData', { count: MIN_EVENTS })"
     />
     <VChart v-else :option autoresize style="height: 100%" />
   </ChartCard>

--- a/client/src/features/statistics/components/user/ProgressFunnelChart.vue
+++ b/client/src/features/statistics/components/user/ProgressFunnelChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Waypoints } from '@lucide/vue'
 
@@ -9,13 +10,10 @@ import ChartCard from '../ChartCard.vue'
 import ChartEmptyState from '../ChartEmptyState.vue'
 
 type FunnelMode = 'percent' | 'counts' | 'dropoff'
-const MODE_LABELS: Record<FunnelMode, string> = {
-  percent: 'Percent',
-  counts: 'Counts',
-  dropoff: 'Drop-off',
-}
 
 const MIN_STARTED = 10
+
+const { t } = useI18n()
 
 const { data, loading, error } = useUserProgressFunnel()
 const option = shallowRef({})
@@ -77,7 +75,12 @@ const lowConfidence = computed(() => startedCount.value > 0 && startedCount.valu
 const isFlatFunnel = computed(() => stages.value.every((stage) => stage.count === startedCount.value))
 const showFlatState = computed(() => !isEmpty.value && !lowConfidence.value && isFlatFunnel.value)
 
-const selectedModeLabel = computed(() => MODE_LABELS[mode.value])
+const MODE_LABEL_KEYS: Record<FunnelMode, string> = {
+  percent: 'statistics.charts.progressFunnel.modePercent',
+  counts: 'statistics.charts.progressFunnel.modeCounts',
+  dropoff: 'statistics.charts.progressFunnel.modeDropoff',
+}
+const selectedModeLabel = computed(() => t(MODE_LABEL_KEYS[mode.value]))
 
 watchEffect(() => {
   option.value = {}
@@ -179,7 +182,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Progress Funnel" :icon="Waypoints" :color-index="10" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.progressFunnel.title')" :icon="Waypoints" :color-index="10" :loading :error :empty="isEmpty">
     <template #controls>
       <DropdownMenu>
         <DropdownMenuTrigger as-child>
@@ -188,9 +191,9 @@ watchEffect(() => {
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" class="text-xs">
-          <DropdownMenuItem @click="mode = 'percent'">Percent</DropdownMenuItem>
-          <DropdownMenuItem @click="mode = 'counts'">Counts</DropdownMenuItem>
-          <DropdownMenuItem @click="mode = 'dropoff'">Drop-off</DropdownMenuItem>
+          <DropdownMenuItem @click="mode = 'percent'">{{ t('statistics.charts.progressFunnel.modePercent') }}</DropdownMenuItem>
+          <DropdownMenuItem @click="mode = 'counts'">{{ t('statistics.charts.progressFunnel.modeCounts') }}</DropdownMenuItem>
+          <DropdownMenuItem @click="mode = 'dropoff'">{{ t('statistics.charts.progressFunnel.modeDropoff') }}</DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
     </template>
@@ -198,19 +201,19 @@ watchEffect(() => {
     <ChartEmptyState
       v-if="lowConfidence"
       :icon="Waypoints"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_STARTED} started books for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.progressFunnel.notEnoughData', { count: MIN_STARTED })"
     />
     <ChartEmptyState
       v-else-if="showFlatState"
       :icon="Waypoints"
-      title="No drop-off observed"
-      description="Every started book progressed through all funnel stages in this period."
+      :title="t('statistics.charts.progressFunnel.noDropOffTitle')"
+      :description="t('statistics.charts.progressFunnel.noDropOffDescription')"
     />
     <div v-else class="flex h-full min-h-0 flex-col gap-2.5">
       <div class="flex flex-wrap gap-1.5 text-xs">
         <span class="border-border bg-muted/20 rounded-md border px-2 py-1">
-          Started {{ current.started }}
+          {{ t('statistics.charts.progressFunnel.started', { count: current.started }) }}
           <span v-if="comparisonSummary" class="text-muted-foreground">
             ({{ comparisonSummary.startedDelta >= 0 ? '+' : '' }}{{ comparisonSummary.startedDelta }})
           </span>

--- a/client/src/features/statistics/components/user/ReadingClockChart.vue
+++ b/client/src/features/statistics/components/user/ReadingClockChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Clock } from '@lucide/vue'
 import type { ReadingSessionSourceBucket } from '@bookorbit/types'
@@ -22,6 +23,8 @@ const HOUR_LABELS = [
 const MIN_EVENTS = 20
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useUserPeakReadingHours()
 const option = shallowRef({})
 
@@ -123,15 +126,15 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Reading Clock" :icon="Clock" :color-index="5" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.readingClock.title')" :icon="Clock" :color-index="5" :loading :error :empty="isEmpty">
     <template #controls>
       <BreakdownSelect v-model="dimension" />
     </template>
     <ChartEmptyState
       v-if="lowConfidence"
       :icon="Clock"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_EVENTS} reading sessions for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.readingClock.notEnoughData', { count: MIN_EVENTS })"
     />
     <template v-else>
       <div v-if="peakHour" class="text-muted-foreground mb-1 text-center text-xs">

--- a/client/src/features/statistics/components/user/ReadingHeatmapChart.vue
+++ b/client/src/features/statistics/components/user/ReadingHeatmapChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Calendar } from '@lucide/vue'
 import { READING_SESSION_SOURCE_BUCKETS, READING_SESSION_SOURCE_BUCKET_LABELS } from '@bookorbit/types'
@@ -13,6 +14,8 @@ import ChartEmptyState from '../ChartEmptyState.vue'
 const MIN_ACTIVE_DAYS = 5
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useUserReadingHeatmap()
 const option = shallowRef({})
 
@@ -143,12 +146,12 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Reading Heatmap" :icon="Calendar" :color-index="4" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.readingHeatmap.title')" :icon="Calendar" :color-index="4" :loading :error :empty="isEmpty">
     <ChartEmptyState
       v-if="lowConfidence"
       :icon="Calendar"
-      title="Not enough data yet"
-      :description="`Need activity on at least ${MIN_ACTIVE_DAYS} days for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.readingHeatmap.notEnoughData', { count: MIN_ACTIVE_DAYS })"
     />
     <div v-else class="h-full min-h-0 rounded-md px-2 py-2">
       <VChart :option autoresize class="h-full w-full" />

--- a/client/src/features/statistics/components/user/ReadingPaceScatterChart.vue
+++ b/client/src/features/statistics/components/user/ReadingPaceScatterChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Zap } from '@lucide/vue'
 
@@ -13,6 +14,8 @@ import ChartEmptyState from '../ChartEmptyState.vue'
 const MIN_SESSIONS = 10
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
+
 const { data, loading, error } = useUserReadingPace()
 
 const isEmpty = computed(() => data.value.length === 0)
@@ -68,15 +71,15 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Reading Pace" :icon="Zap" :color-index="2" :loading :error :empty="isEmpty">
+  <ChartCard :title="t('statistics.charts.readingPace.title')" :icon="Zap" :color-index="2" :loading :error :empty="isEmpty">
     <template #controls>
       <BreakdownSelect v-model="dimension" />
     </template>
     <ChartEmptyState
       v-if="!hasEnoughData"
       :icon="Zap"
-      title="Not enough data yet"
-      :description="`Need at least ${MIN_SESSIONS} sessions with progress data for this chart.`"
+      :title="t('statistics.empty.notEnoughData')"
+      :description="t('statistics.charts.readingPace.notEnoughData', { count: MIN_SESSIONS })"
     />
     <VChart v-else :option autoresize style="height: 100%" />
   </ChartCard>

--- a/client/src/features/statistics/components/user/ReadingSessionTimelineChart.vue
+++ b/client/src/features/statistics/components/user/ReadingSessionTimelineChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { CalendarRange } from '@lucide/vue'
 import { toast } from 'vue-sonner'
@@ -62,6 +63,7 @@ interface PointerOffset {
   y: number
 }
 
+const { t } = useI18n()
 const { filters } = useStatisticsConfig()
 const { coverUrl } = useCoverVersions()
 const themeStore = useThemeStore()
@@ -450,7 +452,7 @@ async function commitDrag() {
 
   if (!state || !preview) return
   if (preview.hasConflict) {
-    toast.error('Session overlaps another session in this window')
+    toast.error(t('statistics.charts.readingSessionTimeline.overlapError'))
     return
   }
 
@@ -462,7 +464,7 @@ async function commitDrag() {
       items: timeline.value.items.map((item) => (item.sessionId === updated.sessionId ? updated : item)),
     }
   } catch {
-    toast.error('Failed to move session')
+    toast.error(t('statistics.charts.readingSessionTimeline.moveError'))
     await loadTimeline()
   } finally {
     persistLoading.value = false
@@ -690,7 +692,14 @@ function getIsoWeekStart(year: number, week: number): Date {
 </script>
 
 <template>
-  <ChartCard title="Reading Session Timeline" :icon="CalendarRange" :color-index="11" :loading="loading" :error="error" :empty="false">
+  <ChartCard
+    :title="t('statistics.charts.readingSessionTimeline.title')"
+    :icon="CalendarRange"
+    :color-index="11"
+    :loading="loading"
+    :error="error"
+    :empty="false"
+  >
     <template #controls>
       <BreakdownSelect v-model="dimension" />
       <button
@@ -703,7 +712,7 @@ function getIsoWeekStart(year: number, week: number): Date {
         ]"
         @click="dragEnabled = !dragEnabled"
       >
-        {{ dragEnabled ? 'Drag: On' : 'Drag: Off' }}
+        {{ dragEnabled ? t('statistics.charts.readingSessionTimeline.dragOn') : t('statistics.charts.readingSessionTimeline.dragOff') }}
       </button>
     </template>
 
@@ -716,7 +725,7 @@ function getIsoWeekStart(year: number, week: number): Date {
             :disabled="persistLoading"
             @click="shiftWeek(-1)"
           >
-            Prev
+            {{ t('statistics.charts.readingSessionTimeline.prev') }}
           </button>
 
           <button
@@ -725,7 +734,7 @@ function getIsoWeekStart(year: number, week: number): Date {
             :disabled="persistLoading"
             @click="shiftWeek(1)"
           >
-            Next
+            {{ t('statistics.charts.readingSessionTimeline.next') }}
           </button>
 
           <select
@@ -741,7 +750,9 @@ function getIsoWeekStart(year: number, week: number): Date {
             class="border-border bg-background text-foreground rounded-md border px-2 py-1 text-xs"
             :disabled="persistLoading"
           >
-            <option v-for="week in weekOptions" :key="week" :value="week">Week {{ week }}</option>
+            <option v-for="week in weekOptions" :key="week" :value="week">
+              {{ t('statistics.charts.readingSessionTimeline.week', { week }) }}
+            </option>
           </select>
         </div>
 
@@ -757,15 +768,15 @@ function getIsoWeekStart(year: number, week: number): Date {
       </div>
 
       <p v-if="dragEnabled" class="text-muted-foreground border-border/60 bg-muted/20 rounded-md border px-2 py-1 text-xs">
-        Drag bars to move sessions. Duration is locked and overlapping sessions are rejected.
+        {{ t('statistics.charts.readingSessionTimeline.dragHint') }}
       </p>
 
       <div class="border-border/60 bg-muted/5 min-h-0 flex-1 rounded-lg border p-2">
         <ChartEmptyState
           v-if="isEmpty"
           :icon="CalendarRange"
-          title="No sessions this week"
-          description="Use Prev/Next or the week selector to view a different week."
+          :title="t('statistics.charts.readingSessionTimeline.noSessionsTitle')"
+          :description="t('statistics.charts.readingSessionTimeline.noSessionsDescription')"
         />
 
         <VChart

--- a/client/src/features/statistics/components/user/SessionArchetypesChart.vue
+++ b/client/src/features/statistics/components/user/SessionArchetypesChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { Layers } from '@lucide/vue'
 
@@ -17,6 +18,8 @@ const DAY_COLORS = [
   '#eab308', // Fri
   '#06b6d4', // Sat
 ]
+
+const { t } = useI18n()
 
 const { data, loading, error } = useUserSessionArchetypes()
 const option = shallowRef({})
@@ -95,7 +98,7 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ChartCard title="Session Archetypes" :icon="Layers" :color-index="8" :loading :error :empty="isEmpty()">
+  <ChartCard :title="t('statistics.charts.sessionArchetypes.title')" :icon="Layers" :color-index="8" :loading :error :empty="isEmpty()">
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>
 </template>

--- a/client/src/features/statistics/components/user/SourceDistributionChart.vue
+++ b/client/src/features/statistics/components/user/SourceDistributionChart.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, shallowRef, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import VChart from 'vue-echarts'
 import { MonitorSmartphone } from '@lucide/vue'
 import { READING_SESSION_SOURCE_BUCKET_LABELS } from '@bookorbit/types'
@@ -9,6 +10,8 @@ import { useThemeStore } from '@/stores/theme'
 import { resolveSourceBucketColors } from '../../lib/source-bucket-colors'
 import { useUserReadingSourceDistribution } from '../../composables/useUserReadingSourceDistribution'
 import ChartCard from '../ChartCard.vue'
+
+const { t } = useI18n()
 
 const themeStore = useThemeStore()
 const { data, loading, error } = useUserReadingSourceDistribution()
@@ -70,14 +73,14 @@ watchEffect(() => {
 
 <template>
   <ChartCard
-    title="Where You Read"
+    :title="t('statistics.charts.sourceDistribution.title')"
     :icon="MonitorSmartphone"
     :color-index="6"
     :loading
     :error
     :empty="isEmpty"
-    empty-title="No reading activity yet"
-    empty-description="Read on the web, KOReader, or Kobo to see your source split."
+    :empty-title="t('statistics.charts.sourceDistribution.emptyTitle')"
+    :empty-description="t('statistics.charts.sourceDistribution.emptyDescription')"
   >
     <VChart :option autoresize style="height: 100%" />
   </ChartCard>

--- a/client/src/features/tools/bulk-rename/components/BulkRenameConfirmDialog.vue
+++ b/client/src/features/tools/bulk-rename/components/BulkRenameConfirmDialog.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { AlertTriangle } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 defineProps<{
   open: boolean
@@ -29,21 +32,26 @@ function handleCancel(): void {
             <AlertTriangle class="w-5 h-5 text-amber-600 dark:text-amber-400" />
           </div>
           <div>
-            <h3 class="text-lg font-semibold text-foreground">Confirm Bulk Rename</h3>
+            <h3 class="text-lg font-semibold text-foreground">{{ t('tools.bulkRename.confirmDialog.title') }}</h3>
             <p class="mt-1 text-sm text-muted-foreground">
-              This will rename <strong>{{ renameCount }}</strong> book{{ renameCount === 1 ? '' : 's' }} on disk. Files with collisions or errors will
-              be skipped. This action cannot be undone.
+              <i18n-t keypath="tools.bulkRename.confirmDialog.body" :plural="renameCount">
+                <template #count>
+                  <strong>{{ renameCount }}</strong>
+                </template>
+              </i18n-t>
             </p>
           </div>
         </div>
 
         <div class="flex justify-end gap-2">
-          <button class="px-4 py-2 text-sm font-medium rounded-md border hover:bg-muted transition-colors" @click="handleCancel">Cancel</button>
+          <button class="px-4 py-2 text-sm font-medium rounded-md border hover:bg-muted transition-colors" @click="handleCancel">
+            {{ t('common.cancel') }}
+          </button>
           <button
             class="px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
             @click="handleConfirm"
           >
-            Rename {{ renameCount }} book{{ renameCount === 1 ? '' : 's' }}
+            {{ t('tools.bulkRename.confirmDialog.renameButton', { count: renameCount }, renameCount) }}
           </button>
         </div>
       </div>

--- a/client/src/features/tools/bulk-rename/components/BulkRenameStatusBadge.vue
+++ b/client/src/features/tools/bulk-rename/components/BulkRenameStatusBadge.vue
@@ -1,21 +1,24 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { BulkRenameStatus } from '@bookorbit/types'
 
 const props = defineProps<{ status: BulkRenameStatus }>()
 
+const { t } = useI18n()
+
 const config = computed(() => {
   switch (props.status) {
     case 'will_rename':
-      return { label: 'Will Rename', classes: 'border-primary/40 bg-primary/15 text-primary' }
+      return { label: t('tools.bulkRename.status.willRename'), classes: 'border-primary/40 bg-primary/15 text-primary' }
     case 'unchanged':
-      return { label: 'Unchanged', classes: 'border-border/70 bg-muted text-muted-foreground' }
+      return { label: t('tools.bulkRename.status.unchanged'), classes: 'border-border/70 bg-muted text-muted-foreground' }
     case 'collision':
-      return { label: 'Collision', classes: 'border-amber-500/40 bg-amber-500/15 text-amber-500' }
+      return { label: t('tools.bulkRename.status.collision'), classes: 'border-amber-500/40 bg-amber-500/15 text-amber-500' }
     case 'no_pattern':
-      return { label: 'No Pattern', classes: 'border-border/70 bg-muted text-muted-foreground' }
+      return { label: t('tools.bulkRename.status.noPattern'), classes: 'border-border/70 bg-muted text-muted-foreground' }
     case 'error':
-      return { label: 'Error', classes: 'border-destructive/40 bg-destructive/15 text-destructive' }
+      return { label: t('tools.bulkRename.status.error'), classes: 'border-destructive/40 bg-destructive/15 text-destructive' }
     default:
       return { label: props.status, classes: 'border-border/70 bg-muted text-muted-foreground' }
   }

--- a/client/src/features/tools/bulk-rename/views/BulkRenameView.vue
+++ b/client/src/features/tools/bulk-rename/views/BulkRenameView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useElementSize } from '@vueuse/core'
 import { ChevronLeft, ChevronRight, ExternalLink, Loader2, Play, RefreshCw, SlidersHorizontal, X } from '@lucide/vue'
 import type { BulkRenameStatus, Library } from '@bookorbit/types'
@@ -11,6 +12,7 @@ import { useBulkRename } from '../../composables/useBulkRename'
 import BulkRenameStatusBadge from '../components/BulkRenameStatusBadge.vue'
 import BulkRenameConfirmDialog from '../components/BulkRenameConfirmDialog.vue'
 
+const { t } = useI18n()
 const { libraries, fetchLibraries } = useLibraries()
 const bulk = useBulkRename()
 
@@ -33,24 +35,24 @@ const columnVisibility = ref<BulkRenameColumnVisibility>(
   storage.get<BulkRenameColumnVisibility>('tools.bulkRename.columnVisibility', defaultColumnVisibility),
 )
 type ColumnOption = { key: keyof BulkRenameColumnVisibility; label: string }
-const columnOptions: ColumnOption[] = [
-  { key: 'title', label: 'Title' },
-  { key: 'currentPath', label: 'Current Path' },
-  { key: 'newPath', label: 'New Path' },
-]
+const columnOptions = computed<ColumnOption[]>(() => [
+  { key: 'title', label: t('tools.bulkRename.columns.title') },
+  { key: 'currentPath', label: t('tools.bulkRename.columns.currentPath') },
+  { key: 'newPath', label: t('tools.bulkRename.columns.newPath') },
+])
 
 const eligibleLibraries = computed(() => libraries.value.filter((lib: Library) => lib.fileRenameEnabled))
 const selectedLibrary = computed(() => eligibleLibraries.value.find((lib: Library) => lib.id === bulk.selectedLibraryId.value) ?? null)
 const selectedLibraryRoots = computed(() => selectedLibrary.value?.folders.map((folder) => folder.path) ?? [])
 
-const statusOptions: { value: BulkRenameStatus | undefined; label: string }[] = [
-  { value: undefined, label: 'All' },
-  { value: 'will_rename', label: 'Will Rename' },
-  { value: 'unchanged', label: 'Unchanged' },
-  { value: 'collision', label: 'Collision' },
-  { value: 'no_pattern', label: 'No Pattern' },
-  { value: 'error', label: 'Error' },
-]
+const statusOptions = computed<{ value: BulkRenameStatus | undefined; label: string }[]>(() => [
+  { value: undefined, label: t('tools.bulkRename.filter.all') },
+  { value: 'will_rename', label: t('tools.bulkRename.status.willRename') },
+  { value: 'unchanged', label: t('tools.bulkRename.status.unchanged') },
+  { value: 'collision', label: t('tools.bulkRename.status.collision') },
+  { value: 'no_pattern', label: t('tools.bulkRename.status.noPattern') },
+  { value: 'error', label: t('tools.bulkRename.status.error') },
+])
 
 const hasPreview = computed(() => bulk.previewItems.value.length > 0 || bulk.previewTotal.value > 0)
 const showTitleColumn = computed(() => columnVisibility.value.title)
@@ -243,21 +245,21 @@ watch(
         <div class="flex flex-col gap-3 lg:grid lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end lg:gap-3">
           <div class="min-w-0 flex flex-col gap-2">
             <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-              <label class="text-sm font-medium text-foreground sm:shrink-0">Library</label>
+              <label class="text-sm font-medium text-foreground sm:shrink-0">{{ t('tools.bulkRename.library') }}</label>
               <select
                 ref="librarySelectRef"
                 class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-primary sm:flex-1"
                 :value="bulk.selectedLibraryId.value ?? ''"
                 @change="handleLibraryChange"
               >
-                <option value="" disabled>Select a library...</option>
+                <option value="" disabled>{{ t('tools.bulkRename.selectLibraryPlaceholder') }}</option>
                 <option v-for="lib in eligibleLibraries" :key="lib.id" :value="lib.id">
                   {{ lib.name }}
                 </option>
               </select>
             </div>
             <p v-if="eligibleLibraries.length === 0" class="text-sm text-muted-foreground">
-              No libraries have file rename enabled. Enable it in Library Settings.
+              {{ t('tools.bulkRename.noEligibleLibraries') }}
             </p>
           </div>
 
@@ -268,7 +270,7 @@ watch(
               @click="handleRefreshPreview"
             >
               <RefreshCw class="h-4 w-4" :class="{ 'animate-spin': bulk.loading.value }" />
-              Refresh
+              {{ t('tools.bulkRename.refresh') }}
             </button>
 
             <button
@@ -278,7 +280,7 @@ watch(
               @click="handleOpenConfirm"
             >
               <Play class="h-4 w-4" />
-              Apply Rename
+              {{ t('tools.bulkRename.applyRename') }}
             </button>
 
             <button
@@ -287,7 +289,7 @@ watch(
               @click="handleCancelExecution"
             >
               <X class="h-4 w-4" />
-              Cancel
+              {{ t('common.cancel') }}
             </button>
           </div>
         </div>
@@ -295,20 +297,24 @@ watch(
         <div v-if="bulk.selectedLibraryId.value !== null" class="rounded-md bg-muted/20 px-3 py-2.5">
           <div class="flex flex-col gap-2 text-sm sm:flex-row sm:items-center sm:justify-between">
             <div class="flex flex-wrap items-center gap-2">
-              <span class="font-medium text-foreground">Summary</span>
-              <span class="rounded-full bg-primary/15 px-2.5 py-0.5 text-primary">{{ bulk.totalByStatus.value.will_rename }} to rename</span>
-              <span class="rounded-full bg-muted px-2.5 py-0.5 text-muted-foreground">{{ bulk.totalByStatus.value.unchanged }} unchanged</span>
+              <span class="font-medium text-foreground">{{ t('tools.bulkRename.summary.label') }}</span>
+              <span class="rounded-full bg-primary/15 px-2.5 py-0.5 text-primary">{{
+                t('tools.bulkRename.summary.toRename', { count: bulk.totalByStatus.value.will_rename })
+              }}</span>
+              <span class="rounded-full bg-muted px-2.5 py-0.5 text-muted-foreground">{{
+                t('tools.bulkRename.summary.unchanged', { count: bulk.totalByStatus.value.unchanged })
+              }}</span>
               <span v-if="bulk.totalByStatus.value.collision > 0" class="rounded-full bg-amber-500/15 px-2.5 py-0.5 text-amber-500">
-                {{ bulk.totalByStatus.value.collision }} collision{{ bulk.totalByStatus.value.collision === 1 ? '' : 's' }}
+                {{ t('tools.bulkRename.summary.collisions', { count: bulk.totalByStatus.value.collision }, bulk.totalByStatus.value.collision) }}
               </span>
               <span v-if="bulk.totalByStatus.value.error > 0" class="rounded-full bg-destructive/15 px-2.5 py-0.5 text-destructive">
-                {{ bulk.totalByStatus.value.error }} error{{ bulk.totalByStatus.value.error === 1 ? '' : 's' }}
+                {{ t('tools.bulkRename.summary.errors', { count: bulk.totalByStatus.value.error }, bulk.totalByStatus.value.error) }}
               </span>
             </div>
             <div class="flex items-center gap-2">
               <label class="inline-flex items-center gap-2 text-xs text-muted-foreground">
                 <input v-model="showFullPaths" type="checkbox" class="h-4 w-4 rounded border-border bg-background text-primary" />
-                Show full paths
+                {{ t('tools.bulkRename.showFullPaths') }}
               </label>
               <DropdownMenu>
                 <DropdownMenuTrigger as-child>
@@ -316,7 +322,7 @@ watch(
                     class="inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-background/70 px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
                   >
                     <SlidersHorizontal class="h-3.5 w-3.5" />
-                    Columns
+                    {{ t('tools.bulkRename.columnsMenu') }}
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" class="w-44">
@@ -362,33 +368,39 @@ watch(
         <SlidersHorizontal class="h-6 w-6 text-muted-foreground" />
       </div>
       <div class="space-y-1">
-        <p class="text-base font-semibold text-foreground">Pick a Library to Start</p>
+        <p class="text-base font-semibold text-foreground">{{ t('tools.bulkRename.empty.title') }}</p>
         <p class="max-w-sm text-sm text-muted-foreground">
-          Select a library above to preview rename changes, filter by status, and apply the bulk rename run.
+          {{ t('tools.bulkRename.empty.description') }}
         </p>
       </div>
       <button
         class="inline-flex h-9 items-center rounded-md border border-border bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted/60"
         @click="focusLibrarySelect"
       >
-        Choose Library
+        {{ t('tools.bulkRename.empty.chooseLibrary') }}
       </button>
     </div>
 
     <template v-else>
       <div v-if="bulk.executing.value" class="flex items-center gap-2 rounded-lg border border-primary/40 bg-primary/10 px-4 py-3 text-primary">
         <Loader2 class="h-4 w-4 animate-spin" />
-        <span class="text-sm">Renaming files - you can cancel at any time.</span>
+        <span class="text-sm">{{ t('tools.bulkRename.renamingInProgress') }}</span>
       </div>
 
       <div
         v-if="bulk.executionStats.value && !bulk.executing.value"
         class="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-emerald-600 dark:text-emerald-400"
       >
-        <p class="text-sm font-medium">Bulk rename completed</p>
+        <p class="text-sm font-medium">{{ t('tools.bulkRename.completed.title') }}</p>
         <p class="mt-1 text-sm">
-          {{ bulk.executionStats.value.succeeded }} renamed, {{ bulk.executionStats.value.failed }} failed,
-          {{ bulk.executionStats.value.skipped }} skipped ({{ bulk.executionStats.value.processed }} total)
+          {{
+            t('tools.bulkRename.completed.stats', {
+              succeeded: bulk.executionStats.value.succeeded,
+              failed: bulk.executionStats.value.failed,
+              skipped: bulk.executionStats.value.skipped,
+              processed: bulk.executionStats.value.processed,
+            })
+          }}
         </p>
       </div>
 
@@ -396,7 +408,7 @@ watch(
         v-if="bulk.executionError.value && !bulk.executing.value"
         class="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-destructive"
       >
-        <p class="text-sm font-medium">Bulk rename failed</p>
+        <p class="text-sm font-medium">{{ t('tools.bulkRename.executionFailed') }}</p>
         <p class="mt-1 text-sm">{{ bulk.executionError.value }}</p>
       </div>
 
@@ -404,7 +416,7 @@ watch(
         v-if="bulk.previewError.value && !hasPreview"
         class="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-6 text-center text-destructive"
       >
-        <p class="text-sm font-medium">Failed to load preview</p>
+        <p class="text-sm font-medium">{{ t('tools.bulkRename.previewFailed') }}</p>
         <p class="mt-1 text-sm">{{ bulk.previewError.value }}</p>
       </div>
 
@@ -427,7 +439,7 @@ watch(
                 <RouterLink
                   :to="{ name: 'book-detail', params: { bookId: item.bookId } }"
                   class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border/70 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-                  aria-label="Open book details"
+                  :aria-label="t('tools.bulkRename.openBookDetails')"
                 >
                   <ExternalLink class="h-3.5 w-3.5" />
                 </RouterLink>
@@ -436,11 +448,11 @@ watch(
                 </p>
               </div>
               <div v-if="showCurrentPathColumn" class="space-y-0.5">
-                <p class="text-[11px] uppercase tracking-wide text-muted-foreground">Current Path</p>
+                <p class="text-[11px] uppercase tracking-wide text-muted-foreground">{{ t('tools.bulkRename.columns.currentPath') }}</p>
                 <p class="truncate font-mono text-xs text-muted-foreground" :title="item.currentPath">{{ formatCardPath(item.currentPath) }}</p>
               </div>
               <div v-if="showNewPathColumn" class="space-y-0.5">
-                <p class="text-[11px] uppercase tracking-wide text-muted-foreground">New Path</p>
+                <p class="text-[11px] uppercase tracking-wide text-muted-foreground">{{ t('tools.bulkRename.columns.newPath') }}</p>
                 <p class="truncate font-mono text-xs text-muted-foreground" :title="item.newPath ?? '-'">{{ formatCardPath(item.newPath) }}</p>
               </div>
             </article>
@@ -457,10 +469,16 @@ watch(
             <thead class="sticky top-0 z-10 bg-muted/70 backdrop-blur-sm">
               <tr>
                 <th class="px-4 py-2.5 text-left font-medium text-muted-foreground">#</th>
-                <th v-if="showTitleColumn" class="w-56 px-4 py-2.5 text-left font-medium text-muted-foreground">Title</th>
-                <th v-if="showCurrentPathColumn" class="px-4 py-2.5 text-left font-medium text-muted-foreground">Current Path</th>
-                <th v-if="showNewPathColumn" class="px-4 py-2.5 text-left font-medium text-muted-foreground">New Path</th>
-                <th class="w-30 px-4 py-2.5 text-left font-medium text-muted-foreground">Status</th>
+                <th v-if="showTitleColumn" class="w-56 px-4 py-2.5 text-left font-medium text-muted-foreground">
+                  {{ t('tools.bulkRename.columns.title') }}
+                </th>
+                <th v-if="showCurrentPathColumn" class="px-4 py-2.5 text-left font-medium text-muted-foreground">
+                  {{ t('tools.bulkRename.columns.currentPath') }}
+                </th>
+                <th v-if="showNewPathColumn" class="px-4 py-2.5 text-left font-medium text-muted-foreground">
+                  {{ t('tools.bulkRename.columns.newPath') }}
+                </th>
+                <th class="w-30 px-4 py-2.5 text-left font-medium text-muted-foreground">{{ t('tools.bulkRename.columns.status') }}</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-border/60">
@@ -471,7 +489,7 @@ watch(
                     <RouterLink
                       :to="{ name: 'book-detail', params: { bookId: item.bookId } }"
                       class="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-border/70 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-                      aria-label="Open book details"
+                      :aria-label="t('tools.bulkRename.openBookDetails')"
                     >
                       <ExternalLink class="h-3.5 w-3.5" />
                     </RouterLink>
@@ -506,10 +524,13 @@ watch(
 
         <div class="flex flex-wrap items-center justify-between gap-2 border-t border-border/60 bg-muted/20 px-4 py-3">
           <p class="text-xs text-muted-foreground sm:text-sm">
-            Showing {{ (bulk.page.value - 1) * bulk.pageSize.value + 1 }}-{{
-              Math.min(bulk.page.value * bulk.pageSize.value, bulk.previewTotal.value)
+            {{
+              t('tools.bulkRename.pagination.showing', {
+                from: (bulk.page.value - 1) * bulk.pageSize.value + 1,
+                to: Math.min(bulk.page.value * bulk.pageSize.value, bulk.previewTotal.value),
+                total: bulk.previewTotal.value,
+              })
             }}
-            of {{ bulk.previewTotal.value }}
           </p>
           <div class="flex items-center gap-1">
             <button
@@ -535,7 +556,7 @@ watch(
         v-else
         class="flex flex-1 items-center justify-center rounded-lg border border-dashed border-border/60 bg-card/20 p-10 text-muted-foreground"
       >
-        <p>No books found matching the current filter.</p>
+        <p>{{ t('tools.bulkRename.noBooksMatch') }}</p>
       </div>
     </template>
 

--- a/client/src/features/tools/components/ToolsHeader.vue
+++ b/client/src/features/tools/components/ToolsHeader.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { usePermissions } from '@/features/auth/composables/usePermissions'
 
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 const { hasPermission } = usePermissions()
 
 interface ToolSection {
@@ -16,8 +18,8 @@ const sections = computed<ToolSection[]>(() => {
   const result: ToolSection[] = []
 
   if (hasPermission('manage_libraries')) {
-    result.push({ label: 'Entity Manager', routeName: 'tools-entity-manager' })
-    result.push({ label: 'Bulk Rename', routeName: 'tools-bulk-rename' })
+    result.push({ label: t('tools.header.entityManager'), routeName: 'tools-entity-manager' })
+    result.push({ label: t('tools.header.bulkRename'), routeName: 'tools-bulk-rename' })
   }
 
   return result

--- a/client/src/features/tools/entity-manager/components/BrowseMergeModal.vue
+++ b/client/src/features/tools/entity-manager/components/BrowseMergeModal.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Check, GitMerge, X } from '@lucide/vue'
 import type { BrowseEntityItem } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   items: BrowseEntityItem[]
@@ -38,7 +41,7 @@ function handleCancel(): void {
       <div class="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
         <h3 class="text-base font-semibold flex items-center gap-2">
           <GitMerge class="h-5 w-5 text-primary" />
-          Merge Entities
+          {{ t('tools.entityManager.mergeModal.title') }}
         </h3>
         <button class="text-muted-foreground hover:text-foreground transition-colors" @click="handleCancel">
           <X class="h-5 w-5" />
@@ -46,11 +49,11 @@ function handleCancel(): void {
       </div>
 
       <div class="px-5 py-4 flex-1 min-h-0 flex flex-col overflow-hidden">
-        <p class="text-sm text-muted-foreground shrink-0 mb-4">Select which entity to keep. The others will be merged into it and removed.</p>
+        <p class="text-sm text-muted-foreground shrink-0 mb-4">{{ t('tools.entityManager.mergeModal.description') }}</p>
 
         <div class="flex-1 min-h-0 overflow-y-auto pr-1">
           <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider mb-1.5 sticky top-0 bg-card py-1 z-10">
-            Select target to keep
+            {{ t('tools.entityManager.selectTargetToKeep') }}
           </p>
           <div class="space-y-1.5">
             <div
@@ -62,7 +65,7 @@ function handleCancel(): void {
             >
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-medium truncate block">{{ item.name }}</span>
-                <span class="text-xs text-muted-foreground">{{ item.bookCount }} {{ item.bookCount === 1 ? 'book' : 'books' }}</span>
+                <span class="text-xs text-muted-foreground">{{ t('tools.entityManager.bookCount', { count: item.bookCount }, item.bookCount) }}</span>
               </div>
               <Check v-if="selectedTargetId === item.id" class="h-4 w-4 text-primary shrink-0" />
             </div>
@@ -71,18 +74,20 @@ function handleCancel(): void {
 
         <label class="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer shrink-0 mt-4">
           <input v-model="writeFiles" type="checkbox" class="rounded accent-primary" />
-          Write changes to files
+          {{ t('tools.entityManager.writeChangesToFiles') }}
         </label>
       </div>
 
       <div class="flex justify-end gap-2 px-5 py-3 border-t border-border bg-muted/20 shrink-0">
-        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">Cancel</button>
+        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">
+          {{ t('common.cancel') }}
+        </button>
         <button
           class="h-9 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
           :disabled="loading || sourceIds.length === 0"
           @click="handleConfirm"
         >
-          Merge {{ sourceIds.length }} into target
+          {{ t('tools.entityManager.mergeIntoTarget', { count: sourceIds.length }) }}
         </button>
       </div>
     </div>

--- a/client/src/features/tools/entity-manager/components/BulkDeleteModal.vue
+++ b/client/src/features/tools/entity-manager/components/BulkDeleteModal.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { AlertTriangle, X } from '@lucide/vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   count: number
@@ -33,7 +36,7 @@ function handleCancel(): void {
       <div class="flex items-center justify-between px-5 py-4 border-b border-border">
         <h3 class="text-base font-semibold text-destructive flex items-center gap-2">
           <AlertTriangle class="h-5 w-5" />
-          Bulk Delete
+          {{ t('tools.entityManager.bulkDeleteModal.title') }}
         </h3>
         <button class="text-muted-foreground hover:text-foreground transition-colors" @click="handleCancel">
           <X class="h-5 w-5" />
@@ -41,40 +44,46 @@ function handleCancel(): void {
       </div>
       <div class="px-5 py-4 space-y-4">
         <p class="text-sm">
-          Are you sure you want to delete <span class="font-semibold">{{ count }}</span> selected {{ count === 1 ? 'entity' : 'entities' }}?
+          <i18n-t keypath="tools.entityManager.bulkDeleteModal.confirm" :plural="count">
+            <template #count>
+              <span class="font-semibold">{{ count }}</span>
+            </template>
+          </i18n-t>
         </p>
 
         <div v-if="!isInline" class="space-y-2">
-          <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">Delete mode</p>
+          <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">{{ t('tools.entityManager.deleteMode.label') }}</p>
           <label class="flex items-start gap-2 cursor-pointer">
             <input v-model="deleteMode" type="radio" value="soft" class="mt-1 accent-primary" />
             <div>
-              <p class="text-sm font-medium">Soft delete</p>
-              <p class="text-xs text-muted-foreground">Unlink from all books but keep the entity records</p>
+              <p class="text-sm font-medium">{{ t('tools.entityManager.deleteMode.softTitle') }}</p>
+              <p class="text-xs text-muted-foreground">{{ t('tools.entityManager.deleteMode.softDescriptionPlural') }}</p>
             </div>
           </label>
           <label class="flex items-start gap-2 cursor-pointer">
             <input v-model="deleteMode" type="radio" value="hard" class="mt-1 accent-primary" />
             <div>
-              <p class="text-sm font-medium">Hard delete</p>
-              <p class="text-xs text-muted-foreground">Remove entities and all associations permanently</p>
+              <p class="text-sm font-medium">{{ t('tools.entityManager.deleteMode.hardTitle') }}</p>
+              <p class="text-xs text-muted-foreground">{{ t('tools.entityManager.deleteMode.hardDescriptionPlural') }}</p>
             </div>
           </label>
         </div>
 
         <label class="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
           <input v-model="writeFiles" type="checkbox" class="rounded accent-primary" />
-          Write changes to files
+          {{ t('tools.entityManager.writeChangesToFiles') }}
         </label>
       </div>
       <div class="flex justify-end gap-2 px-5 py-3 border-t border-border bg-muted/20">
-        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">Cancel</button>
+        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">
+          {{ t('common.cancel') }}
+        </button>
         <button
           class="h-9 px-4 rounded-lg bg-destructive text-destructive-foreground text-sm font-medium hover:bg-destructive/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
           :disabled="loading"
           @click="handleConfirm"
         >
-          Delete {{ count }}
+          {{ t('tools.entityManager.bulkDeleteModal.deleteButton', { count }) }}
         </button>
       </div>
     </div>

--- a/client/src/features/tools/entity-manager/components/DeleteModal.vue
+++ b/client/src/features/tools/entity-manager/components/DeleteModal.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { AlertTriangle, X } from '@lucide/vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   entityName: string
@@ -33,7 +36,7 @@ function handleCancel(): void {
       <div class="flex items-center justify-between px-5 py-4 border-b border-border">
         <h3 class="text-base font-semibold text-destructive flex items-center gap-2">
           <AlertTriangle class="h-5 w-5" />
-          Delete Entity
+          {{ t('tools.entityManager.deleteModal.title') }}
         </h3>
         <button class="text-muted-foreground hover:text-foreground transition-colors" @click="handleCancel">
           <X class="h-5 w-5" />
@@ -41,41 +44,46 @@ function handleCancel(): void {
       </div>
       <div class="px-5 py-4 space-y-4">
         <p class="text-sm">
-          Are you sure you want to delete <span class="font-semibold">{{ entityName }}</span
-          >?
+          <i18n-t keypath="tools.entityManager.deleteModal.confirm">
+            <template #name>
+              <span class="font-semibold">{{ entityName }}</span>
+            </template>
+          </i18n-t>
         </p>
 
         <div v-if="!isInline" class="space-y-2">
-          <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">Delete mode</p>
+          <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">{{ t('tools.entityManager.deleteMode.label') }}</p>
           <label class="flex items-start gap-2 cursor-pointer">
             <input v-model="deleteMode" type="radio" value="soft" class="mt-1 accent-primary" />
             <div>
-              <p class="text-sm font-medium">Soft delete</p>
-              <p class="text-xs text-muted-foreground">Unlink from all books but keep the entity record</p>
+              <p class="text-sm font-medium">{{ t('tools.entityManager.deleteMode.softTitle') }}</p>
+              <p class="text-xs text-muted-foreground">{{ t('tools.entityManager.deleteMode.softDescription') }}</p>
             </div>
           </label>
           <label class="flex items-start gap-2 cursor-pointer">
             <input v-model="deleteMode" type="radio" value="hard" class="mt-1 accent-primary" />
             <div>
-              <p class="text-sm font-medium">Hard delete</p>
-              <p class="text-xs text-muted-foreground">Remove entity and all associations permanently</p>
+              <p class="text-sm font-medium">{{ t('tools.entityManager.deleteMode.hardTitle') }}</p>
+              <p class="text-xs text-muted-foreground">{{ t('tools.entityManager.deleteMode.hardDescription') }}</p>
             </div>
           </label>
         </div>
 
         <label class="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
           <input v-model="writeFiles" type="checkbox" class="rounded accent-primary" />
-          Write changes to files
+          {{ t('tools.entityManager.writeChangesToFiles') }}
         </label>
       </div>
       <div class="flex justify-end gap-2 px-5 py-3 border-t border-border bg-muted/20">
-        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">Cancel</button>
+        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">
+          {{ t('common.cancel') }}
+        </button>
         <button
           class="h-9 px-4 rounded-lg bg-destructive text-destructive-foreground text-sm font-medium hover:bg-destructive/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
           :disabled="loading"
           @click="handleConfirm"
         >
-          Delete
+          {{ t('common.delete') }}
         </button>
       </div>
     </div>

--- a/client/src/features/tools/entity-manager/components/DismissedPairsSection.vue
+++ b/client/src/features/tools/entity-manager/components/DismissedPairsSection.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { RotateCcw } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
 import type { DismissedPairInfo } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 defineProps<{
   pairs: DismissedPairInfo[]
@@ -18,8 +21,8 @@ function handleUndismiss(pair: DismissedPairInfo): void {
 
 <template>
   <div class="space-y-2">
-    <div v-if="loading" class="text-center py-4 text-sm text-muted-foreground">Loading dismissed pairs...</div>
-    <div v-else-if="pairs.length === 0" class="text-center py-4 text-sm text-muted-foreground">No dismissed pairs</div>
+    <div v-if="loading" class="text-center py-4 text-sm text-muted-foreground">{{ t('tools.entityManager.dismissed.loading') }}</div>
+    <div v-else-if="pairs.length === 0" class="text-center py-4 text-sm text-muted-foreground">{{ t('tools.entityManager.dismissed.empty') }}</div>
     <div v-else class="divide-y divide-border border border-border rounded-lg overflow-hidden">
       <div
         v-for="pair in pairs"
@@ -34,11 +37,11 @@ function handleUndismiss(pair: DismissedPairInfo): void {
         </div>
         <button
           class="inline-flex items-center gap-1 h-7 px-2 text-xs rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors shrink-0"
-          title="Restore this pair"
+          :title="t('tools.entityManager.dismissed.restoreTitle')"
           @click="handleUndismiss(pair)"
         >
           <RotateCcw class="h-3.5 w-3.5" />
-          Restore
+          {{ t('tools.entityManager.dismissed.restore') }}
         </button>
       </div>
     </div>

--- a/client/src/features/tools/entity-manager/components/DuplicateClusterCard.vue
+++ b/client/src/features/tools/entity-manager/components/DuplicateClusterCard.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Check, ChevronDown, ChevronUp, UserMinus, X } from '@lucide/vue'
 import type { DuplicateCluster, EntityTypeCapabilities } from '@bookorbit/types'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   cluster: DuplicateCluster
@@ -21,7 +24,7 @@ const selectedTargetId = ref<number | string>(props.cluster.suggestedTargetId)
 
 const sortedEntities = computed(() => [...props.cluster.entities].sort((a, b) => b.bookCount - a.bookCount))
 
-const primaryEntityName = computed(() => sortedEntities.value[0]?.name || 'Unknown')
+const primaryEntityName = computed(() => sortedEntities.value[0]?.name || t('tools.entityManager.unknown'))
 const otherCount = computed(() => sortedEntities.value.length - 1)
 
 const sourceIds = computed(() => props.cluster.entities.filter((e) => e.id !== selectedTargetId.value).map((e) => e.id))
@@ -62,10 +65,12 @@ function toggleExpanded(): void {
       <div class="flex items-center gap-3 min-w-0">
         <span class="text-sm font-medium truncate">
           {{ primaryEntityName }}
-          <span v-if="otherCount > 0" class="text-muted-foreground font-normal"> + {{ otherCount }} other{{ otherCount > 1 ? 's' : '' }}</span>
+          <span v-if="otherCount > 0" class="text-muted-foreground font-normal">
+            {{ t('tools.entityManager.duplicates.plusOthers', { count: otherCount }, otherCount) }}</span
+          >
         </span>
         <span class="text-xs px-2 py-0.5 rounded-full shrink-0 transition-colors" :class="getSimilarityColorClass(cluster.averageSimilarity)">
-          {{ (cluster.averageSimilarity * 100).toFixed(0) }}% similar
+          {{ t('tools.entityManager.duplicates.percentSimilar', { percent: (cluster.averageSimilarity * 100).toFixed(0) }) }}
         </span>
       </div>
       <component :is="expanded ? ChevronUp : ChevronDown" class="h-4 w-4 text-muted-foreground shrink-0" />
@@ -73,7 +78,7 @@ function toggleExpanded(): void {
 
     <div v-if="expanded" class="border-t border-border px-4 py-3 space-y-3">
       <div class="space-y-2">
-        <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">Select target to keep</p>
+        <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">{{ t('tools.entityManager.selectTargetToKeep') }}</p>
         <div
           v-for="entity in sortedEntities"
           :key="String(entity.id)"
@@ -87,8 +92,12 @@ function toggleExpanded(): void {
               <Check v-if="selectedTargetId === entity.id" class="h-4 w-4 text-primary shrink-0" />
             </div>
             <div class="flex items-center gap-2 mt-0.5">
-              <span class="text-xs text-muted-foreground">{{ entity.bookCount }} {{ entity.bookCount === 1 ? 'book' : 'books' }}</span>
-              <span v-if="entity.sortName" class="text-xs text-muted-foreground">· sort: {{ entity.sortName }}</span>
+              <span class="text-xs text-muted-foreground">{{
+                t('tools.entityManager.bookCount', { count: entity.bookCount }, entity.bookCount)
+              }}</span>
+              <span v-if="entity.sortName" class="text-xs text-muted-foreground">{{
+                t('tools.entityManager.sortPrefix', { sortName: entity.sortName })
+              }}</span>
             </div>
             <div v-if="entity.bookTitles.length > 0" class="mt-1">
               <span class="text-xs text-muted-foreground">{{ entity.bookTitles.slice(0, 3).join(', ') }}</span>
@@ -96,7 +105,7 @@ function toggleExpanded(): void {
           </div>
           <button
             class="shrink-0 text-muted-foreground hover:text-destructive transition-colors p-1 rounded"
-            title="Dismiss all pairs for this entity"
+            :title="t('tools.entityManager.duplicates.dismissEntityTitle')"
             @click.stop="handleDismissEntity(entity.id)"
           >
             <UserMinus class="h-4 w-4" />
@@ -105,7 +114,7 @@ function toggleExpanded(): void {
       </div>
 
       <div v-if="cluster.pairDetails.length > 0" class="space-y-1">
-        <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">Pair details</p>
+        <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">{{ t('tools.entityManager.duplicates.pairDetails') }}</p>
         <div v-for="(pair, idx) in cluster.pairDetails" :key="idx" class="flex items-center gap-2 text-xs px-2 py-1 rounded bg-muted/30">
           <span class="flex-1 text-muted-foreground truncate">
             {{ cluster.entities.find((e) => e.id === pair.idA)?.name }} <span class="text-foreground/50">&harr;</span>
@@ -116,7 +125,7 @@ function toggleExpanded(): void {
           </span>
           <button
             class="shrink-0 text-muted-foreground hover:text-destructive transition-colors p-0.5 rounded"
-            title="Dismiss this pair"
+            :title="t('tools.entityManager.duplicates.dismissPairTitle')"
             @click.stop="handleDismissPair(pair.idA, pair.idB)"
           >
             <X class="h-3.5 w-3.5" />
@@ -127,14 +136,14 @@ function toggleExpanded(): void {
       <div class="flex items-center justify-between pt-2 border-t border-border/50">
         <label class="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
           <input v-model="writeFiles" type="checkbox" class="rounded accent-primary" />
-          Write to files
+          {{ t('tools.entityManager.writeToFiles') }}
         </label>
         <button
           class="inline-flex items-center gap-1.5 h-8 px-3 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
           :disabled="operationLoading || sourceIds.length === 0"
           @click="handleMerge"
         >
-          Merge {{ sourceIds.length }} into target
+          {{ t('tools.entityManager.mergeIntoTarget', { count: sourceIds.length }) }}
         </button>
       </div>
     </div>

--- a/client/src/features/tools/entity-manager/components/DuplicateScanControls.vue
+++ b/client/src/features/tools/entity-manager/components/DuplicateScanControls.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { Loader2, Search } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 defineProps<{
   minSimilarity: number
@@ -23,7 +26,7 @@ function handleScan(): void {
 <template>
   <div class="flex flex-wrap items-center gap-4">
     <div class="flex items-center gap-2">
-      <label class="text-sm text-muted-foreground whitespace-nowrap">Similarity:</label>
+      <label class="text-sm text-muted-foreground whitespace-nowrap">{{ t('tools.entityManager.duplicates.similarity') }}</label>
       <input type="range" :value="minSimilarity" min="0.1" max="1.0" step="0.05" class="w-32 accent-primary" @input="handleSimilarityChange" />
       <span class="text-sm font-mono text-muted-foreground w-10 text-right">{{ (minSimilarity * 100).toFixed(0) }}%</span>
     </div>
@@ -35,7 +38,7 @@ function handleScan(): void {
     >
       <Loader2 v-if="scanning" class="h-4 w-4 animate-spin" />
       <Search v-else class="h-4 w-4" />
-      {{ scanning ? 'Scanning...' : 'Scan' }}
+      {{ scanning ? t('tools.entityManager.duplicates.scanning') : t('tools.entityManager.duplicates.scan') }}
     </button>
   </div>
 </template>

--- a/client/src/features/tools/entity-manager/components/EntityBrowseTable.vue
+++ b/client/src/features/tools/entity-manager/components/EntityBrowseTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronLeft, ChevronRight, GitMerge, MoreHorizontal, Pencil, Search, Scissors, Trash2, X } from '@lucide/vue'
 import type {
   BrowseEntityBookCountFilter,
@@ -27,6 +28,8 @@ const props = defineProps<{
   capabilities: EntityTypeCapabilities
   isInline: boolean
 }>()
+
+const { t } = useI18n()
 
 const emit = defineEmits<{
   'update:page': [value: number]
@@ -121,7 +124,7 @@ const emptyOnly = computed(() => props.bookCount === 'empty')
           <input
             type="text"
             :value="search"
-            placeholder="Search..."
+            :placeholder="t('tools.entityManager.browse.searchPlaceholder')"
             class="w-full h-9 pl-9 pr-3 rounded-lg border border-border bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/30"
             @input="handleSearchInput"
           />
@@ -132,14 +135,14 @@ const emptyOnly = computed(() => props.bookCount === 'empty')
             class="h-8 rounded-md border border-border bg-background px-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/30"
             @change="handleSortChange"
           >
-            <option value="name-asc">Name A-Z</option>
-            <option value="name-desc">Name Z-A</option>
-            <option value="bookCount-asc">Fewest books</option>
-            <option value="bookCount-desc">Most books</option>
+            <option value="name-asc">{{ t('tools.entityManager.browse.sort.nameAsc') }}</option>
+            <option value="name-desc">{{ t('tools.entityManager.browse.sort.nameDesc') }}</option>
+            <option value="bookCount-asc">{{ t('tools.entityManager.browse.sort.fewestBooks') }}</option>
+            <option value="bookCount-desc">{{ t('tools.entityManager.browse.sort.mostBooks') }}</option>
           </select>
           <label v-if="!isInline" class="inline-flex h-8 items-center gap-2 rounded-md border border-border px-2 text-sm text-muted-foreground">
             <input type="checkbox" class="rounded accent-primary" :checked="emptyOnly" @change="handleEmptyOnlyChange" />
-            <span>Empty only</span>
+            <span>{{ t('tools.entityManager.browse.emptyOnly') }}</span>
           </label>
           <button
             v-if="hasSelection"
@@ -147,7 +150,7 @@ const emptyOnly = computed(() => props.bookCount === 'empty')
             @click="handleClearSelection"
           >
             <X class="h-3.5 w-3.5" />
-            <span class="text-sm font-medium">Clear</span>
+            <span class="text-sm font-medium">{{ t('tools.entityManager.browse.clear') }}</span>
           </button>
           <button
             v-if="canMerge"
@@ -155,7 +158,7 @@ const emptyOnly = computed(() => props.bookCount === 'empty')
             @click="handleBulkMerge"
           >
             <GitMerge class="h-3.5 w-3.5" />
-            Merge ({{ selectedIds.size }})
+            {{ t('tools.entityManager.browse.mergeCount', { count: selectedIds.size }) }}
           </button>
           <button
             v-if="hasSelection"
@@ -163,18 +166,20 @@ const emptyOnly = computed(() => props.bookCount === 'empty')
             @click="handleBulkDelete"
           >
             <Trash2 class="h-3.5 w-3.5" />
-            Delete ({{ selectedIds.size }})
+            {{ t('tools.entityManager.browse.deleteCount', { count: selectedIds.size }) }}
           </button>
-          <span class="text-sm text-muted-foreground">{{ total }} total</span>
+          <span class="text-sm text-muted-foreground">{{ t('tools.entityManager.browse.totalCount', { count: total }) }}</span>
         </div>
       </div>
     </div>
 
     <!-- Scrollable content area -->
     <div class="flex-1 overflow-y-auto min-h-0 divide-y divide-border">
-      <div v-if="loading" class="text-center py-8 text-muted-foreground text-sm">Loading...</div>
+      <div v-if="loading" class="text-center py-8 text-muted-foreground text-sm">{{ t('common.loading') }}</div>
 
-      <div v-else-if="items.length === 0" class="text-center py-8 text-muted-foreground text-sm">No entities found</div>
+      <div v-else-if="items.length === 0" class="text-center py-8 text-muted-foreground text-sm">
+        {{ t('tools.entityManager.browse.noEntities') }}
+      </div>
 
       <template v-else>
         <div v-for="item in items" :key="String(item.id)" class="flex items-center gap-3 px-4 py-2.5 hover:bg-muted/30 transition-colors">
@@ -186,29 +191,33 @@ const emptyOnly = computed(() => props.bookCount === 'empty')
           />
           <div class="flex-1 min-w-0">
             <span class="text-sm font-medium truncate block">{{ item.name }}</span>
-            <div v-if="item.sortName" class="text-xs text-muted-foreground">sort: {{ item.sortName }}</div>
+            <div v-if="item.sortName" class="text-xs text-muted-foreground">
+              {{ t('tools.entityManager.browse.sortLabel', { sortName: item.sortName }) }}
+            </div>
           </div>
-          <span class="text-xs text-muted-foreground shrink-0">{{ item.bookCount }} {{ item.bookCount === 1 ? 'book' : 'books' }}</span>
+          <span class="text-xs text-muted-foreground shrink-0">{{
+            t('tools.entityManager.bookCount', { count: item.bookCount }, item.bookCount)
+          }}</span>
           <!-- Desktop: inline action buttons -->
           <div class="hidden sm:flex items-center gap-1 shrink-0">
             <button
               class="h-7 px-2 text-xs rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
               @click.stop="handleRename(item)"
             >
-              Rename
+              {{ t('tools.entityManager.actions.rename') }}
             </button>
             <button
               v-if="capabilities.canSplit && !isInline"
               class="h-7 px-2 text-xs rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
               @click.stop="handleSplit(item)"
             >
-              Split
+              {{ t('tools.entityManager.actions.split') }}
             </button>
             <button
               class="h-7 px-2 text-xs rounded hover:bg-muted text-destructive/70 hover:text-destructive transition-colors"
               @click.stop="handleDelete(item)"
             >
-              Delete
+              {{ t('common.delete') }}
             </button>
           </div>
           <!-- Mobile: dropdown menu -->
@@ -221,16 +230,16 @@ const emptyOnly = computed(() => props.bookCount === 'empty')
             <DropdownMenuContent align="end">
               <DropdownMenuItem @click="handleRename(item)">
                 <Pencil class="size-4 mr-2" />
-                Rename
+                {{ t('tools.entityManager.actions.rename') }}
               </DropdownMenuItem>
               <DropdownMenuItem v-if="capabilities.canSplit && !isInline" @click="handleSplit(item)">
                 <Scissors class="size-4 mr-2" />
-                Split
+                {{ t('tools.entityManager.actions.split') }}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem class="text-destructive focus:text-destructive" @click="handleDelete(item)">
                 <Trash2 class="size-4 mr-2" />
-                Delete
+                {{ t('common.delete') }}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/client/src/features/tools/entity-manager/components/EntityTypeSelector.vue
+++ b/client/src/features/tools/entity-manager/components/EntityTypeSelector.vue
@@ -1,18 +1,22 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ALL_ENTITY_TYPES, type EntityType } from '@bookorbit/types'
 
 defineProps<{ modelValue: EntityType }>()
 const emit = defineEmits<{ 'update:modelValue': [value: EntityType] }>()
 
-const labels: Record<EntityType, string> = {
-  author: 'Authors',
-  genre: 'Genres',
-  tag: 'Tags',
-  narrator: 'Narrators',
-  publisher: 'Publishers',
-  language: 'Languages',
-  series: 'Series',
-}
+const { t } = useI18n()
+
+const labels = computed<Record<EntityType, string>>(() => ({
+  author: t('tools.entityTypes.authors'),
+  genre: t('tools.entityTypes.genres'),
+  tag: t('tools.entityTypes.tags'),
+  narrator: t('tools.entityTypes.narrators'),
+  publisher: t('tools.entityTypes.publishers'),
+  language: t('tools.entityTypes.languages'),
+  series: t('tools.entityTypes.series'),
+}))
 
 function handleChange(event: Event): void {
   emit('update:modelValue', (event.target as HTMLSelectElement).value as EntityType)

--- a/client/src/features/tools/entity-manager/components/ModeSwitcher.vue
+++ b/client/src/features/tools/entity-manager/components/ModeSwitcher.vue
@@ -1,13 +1,18 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
 type Mode = 'duplicates' | 'browse'
 
 defineProps<{ modelValue: Mode }>()
 const emit = defineEmits<{ 'update:modelValue': [value: Mode] }>()
 
-const modes: { value: Mode; label: string }[] = [
-  { value: 'browse', label: 'Browse & Manage' },
-  { value: 'duplicates', label: 'Find Duplicates' },
-]
+const { t } = useI18n()
+
+const modes = computed<{ value: Mode; label: string }[]>(() => [
+  { value: 'browse', label: t('tools.entityManager.modes.browse') },
+  { value: 'duplicates', label: t('tools.entityManager.modes.duplicates') },
+])
 
 function handleSelect(value: Mode): void {
   emit('update:modelValue', value)

--- a/client/src/features/tools/entity-manager/components/RenameModal.vue
+++ b/client/src/features/tools/entity-manager/components/RenameModal.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { X } from '@lucide/vue'
+
+const { t } = useI18n()
 
 const props = defineProps<{
   currentName: string
@@ -31,18 +34,18 @@ function handleCancel(): void {
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="handleCancel">
     <div class="bg-card border border-border rounded-lg shadow-lg w-full max-w-md mx-4 overflow-hidden">
       <div class="flex items-center justify-between px-5 py-4 border-b border-border">
-        <h3 class="text-base font-semibold">Rename Entity</h3>
+        <h3 class="text-base font-semibold">{{ t('tools.entityManager.renameModal.title') }}</h3>
         <button class="text-muted-foreground hover:text-foreground transition-colors" @click="handleCancel">
           <X class="h-5 w-5" />
         </button>
       </div>
       <div class="px-5 py-4 space-y-4">
         <div>
-          <label class="text-sm text-muted-foreground block mb-1">Current name</label>
+          <label class="text-sm text-muted-foreground block mb-1">{{ t('tools.entityManager.renameModal.currentName') }}</label>
           <p class="text-sm font-medium">{{ currentName }}</p>
         </div>
         <div>
-          <label class="text-sm text-muted-foreground block mb-1">New name</label>
+          <label class="text-sm text-muted-foreground block mb-1">{{ t('tools.entityManager.renameModal.newName') }}</label>
           <input
             v-model="newName"
             type="text"
@@ -52,17 +55,19 @@ function handleCancel(): void {
         </div>
         <label class="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
           <input v-model="writeFiles" type="checkbox" class="rounded accent-primary" />
-          Write changes to files
+          {{ t('tools.entityManager.writeChangesToFiles') }}
         </label>
       </div>
       <div class="flex justify-end gap-2 px-5 py-3 border-t border-border bg-muted/20">
-        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">Cancel</button>
+        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">
+          {{ t('common.cancel') }}
+        </button>
         <button
           class="h-9 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
           :disabled="loading || !newName.trim() || newName.trim() === currentName"
           @click="handleConfirm"
         >
-          Rename
+          {{ t('tools.entityManager.actions.rename') }}
         </button>
       </div>
     </div>

--- a/client/src/features/tools/entity-manager/components/SplitModal.vue
+++ b/client/src/features/tools/entity-manager/components/SplitModal.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Plus, Trash2, X } from '@lucide/vue'
+
+const { t } = useI18n()
 
 defineProps<{
   entityName: string
@@ -49,23 +52,23 @@ function isValid(): boolean {
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" @click.self="handleCancel">
     <div class="bg-card border border-border rounded-lg shadow-lg w-full max-w-md mx-4 overflow-hidden">
       <div class="flex items-center justify-between px-5 py-4 border-b border-border">
-        <h3 class="text-base font-semibold">Split Entity</h3>
+        <h3 class="text-base font-semibold">{{ t('tools.entityManager.splitModal.title') }}</h3>
         <button class="text-muted-foreground hover:text-foreground transition-colors" @click="handleCancel">
           <X class="h-5 w-5" />
         </button>
       </div>
       <div class="px-5 py-4 space-y-4">
         <div>
-          <p class="text-sm text-muted-foreground mb-1">Splitting</p>
+          <p class="text-sm text-muted-foreground mb-1">{{ t('tools.entityManager.splitModal.splitting') }}</p>
           <p class="text-sm font-semibold">{{ entityName }}</p>
         </div>
         <div class="space-y-2">
-          <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">New names (min 2)</p>
+          <p class="text-xs text-muted-foreground font-medium uppercase tracking-wider">{{ t('tools.entityManager.splitModal.newNames') }}</p>
           <div v-for="(name, idx) in newNames" :key="idx" class="flex items-center gap-2">
             <input
               :value="name"
               type="text"
-              placeholder="Enter name..."
+              :placeholder="t('tools.entityManager.splitModal.namePlaceholder')"
               class="flex-1 h-9 px-3 rounded-lg border border-border bg-background text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
               @input="updateName(idx, $event)"
             />
@@ -79,22 +82,24 @@ function isValid(): boolean {
           </div>
           <button class="flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors" @click="addName">
             <Plus class="h-4 w-4" />
-            Add another
+            {{ t('tools.entityManager.splitModal.addAnother') }}
           </button>
         </div>
         <label class="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
           <input v-model="writeFiles" type="checkbox" class="rounded accent-primary" />
-          Write changes to files
+          {{ t('tools.entityManager.writeChangesToFiles') }}
         </label>
       </div>
       <div class="flex justify-end gap-2 px-5 py-3 border-t border-border bg-muted/20">
-        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">Cancel</button>
+        <button class="h-9 px-4 rounded-lg text-sm font-medium hover:bg-muted transition-colors" @click="handleCancel">
+          {{ t('common.cancel') }}
+        </button>
         <button
           class="h-9 px-4 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
           :disabled="loading || !isValid()"
           @click="handleConfirm"
         >
-          Split
+          {{ t('tools.entityManager.actions.split') }}
         </button>
       </div>
     </div>

--- a/client/src/features/tools/entity-manager/views/EntityManagerView.vue
+++ b/client/src/features/tools/entity-manager/views/EntityManagerView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Loader2, RefreshCw, Search } from '@lucide/vue'
 import type { BrowseEntityItem, DuplicateCluster } from '@bookorbit/types'
 
@@ -16,6 +17,7 @@ import SplitModal from '../components/SplitModal.vue'
 import BulkDeleteModal from '../components/BulkDeleteModal.vue'
 import BrowseMergeModal from '../components/BrowseMergeModal.vue'
 
+const { t } = useI18n()
 const em = useEntityManager()
 
 const renameTarget = ref<BrowseEntityItem | null>(null)
@@ -244,22 +246,24 @@ async function handleBulkDeleteConfirm(mode: 'soft' | 'hard' | 'inline', writeFi
           <template v-if="em.duplicateScanStatus.value.state === 'computing'">
             <Loader2 class="h-3 w-3 animate-spin shrink-0" />
             <span>
-              Computing candidates...
+              {{ t('tools.entityManager.duplicates.computing') }}
               <template v-if="em.duplicateScanStatus.value.progressPct !== null">{{ em.duplicateScanStatus.value.progressPct }}%</template>
             </span>
           </template>
           <template v-else-if="em.duplicateScanStatus.value.state === 'done' && em.duplicateScanStatus.value.computedAt">
-            <span>Candidates computed {{ new Date(em.duplicateScanStatus.value.computedAt).toLocaleString() }}</span>
+            <span>{{
+              t('tools.entityManager.duplicates.computedAt', { date: new Date(em.duplicateScanStatus.value.computedAt).toLocaleString() })
+            }}</span>
             <button class="flex items-center gap-1 hover:text-foreground transition-colors" @click="handleRefreshDuplicates">
               <RefreshCw class="h-3 w-3" />
-              Recompute
+              {{ t('tools.entityManager.duplicates.recompute') }}
             </button>
           </template>
           <template v-else-if="em.duplicateScanStatus.value.state === 'idle'">
-            <span>No candidates computed yet.</span>
+            <span>{{ t('tools.entityManager.duplicates.noneComputed') }}</span>
             <button class="flex items-center gap-1 hover:text-foreground transition-colors" @click="handleRefreshDuplicates">
               <RefreshCw class="h-3 w-3" />
-              Compute now
+              {{ t('tools.entityManager.duplicates.computeNow') }}
             </button>
           </template>
         </div>
@@ -283,8 +287,8 @@ async function handleBulkDeleteConfirm(mode: 'soft' | 'hard' | 'inline', writeFi
               <Search class="h-8 w-8 text-muted-foreground" />
             </div>
             <div class="space-y-1">
-              <p class="text-sm font-medium">Find duplicate entities</p>
-              <p class="text-xs text-muted-foreground max-w-xs">Adjust the similarity threshold and click Scan to detect potential duplicates.</p>
+              <p class="text-sm font-medium">{{ t('tools.entityManager.duplicates.emptyTitle') }}</p>
+              <p class="text-xs text-muted-foreground max-w-xs">{{ t('tools.entityManager.duplicates.emptyDescription') }}</p>
             </div>
           </div>
           <div v-else class="rounded-lg border border-border/50 bg-card/40 px-6 py-12 flex flex-col items-center gap-4 text-center">
@@ -292,14 +296,16 @@ async function handleBulkDeleteConfirm(mode: 'soft' | 'hard' | 'inline', writeFi
               <CheckCircle2 class="h-8 w-8 text-green-500" />
             </div>
             <div class="space-y-1">
-              <p class="text-sm font-medium">No duplicates found</p>
-              <p class="text-xs text-muted-foreground">No potential duplicates were detected with the current settings.</p>
+              <p class="text-sm font-medium">{{ t('tools.entityManager.duplicates.noneFoundTitle') }}</p>
+              <p class="text-xs text-muted-foreground">{{ t('tools.entityManager.duplicates.noneFoundDescription') }}</p>
             </div>
           </div>
         </template>
 
         <div v-if="em.clusters.value.length > 0" class="space-y-3">
-          <p class="text-sm text-muted-foreground">{{ em.scanTotal.value }} {{ em.scanTotal.value === 1 ? 'cluster' : 'clusters' }} found</p>
+          <p class="text-sm text-muted-foreground">
+            {{ t('tools.entityManager.duplicates.clustersFound', { count: em.scanTotal.value }, em.scanTotal.value) }}
+          </p>
           <DuplicateClusterCard
             v-for="(cluster, idx) in em.clusters.value"
             :key="idx"
@@ -337,7 +343,7 @@ async function handleBulkDeleteConfirm(mode: 'soft' | 'hard' | 'inline', writeFi
           >
             <component :is="em.showDismissed.value ? ChevronUp : ChevronDown" class="h-4 w-4" />
             <span>
-              {{ em.showDismissed.value ? 'Hide' : 'Show' }} dismissed pairs
+              {{ em.showDismissed.value ? t('tools.entityManager.dismissed.hidePairs') : t('tools.entityManager.dismissed.showPairs') }}
               <template v-if="!em.showDismissed.value && em.dismissedPairs.value.length > 0"> ({{ em.dismissedPairs.value.length }}) </template>
             </span>
           </button>

--- a/client/src/features/whats-new/WhatsNewDialog.vue
+++ b/client/src/features/whats-new/WhatsNewDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ArrowRight, ChevronDown, ExternalLink, Sparkles, X } from '@lucide/vue'
 import { useModal } from '@/composables/useModal'
 import { useWhatsNew } from './composables/useWhatsNew'
@@ -7,6 +8,7 @@ import { formatReleaseDate } from './lib/whats-new.logic'
 import { anyLightboxOpen } from './lib/lightbox-state'
 import HighlightItem from './components/HighlightItem.vue'
 
+const { t } = useI18n()
 const { version, releases, hasMore, acknowledge, remindLater } = useWhatsNew()
 
 const expanded = ref(new Set<string>(releases.value[0] ? [releases.value[0].version] : []))
@@ -66,16 +68,17 @@ useModal({
                 <Sparkles :size="22" />
               </span>
               <div>
-                <h2 id="whats-new-title" class="text-lg font-semibold tracking-tight text-foreground">What's New</h2>
+                <h2 id="whats-new-title" class="text-lg font-semibold tracking-tight text-foreground">{{ t('whatsNew.title') }}</h2>
                 <p class="text-sm text-muted-foreground">
-                  <template v-if="version">Version {{ version }} · </template>{{ releases.length }} new update{{ releases.length === 1 ? '' : 's' }}
+                  <template v-if="version">{{ t('whatsNew.versionPrefix', { version }) }} · </template
+                  >{{ t('whatsNew.newUpdates', { count: releases.length }, releases.length) }}
                 </p>
               </div>
             </div>
             <button
               type="button"
               class="-mr-1 -mt-1 shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-              aria-label="Remind me later"
+              :aria-label="t('whatsNew.remindLater')"
               @click="handleLater"
             >
               <X :size="18" />
@@ -92,7 +95,7 @@ useModal({
                   v-if="index === 0"
                   class="rounded-full bg-primary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary-foreground"
                 >
-                  Latest
+                  {{ t('whatsNew.latest') }}
                 </span>
                 <span v-if="formatReleaseDate(release.date)" class="text-xs text-muted-foreground">{{ formatReleaseDate(release.date) }}</span>
               </div>
@@ -118,7 +121,7 @@ useModal({
               rel="noopener noreferrer"
               class="mt-3 inline-flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:text-primary/85"
             >
-              Full changelog
+              {{ t('whatsNew.fullChangelog') }}
               <ExternalLink :size="12" />
             </a>
           </section>
@@ -129,7 +132,7 @@ useModal({
             class="inline-flex items-center gap-1 text-sm font-medium text-primary transition-colors hover:text-primary/85"
             @click="handleLater"
           >
-            See all releases
+            {{ t('whatsNew.seeAllReleases') }}
             <ArrowRight :size="14" />
           </RouterLink>
         </div>
@@ -140,7 +143,7 @@ useModal({
             class="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted"
             @click="handleLater"
           >
-            Remind me later
+            {{ t('whatsNew.remindLater') }}
           </button>
           <button
             ref="ackButton"
@@ -148,7 +151,7 @@ useModal({
             class="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             @click="handleAck"
           >
-            Got it
+            {{ t('whatsNew.gotIt') }}
           </button>
         </footer>
       </div>

--- a/client/src/features/whats-new/WhatsNewView.vue
+++ b/client/src/features/whats-new/WhatsNewView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
 import { ChevronDown, ExternalLink, Search, Sparkles } from '@lucide/vue'
 import type { ReleaseNote, ReleaseNotesResponse } from '@bookorbit/types'
@@ -9,6 +10,7 @@ import { formatReleaseDate } from './lib/whats-new.logic'
 import { renderChangelogMarkdown } from './lib/markdown'
 import HighlightItem from './components/HighlightItem.vue'
 
+const { t } = useI18n()
 const { version, markArchiveSeen } = useWhatsNew()
 
 const releases = ref<ReleaseNote[]>([])
@@ -46,7 +48,7 @@ async function loadFirst(): Promise<void> {
   try {
     await loadPage(1)
   } catch (e) {
-    error.value = e instanceof Error ? e.message : 'Failed to load releases'
+    error.value = e instanceof Error ? e.message : t('whatsNew.loadFailed')
   } finally {
     loading.value = false
   }
@@ -58,7 +60,7 @@ async function loadMore(): Promise<void> {
     await loadPage(page.value + 1)
   } catch {
     // Keep the releases already loaded; surface the failure so the button isn't a no-op.
-    toast.error('Could not load more releases. Please try again.')
+    toast.error(t('whatsNew.loadMoreFailed'))
   } finally {
     loadingMore.value = false
   }
@@ -130,15 +132,15 @@ onUnmounted(() => {
         <Sparkles :size="20" />
       </span>
       <div>
-        <h1 class="text-xl font-semibold tracking-tight text-foreground">What's New</h1>
-        <p class="text-sm text-muted-foreground">Everything that's shipped, newest first.</p>
+        <h1 class="text-xl font-semibold tracking-tight text-foreground">{{ t('whatsNew.title') }}</h1>
+        <p class="text-sm text-muted-foreground">{{ t('whatsNew.subtitle') }}</p>
       </div>
     </header>
 
     <div class="lg:flex lg:gap-6">
       <nav v-if="!loading && !error && filtered.length" class="hidden w-48 shrink-0 lg:order-last lg:block">
         <div class="sticky top-2 space-y-1">
-          <p class="px-2 pb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">Versions</p>
+          <p class="px-2 pb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{{ t('whatsNew.versions') }}</p>
           <a
             v-for="release in filtered"
             :key="release.version"
@@ -152,7 +154,7 @@ onUnmounted(() => {
             "
           >
             <span class="truncate">{{ release.version }}</span>
-            <span v-if="isCurrent(release)" class="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" aria-label="Current version" />
+            <span v-if="isCurrent(release)" class="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" :aria-label="t('whatsNew.currentVersion')" />
           </a>
         </div>
       </nav>
@@ -163,7 +165,7 @@ onUnmounted(() => {
           <input
             v-model="search"
             type="search"
-            placeholder="Search releases…"
+            :placeholder="t('whatsNew.searchPlaceholder')"
             class="w-full rounded-md border border-input bg-background py-2 pl-9 pr-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
           />
         </div>
@@ -173,18 +175,18 @@ onUnmounted(() => {
         </div>
 
         <div v-else-if="error" class="rounded-lg border border-border bg-card p-6 text-center">
-          <p class="text-sm text-muted-foreground">Couldn't load releases. Check your connection and try again.</p>
+          <p class="text-sm text-muted-foreground">{{ t('whatsNew.loadErrorHint') }}</p>
           <button
             type="button"
             class="mt-3 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted"
             @click="retry"
           >
-            Retry
+            {{ t('whatsNew.retry') }}
           </button>
         </div>
 
         <div v-else-if="filtered.length === 0" class="rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground">
-          No releases found.
+          {{ t('whatsNew.noReleasesFound') }}
         </div>
 
         <div v-else class="space-y-4">
@@ -196,7 +198,9 @@ onUnmounted(() => {
           >
             <div class="flex flex-wrap items-center gap-2">
               <h2 class="text-base font-semibold text-foreground">{{ release.version }}</h2>
-              <span v-if="isCurrent(release)" class="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">You're here</span>
+              <span v-if="isCurrent(release)" class="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">{{
+                t('whatsNew.youreHere')
+              }}</span>
               <span v-if="formatReleaseDate(release.date)" class="text-xs text-muted-foreground">{{ formatReleaseDate(release.date) }}</span>
             </div>
 
@@ -208,7 +212,7 @@ onUnmounted(() => {
               </ul>
             </template>
 
-            <p v-else class="mt-3 text-sm text-muted-foreground">No highlights for this release.</p>
+            <p v-else class="mt-3 text-sm text-muted-foreground">{{ t('whatsNew.noHighlights') }}</p>
 
             <div class="mt-4 flex flex-wrap items-center gap-4">
               <button
@@ -222,7 +226,7 @@ onUnmounted(() => {
                   class="transition-transform motion-reduce:transition-none"
                   :class="isChangelogOpen(release) ? 'rotate-180' : ''"
                 />
-                {{ isChangelogOpen(release) ? 'Hide' : 'Show' }} full changelog
+                {{ isChangelogOpen(release) ? t('whatsNew.hideChangelog') : t('whatsNew.showChangelog') }}
               </button>
               <a
                 :href="release.changelogUrl"
@@ -230,7 +234,7 @@ onUnmounted(() => {
                 rel="noopener noreferrer"
                 class="inline-flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:text-primary/85"
               >
-                Open on GitHub
+                {{ t('whatsNew.openOnGitHub') }}
                 <ExternalLink :size="12" />
               </a>
             </div>
@@ -250,7 +254,7 @@ onUnmounted(() => {
               class="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted disabled:opacity-50"
               @click="loadMore"
             >
-              {{ loadingMore ? 'Loading…' : 'Load more' }}
+              {{ loadingMore ? t('whatsNew.loadingMore') : t('whatsNew.loadMore') }}
             </button>
           </div>
         </div>

--- a/client/src/features/whats-new/components/ImageLightbox.vue
+++ b/client/src/features/whats-new/components/ImageLightbox.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { ChevronLeft, ChevronRight, X } from '@lucide/vue'
 import { useModal } from '@/composables/useModal'
 import { registerLightbox } from '../lib/lightbox-state'
@@ -8,6 +9,8 @@ const props = withDefaults(defineProps<{ images: string[]; startIndex?: number; 
   startIndex: 0,
 })
 const emit = defineEmits<{ close: [] }>()
+
+const { t } = useI18n()
 
 const current = ref(props.startIndex)
 const panel = ref<HTMLElement | null>(null)
@@ -50,13 +53,13 @@ onUnmounted(() => {
       class="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 p-4 motion-safe:animate-in motion-safe:fade-in"
       role="dialog"
       aria-modal="true"
-      aria-label="Image viewer"
+      :aria-label="t('whatsNew.imageViewer')"
       @click.self="handleClose"
     >
       <button
         type="button"
         class="absolute right-4 top-4 text-white/80 transition-colors hover:text-white"
-        aria-label="Close image"
+        :aria-label="t('whatsNew.closeImage')"
         @click="handleClose"
       >
         <X :size="24" />
@@ -66,7 +69,7 @@ onUnmounted(() => {
         v-if="images.length > 1"
         type="button"
         class="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white/80 transition-colors hover:bg-white/20 hover:text-white"
-        aria-label="Previous image"
+        :aria-label="t('whatsNew.previousImage')"
         @click="prev"
       >
         <ChevronLeft :size="28" />
@@ -78,7 +81,7 @@ onUnmounted(() => {
         v-if="images.length > 1"
         type="button"
         class="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white/80 transition-colors hover:bg-white/20 hover:text-white"
-        aria-label="Next image"
+        :aria-label="t('whatsNew.nextImage')"
         @click="next"
       >
         <ChevronRight :size="28" />

--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -11,6 +11,9 @@ export const i18n = createI18n({
   legacy: false,
   locale: DEFAULT_LOCALE,
   fallbackLocale: DEFAULT_LOCALE,
+  // Some messages intentionally contain inline HTML (e.g. <strong>/<code> in explanatory notes)
+  // rendered via v-html or <i18n-t>. Disable the HTML-in-message warning/throw.
+  warnHtmlMessage: false,
   // Non-default locales are loaded on demand via loadLocaleMessages().
   messages: { en },
 })

--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -1,0 +1,36 @@
+import type { WritableComputedRef } from 'vue'
+import { createI18n } from 'vue-i18n'
+import { DEFAULT_LOCALE, type Locale } from '@bookorbit/types'
+import en from '@/locales/en.json'
+
+export type MessageSchema = typeof en
+
+// `legacy: false` selects the Composition API overload, so `i18n.global` is a Composer
+// and `i18n.global.locale` is a writable ref.
+export const i18n = createI18n({
+  legacy: false,
+  locale: DEFAULT_LOCALE,
+  fallbackLocale: DEFAULT_LOCALE,
+  // Non-default locales are loaded on demand via loadLocaleMessages().
+  messages: { en },
+})
+
+const loaded = new Set<Locale>([DEFAULT_LOCALE])
+
+/** Dynamically import and register the message catalog for a locale (no-op if already loaded). */
+export async function loadLocaleMessages(locale: Locale): Promise<void> {
+  if (loaded.has(locale)) return
+  const messages = (await import(`../locales/${locale}.json`)) as { default: MessageSchema }
+  i18n.global.setLocaleMessage(locale, messages.default)
+  loaded.add(locale)
+}
+
+/** Load (if needed) and activate a locale, updating the document's lang attribute. */
+export async function setI18nLocale(locale: Locale): Promise<void> {
+  await loadLocaleMessages(locale)
+  // The setter is narrowed to the eagerly-bundled locale keys; widen to any supported locale.
+  ;(i18n.global.locale as WritableComputedRef<Locale>).value = locale
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('lang', locale)
+  }
+}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -309,6 +309,13 @@
           "delete": "Failed to delete icon",
           "bulkDelete": "Failed to delete icons"
         }
+      },
+      "tabs": {
+        "theme": "Theme",
+        "book-covers": "Book Covers",
+        "icons": "Icons",
+        "layout": "Layout",
+        "behavior": "Behavior"
       }
     },
     "account": {
@@ -954,6 +961,11 @@
         "recalcStarted": "Score recalculation started in the background",
         "recalcFailed": "Recalculation failed",
         "resetToDefaults": "Weights reset to defaults. Save to apply."
+      },
+      "tabs": {
+        "users": "Users",
+        "magic-links": "Magic Links",
+        "oidc": "OIDC / SSO"
       }
     },
     "common": {
@@ -1279,6 +1291,33 @@
         "clear": "Clear",
         "noLibraries": "No libraries available yet.",
         "allLibraries": "All libraries"
+      },
+      "tabs": {
+        "providers": "Providers",
+        "field-rules": "Field Rules",
+        "custom-fields": "Custom Fields",
+        "genre-blocklist": "Genre Blocklist",
+        "score": "Score",
+        "auto-fetch": "Books",
+        "authors": "Authors"
+      },
+      "tabTitles": {
+        "providers": "Providers",
+        "field-rules": "Field-Level Rules",
+        "custom-fields": "Custom Metadata",
+        "genre-blocklist": "Genre Blocklist",
+        "score": "Confidence Score",
+        "auto-fetch": "Book Auto-Fetch",
+        "authors": "Author Auto-Fetch"
+      },
+      "tabSubtitles": {
+        "providers": "Enable external metadata sources and configure their credentials.",
+        "field-rules": "Control which provider supplies each metadata field and how values are merged across your libraries.",
+        "custom-fields": "Define custom metadata fields and choose which libraries use them.",
+        "genre-blocklist": "Prevent unwanted provider genre values from being written to books.",
+        "score": "Assign weights to metadata fields to calculate how much to trust fetched results.",
+        "auto-fetch": "Automatically fetch covers, descriptions, and other details when new books are added to your library.",
+        "authors": "Automatically fetch biographies and profile photos when new authors appear in your library."
       }
     },
     "reader": {
@@ -1780,6 +1819,22 @@
         "deleteUserFailed": "Failed to delete OPDS user",
         "labelCopied": "{label} copied",
         "copyLabelFailed": "Failed to copy {label}"
+      },
+      "tabs": {
+        "general": "General",
+        "ebook": "eBook",
+        "pdf": "PDF",
+        "comics": "Comics",
+        "audio": "Audiobook",
+        "fonts": "Fonts"
+      }
+    },
+    "system": {
+      "tabs": {
+        "file-naming": "File Naming",
+        "book-dock": "Book Dock",
+        "maintenance": "Maintenance",
+        "audit-log": "Audit Log"
       }
     }
   },
@@ -5579,5 +5634,84 @@
     "closeImage": "Close image",
     "previousImage": "Previous image",
     "nextImage": "Next image"
+  },
+  "titles": {
+    "dashboard": "Dashboard",
+    "libraries": "Libraries",
+    "opds": "OPDS",
+    "koboSync": "Kobo Sync",
+    "koreaderSync": "KOReader Sync",
+    "bookDock": "Book Dock",
+    "whatsNew": "What's New",
+    "annotations": "Annotations",
+    "achievements": "Achievements",
+    "statistics": "Statistics",
+    "authors": "Authors",
+    "series": "Series",
+    "entityManager": "Entity Manager",
+    "bulkRename": "Bulk Rename",
+    "notFound": "Not Found",
+    "signIn": "Sign In",
+    "initialSetup": "Initial Setup",
+    "forgotPassword": "Forgot Password",
+    "resetPassword": "Reset Password",
+    "completingSignIn": "Completing Sign In",
+    "magicLinkLogin": "Magic Link Login",
+    "readPrefix": "Read",
+    "emailSuffix": "Email",
+    "library": "Library",
+    "smartScope": "SmartScope",
+    "collection": "Collection",
+    "author": "Author",
+    "book": "Book",
+    "seriesItem": "Series",
+    "appearance": {
+      "theme": "Display",
+      "book-covers": "Book Covers",
+      "icons": "Icons",
+      "layout": "Display Layout",
+      "behavior": "Library Behavior"
+    },
+    "reader": {
+      "general": "Reader Settings",
+      "ebook": "eBook Reader",
+      "pdf": "PDF Reader",
+      "comics": "Comics Reader",
+      "audio": "Audiobook Player",
+      "fonts": "Reader Fonts"
+    },
+    "email": {
+      "providers": "Providers",
+      "recipients": "Recipients",
+      "groups": "Groups",
+      "templates": "Templates",
+      "preferences": "Preferences",
+      "history": "History"
+    },
+    "metadata": {
+      "providers": "Providers",
+      "field-rules": "Field-Level Rules",
+      "custom-fields": "Custom Metadata",
+      "genre-blocklist": "Genre Blocklist",
+      "score": "Confidence Score",
+      "auto-fetch": "Book Auto-Fetch",
+      "authors": "Author Auto-Fetch"
+    },
+    "admin": {
+      "users": "Users",
+      "magic-links": "Magic Links",
+      "oidc": "OIDC / SSO"
+    },
+    "system": {
+      "file-naming": "File Naming",
+      "book-dock": "Book Dock",
+      "maintenance": "Maintenance",
+      "audit-log": "Audit Log"
+    },
+    "account": {
+      "profile": "Account",
+      "notifications": "Notifications",
+      "restrictions": "Content Restrictions"
+    }
   }
 }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1,0 +1,26 @@
+{
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "close": "Close",
+    "confirm": "Confirm",
+    "loading": "Loading...",
+    "search": "Search",
+    "back": "Back",
+    "next": "Next",
+    "previous": "Previous",
+    "yes": "Yes",
+    "no": "No"
+  },
+  "settings": {
+    "appearance": {
+      "language": {
+        "title": "Language",
+        "description": "Choose the language used across the interface.",
+        "label": "Interface language"
+      }
+    }
+  }
+}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -20,7 +20,5564 @@
         "title": "Language",
         "description": "Choose the language used across the interface.",
         "label": "Interface language"
+      },
+      "pageTitle": "Display",
+      "pageSubtitle": "Control themes, covers, layout, and how your library is presented.",
+      "mobileSummary": "Theme: {theme} • Accent: {accent} • Background: {background}",
+      "themeMode": {
+        "light": "Light",
+        "dark": "Dark"
+      },
+      "theme": {
+        "title": "Theme",
+        "colorScheme": {
+          "label": "Color scheme",
+          "hint": "Light or dark interface"
+        },
+        "accentColor": {
+          "label": "Accent color",
+          "hint": "Controls highlights and interactive elements"
+        },
+        "cornerRadius": {
+          "label": "Corner radius",
+          "hint": "Roundness of cards and UI elements"
+        },
+        "surfaceBrightness": {
+          "label": "Surface brightness",
+          "hint": "Lighten dark mode surfaces",
+          "reset": "Reset"
+        },
+        "libraryBackground": {
+          "title": "Library Background",
+          "pattern": {
+            "label": "Background pattern",
+            "hint": "Pattern shown behind the book grid"
+          }
+        },
+        "backgroundGroups": {
+          "fundamental": "Fundamental",
+          "structural": "Structural",
+          "ambient": "Ambient",
+          "refractive": "Refractive"
+        }
+      },
+      "storage": {
+        "title": "Where to save appearance preferences",
+        "active": "Active",
+        "notAvailable": "Not available",
+        "device": {
+          "title": "This device only",
+          "description": "Preferences stay in your browser. Best if you want a different look on different devices."
+        },
+        "account": {
+          "title": "My account",
+          "description": "Preferences are saved to your account. Best if you want the same appearance on every device."
+        },
+        "toasts": {
+          "synced": "Preferences will now be synced",
+          "local": "Preferences will stay on this device"
+        },
+        "errors": {
+          "demoRestricted": "Demo-restricted account cannot change theme storage mode",
+          "update": "Failed to update storage mode",
+          "generic": "An error occurred while updating storage mode"
+        }
+      },
+      "bookCovers": {
+        "title": "Book Covers",
+        "displayMode": {
+          "title": "Cover display mode",
+          "hint": "Controls how real covers fit inside book slots when aspect ratios differ",
+          "blurredFit": {
+            "label": "Blurred fit",
+            "hint": "Show the full cover with a blurred fill behind it"
+          },
+          "fillCrop": {
+            "label": "Fill card",
+            "hint": "Fill the entire slot by cropping edges when aspect ratios differ"
+          },
+          "naturalBottom": {
+            "label": "Natural bottom",
+            "hint": "Keep the original cover ratio and anchor the cover to the bottom"
+          }
+        },
+        "spine": {
+          "title": "Book spine overlay",
+          "hint": "Adds a stylized spine and gloss effect to cover cards",
+          "off": {
+            "label": "Off",
+            "hint": "No spine/gloss effect on covers"
+          },
+          "subtle": {
+            "label": "Subtle",
+            "hint": "Light spine and sheen, closer to the default look"
+          },
+          "strong": {
+            "label": "Strong",
+            "hint": "More pronounced spine and gloss treatment"
+          }
+        },
+        "showSpineOnComics": {
+          "label": "Show spine on comics",
+          "hint": "Apply the spine and gloss effect to comic covers (cbz, cbr, cb7)"
+        },
+        "shadow": {
+          "title": "Cover shadow strength",
+          "hint": "Controls depth under covers across grid, list, table, and dashboard thumbnails",
+          "default": {
+            "label": "Default",
+            "hint": "Current elevation and depth"
+          },
+          "strong": {
+            "label": "Strong",
+            "hint": "Heavier shelf-like drop shadow under covers"
+          }
+        },
+        "overlays": {
+          "title": "Card overlays",
+          "hint": "Choose metadata shown directly on book cover cards",
+          "progressBar": {
+            "label": "Progress bar",
+            "hint": "Thin colored line along the bottom edge"
+          },
+          "format": {
+            "label": "File format",
+            "hint": "Color-coded EPUB, PDF, CBZ badge at bottom-right"
+          },
+          "rating": {
+            "label": "Rating",
+            "hint": "Star rating indicator at bottom-left"
+          },
+          "readStatus": {
+            "label": "Read status",
+            "hint": "Color icon showing the current reading status at top-left"
+          },
+          "seriesPosition": {
+            "label": "Series number",
+            "hint": "Badge showing the book position in its series at top-right (e.g. #3, #1.5)"
+          },
+          "lockStatus": {
+            "label": "Lock status",
+            "hint": "Metadata lock icon at top-right - orange when locked, green when unlocked"
+          }
+        }
+      },
+      "layout": {
+        "coverSize": "Cover size",
+        "gridSpacing": "Grid spacing",
+        "gridLayout": {
+          "title": "Library Grid Layout"
+        },
+        "coverSizeBehavior": {
+          "label": "Cover size behavior",
+          "hint": "Control whether portrait/square sizes and grid spacing are shared across all views or kept per-view",
+          "perViewHint": "Per-view mode: adjust cover size and spacing from each view's Display panel.",
+          "syncAll": "Sync all views",
+          "perView": "Per-view sizes"
+        },
+        "portraitCoverSize": {
+          "label": "Portrait cover size",
+          "hint": "Used for portrait libraries and views"
+        },
+        "squareCoverSize": {
+          "label": "Square cover size",
+          "hint": "Used for square libraries and views"
+        },
+        "portraitGridSpacing": {
+          "label": "Portrait grid spacing",
+          "hint": "Gap between portrait covers"
+        },
+        "squareGridSpacing": {
+          "label": "Square grid spacing",
+          "hint": "Gap between square covers"
+        },
+        "cardInfoMode": {
+          "label": "Card info mode",
+          "hint": "Where to show book title and author on grid cards",
+          "onHover": "On hover",
+          "belowCover": "Below cover",
+          "off": "Off"
+        },
+        "primaryCardLabel": {
+          "label": "Primary card label",
+          "hint": "Text shown below each book cover (first line)"
+        },
+        "secondaryCardLabel": {
+          "label": "Secondary card label",
+          "hint": "Additional text below the primary label (second line)"
+        },
+        "labelField": {
+          "hidden": "Hidden",
+          "bookTitle": "Book title",
+          "seriesTitle": "Series title",
+          "seriesTitlePosition": "Series title + position",
+          "author": "Author"
+        },
+        "seriesDisplay": {
+          "title": "Series Display",
+          "collapsedCover": {
+            "label": "Collapsed series cover",
+            "hint": "Choose which cover to show when series are collapsed in the book grid"
+          },
+          "stack": "Stack",
+          "mosaic": "Mosaic",
+          "first": "First",
+          "latest": "Latest",
+          "firstUnread": "First Unread"
+        },
+        "authorGrid": {
+          "title": "Author Grid",
+          "coverSize": {
+            "label": "Cover size",
+            "hint": "Width of author covers in the grid"
+          },
+          "coverShape": {
+            "label": "Cover shape",
+            "hint": "Shape of author covers in the grid"
+          },
+          "circle": "Circle",
+          "square": "Square"
+        },
+        "listTableViews": {
+          "title": "List and Table Views"
+        },
+        "zebraStriping": {
+          "label": "Zebra striping",
+          "hint": "Alternate row background colors for easier scanning"
+        }
+      },
+      "behavior": {
+        "title": "Library Behavior",
+        "thumbnailClicks": {
+          "label": "Thumbnail clicks",
+          "hint": "Choose what happens when opening a book from grid and list views",
+          "readFirst": "Read first",
+          "readFirstHint": "Open the reader when a readable file exists",
+          "openDetails": "Open details",
+          "openDetailsHint": "Go to the book details page from grid and list thumbnails"
+        },
+        "filterPreview": {
+          "label": "Show filter preview by default",
+          "hint": "Expand the active filter and sort summary when opening a smartScope"
+        },
+        "collapseSeries": {
+          "label": "Collapse series by default",
+          "hint": "Group books in the same series into a single card in library and collection views"
+        }
+      },
+      "icons": {
+        "title": "Custom Icons",
+        "uploadIcons": "Upload icons",
+        "uploadedCount": "no icons uploaded | {count} icon uploaded | {count} icons uploaded",
+        "searchPlaceholder": "Search icons",
+        "sort": {
+          "newest": "Newest",
+          "name": "Name"
+        },
+        "selectedCount": "{count} selected",
+        "clear": "Clear",
+        "deleteSelected": "Delete selected",
+        "loading": "Loading icons...",
+        "emptySearch": "No icons match your search.",
+        "emptyNoIcons": "No custom icons uploaded yet.",
+        "namePlaceholder": "Name",
+        "checkingUsage": "Checking usage...",
+        "usedBy": "Used by {count}",
+        "notUsedYet": "Not used yet",
+        "rename": "Rename",
+        "replace": "Replace",
+        "usage": {
+          "libraries": "no libraries | {count} library | {count} libraries",
+          "collections": "no collections | {count} collection | {count} collections",
+          "smartScopes": "no smart scopes | {count} smart scope | {count} smart scopes"
+        },
+        "confirm": {
+          "deleteOne": "Delete \"{name}\"? Existing uses will fall back to their default icon.",
+          "deleteMany": "Delete no icons? | Delete {count} icon? Existing uses will fall back to their default icon. | Delete {count} icons? Existing uses will fall back to their default icon."
+        },
+        "toasts": {
+          "saved": "Icon saved",
+          "updated": "Icon updated",
+          "deleted": "Icon deleted",
+          "bulkDeleted": "Deleted no icons | Deleted {count} icon | Deleted {count} icons",
+          "bulkDeletePartial": "Deleted {deleted}, {failed} failed"
+        },
+        "errors": {
+          "load": "Failed to load icons",
+          "save": "Failed to save icon",
+          "replace": "Failed to replace icon",
+          "delete": "Failed to delete icon",
+          "bulkDelete": "Failed to delete icons"
+        }
+      }
+    },
+    "account": {
+      "title": "Account",
+      "subtitle": "Manage your personal profile settings.",
+      "subtitleAll": "Manage your profile and notification preferences.",
+      "tabs": {
+        "profile": "Profile",
+        "notifications": "Notifications",
+        "restrictions": "Restrictions"
+      },
+      "demoRestricted": {
+        "cannotEdit": "Demo-restricted account cannot edit account settings",
+        "notice": "Demo-restricted account: editing profile, password, avatar, and linked identities is disabled."
+      },
+      "feedback": {
+        "unsavedChanges": "Unsaved changes",
+        "allSaved": "All changes saved"
+      },
+      "profile": {
+        "securityHeading": "Profile & Security",
+        "username": "Username",
+        "fullName": "Full name",
+        "email": "Email",
+        "emailHint": "Contact an administrator to change your email address.",
+        "save": "Save profile",
+        "saving": "Saving...",
+        "changePassword": "Change password",
+        "accountType": "Account type:",
+        "accountTypeOidc": "OIDC / SSO",
+        "accountTypeShared": "Shared",
+        "accountTypeLocal": "Local",
+        "nameRequired": "Name is required",
+        "updateFailed": "Failed to update profile",
+        "updated": "Profile updated"
+      },
+      "readingPreferences": {
+        "title": "Reading Preferences",
+        "timezoneHint": "Timezone is used for time-sensitive achievements like Early Bird and All-nighter.",
+        "timezone": "Timezone",
+        "save": "Save preferences"
+      },
+      "preferences": {
+        "saveFailed": "Failed to save preferences",
+        "saved": "Preferences saved"
+      },
+      "avatar": {
+        "title": "Profile Picture",
+        "unknownUser": "Unknown user",
+        "formatHint": "PNG/JPEG/WEBP up to {size} MB",
+        "upload": "Upload picture",
+        "replace": "Replace picture",
+        "uploading": "Uploading...",
+        "remove": "Remove picture",
+        "removing": "Removing...",
+        "updated": "Profile picture updated",
+        "uploadFailed": "Failed to upload profile picture",
+        "removed": "Profile picture removed",
+        "removeFailed": "Failed to remove profile picture",
+        "removeConfirm": {
+          "title": "Remove profile picture?",
+          "description": "Your avatar will be removed and replaced with initials.",
+          "confirm": "Remove"
+        }
+      },
+      "connectedAccounts": {
+        "title": "Connected Accounts",
+        "unlink": "Unlink",
+        "unlinking": "Unlinking...",
+        "linkAdditional": "Link additional providers:",
+        "linkProvider": "Link {provider}",
+        "redirecting": "Redirecting...",
+        "noneConfigured": "No OIDC providers are configured. Ask an administrator to set up SSO.",
+        "linkStateFailed": "Failed to generate link state",
+        "startLinkFailed": "Failed to start OIDC link",
+        "unlinkFailed": "Failed to unlink",
+        "unlinked": "Identity unlinked",
+        "unlinkIdentityFailed": "Failed to unlink identity",
+        "unlinkDialog": {
+          "title": "Unlink {provider} identity?",
+          "description": "Enter your password to confirm. You will no longer be able to sign in with this provider.",
+          "currentPassword": "Current password"
+        }
+      },
+      "tour": {
+        "title": "Guided Tour",
+        "description": "Replay the walkthrough that highlights key features of the app.",
+        "action": "Take the tour again"
+      },
+      "restrictions": {
+        "none": {
+          "title": "No content restrictions",
+          "description": "Your account has full access to all content within your assigned libraries."
+        },
+        "banner": "Your account has content restrictions applied by an administrator. Some books may not be visible to you.",
+        "allowedTags": {
+          "title": "Allowed tags",
+          "description": "Only books that have at least one of these tags are shown to you."
+        },
+        "blockedTags": {
+          "title": "Blocked tags",
+          "description": "Books with any of these tags are hidden from you."
+        },
+        "allowedGenres": {
+          "title": "Allowed genres",
+          "description": "Only books that have at least one of these genres are shown to you."
+        },
+        "blockedGenres": {
+          "title": "Blocked genres",
+          "description": "Books with any of these genres are hidden from you."
+        }
+      }
+    },
+    "magicLinks": {
+      "title": "Magic Links",
+      "subtitle": "Create shareable login links for shared accounts.",
+      "createLink": "Create link",
+      "noSharedAccounts": "No shared accounts found. Create a shared account from the Users page first.",
+      "activeLinks": "Active links",
+      "inactiveLinks": "Inactive links",
+      "paused": "Paused",
+      "deletedUser": "Deleted user",
+      "expiredPrefix": "Expired ",
+      "never": "Never",
+      "noExpiry": "No expiry",
+      "expired": "Expired",
+      "expiresOn": "Expires {date}",
+      "revokedOn": "Revoked {date}",
+      "expiredOn": "Expired {date}",
+      "usesCount": "no uses | one use | {count} uses",
+      "copied": "Copied!",
+      "copyLink": "Copy link",
+      "pause": "Pause",
+      "resume": "Resume",
+      "revoke": "Revoke",
+      "revoking": "Revoking...",
+      "emptyState": "No magic links created yet. Click \"{action}\" to generate a shareable login URL.",
+      "columns": {
+        "label": "Label",
+        "account": "Account",
+        "createdBy": "Created by",
+        "expires": "Expires",
+        "uses": "Uses",
+        "lastUsed": "Last used",
+        "created": "Created",
+        "status": "Status",
+        "totalUses": "Total uses"
+      },
+      "createDialog": {
+        "title": "Create magic link",
+        "description": "Generate a shareable login URL for a shared account.",
+        "sharedAccount": "Shared account",
+        "selectAccount": "Select a shared account",
+        "label": "Label",
+        "labelPlaceholder": "e.g. Demo link for conference",
+        "expiresAt": "Expires at",
+        "optional": "(optional)",
+        "create": "Create",
+        "creating": "Creating..."
+      },
+      "revokeDialog": {
+        "title": "Revoke magic link?",
+        "description": "This will immediately invalidate the link and terminate all active sessions for the linked account."
+      },
+      "errors": {
+        "create": "Failed to create",
+        "copy": "Failed to copy magic link",
+        "update": "Failed to update magic link",
+        "revoke": "Failed to revoke"
+      }
+    },
+    "oidc": {
+      "title": "OIDC / SSO",
+      "subtitle": "Manage OpenID Connect providers for single sign-on.",
+      "providers": "Providers",
+      "addProvider": "Add Provider",
+      "editProvider": "Edit Provider",
+      "configureNew": "Configure a new OIDC provider.",
+      "editing": "Editing {slug}",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "empty": {
+        "title": "No providers yet",
+        "description": "Add an OIDC provider to enable single sign-on for your users."
+      },
+      "form": {
+        "status": "Status",
+        "enableProvider": "Enable provider",
+        "enableProviderHint": "Show this provider on the login page.",
+        "identity": "Provider Identity",
+        "slug": "Slug",
+        "slugHint": "Unique identifier (lowercase, hyphens). Cannot be changed later.",
+        "displayName": "Display Name",
+        "displayNameHint": "Shown on the login button.",
+        "iconUrl": "Icon URL",
+        "iconUrlHint": "Optional logo shown next to the login button.",
+        "iconPreviewAlt": "icon preview",
+        "connection": "Connection",
+        "issuerUri": "Issuer URI",
+        "issuerUriHint": "The provider's base URL.",
+        "test": "Test",
+        "testing": "Testing...",
+        "clientId": "Client ID",
+        "clientSecret": "Client Secret",
+        "clientSecretPlaceholder": "Leave blank to keep existing",
+        "scopes": "Scopes",
+        "claimMapping": "Claim Mapping",
+        "previewClaims": "Preview claims",
+        "redirecting": "Redirecting...",
+        "mappedClaims": "Mapped claims",
+        "rawClaims": "Raw claims",
+        "usernameClaim": "Username claim",
+        "nameClaim": "Name claim",
+        "emailClaim": "Email claim",
+        "groupsClaim": "Groups claim",
+        "autoProvisioning": "Auto-Provisioning",
+        "autoProvisionUsers": "Auto-provision users",
+        "autoProvisionUsersHint": "Create accounts on first OIDC login if user does not exist.",
+        "allowLocalLinking": "Allow local account linking",
+        "allowLocalLinkingHint": "Link OIDC identity to an existing local account by username match.",
+        "defaultPermissions": "Default permissions",
+        "defaultPermissionsHint": "Permissions granted to new users on first OIDC login.",
+        "createProvider": "Create Provider",
+        "saveChanges": "Save Changes",
+        "saving": "Saving...",
+        "deleteProvider": "Delete Provider",
+        "deleting": "Deleting..."
+      },
+      "test": {
+        "connected": "Connected - {issuer}",
+        "connectionFailed": "Connection failed",
+        "hide": "Hide",
+        "details": "Details",
+        "supported": "supported",
+        "notSupported": "not supported"
+      },
+      "groupMappings": {
+        "title": "Group Mappings",
+        "description": "Map OIDC group claims to BookOrbit permissions. Synced on every login.",
+        "noPermission": "No permission",
+        "empty": "No group mappings configured.",
+        "addMapping": "Add mapping",
+        "claimPlaceholder": "OIDC group claim (e.g. admins)",
+        "add": "Add",
+        "adding": "Adding..."
+      },
+      "toasts": {
+        "providerCreated": "Provider created",
+        "providerSaved": "Provider saved",
+        "providerDeleted": "Provider deleted",
+        "mappingAdded": "Group mapping added",
+        "mappingRemoved": "Group mapping removed"
+      },
+      "errors": {
+        "loadProvider": "Failed to load provider",
+        "createProvider": "Failed to create provider",
+        "save": "Failed to save",
+        "delete": "Failed to delete",
+        "deleteProvider": "Failed to delete provider",
+        "requestFailed": "Request failed",
+        "previewState": "Failed to generate preview state",
+        "startPreview": "Failed to start preview",
+        "addMapping": "Failed to add mapping",
+        "removeMapping": "Failed to remove group mapping"
+      }
+    },
+    "admin": {
+      "title": "Admin",
+      "subtitle": "Manage users and authentication settings.",
+      "system": {
+        "title": "System",
+        "subtitle": "File organization, ingestion, and maintenance settings."
+      },
+      "maintenance": {
+        "title": "Maintenance",
+        "subtitle": "Manage background tasks, system indices, and maintenance operations.",
+        "importGroup": "Import",
+        "recommendationsGroup": "Recommendations",
+        "achievementsGroup": "Achievements",
+        "updatesGroup": "Updates",
+        "importFromBooklore": "Import from Booklore",
+        "bookloreImportConfigured": "Booklore import configured",
+        "migrationRunning": "Migration running",
+        "migrationCompleted": "Migration completed",
+        "migrationFailed": "Migration failed",
+        "importDescription": "One-time import of books, metadata, and reading progress from a previous Booklore installation.",
+        "configuredDescription": "Source: {name}. No migration run yet - continue setup to run the import.",
+        "runningDescription": "Stage: {stage} - started {started}",
+        "completedDescription": "From {name} - completed {date}",
+        "migrationErrorGeneric": "An error occurred during migration.",
+        "stageInitializing": "initializing",
+        "recently": "recently",
+        "getStarted": "Get Started",
+        "continueSetup": "Continue Setup",
+        "viewDetails": "View Details",
+        "refreshRecommendationIndex": "Refresh recommendation index",
+        "refreshRecommendationHint": "Update the recommendations engine with your latest library changes. This process runs in the background.",
+        "booksQueuedForProcessing": "no books queued for processing | {count} book queued for processing | {count} books queued for processing",
+        "run": "Run",
+        "running": "Running...",
+        "backfillAchievements": "Backfill achievements",
+        "backfillAchievementsHint": "Re-evaluate achievements across all users.",
+        "backfillResult": "Processed {users} users; granted {awards} awards.",
+        "runBackfill": "Run Backfill",
+        "checkForUpdates": "Check for updates",
+        "checkForUpdatesHint": "Automatically check GitHub for a new release on startup and show an indicator in the sidebar when one is available.",
+        "updateChecksEnabled": "Update checks enabled",
+        "updateChecksDisabled": "Update checks disabled",
+        "updateSettingFailed": "Failed to update setting",
+        "booksQueuedForEmbedding": "no books queued for embedding | {count} book queued for embedding | {count} books queued for embedding",
+        "failed": "Failed",
+        "unknownError": "Unknown error",
+        "rebuildEmbeddingsFailed": "Failed to rebuild embeddings: {error}",
+        "achievementBackfillConfirm": "Run achievement backfill for all achievements across all users? This may take a while.",
+        "achievementBackfillComplete": "Achievement backfill complete: {count} awards granted",
+        "backfillRunFailed": "Failed to run backfill",
+        "achievementBackfillFailed": "Failed to run achievement backfill: {error}"
+      },
+      "migration": {
+        "title": "Migration",
+        "subtitle": "One-time Booklore import: connect source, map users, dry-run, start migration, and export a report.",
+        "progress": "Progress",
+        "stepSourceConnection": "Source Connection",
+        "stepUserPathMapping": "User & Path Mapping",
+        "stepDryRun": "Dry-Run",
+        "stepDryRunTitle": "Dry Run",
+        "stepRunMigration": "Run Migration",
+        "stepReport": "Report",
+        "stepReportTitle": "Migration Report",
+        "subtitleSource": "Configure the database connection to your source Booklore instance.",
+        "subtitleMappings": "Map source users to target users and translate file paths.",
+        "subtitleDryRun": "Preview what will be imported before running the live migration.",
+        "subtitleRun": "Start the live import and monitor its progress.",
+        "subtitleReport": "Review what was imported and export a detailed report.",
+        "continueToMappings": "Continue to Mappings",
+        "continueToDryRun": "Continue to Dry Run",
+        "continueToMigration": "Continue to Migration",
+        "viewReport": "View Report",
+        "badgeValidated": "Validated",
+        "badgeSaved": "Saved",
+        "badgeUpToDate": "Up to date",
+        "badgeCompleted": "Completed",
+        "badgeRunning": "Running",
+        "badgeFailed": "Failed",
+        "mediaPathRequired": "Required for migrating book covers.",
+        "mediaPathAbsolute": "Use an absolute path (for example: /books). Relative paths are not supported.",
+        "mediaPathConfigured": "Cover import path configured. Use Test Connection to verify access and Booklore images folder structure.",
+        "issueSaveSource": "Save source connection settings",
+        "issueValidateSource": "Validate source connection",
+        "issueSaveMappings": "Save user and path mappings",
+        "issueSavePathMappings": "Save path mappings to validate them",
+        "issueFreshDryRun": "Run a fresh dry-run",
+        "issueResolveDuplicates": "Resolve duplicate target book matches in the dry-run",
+        "issueWaitActiveRun": "Wait for active run to finish",
+        "sourceRecordId": "Source record ID #{id}",
+        "byAuthorWithId": "by {author} (ID: {id})",
+        "filePathWithId": "{path} (ID: {id})",
+        "bookloreSourceId": "Booklore source ID: {id}",
+        "libraryBookNum": "Library book #{id}",
+        "errorInitialize": "Failed to initialize migration settings",
+        "errorLoadSourceTypes": "Failed to load supported migration source types",
+        "errorLoadTargetUsers": "Failed to load target users",
+        "errorLoadLibraryFolders": "Failed to load target library folders",
+        "noSourceUsersReturned": "No source users were returned",
+        "userMappingSuggestionsLoaded": "User mapping suggestions loaded",
+        "errorLoadSuggestions": "Failed to load user mapping suggestions",
+        "requiredFields": "Host, user, database, and source name are required",
+        "connectionTestPassedWithWarnings": "Connection test passed with warnings",
+        "connectionTestPassedWithCount": "Connection test passed with {count} warning(s). First: {first}",
+        "connectionTestPassed": "Connection test passed",
+        "connectionOkMissingTables": "Connection ok, but {count} required table(s) are missing",
+        "cannotTestMediaPathActiveRun": "Cannot test media path while a run is active",
+        "mediaRootPathRequiredCover": "Media Root Path is required for cover import.",
+        "useAbsolutePath": "Use an absolute path (for example: /books).",
+        "mediaPathVerified": "Media path verified.",
+        "mediaPathValidReadable": "Media path is valid and readable",
+        "mediaPathValidationFailed": "Media path validation failed.",
+        "connectionFailedBeforeMediaPath": "Connection test failed before media path validation could complete.",
+        "cannotModifySourceActiveRun": "Cannot modify source while a run is active",
+        "sourceSavedValidatedWarnings": "Source saved and validated with {count} warning(s)",
+        "sourceSavedValidated": "Source saved and validated",
+        "errorSaveValidateSource": "Failed to save or validate source",
+        "cannotSaveMappingsActiveRun": "Cannot save mappings while a run is active",
+        "saveSourceFirst": "Save source first",
+        "mapAtLeastOneUser": "Map at least one source user to a target user",
+        "mapEveryUser": "Map every source user before saving",
+        "pathValidationFailedProfileSaved": "Path validation failed, but profile will still be saved",
+        "mappingsSaved": "Mappings saved",
+        "errorSaveMappings": "Failed to save mappings",
+        "cannotRunDryRunActiveRun": "Cannot run dry-run while a run is active",
+        "saveMappingsFirst": "Save mappings first",
+        "dryRunCompleted": "Dry-run completed: {matched} matched, {unresolved} unresolved",
+        "dryRunFailed": "Dry-run failed",
+        "selectSourceForAllGroups": "Select a source book for all {count} duplicate groups",
+        "duplicatesResolved": "Duplicate matches resolved",
+        "errorResolveDuplicates": "Failed to resolve duplicates",
+        "preflightNotReady": "Migration preflight not ready",
+        "runDryRunFirst": "Run dry-run first",
+        "runStarted": "Migration run started",
+        "errorStartMigration": "Failed to start migration",
+        "runCancelled": "Migration run cancelled",
+        "errorCancelMigration": "Failed to cancel migration",
+        "runRetried": "Migration run retried - resuming from last completed stage",
+        "errorRetryMigration": "Failed to retry migration",
+        "errorLoadRunProgress": "Failed to load run progress",
+        "startMigrationFirst": "Start migration first",
+        "reportRefreshed": "Run report refreshed",
+        "errorLoadReport": "Failed to load run report",
+        "reportExported": "Report exported as {format}",
+        "errorExportReport": "Failed to export migration report",
+        "reasonNoTitleAuthorMatch": "No matching book found by title or author",
+        "reasonNoFilePathMatch": "File path did not match any book in this library",
+        "reasonNoFileHashMatch": "File hash did not match any book in this library",
+        "reasonNoIsbnMatch": "ISBN did not match any book in this library",
+        "reasonInsufficientSourceData": "Not enough metadata to attempt matching",
+        "reasonAmbiguousIsbnMatch": "Multiple books matched the same ISBN",
+        "reasonAmbiguousFileHashMatch": "Multiple books matched the same file hash",
+        "reasonAmbiguousFilePathMatch": "Multiple books matched the same file path",
+        "reasonAmbiguousTitleAuthorMatch": "Multiple books matched the same title and author",
+        "reasonUnknown": "Could not determine reason",
+        "strategyIsbn": "Matched by ISBN",
+        "strategyFileHash": "Matched by file hash",
+        "strategyPathMapping": "Matched by mapped file path",
+        "strategyTitleAuthor": "Matched by title and author",
+        "strategyUnavailable": "Match strategy unavailable",
+        "userPreviewCounts": "{statuses} statuses, {progress} progress entries, {bookmarks} bookmarks, {annotations} annotations, {collections} collection entries",
+        "connErrorUnreachable": "Could not reach the database server. Check the host and port.",
+        "connErrorAuth": "Authentication failed. Check the username and password.",
+        "connErrorUnknownDatabase": "Database not found. Check the database name.",
+        "connErrorTimeout": "Connection timed out. Check host and firewall settings.",
+        "connErrorGeneric": "Connection test failed",
+        "sourceType": "Source Type",
+        "sourceName": "Source Name",
+        "host": "Host",
+        "port": "Port",
+        "user": "User",
+        "password": "Password",
+        "passwordSavedPlaceholder": "Saved - leave unchanged",
+        "passwordEmptyPlaceholder": "No password set",
+        "database": "Database",
+        "mediaRootPath": "Media Root Path",
+        "pathOk": "Path OK",
+        "pathIssue": "Path Issue",
+        "testPath": "Test Path",
+        "useTls": "Use TLS/SSL",
+        "testConnection": "Test Connection",
+        "saveAndValidate": "Save & Validate",
+        "sourceValidatedWithWarnings": "Source validated with warnings",
+        "lastValidationSnapshot": "Last validation snapshot",
+        "sourceVersion": "Source version: {version}",
+        "unknown": "Unknown",
+        "missingRequiredTables": "Missing required tables: {tables}",
+        "suggestionsAutoLoad": "User suggestions load automatically after source validation.",
+        "refresh": "Refresh",
+        "sourceUser": "Source User",
+        "targetUser": "Target User",
+        "noSourceUsersLoaded": "No source users loaded yet.",
+        "noActiveTargetUsers": "No active target users found. Create or re-enable a BookOrbit user before mapping.",
+        "pathPrefixMappings": "Path Prefix Mappings",
+        "addMapping": "Add Mapping",
+        "pathMappingsHelp1": "Path mappings translate source file paths to target paths so books can be matched by file location. For example, if your Booklore library stored files under",
+        "pathMappingsHelp2": "and the same files now live under",
+        "pathMappingsHelp3": ", add that mapping here. Books are also matched by ISBN, file hash, and title/author regardless of path mappings - path mapping is only one of four strategies and does not limit which source books are included in the migration.",
+        "noPrefixesFound": "No prefixes found - validate source first",
+        "selectSourcePrefix": "Select source prefix...",
+        "selectTargetFolder": "Select target folder...",
+        "remove": "Remove",
+        "pathValidation": "Path validation",
+        "pathValidationMapped": "{mapped} of {total} source books have a mapped path",
+        "pathValidationUnmatched": "{count} mapped paths not found on disk - those books will fall back to ISBN / title matching",
+        "pathValidationAllMatched": "All {count} mapped paths found on disk",
+        "saveMappings": "Save Mappings",
+        "runDryRun": "Run Dry-Run",
+        "matched": "Matched:",
+        "unresolved": "Unresolved:",
+        "duplicateMatches": "Duplicate matches:",
+        "unresolvedSummary": "Unresolved summary",
+        "resolveDuplicateMatches": "Resolve duplicate target matches",
+        "resolveDuplicateHint": "For each target book, choose one source book to keep. Recommended choices are preselected when there is a single strongest match.",
+        "remainingGroups": "Remaining groups:",
+        "ofCount": "of {count}",
+        "targetBookNum": "Target book #{id}",
+        "recommended": "Recommended",
+        "resolveDuplicatesButton": "Resolve {count} duplicate | Resolve {count} duplicate | Resolve {count} duplicates",
+        "preflightChecks": "Preflight checks",
+        "allChecksPassed": "All checks passed - ready to migrate",
+        "checkSourceValidated": "Source validated",
+        "checkSaveValidateSource": "Save and validate source connection",
+        "checkValidateSource": "Validate source connection",
+        "checkMappingsSaved": "Mappings saved",
+        "checkSaveMappings": "Save user and path mappings",
+        "checkPathMappingsValidated": "Path mappings validated",
+        "checkSavePathMappings": "Save path mappings to validate them",
+        "checkDryRunUpToDate": "Dry-run is up to date",
+        "checkFreshDryRun": "Run a fresh dry-run",
+        "startConfirmPrompt": "This will start the live migration. Are you sure?",
+        "confirmStart": "Confirm Start",
+        "startMigration": "Start Migration",
+        "cancelRun": "Cancel Run",
+        "refreshStatus": "Refresh Status",
+        "statusPollingStopped": "Status polling stopped due to an error.",
+        "retry": "Retry",
+        "stageLabel": "Stage: {stage}",
+        "stageInitializing": "initializing",
+        "endedLabel": "Ended {date}",
+        "stageCompleted": "Completed",
+        "stageInit": "Initializing",
+        "stageSharedOverlays": "Importing metadata",
+        "stageBookCovers": "Importing covers",
+        "stageUserState": "Importing user data",
+        "noRunYet": "No migration run yet. Complete the steps above to start.",
+        "runNum": "Run #{id}",
+        "notStarted": "Not started",
+        "reloadReport": "Reload Report",
+        "loadFullReport": "Load Full Report",
+        "exportJson": "Export JSON",
+        "exportCsv": "Export CSV",
+        "migrationFailed": "Migration failed",
+        "retryFromLastStage": "Retry from last completed stage",
+        "booksCard": "Books",
+        "metadataOverlaysApplied": "Metadata overlays applied",
+        "authorMappingsReplaced": "Author mappings replaced",
+        "narratorMappingsReplaced": "Narrator mappings replaced",
+        "genreMappingsReplaced": "Genre mappings replaced",
+        "tagMappingsReplaced": "Tag mappings replaced",
+        "coversImported": "Covers imported",
+        "coverImportSkipped": "Cover import was skipped - media root path is not configured on the source",
+        "couldNotMatch": "Could not match",
+        "userDataCard": "User Data",
+        "readingStatuses": "Reading statuses",
+        "readingProgressEntries": "Reading progress entries",
+        "audiobookProgressEntries": "Audiobook progress entries",
+        "bookmarksLabel": "Bookmarks",
+        "annotationsLabel": "Annotations",
+        "collectionEntries": "Collection entries",
+        "loadFullReportHint": "Click \"Load Full Report\" to include the dry-run match summary in the exported report.",
+        "completedNoIssues": "Migration completed with no unresolved books or failures.",
+        "matchedBooksHeading": "Matched books ({count})",
+        "matchedBooksHint": "These dry-run matches were used to decide which library books received imported data.",
+        "sourceBookFallback": "Source book {id}",
+        "libraryBookFallback": "Library book {id}",
+        "unresolvedBooksHeading": "Unresolved books ({count})",
+        "unresolvedBooksHint": "These books exist in the source but could not be matched to any book in your library.",
+        "mappedUsersHeading": "Mapped users ({count})",
+        "mappedUsersHint": "Per-user totals come from the dry-run preview cached with the migration plan.",
+        "coverImportsFailed": "{count} cover import(s) failed. Detailed failure rows are not stored.",
+        "backToSetup": "Back to Setup"
+      },
+      "libraries": {
+        "title": "Libraries",
+        "subtitle": "Manage your media libraries and trigger content scans.",
+        "scanAll": "Scan All",
+        "scanning": "Scanning...",
+        "addLibrary": "Add Library",
+        "scan": "Scan",
+        "editLibrary": "Edit library",
+        "refreshCovers": "Refresh covers",
+        "syncMetadataToFiles": "Sync metadata to files",
+        "deleteLibrary": "Delete library",
+        "bookCount": "no books | {count} book | {count} books",
+        "addedDate": "Added {date}",
+        "fileMode": "File mode",
+        "folderMode": "Folder mode",
+        "folderCount": "no folders | {count} folder | {count} folders",
+        "watching": "Watching",
+        "fileWrite": "File write",
+        "fileRename": "File rename",
+        "emptyTitle": "No libraries yet",
+        "emptyHint": "Add a library to start organizing your books.",
+        "addFirstLibrary": "Add your first library",
+        "deleteConfirmTitle": "Delete \"{name}\"?",
+        "deleteConfirmBody": "This will permanently remove all books, metadata, reading progress, bookmarks, and annotations in this library. This cannot be undone.",
+        "deleteConfirmTypeName": "Type the library name to confirm:",
+        "deleting": "Deleting...",
+        "deleteLibraryButton": "Delete Library",
+        "syncConfirmTitle": "Sync metadata to files?",
+        "syncConfirmBodyPrefix": "This will overwrite the metadata inside every supported file in",
+        "syncConfirmBodySuffix": "directly on disk. This cannot be undone.",
+        "syncFiles": "Sync files",
+        "metadataSynced": "Metadata synced to files for \"{name}\"",
+        "fileWriteNotEnabled": "Metadata file write is not enabled for this library. Enable it in the library settings.",
+        "fileSyncFailed": "File sync failed for \"{name}\"",
+        "scanStarted": "Scan started for \"{name}\"",
+        "scanStartFailed": "Failed to start scan for \"{name}\"",
+        "refreshCoversFailed": "Failed to refresh covers for \"{name}\"",
+        "scanStartedAll": "Scan started for all libraries",
+        "librariesFailedToStart": "no libraries failed to start | {count} library failed to start | {count} libraries failed to start",
+        "scansStartFailed": "Failed to start scans",
+        "libraryCreated": "Library \"{name}\" created",
+        "libraryUpdated": "Library \"{name}\" updated",
+        "libraryDeleted": "\"{name}\" deleted",
+        "deleteFailed": "Failed to delete library",
+        "scanningProgress": "Scanning {pct}% ({processed}/{total})",
+        "scanDone": "Done - {added} added, {updated} updated",
+        "scanFailedWithError": "Failed: {error}",
+        "scanFailed": "Scan failed",
+        "refreshingCovers": "Refreshing covers {pct}% ({processed}/{total})",
+        "coversRefreshed": "Covers refreshed ({count} processed)"
+      },
+      "authorEnrichment": {
+        "configuration": "Configuration",
+        "saving": "Saving...",
+        "running": "Running...",
+        "runEligibleShort": "Run eligible",
+        "runAllShort": "Run all",
+        "enableTitle": "Enable auto author enrichment",
+        "enableHint": "Automatically fetch author biographies and profile photos when books are added or updated.",
+        "updateStrategyTitle": "Update strategy",
+        "updateStrategyHint": "What to do when an author already has a biography or photo.",
+        "writeModeMissingOnly": "Only fill missing data (recommended)",
+        "writeModeAlwaysRefetch": "Always refresh existing data",
+        "triggerOnImportTitle": "Trigger on import",
+        "triggerOnImportHint": "Queue authors for enrichment when books are first added to a library.",
+        "eligibilityTitle": "Eligibility conditions",
+        "eligibilityHint": "An author is eligible if it matches any enabled condition.",
+        "neverEnrichedTitle": "Never enriched",
+        "neverEnrichedHint": "Enrich authors that have never had a successful enrichment.",
+        "missingBioTitle": "Missing bio",
+        "missingBioHint": "Enrich if the author has no biography.",
+        "missingPhotoTitle": "Missing photo",
+        "missingPhotoHint": "Enrich if the author has no profile photo.",
+        "runForEligibleAuthors": "Run for eligible authors",
+        "eligibleCount": "~{count} eligible",
+        "runForAllAuthors": "Run for all authors",
+        "saved": "Author enrichment settings saved",
+        "saveFailed": "Failed to save author enrichment settings",
+        "noEligibleAuthors": "No eligible authors found",
+        "noAuthorsToEnrich": "No authors to enrich",
+        "queueFailed": "Failed to queue author backfill"
+      },
+      "scoreWeights": {
+        "groupLabel": "Score Weights",
+        "assignHintPrefix": "Assign a weight to each field. Total weight:",
+        "areYouSure": "Are you sure?",
+        "resetToDefaultsButton": "Reset to defaults",
+        "recalculateAll": "Recalculate all",
+        "confirmReset": "Confirm reset",
+        "reset": "Reset",
+        "recalculate": "Recalculate",
+        "subtotal": "subtotal: {count}",
+        "savedRecalculating": "Score weights saved. Recalculating library scores...",
+        "saveFailed": "Failed to save score weights",
+        "recalcStarted": "Score recalculation started in the background",
+        "recalcFailed": "Recalculation failed",
+        "resetToDefaults": "Weights reset to defaults. Save to apply."
+      }
+    },
+    "common": {
+      "nav": {
+        "libraries": "Libraries",
+        "display": "Display",
+        "reader": "Reader",
+        "metadata": "Metadata",
+        "email": "Email",
+        "opds": "OPDS",
+        "kobo": "Kobo",
+        "koreader": "KOReader",
+        "hardcover": "Hardcover",
+        "admin": "Admin",
+        "system": "System",
+        "account": "Account"
+      }
+    },
+    "metadata": {
+      "title": "Metadata",
+      "noPermission": "You do not have permission to manage metadata settings.",
+      "fields": {
+        "title": "Title",
+        "subtitle": "Subtitle",
+        "description": "Description",
+        "cover": "Cover",
+        "authors": "Authors",
+        "publisher": "Publisher",
+        "publishedYear": "Published year",
+        "language": "Language",
+        "pageCount": "Page count",
+        "communityRating": "Community rating",
+        "seriesName": "Series name",
+        "seriesIndex": "Series index",
+        "genres": "Genres",
+        "narrators": "Narrators",
+        "duration": "Duration",
+        "abridged": "Abridged"
+      },
+      "mergeStrategy": {
+        "fillMissing": {
+          "label": "Fill missing",
+          "description": "Only write if field is currently empty"
+        },
+        "overwriteIfProvided": {
+          "label": "Overwrite if provided",
+          "description": "Write if provider returned a value"
+        },
+        "overwrite": {
+          "label": "Always overwrite",
+          "description": "Always replace existing value"
+        }
+      },
+      "autoFetch": {
+        "globalSettings": "Global Settings",
+        "perLibraryOverrides": "Per-Library Overrides",
+        "saving": "Saving...",
+        "running": "Running...",
+        "runNow": "Run now",
+        "runForEligible": "Run for eligible books",
+        "enable": {
+          "label": "Enable auto-fetch",
+          "hint": "Automatically fetch metadata for eligible books."
+        },
+        "triggerOnImport": {
+          "label": "Trigger on import",
+          "hint": "Queue eligible books when they are first added to a library."
+        },
+        "status": {
+          "inQueuePaused": "{count} in queue - paused",
+          "remaining": "{count} remaining",
+          "eligible": "~{count} eligible"
+        },
+        "trigger": {
+          "queued": "Queued {count} book | Queued {count} books",
+          "noneFound": "No eligible books found"
+        },
+        "lastRun": {
+          "justNow": "just now",
+          "minutesAgo": "{count}m ago",
+          "hoursAgo": "{count}h ago",
+          "yesterday": "yesterday",
+          "daysAgo": "{count} days ago",
+          "label": "Last run: {when}",
+          "labelQueued": "Last run: {when} - queued {count} books",
+          "labelNoneEligible": "Last run: {when} - no eligible books"
+        },
+        "conditions": {
+          "title": "Eligibility conditions",
+          "hint": "A book is eligible if it matches any enabled condition.",
+          "noneEnabled": "No conditions enabled",
+          "neverFetched": {
+            "label": "Never fetched",
+            "hint": "Fetch books that have never had a metadata fetch attempt.",
+            "summary": "Never fetched"
+          },
+          "scoreThreshold": {
+            "label": "Low metadata score",
+            "hint": "Fetch if the metadata score is below a threshold.",
+            "scoreBelow": "Score below",
+            "summary": "Score < {threshold}"
+          },
+          "missingFields": {
+            "label": "Missing fields",
+            "hint": "Fetch if any of the selected fields are empty.",
+            "summary": "Missing {count} field | Missing {count} fields"
+          }
+        },
+        "library": {
+          "inheritingGlobal": "Inheriting global defaults",
+          "inheritFromGlobal": "Inherit from global",
+          "usingGlobalDefaults": "Using global defaults.",
+          "saveOverride": "Save override"
+        }
+      },
+      "providers": {
+        "availableSources": "Available Sources",
+        "saveChanges": "Save Changes",
+        "test": "Test",
+        "testing": "Testing...",
+        "enabled": "Enabled",
+        "retryIn": "Retry in {duration}",
+        "runTestBeforeEnabling": "Run Test before enabling",
+        "hardcoverEnableHint": "Run Test with the current token to unlock the enable switch.",
+        "badge": {
+          "setupRequired": "Setup Required",
+          "throttled": "Throttled",
+          "ready": "Ready"
+        },
+        "fields": {
+          "apiKey": "API Key",
+          "region": "Region",
+          "cookie": "Cookie",
+          "coverResolution": "Cover Resolution",
+          "country": "Country",
+          "language": "Language",
+          "ttbKey": "TTB Key"
+        },
+        "helpers": {
+          "googleApiKey": "Google Books API key from Google Cloud."
+        },
+        "hints": {
+          "google": "Broad coverage from Google's book index. Google Books now requires an API key before this provider can be enabled.",
+          "amazon": "Session cookie is recommended. Paste cookie value only (no \"Cookie:\").",
+          "goodreads": "The largest reading community on the web. No setup required.",
+          "hardcover": "A modern alternative to Goodreads. Token from hardcover.app/account/api. \"Bearer \" prefix is optional.",
+          "openLibrary": "The Internet Archive's free book catalog. No setup required.",
+          "itunes": "Apple's digital book catalog. Choose whether to fetch high or standard resolution covers.",
+          "kobo": "Scrapes Kobo's public book pages. Country and language must match Kobo URL paths; bot protection can block requests.",
+          "audible": "Pulls audiobook metadata from Audible. No additional setup is required.",
+          "audnexus": "Community-driven audiobook metadata. No setup required.",
+          "comicvine": "Comic book metadata from ComicVine. A free API key is required from comicvine.gamespot.com.",
+          "ranobedb": "Japanese light novel metadata from RanobeDB. No setup required.",
+          "lubimyczytac": "Polish book catalog (lubimyczytac.pl). Scrapes public book pages. No setup required.",
+          "aladin": "Korean book metadata from Aladin (알라딘). A TTB Key from aladin.co.kr is required."
+        },
+        "blocked": {
+          "google": "Google Books requires an API key before it can be enabled",
+          "hardcover": "Hardcover requires an API key before it can be enabled",
+          "hardcoverTest": "Hardcover token must pass Test before it can be enabled",
+          "comicvine": "ComicVine requires an API key before it can be enabled",
+          "aladin": "Aladin requires a TTB Key before it can be enabled"
+        }
+      },
+      "fieldRules": {
+        "clearAllProviders": "Clear All Providers",
+        "clearAll": "Clear All",
+        "resetToDefault": "Reset to Default",
+        "reset": "Reset",
+        "dragProvidersHint": "Drag providers from here onto any field to add them",
+        "dragProviderHere": "drag a provider here",
+        "howItWorks": {
+          "title": "How Field Rules Work",
+          "priorityOrder": {
+            "title": "Priority Order",
+            "body": "Drag providers in the list to reorder them. The top-most provider that returns a result will be the primary source for that field."
+          },
+          "mergeStrategy": {
+            "title": "Merge Strategy",
+            "fillMissingTerm": "Fill missing:",
+            "fillMissingBody": "Only write if current value is empty.",
+            "overwriteTerm": "Overwrite:",
+            "overwriteBody": "Replace whenever a provider has data."
+          }
+        },
+        "libraryOverrides": {
+          "title": "Library Overrides",
+          "hint": "Expand a library to customize individual fields. Fields not overridden inherit global defaults."
+        },
+        "global": {
+          "title": "Global Defaults",
+          "hint": "Default rules applied to every library. Override per-library below.",
+          "saveDefaults": "Save Defaults",
+          "clearAllConfirm": "Remove all active providers from every field? This will be saved immediately and cannot be undone.",
+          "resetConfirm": "Reset all global field rules to system defaults? This will overwrite your current configuration."
+        },
+        "advanced": {
+          "title": "Advanced Fetch Behavior",
+          "combineGenres": {
+            "label": "Combine genres from all selected providers",
+            "hint": "Collect and deduplicate genres from every provider assigned to the Genres field, rather than stopping at the first result."
+          },
+          "storeProviderIds": {
+            "label": "Store provider IDs on books",
+            "hint": "When fetching metadata, save the returned provider IDs (ISBN, ASIN, Goodreads ID, etc.) on the book record for more accurate future lookups."
+          }
+        },
+        "library": {
+          "primary": "Primary:",
+          "overrideCount": "{count} Override | {count} Overrides",
+          "unsavedSuffix": "(unsaved)",
+          "unsavedChanges": "Unsaved changes",
+          "globalDefaults": "Global Defaults",
+          "overriding": "Overriding: {fields}",
+          "inheritingAll": "Inheriting all global metadata rules",
+          "subHint": "Fields not overridden inherit global defaults.",
+          "resetTooltip": "Remove all overrides and inherit global defaults",
+          "clearAllConfirm": "Remove all active providers from every field in \"{library}\"?",
+          "resetConfirm": "Reset \"{library}\" to global defaults? All library overrides will be removed."
+        },
+        "groups": {
+          "core": "Core",
+          "contributors": "Contributors",
+          "publication": "Publication",
+          "series": "Series",
+          "classification": "Classification",
+          "audiobook": "Audiobook"
+        },
+        "groupSummary": {
+          "base": "{fields} fields · {enabled} enabled",
+          "withOverrides": "{base} · {overrides} overrides"
+        },
+        "table": {
+          "field": "Field",
+          "activeProviders": "Active Providers (ordered by priority)",
+          "mergeStrategy": "Merge Strategy",
+          "status": "Status"
+        },
+        "field": {
+          "noProviders": "Enabled but has no providers",
+          "empty": "Empty",
+          "config": "Config",
+          "custom": "Custom",
+          "default": "Default",
+          "resetToDefault": "Reset to default"
+        },
+        "reservoir": {
+          "disabled": "{provider} - disabled",
+          "notConfigured": "{provider} - not configured",
+          "dragToAssign": "Drag to assign {provider} to a field"
+        },
+        "sheet": {
+          "subtitle": "Tap providers to assign, use arrows to reorder",
+          "enableField": "Enable this field during refresh",
+          "providers": "Providers",
+          "statusDisabled": "disabled",
+          "statusNotConfigured": "not configured",
+          "done": "Done"
+        }
+      },
+      "genreBlocklist": {
+        "heading": "Global Genre Exclusions",
+        "hint": "Exact genre values in this list are stripped from provider results before metadata is written.",
+        "saving": "Saving",
+        "genreValueLabel": "Genre value",
+        "addPlaceholder": "Add a genre value, for example Audiobook",
+        "duplicate": "This genre is already blocked.",
+        "add": "Add",
+        "filterPlaceholder": "Filter blocklist",
+        "entryCount": "{count} entry | {count} entries",
+        "filteredCount": "{shown} of {total}",
+        "noFilterMatch": "No blocked genres match the current filter.",
+        "emptyTitle": "No blocked genres",
+        "emptyHint": "Add exact values such as Audiobook or Adult to keep them out of fetched metadata.",
+        "removeLabel": "Remove {genre}"
+      },
+      "customFields": {
+        "label": "Label",
+        "labelPlaceholder": "e.g. Original Title",
+        "labelTooLong": "Label must be 255 characters or fewer",
+        "labelDuplicate": "A field with this label already exists",
+        "type": "Type",
+        "usage": "Used by {count} book | Used by {count} books",
+        "newField": {
+          "title": "New Field",
+          "hint": "Define a custom metadata field and choose which libraries use it."
+        },
+        "previewToggle": "Preview how this field appears when editing a book",
+        "untitledField": "Untitled field",
+        "addField": "Add field",
+        "fields": "Fields",
+        "fieldsHint": "Drag to reorder, edit labels, toggle libraries, or archive fields you no longer need.",
+        "searchPlaceholder": "Search fields",
+        "searchAriaLabel": "Search custom fields",
+        "emptyTitle": "No custom fields yet",
+        "emptyHint": "Use the form above to define your first custom metadata field.",
+        "noMatchTitle": "No fields match \"{query}\"",
+        "noMatchHint": "Try a different label, key, or type.",
+        "clearSearchToReorder": "Clear search to reorder",
+        "dragToReorder": "Drag to reorder",
+        "dragToReorderField": "Drag to reorder field",
+        "unsaved": "Unsaved",
+        "archive": "Archive",
+        "archivedFields": "Archived Fields",
+        "archivedSummary": "{count} archived field - restore or permanently delete. | {count} archived fields - restore or permanently delete.",
+        "archivedAt": "Archived {when}",
+        "restore": "Restore",
+        "deleteForever": "Delete forever",
+        "deleteDialog": {
+          "title": "Permanently delete field",
+          "bodyBefore": "This will permanently delete",
+          "bodyMiddle": "and remove its stored values from",
+          "bodyAfter": ". This cannot be undone.",
+          "confirmBefore": "Type",
+          "confirmAfter": "to confirm",
+          "confirmPlaceholder": "Type the field label to confirm"
+        },
+        "preview": "Preview",
+        "sampleValue": "Sample value",
+        "enabledLibraries": "Enabled Libraries",
+        "countOf": "{selected} of {total}",
+        "selectAll": "Select all",
+        "clear": "Clear",
+        "noLibraries": "No libraries available yet.",
+        "allLibraries": "All libraries"
+      }
+    },
+    "reader": {
+      "resetToDefaults": "Reset to defaults",
+      "all": {
+        "title": "Reader",
+        "subtitle": "Configure defaults for all reading modes in one place."
+      },
+      "general": {
+        "title": "Reading",
+        "subtitle": "General behavior that applies across all reader types.",
+        "storageLabel": "Where to save reader preferences",
+        "deviceOnly": "This device only",
+        "deviceOnlyHint": "Preferences stay in your browser. Best if you always read on this device, or want different settings per device.",
+        "myAccount": "My account",
+        "myAccountHint": "Preferences are saved to your account. Best if you log in from multiple devices and want a consistent experience everywhere.",
+        "active": "Active",
+        "notAvailable": "Not available",
+        "demoCannotChangeStorage": "Demo-restricted account cannot change reader storage mode",
+        "preferencesSynced": "Preferences will now be synced",
+        "preferencesLocal": "Preferences will stay on this device",
+        "storageUpdateFailed": "Failed to update storage mode",
+        "storageUpdateError": "An error occurred while updating storage mode"
+      },
+      "ebook": {
+        "title": "eBook Reader",
+        "subtitle": "Default settings applied when opening EPUB, MOBI, FB2, and TXT files.",
+        "newBooks": "New Books",
+        "applySettings": "Apply my settings to new books",
+        "applySettingsHint": "When off, new books open with the publisher's own fonts and layout. Your settings only apply once you change something in-reader.",
+        "layout": "Layout",
+        "readingFlow": "Reading flow",
+        "readingFlowHint": "Paginated flips pages; scrolled flows continuously",
+        "paginated": "Paginated",
+        "scrolled": "Scrolled",
+        "fixedLayoutSpread": "Fixed-layout page spreads",
+        "fixedLayoutSpreadHint": "Default for manga, comics, and image-based EPUBs",
+        "bookDefault": "Book default",
+        "singlePage": "Single page",
+        "columns": "Columns",
+        "columnsHint": "Number of text columns per page",
+        "theme": "Theme",
+        "darkMode": "Dark mode",
+        "darkModeHint": "Use the dark variant of the selected theme",
+        "typography": "Typography",
+        "font": "Font",
+        "fontHint": "Typeface used for body text",
+        "builtInFonts": "Built-in fonts",
+        "yourFonts": "Your Fonts",
+        "fontSize": "Font size",
+        "fontSizeHint": "Base text size in pixels",
+        "lineHeight": "Line height",
+        "lineHeightHint": "Vertical spacing between lines",
+        "justify": "Justify text",
+        "justifyHint": "Align text to both margins",
+        "hyphenation": "Hyphenation",
+        "hyphenationHint": "Automatically break long words with hyphens",
+        "advanced": "Advanced",
+        "maxContentWidth": "Max content width",
+        "maxContentWidthHint": "Maximum width of the text area in pixels",
+        "columnGap": "Column gap",
+        "columnGapHint": "Horizontal padding on each side of the text area"
+      },
+      "pdf": {
+        "title": "PDF Reader",
+        "subtitle": "Default settings applied when opening PDF files.",
+        "layout": "Layout",
+        "scrollMode": "Scroll mode",
+        "scrollModeHint": "Page flips one at a time; continuous scrolls through all pages",
+        "page": "Page",
+        "scrolled": "Scrolled",
+        "pageSpread": "Page spread",
+        "pageSpreadHint": "Which page number starts on the right in two-page view",
+        "spreadNone": "None",
+        "spreadOdd": "Odd",
+        "spreadEven": "Even",
+        "zoom": "Zoom",
+        "defaultFit": "Default fit",
+        "defaultFitHint": "How pages are scaled when a PDF is opened",
+        "fitPage": "Fit Page",
+        "fitWidth": "Fit Width",
+        "custom": "Custom",
+        "zoomLevel": "Zoom level",
+        "zoomLevelHint": "Scale factor for custom zoom mode"
+      },
+      "comics": {
+        "title": "Comics Reader",
+        "subtitle": "Default settings applied when opening CBZ, CBR, and CB7 files.",
+        "view": "View",
+        "readingMode": "Reading mode",
+        "readingModeHint": "How pages are navigated - use \"Infinite (no gaps)\" for webtoons",
+        "paginated": "Paginated",
+        "infiniteSpaced": "Infinite (spaced)",
+        "infiniteNoGaps": "Infinite (no gaps)",
+        "pageView": "Page view",
+        "pageViewHint": "Show one or two pages side by side",
+        "single": "Single",
+        "twoPage": "Two-page",
+        "fitMode": "Fit mode",
+        "fitModeHint": "How pages are scaled to fit the screen",
+        "fitPage": "Page",
+        "fitWidth": "Width",
+        "fitHeight": "Height",
+        "fitActual": "Actual",
+        "readingDirection": "Reading direction",
+        "readingDirectionHint": "Left-to-right for western comics; right-to-left for manga",
+        "ltr": "L to R",
+        "rtl": "R to L",
+        "spreadAlignment": "Spread alignment",
+        "spreadAlignmentHint": "Shift pairing by one page after the cover for off-by-one scans",
+        "alignmentNormal": "Normal",
+        "alignmentShifted": "Shifted",
+        "widePageHandling": "Wide-page handling",
+        "widePageHandlingHint": "Auto shows wide scans alone in two-page paginated mode",
+        "widePageAuto": "Auto",
+        "widePageDisable": "Disable",
+        "forceTwoPage": "Force two-page on small screens",
+        "forceTwoPageHint": "Bypass mobile auto-fallback when paginated two-page mode is selected",
+        "off": "Off",
+        "on": "On",
+        "display": "Display",
+        "backgroundColor": "Background color",
+        "backgroundColorHint": "Canvas color behind pages",
+        "bgBlack": "Black",
+        "bgGray": "Gray",
+        "bgWhite": "White"
+      },
+      "audio": {
+        "title": "Audiobook Player",
+        "subtitle": "Default settings applied when playing M4B, MP3, and other audio formats.",
+        "playback": "Playback",
+        "playbackSpeed": "Default playback speed",
+        "playbackSpeedHint": "Speed multiplier applied when opening a new audiobook",
+        "volume": "Default volume",
+        "volumeHint": "Initial volume level (0 to 100%)",
+        "skipControls": "Skip controls",
+        "skipBack": "Skip back duration",
+        "skipBackHint": "Seconds rewound on skip-back press",
+        "skipForward": "Skip forward duration",
+        "skipForwardHint": "Seconds advanced on skip-forward press"
+      },
+      "fonts": {
+        "title": "Fonts",
+        "subtitle": "Upload custom fonts for use in the eBook reader.",
+        "uploadFonts": "Upload Fonts",
+        "notAvailableDemo": "Not available for demo accounts",
+        "uploading": "Uploading...",
+        "dropFilesHere": "Drop files here",
+        "dragFontsPrefix": "Drag font files here, or",
+        "browse": "browse",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - max 10 MB each",
+        "yourFonts": "Your Fonts",
+        "fontsUsed": "{count} / {max} used",
+        "noFontsYet": "No fonts uploaded yet",
+        "noFontsHint": "Drag a font file above to get started.",
+        "fileCount": "no files | {count} file | {count} files",
+        "pangram": "The quick brown fox jumps over the lazy dog",
+        "renameFamily": "Rename family",
+        "deleteFamily": "Delete family",
+        "editVariant": "Edit weight/style",
+        "deleteVariant": "Delete variant",
+        "styleNormal": "Normal",
+        "styleItalic": "Italic",
+        "weightThin": "Thin",
+        "weightExtraLight": "Extra Light",
+        "weightLight": "Light",
+        "weightRegular": "Regular",
+        "weightMedium": "Medium",
+        "weightSemiBold": "Semi Bold",
+        "weightBold": "Bold",
+        "weightExtraBold": "Extra Bold",
+        "weightBlack": "Black",
+        "renameFamilyFailed": "Failed to rename font family",
+        "renamedTo": "Renamed to \"{name}\"",
+        "updateVariantFailed": "Failed to update font variant",
+        "deleteFontFailed": "Failed to delete font",
+        "deleteFamilyFailed": "Failed to delete font family",
+        "demoCannotManage": "Demo-restricted account cannot manage fonts",
+        "fileAdded": "\"{name}\" added",
+        "uploadFailed": "Upload failed"
+      },
+      "bookDock": {
+        "title": "Book Dock",
+        "subtitle": "Configure how files are processed when they enter Book Dock.",
+        "dropFolder": "Drop folder",
+        "containerPath": "Container path",
+        "containerPathHint": "Copy or move book files into this folder and they will be automatically picked up and processed by Book Dock. Subdirectories are supported.",
+        "changePathPrefix": "To change this path, set",
+        "changePathMiddle": "in your",
+        "changePathSuffix": "file.",
+        "metadata": "Metadata",
+        "autoFetch": "Auto-fetch metadata from providers",
+        "autoFetchHint": "Automatically fetch metadata from configured providers (Google Books, iTunes, Open Library, etc.) after a file is added to Book Dock.",
+        "autoFinalize": "Auto-finalize",
+        "enableAutoFinalize": "Enable auto-finalize",
+        "enableAutoFinalizeHint": "Files with a metadata confidence score at or above the threshold will be finalized automatically.",
+        "confidenceThreshold": "Confidence threshold: {value}%",
+        "thresholdIgnored": "(ignored in Embedded only mode)",
+        "destinationLibrary": "Destination library",
+        "selectLibrary": "Select a library...",
+        "metadataMode": "Metadata mode",
+        "metadataModeSafeMerge": "Safe merge (recommended)",
+        "metadataModeFetchedOnly": "Fetched only",
+        "metadataModeEmbeddedOnly": "Embedded only",
+        "destinationFolder": "Destination folder",
+        "selectFolder": "Select a folder...",
+        "saveSettingFailed": "Failed to save setting",
+        "updateSettingFailed": "Failed to update setting",
+        "autoFetchEnabled": "Auto-fetch enabled",
+        "autoFetchDisabled": "Auto-fetch disabled",
+        "autoFinalizeEnabled": "Auto-finalize enabled",
+        "autoFinalizeDisabled": "Auto-finalize disabled",
+        "destinationLibraryUpdated": "Destination library updated",
+        "destinationFolderUpdated": "Destination folder updated",
+        "confidenceThresholdUpdated": "Confidence threshold updated",
+        "metadataModeUpdated": "Metadata mode updated"
+      },
+      "fileNaming": {
+        "title": "File Naming",
+        "subtitle": "Control how files are organized on disk when uploaded and how they are named when downloaded using placeholder tokens.",
+        "copy": "Copy",
+        "previewLabel": "Preview:",
+        "fileAsBookPreview": "File as Book preview",
+        "folderAsBookPreview": "Folder as Book preview",
+        "downloadPreview": "Download preview",
+        "globalDefaults": "Global Defaults",
+        "crossPlatform": "Cross-platform path sanitization",
+        "crossPlatformHint": "Make generated file and folder names safe on Windows by replacing invalid characters and reserved names, and removing trailing dots and spaces. Disable only for Linux-only setups that intentionally keep those characters.",
+        "fileAsBookDefault": "File as Book default",
+        "fileAsBookDefaultHint": "Upload pattern for libraries using File as Book mode. Each file is one book.",
+        "folderAsBookDefault": "Folder as Book default",
+        "folderAsBookDefaultHint": "Upload pattern for libraries using Folder as Book mode. Each book must be in its own folder.",
+        "downloadPattern": "Download Pattern",
+        "downloadPatternHint": "Suggested filenames for single-file downloads and files inside export ZIPs.",
+        "libraryOverrides": "Library Overrides",
+        "noLibraries": "No libraries configured. Create one in Library settings to set custom naming patterns.",
+        "badgeCustom": "Custom",
+        "badgeDefault": "Default",
+        "orgFolderAsBook": "Folder as Book",
+        "orgFileAsBook": "File as Book",
+        "resetToDefault": "Reset to default",
+        "patternReference": "Pattern Reference",
+        "placeholderReference": "Placeholder Reference",
+        "placeholderReferenceHint": "- guide for creating custom naming patterns",
+        "tokens": "Tokens",
+        "tokensHint": "Copy placeholders quickly",
+        "clickTokenHint": "Click any token to copy it to your clipboard.",
+        "copyValue": "Copy {value}",
+        "modifiers": "Modifiers",
+        "modifiersHint": "Transform token values",
+        "modifiersExplain": "Append a modifier inside a token to transform its value:",
+        "modFirst": "First value only",
+        "modSort": "Last, First format",
+        "modInitial": "First letter only",
+        "folderOnlyPrefix": "End a pattern with",
+        "folderOnlySuffix": "to specify a folder only. The original filename will be preserved inside it.",
+        "conditionalLogic": "Conditional Logic",
+        "conditionalLogicHint": "Optional segments and fallbacks",
+        "conditionalPart1": "Wrap in",
+        "conditionalPart2": "to skip a segment when its token is empty. Use",
+        "conditionalPart3": "for a default value.",
+        "examples": "Examples",
+        "patternExamples": "Pattern Examples",
+        "patternExamplesHint": "Ready-made patterns for common library styles",
+        "copyPatternTooltip": "Copy pattern to clipboard",
+        "exCalibre": "Calibre-style default",
+        "exSeriesReader": "Series reader",
+        "exCleanDownload": "Clean download filename",
+        "exAlphabetical": "Alphabetical grouping with series",
+        "exSeriesFallback": "Series or Standalone fallback",
+        "exOptionalSubtitle": "Download with optional subtitle",
+        "exMultilingual": "Multilingual library",
+        "exPublisher": "Publisher-organized",
+        "exStacked": "Stacked optional folders",
+        "exFolderDrop": "Folder-drop with sort name",
+        "caseWithYear": "with year",
+        "caseNoYear": "no year",
+        "caseInSeries": "in series",
+        "caseStandalone": "standalone",
+        "caseNoSeries": "no series",
+        "caseFull": "full",
+        "caseMinimal": "minimal",
+        "caseWithLanguage": "with language",
+        "caseNoLanguage": "no language",
+        "caseWithPublisher": "with publisher",
+        "caseNoPublisher": "no publisher",
+        "caseAllSet": "all set",
+        "copiedToClipboard": "{value} copied to clipboard",
+        "copyTokenFailed": "Failed to copy token",
+        "patternCopied": "Pattern copied to clipboard",
+        "copyPatternFailed": "Failed to copy pattern",
+        "labelCopied": "{label} copied to clipboard",
+        "copyLabelFailed": "Failed to copy {label}"
+      },
+      "kobo": {
+        "title": "Kobo Sync",
+        "subtitle": "Pair your Kobo device to sync your library.",
+        "copy": "Copy",
+        "never": "Never",
+        "justNow": "Just now",
+        "minutesAgo": "{count}m ago",
+        "hoursAgo": "{count}h ago",
+        "daysAgo": "{count}d ago",
+        "loadFailed": "Failed to load",
+        "devicePaired": "Device paired successfully",
+        "devicePairedHint": "You're ready to set up your Kobo. Follow the instructions below.",
+        "syncUrl": "Sync URL",
+        "urlNotShownAgain": "This URL will not be shown again. Keep it private.",
+        "registeredDevices": "Registered Devices",
+        "addDevice": "Add device",
+        "deviceName": "Device name",
+        "deviceNamePlaceholder": "e.g. My Kobo Libra",
+        "creating": "Creating...",
+        "createDevice": "Create device",
+        "createDeviceFailed": "Failed to create device",
+        "deviceRegistered": "Device \"{name}\" registered",
+        "noDevicesYet": "No devices yet",
+        "noDevicesHint": "Add a device to start syncing your books to your Kobo.",
+        "lastSync": "Last sync: {time}",
+        "renameDevice": "Rename device",
+        "revokeAccess": "Revoke access",
+        "deviceRenamed": "Device renamed",
+        "renameDeviceFailed": "Failed to rename device",
+        "revokeConfirm": "Revoke access for \"{name}\"? The device will not be able to sync until re-paired.",
+        "accessRevoked": "Access revoked for \"{name}\"",
+        "revokeFailed": "Failed to revoke access",
+        "syncUrlCopied": "Sync URL copied to clipboard",
+        "syncUrlCopyFailed": "Failed to copy sync URL",
+        "syncPreferences": "Sync Preferences",
+        "twoWaySync": "Two-way progress sync",
+        "twoWaySyncHint": "Sync reading position between BookOrbit and Kobo. Requires KEPUB delivery for precise locations and reliable page restore.",
+        "syncHighlights": "Sync BookOrbit highlights to Kobo",
+        "syncHighlightsHint": "Send highlights made in BookOrbit or KOReader to your Kobo. Kobo highlights are imported into BookOrbit even when this is off. Linked annotations sync edits and deletes both ways. Requires KEPUB delivery; the book on Kobo must be the KEPUB downloaded from BookOrbit.",
+        "convertKepub": "Convert to KEPUB",
+        "convertKepubHint": "Send eligible EPUBs as KEPUB. This stays on when progress sync or BookOrbit-to-Kobo highlights are enabled. On the next Kobo sync, affected books are offered again as KEPUB downloads; remove any old EPUB copy if Kobo keeps opening it.",
+        "forceHyphenation": "Force hyphenation",
+        "forceHyphenationHint": "Ensures consistent text justification. This will regenerate cached KEPUBs.",
+        "progressThresholds": "Progress Thresholds",
+        "progressThresholdsHint": "Define when Kobo reading progress updates your library status.",
+        "markAsReading": "Mark as Reading",
+        "markAsReadingHint": "Minimum percentage to move a book to \"Reading\".",
+        "markAsFinished": "Mark as Finished",
+        "markAsFinishedHint": "Percentage threshold to mark a book as \"Finished\".",
+        "kepubLimit": "KEPUB conversion limit",
+        "kepubLimitHint": "Books above this limit are sent as regular EPUBs, so BookOrbit will not sync their reader position back to Kobo.",
+        "changesMustBeSaved": "Changes must be saved to take effect.",
+        "saving": "Saving...",
+        "saveSyncSettings": "Save Sync Settings",
+        "thresholdOrderError": "Reading threshold must be less than finished threshold",
+        "saveSettingsFailed": "Failed to save settings",
+        "settingsSaved": "Kobo sync settings saved",
+        "saveFailed": "Failed to save"
+      },
+      "koreader": {
+        "title": "KOReader Sync",
+        "subtitle": "Browse your BookOrbit catalog in KOReader and sync progress, reading activity, highlights, and annotation changes.",
+        "loadingSettings": "Loading KOReader settings...",
+        "loadFailed": "Failed to load KOReader settings",
+        "never": "Never",
+        "justNow": "Just now",
+        "minutesAgo": "{count}m ago",
+        "hoursAgo": "{count}h ago",
+        "daysAgo": "{count}d ago",
+        "unknown": "Unknown",
+        "updateAvailable": "Update available",
+        "upToDate": "Up to date",
+        "versionUnknown": "Version unknown",
+        "latestPlugin": "Latest plugin: v{version}",
+        "latestPluginUnavailable": "Latest plugin unavailable",
+        "notConfigured": "KOReader sync is not configured",
+        "notConfiguredHint": "Create one set of sync credentials, then use them with the BookOrbit KOReader plugin for browsing, downloads, progress, reading events, highlights, and deletes.",
+        "createCredentials": "Create credentials",
+        "createFormTitle": "Create KOReader Sync Credentials",
+        "createFormHint": "These credentials authenticate your KOReader devices with BookOrbit.",
+        "username": "Username",
+        "usernamePlaceholder": "e.g. myreader",
+        "password": "Password",
+        "passwordPlaceholder": "Min 6 characters",
+        "creating": "Creating...",
+        "create": "Create",
+        "credentialsCreated": "KOReader sync credentials created",
+        "createCredentialsFailed": "Failed to create credentials",
+        "status": "KOReader Status",
+        "refresh": "Refresh",
+        "progressSync": "Progress sync",
+        "progressSyncHint": "Allow KOReader devices to sync progress, reading activity, highlights, and annotation deletes with BookOrbit.",
+        "lastSync": "Last sync",
+        "syncedBooks": "Synced books",
+        "bookCount": "no books | {count} book | {count} books",
+        "devices": "Devices",
+        "deviceCount": "no devices | {count} device | {count} devices",
+        "credentialsCreatedLabel": "Credentials created",
+        "setup": "Setup",
+        "pluginServerUrl": "Plugin server URL",
+        "copied": "Copied",
+        "copyUrl": "Copy URL",
+        "preconfiguredPlugin": "Preconfigured BookOrbit plugin",
+        "preconfiguredPluginHintPrefix": "Download a zip with the server URL and your sync login already configured. The plugin includes catalog browsing and sync. Copy the folder to",
+        "preconfiguredPluginHintSuffix": "and restart KOReader.",
+        "latestPluginNote": "{label}. Device updates run from the BookOrbit menu in KOReader.",
+        "preparing": "Preparing...",
+        "downloadPlugin": "Download Plugin",
+        "noDevicesSynced": "No devices have synced yet",
+        "noDevicesSyncedHint": "Install the BookOrbit plugin for full sync, or configure KOReader's stock progress sync for progress-only updates.",
+        "lastSyncLabel": "Last sync:",
+        "lastBookLabel": "Last book:",
+        "noneYet": "None yet",
+        "pluginActivity": "Plugin Activity",
+        "noPluginActivity": "No plugin activity has been reported yet.",
+        "lastFullSync": "Last full sync: {time}",
+        "latestPluginSuffix": "- latest plugin v{version}",
+        "matchedBooks": "Matched books",
+        "readingEvents": "Reading events",
+        "highlights": "Highlights",
+        "syncedTotals": "Synced totals",
+        "trashedHighlights": "Trashed highlights",
+        "pendingDeletes": "no deleted highlights awaiting KOReader plugin acknowledgement. | {count} deleted highlight awaiting KOReader plugin acknowledgement. | {count} deleted highlights awaiting KOReader plugin acknowledgement.",
+        "failedPositions": "no highlight positions need attention. | {count} highlight position needs attention. | {count} highlight positions need attention.",
+        "setupGuide": "Setup Guide",
+        "setupSteps": "KOReader setup steps",
+        "setupStepsHint": "Use the BookOrbit plugin for catalog browsing, downloads, progress, reading events, and highlights. Use the stock plugin for progress only.",
+        "pluginGuideTitle": "BookOrbit plugin",
+        "pluginStep1": "Download the preconfigured plugin above.",
+        "pluginStep2Prefix": "Unzip it and copy",
+        "pluginStep2Middle": "to",
+        "pluginStep2Suffix": "on your device.",
+        "pluginStep3": "Restart KOReader. The server and login are configured automatically.",
+        "pluginStep4Prefix": "Open",
+        "pluginStep4Suffix": "to search, download, and link books to sync.",
+        "stockGuideTitle": "Stock progress sync plugin",
+        "stockStep1Prefix": "On your KOReader device, go to",
+        "stockStep1Suffix": ".",
+        "stockStep2": "Set the custom sync server to the URL shown above.",
+        "stockStep3": "Enter the username and password you created, then tap Login.",
+        "locationNote": "BookOrbit saves KOReader-compatible EPUB locations from the web reader. Restore should land close to the same position, though exact line placement can vary by reader and EPUB layout.",
+        "dangerZone": "Danger Zone",
+        "deleteCredentials": "Delete KOReader credentials",
+        "deleteCredentialsHint": "Remove sync credentials and disconnect all devices. Progress data will be retained.",
+        "credentialsDeleted": "KOReader credentials deleted",
+        "deleteCredentialsFailed": "Failed to delete credentials",
+        "deleteConfirmTitle": "Delete KOReader credentials?",
+        "deleteConfirmBody": "This will remove your sync credentials and disconnect all KOReader devices. Existing progress data will be kept.",
+        "syncEnabled": "KOReader sync enabled",
+        "syncDisabled": "KOReader sync disabled",
+        "toggleSyncFailed": "Failed to toggle sync",
+        "syncUrlCopied": "Sync URL copied to clipboard",
+        "syncUrlCopyFailed": "Failed to copy sync URL",
+        "statusRefreshed": "Sync status refreshed",
+        "refreshFailed": "Failed to refresh",
+        "pluginDownloaded": "Plugin downloaded. Copy bookorbit.koplugin from the zip to koreader/plugins/ on your device.",
+        "pluginDownloadFailed": "Failed to download the plugin"
+      },
+      "opds": {
+        "title": "OPDS",
+        "subtitle": "Connect OPDS-compatible reading apps like KOReader or Thorium Reader to your library.",
+        "copy": "Copy",
+        "loadFailed": "Failed to load",
+        "server": "Server",
+        "catalogServer": "OPDS Catalog Server",
+        "catalogServerHint": "Allow OPDS clients to browse and download books",
+        "endpoint": "Endpoint",
+        "accounts": "OPDS Accounts",
+        "add": "Add",
+        "addAccount": "Add account",
+        "username": "Username",
+        "usernameLabel": "Username",
+        "usernamePlaceholder": "e.g. koreader",
+        "password": "Password",
+        "passwordPlaceholder": "Min 8 characters",
+        "defaultSort": "Default Sort",
+        "sortLabel": "Sort",
+        "creating": "Creating...",
+        "create": "Create",
+        "noAccounts": "No OPDS accounts yet. Create one to start using OPDS clients.",
+        "hideDetails": "Hide details",
+        "showDetails": "Show details",
+        "copyUsername": "Copy username",
+        "notes": "OPDS Notes",
+        "notesBody": "Use OPDS accounts in reader apps. Keep credentials private and rotate passwords if shared accidentally.",
+        "deleteConfirmTitle": "Delete OPDS account?",
+        "deleteConfirmBody": "Delete \"{username}\". This action cannot be undone.",
+        "sortRecent": "Recently Added",
+        "sortTitleAsc": "Title (A-Z)",
+        "sortTitleDesc": "Title (Z-A)",
+        "sortAuthorAsc": "Author (A-Z)",
+        "sortAuthorDesc": "Author (Z-A)",
+        "sortSeriesAsc": "Series (A-Z)",
+        "sortSeriesDesc": "Series (Z-A)",
+        "serverEnabled": "OPDS server enabled",
+        "serverDisabled": "OPDS server disabled",
+        "updateSettingsFailed": "Failed to update OPDS settings",
+        "urlCopied": "OPDS URL copied to clipboard",
+        "urlCopyFailed": "Failed to copy OPDS URL",
+        "createUserFailed": "Failed to create OPDS user",
+        "userCreated": "OPDS user \"{username}\" created",
+        "sortOrderUpdated": "Sort order updated for \"{username}\"",
+        "updateSortFailed": "Failed to update sort order",
+        "userDeleted": "OPDS user \"{username}\" deleted",
+        "deleteUserFailed": "Failed to delete OPDS user",
+        "labelCopied": "{label} copied",
+        "copyLabelFailed": "Failed to copy {label}"
       }
     }
+  },
+  "achievements": {
+    "title": "Achievements",
+    "tiersCount": "{earned} / {total} tiers",
+    "loadFailed": "Failed to load achievements",
+    "tryAgain": "Try again",
+    "noMatchFilter": "No achievements match this filter",
+    "secretAchievement": "Secret Achievement",
+    "earnedOn": "Earned {date}",
+    "whileReading": "While reading “{title}”",
+    "tierProgress": "Tier {earned} of {total}",
+    "progressToNext": "{current} / {threshold} to {name}",
+    "rarity": {
+      "common": "Common",
+      "rare": "Rare",
+      "epic": "Epic",
+      "legendary": "Legendary"
+    },
+    "filter": {
+      "all": "All",
+      "earned": "Earned ({count})",
+      "inProgress": "In Progress ({count})",
+      "locked": "Locked ({count})"
+    }
+  },
+  "adminFeature": {
+    "resetLink": {
+      "title": "Password Reset Link",
+      "description": "Share this link with the user. It expires in 15 minutes.",
+      "copy": "Copy",
+      "copied": "Copied!",
+      "copyFailed": "Copy failed",
+      "notShownAgain": "This link will not be shown again."
+    },
+    "userForm": {
+      "editUser": "Edit User",
+      "createUser": "Create User",
+      "createSharedAccount": "Create Shared Account",
+      "sharedBadge": "Shared",
+      "active": "Active",
+      "suspended": "Suspended",
+      "tabs": {
+        "general": "general",
+        "access": "access",
+        "restrictions": "restrictions"
+      },
+      "sharedAccount": "Shared account",
+      "sharedAccountHint": "No password. Access is granted via magic links only.",
+      "sharedAccountManageHint": "Manage login links from Settings - Magic Links.",
+      "username": "Username",
+      "fullName": "Full name",
+      "email": "Email",
+      "optional": "(optional)",
+      "libraryAccess": "Library Access",
+      "noLibrariesSelected": "No libraries selected. User cannot view any books.",
+      "permissions": "Permissions",
+      "presetStandard": "Standard",
+      "presetAdmin": "Admin",
+      "presetClearAll": "Clear All",
+      "permissionGroups": {
+        "content": "Content",
+        "devicesAccess": "Devices & Access",
+        "email": "Email",
+        "administration": "Administration",
+        "restrictions": "Restrictions"
+      },
+      "superuserTarget": "Superuser Target",
+      "superuserTargetHint": "Content restrictions cannot be applied to superusers.",
+      "noRestrictions": "No content restrictions",
+      "noRestrictionsHint": "This user has full access to all books in their assigned libraries.",
+      "addRestrictions": "+ Add Content Restrictions",
+      "contentRestrictions": "Content Restrictions",
+      "remove": "Remove",
+      "includeTags": "Include tags",
+      "includeTagsHint": "(show only books with these tags)",
+      "excludeTags": "Exclude tags",
+      "excludeTagsHint": "(hide books with these tags)",
+      "includeGenres": "Include genres",
+      "includeGenresHint": "(show only books with these genres)",
+      "excludeGenres": "Exclude genres",
+      "excludeGenresHint": "(hide books with these genres)",
+      "searchTagsPlaceholder": "Search tags...",
+      "searchGenresPlaceholder": "Search genres...",
+      "saving": "Saving...",
+      "errors": {
+        "updateUser": "Failed to update user",
+        "updatePermissions": "Failed to update permissions",
+        "updateLibraryAccess": "Failed to update library access",
+        "updateContentFilters": "Failed to update content filters",
+        "emailRequired": "Email is required",
+        "createSharedAccount": "Failed to create shared account",
+        "createUser": "Failed to create user"
+      }
+    },
+    "usersPage": {
+      "usersTitle": "Users",
+      "magicLinksTitle": "Magic Links",
+      "usersSubtitle": "Manage user accounts and permission assignments.",
+      "magicLinksSubtitle": "Create shareable login links for shared accounts.",
+      "createUser": "Create user",
+      "createLink": "Create link",
+      "usersTab": "Users",
+      "magicLinksTab": "Magic Links",
+      "columns": {
+        "name": "Name",
+        "username": "Username",
+        "email": "Email",
+        "access": "Access",
+        "status": "Status"
+      },
+      "adminBadge": "Admin",
+      "permissionCount": "no permissions | one permission | {count} permissions",
+      "filteredBadge": "Filtered",
+      "contentRestrictionsActive": "Content restrictions active",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "resetPassword": "Reset password",
+      "resetPasswordOidcHint": "OIDC users reset passwords in their identity provider",
+      "resetPasswordSharedHint": "Shared accounts do not have passwords",
+      "resetPasswordOidcHintFull": "OIDC users reset passwords in their identity provider.",
+      "resetPasswordSharedHintFull": "Shared accounts do not have passwords.",
+      "deleteUserAction": "Delete user",
+      "deleteDialogTitle": "Delete user?",
+      "deleteDialogBody": "Delete user \"{username}\". This action cannot be undone.",
+      "deleting": "Deleting...",
+      "errors": {
+        "loadData": "Failed to load data",
+        "load": "Failed to load",
+        "deleteUser": "Failed to delete user"
+      }
+    }
+  },
+  "annotations": {
+    "unknownBook": "Unknown book",
+    "styles": {
+      "highlight": "Highlight",
+      "underline": "Underline",
+      "strike": "Strike",
+      "squiggle": "Squiggle",
+      "invert": "Invert"
+    },
+    "combobox": {
+      "filterByBook": "Filter by book",
+      "allBooks": "All books",
+      "clearBookFilter": "Clear book filter",
+      "searching": "Searching...",
+      "noBooksFound": "No books found"
+    },
+    "bulk": {
+      "countSelected": "{count} selected",
+      "pageSelected": "Page selected",
+      "selectPage": "Select page",
+      "clear": "Clear",
+      "recolorTo": "Recolor to {color}",
+      "restyleTo": "Restyle to {style}"
+    },
+    "chips": {
+      "active": "Active:",
+      "removeFilter": "Remove filter {label}",
+      "clearAll": "Clear all"
+    },
+    "filters": {
+      "colors": "Colors",
+      "dateRange": "Date range",
+      "fromDate": "From date",
+      "toDate": "To date",
+      "to": "to",
+      "clearDateRange": "Clear date range",
+      "clearAll": "Clear all"
+    },
+    "pagination": {
+      "showing": "Showing {start}-{end} of {total}",
+      "pageOf": "Page {page} of {totalPages}",
+      "firstPage": "First page",
+      "previousPage": "Previous page",
+      "nextPage": "Next page",
+      "lastPage": "Last page"
+    },
+    "sync": {
+      "loading": "Loading sync detail",
+      "positions": "Positions",
+      "devices": "Devices",
+      "retryConversion": "Retry conversion",
+      "noStoredPositions": "No stored positions.",
+      "notSynced": "Not synced to any device yet.",
+      "upToDate": "Up to date",
+      "pendingVersion": "Pending v{version}",
+      "syncedAt": "synced {date}",
+      "format": {
+        "webReader": "Web reader",
+        "koreader": "KOReader",
+        "pdf": "PDF",
+        "kobo": "Kobo"
+      },
+      "status": {
+        "exact": "Exact",
+        "repaired": "Repaired",
+        "failed": "Failed",
+        "pending": "Pending"
+      }
+    },
+    "toolbar": {
+      "searchPlaceholder": "Search text and notes",
+      "filters": "Filters",
+      "sortOrder": "Sort order",
+      "switchToCompact": "Switch to compact view",
+      "switchToComfortable": "Switch to comfortable view",
+      "compactView": "Compact view",
+      "comfortableView": "Comfortable view"
+    },
+    "listItem": {
+      "pageNumber": "p. {page}",
+      "chapterNumber": "chapter {chapter}",
+      "selectAnnotation": "Select annotation",
+      "collapse": "Collapse",
+      "expand": "Expand",
+      "hideSyncDetail": "Hide sync detail",
+      "showSyncDetail": "Show sync detail",
+      "exactPositionUnavailable": "Exact reader position unavailable",
+      "saving": "Saving",
+      "bookDetails": "Book details",
+      "openInReader": "Open in reader",
+      "restore": "Restore",
+      "deleteForever": "Delete forever",
+      "editNote": "Edit note",
+      "addNote": "Add note",
+      "colorAndStyle": "Color and style",
+      "copied": "Copied",
+      "copyText": "Copy text",
+      "trash": "Trash",
+      "moveToTrash": "Move to trash"
+    },
+    "hub": {
+      "title": "Annotations",
+      "totalCount": "{count} total",
+      "bookCount": "no books | {count} book | {count} books",
+      "noteCount": "no notes | {count} note | {count} notes",
+      "export": "Export",
+      "exportMarkdown": "Markdown",
+      "exportCsv": "CSV",
+      "exportJson": "JSON",
+      "notesOnly": "Notes only",
+      "style": "Style",
+      "source": "Source",
+      "bulkTrash": "Trash",
+      "bulkRestore": "Restore",
+      "tabs": {
+        "highlights": "Highlights",
+        "trash": "Trash"
+      },
+      "empty": {
+        "noMatch": "No highlights match your filters.",
+        "resetFilters": "Reset filters",
+        "trashEmpty": "Trash is empty",
+        "noAnnotations": "No annotations yet. Highlights you create on the web or your e-reader appear here."
+      },
+      "toast": {
+        "movedToTrash": "Moved to trash",
+        "annotationRestored": "Annotation restored",
+        "annotationDeletedForever": "Annotation deleted forever",
+        "failedToDelete": "Failed to delete",
+        "bulkTrashed": "Moved no annotations to trash | Moved {count} annotation to trash | Moved {count} annotations to trash",
+        "bulkRestored": "Restored no annotations | Restored {count} annotation | Restored {count} annotations",
+        "bulkRecolored": "Recolored no annotations | Recolored {count} annotation | Recolored {count} annotations",
+        "bulkRestyled": "Restyled no annotations | Restyled {count} annotation | Restyled {count} annotations"
+      }
+    }
+  },
+  "audit": {
+    "pageTitle": "Audit Log",
+    "pageSubtitle": "A record of admin-significant actions performed across the system.",
+    "filters": "Filters",
+    "noActiveFilters": "No active filters",
+    "clear": "Clear",
+    "empty": "No audit logs found",
+    "showMore": "Show more",
+    "showLess": "Show less",
+    "details": "Details",
+    "hideDetails": "Hide details",
+    "detailAction": "Action: {value}",
+    "detailIp": "IP: {value}",
+    "showing": "Showing {from}-{to} of {total}",
+    "prev": "Prev",
+    "chips": {
+      "action": "Action: {value}",
+      "user": "User: {value}",
+      "from": "From: {value}",
+      "to": "To: {value}"
+    },
+    "filterLabels": {
+      "action": "Action",
+      "userId": "User ID",
+      "from": "From",
+      "to": "To"
+    },
+    "filterPlaceholders": {
+      "action": "e.g. auth.login",
+      "userId": "e.g. 1"
+    },
+    "columns": {
+      "when": "When",
+      "user": "User",
+      "action": "Action",
+      "description": "Description",
+      "ip": "IP"
+    }
+  },
+  "auth": {
+    "backToSignIn": "Back to sign in",
+    "themePicker": {
+      "switchToLight": "Switch to light",
+      "switchToDark": "Switch to dark",
+      "changeRadius": "Change corner radius",
+      "changeBackground": "Change background",
+      "changeAccent": "Change accent color"
+    },
+    "fields": {
+      "username": "Username",
+      "password": "Password",
+      "email": "Email",
+      "emailAddress": "Email address",
+      "fullName": "Full name",
+      "newPassword": "New password",
+      "confirmPassword": "Confirm password",
+      "confirmNewPassword": "Confirm new password",
+      "currentPassword": "Current password",
+      "passwordHint": "Min. 8 characters with uppercase, lowercase, and a digit"
+    },
+    "errors": {
+      "generic": "Something went wrong. Please try again.",
+      "passwordsDoNotMatch": "Passwords do not match"
+    },
+    "login": {
+      "subtitle": "Sign in to your account",
+      "signIn": "Sign in",
+      "signingIn": "Signing in...",
+      "orDivider": "or",
+      "forgotPassword": "Forgot password?",
+      "errors": {
+        "invalidCredentials": "Invalid username or password",
+        "tooManyAttempts": "Too many login attempts. Please wait a minute and try again."
+      }
+    },
+    "oidc": {
+      "loginFailed": "OIDC login failed",
+      "redirecting": "Redirecting...",
+      "signInWith": "Sign in with {provider}",
+      "completingSignIn": "Completing sign in...",
+      "tryAgain": "Try again",
+      "errors": {
+        "stateExpired": "Your login session expired. Please try signing in again.",
+        "tokenExchangeFailed": "Could not complete sign-in with your provider. Please try again or contact your administrator.",
+        "userNotProvisioned": "Your account has not been set up. Contact your administrator for access.",
+        "userInactive": "Your account has been deactivated. Contact your administrator.",
+        "providerError": "Your identity provider returned an error. Please try again.",
+        "missingCodeOrState": "Missing code or state parameter"
+      },
+      "providerErrors": {
+        "accessDenied": "Access was denied by the identity provider.",
+        "loginRequired": "Authentication is required. Please sign in again.",
+        "interactionRequired": "Additional user interaction is required."
+      }
+    },
+    "forgotPassword": {
+      "subtitle": "Reset your password",
+      "submitted": "If an account with that email exists, a reset link has been sent. Check your inbox.",
+      "sending": "Sending...",
+      "sendResetLink": "Send reset link",
+      "errors": {
+        "emailUnavailable": "Password reset via email is not available. Contact your administrator."
+      }
+    },
+    "resetPassword": {
+      "subtitle": "Set a new password",
+      "saving": "Saving...",
+      "setNewPassword": "Set new password",
+      "errors": {
+        "invalidLink": "Invalid reset link. Please request a new one.",
+        "invalidOrExpired": "Invalid or expired reset link. Please request a new one."
+      }
+    },
+    "setup": {
+      "title": "Initial setup",
+      "subtitle": "Create the first administrator account.",
+      "setupToken": "Setup token",
+      "setupTokenHint": "(required in production)",
+      "creatingAccount": "Creating account...",
+      "createAccount": "Create administrator account",
+      "errors": {
+        "failed": "Failed to complete setup"
+      }
+    },
+    "changePassword": {
+      "title": "Change password",
+      "saving": "Saving…",
+      "forcedNotice": "You must set a new password before continuing.",
+      "errors": {
+        "failed": "Failed to change password"
+      }
+    },
+    "magicLink": {
+      "signingIn": "Signing you in...",
+      "loginFailed": "Login failed",
+      "goToLogin": "Go to login",
+      "errors": {
+        "noToken": "No token provided"
+      }
+    }
+  },
+  "author": {
+    "card": {
+      "portraitAlt": "{name} portrait",
+      "viewDetails": "View Author Details",
+      "refreshMetadata": "Refresh Metadata",
+      "deleteAuthor": "Delete Author"
+    },
+    "listRow": {
+      "noRecentAdditions": "No recent additions",
+      "portraitAlt": "{name} portrait"
+    },
+    "filters": {
+      "title": "Author Filters",
+      "clearAll": "Clear all",
+      "allLibraries": "All Libraries",
+      "allAuthors": "All authors",
+      "hasPhoto": "Has photo",
+      "missingPhoto": "Missing photo",
+      "minBooks": "Min books",
+      "anyPlaceholder": "Any"
+    },
+    "header": {
+      "never": "Never",
+      "portraitAlt": "{name} portrait",
+      "actions": "Actions",
+      "editAuthor": "Edit Author",
+      "mergeAuthors": "Merge Authors",
+      "refreshing": "Refreshing...",
+      "refreshMetadata": "Refresh Metadata",
+      "deleteAuthor": "Delete Author",
+      "showLess": "Show less",
+      "showMore": "Show more",
+      "lookingUpMetadata": "Looking up author metadata...",
+      "noBiography": "No biography available. Use the menu to refresh metadata.",
+      "previewFrom": "Preview from {provider}. Save metadata to persist it.",
+      "booksLabel": "Books",
+      "lastAdded": "Last Added"
+    },
+    "list": {
+      "title": "Authors",
+      "searchPlaceholder": "Search authors",
+      "sortButton": "Sort",
+      "sortBy": "Sort by",
+      "ascending": "Ascending",
+      "descending": "Descending",
+      "asc": "Asc",
+      "desc": "Desc",
+      "filters": "Filters",
+      "clear": "Clear",
+      "allLoaded": "All {total} authors loaded",
+      "sort": {
+        "name": "Name",
+        "sortName": "Sort Name",
+        "bookCount": "Book Count",
+        "recentAdditions": "Recent Additions",
+        "lastEnriched": "Last Enriched"
+      },
+      "empty": {
+        "title": "No authors found",
+        "hint": "Try changing search text, sort, or library filter."
+      },
+      "deleteDialog": {
+        "titleOne": "Delete author?",
+        "titleMany": "Delete {count} authors?",
+        "descriptionOne": "This removes the author from the catalog and unlinks it from associated books. This action cannot be undone.",
+        "descriptionMany": "This removes selected authors from the catalog and unlinks them from associated books. This action cannot be undone."
+      },
+      "selection": {
+        "selectVisible": "Select visible",
+        "refreshMetadata": "Refresh metadata",
+        "refreshingMetadata": "Refreshing metadata...",
+        "deleteSelected": "Delete selected",
+        "deleting": "Deleting...",
+        "exitSelection": "Exit selection",
+        "confirmDeleteCount": "Delete {count} author? | Delete {count} author? | Delete {count} authors?"
+      },
+      "toast": {
+        "refreshed": "Author metadata refreshed",
+        "refreshedNoImage": "Metadata refreshed, but no author image was found.",
+        "refreshFailed": "Failed to refresh author metadata",
+        "bulkRefreshPartial": "Refreshed {updated} author(s), {failed} failed",
+        "bulkRefreshSuccess": "Refreshed metadata for {updated} author(s)",
+        "bulkRefreshFailed": "Failed to refresh selected authors",
+        "deleteSuccess": "Deleted {count} author; affected {books} books | Deleted {count} author; affected {books} books | Deleted {count} authors; affected {books} books",
+        "deleteFailed": "Failed to delete author(s)"
+      }
+    },
+    "detail": {
+      "pageTitle": "Author",
+      "pageTitleNamed": "Author · {name}",
+      "pageTitleId": "Author #{id}",
+      "entityName": "Author",
+      "loadingAuthor": "Loading author...",
+      "previewError": "Could not load external author preview metadata right now.",
+      "edit": {
+        "name": "Name",
+        "sortName": "Sort Name",
+        "description": "Description",
+        "image": "Image",
+        "uploading": "Uploading...",
+        "replaceImage": "Replace image",
+        "uploadImage": "Upload image",
+        "removing": "Removing...",
+        "removeImage": "Remove image",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP up to {size} MB",
+        "saving": "Saving..."
+      },
+      "merge": {
+        "searchPlaceholder": "Search authors to merge into this author",
+        "searching": "Searching...",
+        "bookCount": "no books | {count} book | {count} books",
+        "selectedSummary": "Selected {count} author(s), approx. {books} books affected.",
+        "merging": "Merging...",
+        "mergeSelected": "Merge Selected",
+        "confirmLabel": "Merge"
+      },
+      "mergeDialog": {
+        "title": "Merge {count} author(s) into \"{name}\"?",
+        "titleFallback": "Merge selected authors?",
+        "description": "This will merge selected authors into the current author and re-link associated books. This action cannot be undone.",
+        "descriptionEmpty": "This action cannot be undone."
+      },
+      "deleteDialog": {
+        "title": "Delete author?",
+        "description": "This removes the author from the catalog and unlinks it from associated books. This action cannot be undone."
+      },
+      "books": {
+        "heading": "Books",
+        "allLibraries": "All Libraries",
+        "asc": "Asc",
+        "desc": "Desc",
+        "ascending": "Ascending",
+        "descending": "Descending",
+        "allLoaded": "All {total} books loaded",
+        "sort": {
+          "recentlyAdded": "Recently Added",
+          "title": "Title",
+          "publishedYear": "Published Year"
+        },
+        "empty": {
+          "title": "No books found for this author",
+          "hint": "Try changing sort/order or selecting another library."
+        }
+      },
+      "toast": {
+        "refreshed": "Author metadata refreshed",
+        "refreshedNoImage": "Metadata refreshed, but no author image was found.",
+        "refreshFailed": "Failed to refresh author metadata",
+        "nameRequired": "Author name is required",
+        "updated": "Author updated",
+        "updateFailed": "Failed to update author",
+        "imageUpdated": "Author image updated",
+        "imageUploadFailed": "Failed to upload author image",
+        "imageRemoved": "Author image removed",
+        "imageRemoveFailed": "Failed to remove author image",
+        "mergeSuccess": "Merged {count} author(s); affected {books} books",
+        "mergeFailed": "Failed to merge authors",
+        "deleteSuccess": "Deleted author; affected {books} books",
+        "deleteFailed": "Failed to delete author"
+      }
+    }
+  },
+  "book": {
+    "untitled": "Untitled",
+    "unknownFormat": "unknown",
+    "card": {
+      "missing": "Missing"
+    },
+    "file": {
+      "primary": "Primary",
+      "audiobook": "Audiobook"
+    },
+    "actions": {
+      "read": "Read",
+      "listen": "Listen",
+      "peek": "Peek",
+      "quickView": "Quick View",
+      "details": "Details",
+      "bookDetails": "Book Details",
+      "download": "Download",
+      "metadata": "Metadata",
+      "editMetadata": "Edit Metadata",
+      "refreshMetadata": "Refresh Metadata",
+      "regenerateCover": "Regenerate Cover",
+      "addToCollection": "Add to Collection",
+      "setStatus": "Set Status",
+      "sendViaEmail": "Send via Email",
+      "rate": "Rate {star}",
+      "openAs": "Open as {format}"
+    },
+    "readStatus": {
+      "unread": "Unread",
+      "wantToRead": "Want to Read",
+      "reading": "Reading",
+      "onHold": "On Hold",
+      "rereading": "Rereading",
+      "read": "Read",
+      "skimmed": "Skimmed",
+      "abandoned": "Abandoned"
+    },
+    "download": {
+      "action": "Download",
+      "audiobookZip": "Audiobook (ZIP)",
+      "allFormatsZip": "All formats (ZIP)",
+      "primaryOnlyZip": "Primary only (ZIP)"
+    },
+    "sort": {
+      "moveUp": "Move up",
+      "moveDown": "Move down",
+      "ascending": "Ascending",
+      "descending": "Descending",
+      "remove": "Remove",
+      "emptyState": "No sort configured. Title ascending will be used.",
+      "addLevel": "Add sort level"
+    },
+    "filter": {
+      "match": "Match",
+      "all": "ALL",
+      "any": "ANY",
+      "ofFollowingRules": "of the following rules",
+      "anyProvider": "Any provider",
+      "communityRatingProvider": "Community rating provider",
+      "loadingLibraries": "Loading libraries...",
+      "noLibrariesAvailable": "No libraries available",
+      "selectLibrary": "Select library...",
+      "selectStatus": "Select status...",
+      "withinLastPlaceholder": "e.g. 7",
+      "unit": {
+        "days": "days",
+        "weeks": "weeks",
+        "months": "months"
+      },
+      "scorePreset": {
+        "outstanding": "Outstanding",
+        "good": "Good",
+        "fair": "Fair",
+        "poor": "Poor"
+      },
+      "scoreRangePlaceholder": "0-100",
+      "valuePlaceholder": "value",
+      "maxPlaceholder": "max",
+      "to": "to",
+      "group": "Group",
+      "addRule": "Add rule",
+      "addGroup": "Add group",
+      "typeToSearch": "Type to search..."
+    },
+    "deleteDialog": {
+      "title": "Delete book?",
+      "description": "This will permanently delete the book and all its metadata, files, reading progress, and bookmarks. This cannot be undone."
+    },
+    "bulkEdit": {
+      "title": "Edit metadata - {count} book | Edit metadata - {count} book | Edit metadata - {count} books",
+      "instructions": "Toggle fields to edit, then configure values. Only toggled fields will be changed.",
+      "invalidYear": "Enter a valid year (numbers only)",
+      "clearWarning": "This will remove all {field} from the selected books.",
+      "searchPlaceholder": "Search {field}...",
+      "enterPlaceholder": "Enter {field}",
+      "yearPlaceholder": "e.g. 2024",
+      "leaveEmptyHint": "Leave empty to clear this field on all selected books.",
+      "applying": "Applying...",
+      "apply": "Apply",
+      "mode": {
+        "add": "Add",
+        "remove": "Remove",
+        "replace": "Replace",
+        "clear": "Clear"
+      }
+    },
+    "export": {
+      "title": "Export Metadata",
+      "scope": "Scope",
+      "selectedRows": "Selected rows",
+      "currentlySelected": "{count} currently selected",
+      "allMatchingRows": "All matching rows",
+      "rowsInResult": "{count} rows in current result",
+      "format": "Format",
+      "csvDescription": "Spreadsheet-friendly, UTF-8 BOM included",
+      "jsonDescription": "Structured export with metadata context",
+      "columns": "Columns",
+      "canonicalSchema": "Stable canonical schema",
+      "visibleColumns": "Current visible columns",
+      "options": "Options",
+      "includePersonalData": "Include personal reading data",
+      "includeFilePaths": "Include file paths (advanced)",
+      "includeContextMeta": "Include context metadata",
+      "preflight": "Preflight",
+      "scopeLabel": "Scope: {summary}",
+      "calculatingSize": "Calculating export size...",
+      "estimatedSize": "Estimated size:",
+      "fileLabel": "File: {fileName}",
+      "exportAction": "Export",
+      "selectedRowsSummary": "{count} selected row | {count} selected row | {count} selected rows",
+      "matchingRowsSummary": "{count} matching row | {count} matching row | {count} matching rows",
+      "prepareFailed": "Failed to prepare export",
+      "exportStarted": "Metadata export started: {fileName}",
+      "exportFailed": "Metadata export failed"
+    },
+    "columnPanel": {
+      "columnsHeading": "Columns",
+      "reset": "Reset",
+      "tableDensity": "Table density",
+      "density": {
+        "compact": "Compact",
+        "comfortable": "Comfortable",
+        "roomy": "Roomy"
+      },
+      "presets": "Presets",
+      "exportBackup": "Export presets and saved views",
+      "importBackup": "Import presets and saved views",
+      "rename": "Rename",
+      "renamePrompt": "Enter a new name",
+      "builtIn": "Built in",
+      "saveCurrentPreset": "Save current preset",
+      "savedViews": "Saved views",
+      "savedViewsEmpty": "Save sort, layout, and view-specific filters for quick reuse.",
+      "saveCurrentView": "Save current view",
+      "pinnedLeft": "Pinned left",
+      "pinnedRight": "Pinned right",
+      "columns": {
+        "cover": "Cover",
+        "read": "Read",
+        "actions": "Actions"
+      }
+    },
+    "shortcuts": {
+      "title": "Keyboard Shortcuts",
+      "navigation": {
+        "title": "Navigation",
+        "moveFocusVertical": "Move focus up/down",
+        "moveFocusHorizontal": "Move focus left/right",
+        "jumpFirstColumn": "Jump to first column",
+        "jumpLastColumn": "Jump to last column",
+        "jumpFirstRow": "Jump to first row",
+        "jumpLastRow": "Jump to last row"
+      },
+      "actions": {
+        "title": "Actions",
+        "editCell": "Edit focused cell",
+        "cancelEditing": "Cancel editing / Close overlay",
+        "toggleRowSelection": "Toggle row selection",
+        "copyCell": "Copy cell value",
+        "copyRow": "Copy focused row"
+      },
+      "general": {
+        "title": "General",
+        "toggleHelp": "Toggle this help overlay"
+      }
+    },
+    "jumpRail": {
+      "jumpToSection": "Jump to section",
+      "jumpTo": "Jump to {label}"
+    },
+    "quickView": {
+      "title": "Book quick view",
+      "titleFor": "Quick view for {title}",
+      "description": "Preview book details and run quick actions.",
+      "openIn": "Open in {provider}",
+      "pages": "{count} page | {count} page | {count} pages",
+      "primaryFile": "Primary File",
+      "fileNumber": "File #{id}",
+      "showLess": "Show less",
+      "showMore": "Show more",
+      "collections": "Collections",
+      "noDescription": "No description available.",
+      "openMetadataEditor": "Open metadata editor",
+      "coverPreview": "Book cover preview",
+      "coverPreviewFor": "{title} cover preview",
+      "coverPreviewDescription": "Enlarged cover image preview dialog."
+    },
+    "tableView": {
+      "openBookDetails": "Open book details",
+      "openSeries": "Open series",
+      "metadataRefreshFailed": "Metadata refresh failed",
+      "booksSelected": "{count} book selected | {count} book selected | {count} books selected",
+      "loadingMoreBooks": "Loading more books",
+      "sort": "Sort",
+      "refreshingMetadata": "Refreshing metadata {processed} / {total}",
+      "failedCount": "{count} failed",
+      "remainingCount": "{count} remaining",
+      "readOnlyNotice": "Table editing is disabled on smaller screens. Switch to list or grid for quicker actions.",
+      "fetching": "Fetching...",
+      "updated": "Updated",
+      "failed": "Failed",
+      "noBooks": "No books to display",
+      "scrollToTop": "Scroll to top",
+      "selectedStatus": "{count} selected",
+      "filtered": "Filtered",
+      "loadedStatus": "{loaded} of {total} loaded",
+      "bookCount": "{count} book | {count} book | {count} books",
+      "keyboardShortcutsTitle": "Keyboard shortcuts (?)",
+      "showKeyboardShortcuts": "Show table keyboard shortcuts",
+      "copyHint": "Copy cell: Ctrl/Cmd+C · Copy row: Ctrl/Cmd+Shift+C"
+    },
+    "detail": {
+      "authorBooks": {
+        "alsoByAuthor": "Also by this author",
+        "alsoByAuthors": "Also by these authors"
+      },
+      "header": {
+        "previousBook": "Previous book",
+        "nextBook": "Next book"
+      },
+      "tabs": {
+        "details": "Details",
+        "editMetadata": "Edit Metadata",
+        "files": "Files",
+        "readingLog": "Reading Log",
+        "highlights": "Highlights"
+      },
+      "discover": {
+        "moreInSeries": "More in Series",
+        "byAuthor": "By Author",
+        "similarBooks": "Similar Books"
+      },
+      "recommended": {
+        "moreLikeThis": "More Like This"
+      },
+      "series": {
+        "moreInSeriesPrefix": "More in the",
+        "moreInSeriesSuffix": "series"
+      },
+      "writeRename": {
+        "written": "no fields written | Written (one field) | Written ({count} fields)",
+        "writeFailed": "Write failed",
+        "skipped": "Skipped",
+        "renamedTo": "Renamed to {name}",
+        "fileRenamed": "File renamed",
+        "renameFailed": "Rename failed",
+        "autoWriteAndRenameDisabled": "Auto-write and rename are disabled in library settings. Changes won't sync automatically on future saves.",
+        "autoWriteDisabled": "Auto-write is disabled in library settings. Changes won't sync automatically on future saves.",
+        "autoRenameDisabled": "Auto-rename is disabled in library settings. Changes won't sync automatically on future saves.",
+        "writeLabel": "Write:",
+        "renameLabel": "Rename:"
+      },
+      "addFile": {
+        "uploading": "Uploading...",
+        "uploadComplete": "Upload complete",
+        "title": "Add File",
+        "dropzone": {
+          "title": "Drop files here or click to browse",
+          "hint": "epub, pdf, mobi, cbz, m4b and more - up to 500 MB each"
+        },
+        "addMore": "Add more files",
+        "fileCount": "no files | one file | {count} files",
+        "clearAll": "Clear all",
+        "done": "Done",
+        "retry": "Retry",
+        "filesAdded": "no files added | one file added | {count} files added",
+        "uploadedFailed": "{done} uploaded, {failed} failed",
+        "uploadingProgress": "{done} of {total} uploading...",
+        "renameAfter": "Rename all book files after upload",
+        "uploadCount": "Upload ({count})",
+        "upload": "Upload"
+      },
+      "addSession": {
+        "errors": {
+          "invalidDate": "Pick a valid date and time.",
+          "future": "The session cannot start in the future.",
+          "duration": "Duration must be between 1 and 1440 minutes.",
+          "endProgress": "End progress must be between 0 and 100."
+        },
+        "title": "Add reading session",
+        "startedAt": "Started at",
+        "duration": "Duration (minutes)",
+        "endProgress": "End progress %",
+        "optional": "Optional",
+        "format": "Format",
+        "noFormat": "No specific format",
+        "saving": "Saving...",
+        "submit": "Add session"
+      },
+      "coverEditor": {
+        "unlockCover": "Unlock cover",
+        "lockCover": "Lock cover",
+        "fileTab": "File",
+        "urlTab": "URL",
+        "chooseImage": "Choose image...",
+        "findCoverOnline": "Find cover online",
+        "saving": "Saving...",
+        "saveCover": "Save cover",
+        "revertToOriginal": "Revert to original",
+        "regenerateCover": "Regenerate Cover"
+      },
+      "coverSearch": {
+        "title": "Online Search",
+        "subtitle": "Search for book covers",
+        "titleField": "Title",
+        "authorField": "Author",
+        "sourceField": "Source",
+        "allSources": "All Sources",
+        "audiobookCovers": "Audiobook covers",
+        "squareHint": "(square)",
+        "searching": "Searching...",
+        "findCovers": "Find covers",
+        "selectCover": "Select Cover",
+        "noResultsTitle": "No results found",
+        "noResultsHint": "Try adjusting your search terms",
+        "readyTitle": "Ready to search",
+        "readyHint": "Enter a title and author above",
+        "resolutionTip": "Tip: High resolution covers are marked in green"
+      },
+      "details": {
+        "by": "by",
+        "narratedBy": "narrated by",
+        "ratingLocked": "Rating is locked",
+        "rateStar": "Rate {star}",
+        "listen": "Listen",
+        "read": "Read",
+        "chooseFormat": "Choose format",
+        "audiobook": "Audiobook",
+        "primary": "Primary",
+        "peek": "Peek",
+        "sendViaEmail": "Send via Email",
+        "editCover": "Edit cover",
+        "finished": "Finished",
+        "resetFileProgress": "Reset file progress",
+        "resetting": "Resetting...",
+        "resetProgressConfirm": "Reset stored reading progress for {label}?",
+        "moreCount": "+{count} more",
+        "untitled": "Untitled",
+        "metadataScore": "Metadata Score",
+        "primaryFormat": "Primary format",
+        "openIn": "Open in {provider}",
+        "showLess": "Show less",
+        "showMore": "Show more",
+        "publisher": "Publisher",
+        "published": "Published",
+        "language": "Language",
+        "pages": "Pages",
+        "duration": "Duration",
+        "edition": "Edition",
+        "abridged": "Abridged",
+        "unabridged": "Unabridged",
+        "isbn": "ISBN",
+        "fileSize": "File Size",
+        "library": "Library",
+        "added": "Added",
+        "dateStarted": "Date Started",
+        "saving": "Saving...",
+        "cancelDateStartedEdit": "Cancel date started edit",
+        "editDateStarted": "Edit date started",
+        "dateFinished": "Date Finished",
+        "cancelDateFinishedEdit": "Cancel date finished edit",
+        "editDateFinished": "Edit date finished",
+        "customMetadata": "Custom Metadata",
+        "synopsis": "Synopsis",
+        "noDescription": "No description available.",
+        "dateStartedFutureError": "Date Started cannot be in the future.",
+        "dateFinishedFutureError": "Date Finished cannot be in the future.",
+        "dateFinishedBeforeStartedError": "Date Finished must be on or after Date Started.",
+        "saveReadingDatesError": "Failed to save reading dates.",
+        "koboPendingDelete": "Pending delete from device",
+        "koboPendingDeleteTooltip": "Kobo will remove it on next sync.",
+        "koboRemovedByDevice": "Removed by device",
+        "koboRemovedByDeviceTooltip": "Kobo reported this book removed.",
+        "koboNotSynced": "Not synced",
+        "koboNotSyncedTooltip": "Queued for next Kobo sync.",
+        "filesNotFound": "Files not found",
+        "filesNotFoundDescription": "The file(s) for this book can no longer be found on disk. Metadata is still available. Run a library scan to confirm, or remove the record."
+      },
+      "editMetadata": {
+        "fieldCount": "no fields | one field | {count} fields",
+        "bookFilesTarget": "book files",
+        "formatFilesTarget": "{formats} files",
+        "noPrimaryFile": "No primary file available",
+        "formatNotSupported": "This file format does not support write-back",
+        "formatDisabled": "Write-back is disabled for this format",
+        "fileExceedsSizeLimit": "This file exceeds the write-back size limit",
+        "writing": "Writing...",
+        "saveInProgress": "Save in progress",
+        "writeManualLibraryDisabled": "Write metadata to file and rename now; automatic write-back is disabled for this library",
+        "writeManualTooltip": "Write {fields} to {target} and rename if pattern is set",
+        "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "Skipped no locked fields | Skipped one locked field | Skipped {count} locked fields",
+        "updatedFields": "updated no fields | updated one field | updated {count} fields",
+        "wroteFieldsToFile": "Wrote {fields} to file",
+        "fileWriteFailedReason": "File write failed: {reason}",
+        "fileWriteFailed": "File write failed",
+        "fileWriteSkippedReason": "File write skipped: {reason}",
+        "fileWriteSkipped": "File write skipped",
+        "metadataSaved": "Metadata saved",
+        "metadataWrittenToFile": "Metadata written to file",
+        "savedButWriteFailedReason": "Metadata saved, but file write failed: {reason}",
+        "savedButWriteFailed": "Metadata saved, but file write failed",
+        "savedWriteSkippedReason": "Metadata saved, file write skipped: {reason}",
+        "savedWriteSkipped": "Metadata saved, file write skipped",
+        "loadFromFileFailed": "Failed to load metadata from file",
+        "loadedFieldsFromFile": "Loaded no fields from file | Loaded one field from file | Loaded {count} fields from file",
+        "noMetadataInFile": "No metadata found in file",
+        "loadFromFile": "Load from file",
+        "loadFromFileTooltip": "Load metadata from the primary book file",
+        "writeToFile": "Write to file",
+        "autoFill": "Auto-fill",
+        "fetchingMetadata": "Fetching metadata...",
+        "allFieldsLocked": "All fields are locked",
+        "autoFillTooltip": "Auto-fill fields using your metadata preferences",
+        "lockAll": "Lock all",
+        "lockAllTooltip": "Lock all fields",
+        "unlockAll": "Unlock all",
+        "unlockAllTooltip": "Unlock all fields",
+        "saving": "Saving...",
+        "fileWriteBackDetails": "File write-back details",
+        "fileWriteBack": "File write-back",
+        "enabled": "Enabled",
+        "saveWritesMetadata": "'Save' writes metadata to {target}",
+        "formats": "Formats",
+        "bookFiles": "Book files",
+        "supportedFields": "Supported fields",
+        "titleLabel": "Title",
+        "subtitleLabel": "Subtitle",
+        "authorsLabel": "Authors",
+        "narratorsLabel": "Narrators",
+        "genresLabel": "Genres",
+        "tagsLabel": "Tags",
+        "ratingLabel": "Rating",
+        "rateStar": "Rate {star}",
+        "clear": "Clear",
+        "communityRatingsLabel": "Community Ratings",
+        "noProviderRatings": "No provider ratings",
+        "seriesLabel": "Series",
+        "publisherLabel": "Publisher",
+        "languageLabel": "Language",
+        "yearLabel": "Year",
+        "pageCountLabel": "Page Count",
+        "isbn13Label": "ISBN-13",
+        "isbn10Label": "ISBN-10",
+        "durationLabel": "Duration (s)",
+        "abridgedLabel": "Abridged",
+        "providerIds": "Provider IDs",
+        "comicDetails": "Comic Details",
+        "comicIssueNumberLabel": "Issue Number",
+        "comicVolumeLabel": "Volume",
+        "comicStoryArcsLabel": "Story Arcs",
+        "comicPencillersLabel": "Pencillers",
+        "comicInkersLabel": "Inkers",
+        "comicColoristsLabel": "Colorists",
+        "comicLetterersLabel": "Letterers",
+        "comicCoverArtistsLabel": "Cover Artists",
+        "comicCharactersLabel": "Characters",
+        "comicTeamsLabel": "Teams",
+        "comicLocationsLabel": "Locations",
+        "customMetadata": "Custom Metadata",
+        "descriptionLabel": "Description",
+        "unlockField": "Unlock {field}",
+        "lockField": "Lock {field}",
+        "diffPanel": {
+          "untitled": "Untitled",
+          "noFieldsSelected": "No fields selected",
+          "fieldsSelected": "no fields selected | one field selected | {count} fields selected",
+          "results": "Results",
+          "providerMatches": "{provider} matches",
+          "selectedOf": "Selected {selected} of {total}",
+          "yearUnknown": "Year unknown",
+          "indexOf": "{index} of {total}",
+          "switchedResult": "Switched result. Previous selections from this provider were cleared.",
+          "selectFieldsToApply": "Select fields to apply",
+          "copyMissing": "Copy Missing",
+          "copyAll": "Copy All",
+          "hideUnchanged": "Hide unchanged",
+          "showUnchanged": "Show unchanged",
+          "current": "Current",
+          "noMetadata": "No metadata available from this source.",
+          "noChangedFields": "No changed or missing fields. Use Show unchanged to inspect everything.",
+          "applyToForm": "Apply to form"
+        },
+        "diff": {
+          "locked": "Locked",
+          "previewAlt": "Preview",
+          "currentCoverAlt": "Current cover",
+          "newCoverAlt": "New cover",
+          "pickCoverFromProvider": "Pick cover from another provider",
+          "pickCoverSource": "Pick cover source",
+          "pickFromProvider": "Pick from another provider",
+          "pickSource": "Pick source",
+          "empty": "empty",
+          "showLess": "Show less",
+          "showMore": "Show more",
+          "coverPreviewAlt": "Cover preview"
+        },
+        "searchDrawer": {
+          "searchTitle": "Search Metadata",
+          "compareTitle": "Compare Metadata",
+          "searchSubtitle": "Find the best provider match for this book.",
+          "compareSubtitle": "Review differences and apply only what you want."
+        },
+        "searchPanel": {
+          "untitledQuery": "Untitled query",
+          "titlePlaceholder": "Title",
+          "authorPlaceholder": "Author",
+          "isbnPlaceholder": "ISBN",
+          "searching": "Searching...",
+          "activeQuery": "Active query",
+          "searchScope": "Search scope",
+          "allEnabled": "All enabled",
+          "all": "All",
+          "fieldRules": "Field Rules",
+          "custom": "Custom",
+          "providerNotInFieldRules": "{provider} is enabled but not in Field Rules",
+          "notInFieldRulesLabel": "Not in Field Rules:",
+          "notInFieldRulesText": "{providers}. Included in manual search with All enabled, but not used by automatic metadata fetch.",
+          "noResults": "No results found",
+          "noResultsHint": "Try adjusting the title or author",
+          "searchPrompt": "Search above, then click a result to start comparing metadata."
+        }
+      },
+      "files": {
+        "relative": {
+          "seconds": "{value}s ago",
+          "minutes": "{value}m ago",
+          "hours": "{value}h ago",
+          "days": "{value}d ago"
+        },
+        "renameFailed": "Failed to rename file",
+        "deleteFailed": "Failed to delete file",
+        "addFile": "Add File",
+        "lastSynced": "Last synced: {time}",
+        "sort": {
+          "label": "Sort:",
+          "name": "Name",
+          "format": "Format",
+          "size": "Size",
+          "date": "Date"
+        },
+        "hidePaths": "Hide paths",
+        "showPaths": "Show paths",
+        "hideLog": "Hide log",
+        "viewSyncLog": "View sync log",
+        "noWriteHistory": "No write history yet.",
+        "fieldsWritten": "no fields | one field | {count} fields",
+        "track": "Track {number}",
+        "primary": "Primary",
+        "read": "Read",
+        "play": "Play",
+        "peek": "Peek",
+        "download": "Download",
+        "moreActions": "More actions",
+        "rename": "Rename",
+        "empty": {
+          "title": "No files attached",
+          "description": "This book has no associated files."
+        },
+        "renameModal": {
+          "title": "Rename File",
+          "description": "Rename the physical file on disk.",
+          "placeholder": "New filename"
+        },
+        "saving": "Saving...",
+        "deleteModal": {
+          "title": "Delete file?",
+          "description": "Are you sure you want to delete \"{filename}\"? This action cannot be undone."
+        },
+        "deleting": "Deleting..."
+      },
+      "highlights": {
+        "note": {
+          "placeholder": "Add a note...",
+          "saving": "Saving"
+        },
+        "export": {
+          "trigger": "Export",
+          "plainText": "Plain Text",
+          "page": "Export page",
+          "selected": "Export selected"
+        },
+        "sort": {
+          "position": "Position",
+          "newest": "Newest first",
+          "oldest": "Oldest first"
+        },
+        "summary": {
+          "highlights": "no highlights | one highlight | {count} highlights",
+          "notes": "no notes | one note | {count} notes",
+          "chapters": "no chapters | one chapter | {count} chapters"
+        },
+        "filterByChapter": "Filter by chapter",
+        "allChapters": "All chapters",
+        "untitled": "Untitled",
+        "trash": "Trash",
+        "empty": {
+          "noMatch": "No highlights match your filters.",
+          "resetFilters": "Reset filters",
+          "none": "No highlights yet",
+          "hint": "Select text while reading to create highlights"
+        },
+        "uncategorized": "Uncategorized",
+        "paginationUnit": "highlights"
+      },
+      "readingLog": {
+        "export": {
+          "button": "Export"
+        },
+        "weekdays": {
+          "sun": "Sun",
+          "mon": "Mon",
+          "tue": "Tue",
+          "wed": "Wed",
+          "thu": "Thu",
+          "fri": "Fri",
+          "sat": "Sat"
+        },
+        "months": {
+          "jan": "Jan",
+          "feb": "Feb",
+          "mar": "Mar",
+          "apr": "Apr",
+          "may": "May",
+          "jun": "Jun",
+          "jul": "Jul",
+          "aug": "Aug",
+          "sep": "Sep",
+          "oct": "Oct",
+          "nov": "Nov",
+          "dec": "Dec"
+        },
+        "heatmap": {
+          "subtitle": "{count} active day · {ratio}% consistency | {count} active day · {ratio}% consistency | {count} active days · {ratio}% consistency",
+          "minutesUnit": "min",
+          "title": "Activity",
+          "empty": "No reading activity in this window."
+        },
+        "hero": {
+          "notSet": "Not set",
+          "relative": {
+            "seconds": "{count}s ago",
+            "minutes": "{count}m ago",
+            "hours": "{count}h ago",
+            "days": "{count}d ago",
+            "months": "{count} month ago | {count} month ago | {count} months ago",
+            "years": "{count} year ago | {count} year ago | {count} years ago"
+          },
+          "noSessions": "No sessions",
+          "dateErrors": {
+            "startFuture": "Start date cannot be in the future.",
+            "finishFuture": "Finish date cannot be in the future.",
+            "finishBeforeStart": "Finish date must be on or after the start date.",
+            "saveFailed": "Failed to save reading dates."
+          },
+          "eta": {
+            "max": "99h+ to finish",
+            "minutes": "~{m}m to finish",
+            "hours": "~{h}h to finish",
+            "hoursMinutes": "~{h}h {m}m to finish"
+          },
+          "momentum": {
+            "none": "No activity in the last two weeks",
+            "new": "New activity this week",
+            "up": "+{pct}% vs previous 7 days",
+            "down": "{pct}% vs previous 7 days",
+            "flat": "Unchanged vs previous 7 days"
+          },
+          "stats": {
+            "totalTime": "Total Time",
+            "sessions": "Sessions",
+            "avgSession": "Avg Session",
+            "lastRead": "Last Read"
+          },
+          "firstRead": "First Read",
+          "lastRead": "Last Read",
+          "dateStarted": "Date Started",
+          "dateFinished": "Date Finished",
+          "addSession": "Add session"
+        },
+        "journey": {
+          "tooltipProgress": "Progress",
+          "tooltipReading": "Reading",
+          "minutesUnit": "min",
+          "title": "Progress journey",
+          "empty": "No progress data in this window."
+        },
+        "sourceSplit": {
+          "title": "Where you read this book"
+        },
+        "untitled": "Untitled",
+        "addSessionFailed": "Failed to add session",
+        "filters": {
+          "allTime": "All time",
+          "last30": "Last 30 days",
+          "last90": "Last 90 days",
+          "thisYear": "This year",
+          "allFormats": "All formats"
+        },
+        "table": {
+          "sourceWeb": "Web",
+          "sourceManual": "Manual",
+          "colDate": "Date",
+          "colDateMobile": "Date",
+          "colDuration": "Duration",
+          "colDurationMobile": "Duration",
+          "colProgressChange": "Progress Change",
+          "colProgressChangeMobile": "Delta",
+          "colEndProgress": "End Progress",
+          "colEndProgressMobile": "End",
+          "empty": "No reading sessions recorded yet.",
+          "colPace": "Pace",
+          "colSource": "Source",
+          "colFormatMobile": "Fmt",
+          "colFormat": "Format",
+          "cancelDelete": "Cancel delete",
+          "cancelDeleteAria": "Cancel delete session",
+          "confirmDeleteTitle": "Click again to confirm delete",
+          "confirmDeleteAria": "Confirm delete session",
+          "deleteAria": "Delete session",
+          "loadMore": "Load more",
+          "showing": "Showing {shown} of {total} sessions"
+        }
+      },
+      "richDescription": {
+        "linkProtocolError": "Use http, https, or mailto.",
+        "bold": "Bold",
+        "italic": "Italic",
+        "underline": "Underline",
+        "strikethrough": "Strikethrough",
+        "bulletList": "Bullet list",
+        "numberedList": "Numbered list",
+        "outdentAria": "Outdent list item",
+        "outdent": "Outdent",
+        "indentAria": "Indent list item",
+        "indent": "Indent",
+        "quote": "Quote",
+        "editLink": "Edit link",
+        "link": "Link",
+        "removeLink": "Remove link",
+        "undo": "Undo",
+        "redo": "Redo",
+        "clearFormatting": "Clear formatting",
+        "previewDescription": "Preview description",
+        "preview": "Preview",
+        "linkUrlLabel": "Link URL",
+        "applyLink": "Apply link",
+        "apply": "Apply",
+        "cancelLink": "Cancel link",
+        "noDescription": "No description available."
+      },
+      "seriesMembership": {
+        "addSeries": "Add series",
+        "seriesPlaceholder": "Series",
+        "moveUp": "Move up",
+        "moveDown": "Move down",
+        "removeSeries": "Remove series"
+      }
+    },
+    "table": {
+      "actions": {
+        "quickView": "Quick View",
+        "bookDetails": "Book Details",
+        "editMetadata": "Edit Metadata",
+        "refreshMetadata": "Refresh Metadata",
+        "addToCollection": "Add to Collection",
+        "sendToDevice": "Send to Device"
+      },
+      "boolean": {
+        "ariaNotSet": "Not set - click to set true",
+        "ariaTrue": "True - click to set false",
+        "ariaFalse": "False - click to clear"
+      },
+      "chips": {
+        "addPlaceholder": "Add..."
+      },
+      "cover": {
+        "previewDescription": "Book cover preview",
+        "editDescription": "Edit book cover",
+        "editTitle": "Edit cover",
+        "editCover": "Edit Cover",
+        "view": "View cover"
+      },
+      "date": {
+        "justNow": "just now"
+      },
+      "format": {
+        "unknown": "unknown"
+      },
+      "header": {
+        "sortAscending": "Sort Ascending",
+        "sortDescending": "Sort Descending",
+        "clearSort": "Clear Sort",
+        "hideColumn": "Hide Column",
+        "pinLeft": "Pin Left",
+        "pinRight": "Pin Right",
+        "unpinColumn": "Unpin Column",
+        "autoFitWidth": "Auto-Fit Width",
+        "autoFitAllColumns": "Auto-Fit All Columns",
+        "selectAllBooks": "Select all books",
+        "shiftClickSecondarySort": "Shift+click to add secondary sort",
+        "clickToSort": "Click to sort"
+      },
+      "locks": {
+        "lockAll": "Lock all fields",
+        "unlockAll": "Unlock all fields",
+        "lockField": "Lock field",
+        "unlockField": "Unlock field",
+        "clickToLock": "Click to lock",
+        "clickToUnlock": "Click to unlock"
+      },
+      "progress": {
+        "complete": "{percent} complete"
+      },
+      "rating": {
+        "label": "Rating",
+        "remove": "Remove rating",
+        "rate": "Rate {star} out of 5"
+      },
+      "read": {
+        "play": "Play",
+        "read": "Read",
+        "primary": "Primary",
+        "peekFormat": "Peek {format}",
+        "chooseFormat": "Choose format to read or play",
+        "fileFallback": "FILE"
+      },
+      "readStatus": {
+        "unread": "Unread"
+      },
+      "series": {
+        "bookCount": "(no books) | ({count} book) | ({count} books)",
+        "readOfCount": "{read} of {total} read"
+      },
+      "text": {
+        "openDetails": "Open details"
+      }
+    }
+  },
+  "bookMetadataFetch": {
+    "book": {
+      "title": "Metadata Fetch"
+    },
+    "author": {
+      "title": "Author Enrichment"
+    },
+    "stats": {
+      "queued": "Queued",
+      "processing": "Processing",
+      "rateLimited": "Rate limited",
+      "failed": "Failed"
+    },
+    "actions": {
+      "pause": "Pause",
+      "resume": "Resume",
+      "cancelQueued": "Cancel queued"
+    },
+    "cancel": {
+      "processingWillFinish": "Currently processing items will finish.",
+      "confirm": "Confirm cancel",
+      "keepRunning": "Keep running"
+    },
+    "viewFailed": "View one failed | View {count} failed",
+    "card": {
+      "fetchingMetadata": "Fetching metadata",
+      "enrichingAuthors": "Enriching authors"
+    },
+    "label": {
+      "paused": "Paused",
+      "remaining": "{count} remaining",
+      "processing": "{count} processing",
+      "failed": "{count} failed",
+      "rateLimited": "{count} rate limited"
+    },
+    "report": {
+      "bookTitle": "Failed Metadata Fetches",
+      "authorTitle": "Failed Author Enrichments",
+      "noFailedItems": "No failed items.",
+      "retryAllFailed": "Retry all failed",
+      "bookFallback": "Book #{id}",
+      "authorFallback": "Author #{id}",
+      "columns": {
+        "title": "Title",
+        "library": "Library",
+        "author": "Author",
+        "error": "Error",
+        "http": "HTTP"
+      }
+    },
+    "toast": {
+      "failedToPause": "Failed to pause",
+      "failedToResume": "Failed to resume",
+      "failedToCancel": "Failed to cancel",
+      "failedToRetry": "Failed to retry",
+      "failedItemsRequeued": "Failed items requeued",
+      "bookComplete": "Metadata fetch complete - {done} books updated",
+      "bookDoneWithFailures": "Metadata fetch done - {done} processed, {failed} failed",
+      "authorComplete": "Author enrichment complete - {done} authors updated",
+      "authorDoneWithFailures": "Author enrichment done - {done} processed, {failed} failed"
+    }
+  },
+  "bookDock": {
+    "apply": "Apply",
+    "done": "Done",
+    "discard": "Discard",
+    "finalize": "Finalize",
+    "rescan": "Rescan",
+    "uploadAction": "Upload",
+    "uploading": "Uploading...",
+    "searchPlaceholder": "Search files...",
+    "setDestinationAction": "Set Destination",
+    "bulkEditAction": "Bulk Edit",
+    "applyFetched": "Apply Fetched",
+    "retryErrors": "Retry Errors",
+    "commaSeparated": "comma-separated",
+    "destinationLibrary": "Destination Library",
+    "destinationFolder": "Destination Folder",
+    "nSelected": "no files selected | {count} selected | {count} selected",
+    "nFailed": "{count} failed",
+    "updatedOfFiles": "Updated {updated} of {total} files",
+    "errorStatus": "Error {status}",
+    "applyFetchedTooltip": "Apply auto-fetched provider metadata to {count} files | Apply auto-fetched provider metadata to {count} file | Apply auto-fetched provider metadata to {count} files",
+    "retryErrorsTooltip": "Retry metadata fetch for {count} error files | Retry metadata fetch for {count} error file | Retry metadata fetch for {count} error files",
+    "tab": {
+      "all": "All",
+      "pending": "Pending",
+      "ready": "Ready",
+      "error": "Error"
+    },
+    "status": {
+      "pending": "Pending",
+      "extracting": "Extracting",
+      "fetching": "Fetching",
+      "ready": "Ready",
+      "error": "Error"
+    },
+    "field": {
+      "title": "Title",
+      "subtitle": "Subtitle",
+      "authors": "Authors",
+      "authorsCommaSeparated": "Authors (comma-separated)",
+      "publisher": "Publisher",
+      "year": "Year",
+      "language": "Language",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "series": "Series",
+      "seriesIndex": "Series #",
+      "genres": "Genres",
+      "genresCommaSeparated": "Genres (comma-separated)",
+      "description": "Description"
+    },
+    "upload": {
+      "nDone": "{count} done",
+      "nFailed": "{count} failed",
+      "nTotal": "{count} total"
+    },
+    "fileList": {
+      "emptyTitle": "No files in Book Dock",
+      "emptyMessageDefault": "Upload files or drop them in the Book Dock folder",
+      "colCurrent": "Current",
+      "colNew": "New",
+      "colFile": "File",
+      "colSize": "Size",
+      "colFormat": "Format",
+      "colMatch": "Match",
+      "colApply": "Apply",
+      "colStatus": "Status",
+      "applyFetchedMetadata": "Apply fetched metadata",
+      "coverPreview": "Cover preview",
+      "coverPreviewDescription": "Enlarged cover image preview dialog.",
+      "currentCoverAlt": "{title} current cover",
+      "newCoverAlt": "{title} new cover",
+      "unknownLibrary": "Unknown library",
+      "unassigned": "Unassigned",
+      "targetPath": "Target: {library} · {path}",
+      "targetUnassigned": "Target: Unassigned",
+      "targetUnknownPath": "Target: {library} · Unknown destination path"
+    },
+    "sheet": {
+      "saved": "Saved",
+      "providerMetadataFound": "Provider metadata found",
+      "providerMetadataFoundEdited": "Provider metadata found - bulk apply will skip this file (you have edits)",
+      "review": "Review",
+      "added": "Added {date}",
+      "searchMetadata": "Search Metadata",
+      "results": "Results"
+    },
+    "bulkEdit": {
+      "title": "Bulk Edit no files | Bulk Edit {count} file | Bulk Edit {count} files",
+      "resultTitle": "Bulk Edit Results",
+      "instructions": "Toggle the fields you want to update. Only enabled fields will be applied.",
+      "mergeArrays": "Merge arrays (add to existing values instead of replacing)",
+      "failed": "Bulk edit failed"
+    },
+    "setDestination": {
+      "title": "Set Destination for no files | Set Destination for {count} file | Set Destination for {count} files",
+      "resultTitle": "Destination Updated",
+      "failed": "Failed to set destination"
+    },
+    "finalizeDialog": {
+      "title": "Finalize no files | Finalize {count} file | Finalize {count} files",
+      "resultTitle": "Finalize Results",
+      "needDestination": "{without} of {count} selected files need a destination | {without} of {count} selected file needs a destination | {without} of {count} selected files need a destination",
+      "allHaveDestination": "All selected files already have destination set",
+      "defaultDestinationLibrary": "Default Destination Library",
+      "defaultDestinationFolder": "Default Destination Folder",
+      "renamePreview": "Rename preview",
+      "moreFiles": "+{count} more files",
+      "start": "Start",
+      "filesFinalized": "{succeeded} of {total} files finalized",
+      "failedWithDuplicates": "{failed} failed ({count} duplicates) | {failed} failed ({count} duplicate) | {failed} failed ({count} duplicates)",
+      "view": "View",
+      "viewExisting": "View existing",
+      "importAnyway": "Import anyway",
+      "hide": "Hide",
+      "details": "Details",
+      "alreadyExistsSaveAs": "Already exists - save as:",
+      "renamePlaceholder": "e.g. {name} (2)",
+      "import": "Import"
+    }
+  },
+  "collection": {
+    "dialog": {
+      "name": "Name",
+      "icon": "Icon",
+      "iconPlaceholder": "Choose an icon...",
+      "nameRequired": "Name is required",
+      "iconRequired": "Choose an icon",
+      "creating": "Creating...",
+      "createFailed": "Failed to create collection"
+    },
+    "createDialog": {
+      "title": "New Collection",
+      "namePlaceholder": "e.g. Favorites"
+    },
+    "editDialog": {
+      "title": "Edit Collection",
+      "syncToKobo": "Sync to Kobo",
+      "syncToKoboHint": "Books in this collection will appear on your Kobo device",
+      "deleteCollection": "Delete collection",
+      "confirmDelete": "Confirm?",
+      "deleting": "Deleting...",
+      "saving": "Saving...",
+      "deleted": "\"{name}\" deleted",
+      "updateFailed": "Failed to update collection",
+      "deleteFailed": "Failed to delete collection"
+    },
+    "addToSheet": {
+      "title": "Manage Collections",
+      "selectedCount": "no books selected | one book selected | {count} books selected",
+      "newCollection": "New Collection",
+      "namePlaceholder": "Collection name",
+      "create": "Create",
+      "collections": "Collections",
+      "empty": "No collections yet. Create one above.",
+      "done": "Done",
+      "added": "Added",
+      "allAdded": "All {total} added",
+      "inCollection": "In this collection",
+      "allInCollection": "All {total} in this collection",
+      "partialInCollection": "{partial} of {total} in this collection",
+      "bookCount": "no books | one book | {count} books",
+      "loadFailed": "Failed to load collections",
+      "createdAndAdded": "Created \"{name}\" and added no books | Created \"{name}\" and added one book | Created \"{name}\" and added {count} books",
+      "createdButAddFailed": "Created \"{name}\" but failed to add books",
+      "createFailed": "Failed to create collection",
+      "addedNewWithExisting": "Added one new book to \"{name}\" ({alreadyHad} already there) | Added one new book to \"{name}\" ({alreadyHad} already there) | Added {count} new books to \"{name}\" ({alreadyHad} already there)",
+      "addedToCollection": "Added no books to \"{name}\" | Added one book to \"{name}\" | Added {count} books to \"{name}\"",
+      "addFailed": "Failed to add to collection",
+      "removedFromCollection": "Removed no books from \"{name}\" | Removed one book from \"{name}\" | Removed {count} books from \"{name}\"",
+      "removeFailed": "Failed to remove from collection"
+    }
+  },
+  "components": {
+    "appHeader": {
+      "searchAllBooks": "Search all books...",
+      "searching": "Searching...",
+      "noResults": "No results",
+      "loadingMore": "Loading more...",
+      "loadMore": "Load more ({loaded}/{total})",
+      "allMatchesShown": "All 1 match shown | All 1 match shown | All {count} matches shown",
+      "bookCount": "no books | {count} book | {count} books",
+      "fileCount": "no files | {count} file | {count} files",
+      "uploadedToast": "Uploaded {uploaded}",
+      "uploadFailedToast": "Upload failed for {failed}",
+      "uploadPartialToast": "Uploaded {uploaded}, {failed} failed",
+      "bookDock": "Book Dock",
+      "statistics": "Statistics",
+      "achievements": "Achievements",
+      "annotations": "Annotations",
+      "uploadBooks": "Upload books",
+      "appearance": "Appearance",
+      "theme": "Theme",
+      "accent": "Accent",
+      "radius": "Radius",
+      "background": "Background",
+      "settings": "Settings",
+      "whatsNew": "What's New",
+      "documentation": "Documentation",
+      "help": "Help",
+      "starOnGithub": "Star on GitHub",
+      "new": "New",
+      "newReleaseNotes": "New release notes available",
+      "account": "Account",
+      "changePassword": "Change Password",
+      "signOut": "Sign out",
+      "githubStar": {
+        "title": "Enjoying BookOrbit?",
+        "body": "If BookOrbit is helping with your library, please consider starring the project on GitHub. It helps more people discover the app and supports ongoing development.",
+        "cta": "Star BookOrbit on GitHub"
+      }
+    },
+    "sidebar": {
+      "tagline": "Your Reading Space",
+      "dashboard": "Dashboard",
+      "authors": "Authors",
+      "series": "Series",
+      "tools": "Tools",
+      "libraries": "Libraries",
+      "newLibrary": "New Library",
+      "libraryScanning": "{name} - Scanning {pct}%",
+      "scanProgress": "{processed} / {total} books",
+      "smartScopes": "Smart Scopes",
+      "newSmartScope": "New Smart Scope",
+      "noSmartScopes": "No Smart Scopes yet",
+      "collections": "Collections",
+      "newCollection": "New Collection",
+      "noCollections": "No collections yet",
+      "latest": "Latest {version}",
+      "newReleaseNotes": "New release notes available",
+      "sectionHeader": {
+        "add": "Add",
+        "reorder": "Reorder",
+        "doneReordering": "Done reordering"
+      }
+    },
+    "selectionActionBar": {
+      "setReadingStatus": "Set reading status",
+      "setRating": "Set rating",
+      "openMetadataEditor": "Open metadata editor",
+      "editIndividually": "Edit books individually",
+      "addToCollection": "Add to collection",
+      "removeFromCollection": "Remove from collection",
+      "sendViaEmail": "Send via email",
+      "downloadFilesZip": "Download files as ZIP",
+      "moreActions": "More actions",
+      "setField": "Set field",
+      "refreshMetadata": "Refresh metadata",
+      "reExtractCover": "Re-extract cover",
+      "metadataLock": "Metadata lock",
+      "lockAll": "Lock all",
+      "unlockAll": "Unlock all",
+      "exportMetadata": "Export metadata",
+      "deleteSelected": "Delete selected",
+      "exitSelection": "Exit selection",
+      "downloadFilesZipLabel": "Download files as ZIP:",
+      "primaryOnly": "Primary only",
+      "allFormats": "All formats",
+      "audioOnly": "Audio only",
+      "setRatingLabel": "Set rating:",
+      "clear": "Clear",
+      "setFieldLabel": "Set field:",
+      "apply": "Apply",
+      "fieldPlaceholder": "Leave blank to clear",
+      "fieldPlaceholderArray": "Comma-separated (leave blank to clear)",
+      "deleteConfirm": "Delete {count} book? | Delete {count} book? | Delete {count} books?",
+      "typeDelete": "Type DELETE"
+    },
+    "viewHeader": {
+      "select": "Select",
+      "display": "Display",
+      "displayDescription": "Adjust cover size, grid spacing, and view display options.",
+      "columnVisibilityHint": "Use the column visibility panel in the table header to show or hide columns.",
+      "columnVisibilityMobileHint": "Column visibility can be managed from the table header.",
+      "searchPlaceholder": "Search title, author, series, narrator...",
+      "mobileSearch": {
+        "description": "Search items by title, author, series, or narrator.",
+        "done": "Done"
+      },
+      "mobileMenu": {
+        "grid": "Grid",
+        "list": "List",
+        "select": "Select",
+        "exitSelect": "Exit Select"
+      },
+      "displayControls": {
+        "display": "Display",
+        "coverSize": "Cover size",
+        "gridGap": "Grid gap",
+        "columnsHint": "Use the column visibility panel in the table header to show or hide columns.",
+        "coverShape": "Cover shape",
+        "circle": "Circle",
+        "square": "Square"
+      }
+    },
+    "iconPicker": {
+      "searchLucide": "Search Lucide icons...",
+      "searchCustom": "Search custom icons...",
+      "chooseIcon": "Choose an icon...",
+      "selectIcon": "Select icon",
+      "customTab": "Custom",
+      "searching": "Searching...",
+      "noIconsMatch": "No icons match \"{query}\"",
+      "typeToSearch": "Type to search all icons",
+      "noCustomIcons": "No custom icons uploaded",
+      "noIconsAvailable": "No icons available"
+    },
+    "entityNotFound": {
+      "title": "{entity} not found",
+      "description": "This {entity} doesn't exist or has been deleted.",
+      "goBack": "Go back"
+    },
+    "themePicker": {
+      "light": "Light",
+      "dark": "Dark"
+    },
+    "userAvatar": {
+      "profilePicture": "Profile picture",
+      "profilePictureOf": "{name} profile picture"
+    },
+    "ui": {
+      "sidebar": {
+        "title": "Sidebar",
+        "mobileDescription": "Displays the mobile sidebar.",
+        "toggle": "Toggle Sidebar"
+      },
+      "chipInput": {
+        "typeAndEnter": "Type and press Enter to add",
+        "pressEnter": "Press Enter to add"
+      }
+    }
+  },
+  "customIcons": {
+    "dialogTitle": "Upload custom icons",
+    "dialogDescription": "Review names before adding them to your library.",
+    "readingFiles": "Reading files...",
+    "dropPrompt": "Drop SVG files or click to browse",
+    "fileLimit": "Up to {max} files, 128 KB each",
+    "namePlaceholder": "Name",
+    "nameRequired": "Name is required",
+    "invalidSvg": "Invalid SVG",
+    "invalidSvgFile": "Invalid SVG file",
+    "identicalTo": "Identical to \"{name}\"",
+    "uploadAnyway": "Upload anyway",
+    "skipThisOne": "Skip this one",
+    "readyToUpload": "{count} ready to upload",
+    "noIconsStaged": "No icons staged yet",
+    "uploading": "Uploading...",
+    "upload": "Upload",
+    "uploadCount": "Upload {count}",
+    "onlySvgSupported": "Only SVG files are supported",
+    "maxStaged": "You can stage at most {max} icons at once",
+    "onlyMoreCanStage": "No more icons can be staged | Only {count} more icon can be staged | Only {count} more icons can be staged",
+    "readFailed": "Failed to read SVG files",
+    "uploadedCount": "No icons uploaded | Uploaded {count} icon | Uploaded {count} icons",
+    "uploadedPartial": "Uploaded {created}, {failed} failed",
+    "noIconsUploaded": "No icons uploaded",
+    "uploadFailed": "Failed to upload icons",
+    "uploadFailedEntry": "Upload failed"
+  },
+  "dashboard": {
+    "common": {
+      "failedToLoad": "Failed to load",
+      "retry": "Retry",
+      "untitled": "Untitled",
+      "cover": "Cover",
+      "bookCover": "Book cover"
+    },
+    "scroller": {
+      "failedToLoad": "Failed to load.",
+      "empty": {
+        "continueReading": "No books in progress yet. Start reading one to see it here.",
+        "continueListening": "No audiobooks in progress yet. Start listening to one to see it here.",
+        "wantToRead": "No books marked want to read yet.",
+        "upNextInSeries": "No next-in-series picks yet. Finish a volume to surface the next one.",
+        "recentlyAdded": "No books in your library yet.",
+        "smartScope": "No books match this smartScope.",
+        "default": "No books found."
+      }
+    },
+    "settings": {
+      "title": "Customize Dashboard",
+      "tabs": {
+        "widgets": "Widgets",
+        "shelves": "Shelves"
+      },
+      "reorderHintWidget": "Drag to reorder. Toggle to show or hide a widget.",
+      "reorderHintShelf": "Drag to reorder. Toggle to show or hide a shelf.",
+      "smartScope": "Smart Scope",
+      "noSmartScopes": "No Smart Scopes yet. Create one from the sidebar.",
+      "addShelf": "Add shelf",
+      "resetToDefaults": "Reset to defaults"
+    },
+    "welcome": {
+      "emptyTitle": "Your library is empty",
+      "noLibrariesTitle": "No libraries yet",
+      "emptyDescription": "Create a library to start organizing and reading your books. Point it to a folder and it will do the rest.",
+      "noLibrariesDescription": "Your administrator hasn't set up any libraries yet. Reach out to them to get started.",
+      "createFirstLibrary": "Create your first library"
+    },
+    "widgets": {
+      "currentlyReading": {
+        "title": "Currently Reading",
+        "empty": "No books in progress. Start reading one to see it here.",
+        "continueReading": "Continue reading"
+      },
+      "diversityScore": {
+        "title": "Diversity Score",
+        "notEnoughData": "Read at least 3 books to see your diversity score",
+        "booksAnalyzed": "no books analyzed | {count} book analyzed | {count} books analyzed",
+        "subScores": {
+          "genre": "Genre",
+          "author": "Author",
+          "era": "Era",
+          "language": "Lang"
+        }
+      },
+      "highlightOfTheDay": {
+        "title": "Highlight of the Day",
+        "empty": "Highlight passages while reading to see them here"
+      },
+      "libraryOverview": {
+        "title": "Library Overview",
+        "empty": "Your library is empty. Add some books to get started.",
+        "addedThisYear": "+{count} added this year",
+        "stats": {
+          "books": "Books",
+          "authors": "Authors",
+          "series": "Series",
+          "storage": "Storage"
+        }
+      },
+      "longWait": {
+        "title": "The Long Wait",
+        "empty": "No books waiting. You've started everything!",
+        "daysWaiting": "days waiting",
+        "pages": "no pages | {count} page | {count} pages",
+        "startReading": "Start Reading"
+      },
+      "monthlyChallenge": {
+        "title": "Monthly Challenge",
+        "complete": "Complete!"
+      },
+      "neglectedGems": {
+        "title": "Neglected Gems",
+        "empty": "All your top-rated books have been read!",
+        "rating": "{rating}/5",
+        "daysWaiting": "{count}d waiting",
+        "queued": "Queued",
+        "addToQueue": "Add to queue",
+        "shuffle": "Shuffle"
+      },
+      "readingDna": {
+        "title": "Reading DNA",
+        "notEnoughData": "Read at least 5 books to unlock your Reading DNA",
+        "basedOn": "Based on no books | Based on {count} book | Based on {count} books",
+        "traits": {
+          "length": "Length",
+          "variety": "Variety",
+          "rhythm": "Rhythm",
+          "time": "Time",
+          "speed": "Speed"
+        }
+      },
+      "readingGoal": {
+        "title": "Reading Goal {year}",
+        "setGoalPrompt": "Set a reading goal to track your progress",
+        "setGoal": "Set goal",
+        "booksPerYear": "Books per year",
+        "ofGoal": "of {goal}",
+        "percentComplete": "{percentage}% complete",
+        "editGoal": "Edit goal"
+      },
+      "readingRhythm": {
+        "title": "Reading Rhythm",
+        "empty": "Start reading to see your rhythm take shape",
+        "activeDays": "no active days | {count} active day | {count} active days",
+        "consistency": "{activeDays} · {percent}% consistency",
+        "avgPerDay": "avg {time}/day"
+      },
+      "readingStreak": {
+        "title": "Reading Streak",
+        "empty": "Read today to start your streak",
+        "streakLabel": "day streak | day streak | days streak",
+        "best": "Best: {count} day | Best: {count} day | Best: {count} days",
+        "lastSevenDays": "Last 7 days"
+      },
+      "yearProjection": {
+        "title": "Year Projection",
+        "books": "books",
+        "trendUp": "Trending up",
+        "trendDown": "Trending down",
+        "trendSteady": "Steady pace",
+        "pages": "pages",
+        "hours": "hours",
+        "readCount": "{count} read",
+        "daysLeft": "{count}d left"
+      }
+    }
+  },
+  "email": {
+    "title": "Email",
+    "subtitle": "Send books to your e-reader via email.",
+    "loadFailed": "Failed to load",
+    "saveFailed": "Failed to save",
+    "deleteFailed": "Failed to delete",
+    "setDefaultFailed": "Failed to set default",
+    "setAsDefault": "Set as default",
+    "saving": "Saving...",
+    "update": "Update",
+    "create": "Create",
+    "deleteConfirm": "Delete \"{name}\". This action cannot be undone.",
+    "badge": {
+      "default": "Default",
+      "shared": "Shared",
+      "system": "System"
+    },
+    "tabs": {
+      "providers": "Providers",
+      "recipients": "Recipients",
+      "groups": "Groups",
+      "templates": "Templates",
+      "preferences": "Preferences",
+      "history": "History"
+    },
+    "providers": {
+      "heading": "SMTP Providers",
+      "add": "Add provider",
+      "newTitle": "New Provider",
+      "editTitle": "Edit Provider",
+      "name": "Name",
+      "namePlaceholder": "e.g. Gmail",
+      "host": "Host",
+      "port": "Port",
+      "username": "Username",
+      "password": "Password",
+      "passwordEdit": "Password (leave blank to keep current)",
+      "fromName": "From Name",
+      "fromNamePlaceholder": "My Library",
+      "fromAddress": "From Address",
+      "authentication": "Authentication",
+      "verifyTls": "Verify TLS certificate",
+      "tlsWarning": "TLS verification is disabled. The server's certificate will not be validated - use only for trusted internal servers.",
+      "noFromAddress": "no from address",
+      "emptyManage": "No providers yet. Add an SMTP provider to start sending emails.",
+      "emptyReadonly": "No providers available. Ask an administrator to add one.",
+      "setSystemTooltip": "Set as system mail provider",
+      "removeSystemTooltip": "Remove as system mail provider",
+      "testTooltip": "Test connection",
+      "toggleSharing": "Toggle sharing",
+      "removeSystemBeforeDelete": "Remove the system designation before deleting",
+      "notesHeading": "Provider Notes",
+      "notesBody": "The <strong>System</strong> provider (superuser only) is used for password reset emails. The <strong>Default</strong> provider is used when sending books with no explicit provider selected. Providers marked <strong>Shared</strong> are available to all users.",
+      "deleteTitle": "Delete provider?",
+      "nameHostRequired": "Name and host are required",
+      "created": "Provider created",
+      "updated": "Provider updated",
+      "deleted": "\"{name}\" deleted",
+      "setDefaultSuccess": "\"{name}\" set as default",
+      "unshared": "Provider unshared",
+      "sharedWithAll": "Provider shared with all users",
+      "updateSharingFailed": "Failed to update sharing",
+      "systemRemoved": "\"{name}\" removed as system mail provider",
+      "systemSet": "\"{name}\" set as system mail provider",
+      "updateSystemFailed": "Failed to update system provider",
+      "connectionSuccess": "Connection successful",
+      "connectionFailed": "Connection failed",
+      "testFailed": "Test failed"
+    },
+    "recipients": {
+      "heading": "Recipients",
+      "add": "Add recipient",
+      "newTitle": "New Recipient",
+      "editTitle": "Edit Recipient",
+      "name": "Name",
+      "namePlaceholder": "My Kindle",
+      "emailAddress": "Email address",
+      "deviceType": "Device type",
+      "deviceNone": "None",
+      "deviceOther": "Other",
+      "preferredFormat": "Preferred format",
+      "formatAuto": "Auto",
+      "defaultTemplate": "Default template",
+      "useAccountDefault": "Use account default",
+      "kindleNote": "Kindle recipients automatically receive emails with subject \"convert\" to trigger format conversion.",
+      "empty": "No recipients yet.",
+      "prefersFormat": "prefers {format}",
+      "deleteTitle": "Delete recipient?",
+      "nameEmailRequired": "Name and email are required",
+      "created": "Recipient created",
+      "updated": "Recipient updated",
+      "deleted": "\"{name}\" deleted",
+      "setDefaultSuccess": "\"{name}\" set as default"
+    },
+    "groups": {
+      "heading": "Recipient Groups",
+      "create": "Create group",
+      "newTitle": "New Group",
+      "name": "Group name",
+      "namePlaceholder": "e.g. Book Club",
+      "creating": "Creating...",
+      "empty": "No groups yet. Create a group to send to multiple recipients at once.",
+      "memberCount": "no members | one member | {count} members",
+      "deleteTooltip": "Delete group",
+      "noMembers": "No members yet.",
+      "removeMember": "Remove",
+      "selectRecipient": "Select recipient...",
+      "add": "Add",
+      "addMember": "Add member",
+      "allRecipientsInGroup": "All recipients are already in this group.",
+      "deleteTitle": "Delete group?",
+      "created": "Group created",
+      "createFailed": "Failed to create group",
+      "deleted": "\"{name}\" deleted",
+      "memberAdded": "Member added",
+      "addMemberFailed": "Failed to add member",
+      "memberRemoved": "Member removed",
+      "removeMemberFailed": "Failed to remove member"
+    },
+    "templates": {
+      "heading": "Email Templates",
+      "new": "New template",
+      "newTitle": "New Template",
+      "editTitle": "Edit Template",
+      "name": "Name",
+      "namePlaceholder": "Default",
+      "subject": "Subject",
+      "body": "Body",
+      "availableVariables": "Available variables",
+      "editTemplate": "Edit template",
+      "empty": "No templates yet.",
+      "notesHeading": "Template Notes",
+      "notesBody": "System templates cannot be deleted. Administrators can edit them. Use variables like <code class=\"font-mono text-foreground/80\">&#123;&#123;title&#125;&#125;</code> in subjects and bodies - they are replaced with book details at send time.",
+      "deleteTitle": "Delete template?",
+      "nameSubjectRequired": "Name and subject are required",
+      "created": "Template created",
+      "updated": "Template updated",
+      "deleted": "\"{name}\" deleted",
+      "setDefaultSuccess": "\"{name}\" set as default"
+    },
+    "preferences": {
+      "heading": "Email Preferences",
+      "defaultProvider": "Default provider",
+      "defaultProviderHint": "Used when no provider is specified. If empty, the account default is used.",
+      "noneAccountDefault": "None (use account default)",
+      "defaultRecipient": "Default recipient",
+      "defaultRecipientHint": "Used for quick send. Must be set to use the quick-send action on book cards.",
+      "none": "None",
+      "defaultTemplate": "Default template",
+      "defaultTemplateHint": "Used when no template is specified. Falls back to the system default if empty.",
+      "noneSystemDefault": "None (use system default)",
+      "save": "Save preferences",
+      "saved": "Preferences saved"
+    },
+    "history": {
+      "heading": "Send History",
+      "empty": "No emails sent yet.",
+      "noSubject": "(no subject)",
+      "loadMore": "Load more",
+      "resend": "Resend",
+      "deleteTitle": "Delete history entry?",
+      "entryDeleted": "Entry deleted",
+      "queuedForResend": "Queued for resend",
+      "resendFailed": "Failed to resend",
+      "statusSent": "Sent",
+      "statusFailed": "Failed",
+      "statusQueued": "Queued",
+      "statusPending": "Pending"
+    },
+    "send": {
+      "title": "Send via Email",
+      "bookCount": "no books | one book | {count} books",
+      "recipients": "Recipients",
+      "noRecipients": "No recipients configured. Add one in Email settings.",
+      "groups": "Groups",
+      "options": "Options",
+      "fileFormat": "File format",
+      "autoRecipientPreference": "Auto (use recipient preference)",
+      "unknownFormat": "Unknown",
+      "primarySuffix": "(primary)",
+      "provider": "Provider",
+      "template": "Template",
+      "default": "Default",
+      "send": "Send",
+      "sending": "Sending...",
+      "queued": "no emails queued | one email queued | {count} emails queued",
+      "failed": "Failed to send"
+    }
+  },
+  "hardcover": {
+    "settings": {
+      "subtitle": "Sync your reading progress, status, and ratings to Hardcover."
+    },
+    "bookSync": {
+      "label": "Hardcover Sync",
+      "toggleAriaLabel": "Sync this book with Hardcover",
+      "syncNow": "Sync now"
+    },
+    "connection": {
+      "title": "Connection",
+      "description": "Connect your Hardcover account to sync reading data.",
+      "connected": "Connected",
+      "apiToken": "API Token",
+      "tokenPlaceholder": "Paste your Hardcover API token",
+      "show": "Show",
+      "hide": "Hide",
+      "findTokenAt": "Find your token at",
+      "validateToken": "Validate token",
+      "valid": "Valid ({username})",
+      "invalidToken": "Invalid token",
+      "syncOptions": "Sync options",
+      "syncInfo": "Sync runs only for books that are not unread. This applies to status, progress, and rating triggers. These switches control when a sync runs.",
+      "syncScope": {
+        "title": "Book sync scope",
+        "allEligible": {
+          "label": "All eligible books",
+          "description": "Sync everything unless you exclude a book."
+        },
+        "selectedOnly": {
+          "label": "Selected books only",
+          "description": "Sync only books you explicitly include."
+        }
+      },
+      "enableSync": {
+        "title": "Enable sync",
+        "description": "Pause all Hardcover syncing without disconnecting."
+      },
+      "syncOnStatus": {
+        "title": "Sync on status change",
+        "description": "Push updates when you mark a book as reading, read, etc."
+      },
+      "syncOnProgress": {
+        "title": "Sync on progress update",
+        "description": "Push reading progress and dates when BookOrbit or KOReader progress changes."
+      },
+      "syncOnRating": {
+        "title": "Sync on rating change",
+        "description": "Push your star ratings to Hardcover."
+      },
+      "privacy": {
+        "title": "Privacy",
+        "description": "Default visibility for synced books on Hardcover.",
+        "public": "Public",
+        "followersOnly": "Followers only",
+        "private": "Private"
+      },
+      "disconnect": "Disconnect",
+      "toast": {
+        "enterToken": "Enter your Hardcover API token first",
+        "saved": "Hardcover settings saved",
+        "saveFailed": "Failed to save settings",
+        "disconnected": "Hardcover disconnected"
+      }
+    },
+    "sync": {
+      "title": "Manual sync",
+      "description": "Push your {scope} to Hardcover now.",
+      "scope": {
+        "selected": "selected books",
+        "eligible": "eligible books"
+      },
+      "checkingPending": "Checking pending items...",
+      "pendingOf": "{pending} pending of {total} books.",
+      "noBooksInScope": "No books in sync scope.",
+      "allSynced": "All books are already synced.",
+      "lastSyncedLabel": "Last synced",
+      "lastSuccessfulSync": "Last successful sync",
+      "syncing": "Syncing...",
+      "progressCount": "{synced} / {total} books",
+      "unavailable": {
+        "permissionDenied": "You do not have permission to use Hardcover sync.",
+        "userDisabled": "Sync is paused in your Hardcover settings."
+      },
+      "button": {
+        "unavailable": "Sync unavailable",
+        "syncNow": "Sync now",
+        "syncNowCount": "Sync now ({count})"
+      },
+      "lastSynced": {
+        "justNow": "Just now",
+        "minutesAgo": "{count} min ago",
+        "hoursAgo": "{count} hour ago | {count} hour ago | {count} hours ago",
+        "daysAgo": "{count} day ago | {count} day ago | {count} days ago"
+      }
+    },
+    "import": {
+      "title": "Pull read status",
+      "description": "Preview Hardcover matches before filling blank BookOrbit statuses.",
+      "clear": "Clear",
+      "preview": "Preview",
+      "importProgress": "Import progress",
+      "reviewMatches": "Review matches",
+      "importReady": "Import ready",
+      "exactMatches": "no exact matches can be imported without review | {count} exact match can be imported without review | {count} exact matches can be imported without review",
+      "progressAvailable": "no progress updates available | {count} progress update available | {count} progress updates available",
+      "progressConflicts": "no conflicts | {count} conflict | {count} conflicts",
+      "unavailable": {
+        "permissionDenied": "You do not have permission to use Hardcover sync.",
+        "missingToken": "Connect Hardcover before importing.",
+        "userDisabled": "Sync is paused in your Hardcover settings."
+      },
+      "summary": {
+        "ready": "Ready",
+        "review": "Review",
+        "conflicts": "Conflicts",
+        "unmatched": "Unmatched",
+        "skipped": "Skipped"
+      },
+      "result": {
+        "summary": "{applied} imported{progress}, {failed} failed",
+        "progressUpdated": "{count} progress updated"
+      },
+      "toast": {
+        "importFailed": "Failed to import Hardcover read status",
+        "imported": "no read statuses imported{progress} | {count} read status imported{progress} | {count} read statuses imported{progress}",
+        "progressUpdates": "no progress updates | {count} progress update | {count} progress updates"
+      }
+    },
+    "review": {
+      "title": "Hardcover import review",
+      "subtitle": "{total} Hardcover books, {matched} matched.",
+      "closeAriaLabel": "Close import review",
+      "searchPlaceholder": "Search title or author",
+      "importProgress": "Import progress",
+      "untitled": "Untitled",
+      "blank": "blank",
+      "noRows": "No rows match the current filters.",
+      "selectRowAriaLabel": "Select {title}",
+      "selectionSummary": "{count} selected: {ready} ready, {reviewed} reviewed.",
+      "selectedProgress": "no progress updates | {count} progress update | {count} progress updates",
+      "selectReady": "Select ready",
+      "selectPage": "Select page",
+      "clearPage": "Clear page",
+      "clearSelection": "Clear selection",
+      "importSelected": "Import selected",
+      "previousPage": "Previous page",
+      "nextPage": "Next page",
+      "pageRange": "{start}-{end} of {total}",
+      "tabs": {
+        "all": "All",
+        "ready": "Ready",
+        "review": "Review",
+        "conflicts": "Conflicts",
+        "unmatched": "Unmatched",
+        "skipped": "Skipped"
+      },
+      "summary": {
+        "ready": "Ready",
+        "review": "Review",
+        "conflicts": "Conflicts",
+        "unmatched": "Unmatched",
+        "skipped": "Skipped"
+      },
+      "matchOptions": {
+        "all": "All match types"
+      },
+      "matchMethod": {
+        "hardcoverId": "Hardcover ID",
+        "isbn": "ISBN",
+        "titleAuthor": "Title + author"
+      },
+      "outcome": {
+        "ready": "Ready",
+        "review": "Review",
+        "conflict": "Conflict",
+        "unmatched": "Unmatched",
+        "skipped": "Skipped"
+      },
+      "column": {
+        "progress": "Progress"
+      }
+    }
+  },
+  "library": {
+    "creator": {
+      "createTitle": "Create Library",
+      "editTitle": "Edit: {name}",
+      "stepOf": "Step {current} of {total}",
+      "sections": {
+        "details": "Details",
+        "folders": "Folders",
+        "scanner": "Scanner",
+        "metadata": "Metadata",
+        "fileWrite": "File Write",
+        "reading": "Reading",
+        "schedule": "Schedule",
+        "access": "Access"
+      },
+      "actions": {
+        "saving": "Saving…",
+        "saveChanges": "Save changes",
+        "creating": "Creating…",
+        "createLibrary": "Create library"
+      },
+      "details": {
+        "libraryName": "Library name",
+        "namePlaceholder": "My Library",
+        "coverStyle": {
+          "title": "Cover style",
+          "portrait": "Portrait",
+          "square": "Square",
+          "hint": "Portrait for ebook or mixed libraries. Square for audiobook-only libraries."
+        },
+        "icon": {
+          "label": "Icon",
+          "placeholder": "Choose an icon...",
+          "selected": "Selected"
+        }
+      },
+      "folders": {
+        "title": "Scan folders",
+        "description": "Add one or more directories to scan for books.",
+        "browseAdd": "Browse and add a folder",
+        "manualEntry": "Or enter a path manually:",
+        "pathPlaceholder": "/path/to/books",
+        "test": "Test",
+        "add": "Add",
+        "pathNotAccessible": "Path is not accessible on the server.",
+        "pathAccessible": "Path is accessible.",
+        "pathNotAccessibleShort": "Path is not accessible",
+        "bookFilesFound": "no book files found | {count} book file found | {count} book files found",
+        "overlapsWith": "Overlaps with \"{library}\"",
+        "noneAdded": "No folders added yet",
+        "totalFilesFound": "no book files found | {count} book file found - actual book count may be lower if multiple formats of the same book exist | {count} book files found - actual book count may be lower if multiple formats of the same book exist",
+        "runPrescanHint": "Run a prescan to validate paths before saving.",
+        "scanning": "Scanning…",
+        "prescan": "Prescan"
+      },
+      "scanner": {
+        "scanMode": {
+          "title": "Scan mode",
+          "lockedAria": "Organization mode is locked",
+          "lockTooltip": "Organization mode is fixed after library creation because changing it can create duplicate or missing book entries. To use a different mode, create a new library and rescan.",
+          "recommended": "Recommended",
+          "folderAsBook": {
+            "title": "Folder as Book",
+            "hint": "All files in a folder are grouped into one book. Works well when you keep multiple formats, like EPUB and MOBI, together."
+          },
+          "fileAsBook": {
+            "title": "File as Book",
+            "hint": "Treats every file as an individual book. Best suited for libraries with one format per title. Avoid if your audiobooks span multiple files."
+          }
+        },
+        "allowedFormats": {
+          "title": "Allowed formats",
+          "allowAll": "Allow all",
+          "allAllowed": "All formats are allowed.",
+          "onlySelected": "Only the selected formats will be imported.",
+          "warning": "Books in other formats already in the library will be marked as missing on the next scan."
+        },
+        "excludePatterns": {
+          "title": "Exclude patterns",
+          "hintBefore": "Glob patterns to skip during scanning (e.g. ",
+          "hintAfter": ").",
+          "add": "Add",
+          "empty": "No patterns added."
+        }
+      },
+      "metadata": {
+        "sourcePrecedence": {
+          "title": "Source precedence",
+          "hint": "The highest source in the list is preferred when multiple are available."
+        },
+        "formatPriority": {
+          "title": "Format priority",
+          "hint": "When a book has multiple formats, the format highest in the list is preferred."
+        }
+      },
+      "fileWrite": {
+        "maxFileSizeMb": "Max file size (MB)",
+        "rename": {
+          "title": "Rename files on metadata update",
+          "hint": "When enabled, updating title, author, series, or year will rename the physical file using the library naming pattern."
+        },
+        "write": {
+          "title": "Write metadata to files",
+          "hint": "When enabled, saving metadata will also write changes back into the physical file on disk."
+        },
+        "cover": {
+          "title": "Include cover image",
+          "hint": "Writes the stored cover back into supported file formats."
+        },
+        "epub": {
+          "title": "EPUB",
+          "hint": "Writes metadata into the OPF file inside the EPUB archive."
+        },
+        "pdf": {
+          "title": "PDF",
+          "hint": "Embeds metadata into PDF Info dictionary and XMP stream."
+        },
+        "cbx": {
+          "title": "Comic archives (CBX)",
+          "hint": "Writes ComicInfo.xml into CBZ and CB7 archives."
+        },
+        "audio": {
+          "title": "Audio",
+          "hint": "Embeds the stored cover into M4B, M4A, MP3, and FLAC files."
+        }
+      },
+      "reading": {
+        "readingStart": {
+          "title": "Reading start",
+          "hint": "A book is marked as \"reading\" once this percentage of progress is reached."
+        },
+        "markAsFinished": {
+          "title": "Mark as finished",
+          "hint": "A book is automatically marked as \"read\" when this percentage of progress is reached."
+        }
+      },
+      "schedule": {
+        "fileWatching": "File watching",
+        "autoScanSchedule": "Auto-scan schedule",
+        "cronExpression": "Cron expression",
+        "cronInvalid": "Invalid cron expression.",
+        "cronFormat": "Format: minute hour day month weekday",
+        "watchFolders": {
+          "title": "Watch folders",
+          "hint": "Automatically detect new files added to library folders."
+        },
+        "presets": {
+          "never": "Never",
+          "hourly": "Every hour",
+          "every6Hours": "Every 6 hours",
+          "every12Hours": "Every 12 hours",
+          "daily": "Daily",
+          "weekly": "Weekly",
+          "custom": "Custom"
+        },
+        "human": {
+          "disabled": "Auto-scan disabled",
+          "hourly": "Every hour",
+          "every6Hours": "Every 6 hours",
+          "every12Hours": "Every 12 hours",
+          "dailyMidnight": "Daily at midnight",
+          "weeklyMonday": "Weekly on Monday at midnight",
+          "cron": "Cron: {cron}"
+        }
+      },
+      "access": {
+        "title": "Access control",
+        "description": "Superusers always have full access. Grant access to other users below.",
+        "notYetCreated": "Access can be configured after the library is created.",
+        "selectUser": "Select a user…",
+        "grant": "Grant",
+        "empty": "No users have been granted access yet.",
+        "levels": {
+          "viewer": "Viewer",
+          "editor": "Editor",
+          "owner": "Owner"
+        },
+        "columns": {
+          "user": "User",
+          "accessLevel": "Access level"
+        },
+        "errors": {
+          "grant": "Failed to grant access",
+          "updateLevel": "Failed to update access level",
+          "revoke": "Failed to revoke access"
+        }
+      }
+    },
+    "folderPicker": {
+      "title": "Browse folders",
+      "newFolder": "New folder",
+      "goUp": "Go up",
+      "filterPlaceholder": "Filter folders…",
+      "newFolderNamePlaceholder": "New folder name",
+      "create": "Create",
+      "noFolders": "No folders found",
+      "selectFolder": "Select this folder",
+      "errors": {
+        "readDirectory": "Could not read directory",
+        "connect": "Could not connect",
+        "invalidName": "Enter a single folder name without slashes or leading dots",
+        "createFolder": "Could not create folder"
+      }
+    },
+    "upload": {
+      "library": "Library",
+      "selectLibrary": "Select a library...",
+      "targetFolder": "Target folder",
+      "addMoreFiles": "Add more files",
+      "clearAll": "Clear all",
+      "done": "Done",
+      "retry": "Retry",
+      "upload": "Upload",
+      "uploadWithCount": "Upload ({count})",
+      "viewInLibrary": "View in Library",
+      "fileCount": "no files | {count} file | {count} files",
+      "booksAdded": "no books added | {count} book added | {count} books added",
+      "uploadedFailed": "{done} uploaded, {failed} failed",
+      "progress": "{done} of {total} uploading...",
+      "header": {
+        "uploading": "Uploading...",
+        "complete": "Upload complete",
+        "uploadTo": "Upload to {library}",
+        "uploadBooks": "Upload Books"
+      },
+      "dropzone": {
+        "title": "Drop files here or click to browse",
+        "hint": "{formats} - up to 500 MB each"
+      }
+    }
+  },
+  "metadataScore": {
+    "missingFields": "no fields missing - edit metadata | {count} field missing - edit metadata | {count} fields missing - edit metadata"
+  },
+  "migration": {
+    "sidebarTitle": "Booklore Import",
+    "status": {
+      "done": "Done",
+      "saved": "Saved",
+      "running": "Running",
+      "failed": "Failed"
+    },
+    "badge": {
+      "validated": "Validated",
+      "upToDate": "Up to date",
+      "completed": "Completed"
+    },
+    "steps": {
+      "source": {
+        "short": "Source Connection",
+        "title": "Source Connection",
+        "subtitle": "Configure the database connection to your source Booklore instance."
+      },
+      "mappings": {
+        "short": "User & Path Mapping",
+        "title": "User & Path Mapping",
+        "subtitle": "Map source users to target users and translate file paths."
+      },
+      "dryRun": {
+        "short": "Dry Run",
+        "title": "Dry Run",
+        "subtitle": "Preview what will be imported before running the live migration."
+      },
+      "migration": {
+        "short": "Run Migration",
+        "title": "Run Migration",
+        "subtitle": "Start the live import and monitor its progress."
+      },
+      "report": {
+        "short": "Report",
+        "title": "Migration Report",
+        "subtitle": "Review what was imported and export a detailed report."
+      }
+    },
+    "footer": {
+      "continueToMappings": "Continue to Mappings",
+      "continueToDryRun": "Continue to Dry Run",
+      "continueToMigration": "Continue to Migration",
+      "viewReport": "View Report",
+      "resetSetup": "Reset Setup",
+      "stepOf": "Step {current} of {total}",
+      "backToSetup": "Back to Setup"
+    },
+    "stages": {
+      "init": "Initializing",
+      "sharedOverlays": "Importing metadata",
+      "bookCovers": "Importing covers",
+      "userState": "Importing user data"
+    },
+    "source": {
+      "testConnection": "Test Connection",
+      "saveAndValidate": "Save & Validate",
+      "validatedWithWarnings": "Source validated with warnings",
+      "fields": {
+        "type": "Source Type",
+        "name": "Source Name",
+        "host": "Host",
+        "port": "Port",
+        "user": "User",
+        "password": "Password",
+        "passwordSaved": "Saved - leave unchanged",
+        "passwordNotSet": "No password set",
+        "database": "Database",
+        "mediaRootPath": "Media Root Path",
+        "ssl": "Use TLS/SSL"
+      },
+      "mediaPath": {
+        "hintRequired": "Required for migrating book covers.",
+        "hintAbsolute": "Use an absolute path (for example: /books). Relative paths are not supported.",
+        "hintConfigured": "Cover import path configured. Use Test Connection to verify access and Booklore images folder structure.",
+        "buttonOk": "Path OK",
+        "buttonIssue": "Path Issue",
+        "buttonTest": "Test Path"
+      },
+      "compatibility": {
+        "title": "Tested compatibility",
+        "verifiedAgainst": "Verified against:",
+        "note": "Later versions are likely compatible but have not been verified. Run a dry-run first to confirm before committing data."
+      },
+      "snapshot": {
+        "title": "Last validation snapshot",
+        "sourceVersion": "Source version: {version}",
+        "unknown": "Unknown",
+        "missingTables": "Missing required tables: {tables}"
+      }
+    },
+    "mappings": {
+      "suggestionsAutoLoad": "User suggestions load automatically after source validation.",
+      "refresh": "Refresh",
+      "sourceUser": "Source User",
+      "targetUser": "Target User",
+      "noSourceUsersLoaded": "No source users loaded yet.",
+      "noActiveTargetUsers": "No active target users found. Create or re-enable a BookOrbit user before mapping.",
+      "pathPrefixMappings": "Path Prefix Mappings",
+      "addMapping": "Add Mapping",
+      "pathMappingsExplanation": "Path mappings translate source file paths to target paths so books can be matched by file location. Books are also matched by ISBN, file hash, and title/author regardless of path mappings.",
+      "noPrefixesFound": "No prefixes found - validate source first",
+      "selectSourcePrefix": "Select source prefix...",
+      "selectTargetFolder": "Select target folder...",
+      "remove": "Remove",
+      "saveMappings": "Save Mappings",
+      "pathValidation": {
+        "title": "Path validation",
+        "mappedSummary": "{mapped} of {total} source books have a mapped path",
+        "unmatched": "{count} mapped paths not found on disk",
+        "allMatched": "All {count} mapped paths found on disk"
+      }
+    },
+    "dryRun": {
+      "run": "Run Dry-Run",
+      "matched": "Matched:",
+      "unresolved": "Unresolved:",
+      "duplicates": "Duplicates:",
+      "unresolvedSummary": "Unresolved summary"
+    },
+    "duplicates": {
+      "title": "Resolve duplicate target matches",
+      "explanation": "For each target book, choose one source book to keep. Recommended choices are preselected when there is a single strongest match.",
+      "remainingGroups": "Remaining groups:",
+      "ofCount": "of {total}",
+      "targetBookId": "Target book #{id}",
+      "recommended": "Recommended",
+      "resolveButton": "Resolve {count} duplicate | Resolve {count} duplicate | Resolve {count} duplicates",
+      "sourceRecordId": "Source record ID #{id}",
+      "byAuthor": "by {author} (ID: {id})",
+      "byFilePath": "{filePath} (ID: {id})",
+      "bookloreSourceId": "Booklore source ID: {id}",
+      "libraryBookId": "Library book #{id}"
+    },
+    "preflight": {
+      "title": "Preflight checks",
+      "allPassed": "All checks passed - ready to migrate",
+      "sourceValidated": "Source validated",
+      "saveAndValidateSource": "Save and validate source connection",
+      "validateSourceConnection": "Validate source connection",
+      "mappingsSaved": "Mappings saved",
+      "saveUserAndPathMappings": "Save user and path mappings",
+      "pathMappingsValidated": "Path mappings validated",
+      "savePathMappingsToValidate": "Save path mappings to validate them",
+      "dryRunUpToDate": "Dry-run is up to date",
+      "runFreshDryRun": "Run a fresh dry-run",
+      "issues": {
+        "saveSource": "Save source connection settings",
+        "validateSource": "Validate source connection",
+        "saveMappings": "Save user and path mappings",
+        "savePathMappings": "Save path mappings to validate them",
+        "freshDryRun": "Run a fresh dry-run",
+        "resolveDuplicates": "Resolve duplicate target book matches in the dry-run",
+        "waitForRun": "Wait for active run to finish"
+      }
+    },
+    "run": {
+      "confirmPrompt": "This will start the live migration. Are you sure?",
+      "confirmStart": "Confirm Start",
+      "startMigration": "Start Migration",
+      "cancelRun": "Cancel Run",
+      "refreshStatus": "Refresh Status",
+      "pollingStopped": "Status polling stopped due to an error.",
+      "retry": "Retry",
+      "stage": "Stage: {stage}",
+      "initializing": "initializing",
+      "ended": "Ended {time}"
+    },
+    "report": {
+      "noRunYet": "No migration run yet. Complete the steps above to start.",
+      "runNumber": "Run #{id}",
+      "notStarted": "Not started",
+      "reloadReport": "Reload Report",
+      "loadFullReport": "Load Full Report",
+      "exportJson": "Export JSON",
+      "exportCsv": "Export CSV",
+      "migrationFailed": "Migration failed",
+      "retryFromLastStage": "Retry from last completed stage",
+      "booksSection": "Books",
+      "metadataOverlays": "Metadata overlays applied",
+      "authorMappings": "Author mappings replaced",
+      "narratorMappings": "Narrator mappings replaced",
+      "genreMappings": "Genre mappings replaced",
+      "tagMappings": "Tag mappings replaced",
+      "coversImported": "Covers imported",
+      "coverImportSkipped": "Cover import skipped - media root path not configured",
+      "couldNotMatch": "Could not match",
+      "userDataSection": "User Data",
+      "readingStatuses": "Reading statuses",
+      "readingProgressEntries": "Reading progress entries",
+      "audiobookProgressEntries": "Audiobook progress entries",
+      "readingSessions": "Reading sessions",
+      "bookmarks": "Bookmarks",
+      "annotations": "Annotations",
+      "collectionEntries": "Collection entries",
+      "loadFullReportHint": "Click \"Load Full Report\" to include the dry-run match summary in the exported report.",
+      "completedNoIssues": "Migration completed with no unresolved books or failures.",
+      "matchedBooks": "Matched books ({count})",
+      "matchedBooksExplanation": "These dry-run matches were used to decide which library books received imported data.",
+      "sourceBook": "Source book {id}",
+      "libraryBook": "Library book {id}",
+      "unresolvedBooks": "Unresolved books ({count})",
+      "unresolvedBooksExplanation": "These books exist in the source but could not be matched to any book in your library.",
+      "mappedUsers": "Mapped users ({count})",
+      "mappedUsersExplanation": "Per-user totals come from the dry-run preview cached with the migration plan.",
+      "coverFailures": "{count} cover import(s) failed. Detailed failure rows are not stored.",
+      "userPreviewCounts": "{statuses} statuses, {progress} progress entries, {sessions} reading sessions, {bookmarks} bookmarks, {annotations} annotations, {collections} collection entries"
+    },
+    "unresolvedReason": {
+      "noTitleAuthorMatch": "No matching book found by title or author",
+      "noFilePathMatch": "File path did not match any book in this library",
+      "noFileHashMatch": "File hash did not match any book in this library",
+      "noIsbnMatch": "ISBN did not match any book in this library",
+      "insufficientSourceData": "Not enough metadata to attempt matching",
+      "ambiguousIsbnMatch": "Multiple books matched the same ISBN",
+      "ambiguousFileHashMatch": "Multiple books matched the same file hash",
+      "ambiguousFilePathMatch": "Multiple books matched the same file path",
+      "ambiguousTitleAuthorMatch": "Multiple books matched the same title and author",
+      "unknown": "Could not determine reason"
+    },
+    "matchStrategy": {
+      "isbn": "Matched by ISBN",
+      "fileHash": "Matched by file hash",
+      "pathMapping": "Matched by mapped file path",
+      "titleAuthor": "Matched by title and author",
+      "unavailable": "Match strategy unavailable"
+    },
+    "connectionError": {
+      "unreachable": "Could not reach the database server. Check the host and port.",
+      "authFailed": "Authentication failed. Check the username and password.",
+      "databaseNotFound": "Database not found. Check the database name.",
+      "timeout": "Connection timed out. Check host and firewall settings.",
+      "generic": "Connection test failed"
+    },
+    "userSelect": {
+      "placeholder": "Select user",
+      "noUsersFound": "No users found"
+    },
+    "toast": {
+      "initFailed": "Failed to initialize migration settings",
+      "loadSupportedTypesFailed": "Failed to load supported migration source types",
+      "loadTargetUsersFailed": "Failed to load target users",
+      "loadTargetFoldersFailed": "Failed to load target library folders",
+      "noSourceUsers": "No source users were returned",
+      "suggestionsLoaded": "User mapping suggestions loaded",
+      "loadSuggestionsFailed": "Failed to load user mapping suggestions",
+      "sourceFieldsRequired": "Host, user, database, and source name are required",
+      "connectionPassedWithWarnings": "Connection test passed with warnings",
+      "connectionPassedWithWarningCount": "Connection test passed with {count} warning(s). First: {warning}",
+      "connectionPassed": "Connection test passed",
+      "connectionMissingTables": "Connection ok, but {count} required table(s) are missing",
+      "cannotTestMediaWhileRunning": "Cannot test media path while a run is active",
+      "mediaPathRequired": "Media Root Path is required for cover import.",
+      "mediaPathAbsolute": "Use an absolute path (for example: /books).",
+      "mediaPathVerified": "Media path verified.",
+      "mediaPathValid": "Media path is valid and readable",
+      "mediaPathValidationFailed": "Media path validation failed.",
+      "connectionFailedBeforeMedia": "Connection test failed before media path validation could complete.",
+      "cannotModifySourceWhileRunning": "Cannot modify source while a run is active",
+      "sourceSavedWithWarnings": "Source saved and validated with {count} warning(s)",
+      "sourceSaved": "Source saved and validated",
+      "saveSourceFailed": "Failed to save or validate source",
+      "cannotSaveMappingsWhileRunning": "Cannot save mappings while a run is active",
+      "saveSourceFirst": "Save source first",
+      "mapAtLeastOneUser": "Map at least one source user to a target user",
+      "mapEveryUser": "Map every source user before saving",
+      "pathValidationFailedButSaved": "Path validation failed, but profile will still be saved",
+      "mappingsSaved": "Mappings saved",
+      "saveMappingsFailed": "Failed to save mappings",
+      "cannotDryRunWhileRunning": "Cannot run dry-run while a run is active",
+      "saveMappingsFirst": "Save mappings first",
+      "dryRunCompleted": "Dry-run completed: {matched} matched, {unresolved} unresolved",
+      "dryRunFailed": "Dry-run failed",
+      "selectSourceForDuplicates": "Select a source book for all {count} duplicate groups",
+      "duplicatesResolved": "Duplicate matches resolved",
+      "resolveDuplicatesFailed": "Failed to resolve duplicates",
+      "preflightNotReady": "Migration preflight not ready",
+      "runDryRunFirst": "Run dry-run first",
+      "runStarted": "Migration run started",
+      "startFailed": "Failed to start migration",
+      "runCancelled": "Migration run cancelled",
+      "cancelFailed": "Failed to cancel migration",
+      "runRetried": "Migration run retried - resuming from last completed stage",
+      "retryFailed": "Failed to retry migration",
+      "loadProgressFailed": "Failed to load run progress",
+      "startMigrationFirst": "Start migration first",
+      "reportRefreshed": "Run report refreshed",
+      "loadReportFailed": "Failed to load run report",
+      "reportExported": "Report exported as {format}",
+      "exportFailed": "Failed to export migration report"
+    }
+  },
+  "notifications": {
+    "title": "Notifications",
+    "markAllRead": "Mark all read",
+    "clear": "Clear",
+    "empty": "No notifications yet",
+    "loadMore": "Load more notifications",
+    "preferences": {
+      "title": "Notifications",
+      "subtitle": "Choose which notification categories you want to receive.",
+      "saving": "Saving...",
+      "unsavedChanges": "Unsaved changes",
+      "saved": "Notification preferences saved",
+      "saveFailed": "Failed to save preferences",
+      "savePreferenceFailed": "Failed to save preference",
+      "whatsNewToggle": "Show \"What's New\" after updates",
+      "whatsNewToggleHint": "A popup highlighting new features after the app updates. The archive stays available either way."
+    }
+  },
+  "reader": {
+    "retry": "Retry",
+    "loadingBook": "Loading book…",
+    "failedToLoadBook": "Failed to load book",
+    "chapterNumber": "Chapter {number}",
+    "peek": {
+      "badge": "Peeking",
+      "startReading": "Start reading"
+    },
+    "toast": {
+      "linkedHighlightError": "Could not open the linked highlight position",
+      "resumed": "Resumed at {pct}% - {label}"
+    },
+    "header": {
+      "goBack": "Go back",
+      "tableOfContents": "Table of contents",
+      "toggleBookmark": "Toggle bookmark",
+      "cycleFooterMode": "Cycle footer info mode",
+      "keyboardShortcutsHint": "Keyboard shortcuts (?)",
+      "enterFullscreen": "Enter fullscreen",
+      "exitFullscreen": "Exit fullscreen",
+      "footerMode": {
+        "pageProgress": "Footer info: page + progress",
+        "sessionTimeLeft": "Footer info: reading session + time left",
+        "chapterTimeLeft": "Footer info: chapter + chapter time left"
+      }
+    },
+    "footer": {
+      "previousSection": "Previous section",
+      "nextSection": "Next section",
+      "goToPlaceholder": "45 or p123",
+      "jumpToLocation": "Jump to location",
+      "jumpTooltip": "Jump to % or page (e.g. 45 or p123)",
+      "go": "Go"
+    },
+    "settings": {
+      "title": "Settings",
+      "ariaLabel": "Reader settings",
+      "tabs": {
+        "appearance": "Appearance",
+        "text": "Text",
+        "layout": "Layout"
+      },
+      "appearance": {
+        "mode": "Mode",
+        "light": "Light",
+        "dark": "Dark",
+        "colorTheme": "Color theme"
+      },
+      "text": {
+        "fontSize": "Font size",
+        "fontSizeRange": "Range: 10-32px",
+        "lineHeight": "Line height",
+        "lineHeightRange": "Range: 0.8-3.0",
+        "fontFamily": "Font family",
+        "fontFamilyDescription": "Choose built-in or uploaded fonts for body text.",
+        "builtIn": "Built-in",
+        "yourFonts": "Your fonts"
+      },
+      "layout": {
+        "pageSpreads": "Page spreads",
+        "pageSpreadsDescription": "Choose how this image-based EPUB pairs pages.",
+        "bookDefault": "Book default",
+        "singlePage": "Single page",
+        "readingFlow": "Reading flow",
+        "readingFlowDescription": "Switch between paged and continuous scrolling.",
+        "paginated": "Paginated",
+        "scrolled": "Scrolled",
+        "textColumns": "Text columns",
+        "textColumnsRange": "Range: 1-10",
+        "columnGap": "Column gap",
+        "columnGapRange": "Range: 0-50%",
+        "maxWidth": "Max width",
+        "maxWidthRange": "Range: 400-1600",
+        "justifyText": "Justify text",
+        "justifyTextDescription": "Enable full-width paragraph alignment.",
+        "hyphenation": "Hyphenation",
+        "hyphenationDescription": "Enable automatic word-break hyphenation."
+      }
+    },
+    "search": {
+      "placeholder": "Search in book (min {min} chars)...",
+      "searching": "Searching…",
+      "tooShort": "Type at least {min} characters",
+      "noResults": "No results found",
+      "prompt": "Type to search",
+      "resultCount": "no results | {count} result | {count} results"
+    },
+    "sidebar": {
+      "tabs": {
+        "chapters": "Chapters",
+        "bookmarks": "Bookmarks",
+        "highlights": "Highlights"
+      },
+      "noChapters": "No chapters found",
+      "noBookmarks": "No bookmarks yet",
+      "noBookmarksMatch": "No bookmarks match your filters",
+      "noHighlights": "No highlights yet",
+      "noHighlightsMatch": "No highlights match your filters",
+      "searchBookmarks": "Search bookmarks...",
+      "searchHighlights": "Search highlights...",
+      "bookmarkFallback": "Bookmark",
+      "locationUnavailable": "Location unavailable",
+      "customColor": "Custom ({color})",
+      "allColors": "All colors",
+      "allChapters": "All chapters",
+      "notesOnly": "Notes only",
+      "deleteBookmark": "Delete bookmark",
+      "deleteHighlight": "Delete highlight",
+      "approximatePosition": "Synced from device; exact position unavailable, jumps to the chapter",
+      "sort": {
+        "readingOrder": "Reading order",
+        "newest": "Newest first",
+        "oldest": "Oldest first"
+      }
+    },
+    "selection": {
+      "copy": "Copy",
+      "copied": "Copied!",
+      "highlight": "Highlight",
+      "translate": "Translate",
+      "define": "Define",
+      "deleteAnnotation": "Delete annotation",
+      "apply": "Apply"
+    },
+    "note": {
+      "title": "Add note",
+      "placeholder": "Write your note…"
+    },
+    "dictionary": {
+      "noDefinition": "No definition found",
+      "loadError": "Could not load definition"
+    },
+    "translation": {
+      "original": "Original",
+      "translation": "Translation",
+      "translating": "Translating...",
+      "noTranslation": "No translation yet",
+      "viaProvider": "via {provider}",
+      "copyTranslation": "Copy translation"
+    },
+    "shortcuts": {
+      "title": "Keyboard Shortcuts",
+      "groups": {
+        "panels": "Panels",
+        "reading": "Reading",
+        "actions": "Actions"
+      },
+      "toggleToc": "Toggle table of contents",
+      "toggleSearch": "Toggle search",
+      "toggleHelp": "Show/hide this help",
+      "closePanel": "Close panel",
+      "prevNextPage": "Previous/next page",
+      "goToStart": "Go to start of book",
+      "goToEnd": "Go to end of book",
+      "toggleBookmark": "Toggle bookmark",
+      "toggleFullscreen": "Toggle fullscreen",
+      "cycleFooterMode": "Cycle footer info mode"
+    },
+    "cbz": {
+      "tabs": {
+        "view": "View",
+        "reading": "Reading",
+        "layout": "Layout"
+      },
+      "fitMode": "Fit mode",
+      "background": "Background",
+      "scrollMode": "Scroll mode",
+      "scrollModeHint": "Use \"No gaps\" for webtoons and vertical strips.",
+      "readingDirection": "Reading direction",
+      "pageView": "Page view",
+      "autoFallback": "Auto-fallback",
+      "spreadAlignmentLabel": "Spread alignment",
+      "spreadAlignmentHint": "Spread alignment is unavailable in auto-fallback mode.",
+      "focusTwoPageToggle": "Focus two-page toggle",
+      "forceTwoPage": "Force two-page",
+      "off": "Off",
+      "on": "On",
+      "widePages": "Wide pages",
+      "resetBookViewSettings": "Reset book view settings",
+      "resetConfirm": "Reset view settings for this book to your global defaults?",
+      "firstPage": "First page",
+      "lastPage": "Last page",
+      "fit": {
+        "page": "Page Fit",
+        "width": "Page Width",
+        "height": "Page Height",
+        "actual": "Actual Size"
+      },
+      "view": {
+        "single": "Single",
+        "twoPage": "Two-page"
+      },
+      "scroll": {
+        "paged": "Paged",
+        "infinite": "Infinite",
+        "noGaps": "No gaps"
+      },
+      "direction": {
+        "ltr": "L to R",
+        "rtl": "R to L"
+      },
+      "spreadAlignment": {
+        "normal": "Normal",
+        "shifted": "Shifted"
+      },
+      "widePage": {
+        "auto": "Auto",
+        "inSpreads": "In spreads"
+      },
+      "bg": {
+        "black": "Black",
+        "gray": "Gray",
+        "white": "White"
+      }
+    },
+    "audiobook": {
+      "untitled": "Untitled",
+      "loading": "Loading audiobook...",
+      "loadError": "Failed to load audiobook",
+      "noAudioFiles": "No audio files found for this book.",
+      "speed": "Speed",
+      "chapters": "Chapters",
+      "bookmarks": "Bookmarks",
+      "volume": "Volume",
+      "muted": "Muted",
+      "sleep": "Sleep",
+      "chapterAbbrev": "Ch.",
+      "sleepTimer": "Sleep timer",
+      "minutes": "{count} minutes",
+      "endOfChapter": "End of chapter",
+      "noChaptersAvailable": "No chapters available",
+      "extend15": "+ 15 minutes",
+      "timeLeft": "({time} left)",
+      "playbackSpeed": "Playback speed",
+      "noChapters": "No chapters available.",
+      "noBookmarks": "No bookmarks yet.",
+      "noBookmarksHint": "Tap the bookmark icon at the top to save your current position.",
+      "playerSettings": "Player settings",
+      "skipBack": "Skip back",
+      "skipForward": "Skip forward"
+    }
+  },
+  "scanner": {
+    "filesProgress": "{processed}/{total} files",
+    "booksFound": "no books found | {count} book found | {count} books found"
+  },
+  "series": {
+    "completion": {
+      "readOfTotal": "{read} of {total} read ({percentage}%)"
+    },
+    "gaps": {
+      "label": "Possible gaps:"
+    },
+    "filters": {
+      "title": "Series Filters",
+      "clearAll": "Clear all",
+      "allLibraries": "All Libraries",
+      "allCompletion": "All completion",
+      "notStarted": "Not started",
+      "inProgress": "In progress",
+      "complete": "Complete"
+    },
+    "list": {
+      "title": "Series",
+      "searchPlaceholder": "Search series or author",
+      "sortButton": "Sort",
+      "sortBy": "Sort by",
+      "ascending": "Ascending",
+      "descending": "Descending",
+      "ascShort": "Asc",
+      "descShort": "Desc",
+      "filters": "Filters",
+      "clear": "Clear",
+      "noMatch": "No series match your filters.",
+      "empty": "No series found in your libraries.",
+      "sort": {
+        "name": "Name",
+        "bookCount": "Book Count",
+        "recentAdditions": "Recent Additions",
+        "readingProgress": "Reading Progress"
+      }
+    },
+    "detail": {
+      "pageTitle": "Series",
+      "pageTitleNamed": "Series · {name}",
+      "pageTitleWithId": "Series #{id}",
+      "entityName": "Series",
+      "bookCount": "no books | {count} book | {count} books",
+      "byAuthors": "by {authors}",
+      "moreAuthors": "+{count} more",
+      "preparingEditor": "Preparing editor...",
+      "editMetadata": "Edit Metadata",
+      "firstInSeries": "First in Series",
+      "untitled": "Untitled",
+      "loadingFirstBook": "Loading first book preview...",
+      "showLess": "Show less",
+      "showMore": "Show more",
+      "moreGenres": "+{count} more",
+      "synopsis": "Synopsis",
+      "noDescription": "No description available.",
+      "updatingPreview": "Updating preview...",
+      "noBooksToPreview": "No books available to preview.",
+      "loadingSeries": "Loading series...",
+      "booksHeading": "Books",
+      "allLibraries": "All Libraries",
+      "groupByMedia": "Group by media",
+      "noBooksFound": "No books found in this series",
+      "trySelectingLibrary": "Try selecting another library.",
+      "allBooksLoaded": "All {count} books loaded",
+      "leadBookLoadError": "Failed to load lead book details",
+      "noBooksToEdit": "This series has no books to edit.",
+      "loadFullSeriesError": "Failed to load the full series for editing.",
+      "sort": {
+        "seriesOrder": "Series Order",
+        "title": "Title",
+        "recentlyAdded": "Recently Added"
+      },
+      "order": {
+        "ascending": "Ascending",
+        "descending": "Descending"
+      }
+    }
+  },
+  "smartScope": {
+    "dialog": {
+      "name": "Name",
+      "namePlaceholder": "e.g. Unread Sci-Fi",
+      "icon": "Icon",
+      "iconPlaceholder": "Choose an icon...",
+      "nameRequired": "Name is required",
+      "iconRequired": "Choose an icon",
+      "create": "Create",
+      "creating": "Creating...",
+      "saving": "Saving..."
+    },
+    "createDialog": {
+      "title": "New Smart Scope",
+      "visibleToAll": "Visible to all users",
+      "createFailed": "Failed to create Smart Scope"
+    },
+    "saveAsDialog": {
+      "title": "Save as SmartScope",
+      "save": "Save SmartScope",
+      "saveFailed": "Failed to save Smart Scope"
+    },
+    "editorPanel": {
+      "untitled": "Untitled SmartScope",
+      "subtitle": "Configure smart scope settings",
+      "counting": "counting...",
+      "bookCount": "no books | one book | {count} books",
+      "identity": "Identity",
+      "filters": "Filters",
+      "noFilters": "No filters set. All accessible books will be included in this smart scope.",
+      "buildFromScratch": "Build from scratch",
+      "replaceWithTemplate": "Replace with template:",
+      "defaultSort": "Default Sort",
+      "saveChanges": "Save changes",
+      "saveFailed": "Failed to save",
+      "templates": {
+        "hasSeries": "Has Series",
+        "addedRecently": "Added Recently",
+        "pdfOnly": "PDF Only",
+        "noGenres": "No Genres",
+        "epubOnly": "EPUB Only"
+      }
+    }
+  },
+  "statistics": {
+    "tabs": {
+      "library": "Library Stats",
+      "user": "My Reading"
+    },
+    "filter": {
+      "allLibraries": "All Libraries",
+      "librarySelection": "{count} of {total} Libraries"
+    },
+    "config": {
+      "button": "Configure",
+      "title": "Configure Charts",
+      "description": "Drag to reorder, toggle to show or hide.",
+      "reset": "Reset to defaults"
+    },
+    "summary": {
+      "books": "Books",
+      "authors": "Authors",
+      "series": "Series",
+      "publishers": "Publishers",
+      "storage": "Storage",
+      "genres": "Genres",
+      "languages": "Languages",
+      "published": "Published",
+      "thisYear": "This Year",
+      "started": "Started",
+      "inProgress": "In Progress",
+      "completed": "Completed",
+      "avgProgress": "Avg Progress"
+    },
+    "card": {
+      "loadError": "Failed to load data",
+      "emptyTitle": "No data yet",
+      "emptyDescription": "No data available for this chart",
+      "unknownField": "no data for this field | {count} book has no data for this field | {count} books have no data for this field"
+    },
+    "breakdown": {
+      "ariaLabel": "Break down by source or format"
+    },
+    "empty": {
+      "notEnoughData": "Not enough data yet"
+    },
+    "charts": {
+      "acquisitionLag": {
+        "title": "Acquisition Lag"
+      },
+      "booksAddedOverTime": {
+        "title": "Books Added Over Time",
+        "monthly": "Monthly",
+        "yearly": "Yearly",
+        "allTime": "All Time",
+        "last5Years": "Last 5 Years",
+        "lastYear": "Last Year"
+      },
+      "formatDistribution": {
+        "title": "Format Distribution"
+      },
+      "formatShareOverTime": {
+        "title": "Format Share Over Time"
+      },
+      "genreCooccurrence": {
+        "title": "Genre Co-occurrence"
+      },
+      "genreDistribution": {
+        "title": "Genre Distribution"
+      },
+      "languageDistribution": {
+        "title": "Language Distribution"
+      },
+      "largestBooks": {
+        "title": "Top 50 Largest Books"
+      },
+      "libraryIntegrity": {
+        "title": "Library Integrity"
+      },
+      "libraryMetadataCompleteness": {
+        "title": "Library Metadata Completeness"
+      },
+      "metadataCompleteness": {
+        "title": "Metadata Completeness"
+      },
+      "metadataFreshness": {
+        "title": "Metadata Freshness"
+      },
+      "metadataScoreDistribution": {
+        "title": "Metadata Score Distribution"
+      },
+      "pageCountDistribution": {
+        "title": "Page Count Distribution"
+      },
+      "publicationDecade": {
+        "title": "Publication Decade"
+      },
+      "publicationYearTimeline": {
+        "title": "Publication Year Timeline"
+      },
+      "storageByFormat": {
+        "title": "Storage by Format"
+      },
+      "topAuthors": {
+        "title": "Top 25 Authors"
+      },
+      "topSeries": {
+        "title": "Top 50 Series"
+      },
+      "booksCompleted": {
+        "title": "Books Completed",
+        "notEnoughData": "Need at least {count} completed books for this chart."
+      },
+      "completionLatency": {
+        "title": "Completion Latency",
+        "notEnoughData": "Need at least {count} completed books for this chart."
+      },
+      "completionTimeline": {
+        "title": "Completion Timeline",
+        "notEnoughData": "Need at least {count} completed books for this chart."
+      },
+      "favoriteReadingDays": {
+        "title": "Favorite Reading Days",
+        "notEnoughData": "Need at least {count} reading events for this chart."
+      },
+      "genreReadingTime": {
+        "title": "Genre Reading Time",
+        "notEnoughData": "Need at least {count} genres with reading time for this chart."
+      },
+      "goalTrajectory": {
+        "title": "Pace vs Goal",
+        "noCompletedTitle": "No completed books yet",
+        "noCompletedDescription": "Complete a book in this period to compare your pace against your yearly goal.",
+        "notEnoughData": "Need at least {count} completed books for this chart."
+      },
+      "peakReadingHours": {
+        "title": "Peak Reading Hours",
+        "notEnoughData": "Need at least {count} reading events for this chart."
+      },
+      "progressFunnel": {
+        "title": "Progress Funnel",
+        "modePercent": "Percent",
+        "modeCounts": "Counts",
+        "modeDropoff": "Drop-off",
+        "started": "Started {count}",
+        "notEnoughData": "Need at least {count} started books for this chart.",
+        "noDropOffTitle": "No drop-off observed",
+        "noDropOffDescription": "Every started book progressed through all funnel stages in this period."
+      },
+      "readingClock": {
+        "title": "Reading Clock",
+        "notEnoughData": "Need at least {count} reading sessions for this chart."
+      },
+      "readingHeatmap": {
+        "title": "Reading Heatmap",
+        "notEnoughData": "Need activity on at least {count} days for this chart."
+      },
+      "readingPace": {
+        "title": "Reading Pace",
+        "notEnoughData": "Need at least {count} sessions with progress data for this chart."
+      },
+      "readingSessionTimeline": {
+        "title": "Reading Session Timeline",
+        "dragOn": "Drag: On",
+        "dragOff": "Drag: Off",
+        "prev": "Prev",
+        "next": "Next",
+        "week": "Week {week}",
+        "dragHint": "Drag bars to move sessions. Duration is locked and overlapping sessions are rejected.",
+        "noSessionsTitle": "No sessions this week",
+        "noSessionsDescription": "Use Prev/Next or the week selector to view a different week.",
+        "overlapError": "Session overlaps another session in this window",
+        "moveError": "Failed to move session"
+      },
+      "sessionArchetypes": {
+        "title": "Session Archetypes"
+      },
+      "sourceDistribution": {
+        "title": "Where You Read",
+        "emptyTitle": "No reading activity yet",
+        "emptyDescription": "Read on the web, KOReader, or Kobo to see your source split."
+      }
+    }
+  },
+  "tools": {
+    "header": {
+      "entityManager": "Entity Manager",
+      "bulkRename": "Bulk Rename"
+    },
+    "entityTypes": {
+      "authors": "Authors",
+      "genres": "Genres",
+      "tags": "Tags",
+      "narrators": "Narrators",
+      "publishers": "Publishers",
+      "languages": "Languages",
+      "series": "Series"
+    },
+    "bulkRename": {
+      "library": "Library",
+      "selectLibraryPlaceholder": "Select a library...",
+      "noEligibleLibraries": "No libraries have file rename enabled. Enable it in Library Settings.",
+      "refresh": "Refresh",
+      "applyRename": "Apply Rename",
+      "showFullPaths": "Show full paths",
+      "columnsMenu": "Columns",
+      "renamingInProgress": "Renaming files - you can cancel at any time.",
+      "executionFailed": "Bulk rename failed",
+      "previewFailed": "Failed to load preview",
+      "noBooksMatch": "No books found matching the current filter.",
+      "openBookDetails": "Open book details",
+      "columns": {
+        "title": "Title",
+        "currentPath": "Current Path",
+        "newPath": "New Path",
+        "status": "Status"
+      },
+      "status": {
+        "willRename": "Will Rename",
+        "unchanged": "Unchanged",
+        "collision": "Collision",
+        "noPattern": "No Pattern",
+        "error": "Error"
+      },
+      "filter": {
+        "all": "All"
+      },
+      "summary": {
+        "label": "Summary",
+        "toRename": "{count} to rename",
+        "unchanged": "{count} unchanged",
+        "collisions": "{count} collision | {count} collision | {count} collisions",
+        "errors": "{count} error | {count} error | {count} errors"
+      },
+      "empty": {
+        "title": "Pick a Library to Start",
+        "description": "Select a library above to preview rename changes, filter by status, and apply the bulk rename run.",
+        "chooseLibrary": "Choose Library"
+      },
+      "completed": {
+        "title": "Bulk rename completed",
+        "stats": "{succeeded} renamed, {failed} failed, {skipped} skipped ({processed} total)"
+      },
+      "pagination": {
+        "showing": "Showing {from}-{to} of {total}"
+      },
+      "confirmDialog": {
+        "title": "Confirm Bulk Rename",
+        "body": "This will rename {count} book on disk. Files with collisions or errors will be skipped. This action cannot be undone. | This will rename {count} book on disk. Files with collisions or errors will be skipped. This action cannot be undone. | This will rename {count} books on disk. Files with collisions or errors will be skipped. This action cannot be undone.",
+        "renameButton": "Rename {count} book | Rename {count} book | Rename {count} books"
+      }
+    },
+    "entityManager": {
+      "unknown": "Unknown",
+      "bookCount": "no books | {count} book | {count} books",
+      "sortPrefix": "· sort: {sortName}",
+      "selectTargetToKeep": "Select target to keep",
+      "writeToFiles": "Write to files",
+      "writeChangesToFiles": "Write changes to files",
+      "mergeIntoTarget": "Merge {count} into target",
+      "modes": {
+        "browse": "Browse & Manage",
+        "duplicates": "Find Duplicates"
+      },
+      "actions": {
+        "rename": "Rename",
+        "split": "Split"
+      },
+      "duplicates": {
+        "similarity": "Similarity:",
+        "scan": "Scan",
+        "scanning": "Scanning...",
+        "computing": "Computing candidates...",
+        "computedAt": "Candidates computed {date}",
+        "recompute": "Recompute",
+        "noneComputed": "No candidates computed yet.",
+        "computeNow": "Compute now",
+        "emptyTitle": "Find duplicate entities",
+        "emptyDescription": "Adjust the similarity threshold and click Scan to detect potential duplicates.",
+        "noneFoundTitle": "No duplicates found",
+        "noneFoundDescription": "No potential duplicates were detected with the current settings.",
+        "clustersFound": "no clusters found | {count} cluster found | {count} clusters found",
+        "plusOthers": "+ {count} other | + {count} other | + {count} others",
+        "percentSimilar": "{percent}% similar",
+        "pairDetails": "Pair details",
+        "dismissEntityTitle": "Dismiss all pairs for this entity",
+        "dismissPairTitle": "Dismiss this pair"
+      },
+      "dismissed": {
+        "loading": "Loading dismissed pairs...",
+        "empty": "No dismissed pairs",
+        "restore": "Restore",
+        "restoreTitle": "Restore this pair",
+        "hidePairs": "Hide dismissed pairs",
+        "showPairs": "Show dismissed pairs"
+      },
+      "browse": {
+        "searchPlaceholder": "Search...",
+        "emptyOnly": "Empty only",
+        "clear": "Clear",
+        "noEntities": "No entities found",
+        "mergeCount": "Merge ({count})",
+        "deleteCount": "Delete ({count})",
+        "totalCount": "{count} total",
+        "sortLabel": "sort: {sortName}",
+        "sort": {
+          "nameAsc": "Name A-Z",
+          "nameDesc": "Name Z-A",
+          "fewestBooks": "Fewest books",
+          "mostBooks": "Most books"
+        }
+      },
+      "deleteMode": {
+        "label": "Delete mode",
+        "softTitle": "Soft delete",
+        "softDescription": "Unlink from all books but keep the entity record",
+        "softDescriptionPlural": "Unlink from all books but keep the entity records",
+        "hardTitle": "Hard delete",
+        "hardDescription": "Remove entity and all associations permanently",
+        "hardDescriptionPlural": "Remove entities and all associations permanently"
+      },
+      "renameModal": {
+        "title": "Rename Entity",
+        "currentName": "Current name",
+        "newName": "New name"
+      },
+      "deleteModal": {
+        "title": "Delete Entity",
+        "confirm": "Are you sure you want to delete {name}?"
+      },
+      "splitModal": {
+        "title": "Split Entity",
+        "splitting": "Splitting",
+        "newNames": "New names (min 2)",
+        "namePlaceholder": "Enter name...",
+        "addAnother": "Add another"
+      },
+      "bulkDeleteModal": {
+        "title": "Bulk Delete",
+        "confirm": "Are you sure you want to delete {count} selected entity? | Are you sure you want to delete {count} selected entity? | Are you sure you want to delete {count} selected entities?",
+        "deleteButton": "Delete {count}"
+      },
+      "mergeModal": {
+        "title": "Merge Entities",
+        "description": "Select which entity to keep. The others will be merged into it and removed."
+      }
+    }
+  },
+  "views": {
+    "entity": {
+      "book": "Book",
+      "collection": "Collection",
+      "library": "Library",
+      "smartScope": "SmartScope"
+    },
+    "common": {
+      "retry": "Retry"
+    },
+    "bookView": {
+      "sort": "Sort",
+      "sortOn": "On",
+      "resetSort": "Reset sort to default",
+      "filters": "Filters",
+      "clear": "Clear",
+      "clearAllFilters": "Clear all filters",
+      "expandSeries": "Expand series",
+      "collapseSeries": "Collapse series",
+      "expanded": "Expanded",
+      "exportMetadata": "Export metadata",
+      "export": "Export",
+      "searchPlaceholder": "Search title, author, series, narrator...",
+      "allBooksLoaded": "All {count} books loaded"
+    },
+    "notFound": {
+      "title": "Page not found",
+      "description": "The page you're looking for doesn't exist.",
+      "goHome": "Go home"
+    },
+    "dashboard": {
+      "customize": "Customize dashboard",
+      "allShelvesHidden": "All shelves are hidden.",
+      "greeting": {
+        "morning": "Good morning,",
+        "afternoon": "Good afternoon,",
+        "evening": "Good evening,",
+        "fallbackName": "there"
+      }
+    },
+    "bookDetail": {
+      "title": "Book",
+      "titleWithId": "Book #{id}",
+      "pageTitle": {
+        "book": "Book · {base}",
+        "editMetadata": "Edit Metadata · {base}",
+        "edit": "Edit · {base}",
+        "files": "Files · {base}",
+        "readingLog": "Reading Log · {base}",
+        "highlights": "Highlights · {base}"
+      }
+    },
+    "bookDock": {
+      "title": "Book Dock",
+      "newFilesDetected": "New files detected",
+      "reconnecting": "Reconnecting",
+      "rescanFailed": "Rescan failed",
+      "totalInDock": "{size} in Book Dock",
+      "dropFiles": "Drop files into Book Dock",
+      "supportedFormats": "Supported: {formats}",
+      "empty": {
+        "noSearchMatch": "No files match \"{query}\"",
+        "noStatusFiles": "No {status} files",
+        "uploadPrompt": "Upload files or drop them in the Book Dock folder"
+      },
+      "retry": {
+        "noneToRetry": "No error files to retry",
+        "retrying": "Retrying one file | Retrying one file | Retrying {count} files"
+      },
+      "applyFetched": {
+        "applied": "Applied to no files | Applied to one file | Applied to {count} files",
+        "skippedEdited": "skipped one file because they have manual edits | skipped one file because it has manual edits | skipped {count} files because they have manual edits",
+        "skippedNoMetadata": "skipped one file because they have no fetched metadata | skipped one file because it has no fetched metadata | skipped {count} files because they have no fetched metadata",
+        "noneApplied": "No files applied; {reasons}",
+        "noneSelected": "No files selected"
+      }
+    },
+    "collection": {
+      "title": "Collection",
+      "pageTitle": "Collection · {name}",
+      "pageTitleWithId": "Collection #{id}",
+      "editCollection": "Edit collection",
+      "loadError": "Could not load this collection",
+      "toast": {
+        "removed": "Removed no books from collection | Removed one book from collection | Removed {count} books from collection",
+        "removeFailed": "Failed to remove books from collection"
+      },
+      "empty": {
+        "noSearchMatch": "No books match this search",
+        "noSearchMatchHint": "Try a different search term or clear the search.",
+        "noBooks": "No books in this collection",
+        "noBooksHint": "Select books from your library and add them here."
+      }
+    },
+    "library": {
+      "title": "Library",
+      "pageTitle": "Library · {name}",
+      "pageTitleWithId": "Library #{id}",
+      "filterRules": "Filter rules",
+      "saveAsSmartScope": "Save as Smart Scope",
+      "saveScope": "Save Scope",
+      "saveAsSmartScopeTooltip": "Save this filter as a named Smart Scope",
+      "saved": "Saved",
+      "saveFilter": "Save filter",
+      "filterSaved": "Filter saved",
+      "saveFilterTooltip": "Save filter for this library",
+      "removeSavedFilter": "Remove saved filter",
+      "empty": {
+        "noFilterMatch": "No books match your filters",
+        "noFilterMatchHint": "Try adjusting or clearing your filters to see more books.",
+        "clearFilters": "Clear filters",
+        "scanning": "Scanning your library...",
+        "scanningHint": "Books will appear here as they are discovered.",
+        "emptyLibrary": "Your library is empty",
+        "emptyLibraryHint": "Once you add books to this library, they will appear here."
+      },
+      "querySelection": {
+        "loadedSelected": "{selected} of {total} loaded books selected.",
+        "selectAllMatching": "Select all {total} matching books"
+      }
+    },
+    "smartScope": {
+      "title": "SmartScope",
+      "pageTitle": "SmartScope · {name}",
+      "pageTitleWithId": "SmartScope #{id}",
+      "defaultName": "Smart scope",
+      "filter": "Filter",
+      "hideFilter": "Hide filter",
+      "showFilter": "Show filter",
+      "confirmDelete": "Confirm?",
+      "loadError": "Could not load this SmartScope",
+      "toast": {
+        "deleted": "\"{name}\" deleted",
+        "deleteFailed": "Failed to delete \"{name}\""
+      },
+      "empty": {
+        "noRules": "No rules configured",
+        "noRulesHint": "Open the editor to define which books appear in this smartScope using filters and sort rules.",
+        "configure": "Configure SmartScope",
+        "noMatch": "No books match this smartScope",
+        "noMatchHint": "Try adjusting the filter rules.",
+        "edit": "Edit SmartScope"
+      }
+    }
+  },
+  "whatsNew": {
+    "title": "What's New",
+    "subtitle": "Everything that's shipped, newest first.",
+    "versionPrefix": "Version {version}",
+    "newUpdates": "no new updates | one new update | {count} new updates",
+    "remindLater": "Remind me later",
+    "gotIt": "Got it",
+    "latest": "Latest",
+    "fullChangelog": "Full changelog",
+    "seeAllReleases": "See all releases",
+    "versions": "Versions",
+    "currentVersion": "Current version",
+    "youreHere": "You're here",
+    "searchPlaceholder": "Search releases…",
+    "noReleasesFound": "No releases found.",
+    "noHighlights": "No highlights for this release.",
+    "showChangelog": "Show full changelog",
+    "hideChangelog": "Hide full changelog",
+    "openOnGitHub": "Open on GitHub",
+    "loadMore": "Load more",
+    "loadingMore": "Loading…",
+    "loadFailed": "Failed to load releases",
+    "loadMoreFailed": "Could not load more releases. Please try again.",
+    "loadErrorHint": "Couldn't load releases. Check your connection and try again.",
+    "retry": "Retry",
+    "imageViewer": "Image viewer",
+    "closeImage": "Close image",
+    "previousImage": "Previous image",
+    "nextImage": "Next image"
   }
 }

--- a/client/src/locales/nl.json
+++ b/client/src/locales/nl.json
@@ -20,7 +20,5564 @@
         "title": "Taal",
         "description": "Kies de taal die in de hele interface wordt gebruikt.",
         "label": "Interfacetaal"
+      },
+      "pageTitle": "Weergave",
+      "pageSubtitle": "Beheer thema's, omslagen, indeling en hoe je bibliotheek wordt getoond.",
+      "mobileSummary": "Thema: {theme} • Accent: {accent} • Achtergrond: {background}",
+      "themeMode": {
+        "light": "Licht",
+        "dark": "Donker"
+      },
+      "theme": {
+        "title": "Thema",
+        "colorScheme": {
+          "label": "Kleurenschema",
+          "hint": "Lichte of donkere interface"
+        },
+        "accentColor": {
+          "label": "Accentkleur",
+          "hint": "Bepaalt accenten en interactieve elementen"
+        },
+        "cornerRadius": {
+          "label": "Hoekafronding",
+          "hint": "Afronding van kaarten en UI-elementen"
+        },
+        "surfaceBrightness": {
+          "label": "Oppervlaktehelderheid",
+          "hint": "Maak oppervlakken in donkere modus lichter",
+          "reset": "Herstellen"
+        },
+        "libraryBackground": {
+          "title": "Bibliotheekachtergrond",
+          "pattern": {
+            "label": "Achtergrondpatroon",
+            "hint": "Patroon achter het boekenraster"
+          }
+        },
+        "backgroundGroups": {
+          "fundamental": "Basis",
+          "structural": "Structureel",
+          "ambient": "Sfeervol",
+          "refractive": "Refractief"
+        }
+      },
+      "storage": {
+        "title": "Waar weergavevoorkeuren opslaan",
+        "active": "Actief",
+        "notAvailable": "Niet beschikbaar",
+        "device": {
+          "title": "Alleen dit apparaat",
+          "description": "Voorkeuren blijven in je browser. Handig als je op verschillende apparaten een andere weergave wilt."
+        },
+        "account": {
+          "title": "Mijn account",
+          "description": "Voorkeuren worden opgeslagen bij je account. Handig als je op elk apparaat dezelfde weergave wilt."
+        },
+        "toasts": {
+          "synced": "Voorkeuren worden nu gesynchroniseerd",
+          "local": "Voorkeuren blijven op dit apparaat"
+        },
+        "errors": {
+          "demoRestricted": "Demobeperkt account kan de opslagmodus voor thema niet wijzigen",
+          "update": "Bijwerken van opslagmodus mislukt",
+          "generic": "Er is een fout opgetreden bij het bijwerken van de opslagmodus"
+        }
+      },
+      "bookCovers": {
+        "title": "Boekomslagen",
+        "displayMode": {
+          "title": "Weergavemodus omslag",
+          "hint": "Bepaalt hoe echte omslagen in boekvakken passen wanneer de verhoudingen verschillen",
+          "blurredFit": {
+            "label": "Vervaagd passend",
+            "hint": "Toon de volledige omslag met een vervaagde vulling erachter"
+          },
+          "fillCrop": {
+            "label": "Kaart vullen",
+            "hint": "Vul het hele vak door randen bij te snijden wanneer de verhoudingen verschillen"
+          },
+          "naturalBottom": {
+            "label": "Natuurlijke onderkant",
+            "hint": "Behoud de originele omslagverhouding en veranker de omslag aan de onderkant"
+          }
+        },
+        "spine": {
+          "title": "Boekrug-overlay",
+          "hint": "Voegt een gestileerde rug en glanseffect toe aan omslagkaarten",
+          "off": {
+            "label": "Uit",
+            "hint": "Geen rug-/glanseffect op omslagen"
+          },
+          "subtle": {
+            "label": "Subtiel",
+            "hint": "Lichte rug en glans, dicht bij de standaardweergave"
+          },
+          "strong": {
+            "label": "Sterk",
+            "hint": "Nadrukkelijker rug- en glanseffect"
+          }
+        },
+        "showSpineOnComics": {
+          "label": "Rug tonen bij strips",
+          "hint": "Pas het rug- en glanseffect toe op stripomslagen (cbz, cbr, cb7)"
+        },
+        "shadow": {
+          "title": "Schaduwsterkte omslag",
+          "hint": "Bepaalt de diepte onder omslagen in raster-, lijst-, tabel- en dashboardminiaturen",
+          "default": {
+            "label": "Standaard",
+            "hint": "Huidige verhoging en diepte"
+          },
+          "strong": {
+            "label": "Sterk",
+            "hint": "Zwaardere, plankachtige slagschaduw onder omslagen"
+          }
+        },
+        "overlays": {
+          "title": "Kaartoverlays",
+          "hint": "Kies welke metadata direct op boekomslagkaarten wordt getoond",
+          "progressBar": {
+            "label": "Voortgangsbalk",
+            "hint": "Dunne gekleurde lijn langs de onderrand"
+          },
+          "format": {
+            "label": "Bestandsformaat",
+            "hint": "Kleurgecodeerde EPUB-, PDF-, CBZ-badge rechtsonder"
+          },
+          "rating": {
+            "label": "Beoordeling",
+            "hint": "Sterbeoordelingsindicator linksonder"
+          },
+          "readStatus": {
+            "label": "Leesstatus",
+            "hint": "Gekleurd pictogram dat de huidige leesstatus linksboven toont"
+          },
+          "seriesPosition": {
+            "label": "Reeksnummer",
+            "hint": "Badge die de positie van het boek in de reeks rechtsboven toont (bijv. #3, #1.5)"
+          },
+          "lockStatus": {
+            "label": "Vergrendelstatus",
+            "hint": "Metadata-vergrendelpictogram rechtsboven - oranje bij vergrendeld, groen bij ontgrendeld"
+          }
+        }
+      },
+      "layout": {
+        "coverSize": "Omslagformaat",
+        "gridSpacing": "Rasterafstand",
+        "gridLayout": {
+          "title": "Bibliotheekrasterindeling"
+        },
+        "coverSizeBehavior": {
+          "label": "Gedrag omslagformaat",
+          "hint": "Bepaal of staande/vierkante formaten en rasterafstand voor alle weergaven worden gedeeld of per weergave worden bewaard",
+          "perViewHint": "Modus per weergave: pas omslagformaat en afstand aan via het weergavepaneel van elke weergave.",
+          "syncAll": "Alle weergaven synchroniseren",
+          "perView": "Formaten per weergave"
+        },
+        "portraitCoverSize": {
+          "label": "Staand omslagformaat",
+          "hint": "Gebruikt voor staande bibliotheken en weergaven"
+        },
+        "squareCoverSize": {
+          "label": "Vierkant omslagformaat",
+          "hint": "Gebruikt voor vierkante bibliotheken en weergaven"
+        },
+        "portraitGridSpacing": {
+          "label": "Staande rasterafstand",
+          "hint": "Ruimte tussen staande omslagen"
+        },
+        "squareGridSpacing": {
+          "label": "Vierkante rasterafstand",
+          "hint": "Ruimte tussen vierkante omslagen"
+        },
+        "cardInfoMode": {
+          "label": "Kaartinfomodus",
+          "hint": "Waar boektitel en auteur op rasterkaarten worden getoond",
+          "onHover": "Bij hover",
+          "belowCover": "Onder omslag",
+          "off": "Uit"
+        },
+        "primaryCardLabel": {
+          "label": "Primair kaartlabel",
+          "hint": "Tekst onder elke boekomslag (eerste regel)"
+        },
+        "secondaryCardLabel": {
+          "label": "Secundair kaartlabel",
+          "hint": "Extra tekst onder het primaire label (tweede regel)"
+        },
+        "labelField": {
+          "hidden": "Verborgen",
+          "bookTitle": "Boektitel",
+          "seriesTitle": "Reekstitel",
+          "seriesTitlePosition": "Reekstitel + positie",
+          "author": "Auteur"
+        },
+        "seriesDisplay": {
+          "title": "Reeksweergave",
+          "collapsedCover": {
+            "label": "Omslag bij ingeklapte reeks",
+            "hint": "Kies welke omslag wordt getoond wanneer reeksen zijn ingeklapt in het boekenraster"
+          },
+          "stack": "Stapel",
+          "mosaic": "Mozaïek",
+          "first": "Eerste",
+          "latest": "Nieuwste",
+          "firstUnread": "Eerste ongelezen"
+        },
+        "authorGrid": {
+          "title": "Auteursraster",
+          "coverSize": {
+            "label": "Omslagformaat",
+            "hint": "Breedte van auteursomslagen in het raster"
+          },
+          "coverShape": {
+            "label": "Omslagvorm",
+            "hint": "Vorm van auteursomslagen in het raster"
+          },
+          "circle": "Cirkel",
+          "square": "Vierkant"
+        },
+        "listTableViews": {
+          "title": "Lijst- en tabelweergaven"
+        },
+        "zebraStriping": {
+          "label": "Zebrastrepen",
+          "hint": "Wissel rijachtergrondkleuren af voor makkelijker scannen"
+        }
+      },
+      "behavior": {
+        "title": "Bibliotheekgedrag",
+        "thumbnailClicks": {
+          "label": "Klikken op miniaturen",
+          "hint": "Kies wat er gebeurt bij het openen van een boek vanuit raster- en lijstweergaven",
+          "readFirst": "Eerst lezen",
+          "readFirstHint": "Open de lezer wanneer er een leesbaar bestand bestaat",
+          "openDetails": "Details openen",
+          "openDetailsHint": "Ga naar de boekdetailpagina vanuit raster- en lijstminiaturen"
+        },
+        "filterPreview": {
+          "label": "Filtervoorbeeld standaard tonen",
+          "hint": "Vouw de samenvatting van het actieve filter en de sortering uit bij het openen van een smartScope"
+        },
+        "collapseSeries": {
+          "label": "Reeksen standaard inklappen",
+          "hint": "Groepeer boeken uit dezelfde reeks in één kaart in bibliotheek- en collectieweergaven"
+        }
+      },
+      "icons": {
+        "title": "Aangepaste pictogrammen",
+        "uploadIcons": "Pictogrammen uploaden",
+        "uploadedCount": "geen pictogrammen geüpload | {count} pictogram geüpload | {count} pictogrammen geüpload",
+        "searchPlaceholder": "Pictogrammen zoeken",
+        "sort": {
+          "newest": "Nieuwste",
+          "name": "Naam"
+        },
+        "selectedCount": "{count} geselecteerd",
+        "clear": "Wissen",
+        "deleteSelected": "Selectie verwijderen",
+        "loading": "Pictogrammen laden...",
+        "emptySearch": "Geen pictogrammen komen overeen met je zoekopdracht.",
+        "emptyNoIcons": "Nog geen aangepaste pictogrammen geüpload.",
+        "namePlaceholder": "Naam",
+        "checkingUsage": "Gebruik controleren...",
+        "usedBy": "Gebruikt door {count}",
+        "notUsedYet": "Nog niet gebruikt",
+        "rename": "Hernoemen",
+        "replace": "Vervangen",
+        "usage": {
+          "libraries": "geen bibliotheken | {count} bibliotheek | {count} bibliotheken",
+          "collections": "geen collecties | {count} collectie | {count} collecties",
+          "smartScopes": "geen smart scopes | {count} smart scope | {count} smart scopes"
+        },
+        "confirm": {
+          "deleteOne": "\"{name}\" verwijderen? Bestaand gebruik valt terug op het standaardpictogram.",
+          "deleteMany": "Geen pictogrammen verwijderen? | {count} pictogram verwijderen? Bestaand gebruik valt terug op het standaardpictogram. | {count} pictogrammen verwijderen? Bestaand gebruik valt terug op het standaardpictogram."
+        },
+        "toasts": {
+          "saved": "Pictogram opgeslagen",
+          "updated": "Pictogram bijgewerkt",
+          "deleted": "Pictogram verwijderd",
+          "bulkDeleted": "Geen pictogrammen verwijderd | {count} pictogram verwijderd | {count} pictogrammen verwijderd",
+          "bulkDeletePartial": "{deleted} verwijderd, {failed} mislukt"
+        },
+        "errors": {
+          "load": "Pictogrammen laden mislukt",
+          "save": "Pictogram opslaan mislukt",
+          "replace": "Pictogram vervangen mislukt",
+          "delete": "Pictogram verwijderen mislukt",
+          "bulkDelete": "Pictogrammen verwijderen mislukt"
+        }
+      }
+    },
+    "account": {
+      "title": "Account",
+      "subtitle": "Beheer je persoonlijke profielinstellingen.",
+      "subtitleAll": "Beheer je profiel en meldingsvoorkeuren.",
+      "tabs": {
+        "profile": "Profiel",
+        "notifications": "Meldingen",
+        "restrictions": "Beperkingen"
+      },
+      "demoRestricted": {
+        "cannotEdit": "Demo-beperkt account kan accountinstellingen niet bewerken",
+        "notice": "Demo-beperkt account: het bewerken van profiel, wachtwoord, avatar en gekoppelde identiteiten is uitgeschakeld."
+      },
+      "feedback": {
+        "unsavedChanges": "Niet-opgeslagen wijzigingen",
+        "allSaved": "Alle wijzigingen opgeslagen"
+      },
+      "profile": {
+        "securityHeading": "Profiel & Beveiliging",
+        "username": "Gebruikersnaam",
+        "fullName": "Volledige naam",
+        "email": "E-mail",
+        "emailHint": "Neem contact op met een beheerder om je e-mailadres te wijzigen.",
+        "save": "Profiel opslaan",
+        "saving": "Opslaan...",
+        "changePassword": "Wachtwoord wijzigen",
+        "accountType": "Accounttype:",
+        "accountTypeOidc": "OIDC / SSO",
+        "accountTypeShared": "Gedeeld",
+        "accountTypeLocal": "Lokaal",
+        "nameRequired": "Naam is verplicht",
+        "updateFailed": "Bijwerken van profiel mislukt",
+        "updated": "Profiel bijgewerkt"
+      },
+      "readingPreferences": {
+        "title": "Leesvoorkeuren",
+        "timezoneHint": "De tijdzone wordt gebruikt voor tijdgevoelige prestaties zoals Vroege Vogel en Nachtbraker.",
+        "timezone": "Tijdzone",
+        "save": "Voorkeuren opslaan"
+      },
+      "preferences": {
+        "saveFailed": "Opslaan van voorkeuren mislukt",
+        "saved": "Voorkeuren opgeslagen"
+      },
+      "avatar": {
+        "title": "Profielfoto",
+        "unknownUser": "Onbekende gebruiker",
+        "formatHint": "PNG/JPEG/WEBP tot {size} MB",
+        "upload": "Foto uploaden",
+        "replace": "Foto vervangen",
+        "uploading": "Uploaden...",
+        "remove": "Foto verwijderen",
+        "removing": "Verwijderen...",
+        "updated": "Profielfoto bijgewerkt",
+        "uploadFailed": "Uploaden van profielfoto mislukt",
+        "removed": "Profielfoto verwijderd",
+        "removeFailed": "Verwijderen van profielfoto mislukt",
+        "removeConfirm": {
+          "title": "Profielfoto verwijderen?",
+          "description": "Je avatar wordt verwijderd en vervangen door initialen.",
+          "confirm": "Verwijderen"
+        }
+      },
+      "connectedAccounts": {
+        "title": "Gekoppelde accounts",
+        "unlink": "Ontkoppelen",
+        "unlinking": "Ontkoppelen...",
+        "linkAdditional": "Koppel extra providers:",
+        "linkProvider": "Koppel {provider}",
+        "redirecting": "Doorsturen...",
+        "noneConfigured": "Er zijn geen OIDC-providers geconfigureerd. Vraag een beheerder om SSO in te stellen.",
+        "linkStateFailed": "Genereren van koppelingsstatus mislukt",
+        "startLinkFailed": "Starten van OIDC-koppeling mislukt",
+        "unlinkFailed": "Ontkoppelen mislukt",
+        "unlinked": "Identiteit ontkoppeld",
+        "unlinkIdentityFailed": "Ontkoppelen van identiteit mislukt",
+        "unlinkDialog": {
+          "title": "{provider}-identiteit ontkoppelen?",
+          "description": "Voer je wachtwoord in om te bevestigen. Je kunt daarna niet meer inloggen met deze provider.",
+          "currentPassword": "Huidig wachtwoord"
+        }
+      },
+      "tour": {
+        "title": "Rondleiding",
+        "description": "Speel de rondleiding opnieuw af die de belangrijkste functies van de app laat zien.",
+        "action": "Rondleiding opnieuw starten"
+      },
+      "restrictions": {
+        "none": {
+          "title": "Geen contentbeperkingen",
+          "description": "Je account heeft volledige toegang tot alle content binnen je toegewezen bibliotheken."
+        },
+        "banner": "Je account heeft contentbeperkingen die door een beheerder zijn toegepast. Sommige boeken zijn mogelijk niet zichtbaar voor je.",
+        "allowedTags": {
+          "title": "Toegestane labels",
+          "description": "Alleen boeken met ten minste een van deze labels worden aan je getoond."
+        },
+        "blockedTags": {
+          "title": "Geblokkeerde labels",
+          "description": "Boeken met een van deze labels worden voor je verborgen."
+        },
+        "allowedGenres": {
+          "title": "Toegestane genres",
+          "description": "Alleen boeken met ten minste een van deze genres worden aan je getoond."
+        },
+        "blockedGenres": {
+          "title": "Geblokkeerde genres",
+          "description": "Boeken met een van deze genres worden voor je verborgen."
+        }
+      }
+    },
+    "magicLinks": {
+      "title": "Magic Links",
+      "subtitle": "Maak deelbare inloglinks voor gedeelde accounts.",
+      "createLink": "Link maken",
+      "noSharedAccounts": "Geen gedeelde accounts gevonden. Maak eerst een gedeeld account aan op de pagina Gebruikers.",
+      "activeLinks": "Actieve links",
+      "inactiveLinks": "Inactieve links",
+      "paused": "Gepauzeerd",
+      "deletedUser": "Verwijderde gebruiker",
+      "expiredPrefix": "Verlopen ",
+      "never": "Nooit",
+      "noExpiry": "Geen vervaldatum",
+      "expired": "Verlopen",
+      "expiresOn": "Verloopt {date}",
+      "revokedOn": "Ingetrokken {date}",
+      "expiredOn": "Verlopen {date}",
+      "usesCount": "geen keer gebruikt | een keer gebruikt | {count} keer gebruikt",
+      "copied": "Gekopieerd!",
+      "copyLink": "Link kopieren",
+      "pause": "Pauzeren",
+      "resume": "Hervatten",
+      "revoke": "Intrekken",
+      "revoking": "Intrekken...",
+      "emptyState": "Nog geen magic links gemaakt. Klik op \"{action}\" om een deelbare inlog-URL te genereren.",
+      "columns": {
+        "label": "Label",
+        "account": "Account",
+        "createdBy": "Gemaakt door",
+        "expires": "Verloopt",
+        "uses": "Gebruik",
+        "lastUsed": "Laatst gebruikt",
+        "created": "Gemaakt",
+        "status": "Status",
+        "totalUses": "Totaal gebruik"
+      },
+      "createDialog": {
+        "title": "Magic link maken",
+        "description": "Genereer een deelbare inlog-URL voor een gedeeld account.",
+        "sharedAccount": "Gedeeld account",
+        "selectAccount": "Selecteer een gedeeld account",
+        "label": "Label",
+        "labelPlaceholder": "bijv. Demolink voor conferentie",
+        "expiresAt": "Verloopt op",
+        "optional": "(optioneel)",
+        "create": "Maken",
+        "creating": "Maken..."
+      },
+      "revokeDialog": {
+        "title": "Magic link intrekken?",
+        "description": "Dit maakt de link onmiddellijk ongeldig en beeindigt alle actieve sessies voor het gekoppelde account."
+      },
+      "errors": {
+        "create": "Maken mislukt",
+        "copy": "Kopieren van magic link mislukt",
+        "update": "Bijwerken van magic link mislukt",
+        "revoke": "Intrekken mislukt"
+      }
+    },
+    "oidc": {
+      "title": "OIDC / SSO",
+      "subtitle": "Beheer OpenID Connect-providers voor single sign-on.",
+      "providers": "Providers",
+      "addProvider": "Provider toevoegen",
+      "editProvider": "Provider bewerken",
+      "configureNew": "Configureer een nieuwe OIDC-provider.",
+      "editing": "{slug} bewerken",
+      "enabled": "Ingeschakeld",
+      "disabled": "Uitgeschakeld",
+      "empty": {
+        "title": "Nog geen providers",
+        "description": "Voeg een OIDC-provider toe om single sign-on voor je gebruikers in te schakelen."
+      },
+      "form": {
+        "status": "Status",
+        "enableProvider": "Provider inschakelen",
+        "enableProviderHint": "Toon deze provider op de inlogpagina.",
+        "identity": "Provideridentiteit",
+        "slug": "Slug",
+        "slugHint": "Unieke identificatie (kleine letters, koppeltekens). Kan later niet worden gewijzigd.",
+        "displayName": "Weergavenaam",
+        "displayNameHint": "Getoond op de inlogknop.",
+        "iconUrl": "Icoon-URL",
+        "iconUrlHint": "Optioneel logo dat naast de inlogknop wordt getoond.",
+        "iconPreviewAlt": "iconvoorbeeld",
+        "connection": "Verbinding",
+        "issuerUri": "Issuer-URI",
+        "issuerUriHint": "De basis-URL van de provider.",
+        "test": "Testen",
+        "testing": "Testen...",
+        "clientId": "Client-ID",
+        "clientSecret": "Client-secret",
+        "clientSecretPlaceholder": "Laat leeg om het bestaande te behouden",
+        "scopes": "Scopes",
+        "claimMapping": "Claim-mapping",
+        "previewClaims": "Claims bekijken",
+        "redirecting": "Doorsturen...",
+        "mappedClaims": "Gemapte claims",
+        "rawClaims": "Ruwe claims",
+        "usernameClaim": "Gebruikersnaam-claim",
+        "nameClaim": "Naam-claim",
+        "emailClaim": "E-mail-claim",
+        "groupsClaim": "Groepen-claim",
+        "autoProvisioning": "Automatisch aanmaken",
+        "autoProvisionUsers": "Gebruikers automatisch aanmaken",
+        "autoProvisionUsersHint": "Maak accounts aan bij eerste OIDC-login als de gebruiker niet bestaat.",
+        "allowLocalLinking": "Koppeling met lokaal account toestaan",
+        "allowLocalLinkingHint": "Koppel OIDC-identiteit aan een bestaand lokaal account op basis van gebruikersnaam.",
+        "defaultPermissions": "Standaardrechten",
+        "defaultPermissionsHint": "Rechten die aan nieuwe gebruikers worden toegekend bij eerste OIDC-login.",
+        "createProvider": "Provider maken",
+        "saveChanges": "Wijzigingen opslaan",
+        "saving": "Opslaan...",
+        "deleteProvider": "Provider verwijderen",
+        "deleting": "Verwijderen..."
+      },
+      "test": {
+        "connected": "Verbonden - {issuer}",
+        "connectionFailed": "Verbinding mislukt",
+        "hide": "Verbergen",
+        "details": "Details",
+        "supported": "ondersteund",
+        "notSupported": "niet ondersteund"
+      },
+      "groupMappings": {
+        "title": "Groepsmappings",
+        "description": "Wijs OIDC-groepsclaims toe aan BookOrbit-rechten. Gesynchroniseerd bij elke login.",
+        "noPermission": "Geen recht",
+        "empty": "Geen groepsmappings geconfigureerd.",
+        "addMapping": "Mapping toevoegen",
+        "claimPlaceholder": "OIDC-groepsclaim (bijv. admins)",
+        "add": "Toevoegen",
+        "adding": "Toevoegen..."
+      },
+      "toasts": {
+        "providerCreated": "Provider gemaakt",
+        "providerSaved": "Provider opgeslagen",
+        "providerDeleted": "Provider verwijderd",
+        "mappingAdded": "Groepsmapping toegevoegd",
+        "mappingRemoved": "Groepsmapping verwijderd"
+      },
+      "errors": {
+        "loadProvider": "Laden van provider mislukt",
+        "createProvider": "Maken van provider mislukt",
+        "save": "Opslaan mislukt",
+        "delete": "Verwijderen mislukt",
+        "deleteProvider": "Verwijderen van provider mislukt",
+        "requestFailed": "Verzoek mislukt",
+        "previewState": "Genereren van voorbeeldstatus mislukt",
+        "startPreview": "Starten van voorbeeld mislukt",
+        "addMapping": "Toevoegen van mapping mislukt",
+        "removeMapping": "Verwijderen van groepsmapping mislukt"
+      }
+    },
+    "admin": {
+      "title": "Beheer",
+      "subtitle": "Beheer gebruikers en authenticatie-instellingen.",
+      "system": {
+        "title": "Systeem",
+        "subtitle": "Instellingen voor bestandsordening, invoer en onderhoud."
+      },
+      "maintenance": {
+        "title": "Onderhoud",
+        "subtitle": "Beheer achtergrondtaken, systeemindexen en onderhoudsbewerkingen.",
+        "importGroup": "Importeren",
+        "recommendationsGroup": "Aanbevelingen",
+        "achievementsGroup": "Prestaties",
+        "updatesGroup": "Updates",
+        "importFromBooklore": "Importeren uit Booklore",
+        "bookloreImportConfigured": "Booklore-import geconfigureerd",
+        "migrationRunning": "Migratie bezig",
+        "migrationCompleted": "Migratie voltooid",
+        "migrationFailed": "Migratie mislukt",
+        "importDescription": "Eenmalige import van boeken, metadata en leesvoortgang uit een eerdere Booklore-installatie.",
+        "configuredDescription": "Bron: {name}. Nog geen migratie uitgevoerd - ga verder met de installatie om de import uit te voeren.",
+        "runningDescription": "Fase: {stage} - gestart {started}",
+        "completedDescription": "Van {name} - voltooid {date}",
+        "migrationErrorGeneric": "Er is een fout opgetreden tijdens de migratie.",
+        "stageInitializing": "initialiseren",
+        "recently": "onlangs",
+        "getStarted": "Aan de slag",
+        "continueSetup": "Installatie voortzetten",
+        "viewDetails": "Details bekijken",
+        "refreshRecommendationIndex": "Aanbevelingsindex vernieuwen",
+        "refreshRecommendationHint": "Werk de aanbevelingsengine bij met je laatste bibliotheekwijzigingen. Dit proces draait op de achtergrond.",
+        "booksQueuedForProcessing": "geen boeken in de wachtrij voor verwerking | {count} boek in de wachtrij voor verwerking | {count} boeken in de wachtrij voor verwerking",
+        "run": "Uitvoeren",
+        "running": "Bezig...",
+        "backfillAchievements": "Prestaties aanvullen",
+        "backfillAchievementsHint": "Prestaties opnieuw evalueren voor alle gebruikers.",
+        "backfillResult": "{users} gebruikers verwerkt; {awards} onderscheidingen toegekend.",
+        "runBackfill": "Aanvulling uitvoeren",
+        "checkForUpdates": "Controleren op updates",
+        "checkForUpdatesHint": "Controleer bij het opstarten automatisch GitHub op een nieuwe release en toon een indicator in de zijbalk wanneer er een beschikbaar is.",
+        "updateChecksEnabled": "Updatecontroles ingeschakeld",
+        "updateChecksDisabled": "Updatecontroles uitgeschakeld",
+        "updateSettingFailed": "Instelling bijwerken mislukt",
+        "booksQueuedForEmbedding": "geen boeken in de wachtrij voor embedding | {count} boek in de wachtrij voor embedding | {count} boeken in de wachtrij voor embedding",
+        "failed": "Mislukt",
+        "unknownError": "Onbekende fout",
+        "rebuildEmbeddingsFailed": "Opnieuw opbouwen van embeddings mislukt: {error}",
+        "achievementBackfillConfirm": "Prestatie-aanvulling uitvoeren voor alle prestaties van alle gebruikers? Dit kan even duren.",
+        "achievementBackfillComplete": "Prestatie-aanvulling voltooid: {count} onderscheidingen toegekend",
+        "backfillRunFailed": "Aanvulling uitvoeren mislukt",
+        "achievementBackfillFailed": "Prestatie-aanvulling uitvoeren mislukt: {error}"
+      },
+      "migration": {
+        "title": "Migratie",
+        "subtitle": "Eenmalige Booklore-import: verbind de bron, koppel gebruikers, voer een proefrun uit, start de migratie en exporteer een rapport.",
+        "progress": "Voortgang",
+        "stepSourceConnection": "Bronverbinding",
+        "stepUserPathMapping": "Gebruikers- & padkoppeling",
+        "stepDryRun": "Proefrun",
+        "stepDryRunTitle": "Proefrun",
+        "stepRunMigration": "Migratie uitvoeren",
+        "stepReport": "Rapport",
+        "stepReportTitle": "Migratierapport",
+        "subtitleSource": "Configureer de databaseverbinding met je Booklore-bron.",
+        "subtitleMappings": "Koppel bron-gebruikers aan doel-gebruikers en vertaal bestandspaden.",
+        "subtitleDryRun": "Bekijk wat wordt geïmporteerd voordat je de live migratie uitvoert.",
+        "subtitleRun": "Start de live import en volg de voortgang.",
+        "subtitleReport": "Bekijk wat is geïmporteerd en exporteer een gedetailleerd rapport.",
+        "continueToMappings": "Verder naar koppelingen",
+        "continueToDryRun": "Verder naar proefrun",
+        "continueToMigration": "Verder naar migratie",
+        "viewReport": "Rapport bekijken",
+        "badgeValidated": "Gevalideerd",
+        "badgeSaved": "Opgeslagen",
+        "badgeUpToDate": "Actueel",
+        "badgeCompleted": "Voltooid",
+        "badgeRunning": "Bezig",
+        "badgeFailed": "Mislukt",
+        "mediaPathRequired": "Vereist voor het migreren van boekomslagen.",
+        "mediaPathAbsolute": "Gebruik een absoluut pad (bijvoorbeeld: /books). Relatieve paden worden niet ondersteund.",
+        "mediaPathConfigured": "Pad voor omslagimport geconfigureerd. Gebruik Verbinding testen om toegang en de mappenstructuur van Booklore-afbeeldingen te verifiëren.",
+        "issueSaveSource": "Bronverbindingsinstellingen opslaan",
+        "issueValidateSource": "Bronverbinding valideren",
+        "issueSaveMappings": "Gebruikers- en padkoppelingen opslaan",
+        "issueSavePathMappings": "Padkoppelingen opslaan om ze te valideren",
+        "issueFreshDryRun": "Voer een nieuwe proefrun uit",
+        "issueResolveDuplicates": "Los dubbele doelboek-overeenkomsten op in de proefrun",
+        "issueWaitActiveRun": "Wacht tot de actieve run is voltooid",
+        "sourceRecordId": "Bronrecord-ID #{id}",
+        "byAuthorWithId": "door {author} (ID: {id})",
+        "filePathWithId": "{path} (ID: {id})",
+        "bookloreSourceId": "Booklore-bron-ID: {id}",
+        "libraryBookNum": "Bibliotheekboek #{id}",
+        "errorInitialize": "Migratie-instellingen initialiseren mislukt",
+        "errorLoadSourceTypes": "Ondersteunde migratiebrontypen laden mislukt",
+        "errorLoadTargetUsers": "Doel-gebruikers laden mislukt",
+        "errorLoadLibraryFolders": "Doel-bibliotheekmappen laden mislukt",
+        "noSourceUsersReturned": "Geen bron-gebruikers gevonden",
+        "userMappingSuggestionsLoaded": "Suggesties voor gebruikerskoppeling geladen",
+        "errorLoadSuggestions": "Suggesties voor gebruikerskoppeling laden mislukt",
+        "requiredFields": "Host, gebruiker, database en bronnaam zijn vereist",
+        "connectionTestPassedWithWarnings": "Verbindingstest geslaagd met waarschuwingen",
+        "connectionTestPassedWithCount": "Verbindingstest geslaagd met {count} waarschuwing(en). Eerste: {first}",
+        "connectionTestPassed": "Verbindingstest geslaagd",
+        "connectionOkMissingTables": "Verbinding in orde, maar {count} vereiste tabel(len) ontbreken",
+        "cannotTestMediaPathActiveRun": "Kan het mediapad niet testen terwijl een run actief is",
+        "mediaRootPathRequiredCover": "Media Root Path is vereist voor omslagimport.",
+        "useAbsolutePath": "Gebruik een absoluut pad (bijvoorbeeld: /books).",
+        "mediaPathVerified": "Mediapad geverifieerd.",
+        "mediaPathValidReadable": "Mediapad is geldig en leesbaar",
+        "mediaPathValidationFailed": "Validatie van mediapad mislukt.",
+        "connectionFailedBeforeMediaPath": "Verbindingstest mislukt voordat de validatie van het mediapad kon worden voltooid.",
+        "cannotModifySourceActiveRun": "Kan de bron niet wijzigen terwijl een run actief is",
+        "sourceSavedValidatedWarnings": "Bron opgeslagen en gevalideerd met {count} waarschuwing(en)",
+        "sourceSavedValidated": "Bron opgeslagen en gevalideerd",
+        "errorSaveValidateSource": "Bron opslaan of valideren mislukt",
+        "cannotSaveMappingsActiveRun": "Kan koppelingen niet opslaan terwijl een run actief is",
+        "saveSourceFirst": "Sla eerst de bron op",
+        "mapAtLeastOneUser": "Koppel ten minste één bron-gebruiker aan een doel-gebruiker",
+        "mapEveryUser": "Koppel elke bron-gebruiker voordat je opslaat",
+        "pathValidationFailedProfileSaved": "Padvalidatie mislukt, maar het profiel wordt toch opgeslagen",
+        "mappingsSaved": "Koppelingen opgeslagen",
+        "errorSaveMappings": "Koppelingen opslaan mislukt",
+        "cannotRunDryRunActiveRun": "Kan geen proefrun uitvoeren terwijl een run actief is",
+        "saveMappingsFirst": "Sla eerst de koppelingen op",
+        "dryRunCompleted": "Proefrun voltooid: {matched} gekoppeld, {unresolved} niet opgelost",
+        "dryRunFailed": "Proefrun mislukt",
+        "selectSourceForAllGroups": "Selecteer een bronboek voor alle {count} dubbele groepen",
+        "duplicatesResolved": "Dubbele overeenkomsten opgelost",
+        "errorResolveDuplicates": "Dubbele overeenkomsten oplossen mislukt",
+        "preflightNotReady": "Migratie preflight niet gereed",
+        "runDryRunFirst": "Voer eerst een proefrun uit",
+        "runStarted": "Migratierun gestart",
+        "errorStartMigration": "Migratie starten mislukt",
+        "runCancelled": "Migratierun geannuleerd",
+        "errorCancelMigration": "Migratie annuleren mislukt",
+        "runRetried": "Migratierun opnieuw geprobeerd - hervatten vanaf de laatst voltooide fase",
+        "errorRetryMigration": "Migratie opnieuw proberen mislukt",
+        "errorLoadRunProgress": "Runvoortgang laden mislukt",
+        "startMigrationFirst": "Start eerst de migratie",
+        "reportRefreshed": "Runrapport vernieuwd",
+        "errorLoadReport": "Runrapport laden mislukt",
+        "reportExported": "Rapport geëxporteerd als {format}",
+        "errorExportReport": "Migratierapport exporteren mislukt",
+        "reasonNoTitleAuthorMatch": "Geen overeenkomend boek gevonden op titel of auteur",
+        "reasonNoFilePathMatch": "Bestandspad kwam niet overeen met een boek in deze bibliotheek",
+        "reasonNoFileHashMatch": "Bestandshash kwam niet overeen met een boek in deze bibliotheek",
+        "reasonNoIsbnMatch": "ISBN kwam niet overeen met een boek in deze bibliotheek",
+        "reasonInsufficientSourceData": "Onvoldoende metadata om een koppeling te proberen",
+        "reasonAmbiguousIsbnMatch": "Meerdere boeken kwamen overeen met hetzelfde ISBN",
+        "reasonAmbiguousFileHashMatch": "Meerdere boeken kwamen overeen met dezelfde bestandshash",
+        "reasonAmbiguousFilePathMatch": "Meerdere boeken kwamen overeen met hetzelfde bestandspad",
+        "reasonAmbiguousTitleAuthorMatch": "Meerdere boeken kwamen overeen met dezelfde titel en auteur",
+        "reasonUnknown": "Kon de reden niet bepalen",
+        "strategyIsbn": "Gekoppeld op ISBN",
+        "strategyFileHash": "Gekoppeld op bestandshash",
+        "strategyPathMapping": "Gekoppeld op gekoppeld bestandspad",
+        "strategyTitleAuthor": "Gekoppeld op titel en auteur",
+        "strategyUnavailable": "Koppelstrategie niet beschikbaar",
+        "userPreviewCounts": "{statuses} statussen, {progress} voortgangsvermeldingen, {bookmarks} bladwijzers, {annotations} annotaties, {collections} collectievermeldingen",
+        "connErrorUnreachable": "Kon de databaseserver niet bereiken. Controleer de host en poort.",
+        "connErrorAuth": "Authenticatie mislukt. Controleer de gebruikersnaam en het wachtwoord.",
+        "connErrorUnknownDatabase": "Database niet gevonden. Controleer de databasenaam.",
+        "connErrorTimeout": "Verbinding time-out. Controleer de host- en firewallinstellingen.",
+        "connErrorGeneric": "Verbindingstest mislukt",
+        "sourceType": "Brontype",
+        "sourceName": "Bronnaam",
+        "host": "Host",
+        "port": "Poort",
+        "user": "Gebruiker",
+        "password": "Wachtwoord",
+        "passwordSavedPlaceholder": "Opgeslagen - laat ongewijzigd",
+        "passwordEmptyPlaceholder": "Geen wachtwoord ingesteld",
+        "database": "Database",
+        "mediaRootPath": "Media Root Path",
+        "pathOk": "Pad OK",
+        "pathIssue": "Padprobleem",
+        "testPath": "Pad testen",
+        "useTls": "TLS/SSL gebruiken",
+        "testConnection": "Verbinding testen",
+        "saveAndValidate": "Opslaan & valideren",
+        "sourceValidatedWithWarnings": "Bron gevalideerd met waarschuwingen",
+        "lastValidationSnapshot": "Laatste validatiemomentopname",
+        "sourceVersion": "Bronversie: {version}",
+        "unknown": "Onbekend",
+        "missingRequiredTables": "Ontbrekende vereiste tabellen: {tables}",
+        "suggestionsAutoLoad": "Gebruikerssuggesties worden automatisch geladen na bronvalidatie.",
+        "refresh": "Vernieuwen",
+        "sourceUser": "Bron-gebruiker",
+        "targetUser": "Doel-gebruiker",
+        "noSourceUsersLoaded": "Nog geen bron-gebruikers geladen.",
+        "noActiveTargetUsers": "Geen actieve doel-gebruikers gevonden. Maak een BookOrbit-gebruiker aan of schakel deze opnieuw in voordat je koppelt.",
+        "pathPrefixMappings": "Padprefix-koppelingen",
+        "addMapping": "Koppeling toevoegen",
+        "pathMappingsHelp1": "Padkoppelingen vertalen bronbestandspaden naar doelpaden zodat boeken op bestandslocatie kunnen worden gekoppeld. Als je Booklore-bibliotheek bijvoorbeeld bestanden opsloeg onder",
+        "pathMappingsHelp2": "en dezelfde bestanden nu onder",
+        "pathMappingsHelp3": "staan, voeg dan die koppeling hier toe. Boeken worden ook gekoppeld op ISBN, bestandshash en titel/auteur ongeacht padkoppelingen - padkoppeling is slechts een van de vier strategieën en beperkt niet welke bronboeken in de migratie worden opgenomen.",
+        "noPrefixesFound": "Geen prefixen gevonden - valideer eerst de bron",
+        "selectSourcePrefix": "Selecteer bronprefix...",
+        "selectTargetFolder": "Selecteer doelmap...",
+        "remove": "Verwijderen",
+        "pathValidation": "Padvalidatie",
+        "pathValidationMapped": "{mapped} van {total} bronboeken hebben een gekoppeld pad",
+        "pathValidationUnmatched": "{count} gekoppelde paden niet op schijf gevonden - die boeken vallen terug op ISBN- / titelkoppeling",
+        "pathValidationAllMatched": "Alle {count} gekoppelde paden op schijf gevonden",
+        "saveMappings": "Koppelingen opslaan",
+        "runDryRun": "Proefrun uitvoeren",
+        "matched": "Gekoppeld:",
+        "unresolved": "Niet opgelost:",
+        "duplicateMatches": "Dubbele overeenkomsten:",
+        "unresolvedSummary": "Overzicht niet opgelost",
+        "resolveDuplicateMatches": "Dubbele doel-overeenkomsten oplossen",
+        "resolveDuplicateHint": "Kies voor elk doelboek één bronboek om te behouden. Aanbevolen keuzes worden vooraf geselecteerd wanneer er één sterkste overeenkomst is.",
+        "remainingGroups": "Resterende groepen:",
+        "ofCount": "van {count}",
+        "targetBookNum": "Doelboek #{id}",
+        "recommended": "Aanbevolen",
+        "resolveDuplicatesButton": "{count} duplicaat oplossen | {count} duplicaat oplossen | {count} duplicaten oplossen",
+        "preflightChecks": "Preflight-controles",
+        "allChecksPassed": "Alle controles geslaagd - klaar om te migreren",
+        "checkSourceValidated": "Bron gevalideerd",
+        "checkSaveValidateSource": "Bronverbinding opslaan en valideren",
+        "checkValidateSource": "Bronverbinding valideren",
+        "checkMappingsSaved": "Koppelingen opgeslagen",
+        "checkSaveMappings": "Gebruikers- en padkoppelingen opslaan",
+        "checkPathMappingsValidated": "Padkoppelingen gevalideerd",
+        "checkSavePathMappings": "Padkoppelingen opslaan om ze te valideren",
+        "checkDryRunUpToDate": "Proefrun is actueel",
+        "checkFreshDryRun": "Voer een nieuwe proefrun uit",
+        "startConfirmPrompt": "Dit start de live migratie. Weet je het zeker?",
+        "confirmStart": "Start bevestigen",
+        "startMigration": "Migratie starten",
+        "cancelRun": "Run annuleren",
+        "refreshStatus": "Status vernieuwen",
+        "statusPollingStopped": "Statuspolling gestopt door een fout.",
+        "retry": "Opnieuw proberen",
+        "stageLabel": "Fase: {stage}",
+        "stageInitializing": "initialiseren",
+        "endedLabel": "Beëindigd {date}",
+        "stageCompleted": "Voltooid",
+        "stageInit": "Initialiseren",
+        "stageSharedOverlays": "Metadata importeren",
+        "stageBookCovers": "Omslagen importeren",
+        "stageUserState": "Gebruikersgegevens importeren",
+        "noRunYet": "Nog geen migratierun. Voltooi de bovenstaande stappen om te starten.",
+        "runNum": "Run #{id}",
+        "notStarted": "Niet gestart",
+        "reloadReport": "Rapport herladen",
+        "loadFullReport": "Volledig rapport laden",
+        "exportJson": "JSON exporteren",
+        "exportCsv": "CSV exporteren",
+        "migrationFailed": "Migratie mislukt",
+        "retryFromLastStage": "Opnieuw proberen vanaf de laatst voltooide fase",
+        "booksCard": "Boeken",
+        "metadataOverlaysApplied": "Metadata-overlays toegepast",
+        "authorMappingsReplaced": "Auteurskoppelingen vervangen",
+        "narratorMappingsReplaced": "Verteller-koppelingen vervangen",
+        "genreMappingsReplaced": "Genre-koppelingen vervangen",
+        "tagMappingsReplaced": "Labelkoppelingen vervangen",
+        "coversImported": "Omslagen geïmporteerd",
+        "coverImportSkipped": "Omslagimport is overgeslagen - media root path is niet geconfigureerd op de bron",
+        "couldNotMatch": "Kon niet worden gekoppeld",
+        "userDataCard": "Gebruikersgegevens",
+        "readingStatuses": "Leesstatussen",
+        "readingProgressEntries": "Leesvoortgangsvermeldingen",
+        "audiobookProgressEntries": "Audioboekvoortgangsvermeldingen",
+        "bookmarksLabel": "Bladwijzers",
+        "annotationsLabel": "Annotaties",
+        "collectionEntries": "Collectievermeldingen",
+        "loadFullReportHint": "Klik op \"Volledig rapport laden\" om het overzicht van proefrun-overeenkomsten in het geëxporteerde rapport op te nemen.",
+        "completedNoIssues": "Migratie voltooid zonder niet-opgeloste boeken of fouten.",
+        "matchedBooksHeading": "Gekoppelde boeken ({count})",
+        "matchedBooksHint": "Deze proefrun-overeenkomsten zijn gebruikt om te bepalen welke bibliotheekboeken geïmporteerde gegevens ontvingen.",
+        "sourceBookFallback": "Bronboek {id}",
+        "libraryBookFallback": "Bibliotheekboek {id}",
+        "unresolvedBooksHeading": "Niet-opgeloste boeken ({count})",
+        "unresolvedBooksHint": "Deze boeken bestaan in de bron maar konden niet worden gekoppeld aan een boek in je bibliotheek.",
+        "mappedUsersHeading": "Gekoppelde gebruikers ({count})",
+        "mappedUsersHint": "Totalen per gebruiker komen uit de proefrun-preview die met het migratieplan is opgeslagen.",
+        "coverImportsFailed": "{count} omslagimport(en) mislukt. Gedetailleerde foutregels worden niet opgeslagen.",
+        "backToSetup": "Terug naar installatie"
+      },
+      "libraries": {
+        "title": "Bibliotheken",
+        "subtitle": "Beheer je mediabibliotheken en start contentscans.",
+        "scanAll": "Alles scannen",
+        "scanning": "Scannen...",
+        "addLibrary": "Bibliotheek toevoegen",
+        "scan": "Scannen",
+        "editLibrary": "Bibliotheek bewerken",
+        "refreshCovers": "Omslagen vernieuwen",
+        "syncMetadataToFiles": "Metadata naar bestanden synchroniseren",
+        "deleteLibrary": "Bibliotheek verwijderen",
+        "bookCount": "geen boeken | {count} boek | {count} boeken",
+        "addedDate": "Toegevoegd {date}",
+        "fileMode": "Bestandsmodus",
+        "folderMode": "Mapmodus",
+        "folderCount": "geen mappen | {count} map | {count} mappen",
+        "watching": "Bewaken",
+        "fileWrite": "Bestand schrijven",
+        "fileRename": "Bestand hernoemen",
+        "emptyTitle": "Nog geen bibliotheken",
+        "emptyHint": "Voeg een bibliotheek toe om je boeken te ordenen.",
+        "addFirstLibrary": "Voeg je eerste bibliotheek toe",
+        "deleteConfirmTitle": "\"{name}\" verwijderen?",
+        "deleteConfirmBody": "Hiermee worden alle boeken, metadata, leesvoortgang, bladwijzers en annotaties in deze bibliotheek permanent verwijderd. Dit kan niet ongedaan worden gemaakt.",
+        "deleteConfirmTypeName": "Typ de bibliotheeknaam om te bevestigen:",
+        "deleting": "Verwijderen...",
+        "deleteLibraryButton": "Bibliotheek verwijderen",
+        "syncConfirmTitle": "Metadata naar bestanden synchroniseren?",
+        "syncConfirmBodyPrefix": "Hiermee wordt de metadata in elk ondersteund bestand in",
+        "syncConfirmBodySuffix": "rechtstreeks op schijf overschreven. Dit kan niet ongedaan worden gemaakt.",
+        "syncFiles": "Bestanden synchroniseren",
+        "metadataSynced": "Metadata gesynchroniseerd naar bestanden voor \"{name}\"",
+        "fileWriteNotEnabled": "Metadata naar bestanden schrijven is niet ingeschakeld voor deze bibliotheek. Schakel dit in bij de bibliotheekinstellingen.",
+        "fileSyncFailed": "Bestandssynchronisatie mislukt voor \"{name}\"",
+        "scanStarted": "Scan gestart voor \"{name}\"",
+        "scanStartFailed": "Scan starten mislukt voor \"{name}\"",
+        "refreshCoversFailed": "Omslagen vernieuwen mislukt voor \"{name}\"",
+        "scanStartedAll": "Scan gestart voor alle bibliotheken",
+        "librariesFailedToStart": "geen bibliotheken konden worden gestart | {count} bibliotheek kon niet worden gestart | {count} bibliotheken konden niet worden gestart",
+        "scansStartFailed": "Scans starten mislukt",
+        "libraryCreated": "Bibliotheek \"{name}\" aangemaakt",
+        "libraryUpdated": "Bibliotheek \"{name}\" bijgewerkt",
+        "libraryDeleted": "\"{name}\" verwijderd",
+        "deleteFailed": "Bibliotheek verwijderen mislukt",
+        "scanningProgress": "Scannen {pct}% ({processed}/{total})",
+        "scanDone": "Klaar - {added} toegevoegd, {updated} bijgewerkt",
+        "scanFailedWithError": "Mislukt: {error}",
+        "scanFailed": "Scan mislukt",
+        "refreshingCovers": "Omslagen vernieuwen {pct}% ({processed}/{total})",
+        "coversRefreshed": "Omslagen vernieuwd ({count} verwerkt)"
+      },
+      "authorEnrichment": {
+        "configuration": "Configuratie",
+        "saving": "Opslaan...",
+        "running": "Bezig...",
+        "runEligibleShort": "In aanmerking komende uitvoeren",
+        "runAllShort": "Alles uitvoeren",
+        "enableTitle": "Automatische auteursverrijking inschakelen",
+        "enableHint": "Haal automatisch auteursbiografieën en profielfoto's op wanneer boeken worden toegevoegd of bijgewerkt.",
+        "updateStrategyTitle": "Bijwerkstrategie",
+        "updateStrategyHint": "Wat te doen wanneer een auteur al een biografie of foto heeft.",
+        "writeModeMissingOnly": "Alleen ontbrekende gegevens invullen (aanbevolen)",
+        "writeModeAlwaysRefetch": "Bestaande gegevens altijd vernieuwen",
+        "triggerOnImportTitle": "Activeren bij import",
+        "triggerOnImportHint": "Zet auteurs in de wachtrij voor verrijking wanneer boeken voor het eerst aan een bibliotheek worden toegevoegd.",
+        "eligibilityTitle": "Geschiktheidsvoorwaarden",
+        "eligibilityHint": "Een auteur komt in aanmerking als deze aan een ingeschakelde voorwaarde voldoet.",
+        "neverEnrichedTitle": "Nooit verrijkt",
+        "neverEnrichedHint": "Verrijk auteurs die nog nooit succesvol zijn verrijkt.",
+        "missingBioTitle": "Biografie ontbreekt",
+        "missingBioHint": "Verrijk als de auteur geen biografie heeft.",
+        "missingPhotoTitle": "Foto ontbreekt",
+        "missingPhotoHint": "Verrijk als de auteur geen profielfoto heeft.",
+        "runForEligibleAuthors": "Uitvoeren voor in aanmerking komende auteurs",
+        "eligibleCount": "~{count} in aanmerking komend",
+        "runForAllAuthors": "Uitvoeren voor alle auteurs",
+        "saved": "Instellingen voor auteursverrijking opgeslagen",
+        "saveFailed": "Instellingen voor auteursverrijking opslaan mislukt",
+        "noEligibleAuthors": "Geen in aanmerking komende auteurs gevonden",
+        "noAuthorsToEnrich": "Geen auteurs om te verrijken",
+        "queueFailed": "Auteursaanvulling in de wachtrij zetten mislukt"
+      },
+      "scoreWeights": {
+        "groupLabel": "Scoregewichten",
+        "assignHintPrefix": "Ken aan elk veld een gewicht toe. Totaalgewicht:",
+        "areYouSure": "Weet je het zeker?",
+        "resetToDefaultsButton": "Terug naar standaardwaarden",
+        "recalculateAll": "Alles herberekenen",
+        "confirmReset": "Reset bevestigen",
+        "reset": "Resetten",
+        "recalculate": "Herberekenen",
+        "subtotal": "subtotaal: {count}",
+        "savedRecalculating": "Scoregewichten opgeslagen. Bibliotheekscores worden herberekend...",
+        "saveFailed": "Scoregewichten opslaan mislukt",
+        "recalcStarted": "Herberekening van scores gestart op de achtergrond",
+        "recalcFailed": "Herberekening mislukt",
+        "resetToDefaults": "Gewichten teruggezet naar standaardwaarden. Sla op om toe te passen."
+      }
+    },
+    "common": {
+      "nav": {
+        "libraries": "Bibliotheken",
+        "display": "Weergave",
+        "reader": "Lezer",
+        "metadata": "Metadata",
+        "email": "E-mail",
+        "opds": "OPDS",
+        "kobo": "Kobo",
+        "koreader": "KOReader",
+        "hardcover": "Hardcover",
+        "admin": "Beheer",
+        "system": "Systeem",
+        "account": "Account"
+      }
+    },
+    "metadata": {
+      "title": "Metadata",
+      "noPermission": "Je hebt geen toestemming om metadata-instellingen te beheren.",
+      "fields": {
+        "title": "Titel",
+        "subtitle": "Ondertitel",
+        "description": "Beschrijving",
+        "cover": "Omslag",
+        "authors": "Auteurs",
+        "publisher": "Uitgever",
+        "publishedYear": "Publicatiejaar",
+        "language": "Taal",
+        "pageCount": "Aantal pagina's",
+        "communityRating": "Communitybeoordeling",
+        "seriesName": "Reeksnaam",
+        "seriesIndex": "Reeksnummer",
+        "genres": "Genres",
+        "narrators": "Vertellers",
+        "duration": "Duur",
+        "abridged": "Verkort"
+      },
+      "mergeStrategy": {
+        "fillMissing": {
+          "label": "Ontbrekende aanvullen",
+          "description": "Alleen schrijven als het veld nu leeg is"
+        },
+        "overwriteIfProvided": {
+          "label": "Overschrijven indien aanwezig",
+          "description": "Schrijven als de provider een waarde teruggaf"
+        },
+        "overwrite": {
+          "label": "Altijd overschrijven",
+          "description": "Bestaande waarde altijd vervangen"
+        }
+      },
+      "autoFetch": {
+        "globalSettings": "Globale instellingen",
+        "perLibraryOverrides": "Overschrijvingen per bibliotheek",
+        "saving": "Opslaan...",
+        "running": "Bezig...",
+        "runNow": "Nu uitvoeren",
+        "runForEligible": "Uitvoeren voor in aanmerking komende boeken",
+        "enable": {
+          "label": "Automatisch ophalen inschakelen",
+          "hint": "Haal automatisch metadata op voor in aanmerking komende boeken."
+        },
+        "triggerOnImport": {
+          "label": "Activeren bij importeren",
+          "hint": "In aanmerking komende boeken in de wachtrij plaatsen wanneer ze voor het eerst aan een bibliotheek worden toegevoegd."
+        },
+        "status": {
+          "inQueuePaused": "{count} in wachtrij - gepauzeerd",
+          "remaining": "{count} resterend",
+          "eligible": "~{count} in aanmerking"
+        },
+        "trigger": {
+          "queued": "{count} boek in wachtrij geplaatst | {count} boeken in wachtrij geplaatst",
+          "noneFound": "Geen in aanmerking komende boeken gevonden"
+        },
+        "lastRun": {
+          "justNow": "zojuist",
+          "minutesAgo": "{count}m geleden",
+          "hoursAgo": "{count}u geleden",
+          "yesterday": "gisteren",
+          "daysAgo": "{count} dagen geleden",
+          "label": "Laatste uitvoering: {when}",
+          "labelQueued": "Laatste uitvoering: {when} - {count} boeken in wachtrij geplaatst",
+          "labelNoneEligible": "Laatste uitvoering: {when} - geen in aanmerking komende boeken"
+        },
+        "conditions": {
+          "title": "Voorwaarden voor in aanmerking komen",
+          "hint": "Een boek komt in aanmerking als het aan een ingeschakelde voorwaarde voldoet.",
+          "noneEnabled": "Geen voorwaarden ingeschakeld",
+          "neverFetched": {
+            "label": "Nooit opgehaald",
+            "hint": "Haal boeken op die nog nooit een poging tot metadata ophalen hebben gehad.",
+            "summary": "Nooit opgehaald"
+          },
+          "scoreThreshold": {
+            "label": "Lage metadatascore",
+            "hint": "Ophalen als de metadatascore onder een drempel ligt.",
+            "scoreBelow": "Score onder",
+            "summary": "Score < {threshold}"
+          },
+          "missingFields": {
+            "label": "Ontbrekende velden",
+            "hint": "Ophalen als een van de geselecteerde velden leeg is.",
+            "summary": "{count} veld ontbreekt | {count} velden ontbreken"
+          }
+        },
+        "library": {
+          "inheritingGlobal": "Globale standaardinstellingen worden overgenomen",
+          "inheritFromGlobal": "Overnemen van globaal",
+          "usingGlobalDefaults": "Globale standaardinstellingen worden gebruikt.",
+          "saveOverride": "Overschrijving opslaan"
+        }
+      },
+      "providers": {
+        "availableSources": "Beschikbare bronnen",
+        "saveChanges": "Wijzigingen opslaan",
+        "test": "Testen",
+        "testing": "Testen...",
+        "enabled": "Ingeschakeld",
+        "retryIn": "Opnieuw proberen over {duration}",
+        "runTestBeforeEnabling": "Voer Testen uit voordat je inschakelt",
+        "hardcoverEnableHint": "Voer Testen uit met het huidige token om de inschakelknop te ontgrendelen.",
+        "badge": {
+          "setupRequired": "Instellen vereist",
+          "throttled": "Beperkt",
+          "ready": "Gereed"
+        },
+        "fields": {
+          "apiKey": "API-sleutel",
+          "region": "Regio",
+          "cookie": "Cookie",
+          "coverResolution": "Omslagresolutie",
+          "country": "Land",
+          "language": "Taal",
+          "ttbKey": "TTB-sleutel"
+        },
+        "helpers": {
+          "googleApiKey": "Google Books API-sleutel van Google Cloud."
+        },
+        "hints": {
+          "google": "Brede dekking uit de boekindex van Google. Google Books vereist nu een API-sleutel voordat deze provider kan worden ingeschakeld.",
+          "amazon": "Een sessiecookie wordt aanbevolen. Plak alleen de cookiewaarde (geen \"Cookie:\").",
+          "goodreads": "De grootste leescommunity op het web. Geen configuratie nodig.",
+          "hardcover": "Een modern alternatief voor Goodreads. Token van hardcover.app/account/api. Het voorvoegsel \"Bearer \" is optioneel.",
+          "openLibrary": "De gratis boekcatalogus van het Internet Archive. Geen configuratie nodig.",
+          "itunes": "Apple's digitale boekcatalogus. Kies of je omslagen in hoge of standaardresolutie ophaalt.",
+          "kobo": "Haalt gegevens van de openbare boekpagina's van Kobo. Land en taal moeten overeenkomen met Kobo-URL-paden; botbeveiliging kan verzoeken blokkeren.",
+          "audible": "Haalt audioboekmetadata op van Audible. Geen extra configuratie nodig.",
+          "audnexus": "Door de community aangedreven audioboekmetadata. Geen configuratie nodig.",
+          "comicvine": "Stripboekmetadata van ComicVine. Een gratis API-sleutel is vereist van comicvine.gamespot.com.",
+          "ranobedb": "Japanse light novel-metadata van RanobeDB. Geen configuratie nodig.",
+          "lubimyczytac": "Poolse boekcatalogus (lubimyczytac.pl). Haalt gegevens van openbare boekpagina's. Geen configuratie nodig.",
+          "aladin": "Koreaanse boekmetadata van Aladin (알라딘). Een TTB-sleutel van aladin.co.kr is vereist."
+        },
+        "blocked": {
+          "google": "Google Books vereist een API-sleutel voordat het kan worden ingeschakeld",
+          "hardcover": "Hardcover vereist een API-sleutel voordat het kan worden ingeschakeld",
+          "hardcoverTest": "Het Hardcover-token moet Testen doorstaan voordat het kan worden ingeschakeld",
+          "comicvine": "ComicVine vereist een API-sleutel voordat het kan worden ingeschakeld",
+          "aladin": "Aladin vereist een TTB-sleutel voordat het kan worden ingeschakeld"
+        }
+      },
+      "fieldRules": {
+        "clearAllProviders": "Alle providers wissen",
+        "clearAll": "Alles wissen",
+        "resetToDefault": "Terugzetten naar standaard",
+        "reset": "Terugzetten",
+        "dragProvidersHint": "Sleep providers vanaf hier naar een veld om ze toe te voegen",
+        "dragProviderHere": "sleep hier een provider naartoe",
+        "howItWorks": {
+          "title": "Hoe veldregels werken",
+          "priorityOrder": {
+            "title": "Prioriteitsvolgorde",
+            "body": "Sleep providers in de lijst om ze opnieuw te ordenen. De bovenste provider die een resultaat teruggeeft, wordt de primaire bron voor dat veld."
+          },
+          "mergeStrategy": {
+            "title": "Samenvoegstrategie",
+            "fillMissingTerm": "Ontbrekende aanvullen:",
+            "fillMissingBody": "Alleen schrijven als de huidige waarde leeg is.",
+            "overwriteTerm": "Overschrijven:",
+            "overwriteBody": "Vervangen zodra een provider gegevens heeft."
+          }
+        },
+        "libraryOverrides": {
+          "title": "Bibliotheekoverschrijvingen",
+          "hint": "Vouw een bibliotheek uit om afzonderlijke velden aan te passen. Velden zonder overschrijving nemen de globale standaardinstellingen over."
+        },
+        "global": {
+          "title": "Globale standaardinstellingen",
+          "hint": "Standaardregels die op elke bibliotheek worden toegepast. Overschrijf per bibliotheek hieronder.",
+          "saveDefaults": "Standaardinstellingen opslaan",
+          "clearAllConfirm": "Alle actieve providers uit elk veld verwijderen? Dit wordt direct opgeslagen en kan niet ongedaan worden gemaakt.",
+          "resetConfirm": "Alle globale veldregels terugzetten naar de systeemstandaarden? Dit overschrijft je huidige configuratie."
+        },
+        "advanced": {
+          "title": "Geavanceerd ophaalgedrag",
+          "combineGenres": {
+            "label": "Genres van alle geselecteerde providers combineren",
+            "hint": "Verzamel en ontdubbel genres van elke provider die aan het veld Genres is toegewezen, in plaats van te stoppen bij het eerste resultaat."
+          },
+          "storeProviderIds": {
+            "label": "Provider-ID's op boeken opslaan",
+            "hint": "Sla bij het ophalen van metadata de teruggegeven provider-ID's (ISBN, ASIN, Goodreads-ID, enz.) op in het boekrecord voor nauwkeurigere toekomstige zoekopdrachten."
+          }
+        },
+        "library": {
+          "primary": "Primair:",
+          "overrideCount": "{count} overschrijving | {count} overschrijvingen",
+          "unsavedSuffix": "(niet opgeslagen)",
+          "unsavedChanges": "Niet-opgeslagen wijzigingen",
+          "globalDefaults": "Globale standaardinstellingen",
+          "overriding": "Overschrijft: {fields}",
+          "inheritingAll": "Neemt alle globale metadataregels over",
+          "subHint": "Velden zonder overschrijving nemen de globale standaardinstellingen over.",
+          "resetTooltip": "Alle overschrijvingen verwijderen en globale standaardinstellingen overnemen",
+          "clearAllConfirm": "Alle actieve providers uit elk veld in \"{library}\" verwijderen?",
+          "resetConfirm": "\"{library}\" terugzetten naar globale standaardinstellingen? Alle bibliotheekoverschrijvingen worden verwijderd."
+        },
+        "groups": {
+          "core": "Kern",
+          "contributors": "Bijdragers",
+          "publication": "Publicatie",
+          "series": "Reeks",
+          "classification": "Classificatie",
+          "audiobook": "Audioboek"
+        },
+        "groupSummary": {
+          "base": "{fields} velden · {enabled} ingeschakeld",
+          "withOverrides": "{base} · {overrides} overschrijvingen"
+        },
+        "table": {
+          "field": "Veld",
+          "activeProviders": "Actieve providers (op prioriteit geordend)",
+          "mergeStrategy": "Samenvoegstrategie",
+          "status": "Status"
+        },
+        "field": {
+          "noProviders": "Ingeschakeld maar heeft geen providers",
+          "empty": "Leeg",
+          "config": "Configuratie",
+          "custom": "Aangepast",
+          "default": "Standaard",
+          "resetToDefault": "Terugzetten naar standaard"
+        },
+        "reservoir": {
+          "disabled": "{provider} - uitgeschakeld",
+          "notConfigured": "{provider} - niet geconfigureerd",
+          "dragToAssign": "Sleep om {provider} aan een veld toe te wijzen"
+        },
+        "sheet": {
+          "subtitle": "Tik op providers om toe te wijzen, gebruik de pijlen om te herordenen",
+          "enableField": "Dit veld inschakelen tijdens vernieuwen",
+          "providers": "Providers",
+          "statusDisabled": "uitgeschakeld",
+          "statusNotConfigured": "niet geconfigureerd",
+          "done": "Klaar"
+        }
+      },
+      "genreBlocklist": {
+        "heading": "Globale genre-uitsluitingen",
+        "hint": "Exacte genrewaarden in deze lijst worden uit providerresultaten verwijderd voordat metadata wordt geschreven.",
+        "saving": "Opslaan",
+        "genreValueLabel": "Genrewaarde",
+        "addPlaceholder": "Voeg een genrewaarde toe, bijvoorbeeld Audioboek",
+        "duplicate": "Dit genre is al geblokkeerd.",
+        "add": "Toevoegen",
+        "filterPlaceholder": "Blokkeerlijst filteren",
+        "entryCount": "{count} vermelding | {count} vermeldingen",
+        "filteredCount": "{shown} van {total}",
+        "noFilterMatch": "Geen geblokkeerde genres komen overeen met het huidige filter.",
+        "emptyTitle": "Geen geblokkeerde genres",
+        "emptyHint": "Voeg exacte waarden toe zoals Audioboek of Volwassen om ze uit opgehaalde metadata te houden.",
+        "removeLabel": "{genre} verwijderen"
+      },
+      "customFields": {
+        "label": "Label",
+        "labelPlaceholder": "bijv. Originele titel",
+        "labelTooLong": "Label mag maximaal 255 tekens bevatten",
+        "labelDuplicate": "Er bestaat al een veld met dit label",
+        "type": "Type",
+        "usage": "Gebruikt door {count} boek | Gebruikt door {count} boeken",
+        "newField": {
+          "title": "Nieuw veld",
+          "hint": "Definieer een aangepast metadataveld en kies welke bibliotheken het gebruiken."
+        },
+        "previewToggle": "Voorbeeld van hoe dit veld verschijnt bij het bewerken van een boek",
+        "untitledField": "Naamloos veld",
+        "addField": "Veld toevoegen",
+        "fields": "Velden",
+        "fieldsHint": "Sleep om te herordenen, bewerk labels, schakel bibliotheken in/uit of archiveer velden die je niet meer nodig hebt.",
+        "searchPlaceholder": "Velden zoeken",
+        "searchAriaLabel": "Aangepaste velden zoeken",
+        "emptyTitle": "Nog geen aangepaste velden",
+        "emptyHint": "Gebruik het formulier hierboven om je eerste aangepaste metadataveld te definiëren.",
+        "noMatchTitle": "Geen velden komen overeen met \"{query}\"",
+        "noMatchHint": "Probeer een ander label, sleutel of type.",
+        "clearSearchToReorder": "Wis het zoekveld om te herordenen",
+        "dragToReorder": "Sleep om te herordenen",
+        "dragToReorderField": "Sleep om veld te herordenen",
+        "unsaved": "Niet opgeslagen",
+        "archive": "Archiveren",
+        "archivedFields": "Gearchiveerde velden",
+        "archivedSummary": "{count} gearchiveerd veld - herstellen of permanent verwijderen. | {count} gearchiveerde velden - herstellen of permanent verwijderen.",
+        "archivedAt": "Gearchiveerd {when}",
+        "restore": "Herstellen",
+        "deleteForever": "Definitief verwijderen",
+        "deleteDialog": {
+          "title": "Veld permanent verwijderen",
+          "bodyBefore": "Dit verwijdert permanent",
+          "bodyMiddle": "en verwijdert de opgeslagen waarden uit",
+          "bodyAfter": ". Dit kan niet ongedaan worden gemaakt.",
+          "confirmBefore": "Typ",
+          "confirmAfter": "om te bevestigen",
+          "confirmPlaceholder": "Typ het veldlabel om te bevestigen"
+        },
+        "preview": "Voorbeeld",
+        "sampleValue": "Voorbeeldwaarde",
+        "enabledLibraries": "Ingeschakelde bibliotheken",
+        "countOf": "{selected} van {total}",
+        "selectAll": "Alles selecteren",
+        "clear": "Wissen",
+        "noLibraries": "Nog geen bibliotheken beschikbaar.",
+        "allLibraries": "Alle bibliotheken"
+      }
+    },
+    "reader": {
+      "resetToDefaults": "Standaardwaarden herstellen",
+      "all": {
+        "title": "Lezer",
+        "subtitle": "Configureer standaardwaarden voor alle leesmodi op één plek."
+      },
+      "general": {
+        "title": "Lezen",
+        "subtitle": "Algemeen gedrag dat van toepassing is op alle lezertypen.",
+        "storageLabel": "Waar lezervoorkeuren op te slaan",
+        "deviceOnly": "Alleen dit apparaat",
+        "deviceOnlyHint": "Voorkeuren blijven in je browser. Het beste als je altijd op dit apparaat leest of per apparaat andere instellingen wilt.",
+        "myAccount": "Mijn account",
+        "myAccountHint": "Voorkeuren worden opgeslagen in je account. Het beste als je vanaf meerdere apparaten inlogt en overal een consistente ervaring wilt.",
+        "active": "Actief",
+        "notAvailable": "Niet beschikbaar",
+        "demoCannotChangeStorage": "Demo-beperkt account kan de opslagmodus van de lezer niet wijzigen",
+        "preferencesSynced": "Voorkeuren worden nu gesynchroniseerd",
+        "preferencesLocal": "Voorkeuren blijven op dit apparaat",
+        "storageUpdateFailed": "Kan opslagmodus niet bijwerken",
+        "storageUpdateError": "Er is een fout opgetreden bij het bijwerken van de opslagmodus"
+      },
+      "ebook": {
+        "title": "eBook-lezer",
+        "subtitle": "Standaardinstellingen die worden toegepast bij het openen van EPUB-, MOBI-, FB2- en TXT-bestanden.",
+        "newBooks": "Nieuwe boeken",
+        "applySettings": "Mijn instellingen toepassen op nieuwe boeken",
+        "applySettingsHint": "Wanneer uit, openen nieuwe boeken met de eigen lettertypen en opmaak van de uitgever. Je instellingen worden pas toegepast zodra je iets wijzigt in de lezer.",
+        "layout": "Opmaak",
+        "readingFlow": "Leesrichting",
+        "readingFlowHint": "Gepagineerd bladert door pagina's; scrollend loopt doorlopend",
+        "paginated": "Gepagineerd",
+        "scrolled": "Scrollend",
+        "fixedLayoutSpread": "Pagina-spreads bij vaste opmaak",
+        "fixedLayoutSpreadHint": "Standaard voor manga, strips en op afbeeldingen gebaseerde EPUB's",
+        "bookDefault": "Boekstandaard",
+        "singlePage": "Eén pagina",
+        "columns": "Kolommen",
+        "columnsHint": "Aantal tekstkolommen per pagina",
+        "theme": "Thema",
+        "darkMode": "Donkere modus",
+        "darkModeHint": "Gebruik de donkere variant van het geselecteerde thema",
+        "typography": "Typografie",
+        "font": "Lettertype",
+        "fontHint": "Lettertype gebruikt voor de hoofdtekst",
+        "builtInFonts": "Ingebouwde lettertypen",
+        "yourFonts": "Jouw lettertypen",
+        "fontSize": "Lettergrootte",
+        "fontSizeHint": "Basisgrootte van de tekst in pixels",
+        "lineHeight": "Regelhoogte",
+        "lineHeightHint": "Verticale ruimte tussen regels",
+        "justify": "Tekst uitvullen",
+        "justifyHint": "Tekst uitlijnen op beide marges",
+        "hyphenation": "Woordafbreking",
+        "hyphenationHint": "Lange woorden automatisch afbreken met koppeltekens",
+        "advanced": "Geavanceerd",
+        "maxContentWidth": "Maximale inhoudsbreedte",
+        "maxContentWidthHint": "Maximale breedte van het tekstgebied in pixels",
+        "columnGap": "Kolomtussenruimte",
+        "columnGapHint": "Horizontale opvulling aan weerszijden van het tekstgebied"
+      },
+      "pdf": {
+        "title": "PDF-lezer",
+        "subtitle": "Standaardinstellingen die worden toegepast bij het openen van PDF-bestanden.",
+        "layout": "Opmaak",
+        "scrollMode": "Scrollmodus",
+        "scrollModeHint": "Pagina bladert één voor één; doorlopend scrolt door alle pagina's",
+        "page": "Pagina",
+        "scrolled": "Scrollend",
+        "pageSpread": "Pagina-spread",
+        "pageSpreadHint": "Welk paginanummer rechts begint in de weergave met twee pagina's",
+        "spreadNone": "Geen",
+        "spreadOdd": "Oneven",
+        "spreadEven": "Even",
+        "zoom": "Zoom",
+        "defaultFit": "Standaardpassing",
+        "defaultFitHint": "Hoe pagina's worden geschaald wanneer een PDF wordt geopend",
+        "fitPage": "Pagina passend",
+        "fitWidth": "Breedte passend",
+        "custom": "Aangepast",
+        "zoomLevel": "Zoomniveau",
+        "zoomLevelHint": "Schaalfactor voor aangepaste zoommodus"
+      },
+      "comics": {
+        "title": "Stripboeklezer",
+        "subtitle": "Standaardinstellingen die worden toegepast bij het openen van CBZ-, CBR- en CB7-bestanden.",
+        "view": "Weergave",
+        "readingMode": "Leesmodus",
+        "readingModeHint": "Hoe pagina's worden genavigeerd - gebruik \"Oneindig (geen tussenruimte)\" voor webtoons",
+        "paginated": "Gepagineerd",
+        "infiniteSpaced": "Oneindig (met tussenruimte)",
+        "infiniteNoGaps": "Oneindig (geen tussenruimte)",
+        "pageView": "Paginaweergave",
+        "pageViewHint": "Toon één of twee pagina's naast elkaar",
+        "single": "Enkel",
+        "twoPage": "Twee pagina's",
+        "fitMode": "Passingsmodus",
+        "fitModeHint": "Hoe pagina's worden geschaald om op het scherm te passen",
+        "fitPage": "Pagina",
+        "fitWidth": "Breedte",
+        "fitHeight": "Hoogte",
+        "fitActual": "Werkelijk",
+        "readingDirection": "Leesrichting",
+        "readingDirectionHint": "Links-naar-rechts voor westerse strips; rechts-naar-links voor manga",
+        "ltr": "L naar R",
+        "rtl": "R naar L",
+        "spreadAlignment": "Spread-uitlijning",
+        "spreadAlignmentHint": "Verschuif de koppeling met één pagina na de omslag voor scans die net verschoven zijn",
+        "alignmentNormal": "Normaal",
+        "alignmentShifted": "Verschoven",
+        "widePageHandling": "Verwerking van brede pagina's",
+        "widePageHandlingHint": "Auto toont brede scans alleen in gepagineerde modus met twee pagina's",
+        "widePageAuto": "Auto",
+        "widePageDisable": "Uitschakelen",
+        "forceTwoPage": "Twee pagina's forceren op kleine schermen",
+        "forceTwoPageHint": "Omzeil de automatische terugval op mobiel wanneer gepagineerde modus met twee pagina's is geselecteerd",
+        "off": "Uit",
+        "on": "Aan",
+        "display": "Weergave",
+        "backgroundColor": "Achtergrondkleur",
+        "backgroundColorHint": "Achtergrondkleur achter pagina's",
+        "bgBlack": "Zwart",
+        "bgGray": "Grijs",
+        "bgWhite": "Wit"
+      },
+      "audio": {
+        "title": "Audioboekspeler",
+        "subtitle": "Standaardinstellingen die worden toegepast bij het afspelen van M4B, MP3 en andere audioformaten.",
+        "playback": "Afspelen",
+        "playbackSpeed": "Standaard afspeelsnelheid",
+        "playbackSpeedHint": "Snelheidsvermenigvuldiger toegepast bij het openen van een nieuw audioboek",
+        "volume": "Standaardvolume",
+        "volumeHint": "Beginvolume (0 tot 100%)",
+        "skipControls": "Overslaanbediening",
+        "skipBack": "Duur terugspringen",
+        "skipBackHint": "Seconden teruggespoeld bij het indrukken van terugspringen",
+        "skipForward": "Duur vooruitspringen",
+        "skipForwardHint": "Seconden vooruitgespoeld bij het indrukken van vooruitspringen"
+      },
+      "fonts": {
+        "title": "Lettertypen",
+        "subtitle": "Upload aangepaste lettertypen voor gebruik in de eBook-lezer.",
+        "uploadFonts": "Lettertypen uploaden",
+        "notAvailableDemo": "Niet beschikbaar voor demo-accounts",
+        "uploading": "Uploaden...",
+        "dropFilesHere": "Sleep bestanden hierheen",
+        "dragFontsPrefix": "Sleep lettertypebestanden hierheen, of",
+        "browse": "bladeren",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - max. 10 MB per stuk",
+        "yourFonts": "Jouw lettertypen",
+        "fontsUsed": "{count} / {max} gebruikt",
+        "noFontsYet": "Nog geen lettertypen geüpload",
+        "noFontsHint": "Sleep hierboven een lettertypebestand om te beginnen.",
+        "fileCount": "geen bestanden | {count} bestand | {count} bestanden",
+        "pangram": "Wazig glimt het jonge vosje bij de kachel",
+        "renameFamily": "Familie hernoemen",
+        "deleteFamily": "Familie verwijderen",
+        "editVariant": "Gewicht/stijl bewerken",
+        "deleteVariant": "Variant verwijderen",
+        "styleNormal": "Normaal",
+        "styleItalic": "Cursief",
+        "weightThin": "Dun",
+        "weightExtraLight": "Extra licht",
+        "weightLight": "Licht",
+        "weightRegular": "Normaal",
+        "weightMedium": "Medium",
+        "weightSemiBold": "Halfvet",
+        "weightBold": "Vet",
+        "weightExtraBold": "Extra vet",
+        "weightBlack": "Zwart",
+        "renameFamilyFailed": "Kan lettertypefamilie niet hernoemen",
+        "renamedTo": "Hernoemd naar \"{name}\"",
+        "updateVariantFailed": "Kan lettertypevariant niet bijwerken",
+        "deleteFontFailed": "Kan lettertype niet verwijderen",
+        "deleteFamilyFailed": "Kan lettertypefamilie niet verwijderen",
+        "demoCannotManage": "Demo-beperkt account kan geen lettertypen beheren",
+        "fileAdded": "\"{name}\" toegevoegd",
+        "uploadFailed": "Uploaden mislukt"
+      },
+      "bookDock": {
+        "title": "Book Dock",
+        "subtitle": "Configureer hoe bestanden worden verwerkt wanneer ze in Book Dock terechtkomen.",
+        "dropFolder": "Doelmap",
+        "containerPath": "Containerpad",
+        "containerPathHint": "Kopieer of verplaats boekbestanden naar deze map en ze worden automatisch opgepakt en verwerkt door Book Dock. Submappen worden ondersteund.",
+        "changePathPrefix": "Om dit pad te wijzigen, stel",
+        "changePathMiddle": "in je",
+        "changePathSuffix": "bestand in.",
+        "metadata": "Metadata",
+        "autoFetch": "Metadata automatisch ophalen van providers",
+        "autoFetchHint": "Haal automatisch metadata op van geconfigureerde providers (Google Books, iTunes, Open Library, enz.) nadat een bestand aan Book Dock is toegevoegd.",
+        "autoFinalize": "Automatisch afronden",
+        "enableAutoFinalize": "Automatisch afronden inschakelen",
+        "enableAutoFinalizeHint": "Bestanden met een betrouwbaarheidsscore van metadata op of boven de drempelwaarde worden automatisch afgerond.",
+        "confidenceThreshold": "Betrouwbaarheidsdrempel: {value}%",
+        "thresholdIgnored": "(genegeerd in modus Alleen ingesloten)",
+        "destinationLibrary": "Doelbibliotheek",
+        "selectLibrary": "Selecteer een bibliotheek...",
+        "metadataMode": "Metadata-modus",
+        "metadataModeSafeMerge": "Veilig samenvoegen (aanbevolen)",
+        "metadataModeFetchedOnly": "Alleen opgehaald",
+        "metadataModeEmbeddedOnly": "Alleen ingesloten",
+        "destinationFolder": "Doelmap",
+        "selectFolder": "Selecteer een map...",
+        "saveSettingFailed": "Kan instelling niet opslaan",
+        "updateSettingFailed": "Kan instelling niet bijwerken",
+        "autoFetchEnabled": "Automatisch ophalen ingeschakeld",
+        "autoFetchDisabled": "Automatisch ophalen uitgeschakeld",
+        "autoFinalizeEnabled": "Automatisch afronden ingeschakeld",
+        "autoFinalizeDisabled": "Automatisch afronden uitgeschakeld",
+        "destinationLibraryUpdated": "Doelbibliotheek bijgewerkt",
+        "destinationFolderUpdated": "Doelmap bijgewerkt",
+        "confidenceThresholdUpdated": "Betrouwbaarheidsdrempel bijgewerkt",
+        "metadataModeUpdated": "Metadata-modus bijgewerkt"
+      },
+      "fileNaming": {
+        "title": "Bestandsnaamgeving",
+        "subtitle": "Bepaal hoe bestanden op de schijf worden georganiseerd bij het uploaden en hoe ze worden benoemd bij het downloaden met behulp van placeholdertokens.",
+        "copy": "Kopiëren",
+        "previewLabel": "Voorbeeld:",
+        "fileAsBookPreview": "Voorbeeld Bestand als Boek",
+        "folderAsBookPreview": "Voorbeeld Map als Boek",
+        "downloadPreview": "Voorbeeld download",
+        "globalDefaults": "Algemene standaardwaarden",
+        "crossPlatform": "Platformonafhankelijke padopschoning",
+        "crossPlatformHint": "Maak gegenereerde bestands- en mapnamen veilig op Windows door ongeldige tekens en gereserveerde namen te vervangen en volgpunten en spaties te verwijderen. Schakel dit alleen uit voor Linux-only-configuraties die die tekens bewust behouden.",
+        "fileAsBookDefault": "Standaard Bestand als Boek",
+        "fileAsBookDefaultHint": "Uploadpatroon voor bibliotheken die de modus Bestand als Boek gebruiken. Elk bestand is één boek.",
+        "folderAsBookDefault": "Standaard Map als Boek",
+        "folderAsBookDefaultHint": "Uploadpatroon voor bibliotheken die de modus Map als Boek gebruiken. Elk boek moet in een eigen map staan.",
+        "downloadPattern": "Downloadpatroon",
+        "downloadPatternHint": "Voorgestelde bestandsnamen voor downloads van losse bestanden en bestanden in export-ZIP's.",
+        "libraryOverrides": "Bibliotheekuitzonderingen",
+        "noLibraries": "Geen bibliotheken geconfigureerd. Maak er een aan in de bibliotheekinstellingen om aangepaste naamgevingspatronen in te stellen.",
+        "badgeCustom": "Aangepast",
+        "badgeDefault": "Standaard",
+        "orgFolderAsBook": "Map als Boek",
+        "orgFileAsBook": "Bestand als Boek",
+        "resetToDefault": "Standaardwaarde herstellen",
+        "patternReference": "Patroonreferentie",
+        "placeholderReference": "Placeholderreferentie",
+        "placeholderReferenceHint": "- gids voor het maken van aangepaste naamgevingspatronen",
+        "tokens": "Tokens",
+        "tokensHint": "Kopieer placeholders snel",
+        "clickTokenHint": "Klik op een token om het naar je klembord te kopiëren.",
+        "copyValue": "Kopieer {value}",
+        "modifiers": "Modificaties",
+        "modifiersHint": "Tokenwaarden transformeren",
+        "modifiersExplain": "Voeg een modificatie toe binnen een token om de waarde te transformeren:",
+        "modFirst": "Alleen eerste waarde",
+        "modSort": "Achternaam, voornaam-notatie",
+        "modInitial": "Alleen eerste letter",
+        "folderOnlyPrefix": "Beëindig een patroon met",
+        "folderOnlySuffix": "om alleen een map op te geven. De oorspronkelijke bestandsnaam blijft daarbinnen behouden.",
+        "conditionalLogic": "Voorwaardelijke logica",
+        "conditionalLogicHint": "Optionele segmenten en terugvallen",
+        "conditionalPart1": "Zet tussen",
+        "conditionalPart2": "om een segment over te slaan wanneer het token leeg is. Gebruik",
+        "conditionalPart3": "voor een standaardwaarde.",
+        "examples": "Voorbeelden",
+        "patternExamples": "Patroonvoorbeelden",
+        "patternExamplesHint": "Kant-en-klare patronen voor veelvoorkomende bibliotheekstijlen",
+        "copyPatternTooltip": "Patroon naar klembord kopiëren",
+        "exCalibre": "Calibre-achtige standaard",
+        "exSeriesReader": "Reekslezer",
+        "exCleanDownload": "Nette downloadbestandsnaam",
+        "exAlphabetical": "Alfabetische groepering met reeks",
+        "exSeriesFallback": "Reeks of Standalone-terugval",
+        "exOptionalSubtitle": "Download met optionele ondertitel",
+        "exMultilingual": "Meertalige bibliotheek",
+        "exPublisher": "Uitgever-georganiseerd",
+        "exStacked": "Gestapelde optionele mappen",
+        "exFolderDrop": "Map-drop met sorteernaam",
+        "caseWithYear": "met jaar",
+        "caseNoYear": "geen jaar",
+        "caseInSeries": "in reeks",
+        "caseStandalone": "standalone",
+        "caseNoSeries": "geen reeks",
+        "caseFull": "volledig",
+        "caseMinimal": "minimaal",
+        "caseWithLanguage": "met taal",
+        "caseNoLanguage": "geen taal",
+        "caseWithPublisher": "met uitgever",
+        "caseNoPublisher": "geen uitgever",
+        "caseAllSet": "alles ingesteld",
+        "copiedToClipboard": "{value} gekopieerd naar klembord",
+        "copyTokenFailed": "Kan token niet kopiëren",
+        "patternCopied": "Patroon gekopieerd naar klembord",
+        "copyPatternFailed": "Kan patroon niet kopiëren",
+        "labelCopied": "{label} gekopieerd naar klembord",
+        "copyLabelFailed": "Kan {label} niet kopiëren"
+      },
+      "kobo": {
+        "title": "Kobo-synchronisatie",
+        "subtitle": "Koppel je Kobo-apparaat om je bibliotheek te synchroniseren.",
+        "copy": "Kopiëren",
+        "never": "Nooit",
+        "justNow": "Zojuist",
+        "minutesAgo": "{count}m geleden",
+        "hoursAgo": "{count}u geleden",
+        "daysAgo": "{count}d geleden",
+        "loadFailed": "Laden mislukt",
+        "devicePaired": "Apparaat succesvol gekoppeld",
+        "devicePairedHint": "Je bent klaar om je Kobo in te stellen. Volg de onderstaande instructies.",
+        "syncUrl": "Synchronisatie-URL",
+        "urlNotShownAgain": "Deze URL wordt niet opnieuw getoond. Houd hem privé.",
+        "registeredDevices": "Geregistreerde apparaten",
+        "addDevice": "Apparaat toevoegen",
+        "deviceName": "Apparaatnaam",
+        "deviceNamePlaceholder": "bijv. Mijn Kobo Libra",
+        "creating": "Aanmaken...",
+        "createDevice": "Apparaat aanmaken",
+        "createDeviceFailed": "Kan apparaat niet aanmaken",
+        "deviceRegistered": "Apparaat \"{name}\" geregistreerd",
+        "noDevicesYet": "Nog geen apparaten",
+        "noDevicesHint": "Voeg een apparaat toe om je boeken naar je Kobo te synchroniseren.",
+        "lastSync": "Laatste synchronisatie: {time}",
+        "renameDevice": "Apparaat hernoemen",
+        "revokeAccess": "Toegang intrekken",
+        "deviceRenamed": "Apparaat hernoemd",
+        "renameDeviceFailed": "Kan apparaat niet hernoemen",
+        "revokeConfirm": "Toegang intrekken voor \"{name}\"? Het apparaat kan pas weer synchroniseren na opnieuw koppelen.",
+        "accessRevoked": "Toegang ingetrokken voor \"{name}\"",
+        "revokeFailed": "Kan toegang niet intrekken",
+        "syncUrlCopied": "Synchronisatie-URL gekopieerd naar klembord",
+        "syncUrlCopyFailed": "Kan synchronisatie-URL niet kopiëren",
+        "syncPreferences": "Synchronisatievoorkeuren",
+        "twoWaySync": "Tweerichtings-voortgangssynchronisatie",
+        "twoWaySyncHint": "Synchroniseer de leespositie tussen BookOrbit en Kobo. Vereist KEPUB-levering voor nauwkeurige locaties en betrouwbaar herstel van de pagina.",
+        "syncHighlights": "BookOrbit-markeringen synchroniseren naar Kobo",
+        "syncHighlightsHint": "Stuur markeringen gemaakt in BookOrbit of KOReader naar je Kobo. Kobo-markeringen worden geïmporteerd in BookOrbit, ook wanneer dit uit staat. Gekoppelde annotaties synchroniseren bewerkingen en verwijderingen in beide richtingen. Vereist KEPUB-levering; het boek op Kobo moet de KEPUB zijn die vanuit BookOrbit is gedownload.",
+        "convertKepub": "Converteren naar KEPUB",
+        "convertKepubHint": "Stuur in aanmerking komende EPUB's als KEPUB. Dit blijft aan wanneer voortgangssynchronisatie of BookOrbit-naar-Kobo-markeringen zijn ingeschakeld. Bij de volgende Kobo-synchronisatie worden betrokken boeken opnieuw aangeboden als KEPUB-downloads; verwijder een oude EPUB-kopie als Kobo die blijft openen.",
+        "forceHyphenation": "Woordafbreking forceren",
+        "forceHyphenationHint": "Zorgt voor consistente tekstuitvulling. Hiermee worden gecachte KEPUB's opnieuw gegenereerd.",
+        "progressThresholds": "Voortgangsdrempels",
+        "progressThresholdsHint": "Bepaal wanneer de Kobo-leesvoortgang je bibliotheekstatus bijwerkt.",
+        "markAsReading": "Markeren als Aan het lezen",
+        "markAsReadingHint": "Minimumpercentage om een boek naar \"Aan het lezen\" te verplaatsen.",
+        "markAsFinished": "Markeren als Voltooid",
+        "markAsFinishedHint": "Percentagedrempel om een boek als \"Voltooid\" te markeren.",
+        "kepubLimit": "KEPUB-conversielimiet",
+        "kepubLimitHint": "Boeken boven deze limiet worden verzonden als gewone EPUB's, dus BookOrbit synchroniseert hun lezerpositie niet terug naar Kobo.",
+        "changesMustBeSaved": "Wijzigingen moeten worden opgeslagen om effect te hebben.",
+        "saving": "Opslaan...",
+        "saveSyncSettings": "Synchronisatie-instellingen opslaan",
+        "thresholdOrderError": "De leesdrempel moet lager zijn dan de voltooiingsdrempel",
+        "saveSettingsFailed": "Kan instellingen niet opslaan",
+        "settingsSaved": "Kobo-synchronisatie-instellingen opgeslagen",
+        "saveFailed": "Opslaan mislukt"
+      },
+      "koreader": {
+        "title": "KOReader-synchronisatie",
+        "subtitle": "Blader door je BookOrbit-catalogus in KOReader en synchroniseer voortgang, leesactiviteit, markeringen en annotatiewijzigingen.",
+        "loadingSettings": "KOReader-instellingen laden...",
+        "loadFailed": "Kan KOReader-instellingen niet laden",
+        "never": "Nooit",
+        "justNow": "Zojuist",
+        "minutesAgo": "{count}m geleden",
+        "hoursAgo": "{count}u geleden",
+        "daysAgo": "{count}d geleden",
+        "unknown": "Onbekend",
+        "updateAvailable": "Update beschikbaar",
+        "upToDate": "Up-to-date",
+        "versionUnknown": "Versie onbekend",
+        "latestPlugin": "Nieuwste plug-in: v{version}",
+        "latestPluginUnavailable": "Nieuwste plug-in niet beschikbaar",
+        "notConfigured": "KOReader-synchronisatie is niet geconfigureerd",
+        "notConfiguredHint": "Maak één set synchronisatiegegevens aan en gebruik ze vervolgens met de BookOrbit KOReader-plug-in voor bladeren, downloads, voortgang, leesgebeurtenissen, markeringen en verwijderingen.",
+        "createCredentials": "Inloggegevens aanmaken",
+        "createFormTitle": "KOReader-synchronisatiegegevens aanmaken",
+        "createFormHint": "Deze inloggegevens authenticeren je KOReader-apparaten bij BookOrbit.",
+        "username": "Gebruikersnaam",
+        "usernamePlaceholder": "bijv. mijnlezer",
+        "password": "Wachtwoord",
+        "passwordPlaceholder": "Minimaal 6 tekens",
+        "creating": "Aanmaken...",
+        "create": "Aanmaken",
+        "credentialsCreated": "KOReader-synchronisatiegegevens aangemaakt",
+        "createCredentialsFailed": "Kan inloggegevens niet aanmaken",
+        "status": "KOReader-status",
+        "refresh": "Vernieuwen",
+        "progressSync": "Voortgangssynchronisatie",
+        "progressSyncHint": "Sta KOReader-apparaten toe voortgang, leesactiviteit, markeringen en annotatieverwijderingen te synchroniseren met BookOrbit.",
+        "lastSync": "Laatste synchronisatie",
+        "syncedBooks": "Gesynchroniseerde boeken",
+        "bookCount": "geen boeken | {count} boek | {count} boeken",
+        "devices": "Apparaten",
+        "deviceCount": "geen apparaten | {count} apparaat | {count} apparaten",
+        "credentialsCreatedLabel": "Inloggegevens aangemaakt",
+        "setup": "Instellen",
+        "pluginServerUrl": "Plug-in-server-URL",
+        "copied": "Gekopieerd",
+        "copyUrl": "URL kopiëren",
+        "preconfiguredPlugin": "Voorgeconfigureerde BookOrbit-plug-in",
+        "preconfiguredPluginHintPrefix": "Download een zip met de server-URL en je synchronisatie-login al geconfigureerd. De plug-in bevat catalogus bladeren en synchronisatie. Kopieer de map naar",
+        "preconfiguredPluginHintSuffix": "en herstart KOReader.",
+        "latestPluginNote": "{label}. Apparaatupdates worden uitgevoerd vanuit het BookOrbit-menu in KOReader.",
+        "preparing": "Voorbereiden...",
+        "downloadPlugin": "Plug-in downloaden",
+        "noDevicesSynced": "Nog geen apparaten gesynchroniseerd",
+        "noDevicesSyncedHint": "Installeer de BookOrbit-plug-in voor volledige synchronisatie, of configureer KOReaders standaard voortgangssynchronisatie voor alleen voortgangsupdates.",
+        "lastSyncLabel": "Laatste synchronisatie:",
+        "lastBookLabel": "Laatste boek:",
+        "noneYet": "Nog geen",
+        "pluginActivity": "Plug-in-activiteit",
+        "noPluginActivity": "Er is nog geen plug-in-activiteit gerapporteerd.",
+        "lastFullSync": "Laatste volledige synchronisatie: {time}",
+        "latestPluginSuffix": "- nieuwste plug-in v{version}",
+        "matchedBooks": "Gematchte boeken",
+        "readingEvents": "Leesgebeurtenissen",
+        "highlights": "Markeringen",
+        "syncedTotals": "Gesynchroniseerde totalen",
+        "trashedHighlights": "Verwijderde markeringen",
+        "pendingDeletes": "geen verwijderde markeringen wachten op bevestiging door de KOReader-plug-in. | {count} verwijderde markering wacht op bevestiging door de KOReader-plug-in. | {count} verwijderde markeringen wachten op bevestiging door de KOReader-plug-in.",
+        "failedPositions": "geen markeringsposities vereisen aandacht. | {count} markeringspositie vereist aandacht. | {count} markeringsposities vereisen aandacht.",
+        "setupGuide": "Installatiegids",
+        "setupSteps": "KOReader-installatiestappen",
+        "setupStepsHint": "Gebruik de BookOrbit-plug-in voor catalogus bladeren, downloads, voortgang, leesgebeurtenissen en markeringen. Gebruik de standaard-plug-in voor alleen voortgang.",
+        "pluginGuideTitle": "BookOrbit-plug-in",
+        "pluginStep1": "Download de voorgeconfigureerde plug-in hierboven.",
+        "pluginStep2Prefix": "Pak het uit en kopieer",
+        "pluginStep2Middle": "naar",
+        "pluginStep2Suffix": "op je apparaat.",
+        "pluginStep3": "Herstart KOReader. De server en login worden automatisch geconfigureerd.",
+        "pluginStep4Prefix": "Open",
+        "pluginStep4Suffix": "om boeken te zoeken, downloaden en koppelen voor synchronisatie.",
+        "stockGuideTitle": "Standaard voortgangssynchronisatie-plug-in",
+        "stockStep1Prefix": "Ga op je KOReader-apparaat naar",
+        "stockStep1Suffix": ".",
+        "stockStep2": "Stel de aangepaste synchronisatieserver in op de hierboven getoonde URL.",
+        "stockStep3": "Voer de gebruikersnaam en het wachtwoord in die je hebt aangemaakt en tik op Inloggen.",
+        "locationNote": "BookOrbit slaat KOReader-compatibele EPUB-locaties op vanuit de weblezer. Herstel zou dicht bij dezelfde positie moeten uitkomen, hoewel de exacte regelplaatsing kan variëren per lezer en EPUB-opmaak.",
+        "dangerZone": "Gevarenzone",
+        "deleteCredentials": "KOReader-inloggegevens verwijderen",
+        "deleteCredentialsHint": "Verwijder synchronisatiegegevens en ontkoppel alle apparaten. Voortgangsgegevens blijven behouden.",
+        "credentialsDeleted": "KOReader-inloggegevens verwijderd",
+        "deleteCredentialsFailed": "Kan inloggegevens niet verwijderen",
+        "deleteConfirmTitle": "KOReader-inloggegevens verwijderen?",
+        "deleteConfirmBody": "Hiermee worden je synchronisatiegegevens verwijderd en alle KOReader-apparaten ontkoppeld. Bestaande voortgangsgegevens blijven behouden.",
+        "syncEnabled": "KOReader-synchronisatie ingeschakeld",
+        "syncDisabled": "KOReader-synchronisatie uitgeschakeld",
+        "toggleSyncFailed": "Kan synchronisatie niet omschakelen",
+        "syncUrlCopied": "Synchronisatie-URL gekopieerd naar klembord",
+        "syncUrlCopyFailed": "Kan synchronisatie-URL niet kopiëren",
+        "statusRefreshed": "Synchronisatiestatus vernieuwd",
+        "refreshFailed": "Vernieuwen mislukt",
+        "pluginDownloaded": "Plug-in gedownload. Kopieer bookorbit.koplugin uit de zip naar koreader/plugins/ op je apparaat.",
+        "pluginDownloadFailed": "Kan de plug-in niet downloaden"
+      },
+      "opds": {
+        "title": "OPDS",
+        "subtitle": "Verbind OPDS-compatibele leesapps zoals KOReader of Thorium Reader met je bibliotheek.",
+        "copy": "Kopiëren",
+        "loadFailed": "Laden mislukt",
+        "server": "Server",
+        "catalogServer": "OPDS-catalogusserver",
+        "catalogServerHint": "Sta OPDS-clients toe boeken te bladeren en downloaden",
+        "endpoint": "Endpoint",
+        "accounts": "OPDS-accounts",
+        "add": "Toevoegen",
+        "addAccount": "Account toevoegen",
+        "username": "Gebruikersnaam",
+        "usernameLabel": "Gebruikersnaam",
+        "usernamePlaceholder": "bijv. koreader",
+        "password": "Wachtwoord",
+        "passwordPlaceholder": "Minimaal 8 tekens",
+        "defaultSort": "Standaardsortering",
+        "sortLabel": "Sortering",
+        "creating": "Aanmaken...",
+        "create": "Aanmaken",
+        "noAccounts": "Nog geen OPDS-accounts. Maak er een aan om OPDS-clients te gaan gebruiken.",
+        "hideDetails": "Details verbergen",
+        "showDetails": "Details tonen",
+        "copyUsername": "Gebruikersnaam kopiëren",
+        "notes": "OPDS-notities",
+        "notesBody": "Gebruik OPDS-accounts in leesapps. Houd inloggegevens privé en wijzig wachtwoorden als ze per ongeluk zijn gedeeld.",
+        "deleteConfirmTitle": "OPDS-account verwijderen?",
+        "deleteConfirmBody": "Verwijder \"{username}\". Deze actie kan niet ongedaan worden gemaakt.",
+        "sortRecent": "Recent toegevoegd",
+        "sortTitleAsc": "Titel (A-Z)",
+        "sortTitleDesc": "Titel (Z-A)",
+        "sortAuthorAsc": "Auteur (A-Z)",
+        "sortAuthorDesc": "Auteur (Z-A)",
+        "sortSeriesAsc": "Reeks (A-Z)",
+        "sortSeriesDesc": "Reeks (Z-A)",
+        "serverEnabled": "OPDS-server ingeschakeld",
+        "serverDisabled": "OPDS-server uitgeschakeld",
+        "updateSettingsFailed": "Kan OPDS-instellingen niet bijwerken",
+        "urlCopied": "OPDS-URL gekopieerd naar klembord",
+        "urlCopyFailed": "Kan OPDS-URL niet kopiëren",
+        "createUserFailed": "Kan OPDS-gebruiker niet aanmaken",
+        "userCreated": "OPDS-gebruiker \"{username}\" aangemaakt",
+        "sortOrderUpdated": "Sorteervolgorde bijgewerkt voor \"{username}\"",
+        "updateSortFailed": "Kan sorteervolgorde niet bijwerken",
+        "userDeleted": "OPDS-gebruiker \"{username}\" verwijderd",
+        "deleteUserFailed": "Kan OPDS-gebruiker niet verwijderen",
+        "labelCopied": "{label} gekopieerd",
+        "copyLabelFailed": "Kan {label} niet kopiëren"
       }
     }
+  },
+  "achievements": {
+    "title": "Prestaties",
+    "tiersCount": "{earned} / {total} niveaus",
+    "loadFailed": "Laden van prestaties mislukt",
+    "tryAgain": "Opnieuw proberen",
+    "noMatchFilter": "Geen prestaties komen overeen met dit filter",
+    "secretAchievement": "Geheime prestatie",
+    "earnedOn": "Behaald {date}",
+    "whileReading": "Tijdens het lezen van “{title}”",
+    "tierProgress": "Niveau {earned} van {total}",
+    "progressToNext": "{current} / {threshold} tot {name}",
+    "rarity": {
+      "common": "Gewoon",
+      "rare": "Zeldzaam",
+      "epic": "Episch",
+      "legendary": "Legendarisch"
+    },
+    "filter": {
+      "all": "Alle",
+      "earned": "Behaald ({count})",
+      "inProgress": "Bezig ({count})",
+      "locked": "Vergrendeld ({count})"
+    }
+  },
+  "adminFeature": {
+    "resetLink": {
+      "title": "Wachtwoordherstellink",
+      "description": "Deel deze link met de gebruiker. Deze verloopt over 15 minuten.",
+      "copy": "Kopiëren",
+      "copied": "Gekopieerd!",
+      "copyFailed": "Kopiëren mislukt",
+      "notShownAgain": "Deze link wordt niet nogmaals getoond."
+    },
+    "userForm": {
+      "editUser": "Gebruiker bewerken",
+      "createUser": "Gebruiker aanmaken",
+      "createSharedAccount": "Gedeeld account aanmaken",
+      "sharedBadge": "Gedeeld",
+      "active": "Actief",
+      "suspended": "Opgeschort",
+      "tabs": {
+        "general": "algemeen",
+        "access": "toegang",
+        "restrictions": "beperkingen"
+      },
+      "sharedAccount": "Gedeeld account",
+      "sharedAccountHint": "Geen wachtwoord. Toegang wordt alleen verleend via magic links.",
+      "sharedAccountManageHint": "Beheer inloglinks via Instellingen - Magic Links.",
+      "username": "Gebruikersnaam",
+      "fullName": "Volledige naam",
+      "email": "E-mail",
+      "optional": "(optioneel)",
+      "libraryAccess": "Bibliotheektoegang",
+      "noLibrariesSelected": "Geen bibliotheken geselecteerd. De gebruiker kan geen boeken bekijken.",
+      "permissions": "Rechten",
+      "presetStandard": "Standaard",
+      "presetAdmin": "Beheer",
+      "presetClearAll": "Alles wissen",
+      "permissionGroups": {
+        "content": "Inhoud",
+        "devicesAccess": "Apparaten & toegang",
+        "email": "E-mail",
+        "administration": "Beheer",
+        "restrictions": "Beperkingen"
+      },
+      "superuserTarget": "Supergebruiker",
+      "superuserTargetHint": "Inhoudsbeperkingen kunnen niet worden toegepast op supergebruikers.",
+      "noRestrictions": "Geen inhoudsbeperkingen",
+      "noRestrictionsHint": "Deze gebruiker heeft volledige toegang tot alle boeken in de toegewezen bibliotheken.",
+      "addRestrictions": "+ Inhoudsbeperkingen toevoegen",
+      "contentRestrictions": "Inhoudsbeperkingen",
+      "remove": "Verwijderen",
+      "includeTags": "Labels opnemen",
+      "includeTagsHint": "(toon alleen boeken met deze labels)",
+      "excludeTags": "Labels uitsluiten",
+      "excludeTagsHint": "(verberg boeken met deze labels)",
+      "includeGenres": "Genres opnemen",
+      "includeGenresHint": "(toon alleen boeken met deze genres)",
+      "excludeGenres": "Genres uitsluiten",
+      "excludeGenresHint": "(verberg boeken met deze genres)",
+      "searchTagsPlaceholder": "Labels zoeken...",
+      "searchGenresPlaceholder": "Genres zoeken...",
+      "saving": "Opslaan...",
+      "errors": {
+        "updateUser": "Gebruiker bijwerken mislukt",
+        "updatePermissions": "Rechten bijwerken mislukt",
+        "updateLibraryAccess": "Bibliotheektoegang bijwerken mislukt",
+        "updateContentFilters": "Inhoudsfilters bijwerken mislukt",
+        "emailRequired": "E-mail is verplicht",
+        "createSharedAccount": "Gedeeld account aanmaken mislukt",
+        "createUser": "Gebruiker aanmaken mislukt"
+      }
+    },
+    "usersPage": {
+      "usersTitle": "Gebruikers",
+      "magicLinksTitle": "Magic Links",
+      "usersSubtitle": "Beheer gebruikersaccounts en rechtentoewijzingen.",
+      "magicLinksSubtitle": "Maak deelbare inloglinks voor gedeelde accounts.",
+      "createUser": "Gebruiker aanmaken",
+      "createLink": "Link aanmaken",
+      "usersTab": "Gebruikers",
+      "magicLinksTab": "Magic Links",
+      "columns": {
+        "name": "Naam",
+        "username": "Gebruikersnaam",
+        "email": "E-mail",
+        "access": "Toegang",
+        "status": "Status"
+      },
+      "adminBadge": "Beheer",
+      "permissionCount": "geen rechten | één recht | {count} rechten",
+      "filteredBadge": "Gefilterd",
+      "contentRestrictionsActive": "Inhoudsbeperkingen actief",
+      "statusActive": "Actief",
+      "statusInactive": "Inactief",
+      "resetPassword": "Wachtwoord opnieuw instellen",
+      "resetPasswordOidcHint": "OIDC-gebruikers stellen wachtwoorden opnieuw in bij hun identiteitsprovider",
+      "resetPasswordSharedHint": "Gedeelde accounts hebben geen wachtwoord",
+      "resetPasswordOidcHintFull": "OIDC-gebruikers stellen wachtwoorden opnieuw in bij hun identiteitsprovider.",
+      "resetPasswordSharedHintFull": "Gedeelde accounts hebben geen wachtwoord.",
+      "deleteUserAction": "Gebruiker verwijderen",
+      "deleteDialogTitle": "Gebruiker verwijderen?",
+      "deleteDialogBody": "Gebruiker \"{username}\" verwijderen. Deze actie kan niet ongedaan worden gemaakt.",
+      "deleting": "Verwijderen...",
+      "errors": {
+        "loadData": "Gegevens laden mislukt",
+        "load": "Laden mislukt",
+        "deleteUser": "Gebruiker verwijderen mislukt"
+      }
+    }
+  },
+  "annotations": {
+    "unknownBook": "Onbekend boek",
+    "styles": {
+      "highlight": "Markering",
+      "underline": "Onderstrepen",
+      "strike": "Doorhalen",
+      "squiggle": "Golflijn",
+      "invert": "Omkeren"
+    },
+    "combobox": {
+      "filterByBook": "Filteren op boek",
+      "allBooks": "Alle boeken",
+      "clearBookFilter": "Boekfilter wissen",
+      "searching": "Zoeken...",
+      "noBooksFound": "Geen boeken gevonden"
+    },
+    "bulk": {
+      "countSelected": "{count} geselecteerd",
+      "pageSelected": "Pagina geselecteerd",
+      "selectPage": "Pagina selecteren",
+      "clear": "Wissen",
+      "recolorTo": "Verkleuren naar {color}",
+      "restyleTo": "Restylen naar {style}"
+    },
+    "chips": {
+      "active": "Actief:",
+      "removeFilter": "Filter {label} verwijderen",
+      "clearAll": "Alles wissen"
+    },
+    "filters": {
+      "colors": "Kleuren",
+      "dateRange": "Datumbereik",
+      "fromDate": "Vanaf datum",
+      "toDate": "Tot datum",
+      "to": "tot",
+      "clearDateRange": "Datumbereik wissen",
+      "clearAll": "Alles wissen"
+    },
+    "pagination": {
+      "showing": "{start}-{end} van {total} weergegeven",
+      "pageOf": "Pagina {page} van {totalPages}",
+      "firstPage": "Eerste pagina",
+      "previousPage": "Vorige pagina",
+      "nextPage": "Volgende pagina",
+      "lastPage": "Laatste pagina"
+    },
+    "sync": {
+      "loading": "Synchronisatiedetails laden",
+      "positions": "Posities",
+      "devices": "Apparaten",
+      "retryConversion": "Conversie opnieuw proberen",
+      "noStoredPositions": "Geen opgeslagen posities.",
+      "notSynced": "Nog niet gesynchroniseerd met een apparaat.",
+      "upToDate": "Up-to-date",
+      "pendingVersion": "In afwachting v{version}",
+      "syncedAt": "gesynchroniseerd {date}",
+      "format": {
+        "webReader": "Weblezer",
+        "koreader": "KOReader",
+        "pdf": "PDF",
+        "kobo": "Kobo"
+      },
+      "status": {
+        "exact": "Exact",
+        "repaired": "Hersteld",
+        "failed": "Mislukt",
+        "pending": "In afwachting"
+      }
+    },
+    "toolbar": {
+      "searchPlaceholder": "Zoek in tekst en notities",
+      "filters": "Filters",
+      "sortOrder": "Sorteervolgorde",
+      "switchToCompact": "Overschakelen naar compacte weergave",
+      "switchToComfortable": "Overschakelen naar ruime weergave",
+      "compactView": "Compacte weergave",
+      "comfortableView": "Ruime weergave"
+    },
+    "listItem": {
+      "pageNumber": "p. {page}",
+      "chapterNumber": "hoofdstuk {chapter}",
+      "selectAnnotation": "Annotatie selecteren",
+      "collapse": "Inklappen",
+      "expand": "Uitklappen",
+      "hideSyncDetail": "Synchronisatiedetails verbergen",
+      "showSyncDetail": "Synchronisatiedetails tonen",
+      "exactPositionUnavailable": "Exacte lezerpositie niet beschikbaar",
+      "saving": "Opslaan",
+      "bookDetails": "Boekdetails",
+      "openInReader": "Openen in lezer",
+      "restore": "Herstellen",
+      "deleteForever": "Definitief verwijderen",
+      "editNote": "Notitie bewerken",
+      "addNote": "Notitie toevoegen",
+      "colorAndStyle": "Kleur en stijl",
+      "copied": "Gekopieerd",
+      "copyText": "Tekst kopiëren",
+      "trash": "Prullenbak",
+      "moveToTrash": "Naar prullenbak verplaatsen"
+    },
+    "hub": {
+      "title": "Annotaties",
+      "totalCount": "{count} totaal",
+      "bookCount": "geen boeken | {count} boek | {count} boeken",
+      "noteCount": "geen notities | {count} notitie | {count} notities",
+      "export": "Exporteren",
+      "exportMarkdown": "Markdown",
+      "exportCsv": "CSV",
+      "exportJson": "JSON",
+      "notesOnly": "Alleen notities",
+      "style": "Stijl",
+      "source": "Bron",
+      "bulkTrash": "Prullenbak",
+      "bulkRestore": "Herstellen",
+      "tabs": {
+        "highlights": "Markeringen",
+        "trash": "Prullenbak"
+      },
+      "empty": {
+        "noMatch": "Geen markeringen komen overeen met je filters.",
+        "resetFilters": "Filters opnieuw instellen",
+        "trashEmpty": "Prullenbak is leeg",
+        "noAnnotations": "Nog geen annotaties. Markeringen die je op het web of je e-reader maakt, verschijnen hier."
+      },
+      "toast": {
+        "movedToTrash": "Naar prullenbak verplaatst",
+        "annotationRestored": "Annotatie hersteld",
+        "annotationDeletedForever": "Annotatie definitief verwijderd",
+        "failedToDelete": "Verwijderen mislukt",
+        "bulkTrashed": "Geen annotaties naar prullenbak verplaatst | {count} annotatie naar prullenbak verplaatst | {count} annotaties naar prullenbak verplaatst",
+        "bulkRestored": "Geen annotaties hersteld | {count} annotatie hersteld | {count} annotaties hersteld",
+        "bulkRecolored": "Geen annotaties verkleurd | {count} annotatie verkleurd | {count} annotaties verkleurd",
+        "bulkRestyled": "Geen annotaties gerestyled | {count} annotatie gerestyled | {count} annotaties gerestyled"
+      }
+    }
+  },
+  "audit": {
+    "pageTitle": "Auditlogboek",
+    "pageSubtitle": "Een overzicht van beheerrelevante acties die in het systeem zijn uitgevoerd.",
+    "filters": "Filters",
+    "noActiveFilters": "Geen actieve filters",
+    "clear": "Wissen",
+    "empty": "Geen auditlogs gevonden",
+    "showMore": "Meer tonen",
+    "showLess": "Minder tonen",
+    "details": "Details",
+    "hideDetails": "Details verbergen",
+    "detailAction": "Actie: {value}",
+    "detailIp": "IP: {value}",
+    "showing": "{from}-{to} van {total} weergegeven",
+    "prev": "Vorige",
+    "chips": {
+      "action": "Actie: {value}",
+      "user": "Gebruiker: {value}",
+      "from": "Van: {value}",
+      "to": "Tot: {value}"
+    },
+    "filterLabels": {
+      "action": "Actie",
+      "userId": "Gebruikers-ID",
+      "from": "Van",
+      "to": "Tot"
+    },
+    "filterPlaceholders": {
+      "action": "bijv. auth.login",
+      "userId": "bijv. 1"
+    },
+    "columns": {
+      "when": "Wanneer",
+      "user": "Gebruiker",
+      "action": "Actie",
+      "description": "Beschrijving",
+      "ip": "IP"
+    }
+  },
+  "auth": {
+    "backToSignIn": "Terug naar inloggen",
+    "themePicker": {
+      "switchToLight": "Naar licht schakelen",
+      "switchToDark": "Naar donker schakelen",
+      "changeRadius": "Hoekradius wijzigen",
+      "changeBackground": "Achtergrond wijzigen",
+      "changeAccent": "Accentkleur wijzigen"
+    },
+    "fields": {
+      "username": "Gebruikersnaam",
+      "password": "Wachtwoord",
+      "email": "E-mail",
+      "emailAddress": "E-mailadres",
+      "fullName": "Volledige naam",
+      "newPassword": "Nieuw wachtwoord",
+      "confirmPassword": "Wachtwoord bevestigen",
+      "confirmNewPassword": "Nieuw wachtwoord bevestigen",
+      "currentPassword": "Huidig wachtwoord",
+      "passwordHint": "Min. 8 tekens met hoofdletter, kleine letter en een cijfer"
+    },
+    "errors": {
+      "generic": "Er is iets misgegaan. Probeer het opnieuw.",
+      "passwordsDoNotMatch": "Wachtwoorden komen niet overeen"
+    },
+    "login": {
+      "subtitle": "Log in op je account",
+      "signIn": "Inloggen",
+      "signingIn": "Inloggen...",
+      "orDivider": "of",
+      "forgotPassword": "Wachtwoord vergeten?",
+      "errors": {
+        "invalidCredentials": "Ongeldige gebruikersnaam of wachtwoord",
+        "tooManyAttempts": "Te veel inlogpogingen. Wacht een minuut en probeer het opnieuw."
+      }
+    },
+    "oidc": {
+      "loginFailed": "OIDC-inloggen mislukt",
+      "redirecting": "Doorsturen...",
+      "signInWith": "Inloggen met {provider}",
+      "completingSignIn": "Inloggen afronden...",
+      "tryAgain": "Opnieuw proberen",
+      "errors": {
+        "stateExpired": "Je inlogsessie is verlopen. Probeer opnieuw in te loggen.",
+        "tokenExchangeFailed": "Kon het inloggen bij je provider niet voltooien. Probeer het opnieuw of neem contact op met je beheerder.",
+        "userNotProvisioned": "Je account is niet ingesteld. Neem contact op met je beheerder voor toegang.",
+        "userInactive": "Je account is gedeactiveerd. Neem contact op met je beheerder.",
+        "providerError": "Je identiteitsprovider heeft een fout gemeld. Probeer het opnieuw.",
+        "missingCodeOrState": "Ontbrekende code- of state-parameter"
+      },
+      "providerErrors": {
+        "accessDenied": "Toegang is geweigerd door de identiteitsprovider.",
+        "loginRequired": "Authenticatie is vereist. Log opnieuw in.",
+        "interactionRequired": "Aanvullende gebruikersinteractie is vereist."
+      }
+    },
+    "forgotPassword": {
+      "subtitle": "Wachtwoord opnieuw instellen",
+      "submitted": "Als er een account met dat e-mailadres bestaat, is er een herstellink verzonden. Controleer je inbox.",
+      "sending": "Verzenden...",
+      "sendResetLink": "Herstellink verzenden",
+      "errors": {
+        "emailUnavailable": "Wachtwoordherstel via e-mail is niet beschikbaar. Neem contact op met je beheerder."
+      }
+    },
+    "resetPassword": {
+      "subtitle": "Nieuw wachtwoord instellen",
+      "saving": "Opslaan...",
+      "setNewPassword": "Nieuw wachtwoord instellen",
+      "errors": {
+        "invalidLink": "Ongeldige herstellink. Vraag een nieuwe aan.",
+        "invalidOrExpired": "Ongeldige of verlopen herstellink. Vraag een nieuwe aan."
+      }
+    },
+    "setup": {
+      "title": "Eerste installatie",
+      "subtitle": "Maak het eerste beheerdersaccount aan.",
+      "setupToken": "Installatietoken",
+      "setupTokenHint": "(vereist in productie)",
+      "creatingAccount": "Account aanmaken...",
+      "createAccount": "Beheerdersaccount aanmaken",
+      "errors": {
+        "failed": "Installatie voltooien mislukt"
+      }
+    },
+    "changePassword": {
+      "title": "Wachtwoord wijzigen",
+      "saving": "Opslaan…",
+      "forcedNotice": "Je moet een nieuw wachtwoord instellen voordat je verdergaat.",
+      "errors": {
+        "failed": "Wachtwoord wijzigen mislukt"
+      }
+    },
+    "magicLink": {
+      "signingIn": "Je wordt ingelogd...",
+      "loginFailed": "Inloggen mislukt",
+      "goToLogin": "Naar inloggen",
+      "errors": {
+        "noToken": "Geen token opgegeven"
+      }
+    }
+  },
+  "author": {
+    "card": {
+      "portraitAlt": "Portret van {name}",
+      "viewDetails": "Auteurdetails bekijken",
+      "refreshMetadata": "Metadata vernieuwen",
+      "deleteAuthor": "Auteur verwijderen"
+    },
+    "listRow": {
+      "noRecentAdditions": "Geen recente toevoegingen",
+      "portraitAlt": "Portret van {name}"
+    },
+    "filters": {
+      "title": "Auteurfilters",
+      "clearAll": "Alles wissen",
+      "allLibraries": "Alle bibliotheken",
+      "allAuthors": "Alle auteurs",
+      "hasPhoto": "Met foto",
+      "missingPhoto": "Zonder foto",
+      "minBooks": "Min. boeken",
+      "anyPlaceholder": "Alle"
+    },
+    "header": {
+      "never": "Nooit",
+      "portraitAlt": "Portret van {name}",
+      "actions": "Acties",
+      "editAuthor": "Auteur bewerken",
+      "mergeAuthors": "Auteurs samenvoegen",
+      "refreshing": "Vernieuwen...",
+      "refreshMetadata": "Metadata vernieuwen",
+      "deleteAuthor": "Auteur verwijderen",
+      "showLess": "Minder tonen",
+      "showMore": "Meer tonen",
+      "lookingUpMetadata": "Auteurmetadata opzoeken...",
+      "noBiography": "Geen biografie beschikbaar. Gebruik het menu om de metadata te vernieuwen.",
+      "previewFrom": "Voorbeeld van {provider}. Sla de metadata op om deze te bewaren.",
+      "booksLabel": "Boeken",
+      "lastAdded": "Laatst toegevoegd"
+    },
+    "list": {
+      "title": "Auteurs",
+      "searchPlaceholder": "Auteurs zoeken",
+      "sortButton": "Sorteren",
+      "sortBy": "Sorteren op",
+      "ascending": "Oplopend",
+      "descending": "Aflopend",
+      "asc": "Opl.",
+      "desc": "Afl.",
+      "filters": "Filters",
+      "clear": "Wissen",
+      "allLoaded": "Alle {total} auteurs geladen",
+      "sort": {
+        "name": "Naam",
+        "sortName": "Sorteernaam",
+        "bookCount": "Aantal boeken",
+        "recentAdditions": "Recente toevoegingen",
+        "lastEnriched": "Laatst verrijkt"
+      },
+      "empty": {
+        "title": "Geen auteurs gevonden",
+        "hint": "Probeer de zoektekst, sortering of bibliotheekfilter te wijzigen."
+      },
+      "deleteDialog": {
+        "titleOne": "Auteur verwijderen?",
+        "titleMany": "{count} auteurs verwijderen?",
+        "descriptionOne": "Hiermee wordt de auteur uit de catalogus verwijderd en ontkoppeld van bijbehorende boeken. Deze actie kan niet ongedaan worden gemaakt.",
+        "descriptionMany": "Hiermee worden de geselecteerde auteurs uit de catalogus verwijderd en ontkoppeld van bijbehorende boeken. Deze actie kan niet ongedaan worden gemaakt."
+      },
+      "selection": {
+        "selectVisible": "Zichtbare selecteren",
+        "refreshMetadata": "Metadata vernieuwen",
+        "refreshingMetadata": "Metadata vernieuwen...",
+        "deleteSelected": "Selectie verwijderen",
+        "deleting": "Verwijderen...",
+        "exitSelection": "Selectie afsluiten",
+        "confirmDeleteCount": "{count} auteur verwijderen? | {count} auteur verwijderen? | {count} auteurs verwijderen?"
+      },
+      "toast": {
+        "refreshed": "Auteurmetadata vernieuwd",
+        "refreshedNoImage": "Metadata vernieuwd, maar er is geen auteurafbeelding gevonden.",
+        "refreshFailed": "Vernieuwen van auteurmetadata mislukt",
+        "bulkRefreshPartial": "{updated} auteur(s) vernieuwd, {failed} mislukt",
+        "bulkRefreshSuccess": "Metadata vernieuwd voor {updated} auteur(s)",
+        "bulkRefreshFailed": "Vernieuwen van geselecteerde auteurs mislukt",
+        "deleteSuccess": "{count} auteur verwijderd; {books} boeken beïnvloed | {count} auteur verwijderd; {books} boeken beïnvloed | {count} auteurs verwijderd; {books} boeken beïnvloed",
+        "deleteFailed": "Verwijderen van auteur(s) mislukt"
+      }
+    },
+    "detail": {
+      "pageTitle": "Auteur",
+      "pageTitleNamed": "Auteur · {name}",
+      "pageTitleId": "Auteur #{id}",
+      "entityName": "Auteur",
+      "loadingAuthor": "Auteur laden...",
+      "previewError": "Kon nu geen externe voorbeeldmetadata voor de auteur laden.",
+      "edit": {
+        "name": "Naam",
+        "sortName": "Sorteernaam",
+        "description": "Beschrijving",
+        "image": "Afbeelding",
+        "uploading": "Uploaden...",
+        "replaceImage": "Afbeelding vervangen",
+        "uploadImage": "Afbeelding uploaden",
+        "removing": "Verwijderen...",
+        "removeImage": "Afbeelding verwijderen",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP tot {size} MB",
+        "saving": "Opslaan..."
+      },
+      "merge": {
+        "searchPlaceholder": "Auteurs zoeken om samen te voegen met deze auteur",
+        "searching": "Zoeken...",
+        "bookCount": "geen boeken | {count} boek | {count} boeken",
+        "selectedSummary": "{count} auteur(s) geselecteerd, ca. {books} boeken beïnvloed.",
+        "merging": "Samenvoegen...",
+        "mergeSelected": "Selectie samenvoegen",
+        "confirmLabel": "Samenvoegen"
+      },
+      "mergeDialog": {
+        "title": "{count} auteur(s) samenvoegen met \"{name}\"?",
+        "titleFallback": "Geselecteerde auteurs samenvoegen?",
+        "description": "Hiermee worden de geselecteerde auteurs samengevoegd met de huidige auteur en worden bijbehorende boeken opnieuw gekoppeld. Deze actie kan niet ongedaan worden gemaakt.",
+        "descriptionEmpty": "Deze actie kan niet ongedaan worden gemaakt."
+      },
+      "deleteDialog": {
+        "title": "Auteur verwijderen?",
+        "description": "Hiermee wordt de auteur uit de catalogus verwijderd en ontkoppeld van bijbehorende boeken. Deze actie kan niet ongedaan worden gemaakt."
+      },
+      "books": {
+        "heading": "Boeken",
+        "allLibraries": "Alle bibliotheken",
+        "asc": "Opl.",
+        "desc": "Afl.",
+        "ascending": "Oplopend",
+        "descending": "Aflopend",
+        "allLoaded": "Alle {total} boeken geladen",
+        "sort": {
+          "recentlyAdded": "Recent toegevoegd",
+          "title": "Titel",
+          "publishedYear": "Publicatiejaar"
+        },
+        "empty": {
+          "title": "Geen boeken gevonden voor deze auteur",
+          "hint": "Probeer de sortering/volgorde te wijzigen of een andere bibliotheek te selecteren."
+        }
+      },
+      "toast": {
+        "refreshed": "Auteurmetadata vernieuwd",
+        "refreshedNoImage": "Metadata vernieuwd, maar er is geen auteurafbeelding gevonden.",
+        "refreshFailed": "Vernieuwen van auteurmetadata mislukt",
+        "nameRequired": "Auteurnaam is verplicht",
+        "updated": "Auteur bijgewerkt",
+        "updateFailed": "Bijwerken van auteur mislukt",
+        "imageUpdated": "Auteurafbeelding bijgewerkt",
+        "imageUploadFailed": "Uploaden van auteurafbeelding mislukt",
+        "imageRemoved": "Auteurafbeelding verwijderd",
+        "imageRemoveFailed": "Verwijderen van auteurafbeelding mislukt",
+        "mergeSuccess": "{count} auteur(s) samengevoegd; {books} boeken beïnvloed",
+        "mergeFailed": "Samenvoegen van auteurs mislukt",
+        "deleteSuccess": "Auteur verwijderd; {books} boeken beïnvloed",
+        "deleteFailed": "Verwijderen van auteur mislukt"
+      }
+    }
+  },
+  "book": {
+    "untitled": "Naamloos",
+    "unknownFormat": "onbekend",
+    "card": {
+      "missing": "Ontbreekt"
+    },
+    "file": {
+      "primary": "Primair",
+      "audiobook": "Luisterboek"
+    },
+    "actions": {
+      "read": "Lezen",
+      "listen": "Luisteren",
+      "peek": "Voorbeeld",
+      "quickView": "Snelweergave",
+      "details": "Details",
+      "bookDetails": "Boekdetails",
+      "download": "Downloaden",
+      "metadata": "Metadata",
+      "editMetadata": "Metadata bewerken",
+      "refreshMetadata": "Metadata vernieuwen",
+      "regenerateCover": "Omslag opnieuw genereren",
+      "addToCollection": "Aan collectie toevoegen",
+      "setStatus": "Status instellen",
+      "sendViaEmail": "Verzenden via e-mail",
+      "rate": "Beoordeel {star}",
+      "openAs": "Openen als {format}"
+    },
+    "readStatus": {
+      "unread": "Ongelezen",
+      "wantToRead": "Wil ik lezen",
+      "reading": "Aan het lezen",
+      "onHold": "In de wacht",
+      "rereading": "Aan het herlezen",
+      "read": "Gelezen",
+      "skimmed": "Doorgebladerd",
+      "abandoned": "Gestopt"
+    },
+    "download": {
+      "action": "Downloaden",
+      "audiobookZip": "Luisterboek (ZIP)",
+      "allFormatsZip": "Alle formaten (ZIP)",
+      "primaryOnlyZip": "Alleen primair (ZIP)"
+    },
+    "sort": {
+      "moveUp": "Omhoog verplaatsen",
+      "moveDown": "Omlaag verplaatsen",
+      "ascending": "Oplopend",
+      "descending": "Aflopend",
+      "remove": "Verwijderen",
+      "emptyState": "Geen sortering ingesteld. Titel oplopend wordt gebruikt.",
+      "addLevel": "Sorteerniveau toevoegen"
+    },
+    "filter": {
+      "match": "Overeenkomst",
+      "all": "ALLE",
+      "any": "ELKE",
+      "ofFollowingRules": "van de volgende regels",
+      "anyProvider": "Elke aanbieder",
+      "communityRatingProvider": "Aanbieder van communitybeoordeling",
+      "loadingLibraries": "Bibliotheken laden...",
+      "noLibrariesAvailable": "Geen bibliotheken beschikbaar",
+      "selectLibrary": "Bibliotheek selecteren...",
+      "selectStatus": "Status selecteren...",
+      "withinLastPlaceholder": "bijv. 7",
+      "unit": {
+        "days": "dagen",
+        "weeks": "weken",
+        "months": "maanden"
+      },
+      "scorePreset": {
+        "outstanding": "Uitstekend",
+        "good": "Goed",
+        "fair": "Redelijk",
+        "poor": "Slecht"
+      },
+      "scoreRangePlaceholder": "0-100",
+      "valuePlaceholder": "waarde",
+      "maxPlaceholder": "max",
+      "to": "tot",
+      "group": "Groep",
+      "addRule": "Regel toevoegen",
+      "addGroup": "Groep toevoegen",
+      "typeToSearch": "Typ om te zoeken..."
+    },
+    "deleteDialog": {
+      "title": "Boek verwijderen?",
+      "description": "Hiermee worden het boek en alle bijbehorende metadata, bestanden, leesvoortgang en bladwijzers permanent verwijderd. Dit kan niet ongedaan worden gemaakt."
+    },
+    "bulkEdit": {
+      "title": "Metadata bewerken - {count} boek | Metadata bewerken - {count} boek | Metadata bewerken - {count} boeken",
+      "instructions": "Schakel velden in om te bewerken en stel vervolgens waarden in. Alleen ingeschakelde velden worden gewijzigd.",
+      "invalidYear": "Voer een geldig jaar in (alleen cijfers)",
+      "clearWarning": "Hiermee worden alle {field} van de geselecteerde boeken verwijderd.",
+      "searchPlaceholder": "Zoek {field}...",
+      "enterPlaceholder": "Voer {field} in",
+      "yearPlaceholder": "bijv. 2024",
+      "leaveEmptyHint": "Laat leeg om dit veld op alle geselecteerde boeken te wissen.",
+      "applying": "Toepassen...",
+      "apply": "Toepassen",
+      "mode": {
+        "add": "Toevoegen",
+        "remove": "Verwijderen",
+        "replace": "Vervangen",
+        "clear": "Wissen"
+      }
+    },
+    "export": {
+      "title": "Metadata exporteren",
+      "scope": "Bereik",
+      "selectedRows": "Geselecteerde rijen",
+      "currentlySelected": "{count} nu geselecteerd",
+      "allMatchingRows": "Alle overeenkomende rijen",
+      "rowsInResult": "{count} rijen in huidig resultaat",
+      "format": "Formaat",
+      "csvDescription": "Geschikt voor spreadsheets, inclusief UTF-8 BOM",
+      "jsonDescription": "Gestructureerde export met metadatacontext",
+      "columns": "Kolommen",
+      "canonicalSchema": "Stabiel canoniek schema",
+      "visibleColumns": "Huidige zichtbare kolommen",
+      "options": "Opties",
+      "includePersonalData": "Persoonlijke leesgegevens opnemen",
+      "includeFilePaths": "Bestandspaden opnemen (geavanceerd)",
+      "includeContextMeta": "Contextmetadata opnemen",
+      "preflight": "Voorbereiding",
+      "scopeLabel": "Bereik: {summary}",
+      "calculatingSize": "Exportgrootte berekenen...",
+      "estimatedSize": "Geschatte grootte:",
+      "fileLabel": "Bestand: {fileName}",
+      "exportAction": "Exporteren",
+      "selectedRowsSummary": "{count} geselecteerde rij | {count} geselecteerde rij | {count} geselecteerde rijen",
+      "matchingRowsSummary": "{count} overeenkomende rij | {count} overeenkomende rij | {count} overeenkomende rijen",
+      "prepareFailed": "Voorbereiden van export mislukt",
+      "exportStarted": "Metadata-export gestart: {fileName}",
+      "exportFailed": "Metadata-export mislukt"
+    },
+    "columnPanel": {
+      "columnsHeading": "Kolommen",
+      "reset": "Herstellen",
+      "tableDensity": "Tabeldichtheid",
+      "density": {
+        "compact": "Compact",
+        "comfortable": "Comfortabel",
+        "roomy": "Ruim"
+      },
+      "presets": "Voorinstellingen",
+      "exportBackup": "Voorinstellingen en opgeslagen weergaven exporteren",
+      "importBackup": "Voorinstellingen en opgeslagen weergaven importeren",
+      "rename": "Naam wijzigen",
+      "renamePrompt": "Voer een nieuwe naam in",
+      "builtIn": "Ingebouwd",
+      "saveCurrentPreset": "Huidige voorinstelling opslaan",
+      "savedViews": "Opgeslagen weergaven",
+      "savedViewsEmpty": "Sla sortering, indeling en weergavespecifieke filters op voor snel hergebruik.",
+      "saveCurrentView": "Huidige weergave opslaan",
+      "pinnedLeft": "Links vastgezet",
+      "pinnedRight": "Rechts vastgezet",
+      "columns": {
+        "cover": "Omslag",
+        "read": "Gelezen",
+        "actions": "Acties"
+      }
+    },
+    "shortcuts": {
+      "title": "Sneltoetsen",
+      "navigation": {
+        "title": "Navigatie",
+        "moveFocusVertical": "Focus omhoog/omlaag verplaatsen",
+        "moveFocusHorizontal": "Focus links/rechts verplaatsen",
+        "jumpFirstColumn": "Naar eerste kolom springen",
+        "jumpLastColumn": "Naar laatste kolom springen",
+        "jumpFirstRow": "Naar eerste rij springen",
+        "jumpLastRow": "Naar laatste rij springen"
+      },
+      "actions": {
+        "title": "Acties",
+        "editCell": "Gefocuste cel bewerken",
+        "cancelEditing": "Bewerken annuleren / Overlay sluiten",
+        "toggleRowSelection": "Rijselectie in-/uitschakelen",
+        "copyCell": "Celwaarde kopiëren",
+        "copyRow": "Gefocuste rij kopiëren"
+      },
+      "general": {
+        "title": "Algemeen",
+        "toggleHelp": "Deze hulp-overlay in-/uitschakelen"
+      }
+    },
+    "jumpRail": {
+      "jumpToSection": "Naar sectie springen",
+      "jumpTo": "Naar {label} springen"
+    },
+    "quickView": {
+      "title": "Snelweergave boek",
+      "titleFor": "Snelweergave voor {title}",
+      "description": "Bekijk boekdetails en voer snelle acties uit.",
+      "openIn": "Openen in {provider}",
+      "pages": "{count} pagina | {count} pagina | {count} pagina's",
+      "primaryFile": "Primair bestand",
+      "fileNumber": "Bestand #{id}",
+      "showLess": "Minder tonen",
+      "showMore": "Meer tonen",
+      "collections": "Collecties",
+      "noDescription": "Geen beschrijving beschikbaar.",
+      "openMetadataEditor": "Metadata-editor openen",
+      "coverPreview": "Voorbeeld boekomslag",
+      "coverPreviewFor": "Voorbeeld omslag van {title}",
+      "coverPreviewDescription": "Dialoogvenster met vergroot voorbeeld van de omslag."
+    },
+    "tableView": {
+      "openBookDetails": "Boekdetails openen",
+      "openSeries": "Reeks openen",
+      "metadataRefreshFailed": "Metadata vernieuwen mislukt",
+      "booksSelected": "{count} boek geselecteerd | {count} boek geselecteerd | {count} boeken geselecteerd",
+      "loadingMoreBooks": "Meer boeken laden",
+      "sort": "Sorteren",
+      "refreshingMetadata": "Metadata vernieuwen {processed} / {total}",
+      "failedCount": "{count} mislukt",
+      "remainingCount": "{count} resterend",
+      "readOnlyNotice": "Tabelbewerking is uitgeschakeld op kleinere schermen. Schakel over naar lijst of raster voor snellere acties.",
+      "fetching": "Ophalen...",
+      "updated": "Bijgewerkt",
+      "failed": "Mislukt",
+      "noBooks": "Geen boeken om weer te geven",
+      "scrollToTop": "Naar boven scrollen",
+      "selectedStatus": "{count} geselecteerd",
+      "filtered": "Gefilterd",
+      "loadedStatus": "{loaded} van {total} geladen",
+      "bookCount": "{count} boek | {count} boek | {count} boeken",
+      "keyboardShortcutsTitle": "Sneltoetsen (?)",
+      "showKeyboardShortcuts": "Sneltoetsen voor tabel tonen",
+      "copyHint": "Cel kopiëren: Ctrl/Cmd+C · Rij kopiëren: Ctrl/Cmd+Shift+C"
+    },
+    "detail": {
+      "authorBooks": {
+        "alsoByAuthor": "Ook door deze auteur",
+        "alsoByAuthors": "Ook door deze auteurs"
+      },
+      "header": {
+        "previousBook": "Vorige boek",
+        "nextBook": "Volgende boek"
+      },
+      "tabs": {
+        "details": "Details",
+        "editMetadata": "Metadata bewerken",
+        "files": "Bestanden",
+        "readingLog": "Leeslogboek",
+        "highlights": "Markeringen"
+      },
+      "discover": {
+        "moreInSeries": "Meer in reeks",
+        "byAuthor": "Van auteur",
+        "similarBooks": "Vergelijkbare boeken"
+      },
+      "recommended": {
+        "moreLikeThis": "Meer zoals dit"
+      },
+      "series": {
+        "moreInSeriesPrefix": "Meer in de",
+        "moreInSeriesSuffix": "reeks"
+      },
+      "writeRename": {
+        "written": "geen velden geschreven | Geschreven (één veld) | Geschreven ({count} velden)",
+        "writeFailed": "Schrijven mislukt",
+        "skipped": "Overgeslagen",
+        "renamedTo": "Hernoemd naar {name}",
+        "fileRenamed": "Bestand hernoemd",
+        "renameFailed": "Hernoemen mislukt",
+        "autoWriteAndRenameDisabled": "Automatisch schrijven en hernoemen zijn uitgeschakeld in de bibliotheekinstellingen. Wijzigingen worden bij toekomstige acties niet automatisch gesynchroniseerd.",
+        "autoWriteDisabled": "Automatisch schrijven is uitgeschakeld in de bibliotheekinstellingen. Wijzigingen worden bij toekomstige acties niet automatisch gesynchroniseerd.",
+        "autoRenameDisabled": "Automatisch hernoemen is uitgeschakeld in de bibliotheekinstellingen. Wijzigingen worden bij toekomstige acties niet automatisch gesynchroniseerd.",
+        "writeLabel": "Schrijven:",
+        "renameLabel": "Hernoemen:"
+      },
+      "addFile": {
+        "uploading": "Uploaden...",
+        "uploadComplete": "Upload voltooid",
+        "title": "Bestand toevoegen",
+        "dropzone": {
+          "title": "Sleep bestanden hierheen of klik om te bladeren",
+          "hint": "epub, pdf, mobi, cbz, m4b en meer - tot 500 MB per stuk"
+        },
+        "addMore": "Meer bestanden toevoegen",
+        "fileCount": "geen bestanden | één bestand | {count} bestanden",
+        "clearAll": "Alles wissen",
+        "done": "Klaar",
+        "retry": "Opnieuw proberen",
+        "filesAdded": "geen bestanden toegevoegd | één bestand toegevoegd | {count} bestanden toegevoegd",
+        "uploadedFailed": "{done} geüpload, {failed} mislukt",
+        "uploadingProgress": "{done} van {total} uploaden...",
+        "renameAfter": "Alle boekbestanden hernoemen na uploaden",
+        "uploadCount": "Uploaden ({count})",
+        "upload": "Uploaden"
+      },
+      "addSession": {
+        "errors": {
+          "invalidDate": "Kies een geldige datum en tijd.",
+          "future": "De sessie kan niet in de toekomst beginnen.",
+          "duration": "Duur moet tussen 1 en 1440 minuten zijn.",
+          "endProgress": "Eindvoortgang moet tussen 0 en 100 zijn."
+        },
+        "title": "Leessessie toevoegen",
+        "startedAt": "Gestart op",
+        "duration": "Duur (minuten)",
+        "endProgress": "Eindvoortgang %",
+        "optional": "Optioneel",
+        "format": "Formaat",
+        "noFormat": "Geen specifiek formaat",
+        "saving": "Opslaan...",
+        "submit": "Sessie toevoegen"
+      },
+      "coverEditor": {
+        "unlockCover": "Omslag ontgrendelen",
+        "lockCover": "Omslag vergrendelen",
+        "fileTab": "Bestand",
+        "urlTab": "URL",
+        "chooseImage": "Kies afbeelding...",
+        "findCoverOnline": "Omslag online zoeken",
+        "saving": "Opslaan...",
+        "saveCover": "Omslag opslaan",
+        "revertToOriginal": "Terug naar origineel",
+        "regenerateCover": "Omslag opnieuw genereren"
+      },
+      "coverSearch": {
+        "title": "Online zoeken",
+        "subtitle": "Zoeken naar boekomslagen",
+        "titleField": "Titel",
+        "authorField": "Auteur",
+        "sourceField": "Bron",
+        "allSources": "Alle bronnen",
+        "audiobookCovers": "Luisterboekomslagen",
+        "squareHint": "(vierkant)",
+        "searching": "Zoeken...",
+        "findCovers": "Omslagen zoeken",
+        "selectCover": "Omslag selecteren",
+        "noResultsTitle": "Geen resultaten gevonden",
+        "noResultsHint": "Probeer je zoektermen aan te passen",
+        "readyTitle": "Klaar om te zoeken",
+        "readyHint": "Voer hierboven een titel en auteur in",
+        "resolutionTip": "Tip: omslagen met hoge resolutie zijn groen gemarkeerd"
+      },
+      "details": {
+        "by": "door",
+        "narratedBy": "voorgelezen door",
+        "ratingLocked": "Beoordeling is vergrendeld",
+        "rateStar": "Beoordeel met {star}",
+        "listen": "Luisteren",
+        "read": "Lezen",
+        "chooseFormat": "Kies formaat",
+        "audiobook": "Luisterboek",
+        "primary": "Primair",
+        "peek": "Voorvertoning",
+        "sendViaEmail": "Verzenden via e-mail",
+        "editCover": "Omslag bewerken",
+        "finished": "Voltooid",
+        "resetFileProgress": "Bestandsvoortgang resetten",
+        "resetting": "Resetten...",
+        "resetProgressConfirm": "Opgeslagen leesvoortgang voor {label} resetten?",
+        "moreCount": "+{count} meer",
+        "untitled": "Zonder titel",
+        "metadataScore": "Metadatascore",
+        "primaryFormat": "Primair formaat",
+        "openIn": "Openen in {provider}",
+        "showLess": "Minder tonen",
+        "showMore": "Meer tonen",
+        "publisher": "Uitgever",
+        "published": "Gepubliceerd",
+        "language": "Taal",
+        "pages": "Pagina's",
+        "duration": "Duur",
+        "edition": "Editie",
+        "abridged": "Verkort",
+        "unabridged": "Onverkort",
+        "isbn": "ISBN",
+        "fileSize": "Bestandsgrootte",
+        "library": "Bibliotheek",
+        "added": "Toegevoegd",
+        "dateStarted": "Startdatum",
+        "saving": "Opslaan...",
+        "cancelDateStartedEdit": "Bewerken startdatum annuleren",
+        "editDateStarted": "Startdatum bewerken",
+        "dateFinished": "Einddatum",
+        "cancelDateFinishedEdit": "Bewerken einddatum annuleren",
+        "editDateFinished": "Einddatum bewerken",
+        "customMetadata": "Aangepaste metadata",
+        "synopsis": "Samenvatting",
+        "noDescription": "Geen beschrijving beschikbaar.",
+        "dateStartedFutureError": "Startdatum kan niet in de toekomst liggen.",
+        "dateFinishedFutureError": "Einddatum kan niet in de toekomst liggen.",
+        "dateFinishedBeforeStartedError": "Einddatum moet op of na de startdatum liggen.",
+        "saveReadingDatesError": "Opslaan van leesdata mislukt.",
+        "koboPendingDelete": "Verwijdering van apparaat in behandeling",
+        "koboPendingDeleteTooltip": "Kobo verwijdert het bij de volgende synchronisatie.",
+        "koboRemovedByDevice": "Verwijderd door apparaat",
+        "koboRemovedByDeviceTooltip": "Kobo heeft gemeld dat dit boek is verwijderd.",
+        "koboNotSynced": "Niet gesynchroniseerd",
+        "koboNotSyncedTooltip": "In wachtrij voor volgende Kobo-synchronisatie.",
+        "filesNotFound": "Bestanden niet gevonden",
+        "filesNotFoundDescription": "De bestanden voor dit boek zijn niet meer op schijf te vinden. De metadata is nog beschikbaar. Voer een bibliotheekscan uit om dit te bevestigen, of verwijder het record."
+      },
+      "editMetadata": {
+        "fieldCount": "geen velden | één veld | {count} velden",
+        "bookFilesTarget": "boekbestanden",
+        "formatFilesTarget": "{formats}-bestanden",
+        "noPrimaryFile": "Geen primair bestand beschikbaar",
+        "formatNotSupported": "Dit bestandsformaat ondersteunt geen terugschrijven",
+        "formatDisabled": "Terugschrijven is uitgeschakeld voor dit formaat",
+        "fileExceedsSizeLimit": "Dit bestand overschrijdt de groottelimiet voor terugschrijven",
+        "writing": "Schrijven...",
+        "saveInProgress": "Bezig met opslaan",
+        "writeManualLibraryDisabled": "Schrijf metadata nu naar bestand en hernoem; automatisch terugschrijven is uitgeschakeld voor deze bibliotheek",
+        "writeManualTooltip": "Schrijf {fields} naar {target} en hernoem als een patroon is ingesteld",
+        "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "Geen vergrendelde velden overgeslagen | Eén vergrendeld veld overgeslagen | {count} vergrendelde velden overgeslagen",
+        "updatedFields": "geen velden bijgewerkt | één veld bijgewerkt | {count} velden bijgewerkt",
+        "wroteFieldsToFile": "{fields} naar bestand geschreven",
+        "fileWriteFailedReason": "Schrijven naar bestand mislukt: {reason}",
+        "fileWriteFailed": "Schrijven naar bestand mislukt",
+        "fileWriteSkippedReason": "Schrijven naar bestand overgeslagen: {reason}",
+        "fileWriteSkipped": "Schrijven naar bestand overgeslagen",
+        "metadataSaved": "Metadata opgeslagen",
+        "metadataWrittenToFile": "Metadata naar bestand geschreven",
+        "savedButWriteFailedReason": "Metadata opgeslagen, maar schrijven naar bestand mislukt: {reason}",
+        "savedButWriteFailed": "Metadata opgeslagen, maar schrijven naar bestand mislukt",
+        "savedWriteSkippedReason": "Metadata opgeslagen, schrijven naar bestand overgeslagen: {reason}",
+        "savedWriteSkipped": "Metadata opgeslagen, schrijven naar bestand overgeslagen",
+        "loadFromFileFailed": "Laden van metadata uit bestand mislukt",
+        "loadedFieldsFromFile": "Geen velden uit bestand geladen | Eén veld uit bestand geladen | {count} velden uit bestand geladen",
+        "noMetadataInFile": "Geen metadata gevonden in bestand",
+        "loadFromFile": "Laden uit bestand",
+        "loadFromFileTooltip": "Metadata laden uit het primaire boekbestand",
+        "writeToFile": "Naar bestand schrijven",
+        "autoFill": "Automatisch invullen",
+        "fetchingMetadata": "Metadata ophalen...",
+        "allFieldsLocked": "Alle velden zijn vergrendeld",
+        "autoFillTooltip": "Velden automatisch invullen met je metadatavoorkeuren",
+        "lockAll": "Alles vergrendelen",
+        "lockAllTooltip": "Alle velden vergrendelen",
+        "unlockAll": "Alles ontgrendelen",
+        "unlockAllTooltip": "Alle velden ontgrendelen",
+        "saving": "Opslaan...",
+        "fileWriteBackDetails": "Details terugschrijven naar bestand",
+        "fileWriteBack": "Terugschrijven naar bestand",
+        "enabled": "Ingeschakeld",
+        "saveWritesMetadata": "'Opslaan' schrijft metadata naar {target}",
+        "formats": "Formaten",
+        "bookFiles": "Boekbestanden",
+        "supportedFields": "Ondersteunde velden",
+        "titleLabel": "Titel",
+        "subtitleLabel": "Ondertitel",
+        "authorsLabel": "Auteurs",
+        "narratorsLabel": "Voorlezers",
+        "genresLabel": "Genres",
+        "tagsLabel": "Labels",
+        "ratingLabel": "Beoordeling",
+        "rateStar": "Beoordeel met {star}",
+        "clear": "Wissen",
+        "communityRatingsLabel": "Communitybeoordelingen",
+        "noProviderRatings": "Geen providerbeoordelingen",
+        "seriesLabel": "Reeks",
+        "publisherLabel": "Uitgever",
+        "languageLabel": "Taal",
+        "yearLabel": "Jaar",
+        "pageCountLabel": "Aantal pagina's",
+        "isbn13Label": "ISBN-13",
+        "isbn10Label": "ISBN-10",
+        "durationLabel": "Duur (s)",
+        "abridgedLabel": "Verkort",
+        "providerIds": "Provider-ID's",
+        "comicDetails": "Stripdetails",
+        "comicIssueNumberLabel": "Nummer",
+        "comicVolumeLabel": "Deel",
+        "comicStoryArcsLabel": "Verhaallijnen",
+        "comicPencillersLabel": "Tekenaars",
+        "comicInkersLabel": "Inkters",
+        "comicColoristsLabel": "Inkleurders",
+        "comicLetterersLabel": "Letteraars",
+        "comicCoverArtistsLabel": "Omslagtekenaars",
+        "comicCharactersLabel": "Personages",
+        "comicTeamsLabel": "Teams",
+        "comicLocationsLabel": "Locaties",
+        "customMetadata": "Aangepaste metadata",
+        "descriptionLabel": "Beschrijving",
+        "unlockField": "{field} ontgrendelen",
+        "lockField": "{field} vergrendelen",
+        "diffPanel": {
+          "untitled": "Zonder titel",
+          "noFieldsSelected": "Geen velden geselecteerd",
+          "fieldsSelected": "geen velden geselecteerd | één veld geselecteerd | {count} velden geselecteerd",
+          "results": "Resultaten",
+          "providerMatches": "Overeenkomsten van {provider}",
+          "selectedOf": "{selected} van {total} geselecteerd",
+          "yearUnknown": "Jaar onbekend",
+          "indexOf": "{index} van {total}",
+          "switchedResult": "Resultaat gewisseld. Eerdere selecties van deze provider zijn gewist.",
+          "selectFieldsToApply": "Selecteer velden om toe te passen",
+          "copyMissing": "Ontbrekende kopiëren",
+          "copyAll": "Alles kopiëren",
+          "hideUnchanged": "Ongewijzigde verbergen",
+          "showUnchanged": "Ongewijzigde tonen",
+          "current": "Huidig",
+          "noMetadata": "Geen metadata beschikbaar van deze bron.",
+          "noChangedFields": "Geen gewijzigde of ontbrekende velden. Gebruik Ongewijzigde tonen om alles te bekijken.",
+          "applyToForm": "Toepassen op formulier"
+        },
+        "diff": {
+          "locked": "Vergrendeld",
+          "previewAlt": "Voorvertoning",
+          "currentCoverAlt": "Huidige omslag",
+          "newCoverAlt": "Nieuwe omslag",
+          "pickCoverFromProvider": "Kies omslag van een andere provider",
+          "pickCoverSource": "Kies omslagbron",
+          "pickFromProvider": "Kies van een andere provider",
+          "pickSource": "Kies bron",
+          "empty": "leeg",
+          "showLess": "Minder tonen",
+          "showMore": "Meer tonen",
+          "coverPreviewAlt": "Voorvertoning omslag"
+        },
+        "searchDrawer": {
+          "searchTitle": "Metadata zoeken",
+          "compareTitle": "Metadata vergelijken",
+          "searchSubtitle": "Vind de beste provider-overeenkomst voor dit boek.",
+          "compareSubtitle": "Bekijk verschillen en pas alleen toe wat je wilt."
+        },
+        "searchPanel": {
+          "untitledQuery": "Zoekopdracht zonder titel",
+          "titlePlaceholder": "Titel",
+          "authorPlaceholder": "Auteur",
+          "isbnPlaceholder": "ISBN",
+          "searching": "Zoeken...",
+          "activeQuery": "Actieve zoekopdracht",
+          "searchScope": "Zoekbereik",
+          "allEnabled": "Alle ingeschakeld",
+          "all": "Alle",
+          "fieldRules": "Veldregels",
+          "custom": "Aangepast",
+          "providerNotInFieldRules": "{provider} is ingeschakeld maar staat niet in de veldregels",
+          "notInFieldRulesLabel": "Niet in veldregels:",
+          "notInFieldRulesText": "{providers}. Opgenomen in handmatig zoeken met Alle ingeschakeld, maar niet gebruikt bij automatisch ophalen van metadata.",
+          "noResults": "Geen resultaten gevonden",
+          "noResultsHint": "Probeer de titel of auteur aan te passen",
+          "searchPrompt": "Zoek hierboven en klik op een resultaat om metadata te vergelijken."
+        }
+      },
+      "files": {
+        "relative": {
+          "seconds": "{value}s geleden",
+          "minutes": "{value}m geleden",
+          "hours": "{value}u geleden",
+          "days": "{value}d geleden"
+        },
+        "renameFailed": "Hernoemen van bestand mislukt",
+        "deleteFailed": "Verwijderen van bestand mislukt",
+        "addFile": "Bestand toevoegen",
+        "lastSynced": "Laatst gesynchroniseerd: {time}",
+        "sort": {
+          "label": "Sorteren:",
+          "name": "Naam",
+          "format": "Formaat",
+          "size": "Grootte",
+          "date": "Datum"
+        },
+        "hidePaths": "Paden verbergen",
+        "showPaths": "Paden tonen",
+        "hideLog": "Logboek verbergen",
+        "viewSyncLog": "Synchronisatielogboek bekijken",
+        "noWriteHistory": "Nog geen schrijfgeschiedenis.",
+        "fieldsWritten": "geen velden | één veld | {count} velden",
+        "track": "Track {number}",
+        "primary": "Primair",
+        "read": "Lezen",
+        "play": "Afspelen",
+        "peek": "Voorvertoning",
+        "download": "Downloaden",
+        "moreActions": "Meer acties",
+        "rename": "Hernoemen",
+        "empty": {
+          "title": "Geen bestanden gekoppeld",
+          "description": "Dit boek heeft geen bijbehorende bestanden."
+        },
+        "renameModal": {
+          "title": "Bestand hernoemen",
+          "description": "Hernoem het fysieke bestand op schijf.",
+          "placeholder": "Nieuwe bestandsnaam"
+        },
+        "saving": "Opslaan...",
+        "deleteModal": {
+          "title": "Bestand verwijderen?",
+          "description": "Weet je zeker dat je \"{filename}\" wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt."
+        },
+        "deleting": "Verwijderen..."
+      },
+      "highlights": {
+        "note": {
+          "placeholder": "Voeg een notitie toe...",
+          "saving": "Opslaan"
+        },
+        "export": {
+          "trigger": "Exporteren",
+          "plainText": "Platte tekst",
+          "page": "Pagina exporteren",
+          "selected": "Selectie exporteren"
+        },
+        "sort": {
+          "position": "Positie",
+          "newest": "Nieuwste eerst",
+          "oldest": "Oudste eerst"
+        },
+        "summary": {
+          "highlights": "geen markeringen | één markering | {count} markeringen",
+          "notes": "geen notities | één notitie | {count} notities",
+          "chapters": "geen hoofdstukken | één hoofdstuk | {count} hoofdstukken"
+        },
+        "filterByChapter": "Filteren op hoofdstuk",
+        "allChapters": "Alle hoofdstukken",
+        "untitled": "Zonder titel",
+        "trash": "Prullenbak",
+        "empty": {
+          "noMatch": "Geen markeringen komen overeen met je filters.",
+          "resetFilters": "Filters resetten",
+          "none": "Nog geen markeringen",
+          "hint": "Selecteer tekst tijdens het lezen om markeringen te maken"
+        },
+        "uncategorized": "Niet-gecategoriseerd",
+        "paginationUnit": "markeringen"
+      },
+      "readingLog": {
+        "export": {
+          "button": "Exporteren"
+        },
+        "weekdays": {
+          "sun": "Zo",
+          "mon": "Ma",
+          "tue": "Di",
+          "wed": "Wo",
+          "thu": "Do",
+          "fri": "Vr",
+          "sat": "Za"
+        },
+        "months": {
+          "jan": "jan",
+          "feb": "feb",
+          "mar": "mrt",
+          "apr": "apr",
+          "may": "mei",
+          "jun": "jun",
+          "jul": "jul",
+          "aug": "aug",
+          "sep": "sep",
+          "oct": "okt",
+          "nov": "nov",
+          "dec": "dec"
+        },
+        "heatmap": {
+          "subtitle": "{count} actieve dag · {ratio}% consistentie | {count} actieve dag · {ratio}% consistentie | {count} actieve dagen · {ratio}% consistentie",
+          "minutesUnit": "min",
+          "title": "Activiteit",
+          "empty": "Geen leesactiviteit in deze periode."
+        },
+        "hero": {
+          "notSet": "Niet ingesteld",
+          "relative": {
+            "seconds": "{count}s geleden",
+            "minutes": "{count}m geleden",
+            "hours": "{count}u geleden",
+            "days": "{count}d geleden",
+            "months": "{count} maand geleden | {count} maand geleden | {count} maanden geleden",
+            "years": "{count} jaar geleden | {count} jaar geleden | {count} jaar geleden"
+          },
+          "noSessions": "Geen sessies",
+          "dateErrors": {
+            "startFuture": "Startdatum kan niet in de toekomst liggen.",
+            "finishFuture": "Einddatum kan niet in de toekomst liggen.",
+            "finishBeforeStart": "Einddatum moet op of na de startdatum liggen.",
+            "saveFailed": "Opslaan van leesdata mislukt."
+          },
+          "eta": {
+            "max": "99u+ tot einde",
+            "minutes": "~{m}m tot einde",
+            "hours": "~{h}u tot einde",
+            "hoursMinutes": "~{h}u {m}m tot einde"
+          },
+          "momentum": {
+            "none": "Geen activiteit in de afgelopen twee weken",
+            "new": "Nieuwe activiteit deze week",
+            "up": "+{pct}% t.o.v. vorige 7 dagen",
+            "down": "{pct}% t.o.v. vorige 7 dagen",
+            "flat": "Ongewijzigd t.o.v. vorige 7 dagen"
+          },
+          "stats": {
+            "totalTime": "Totale tijd",
+            "sessions": "Sessies",
+            "avgSession": "Gem. sessie",
+            "lastRead": "Laatst gelezen"
+          },
+          "firstRead": "Eerst gelezen",
+          "lastRead": "Laatst gelezen",
+          "dateStarted": "Startdatum",
+          "dateFinished": "Einddatum",
+          "addSession": "Sessie toevoegen"
+        },
+        "journey": {
+          "tooltipProgress": "Voortgang",
+          "tooltipReading": "Lezen",
+          "minutesUnit": "min",
+          "title": "Voortgangsreis",
+          "empty": "Geen voortgangsgegevens in deze periode."
+        },
+        "sourceSplit": {
+          "title": "Waar je dit boek hebt gelezen"
+        },
+        "untitled": "Zonder titel",
+        "addSessionFailed": "Toevoegen van sessie mislukt",
+        "filters": {
+          "allTime": "Altijd",
+          "last30": "Laatste 30 dagen",
+          "last90": "Laatste 90 dagen",
+          "thisYear": "Dit jaar",
+          "allFormats": "Alle formaten"
+        },
+        "table": {
+          "sourceWeb": "Web",
+          "sourceManual": "Handmatig",
+          "colDate": "Datum",
+          "colDateMobile": "Datum",
+          "colDuration": "Duur",
+          "colDurationMobile": "Duur",
+          "colProgressChange": "Voortgangswijziging",
+          "colProgressChangeMobile": "Delta",
+          "colEndProgress": "Eindvoortgang",
+          "colEndProgressMobile": "Einde",
+          "empty": "Nog geen leessessies vastgelegd.",
+          "colPace": "Tempo",
+          "colSource": "Bron",
+          "colFormatMobile": "Fmt",
+          "colFormat": "Formaat",
+          "cancelDelete": "Verwijderen annuleren",
+          "cancelDeleteAria": "Verwijderen sessie annuleren",
+          "confirmDeleteTitle": "Klik nogmaals om verwijderen te bevestigen",
+          "confirmDeleteAria": "Verwijderen sessie bevestigen",
+          "deleteAria": "Sessie verwijderen",
+          "loadMore": "Meer laden",
+          "showing": "{shown} van {total} sessies weergegeven"
+        }
+      },
+      "richDescription": {
+        "linkProtocolError": "Gebruik http, https of mailto.",
+        "bold": "Vet",
+        "italic": "Cursief",
+        "underline": "Onderstrepen",
+        "strikethrough": "Doorhalen",
+        "bulletList": "Opsomming",
+        "numberedList": "Genummerde lijst",
+        "outdentAria": "Lijstitem uitspringen",
+        "outdent": "Uitspringen",
+        "indentAria": "Lijstitem inspringen",
+        "indent": "Inspringen",
+        "quote": "Citaat",
+        "editLink": "Link bewerken",
+        "link": "Link",
+        "removeLink": "Link verwijderen",
+        "undo": "Ongedaan maken",
+        "redo": "Opnieuw",
+        "clearFormatting": "Opmaak wissen",
+        "previewDescription": "Beschrijving voorvertonen",
+        "preview": "Voorvertoning",
+        "linkUrlLabel": "Link-URL",
+        "applyLink": "Link toepassen",
+        "apply": "Toepassen",
+        "cancelLink": "Link annuleren",
+        "noDescription": "Geen beschrijving beschikbaar."
+      },
+      "seriesMembership": {
+        "addSeries": "Reeks toevoegen",
+        "seriesPlaceholder": "Reeks",
+        "moveUp": "Omhoog",
+        "moveDown": "Omlaag",
+        "removeSeries": "Reeks verwijderen"
+      }
+    },
+    "table": {
+      "actions": {
+        "quickView": "Snelweergave",
+        "bookDetails": "Boekdetails",
+        "editMetadata": "Metadata bewerken",
+        "refreshMetadata": "Metadata vernieuwen",
+        "addToCollection": "Aan collectie toevoegen",
+        "sendToDevice": "Naar apparaat sturen"
+      },
+      "boolean": {
+        "ariaNotSet": "Niet ingesteld - klik om waar in te stellen",
+        "ariaTrue": "Waar - klik om onwaar in te stellen",
+        "ariaFalse": "Onwaar - klik om te wissen"
+      },
+      "chips": {
+        "addPlaceholder": "Toevoegen..."
+      },
+      "cover": {
+        "previewDescription": "Voorbeeld van omslag",
+        "editDescription": "Omslag bewerken",
+        "editTitle": "Omslag bewerken",
+        "editCover": "Omslag bewerken",
+        "view": "Omslag bekijken"
+      },
+      "date": {
+        "justNow": "zojuist"
+      },
+      "format": {
+        "unknown": "onbekend"
+      },
+      "header": {
+        "sortAscending": "Oplopend sorteren",
+        "sortDescending": "Aflopend sorteren",
+        "clearSort": "Sortering wissen",
+        "hideColumn": "Kolom verbergen",
+        "pinLeft": "Links vastzetten",
+        "pinRight": "Rechts vastzetten",
+        "unpinColumn": "Kolom losmaken",
+        "autoFitWidth": "Breedte automatisch aanpassen",
+        "autoFitAllColumns": "Alle kolommen automatisch aanpassen",
+        "selectAllBooks": "Alle boeken selecteren",
+        "shiftClickSecondarySort": "Shift+klik om secundaire sortering toe te voegen",
+        "clickToSort": "Klik om te sorteren"
+      },
+      "locks": {
+        "lockAll": "Alle velden vergrendelen",
+        "unlockAll": "Alle velden ontgrendelen",
+        "lockField": "Veld vergrendelen",
+        "unlockField": "Veld ontgrendelen",
+        "clickToLock": "Klik om te vergrendelen",
+        "clickToUnlock": "Klik om te ontgrendelen"
+      },
+      "progress": {
+        "complete": "{percent} voltooid"
+      },
+      "rating": {
+        "label": "Beoordeling",
+        "remove": "Beoordeling verwijderen",
+        "rate": "Geef {star} van de 5"
+      },
+      "read": {
+        "play": "Afspelen",
+        "read": "Lezen",
+        "primary": "Primair",
+        "peekFormat": "Snel bekijken {format}",
+        "chooseFormat": "Kies formaat om te lezen of af te spelen",
+        "fileFallback": "BESTAND"
+      },
+      "readStatus": {
+        "unread": "Ongelezen"
+      },
+      "series": {
+        "bookCount": "(geen boeken) | ({count} boek) | ({count} boeken)",
+        "readOfCount": "{read} van {total} gelezen"
+      },
+      "text": {
+        "openDetails": "Details openen"
+      }
+    }
+  },
+  "bookMetadataFetch": {
+    "book": {
+      "title": "Metadata ophalen"
+    },
+    "author": {
+      "title": "Auteurverrijking"
+    },
+    "stats": {
+      "queued": "In wachtrij",
+      "processing": "Verwerken",
+      "rateLimited": "Snelheidslimiet",
+      "failed": "Mislukt"
+    },
+    "actions": {
+      "pause": "Pauzeren",
+      "resume": "Hervatten",
+      "cancelQueued": "Wachtrij annuleren"
+    },
+    "cancel": {
+      "processingWillFinish": "Items die nu worden verwerkt, worden afgemaakt.",
+      "confirm": "Annuleren bevestigen",
+      "keepRunning": "Doorgaan"
+    },
+    "viewFailed": "Bekijk een mislukt item | Bekijk {count} mislukte items",
+    "card": {
+      "fetchingMetadata": "Metadata ophalen",
+      "enrichingAuthors": "Auteurs verrijken"
+    },
+    "label": {
+      "paused": "Gepauzeerd",
+      "remaining": "{count} resterend",
+      "processing": "{count} in verwerking",
+      "failed": "{count} mislukt",
+      "rateLimited": "{count} met snelheidslimiet"
+    },
+    "report": {
+      "bookTitle": "Mislukte metadata-ophaalacties",
+      "authorTitle": "Mislukte auteurverrijkingen",
+      "noFailedItems": "Geen mislukte items.",
+      "retryAllFailed": "Alle mislukte opnieuw proberen",
+      "bookFallback": "Boek #{id}",
+      "authorFallback": "Auteur #{id}",
+      "columns": {
+        "title": "Titel",
+        "library": "Bibliotheek",
+        "author": "Auteur",
+        "error": "Fout",
+        "http": "HTTP"
+      }
+    },
+    "toast": {
+      "failedToPause": "Pauzeren mislukt",
+      "failedToResume": "Hervatten mislukt",
+      "failedToCancel": "Annuleren mislukt",
+      "failedToRetry": "Opnieuw proberen mislukt",
+      "failedItemsRequeued": "Mislukte items opnieuw in wachtrij gezet",
+      "bookComplete": "Metadata ophalen voltooid - {done} boeken bijgewerkt",
+      "bookDoneWithFailures": "Metadata ophalen klaar - {done} verwerkt, {failed} mislukt",
+      "authorComplete": "Auteurverrijking voltooid - {done} auteurs bijgewerkt",
+      "authorDoneWithFailures": "Auteurverrijking klaar - {done} verwerkt, {failed} mislukt"
+    }
+  },
+  "bookDock": {
+    "apply": "Toepassen",
+    "done": "Klaar",
+    "discard": "Weggooien",
+    "finalize": "Afronden",
+    "rescan": "Opnieuw scannen",
+    "uploadAction": "Uploaden",
+    "uploading": "Uploaden...",
+    "searchPlaceholder": "Bestanden zoeken...",
+    "setDestinationAction": "Bestemming instellen",
+    "bulkEditAction": "Bulkbewerking",
+    "applyFetched": "Opgehaalde toepassen",
+    "retryErrors": "Fouten opnieuw proberen",
+    "commaSeparated": "kommagescheiden",
+    "destinationLibrary": "Doelbibliotheek",
+    "destinationFolder": "Doelmap",
+    "nSelected": "geen bestanden geselecteerd | {count} geselecteerd | {count} geselecteerd",
+    "nFailed": "{count} mislukt",
+    "updatedOfFiles": "{updated} van {total} bestanden bijgewerkt",
+    "errorStatus": "Fout {status}",
+    "applyFetchedTooltip": "Automatisch opgehaalde providermetadata toepassen op {count} bestanden | Automatisch opgehaalde providermetadata toepassen op {count} bestand | Automatisch opgehaalde providermetadata toepassen op {count} bestanden",
+    "retryErrorsTooltip": "Metadata opnieuw ophalen voor {count} bestanden met fouten | Metadata opnieuw ophalen voor {count} bestand met fout | Metadata opnieuw ophalen voor {count} bestanden met fouten",
+    "tab": {
+      "all": "Alles",
+      "pending": "In afwachting",
+      "ready": "Gereed",
+      "error": "Fout"
+    },
+    "status": {
+      "pending": "In afwachting",
+      "extracting": "Uitpakken",
+      "fetching": "Ophalen",
+      "ready": "Gereed",
+      "error": "Fout"
+    },
+    "field": {
+      "title": "Titel",
+      "subtitle": "Ondertitel",
+      "authors": "Auteurs",
+      "authorsCommaSeparated": "Auteurs (kommagescheiden)",
+      "publisher": "Uitgever",
+      "year": "Jaar",
+      "language": "Taal",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "series": "Reeks",
+      "seriesIndex": "Reeks #",
+      "genres": "Genres",
+      "genresCommaSeparated": "Genres (kommagescheiden)",
+      "description": "Beschrijving"
+    },
+    "upload": {
+      "nDone": "{count} klaar",
+      "nFailed": "{count} mislukt",
+      "nTotal": "{count} totaal"
+    },
+    "fileList": {
+      "emptyTitle": "Geen bestanden in Book Dock",
+      "emptyMessageDefault": "Upload bestanden of plaats ze in de Book Dock-map",
+      "colCurrent": "Huidig",
+      "colNew": "Nieuw",
+      "colFile": "Bestand",
+      "colSize": "Grootte",
+      "colFormat": "Formaat",
+      "colMatch": "Match",
+      "colApply": "Toepassen",
+      "colStatus": "Status",
+      "applyFetchedMetadata": "Opgehaalde metadata toepassen",
+      "coverPreview": "Omslagvoorbeeld",
+      "coverPreviewDescription": "Vergroot omslagvoorbeeld-dialoogvenster.",
+      "currentCoverAlt": "{title} huidige omslag",
+      "newCoverAlt": "{title} nieuwe omslag",
+      "unknownLibrary": "Onbekende bibliotheek",
+      "unassigned": "Niet toegewezen",
+      "targetPath": "Doel: {library} · {path}",
+      "targetUnassigned": "Doel: Niet toegewezen",
+      "targetUnknownPath": "Doel: {library} · Onbekend doelpad"
+    },
+    "sheet": {
+      "saved": "Opgeslagen",
+      "providerMetadataFound": "Providermetadata gevonden",
+      "providerMetadataFoundEdited": "Providermetadata gevonden - bulk toepassen slaat dit bestand over (je hebt bewerkingen)",
+      "review": "Bekijken",
+      "added": "Toegevoegd {date}",
+      "searchMetadata": "Metadata zoeken",
+      "results": "Resultaten"
+    },
+    "bulkEdit": {
+      "title": "Bulkbewerking geen bestanden | Bulkbewerking {count} bestand | Bulkbewerking {count} bestanden",
+      "resultTitle": "Resultaten bulkbewerking",
+      "instructions": "Schakel de velden in die je wilt bijwerken. Alleen ingeschakelde velden worden toegepast.",
+      "mergeArrays": "Arrays samenvoegen (toevoegen aan bestaande waarden in plaats van vervangen)",
+      "failed": "Bulkbewerking mislukt"
+    },
+    "setDestination": {
+      "title": "Bestemming instellen voor geen bestanden | Bestemming instellen voor {count} bestand | Bestemming instellen voor {count} bestanden",
+      "resultTitle": "Bestemming bijgewerkt",
+      "failed": "Bestemming instellen mislukt"
+    },
+    "finalizeDialog": {
+      "title": "Afronden geen bestanden | Afronden {count} bestand | Afronden {count} bestanden",
+      "resultTitle": "Resultaten afronden",
+      "needDestination": "{without} van {count} geselecteerde bestanden hebben een bestemming nodig | {without} van {count} geselecteerd bestand heeft een bestemming nodig | {without} van {count} geselecteerde bestanden hebben een bestemming nodig",
+      "allHaveDestination": "Alle geselecteerde bestanden hebben al een bestemming ingesteld",
+      "defaultDestinationLibrary": "Standaard doelbibliotheek",
+      "defaultDestinationFolder": "Standaard doelmap",
+      "renamePreview": "Voorbeeld hernoemen",
+      "moreFiles": "+{count} meer bestanden",
+      "start": "Starten",
+      "filesFinalized": "{succeeded} van {total} bestanden afgerond",
+      "failedWithDuplicates": "{failed} mislukt ({count} duplicaten) | {failed} mislukt ({count} duplicaat) | {failed} mislukt ({count} duplicaten)",
+      "view": "Bekijken",
+      "viewExisting": "Bestaande bekijken",
+      "importAnyway": "Toch importeren",
+      "hide": "Verbergen",
+      "details": "Details",
+      "alreadyExistsSaveAs": "Bestaat al - opslaan als:",
+      "renamePlaceholder": "bijv. {name} (2)",
+      "import": "Importeren"
+    }
+  },
+  "collection": {
+    "dialog": {
+      "name": "Naam",
+      "icon": "Pictogram",
+      "iconPlaceholder": "Kies een pictogram...",
+      "nameRequired": "Naam is verplicht",
+      "iconRequired": "Kies een pictogram",
+      "creating": "Aanmaken...",
+      "createFailed": "Collectie aanmaken mislukt"
+    },
+    "createDialog": {
+      "title": "Nieuwe collectie",
+      "namePlaceholder": "bijv. Favorieten"
+    },
+    "editDialog": {
+      "title": "Collectie bewerken",
+      "syncToKobo": "Synchroniseren met Kobo",
+      "syncToKoboHint": "Boeken in deze collectie verschijnen op je Kobo-apparaat",
+      "deleteCollection": "Collectie verwijderen",
+      "confirmDelete": "Bevestigen?",
+      "deleting": "Verwijderen...",
+      "saving": "Opslaan...",
+      "deleted": "\"{name}\" verwijderd",
+      "updateFailed": "Collectie bijwerken mislukt",
+      "deleteFailed": "Collectie verwijderen mislukt"
+    },
+    "addToSheet": {
+      "title": "Collecties beheren",
+      "selectedCount": "geen boeken geselecteerd | een boek geselecteerd | {count} boeken geselecteerd",
+      "newCollection": "Nieuwe collectie",
+      "namePlaceholder": "Collectienaam",
+      "create": "Aanmaken",
+      "collections": "Collecties",
+      "empty": "Nog geen collecties. Maak er hierboven een aan.",
+      "done": "Klaar",
+      "added": "Toegevoegd",
+      "allAdded": "Alle {total} toegevoegd",
+      "inCollection": "In deze collectie",
+      "allInCollection": "Alle {total} in deze collectie",
+      "partialInCollection": "{partial} van {total} in deze collectie",
+      "bookCount": "geen boeken | een boek | {count} boeken",
+      "loadFailed": "Collecties laden mislukt",
+      "createdAndAdded": "\"{name}\" aangemaakt en geen boeken toegevoegd | \"{name}\" aangemaakt en een boek toegevoegd | \"{name}\" aangemaakt en {count} boeken toegevoegd",
+      "createdButAddFailed": "\"{name}\" aangemaakt maar boeken toevoegen mislukt",
+      "createFailed": "Collectie aanmaken mislukt",
+      "addedNewWithExisting": "Een nieuw boek toegevoegd aan \"{name}\" ({alreadyHad} al aanwezig) | Een nieuw boek toegevoegd aan \"{name}\" ({alreadyHad} al aanwezig) | {count} nieuwe boeken toegevoegd aan \"{name}\" ({alreadyHad} al aanwezig)",
+      "addedToCollection": "Geen boeken toegevoegd aan \"{name}\" | Een boek toegevoegd aan \"{name}\" | {count} boeken toegevoegd aan \"{name}\"",
+      "addFailed": "Toevoegen aan collectie mislukt",
+      "removedFromCollection": "Geen boeken verwijderd uit \"{name}\" | Een boek verwijderd uit \"{name}\" | {count} boeken verwijderd uit \"{name}\"",
+      "removeFailed": "Verwijderen uit collectie mislukt"
+    }
+  },
+  "components": {
+    "appHeader": {
+      "searchAllBooks": "Alle boeken doorzoeken...",
+      "searching": "Zoeken...",
+      "noResults": "Geen resultaten",
+      "loadingMore": "Meer laden...",
+      "loadMore": "Meer laden ({loaded}/{total})",
+      "allMatchesShown": "Alle 1 resultaat getoond | Alle 1 resultaat getoond | Alle {count} resultaten getoond",
+      "bookCount": "geen boeken | {count} boek | {count} boeken",
+      "fileCount": "geen bestanden | {count} bestand | {count} bestanden",
+      "uploadedToast": "{uploaded} geüpload",
+      "uploadFailedToast": "Uploaden mislukt voor {failed}",
+      "uploadPartialToast": "{uploaded} geüpload, {failed} mislukt",
+      "bookDock": "Book Dock",
+      "statistics": "Statistieken",
+      "achievements": "Prestaties",
+      "annotations": "Annotaties",
+      "uploadBooks": "Boeken uploaden",
+      "appearance": "Weergave",
+      "theme": "Thema",
+      "accent": "Accent",
+      "radius": "Radius",
+      "background": "Achtergrond",
+      "settings": "Instellingen",
+      "whatsNew": "Wat is nieuw",
+      "documentation": "Documentatie",
+      "help": "Help",
+      "starOnGithub": "Ster op GitHub",
+      "new": "Nieuw",
+      "newReleaseNotes": "Nieuwe release-opmerkingen beschikbaar",
+      "account": "Account",
+      "changePassword": "Wachtwoord wijzigen",
+      "signOut": "Uitloggen",
+      "githubStar": {
+        "title": "Vind je BookOrbit leuk?",
+        "body": "Als BookOrbit je helpt met je bibliotheek, overweeg dan om het project een ster te geven op GitHub. Het helpt meer mensen de app te ontdekken en ondersteunt de doorlopende ontwikkeling.",
+        "cta": "Geef BookOrbit een ster op GitHub"
+      }
+    },
+    "sidebar": {
+      "tagline": "Jouw leesruimte",
+      "dashboard": "Dashboard",
+      "authors": "Auteurs",
+      "series": "Reeksen",
+      "tools": "Hulpmiddelen",
+      "libraries": "Bibliotheken",
+      "newLibrary": "Nieuwe bibliotheek",
+      "libraryScanning": "{name} - Scannen {pct}%",
+      "scanProgress": "{processed} / {total} boeken",
+      "smartScopes": "Smart Scopes",
+      "newSmartScope": "Nieuwe Smart Scope",
+      "noSmartScopes": "Nog geen Smart Scopes",
+      "collections": "Collecties",
+      "newCollection": "Nieuwe collectie",
+      "noCollections": "Nog geen collecties",
+      "latest": "Nieuwste {version}",
+      "newReleaseNotes": "Nieuwe release-opmerkingen beschikbaar",
+      "sectionHeader": {
+        "add": "Toevoegen",
+        "reorder": "Herschikken",
+        "doneReordering": "Klaar met herschikken"
+      }
+    },
+    "selectionActionBar": {
+      "setReadingStatus": "Leesstatus instellen",
+      "setRating": "Beoordeling instellen",
+      "openMetadataEditor": "Metadata-editor openen",
+      "editIndividually": "Boeken afzonderlijk bewerken",
+      "addToCollection": "Aan collectie toevoegen",
+      "removeFromCollection": "Uit collectie verwijderen",
+      "sendViaEmail": "Verzenden via e-mail",
+      "downloadFilesZip": "Bestanden downloaden als ZIP",
+      "moreActions": "Meer acties",
+      "setField": "Veld instellen",
+      "refreshMetadata": "Metadata vernieuwen",
+      "reExtractCover": "Omslag opnieuw extraheren",
+      "metadataLock": "Metadata vergrendelen",
+      "lockAll": "Alles vergrendelen",
+      "unlockAll": "Alles ontgrendelen",
+      "exportMetadata": "Metadata exporteren",
+      "deleteSelected": "Selectie verwijderen",
+      "exitSelection": "Selectie afsluiten",
+      "downloadFilesZipLabel": "Bestanden downloaden als ZIP:",
+      "primaryOnly": "Alleen primair",
+      "allFormats": "Alle formaten",
+      "audioOnly": "Alleen audio",
+      "setRatingLabel": "Beoordeling instellen:",
+      "clear": "Wissen",
+      "setFieldLabel": "Veld instellen:",
+      "apply": "Toepassen",
+      "fieldPlaceholder": "Laat leeg om te wissen",
+      "fieldPlaceholderArray": "Komma-gescheiden (laat leeg om te wissen)",
+      "deleteConfirm": "{count} boek verwijderen? | {count} boek verwijderen? | {count} boeken verwijderen?",
+      "typeDelete": "Typ DELETE"
+    },
+    "viewHeader": {
+      "select": "Selecteren",
+      "display": "Weergave",
+      "displayDescription": "Pas omslaggrootte, rasterafstand en weergaveopties aan.",
+      "columnVisibilityHint": "Gebruik het paneel voor kolomzichtbaarheid in de tabelkop om kolommen te tonen of verbergen.",
+      "columnVisibilityMobileHint": "Kolomzichtbaarheid kan worden beheerd vanuit de tabelkop.",
+      "searchPlaceholder": "Zoek op titel, auteur, reeks, verteller...",
+      "mobileSearch": {
+        "description": "Zoek items op titel, auteur, reeks of verteller.",
+        "done": "Klaar"
+      },
+      "mobileMenu": {
+        "grid": "Raster",
+        "list": "Lijst",
+        "select": "Selecteren",
+        "exitSelect": "Selectie sluiten"
+      },
+      "displayControls": {
+        "display": "Weergave",
+        "coverSize": "Omslaggrootte",
+        "gridGap": "Rasterafstand",
+        "columnsHint": "Gebruik het paneel voor kolomzichtbaarheid in de tabelkop om kolommen te tonen of te verbergen.",
+        "coverShape": "Omslagvorm",
+        "circle": "Cirkel",
+        "square": "Vierkant"
+      }
+    },
+    "iconPicker": {
+      "searchLucide": "Lucide-pictogrammen zoeken...",
+      "searchCustom": "Aangepaste pictogrammen zoeken...",
+      "chooseIcon": "Kies een pictogram...",
+      "selectIcon": "Pictogram selecteren",
+      "customTab": "Aangepast",
+      "searching": "Zoeken...",
+      "noIconsMatch": "Geen pictogrammen komen overeen met \"{query}\"",
+      "typeToSearch": "Typ om alle pictogrammen te doorzoeken",
+      "noCustomIcons": "Geen aangepaste pictogrammen geüpload",
+      "noIconsAvailable": "Geen pictogrammen beschikbaar"
+    },
+    "entityNotFound": {
+      "title": "{entity} niet gevonden",
+      "description": "Deze {entity} bestaat niet of is verwijderd.",
+      "goBack": "Ga terug"
+    },
+    "themePicker": {
+      "light": "Licht",
+      "dark": "Donker"
+    },
+    "userAvatar": {
+      "profilePicture": "Profielfoto",
+      "profilePictureOf": "Profielfoto van {name}"
+    },
+    "ui": {
+      "sidebar": {
+        "title": "Zijbalk",
+        "mobileDescription": "Toont de mobiele zijbalk.",
+        "toggle": "Zijbalk in-/uitklappen"
+      },
+      "chipInput": {
+        "typeAndEnter": "Typ en druk op Enter om toe te voegen",
+        "pressEnter": "Druk op Enter om toe te voegen"
+      }
+    }
+  },
+  "customIcons": {
+    "dialogTitle": "Eigen iconen uploaden",
+    "dialogDescription": "Controleer de namen voordat je ze aan je bibliotheek toevoegt.",
+    "readingFiles": "Bestanden lezen...",
+    "dropPrompt": "Sleep SVG-bestanden hierheen of klik om te bladeren",
+    "fileLimit": "Maximaal {max} bestanden, 128 KB elk",
+    "namePlaceholder": "Naam",
+    "nameRequired": "Naam is verplicht",
+    "invalidSvg": "Ongeldige SVG",
+    "invalidSvgFile": "Ongeldig SVG-bestand",
+    "identicalTo": "Identiek aan \"{name}\"",
+    "uploadAnyway": "Toch uploaden",
+    "skipThisOne": "Deze overslaan",
+    "readyToUpload": "{count} klaar om te uploaden",
+    "noIconsStaged": "Nog geen iconen klaargezet",
+    "uploading": "Uploaden...",
+    "upload": "Uploaden",
+    "uploadCount": "{count} uploaden",
+    "onlySvgSupported": "Alleen SVG-bestanden worden ondersteund",
+    "maxStaged": "Je kunt maximaal {max} iconen tegelijk klaarzetten",
+    "onlyMoreCanStage": "Er kunnen geen iconen meer worden klaargezet | Er kan nog maar {count} icoon worden klaargezet | Er kunnen nog maar {count} iconen worden klaargezet",
+    "readFailed": "Lezen van SVG-bestanden mislukt",
+    "uploadedCount": "Geen iconen geüpload | {count} icoon geüpload | {count} iconen geüpload",
+    "uploadedPartial": "{created} geüpload, {failed} mislukt",
+    "noIconsUploaded": "Geen iconen geüpload",
+    "uploadFailed": "Uploaden van iconen mislukt",
+    "uploadFailedEntry": "Uploaden mislukt"
+  },
+  "dashboard": {
+    "common": {
+      "failedToLoad": "Laden mislukt",
+      "retry": "Opnieuw proberen",
+      "untitled": "Naamloos",
+      "cover": "Omslag",
+      "bookCover": "Boekomslag"
+    },
+    "scroller": {
+      "failedToLoad": "Laden mislukt.",
+      "empty": {
+        "continueReading": "Nog geen boeken in behandeling. Begin er een te lezen om het hier te zien.",
+        "continueListening": "Nog geen audioboeken in behandeling. Begin er een te beluisteren om het hier te zien.",
+        "wantToRead": "Nog geen boeken gemarkeerd als wil ik lezen.",
+        "upNextInSeries": "Nog geen volgende delen in reeks. Rond een deel af om het volgende te tonen.",
+        "recentlyAdded": "Nog geen boeken in je bibliotheek.",
+        "smartScope": "Geen boeken komen overeen met deze smartScope.",
+        "default": "Geen boeken gevonden."
+      }
+    },
+    "settings": {
+      "title": "Dashboard aanpassen",
+      "tabs": {
+        "widgets": "Widgets",
+        "shelves": "Planken"
+      },
+      "reorderHintWidget": "Sleep om te herordenen. Schakel in of uit om een widget te tonen of verbergen.",
+      "reorderHintShelf": "Sleep om te herordenen. Schakel in of uit om een plank te tonen of verbergen.",
+      "smartScope": "Smart Scope",
+      "noSmartScopes": "Nog geen Smart Scopes. Maak er een aan vanuit de zijbalk.",
+      "addShelf": "Plank toevoegen",
+      "resetToDefaults": "Standaardwaarden herstellen"
+    },
+    "welcome": {
+      "emptyTitle": "Je bibliotheek is leeg",
+      "noLibrariesTitle": "Nog geen bibliotheken",
+      "emptyDescription": "Maak een bibliotheek aan om je boeken te ordenen en te lezen. Wijs een map aan en de rest gaat vanzelf.",
+      "noLibrariesDescription": "Je beheerder heeft nog geen bibliotheken ingesteld. Neem contact met hen op om te beginnen.",
+      "createFirstLibrary": "Maak je eerste bibliotheek"
+    },
+    "widgets": {
+      "currentlyReading": {
+        "title": "Nu aan het lezen",
+        "empty": "Geen boeken in behandeling. Begin er een te lezen om het hier te zien.",
+        "continueReading": "Verder lezen"
+      },
+      "diversityScore": {
+        "title": "Diversiteitsscore",
+        "notEnoughData": "Lees minstens 3 boeken om je diversiteitsscore te zien",
+        "booksAnalyzed": "geen boeken geanalyseerd | {count} boek geanalyseerd | {count} boeken geanalyseerd",
+        "subScores": {
+          "genre": "Genre",
+          "author": "Auteur",
+          "era": "Tijdperk",
+          "language": "Taal"
+        }
+      },
+      "highlightOfTheDay": {
+        "title": "Markering van de dag",
+        "empty": "Markeer passages tijdens het lezen om ze hier te zien"
+      },
+      "libraryOverview": {
+        "title": "Bibliotheekoverzicht",
+        "empty": "Je bibliotheek is leeg. Voeg wat boeken toe om te beginnen.",
+        "addedThisYear": "+{count} toegevoegd dit jaar",
+        "stats": {
+          "books": "Boeken",
+          "authors": "Auteurs",
+          "series": "Reeksen",
+          "storage": "Opslag"
+        }
+      },
+      "longWait": {
+        "title": "Het lange wachten",
+        "empty": "Geen boeken in de wacht. Je bent overal aan begonnen!",
+        "daysWaiting": "dagen wachten",
+        "pages": "geen pagina's | {count} pagina | {count} pagina's",
+        "startReading": "Begin met lezen"
+      },
+      "monthlyChallenge": {
+        "title": "Maandelijkse uitdaging",
+        "complete": "Voltooid!"
+      },
+      "neglectedGems": {
+        "title": "Vergeten pareltjes",
+        "empty": "Al je best beoordeelde boeken zijn gelezen!",
+        "rating": "{rating}/5",
+        "daysWaiting": "{count}d wachten",
+        "queued": "In wachtrij",
+        "addToQueue": "Toevoegen aan wachtrij",
+        "shuffle": "Schudden"
+      },
+      "readingDna": {
+        "title": "Lees-DNA",
+        "notEnoughData": "Lees minstens 5 boeken om je Lees-DNA te ontgrendelen",
+        "basedOn": "Gebaseerd op geen boeken | Gebaseerd op {count} boek | Gebaseerd op {count} boeken",
+        "traits": {
+          "length": "Lengte",
+          "variety": "Variatie",
+          "rhythm": "Ritme",
+          "time": "Tijd",
+          "speed": "Snelheid"
+        }
+      },
+      "readingGoal": {
+        "title": "Leesdoel {year}",
+        "setGoalPrompt": "Stel een leesdoel in om je voortgang te volgen",
+        "setGoal": "Doel instellen",
+        "booksPerYear": "Boeken per jaar",
+        "ofGoal": "van {goal}",
+        "percentComplete": "{percentage}% voltooid",
+        "editGoal": "Doel bewerken"
+      },
+      "readingRhythm": {
+        "title": "Leesritme",
+        "empty": "Begin met lezen om je ritme vorm te zien krijgen",
+        "activeDays": "geen actieve dagen | {count} actieve dag | {count} actieve dagen",
+        "consistency": "{activeDays} · {percent}% consistentie",
+        "avgPerDay": "gem. {time}/dag"
+      },
+      "readingStreak": {
+        "title": "Leesreeks",
+        "empty": "Lees vandaag om je reeks te starten",
+        "streakLabel": "dag reeks | dag reeks | dagen reeks",
+        "best": "Beste: {count} dag | Beste: {count} dag | Beste: {count} dagen",
+        "lastSevenDays": "Laatste 7 dagen"
+      },
+      "yearProjection": {
+        "title": "Jaarprognose",
+        "books": "boeken",
+        "trendUp": "Stijgende trend",
+        "trendDown": "Dalende trend",
+        "trendSteady": "Gelijkmatig tempo",
+        "pages": "pagina's",
+        "hours": "uur",
+        "readCount": "{count} gelezen",
+        "daysLeft": "{count}d resterend"
+      }
+    }
+  },
+  "email": {
+    "title": "E-mail",
+    "subtitle": "Verstuur boeken via e-mail naar je e-reader.",
+    "loadFailed": "Laden mislukt",
+    "saveFailed": "Opslaan mislukt",
+    "deleteFailed": "Verwijderen mislukt",
+    "setDefaultFailed": "Instellen als standaard mislukt",
+    "setAsDefault": "Als standaard instellen",
+    "saving": "Opslaan...",
+    "update": "Bijwerken",
+    "create": "Aanmaken",
+    "deleteConfirm": "\"{name}\" verwijderen. Deze actie kan niet ongedaan worden gemaakt.",
+    "badge": {
+      "default": "Standaard",
+      "shared": "Gedeeld",
+      "system": "Systeem"
+    },
+    "tabs": {
+      "providers": "Providers",
+      "recipients": "Ontvangers",
+      "groups": "Groepen",
+      "templates": "Sjablonen",
+      "preferences": "Voorkeuren",
+      "history": "Geschiedenis"
+    },
+    "providers": {
+      "heading": "SMTP-providers",
+      "add": "Provider toevoegen",
+      "newTitle": "Nieuwe provider",
+      "editTitle": "Provider bewerken",
+      "name": "Naam",
+      "namePlaceholder": "bijv. Gmail",
+      "host": "Host",
+      "port": "Poort",
+      "username": "Gebruikersnaam",
+      "password": "Wachtwoord",
+      "passwordEdit": "Wachtwoord (laat leeg om huidige te behouden)",
+      "fromName": "Afzendernaam",
+      "fromNamePlaceholder": "Mijn bibliotheek",
+      "fromAddress": "Afzenderadres",
+      "authentication": "Authenticatie",
+      "verifyTls": "TLS-certificaat verifiëren",
+      "tlsWarning": "TLS-verificatie is uitgeschakeld. Het certificaat van de server wordt niet gevalideerd - gebruik dit alleen voor vertrouwde interne servers.",
+      "noFromAddress": "geen afzenderadres",
+      "emptyManage": "Nog geen providers. Voeg een SMTP-provider toe om e-mails te versturen.",
+      "emptyReadonly": "Geen providers beschikbaar. Vraag een beheerder om er een toe te voegen.",
+      "setSystemTooltip": "Instellen als systeem-mailprovider",
+      "removeSystemTooltip": "Verwijderen als systeem-mailprovider",
+      "testTooltip": "Verbinding testen",
+      "toggleSharing": "Delen in-/uitschakelen",
+      "removeSystemBeforeDelete": "Verwijder de systeemaanduiding voordat je verwijdert",
+      "notesHeading": "Provideropmerkingen",
+      "notesBody": "De <strong>Systeem</strong>-provider (alleen superuser) wordt gebruikt voor e-mails om wachtwoorden te herstellen. De <strong>Standaard</strong>-provider wordt gebruikt bij het versturen van boeken zonder expliciet geselecteerde provider. Providers gemarkeerd als <strong>Gedeeld</strong> zijn beschikbaar voor alle gebruikers.",
+      "deleteTitle": "Provider verwijderen?",
+      "nameHostRequired": "Naam en host zijn verplicht",
+      "created": "Provider aangemaakt",
+      "updated": "Provider bijgewerkt",
+      "deleted": "\"{name}\" verwijderd",
+      "setDefaultSuccess": "\"{name}\" ingesteld als standaard",
+      "unshared": "Provider niet meer gedeeld",
+      "sharedWithAll": "Provider gedeeld met alle gebruikers",
+      "updateSharingFailed": "Bijwerken van delen mislukt",
+      "systemRemoved": "\"{name}\" verwijderd als systeem-mailprovider",
+      "systemSet": "\"{name}\" ingesteld als systeem-mailprovider",
+      "updateSystemFailed": "Bijwerken van systeemprovider mislukt",
+      "connectionSuccess": "Verbinding geslaagd",
+      "connectionFailed": "Verbinding mislukt",
+      "testFailed": "Test mislukt"
+    },
+    "recipients": {
+      "heading": "Ontvangers",
+      "add": "Ontvanger toevoegen",
+      "newTitle": "Nieuwe ontvanger",
+      "editTitle": "Ontvanger bewerken",
+      "name": "Naam",
+      "namePlaceholder": "Mijn Kindle",
+      "emailAddress": "E-mailadres",
+      "deviceType": "Apparaattype",
+      "deviceNone": "Geen",
+      "deviceOther": "Overig",
+      "preferredFormat": "Voorkeursformaat",
+      "formatAuto": "Automatisch",
+      "defaultTemplate": "Standaardsjabloon",
+      "useAccountDefault": "Accountstandaard gebruiken",
+      "kindleNote": "Kindle-ontvangers krijgen e-mails automatisch met onderwerp \"convert\" om formaatconversie te activeren.",
+      "empty": "Nog geen ontvangers.",
+      "prefersFormat": "voorkeur voor {format}",
+      "deleteTitle": "Ontvanger verwijderen?",
+      "nameEmailRequired": "Naam en e-mail zijn verplicht",
+      "created": "Ontvanger aangemaakt",
+      "updated": "Ontvanger bijgewerkt",
+      "deleted": "\"{name}\" verwijderd",
+      "setDefaultSuccess": "\"{name}\" ingesteld als standaard"
+    },
+    "groups": {
+      "heading": "Ontvangersgroepen",
+      "create": "Groep aanmaken",
+      "newTitle": "Nieuwe groep",
+      "name": "Groepsnaam",
+      "namePlaceholder": "bijv. Boekenclub",
+      "creating": "Aanmaken...",
+      "empty": "Nog geen groepen. Maak een groep aan om naar meerdere ontvangers tegelijk te versturen.",
+      "memberCount": "geen leden | één lid | {count} leden",
+      "deleteTooltip": "Groep verwijderen",
+      "noMembers": "Nog geen leden.",
+      "removeMember": "Verwijderen",
+      "selectRecipient": "Selecteer ontvanger...",
+      "add": "Toevoegen",
+      "addMember": "Lid toevoegen",
+      "allRecipientsInGroup": "Alle ontvangers zitten al in deze groep.",
+      "deleteTitle": "Groep verwijderen?",
+      "created": "Groep aangemaakt",
+      "createFailed": "Aanmaken van groep mislukt",
+      "deleted": "\"{name}\" verwijderd",
+      "memberAdded": "Lid toegevoegd",
+      "addMemberFailed": "Lid toevoegen mislukt",
+      "memberRemoved": "Lid verwijderd",
+      "removeMemberFailed": "Lid verwijderen mislukt"
+    },
+    "templates": {
+      "heading": "E-mailsjablonen",
+      "new": "Nieuw sjabloon",
+      "newTitle": "Nieuw sjabloon",
+      "editTitle": "Sjabloon bewerken",
+      "name": "Naam",
+      "namePlaceholder": "Standaard",
+      "subject": "Onderwerp",
+      "body": "Inhoud",
+      "availableVariables": "Beschikbare variabelen",
+      "editTemplate": "Sjabloon bewerken",
+      "empty": "Nog geen sjablonen.",
+      "notesHeading": "Sjabloonopmerkingen",
+      "notesBody": "Systeemsjablonen kunnen niet worden verwijderd. Beheerders kunnen ze bewerken. Gebruik variabelen zoals <code class=\"font-mono text-foreground/80\">&#123;&#123;title&#125;&#125;</code> in onderwerpen en inhoud - deze worden bij het versturen vervangen door boekgegevens.",
+      "deleteTitle": "Sjabloon verwijderen?",
+      "nameSubjectRequired": "Naam en onderwerp zijn verplicht",
+      "created": "Sjabloon aangemaakt",
+      "updated": "Sjabloon bijgewerkt",
+      "deleted": "\"{name}\" verwijderd",
+      "setDefaultSuccess": "\"{name}\" ingesteld als standaard"
+    },
+    "preferences": {
+      "heading": "E-mailvoorkeuren",
+      "defaultProvider": "Standaardprovider",
+      "defaultProviderHint": "Wordt gebruikt wanneer geen provider is opgegeven. Als dit leeg is, wordt de accountstandaard gebruikt.",
+      "noneAccountDefault": "Geen (accountstandaard gebruiken)",
+      "defaultRecipient": "Standaardontvanger",
+      "defaultRecipientHint": "Wordt gebruikt voor snel versturen. Moet ingesteld zijn om de snel-versturen-actie op boekkaarten te gebruiken.",
+      "none": "Geen",
+      "defaultTemplate": "Standaardsjabloon",
+      "defaultTemplateHint": "Wordt gebruikt wanneer geen sjabloon is opgegeven. Valt terug op de systeemstandaard als dit leeg is.",
+      "noneSystemDefault": "Geen (systeemstandaard gebruiken)",
+      "save": "Voorkeuren opslaan",
+      "saved": "Voorkeuren opgeslagen"
+    },
+    "history": {
+      "heading": "Verzendgeschiedenis",
+      "empty": "Nog geen e-mails verstuurd.",
+      "noSubject": "(geen onderwerp)",
+      "loadMore": "Meer laden",
+      "resend": "Opnieuw versturen",
+      "deleteTitle": "Geschiedenisitem verwijderen?",
+      "entryDeleted": "Item verwijderd",
+      "queuedForResend": "In wachtrij voor opnieuw versturen",
+      "resendFailed": "Opnieuw versturen mislukt",
+      "statusSent": "Verstuurd",
+      "statusFailed": "Mislukt",
+      "statusQueued": "In wachtrij",
+      "statusPending": "In behandeling"
+    },
+    "send": {
+      "title": "Versturen via e-mail",
+      "bookCount": "geen boeken | één boek | {count} boeken",
+      "recipients": "Ontvangers",
+      "noRecipients": "Geen ontvangers geconfigureerd. Voeg er een toe in E-mailinstellingen.",
+      "groups": "Groepen",
+      "options": "Opties",
+      "fileFormat": "Bestandsformaat",
+      "autoRecipientPreference": "Automatisch (voorkeur ontvanger gebruiken)",
+      "unknownFormat": "Onbekend",
+      "primarySuffix": "(primair)",
+      "provider": "Provider",
+      "template": "Sjabloon",
+      "default": "Standaard",
+      "send": "Versturen",
+      "sending": "Versturen...",
+      "queued": "geen e-mails in wachtrij | één e-mail in wachtrij | {count} e-mails in wachtrij",
+      "failed": "Versturen mislukt"
+    }
+  },
+  "hardcover": {
+    "settings": {
+      "subtitle": "Synchroniseer je leesvoortgang, status en beoordelingen met Hardcover."
+    },
+    "bookSync": {
+      "label": "Hardcover-synchronisatie",
+      "toggleAriaLabel": "Dit boek synchroniseren met Hardcover",
+      "syncNow": "Nu synchroniseren"
+    },
+    "connection": {
+      "title": "Verbinding",
+      "description": "Verbind je Hardcover-account om leesgegevens te synchroniseren.",
+      "connected": "Verbonden",
+      "apiToken": "API-token",
+      "tokenPlaceholder": "Plak je Hardcover API-token",
+      "show": "Tonen",
+      "hide": "Verbergen",
+      "findTokenAt": "Vind je token op",
+      "validateToken": "Token valideren",
+      "valid": "Geldig ({username})",
+      "invalidToken": "Ongeldig token",
+      "syncOptions": "Synchronisatieopties",
+      "syncInfo": "Synchronisatie werkt alleen voor boeken die niet ongelezen zijn. Dit geldt voor status-, voortgangs- en beoordelingstriggers. Deze schakelaars bepalen wanneer een synchronisatie plaatsvindt.",
+      "syncScope": {
+        "title": "Bereik van boeksynchronisatie",
+        "allEligible": {
+          "label": "Alle in aanmerking komende boeken",
+          "description": "Synchroniseer alles, tenzij je een boek uitsluit."
+        },
+        "selectedOnly": {
+          "label": "Alleen geselecteerde boeken",
+          "description": "Synchroniseer alleen boeken die je expliciet opneemt."
+        }
+      },
+      "enableSync": {
+        "title": "Synchronisatie inschakelen",
+        "description": "Pauzeer alle Hardcover-synchronisatie zonder de verbinding te verbreken."
+      },
+      "syncOnStatus": {
+        "title": "Synchroniseren bij statuswijziging",
+        "description": "Verstuur updates wanneer je een boek markeert als lezen, gelezen, enzovoort."
+      },
+      "syncOnProgress": {
+        "title": "Synchroniseren bij voortgangsupdate",
+        "description": "Verstuur leesvoortgang en datums wanneer de voortgang in BookOrbit of KOReader wijzigt."
+      },
+      "syncOnRating": {
+        "title": "Synchroniseren bij beoordelingswijziging",
+        "description": "Verstuur je sterbeoordelingen naar Hardcover."
+      },
+      "privacy": {
+        "title": "Privacy",
+        "description": "Standaardzichtbaarheid voor gesynchroniseerde boeken op Hardcover.",
+        "public": "Openbaar",
+        "followersOnly": "Alleen volgers",
+        "private": "Privé"
+      },
+      "disconnect": "Verbinding verbreken",
+      "toast": {
+        "enterToken": "Voer eerst je Hardcover API-token in",
+        "saved": "Hardcover-instellingen opgeslagen",
+        "saveFailed": "Instellingen opslaan mislukt",
+        "disconnected": "Hardcover ontkoppeld"
+      }
+    },
+    "sync": {
+      "title": "Handmatige synchronisatie",
+      "description": "Verstuur je {scope} nu naar Hardcover.",
+      "scope": {
+        "selected": "geselecteerde boeken",
+        "eligible": "in aanmerking komende boeken"
+      },
+      "checkingPending": "Openstaande items controleren...",
+      "pendingOf": "{pending} openstaand van {total} boeken.",
+      "noBooksInScope": "Geen boeken binnen het synchronisatiebereik.",
+      "allSynced": "Alle boeken zijn al gesynchroniseerd.",
+      "lastSyncedLabel": "Laatst gesynchroniseerd",
+      "lastSuccessfulSync": "Laatste geslaagde synchronisatie",
+      "syncing": "Synchroniseren...",
+      "progressCount": "{synced} / {total} boeken",
+      "unavailable": {
+        "permissionDenied": "Je hebt geen toestemming om Hardcover-synchronisatie te gebruiken.",
+        "userDisabled": "Synchronisatie is gepauzeerd in je Hardcover-instellingen."
+      },
+      "button": {
+        "unavailable": "Synchronisatie niet beschikbaar",
+        "syncNow": "Nu synchroniseren",
+        "syncNowCount": "Nu synchroniseren ({count})"
+      },
+      "lastSynced": {
+        "justNow": "Zojuist",
+        "minutesAgo": "{count} min geleden",
+        "hoursAgo": "{count} uur geleden | {count} uur geleden | {count} uur geleden",
+        "daysAgo": "{count} dag geleden | {count} dag geleden | {count} dagen geleden"
+      }
+    },
+    "import": {
+      "title": "Leesstatus ophalen",
+      "description": "Bekijk Hardcover-overeenkomsten voordat je lege BookOrbit-statussen invult.",
+      "clear": "Wissen",
+      "preview": "Voorbeeld",
+      "importProgress": "Voortgang importeren",
+      "reviewMatches": "Overeenkomsten bekijken",
+      "importReady": "Klaar importeren",
+      "exactMatches": "geen exacte overeenkomsten kunnen zonder controle worden geïmporteerd | {count} exacte overeenkomst kan zonder controle worden geïmporteerd | {count} exacte overeenkomsten kunnen zonder controle worden geïmporteerd",
+      "progressAvailable": "geen voortgangsupdates beschikbaar | {count} voortgangsupdate beschikbaar | {count} voortgangsupdates beschikbaar",
+      "progressConflicts": "geen conflicten | {count} conflict | {count} conflicten",
+      "unavailable": {
+        "permissionDenied": "Je hebt geen toestemming om Hardcover-synchronisatie te gebruiken.",
+        "missingToken": "Verbind Hardcover voordat je importeert.",
+        "userDisabled": "Synchronisatie is gepauzeerd in je Hardcover-instellingen."
+      },
+      "summary": {
+        "ready": "Klaar",
+        "review": "Controleren",
+        "conflicts": "Conflicten",
+        "unmatched": "Geen overeenkomst",
+        "skipped": "Overgeslagen"
+      },
+      "result": {
+        "summary": "{applied} geïmporteerd{progress}, {failed} mislukt",
+        "progressUpdated": "{count} voortgang bijgewerkt"
+      },
+      "toast": {
+        "importFailed": "Importeren van Hardcover-leesstatus mislukt",
+        "imported": "geen leesstatussen geïmporteerd{progress} | {count} leesstatus geïmporteerd{progress} | {count} leesstatussen geïmporteerd{progress}",
+        "progressUpdates": "geen voortgangsupdates | {count} voortgangsupdate | {count} voortgangsupdates"
+      }
+    },
+    "review": {
+      "title": "Hardcover-importcontrole",
+      "subtitle": "{total} Hardcover-boeken, {matched} overeenkomsten.",
+      "closeAriaLabel": "Importcontrole sluiten",
+      "searchPlaceholder": "Zoek op titel of auteur",
+      "importProgress": "Voortgang importeren",
+      "untitled": "Zonder titel",
+      "blank": "leeg",
+      "noRows": "Geen rijen komen overeen met de huidige filters.",
+      "selectRowAriaLabel": "{title} selecteren",
+      "selectionSummary": "{count} geselecteerd: {ready} klaar, {reviewed} gecontroleerd.",
+      "selectedProgress": "geen voortgangsupdates | {count} voortgangsupdate | {count} voortgangsupdates",
+      "selectReady": "Klaar selecteren",
+      "selectPage": "Pagina selecteren",
+      "clearPage": "Pagina wissen",
+      "clearSelection": "Selectie wissen",
+      "importSelected": "Selectie importeren",
+      "previousPage": "Vorige pagina",
+      "nextPage": "Volgende pagina",
+      "pageRange": "{start}-{end} van {total}",
+      "tabs": {
+        "all": "Alle",
+        "ready": "Klaar",
+        "review": "Controleren",
+        "conflicts": "Conflicten",
+        "unmatched": "Geen overeenkomst",
+        "skipped": "Overgeslagen"
+      },
+      "summary": {
+        "ready": "Klaar",
+        "review": "Controleren",
+        "conflicts": "Conflicten",
+        "unmatched": "Geen overeenkomst",
+        "skipped": "Overgeslagen"
+      },
+      "matchOptions": {
+        "all": "Alle overeenkomsttypen"
+      },
+      "matchMethod": {
+        "hardcoverId": "Hardcover-ID",
+        "isbn": "ISBN",
+        "titleAuthor": "Titel + auteur"
+      },
+      "outcome": {
+        "ready": "Klaar",
+        "review": "Controleren",
+        "conflict": "Conflict",
+        "unmatched": "Geen overeenkomst",
+        "skipped": "Overgeslagen"
+      },
+      "column": {
+        "progress": "Voortgang"
+      }
+    }
+  },
+  "library": {
+    "creator": {
+      "createTitle": "Bibliotheek aanmaken",
+      "editTitle": "Bewerken: {name}",
+      "stepOf": "Stap {current} van {total}",
+      "sections": {
+        "details": "Details",
+        "folders": "Mappen",
+        "scanner": "Scanner",
+        "metadata": "Metadata",
+        "fileWrite": "Bestanden schrijven",
+        "reading": "Lezen",
+        "schedule": "Planning",
+        "access": "Toegang"
+      },
+      "actions": {
+        "saving": "Opslaan…",
+        "saveChanges": "Wijzigingen opslaan",
+        "creating": "Aanmaken…",
+        "createLibrary": "Bibliotheek aanmaken"
+      },
+      "details": {
+        "libraryName": "Bibliotheeknaam",
+        "namePlaceholder": "Mijn bibliotheek",
+        "coverStyle": {
+          "title": "Omslagstijl",
+          "portrait": "Staand",
+          "square": "Vierkant",
+          "hint": "Staand voor ebook- of gemengde bibliotheken. Vierkant voor bibliotheken met alleen luisterboeken."
+        },
+        "icon": {
+          "label": "Pictogram",
+          "placeholder": "Kies een pictogram...",
+          "selected": "Geselecteerd"
+        }
+      },
+      "folders": {
+        "title": "Scanmappen",
+        "description": "Voeg een of meer mappen toe om te scannen op boeken.",
+        "browseAdd": "Blader en voeg een map toe",
+        "manualEntry": "Of voer handmatig een pad in:",
+        "pathPlaceholder": "/pad/naar/boeken",
+        "test": "Testen",
+        "add": "Toevoegen",
+        "pathNotAccessible": "Pad is niet toegankelijk op de server.",
+        "pathAccessible": "Pad is toegankelijk.",
+        "pathNotAccessibleShort": "Pad is niet toegankelijk",
+        "bookFilesFound": "geen boekbestanden gevonden | {count} boekbestand gevonden | {count} boekbestanden gevonden",
+        "overlapsWith": "Overlapt met \"{library}\"",
+        "noneAdded": "Nog geen mappen toegevoegd",
+        "totalFilesFound": "geen boekbestanden gevonden | {count} boekbestand gevonden - het werkelijke aantal boeken kan lager zijn als er meerdere formaten van hetzelfde boek bestaan | {count} boekbestanden gevonden - het werkelijke aantal boeken kan lager zijn als er meerdere formaten van hetzelfde boek bestaan",
+        "runPrescanHint": "Voer een prescan uit om paden te valideren voordat u opslaat.",
+        "scanning": "Scannen…",
+        "prescan": "Prescan"
+      },
+      "scanner": {
+        "scanMode": {
+          "title": "Scanmodus",
+          "lockedAria": "Organisatiemodus is vergrendeld",
+          "lockTooltip": "De organisatiemodus ligt vast na het aanmaken van de bibliotheek, omdat wijziging dubbele of ontbrekende boekvermeldingen kan veroorzaken. Maak een nieuwe bibliotheek aan en scan opnieuw om een andere modus te gebruiken.",
+          "recommended": "Aanbevolen",
+          "folderAsBook": {
+            "title": "Map als boek",
+            "hint": "Alle bestanden in een map worden gegroepeerd tot één boek. Werkt goed wanneer u meerdere formaten, zoals EPUB en MOBI, samen bewaart."
+          },
+          "fileAsBook": {
+            "title": "Bestand als boek",
+            "hint": "Behandelt elk bestand als een afzonderlijk boek. Het meest geschikt voor bibliotheken met één formaat per titel. Vermijd dit als uw luisterboeken uit meerdere bestanden bestaan."
+          }
+        },
+        "allowedFormats": {
+          "title": "Toegestane formaten",
+          "allowAll": "Alle toestaan",
+          "allAllowed": "Alle formaten zijn toegestaan.",
+          "onlySelected": "Alleen de geselecteerde formaten worden geïmporteerd.",
+          "warning": "Boeken in andere formaten die al in de bibliotheek staan, worden bij de volgende scan als ontbrekend gemarkeerd."
+        },
+        "excludePatterns": {
+          "title": "Uitsluitpatronen",
+          "hintBefore": "Glob-patronen om over te slaan tijdens het scannen (bijv. ",
+          "hintAfter": ").",
+          "add": "Toevoegen",
+          "empty": "Geen patronen toegevoegd."
+        }
+      },
+      "metadata": {
+        "sourcePrecedence": {
+          "title": "Bronvoorrang",
+          "hint": "De bovenste bron in de lijst heeft voorrang wanneer er meerdere beschikbaar zijn."
+        },
+        "formatPriority": {
+          "title": "Formaatprioriteit",
+          "hint": "Wanneer een boek meerdere formaten heeft, heeft het formaat dat het hoogst in de lijst staat voorrang."
+        }
+      },
+      "fileWrite": {
+        "maxFileSizeMb": "Maximale bestandsgrootte (MB)",
+        "rename": {
+          "title": "Bestanden hernoemen bij metadata-update",
+          "hint": "Indien ingeschakeld, wordt bij het bijwerken van titel, auteur, reeks of jaar het fysieke bestand hernoemd volgens het naampatroon van de bibliotheek."
+        },
+        "write": {
+          "title": "Metadata naar bestanden schrijven",
+          "hint": "Indien ingeschakeld, worden bij het opslaan van metadata de wijzigingen ook teruggeschreven naar het fysieke bestand op schijf."
+        },
+        "cover": {
+          "title": "Omslagafbeelding toevoegen",
+          "hint": "Schrijft de opgeslagen omslag terug naar ondersteunde bestandsformaten."
+        },
+        "epub": {
+          "title": "EPUB",
+          "hint": "Schrijft metadata naar het OPF-bestand in het EPUB-archief."
+        },
+        "pdf": {
+          "title": "PDF",
+          "hint": "Sluit metadata in de PDF Info-dictionary en XMP-stream in."
+        },
+        "cbx": {
+          "title": "Striparchieven (CBX)",
+          "hint": "Schrijft ComicInfo.xml naar CBZ- en CB7-archieven."
+        },
+        "audio": {
+          "title": "Audio",
+          "hint": "Sluit de opgeslagen omslag in M4B-, M4A-, MP3- en FLAC-bestanden in."
+        }
+      },
+      "reading": {
+        "readingStart": {
+          "title": "Start van lezen",
+          "hint": "Een boek wordt als \"lezen\" gemarkeerd zodra dit percentage voortgang is bereikt."
+        },
+        "markAsFinished": {
+          "title": "Markeren als voltooid",
+          "hint": "Een boek wordt automatisch als \"gelezen\" gemarkeerd wanneer dit percentage voortgang is bereikt."
+        }
+      },
+      "schedule": {
+        "fileWatching": "Bestandsbewaking",
+        "autoScanSchedule": "Planning voor automatisch scannen",
+        "cronExpression": "Cron-expressie",
+        "cronInvalid": "Ongeldige cron-expressie.",
+        "cronFormat": "Formaat: minuut uur dag maand weekdag",
+        "watchFolders": {
+          "title": "Mappen bewaken",
+          "hint": "Detecteer automatisch nieuwe bestanden die aan bibliotheekmappen worden toegevoegd."
+        },
+        "presets": {
+          "never": "Nooit",
+          "hourly": "Elk uur",
+          "every6Hours": "Elke 6 uur",
+          "every12Hours": "Elke 12 uur",
+          "daily": "Dagelijks",
+          "weekly": "Wekelijks",
+          "custom": "Aangepast"
+        },
+        "human": {
+          "disabled": "Automatisch scannen uitgeschakeld",
+          "hourly": "Elk uur",
+          "every6Hours": "Elke 6 uur",
+          "every12Hours": "Elke 12 uur",
+          "dailyMidnight": "Dagelijks om middernacht",
+          "weeklyMonday": "Wekelijks op maandag om middernacht",
+          "cron": "Cron: {cron}"
+        }
+      },
+      "access": {
+        "title": "Toegangsbeheer",
+        "description": "Supergebruikers hebben altijd volledige toegang. Verleen hieronder toegang aan andere gebruikers.",
+        "notYetCreated": "Toegang kan worden ingesteld nadat de bibliotheek is aangemaakt.",
+        "selectUser": "Selecteer een gebruiker…",
+        "grant": "Verlenen",
+        "empty": "Er is nog geen enkele gebruiker toegang verleend.",
+        "levels": {
+          "viewer": "Kijker",
+          "editor": "Bewerker",
+          "owner": "Eigenaar"
+        },
+        "columns": {
+          "user": "Gebruiker",
+          "accessLevel": "Toegangsniveau"
+        },
+        "errors": {
+          "grant": "Toegang verlenen mislukt",
+          "updateLevel": "Toegangsniveau bijwerken mislukt",
+          "revoke": "Toegang intrekken mislukt"
+        }
+      }
+    },
+    "folderPicker": {
+      "title": "Mappen doorbladeren",
+      "newFolder": "Nieuwe map",
+      "goUp": "Omhoog",
+      "filterPlaceholder": "Mappen filteren…",
+      "newFolderNamePlaceholder": "Naam van nieuwe map",
+      "create": "Aanmaken",
+      "noFolders": "Geen mappen gevonden",
+      "selectFolder": "Deze map selecteren",
+      "errors": {
+        "readDirectory": "Kan map niet lezen",
+        "connect": "Kan geen verbinding maken",
+        "invalidName": "Voer één mapnaam in zonder schuine strepen of voorlooppunten",
+        "createFolder": "Kan map niet aanmaken"
+      }
+    },
+    "upload": {
+      "library": "Bibliotheek",
+      "selectLibrary": "Selecteer een bibliotheek...",
+      "targetFolder": "Doelmap",
+      "addMoreFiles": "Meer bestanden toevoegen",
+      "clearAll": "Alles wissen",
+      "done": "Klaar",
+      "retry": "Opnieuw proberen",
+      "upload": "Uploaden",
+      "uploadWithCount": "Uploaden ({count})",
+      "viewInLibrary": "Bekijken in bibliotheek",
+      "fileCount": "geen bestanden | {count} bestand | {count} bestanden",
+      "booksAdded": "geen boeken toegevoegd | {count} boek toegevoegd | {count} boeken toegevoegd",
+      "uploadedFailed": "{done} geüpload, {failed} mislukt",
+      "progress": "{done} van {total} uploaden...",
+      "header": {
+        "uploading": "Uploaden...",
+        "complete": "Upload voltooid",
+        "uploadTo": "Uploaden naar {library}",
+        "uploadBooks": "Boeken uploaden"
+      },
+      "dropzone": {
+        "title": "Sleep bestanden hierheen of klik om te bladeren",
+        "hint": "{formats} - tot 500 MB per stuk"
+      }
+    }
+  },
+  "metadataScore": {
+    "missingFields": "geen velden ontbreken - metadata bewerken | {count} veld ontbreekt - metadata bewerken | {count} velden ontbreken - metadata bewerken"
+  },
+  "migration": {
+    "sidebarTitle": "Booklore-import",
+    "status": {
+      "done": "Voltooid",
+      "saved": "Opgeslagen",
+      "running": "Bezig",
+      "failed": "Mislukt"
+    },
+    "badge": {
+      "validated": "Gevalideerd",
+      "upToDate": "Actueel",
+      "completed": "Voltooid"
+    },
+    "steps": {
+      "source": {
+        "short": "Bronverbinding",
+        "title": "Bronverbinding",
+        "subtitle": "Configureer de databaseverbinding naar je Booklore-broninstantie."
+      },
+      "mappings": {
+        "short": "Gebruikers- en padkoppeling",
+        "title": "Gebruikers- en padkoppeling",
+        "subtitle": "Koppel brongebruikers aan doelgebruikers en vertaal bestandspaden."
+      },
+      "dryRun": {
+        "short": "Testrun",
+        "title": "Testrun",
+        "subtitle": "Bekijk een voorbeeld van wat wordt geïmporteerd voordat de live-migratie start."
+      },
+      "migration": {
+        "short": "Migratie uitvoeren",
+        "title": "Migratie uitvoeren",
+        "subtitle": "Start de live-import en volg de voortgang."
+      },
+      "report": {
+        "short": "Rapport",
+        "title": "Migratierapport",
+        "subtitle": "Bekijk wat er is geïmporteerd en exporteer een gedetailleerd rapport."
+      }
+    },
+    "footer": {
+      "continueToMappings": "Doorgaan naar koppelingen",
+      "continueToDryRun": "Doorgaan naar testrun",
+      "continueToMigration": "Doorgaan naar migratie",
+      "viewReport": "Rapport bekijken",
+      "resetSetup": "Instellingen herstellen",
+      "stepOf": "Stap {current} van {total}",
+      "backToSetup": "Terug naar instellingen"
+    },
+    "stages": {
+      "init": "Initialiseren",
+      "sharedOverlays": "Metadata importeren",
+      "bookCovers": "Omslagen importeren",
+      "userState": "Gebruikersgegevens importeren"
+    },
+    "source": {
+      "testConnection": "Verbinding testen",
+      "saveAndValidate": "Opslaan en valideren",
+      "validatedWithWarnings": "Bron gevalideerd met waarschuwingen",
+      "fields": {
+        "type": "Brontype",
+        "name": "Bronnaam",
+        "host": "Host",
+        "port": "Poort",
+        "user": "Gebruiker",
+        "password": "Wachtwoord",
+        "passwordSaved": "Opgeslagen - laat ongewijzigd",
+        "passwordNotSet": "Geen wachtwoord ingesteld",
+        "database": "Database",
+        "mediaRootPath": "Media-hoofdpad",
+        "ssl": "TLS/SSL gebruiken"
+      },
+      "mediaPath": {
+        "hintRequired": "Vereist voor het migreren van boekomslagen.",
+        "hintAbsolute": "Gebruik een absoluut pad (bijvoorbeeld: /books). Relatieve paden worden niet ondersteund.",
+        "hintConfigured": "Pad voor omslagimport geconfigureerd. Gebruik Verbinding testen om toegang en de Booklore-afbeeldingenmapstructuur te verifiëren.",
+        "buttonOk": "Pad OK",
+        "buttonIssue": "Padprobleem",
+        "buttonTest": "Pad testen"
+      },
+      "compatibility": {
+        "title": "Geteste compatibiliteit",
+        "verifiedAgainst": "Geverifieerd tegen:",
+        "note": "Latere versies zijn waarschijnlijk compatibel maar zijn niet geverifieerd. Voer eerst een testrun uit ter bevestiging voordat je gegevens vastlegt."
+      },
+      "snapshot": {
+        "title": "Laatste validatiemomentopname",
+        "sourceVersion": "Bronversie: {version}",
+        "unknown": "Onbekend",
+        "missingTables": "Ontbrekende vereiste tabellen: {tables}"
+      }
+    },
+    "mappings": {
+      "suggestionsAutoLoad": "Gebruikerssuggesties worden automatisch geladen na bronvalidatie.",
+      "refresh": "Vernieuwen",
+      "sourceUser": "Brongebruiker",
+      "targetUser": "Doelgebruiker",
+      "noSourceUsersLoaded": "Nog geen brongebruikers geladen.",
+      "noActiveTargetUsers": "Geen actieve doelgebruikers gevonden. Maak een BookOrbit-gebruiker aan of schakel deze opnieuw in voordat je koppelt.",
+      "pathPrefixMappings": "Padvoorvoegselkoppelingen",
+      "addMapping": "Koppeling toevoegen",
+      "pathMappingsExplanation": "Padkoppelingen vertalen bronbestandspaden naar doelpaden zodat boeken op bestandslocatie kunnen worden gematcht. Boeken worden ook gematcht op ISBN, bestandshash en titel/auteur, ongeacht padkoppelingen.",
+      "noPrefixesFound": "Geen voorvoegsels gevonden - valideer eerst de bron",
+      "selectSourcePrefix": "Selecteer bronvoorvoegsel...",
+      "selectTargetFolder": "Selecteer doelmap...",
+      "remove": "Verwijderen",
+      "saveMappings": "Koppelingen opslaan",
+      "pathValidation": {
+        "title": "Padvalidatie",
+        "mappedSummary": "{mapped} van {total} bronboeken hebben een gekoppeld pad",
+        "unmatched": "{count} gekoppelde paden niet op schijf gevonden",
+        "allMatched": "Alle {count} gekoppelde paden op schijf gevonden"
+      }
+    },
+    "dryRun": {
+      "run": "Testrun uitvoeren",
+      "matched": "Gematcht:",
+      "unresolved": "Onopgelost:",
+      "duplicates": "Duplicaten:",
+      "unresolvedSummary": "Overzicht onopgelost"
+    },
+    "duplicates": {
+      "title": "Los dubbele doelmatches op",
+      "explanation": "Kies voor elk doelboek één bronboek om te behouden. Aanbevolen keuzes worden vooraf geselecteerd wanneer er één sterkste match is.",
+      "remainingGroups": "Resterende groepen:",
+      "ofCount": "van {total}",
+      "targetBookId": "Doelboek #{id}",
+      "recommended": "Aanbevolen",
+      "resolveButton": "{count} duplicaat oplossen | {count} duplicaat oplossen | {count} duplicaten oplossen",
+      "sourceRecordId": "Bronrecord-ID #{id}",
+      "byAuthor": "door {author} (ID: {id})",
+      "byFilePath": "{filePath} (ID: {id})",
+      "bookloreSourceId": "Booklore-bron-ID: {id}",
+      "libraryBookId": "Bibliotheekboek #{id}"
+    },
+    "preflight": {
+      "title": "Preflight-controles",
+      "allPassed": "Alle controles geslaagd - klaar om te migreren",
+      "sourceValidated": "Bron gevalideerd",
+      "saveAndValidateSource": "Bronverbinding opslaan en valideren",
+      "validateSourceConnection": "Bronverbinding valideren",
+      "mappingsSaved": "Koppelingen opgeslagen",
+      "saveUserAndPathMappings": "Gebruikers- en padkoppelingen opslaan",
+      "pathMappingsValidated": "Padkoppelingen gevalideerd",
+      "savePathMappingsToValidate": "Sla padkoppelingen op om ze te valideren",
+      "dryRunUpToDate": "Testrun is actueel",
+      "runFreshDryRun": "Voer een nieuwe testrun uit",
+      "issues": {
+        "saveSource": "Bronverbindingsinstellingen opslaan",
+        "validateSource": "Bronverbinding valideren",
+        "saveMappings": "Gebruikers- en padkoppelingen opslaan",
+        "savePathMappings": "Sla padkoppelingen op om ze te valideren",
+        "freshDryRun": "Voer een nieuwe testrun uit",
+        "resolveDuplicates": "Los dubbele doelboekmatches op in de testrun",
+        "waitForRun": "Wacht tot de actieve run is voltooid"
+      }
+    },
+    "run": {
+      "confirmPrompt": "Dit start de live-migratie. Weet je het zeker?",
+      "confirmStart": "Start bevestigen",
+      "startMigration": "Migratie starten",
+      "cancelRun": "Run annuleren",
+      "refreshStatus": "Status vernieuwen",
+      "pollingStopped": "Statuspolling gestopt door een fout.",
+      "retry": "Opnieuw proberen",
+      "stage": "Fase: {stage}",
+      "initializing": "initialiseren",
+      "ended": "Beëindigd {time}"
+    },
+    "report": {
+      "noRunYet": "Nog geen migratierun. Voltooi de bovenstaande stappen om te starten.",
+      "runNumber": "Run #{id}",
+      "notStarted": "Niet gestart",
+      "reloadReport": "Rapport opnieuw laden",
+      "loadFullReport": "Volledig rapport laden",
+      "exportJson": "JSON exporteren",
+      "exportCsv": "CSV exporteren",
+      "migrationFailed": "Migratie mislukt",
+      "retryFromLastStage": "Opnieuw proberen vanaf laatste voltooide fase",
+      "booksSection": "Boeken",
+      "metadataOverlays": "Metadata-overlays toegepast",
+      "authorMappings": "Auteurkoppelingen vervangen",
+      "narratorMappings": "Verteller-koppelingen vervangen",
+      "genreMappings": "Genrekoppelingen vervangen",
+      "tagMappings": "Labelkoppelingen vervangen",
+      "coversImported": "Omslagen geïmporteerd",
+      "coverImportSkipped": "Omslagimport overgeslagen - media-hoofdpad niet geconfigureerd",
+      "couldNotMatch": "Kon niet matchen",
+      "userDataSection": "Gebruikersgegevens",
+      "readingStatuses": "Leesstatussen",
+      "readingProgressEntries": "Leesvoortgangsvermeldingen",
+      "audiobookProgressEntries": "Luisterboekvoortgangsvermeldingen",
+      "readingSessions": "Leessessies",
+      "bookmarks": "Bladwijzers",
+      "annotations": "Annotaties",
+      "collectionEntries": "Collectievermeldingen",
+      "loadFullReportHint": "Klik op \"Volledig rapport laden\" om het testrun-matchoverzicht op te nemen in het geëxporteerde rapport.",
+      "completedNoIssues": "Migratie voltooid zonder onopgeloste boeken of fouten.",
+      "matchedBooks": "Gematchte boeken ({count})",
+      "matchedBooksExplanation": "Deze testrun-matches zijn gebruikt om te bepalen welke bibliotheekboeken geïmporteerde gegevens ontvingen.",
+      "sourceBook": "Bronboek {id}",
+      "libraryBook": "Bibliotheekboek {id}",
+      "unresolvedBooks": "Onopgeloste boeken ({count})",
+      "unresolvedBooksExplanation": "Deze boeken bestaan in de bron maar konden niet worden gematcht aan een boek in je bibliotheek.",
+      "mappedUsers": "Gekoppelde gebruikers ({count})",
+      "mappedUsersExplanation": "Totalen per gebruiker komen uit het testrun-voorbeeld dat met het migratieplan is opgeslagen.",
+      "coverFailures": "{count} omslagimport(s) mislukt. Gedetailleerde foutregels worden niet opgeslagen.",
+      "userPreviewCounts": "{statuses} statussen, {progress} voortgangsvermeldingen, {sessions} leessessies, {bookmarks} bladwijzers, {annotations} annotaties, {collections} collectievermeldingen"
+    },
+    "unresolvedReason": {
+      "noTitleAuthorMatch": "Geen overeenkomend boek gevonden op titel of auteur",
+      "noFilePathMatch": "Bestandspad kwam niet overeen met een boek in deze bibliotheek",
+      "noFileHashMatch": "Bestandshash kwam niet overeen met een boek in deze bibliotheek",
+      "noIsbnMatch": "ISBN kwam niet overeen met een boek in deze bibliotheek",
+      "insufficientSourceData": "Niet genoeg metadata om te proberen te matchen",
+      "ambiguousIsbnMatch": "Meerdere boeken kwamen overeen met hetzelfde ISBN",
+      "ambiguousFileHashMatch": "Meerdere boeken kwamen overeen met dezelfde bestandshash",
+      "ambiguousFilePathMatch": "Meerdere boeken kwamen overeen met hetzelfde bestandspad",
+      "ambiguousTitleAuthorMatch": "Meerdere boeken kwamen overeen met dezelfde titel en auteur",
+      "unknown": "Kon reden niet bepalen"
+    },
+    "matchStrategy": {
+      "isbn": "Gematcht op ISBN",
+      "fileHash": "Gematcht op bestandshash",
+      "pathMapping": "Gematcht op gekoppeld bestandspad",
+      "titleAuthor": "Gematcht op titel en auteur",
+      "unavailable": "Matchstrategie niet beschikbaar"
+    },
+    "connectionError": {
+      "unreachable": "Kon de databaseserver niet bereiken. Controleer de host en poort.",
+      "authFailed": "Authenticatie mislukt. Controleer de gebruikersnaam en het wachtwoord.",
+      "databaseNotFound": "Database niet gevonden. Controleer de databasenaam.",
+      "timeout": "Verbinding time-out. Controleer host- en firewallinstellingen.",
+      "generic": "Verbindingstest mislukt"
+    },
+    "userSelect": {
+      "placeholder": "Selecteer gebruiker",
+      "noUsersFound": "Geen gebruikers gevonden"
+    },
+    "toast": {
+      "initFailed": "Kon migratie-instellingen niet initialiseren",
+      "loadSupportedTypesFailed": "Kon ondersteunde migratiebrontypes niet laden",
+      "loadTargetUsersFailed": "Kon doelgebruikers niet laden",
+      "loadTargetFoldersFailed": "Kon doelbibliotheekmappen niet laden",
+      "noSourceUsers": "Er werden geen brongebruikers geretourneerd",
+      "suggestionsLoaded": "Gebruikerskoppelingssuggesties geladen",
+      "loadSuggestionsFailed": "Kon gebruikerskoppelingssuggesties niet laden",
+      "sourceFieldsRequired": "Host, gebruiker, database en bronnaam zijn vereist",
+      "connectionPassedWithWarnings": "Verbindingstest geslaagd met waarschuwingen",
+      "connectionPassedWithWarningCount": "Verbindingstest geslaagd met {count} waarschuwing(en). Eerste: {warning}",
+      "connectionPassed": "Verbindingstest geslaagd",
+      "connectionMissingTables": "Verbinding oké, maar {count} vereiste tabel(len) ontbreken",
+      "cannotTestMediaWhileRunning": "Kan mediapad niet testen terwijl een run actief is",
+      "mediaPathRequired": "Media-hoofdpad is vereist voor omslagimport.",
+      "mediaPathAbsolute": "Gebruik een absoluut pad (bijvoorbeeld: /books).",
+      "mediaPathVerified": "Mediapad geverifieerd.",
+      "mediaPathValid": "Mediapad is geldig en leesbaar",
+      "mediaPathValidationFailed": "Mediapadvalidatie mislukt.",
+      "connectionFailedBeforeMedia": "Verbindingstest mislukt voordat de mediapadvalidatie kon worden voltooid.",
+      "cannotModifySourceWhileRunning": "Kan bron niet wijzigen terwijl een run actief is",
+      "sourceSavedWithWarnings": "Bron opgeslagen en gevalideerd met {count} waarschuwing(en)",
+      "sourceSaved": "Bron opgeslagen en gevalideerd",
+      "saveSourceFailed": "Kon bron niet opslaan of valideren",
+      "cannotSaveMappingsWhileRunning": "Kan koppelingen niet opslaan terwijl een run actief is",
+      "saveSourceFirst": "Sla eerst de bron op",
+      "mapAtLeastOneUser": "Koppel ten minste één brongebruiker aan een doelgebruiker",
+      "mapEveryUser": "Koppel elke brongebruiker voordat je opslaat",
+      "pathValidationFailedButSaved": "Padvalidatie mislukt, maar het profiel wordt toch opgeslagen",
+      "mappingsSaved": "Koppelingen opgeslagen",
+      "saveMappingsFailed": "Kon koppelingen niet opslaan",
+      "cannotDryRunWhileRunning": "Kan geen testrun uitvoeren terwijl een run actief is",
+      "saveMappingsFirst": "Sla eerst de koppelingen op",
+      "dryRunCompleted": "Testrun voltooid: {matched} gematcht, {unresolved} onopgelost",
+      "dryRunFailed": "Testrun mislukt",
+      "selectSourceForDuplicates": "Selecteer een bronboek voor alle {count} duplicaatgroepen",
+      "duplicatesResolved": "Dubbele matches opgelost",
+      "resolveDuplicatesFailed": "Kon duplicaten niet oplossen",
+      "preflightNotReady": "Migratie-preflight niet gereed",
+      "runDryRunFirst": "Voer eerst een testrun uit",
+      "runStarted": "Migratierun gestart",
+      "startFailed": "Kon migratie niet starten",
+      "runCancelled": "Migratierun geannuleerd",
+      "cancelFailed": "Kon migratie niet annuleren",
+      "runRetried": "Migratierun opnieuw geprobeerd - hervat vanaf laatste voltooide fase",
+      "retryFailed": "Kon migratie niet opnieuw proberen",
+      "loadProgressFailed": "Kon runvoortgang niet laden",
+      "startMigrationFirst": "Start eerst de migratie",
+      "reportRefreshed": "Runrapport vernieuwd",
+      "loadReportFailed": "Kon runrapport niet laden",
+      "reportExported": "Rapport geëxporteerd als {format}",
+      "exportFailed": "Kon migratierapport niet exporteren"
+    }
+  },
+  "notifications": {
+    "title": "Meldingen",
+    "markAllRead": "Alles als gelezen markeren",
+    "clear": "Wissen",
+    "empty": "Nog geen meldingen",
+    "loadMore": "Meer meldingen laden",
+    "preferences": {
+      "title": "Meldingen",
+      "subtitle": "Kies welke meldingscategorieën je wilt ontvangen.",
+      "saving": "Opslaan...",
+      "unsavedChanges": "Niet-opgeslagen wijzigingen",
+      "saved": "Meldingsvoorkeuren opgeslagen",
+      "saveFailed": "Opslaan van voorkeuren mislukt",
+      "savePreferenceFailed": "Opslaan van voorkeur mislukt",
+      "whatsNewToggle": "\"Wat is er nieuw\" tonen na updates",
+      "whatsNewToggleHint": "Een popup die nieuwe functies benadrukt nadat de app is bijgewerkt. Het archief blijft hoe dan ook beschikbaar."
+    }
+  },
+  "reader": {
+    "retry": "Opnieuw proberen",
+    "loadingBook": "Boek laden…",
+    "failedToLoadBook": "Boek kon niet worden geladen",
+    "chapterNumber": "Hoofdstuk {number}",
+    "peek": {
+      "badge": "Voorproefje",
+      "startReading": "Beginnen met lezen"
+    },
+    "toast": {
+      "linkedHighlightError": "De gekoppelde markeringspositie kon niet worden geopend",
+      "resumed": "Hervat op {pct}% - {label}"
+    },
+    "header": {
+      "goBack": "Terug",
+      "tableOfContents": "Inhoudsopgave",
+      "toggleBookmark": "Bladwijzer in-/uitschakelen",
+      "cycleFooterMode": "Voettekstinfo wisselen",
+      "keyboardShortcutsHint": "Sneltoetsen (?)",
+      "enterFullscreen": "Volledig scherm openen",
+      "exitFullscreen": "Volledig scherm sluiten",
+      "footerMode": {
+        "pageProgress": "Voettekstinfo: pagina + voortgang",
+        "sessionTimeLeft": "Voettekstinfo: leessessie + resterende tijd",
+        "chapterTimeLeft": "Voettekstinfo: hoofdstuk + resterende tijd hoofdstuk"
+      }
+    },
+    "footer": {
+      "previousSection": "Vorige sectie",
+      "nextSection": "Volgende sectie",
+      "goToPlaceholder": "45 of p123",
+      "jumpToLocation": "Naar locatie springen",
+      "jumpTooltip": "Naar % of pagina springen (bijv. 45 of p123)",
+      "go": "Ga"
+    },
+    "settings": {
+      "title": "Instellingen",
+      "ariaLabel": "Lezerinstellingen",
+      "tabs": {
+        "appearance": "Weergave",
+        "text": "Tekst",
+        "layout": "Indeling"
+      },
+      "appearance": {
+        "mode": "Modus",
+        "light": "Licht",
+        "dark": "Donker",
+        "colorTheme": "Kleurthema"
+      },
+      "text": {
+        "fontSize": "Lettergrootte",
+        "fontSizeRange": "Bereik: 10-32px",
+        "lineHeight": "Regelhoogte",
+        "lineHeightRange": "Bereik: 0,8-3,0",
+        "fontFamily": "Lettertype",
+        "fontFamilyDescription": "Kies ingebouwde of geüploade lettertypen voor de tekst.",
+        "builtIn": "Ingebouwd",
+        "yourFonts": "Jouw lettertypen"
+      },
+      "layout": {
+        "pageSpreads": "Paginaspreads",
+        "pageSpreadsDescription": "Kies hoe deze op afbeeldingen gebaseerde EPUB pagina's koppelt.",
+        "bookDefault": "Standaard van boek",
+        "singlePage": "Enkele pagina",
+        "readingFlow": "Leesstroom",
+        "readingFlowDescription": "Wissel tussen gepagineerd en doorlopend scrollen.",
+        "paginated": "Gepagineerd",
+        "scrolled": "Scrollend",
+        "textColumns": "Tekstkolommen",
+        "textColumnsRange": "Bereik: 1-10",
+        "columnGap": "Kolomtussenruimte",
+        "columnGapRange": "Bereik: 0-50%",
+        "maxWidth": "Maximale breedte",
+        "maxWidthRange": "Bereik: 400-1600",
+        "justifyText": "Tekst uitvullen",
+        "justifyTextDescription": "Uitlijning over de volledige breedte inschakelen.",
+        "hyphenation": "Woordafbreking",
+        "hyphenationDescription": "Automatische woordafbreking inschakelen."
+      }
+    },
+    "search": {
+      "placeholder": "Zoeken in boek (min. {min} tekens)...",
+      "searching": "Zoeken…",
+      "tooShort": "Typ minstens {min} tekens",
+      "noResults": "Geen resultaten gevonden",
+      "prompt": "Typ om te zoeken",
+      "resultCount": "geen resultaten | {count} resultaat | {count} resultaten"
+    },
+    "sidebar": {
+      "tabs": {
+        "chapters": "Hoofdstukken",
+        "bookmarks": "Bladwijzers",
+        "highlights": "Markeringen"
+      },
+      "noChapters": "Geen hoofdstukken gevonden",
+      "noBookmarks": "Nog geen bladwijzers",
+      "noBookmarksMatch": "Geen bladwijzers komen overeen met je filters",
+      "noHighlights": "Nog geen markeringen",
+      "noHighlightsMatch": "Geen markeringen komen overeen met je filters",
+      "searchBookmarks": "Bladwijzers zoeken...",
+      "searchHighlights": "Markeringen zoeken...",
+      "bookmarkFallback": "Bladwijzer",
+      "locationUnavailable": "Locatie niet beschikbaar",
+      "customColor": "Aangepast ({color})",
+      "allColors": "Alle kleuren",
+      "allChapters": "Alle hoofdstukken",
+      "notesOnly": "Alleen notities",
+      "deleteBookmark": "Bladwijzer verwijderen",
+      "deleteHighlight": "Markering verwijderen",
+      "approximatePosition": "Gesynchroniseerd vanaf apparaat; exacte positie niet beschikbaar, springt naar het hoofdstuk",
+      "sort": {
+        "readingOrder": "Leesvolgorde",
+        "newest": "Nieuwste eerst",
+        "oldest": "Oudste eerst"
+      }
+    },
+    "selection": {
+      "copy": "Kopiëren",
+      "copied": "Gekopieerd!",
+      "highlight": "Markeren",
+      "translate": "Vertalen",
+      "define": "Definiëren",
+      "deleteAnnotation": "Annotatie verwijderen",
+      "apply": "Toepassen"
+    },
+    "note": {
+      "title": "Notitie toevoegen",
+      "placeholder": "Schrijf je notitie…"
+    },
+    "dictionary": {
+      "noDefinition": "Geen definitie gevonden",
+      "loadError": "Definitie kon niet worden geladen"
+    },
+    "translation": {
+      "original": "Origineel",
+      "translation": "Vertaling",
+      "translating": "Vertalen...",
+      "noTranslation": "Nog geen vertaling",
+      "viaProvider": "via {provider}",
+      "copyTranslation": "Vertaling kopiëren"
+    },
+    "shortcuts": {
+      "title": "Sneltoetsen",
+      "groups": {
+        "panels": "Panelen",
+        "reading": "Lezen",
+        "actions": "Acties"
+      },
+      "toggleToc": "Inhoudsopgave in-/uitschakelen",
+      "toggleSearch": "Zoeken in-/uitschakelen",
+      "toggleHelp": "Deze hulp tonen/verbergen",
+      "closePanel": "Paneel sluiten",
+      "prevNextPage": "Vorige/volgende pagina",
+      "goToStart": "Naar begin van boek",
+      "goToEnd": "Naar einde van boek",
+      "toggleBookmark": "Bladwijzer in-/uitschakelen",
+      "toggleFullscreen": "Volledig scherm in-/uitschakelen",
+      "cycleFooterMode": "Voettekstinfo wisselen"
+    },
+    "cbz": {
+      "tabs": {
+        "view": "Weergave",
+        "reading": "Lezen",
+        "layout": "Indeling"
+      },
+      "fitMode": "Passingsmodus",
+      "background": "Achtergrond",
+      "scrollMode": "Scrollmodus",
+      "scrollModeHint": "Gebruik \"Geen tussenruimte\" voor webtoons en verticale stroken.",
+      "readingDirection": "Leesrichting",
+      "pageView": "Paginaweergave",
+      "autoFallback": "Auto-terugval",
+      "spreadAlignmentLabel": "Spreaduitlijning",
+      "spreadAlignmentHint": "Spreaduitlijning is niet beschikbaar in de auto-terugvalmodus.",
+      "focusTwoPageToggle": "Focus op tweepaginaschakelaar",
+      "forceTwoPage": "Twee pagina's forceren",
+      "off": "Uit",
+      "on": "Aan",
+      "widePages": "Brede pagina's",
+      "resetBookViewSettings": "Weergave-instellingen van boek herstellen",
+      "resetConfirm": "Weergave-instellingen voor dit boek herstellen naar je algemene standaardwaarden?",
+      "firstPage": "Eerste pagina",
+      "lastPage": "Laatste pagina",
+      "fit": {
+        "page": "Passend op pagina",
+        "width": "Paginabreedte",
+        "height": "Paginahoogte",
+        "actual": "Werkelijke grootte"
+      },
+      "view": {
+        "single": "Enkel",
+        "twoPage": "Twee pagina's"
+      },
+      "scroll": {
+        "paged": "Gepagineerd",
+        "infinite": "Oneindig",
+        "noGaps": "Geen tussenruimte"
+      },
+      "direction": {
+        "ltr": "L naar R",
+        "rtl": "R naar L"
+      },
+      "spreadAlignment": {
+        "normal": "Normaal",
+        "shifted": "Verschoven"
+      },
+      "widePage": {
+        "auto": "Auto",
+        "inSpreads": "In spreads"
+      },
+      "bg": {
+        "black": "Zwart",
+        "gray": "Grijs",
+        "white": "Wit"
+      }
+    },
+    "audiobook": {
+      "untitled": "Naamloos",
+      "loading": "Luisterboek laden...",
+      "loadError": "Luisterboek kon niet worden geladen",
+      "noAudioFiles": "Geen audiobestanden gevonden voor dit boek.",
+      "speed": "Snelheid",
+      "chapters": "Hoofdstukken",
+      "bookmarks": "Bladwijzers",
+      "volume": "Volume",
+      "muted": "Gedempt",
+      "sleep": "Slaap",
+      "chapterAbbrev": "Hfst.",
+      "sleepTimer": "Slaaptimer",
+      "minutes": "{count} minuten",
+      "endOfChapter": "Einde van hoofdstuk",
+      "noChaptersAvailable": "Geen hoofdstukken beschikbaar",
+      "extend15": "+ 15 minuten",
+      "timeLeft": "(nog {time})",
+      "playbackSpeed": "Afspeelsnelheid",
+      "noChapters": "Geen hoofdstukken beschikbaar.",
+      "noBookmarks": "Nog geen bladwijzers.",
+      "noBookmarksHint": "Tik op het bladwijzerpictogram bovenaan om je huidige positie op te slaan.",
+      "playerSettings": "Spelerinstellingen",
+      "skipBack": "Terugspoelen",
+      "skipForward": "Vooruitspoelen"
+    }
+  },
+  "scanner": {
+    "filesProgress": "{processed}/{total} bestanden",
+    "booksFound": "geen boeken gevonden | {count} boek gevonden | {count} boeken gevonden"
+  },
+  "series": {
+    "completion": {
+      "readOfTotal": "{read} van {total} gelezen ({percentage}%)"
+    },
+    "gaps": {
+      "label": "Mogelijke hiaten:"
+    },
+    "filters": {
+      "title": "Reeksfilters",
+      "clearAll": "Alles wissen",
+      "allLibraries": "Alle bibliotheken",
+      "allCompletion": "Alle voltooiing",
+      "notStarted": "Niet gestart",
+      "inProgress": "Bezig",
+      "complete": "Voltooid"
+    },
+    "list": {
+      "title": "Reeksen",
+      "searchPlaceholder": "Zoek reeks of auteur",
+      "sortButton": "Sorteren",
+      "sortBy": "Sorteren op",
+      "ascending": "Oplopend",
+      "descending": "Aflopend",
+      "ascShort": "Opl.",
+      "descShort": "Afl.",
+      "filters": "Filters",
+      "clear": "Wissen",
+      "noMatch": "Geen reeksen komen overeen met je filters.",
+      "empty": "Geen reeksen gevonden in je bibliotheken.",
+      "sort": {
+        "name": "Naam",
+        "bookCount": "Aantal boeken",
+        "recentAdditions": "Recent toegevoegd",
+        "readingProgress": "Leesvoortgang"
+      }
+    },
+    "detail": {
+      "pageTitle": "Reeks",
+      "pageTitleNamed": "Reeks · {name}",
+      "pageTitleWithId": "Reeks #{id}",
+      "entityName": "Reeks",
+      "bookCount": "geen boeken | {count} boek | {count} boeken",
+      "byAuthors": "door {authors}",
+      "moreAuthors": "+{count} meer",
+      "preparingEditor": "Editor voorbereiden...",
+      "editMetadata": "Metadata bewerken",
+      "firstInSeries": "Eerste in reeks",
+      "untitled": "Zonder titel",
+      "loadingFirstBook": "Voorbeeld van eerste boek laden...",
+      "showLess": "Minder tonen",
+      "showMore": "Meer tonen",
+      "moreGenres": "+{count} meer",
+      "synopsis": "Samenvatting",
+      "noDescription": "Geen beschrijving beschikbaar.",
+      "updatingPreview": "Voorbeeld bijwerken...",
+      "noBooksToPreview": "Geen boeken beschikbaar voor voorbeeld.",
+      "loadingSeries": "Reeks laden...",
+      "booksHeading": "Boeken",
+      "allLibraries": "Alle bibliotheken",
+      "groupByMedia": "Groeperen op media",
+      "noBooksFound": "Geen boeken gevonden in deze reeks",
+      "trySelectingLibrary": "Probeer een andere bibliotheek te selecteren.",
+      "allBooksLoaded": "Alle {count} boeken geladen",
+      "leadBookLoadError": "Details van eerste boek konden niet worden geladen",
+      "noBooksToEdit": "Deze reeks heeft geen boeken om te bewerken.",
+      "loadFullSeriesError": "De volledige reeks kon niet worden geladen om te bewerken.",
+      "sort": {
+        "seriesOrder": "Reeksvolgorde",
+        "title": "Titel",
+        "recentlyAdded": "Recent toegevoegd"
+      },
+      "order": {
+        "ascending": "Oplopend",
+        "descending": "Aflopend"
+      }
+    }
+  },
+  "smartScope": {
+    "dialog": {
+      "name": "Naam",
+      "namePlaceholder": "bijv. Ongelezen sci-fi",
+      "icon": "Pictogram",
+      "iconPlaceholder": "Kies een pictogram...",
+      "nameRequired": "Naam is verplicht",
+      "iconRequired": "Kies een pictogram",
+      "create": "Aanmaken",
+      "creating": "Aanmaken...",
+      "saving": "Opslaan..."
+    },
+    "createDialog": {
+      "title": "Nieuwe Smart Scope",
+      "visibleToAll": "Zichtbaar voor alle gebruikers",
+      "createFailed": "Smart Scope aanmaken mislukt"
+    },
+    "saveAsDialog": {
+      "title": "Opslaan als SmartScope",
+      "save": "SmartScope opslaan",
+      "saveFailed": "Smart Scope opslaan mislukt"
+    },
+    "editorPanel": {
+      "untitled": "Naamloze SmartScope",
+      "subtitle": "Smart scope-instellingen configureren",
+      "counting": "tellen...",
+      "bookCount": "geen boeken | een boek | {count} boeken",
+      "identity": "Identiteit",
+      "filters": "Filters",
+      "noFilters": "Geen filters ingesteld. Alle toegankelijke boeken worden opgenomen in deze smart scope.",
+      "buildFromScratch": "Vanaf nul opbouwen",
+      "replaceWithTemplate": "Vervangen door sjabloon:",
+      "defaultSort": "Standaardsortering",
+      "saveChanges": "Wijzigingen opslaan",
+      "saveFailed": "Opslaan mislukt",
+      "templates": {
+        "hasSeries": "Heeft reeks",
+        "addedRecently": "Recent toegevoegd",
+        "pdfOnly": "Alleen PDF",
+        "noGenres": "Geen genres",
+        "epubOnly": "Alleen EPUB"
+      }
+    }
+  },
+  "statistics": {
+    "tabs": {
+      "library": "Bibliotheekstatistieken",
+      "user": "Mijn lezen"
+    },
+    "filter": {
+      "allLibraries": "Alle bibliotheken",
+      "librarySelection": "{count} van {total} bibliotheken"
+    },
+    "config": {
+      "button": "Configureren",
+      "title": "Grafieken configureren",
+      "description": "Sleep om te herordenen, schakel om te tonen of verbergen.",
+      "reset": "Standaardwaarden herstellen"
+    },
+    "summary": {
+      "books": "Boeken",
+      "authors": "Auteurs",
+      "series": "Reeksen",
+      "publishers": "Uitgevers",
+      "storage": "Opslag",
+      "genres": "Genres",
+      "languages": "Talen",
+      "published": "Gepubliceerd",
+      "thisYear": "Dit jaar",
+      "started": "Gestart",
+      "inProgress": "Bezig",
+      "completed": "Voltooid",
+      "avgProgress": "Gem. voortgang"
+    },
+    "card": {
+      "loadError": "Laden van gegevens mislukt",
+      "emptyTitle": "Nog geen gegevens",
+      "emptyDescription": "Geen gegevens beschikbaar voor deze grafiek",
+      "unknownField": "geen gegevens voor dit veld | {count} boek heeft geen gegevens voor dit veld | {count} boeken hebben geen gegevens voor dit veld"
+    },
+    "breakdown": {
+      "ariaLabel": "Uitsplitsen op bron of formaat"
+    },
+    "empty": {
+      "notEnoughData": "Nog niet genoeg gegevens"
+    },
+    "charts": {
+      "acquisitionLag": {
+        "title": "Aanschafvertraging"
+      },
+      "booksAddedOverTime": {
+        "title": "Toegevoegde boeken in de tijd",
+        "monthly": "Maandelijks",
+        "yearly": "Jaarlijks",
+        "allTime": "Alle tijd",
+        "last5Years": "Laatste 5 jaar",
+        "lastYear": "Afgelopen jaar"
+      },
+      "formatDistribution": {
+        "title": "Formaatverdeling"
+      },
+      "formatShareOverTime": {
+        "title": "Formaataandeel in de tijd"
+      },
+      "genreCooccurrence": {
+        "title": "Gezamenlijk voorkomen van genres"
+      },
+      "genreDistribution": {
+        "title": "Genreverdeling"
+      },
+      "languageDistribution": {
+        "title": "Taalverdeling"
+      },
+      "largestBooks": {
+        "title": "Top 50 grootste boeken"
+      },
+      "libraryIntegrity": {
+        "title": "Bibliotheekintegriteit"
+      },
+      "libraryMetadataCompleteness": {
+        "title": "Metadata-volledigheid bibliotheek"
+      },
+      "metadataCompleteness": {
+        "title": "Metadata-volledigheid"
+      },
+      "metadataFreshness": {
+        "title": "Metadata-actualiteit"
+      },
+      "metadataScoreDistribution": {
+        "title": "Verdeling metadata-score"
+      },
+      "pageCountDistribution": {
+        "title": "Verdeling paginaaantal"
+      },
+      "publicationDecade": {
+        "title": "Publicatiedecennium"
+      },
+      "publicationYearTimeline": {
+        "title": "Tijdlijn publicatiejaar"
+      },
+      "storageByFormat": {
+        "title": "Opslag per formaat"
+      },
+      "topAuthors": {
+        "title": "Top 25 auteurs"
+      },
+      "topSeries": {
+        "title": "Top 50 reeksen"
+      },
+      "booksCompleted": {
+        "title": "Voltooide boeken",
+        "notEnoughData": "Minimaal {count} voltooide boeken nodig voor deze grafiek."
+      },
+      "completionLatency": {
+        "title": "Voltooiingsvertraging",
+        "notEnoughData": "Minimaal {count} voltooide boeken nodig voor deze grafiek."
+      },
+      "completionTimeline": {
+        "title": "Voltooiingstijdlijn",
+        "notEnoughData": "Minimaal {count} voltooide boeken nodig voor deze grafiek."
+      },
+      "favoriteReadingDays": {
+        "title": "Favoriete leesdagen",
+        "notEnoughData": "Minimaal {count} leesgebeurtenissen nodig voor deze grafiek."
+      },
+      "genreReadingTime": {
+        "title": "Leestijd per genre",
+        "notEnoughData": "Minimaal {count} genres met leestijd nodig voor deze grafiek."
+      },
+      "goalTrajectory": {
+        "title": "Tempo versus doel",
+        "noCompletedTitle": "Nog geen voltooide boeken",
+        "noCompletedDescription": "Voltooi een boek in deze periode om je tempo te vergelijken met je jaardoel.",
+        "notEnoughData": "Minimaal {count} voltooide boeken nodig voor deze grafiek."
+      },
+      "peakReadingHours": {
+        "title": "Piekleesuren",
+        "notEnoughData": "Minimaal {count} leesgebeurtenissen nodig voor deze grafiek."
+      },
+      "progressFunnel": {
+        "title": "Voortgangstrechter",
+        "modePercent": "Percentage",
+        "modeCounts": "Aantallen",
+        "modeDropoff": "Uitval",
+        "started": "Gestart {count}",
+        "notEnoughData": "Minimaal {count} gestarte boeken nodig voor deze grafiek.",
+        "noDropOffTitle": "Geen uitval waargenomen",
+        "noDropOffDescription": "Elk gestart boek doorliep alle trechterfasen in deze periode."
+      },
+      "readingClock": {
+        "title": "Leesklok",
+        "notEnoughData": "Minimaal {count} leessessies nodig voor deze grafiek."
+      },
+      "readingHeatmap": {
+        "title": "Lees-heatmap",
+        "notEnoughData": "Activiteit op minimaal {count} dagen nodig voor deze grafiek."
+      },
+      "readingPace": {
+        "title": "Leestempo",
+        "notEnoughData": "Minimaal {count} sessies met voortgangsgegevens nodig voor deze grafiek."
+      },
+      "readingSessionTimeline": {
+        "title": "Tijdlijn leessessies",
+        "dragOn": "Slepen: aan",
+        "dragOff": "Slepen: uit",
+        "prev": "Vorige",
+        "next": "Volgende",
+        "week": "Week {week}",
+        "dragHint": "Sleep balken om sessies te verplaatsen. De duur is vergrendeld en overlappende sessies worden geweigerd.",
+        "noSessionsTitle": "Geen sessies deze week",
+        "noSessionsDescription": "Gebruik Vorige/Volgende of de weekkiezer om een andere week te bekijken.",
+        "overlapError": "Sessie overlapt met een andere sessie in dit venster",
+        "moveError": "Verplaatsen van sessie mislukt"
+      },
+      "sessionArchetypes": {
+        "title": "Sessie-archetypen"
+      },
+      "sourceDistribution": {
+        "title": "Waar je leest",
+        "emptyTitle": "Nog geen leesactiviteit",
+        "emptyDescription": "Lees op het web, in KOReader of op Kobo om je bronverdeling te zien."
+      }
+    }
+  },
+  "tools": {
+    "header": {
+      "entityManager": "Entiteitenbeheer",
+      "bulkRename": "Bulk hernoemen"
+    },
+    "entityTypes": {
+      "authors": "Auteurs",
+      "genres": "Genres",
+      "tags": "Labels",
+      "narrators": "Vertellers",
+      "publishers": "Uitgevers",
+      "languages": "Talen",
+      "series": "Reeksen"
+    },
+    "bulkRename": {
+      "library": "Bibliotheek",
+      "selectLibraryPlaceholder": "Selecteer een bibliotheek...",
+      "noEligibleLibraries": "Geen bibliotheken hebben bestand hernoemen ingeschakeld. Schakel het in bij Bibliotheekinstellingen.",
+      "refresh": "Vernieuwen",
+      "applyRename": "Hernoemen toepassen",
+      "showFullPaths": "Volledige paden tonen",
+      "columnsMenu": "Kolommen",
+      "renamingInProgress": "Bestanden worden hernoemd - je kunt op elk moment annuleren.",
+      "executionFailed": "Bulk hernoemen mislukt",
+      "previewFailed": "Voorbeeld laden mislukt",
+      "noBooksMatch": "Geen boeken gevonden die aan het huidige filter voldoen.",
+      "openBookDetails": "Boekdetails openen",
+      "columns": {
+        "title": "Titel",
+        "currentPath": "Huidig pad",
+        "newPath": "Nieuw pad",
+        "status": "Status"
+      },
+      "status": {
+        "willRename": "Wordt hernoemd",
+        "unchanged": "Ongewijzigd",
+        "collision": "Conflict",
+        "noPattern": "Geen patroon",
+        "error": "Fout"
+      },
+      "filter": {
+        "all": "Alle"
+      },
+      "summary": {
+        "label": "Samenvatting",
+        "toRename": "{count} te hernoemen",
+        "unchanged": "{count} ongewijzigd",
+        "collisions": "{count} conflicten | {count} conflict | {count} conflicten",
+        "errors": "{count} fouten | {count} fout | {count} fouten"
+      },
+      "empty": {
+        "title": "Kies een bibliotheek om te beginnen",
+        "description": "Selecteer hierboven een bibliotheek om hernoemwijzigingen te bekijken, op status te filteren en de bulk hernoem-actie toe te passen.",
+        "chooseLibrary": "Bibliotheek kiezen"
+      },
+      "completed": {
+        "title": "Bulk hernoemen voltooid",
+        "stats": "{succeeded} hernoemd, {failed} mislukt, {skipped} overgeslagen ({processed} totaal)"
+      },
+      "pagination": {
+        "showing": "{from}-{to} van {total} weergegeven"
+      },
+      "confirmDialog": {
+        "title": "Bulk hernoemen bevestigen",
+        "body": "Hiermee wordt {count} boek op schijf hernoemd. Bestanden met conflicten of fouten worden overgeslagen. Deze actie kan niet ongedaan worden gemaakt. | Hiermee wordt {count} boek op schijf hernoemd. Bestanden met conflicten of fouten worden overgeslagen. Deze actie kan niet ongedaan worden gemaakt. | Hiermee worden {count} boeken op schijf hernoemd. Bestanden met conflicten of fouten worden overgeslagen. Deze actie kan niet ongedaan worden gemaakt.",
+        "renameButton": "{count} boek hernoemen | {count} boek hernoemen | {count} boeken hernoemen"
+      }
+    },
+    "entityManager": {
+      "unknown": "Onbekend",
+      "bookCount": "geen boeken | {count} boek | {count} boeken",
+      "sortPrefix": "· sorteer: {sortName}",
+      "selectTargetToKeep": "Selecteer doel om te behouden",
+      "writeToFiles": "Naar bestanden schrijven",
+      "writeChangesToFiles": "Wijzigingen naar bestanden schrijven",
+      "mergeIntoTarget": "{count} samenvoegen in doel",
+      "modes": {
+        "browse": "Bladeren & beheren",
+        "duplicates": "Duplicaten zoeken"
+      },
+      "actions": {
+        "rename": "Hernoemen",
+        "split": "Splitsen"
+      },
+      "duplicates": {
+        "similarity": "Gelijkenis:",
+        "scan": "Scannen",
+        "scanning": "Scannen...",
+        "computing": "Kandidaten berekenen...",
+        "computedAt": "Kandidaten berekend op {date}",
+        "recompute": "Opnieuw berekenen",
+        "noneComputed": "Nog geen kandidaten berekend.",
+        "computeNow": "Nu berekenen",
+        "emptyTitle": "Dubbele entiteiten zoeken",
+        "emptyDescription": "Pas de gelijkenisdrempel aan en klik op Scannen om mogelijke duplicaten te detecteren.",
+        "noneFoundTitle": "Geen duplicaten gevonden",
+        "noneFoundDescription": "Er zijn geen mogelijke duplicaten gedetecteerd met de huidige instellingen.",
+        "clustersFound": "geen clusters gevonden | {count} cluster gevonden | {count} clusters gevonden",
+        "plusOthers": "+ {count} andere | + {count} andere | + {count} andere",
+        "percentSimilar": "{percent}% gelijk",
+        "pairDetails": "Paardetails",
+        "dismissEntityTitle": "Alle paren voor deze entiteit negeren",
+        "dismissPairTitle": "Dit paar negeren"
+      },
+      "dismissed": {
+        "loading": "Genegeerde paren laden...",
+        "empty": "Geen genegeerde paren",
+        "restore": "Herstellen",
+        "restoreTitle": "Dit paar herstellen",
+        "hidePairs": "Genegeerde paren verbergen",
+        "showPairs": "Genegeerde paren tonen"
+      },
+      "browse": {
+        "searchPlaceholder": "Zoeken...",
+        "emptyOnly": "Alleen leeg",
+        "clear": "Wissen",
+        "noEntities": "Geen entiteiten gevonden",
+        "mergeCount": "Samenvoegen ({count})",
+        "deleteCount": "Verwijderen ({count})",
+        "totalCount": "{count} totaal",
+        "sortLabel": "sorteer: {sortName}",
+        "sort": {
+          "nameAsc": "Naam A-Z",
+          "nameDesc": "Naam Z-A",
+          "fewestBooks": "Minste boeken",
+          "mostBooks": "Meeste boeken"
+        }
+      },
+      "deleteMode": {
+        "label": "Verwijdermodus",
+        "softTitle": "Zacht verwijderen",
+        "softDescription": "Loskoppelen van alle boeken maar het entiteitsrecord behouden",
+        "softDescriptionPlural": "Loskoppelen van alle boeken maar de entiteitsrecords behouden",
+        "hardTitle": "Hard verwijderen",
+        "hardDescription": "Entiteit en alle koppelingen permanent verwijderen",
+        "hardDescriptionPlural": "Entiteiten en alle koppelingen permanent verwijderen"
+      },
+      "renameModal": {
+        "title": "Entiteit hernoemen",
+        "currentName": "Huidige naam",
+        "newName": "Nieuwe naam"
+      },
+      "deleteModal": {
+        "title": "Entiteit verwijderen",
+        "confirm": "Weet je zeker dat je {name} wilt verwijderen?"
+      },
+      "splitModal": {
+        "title": "Entiteit splitsen",
+        "splitting": "Splitsen",
+        "newNames": "Nieuwe namen (min. 2)",
+        "namePlaceholder": "Voer een naam in...",
+        "addAnother": "Nog een toevoegen"
+      },
+      "bulkDeleteModal": {
+        "title": "Bulk verwijderen",
+        "confirm": "Weet je zeker dat je {count} geselecteerde entiteit wilt verwijderen? | Weet je zeker dat je {count} geselecteerde entiteit wilt verwijderen? | Weet je zeker dat je {count} geselecteerde entiteiten wilt verwijderen?",
+        "deleteButton": "{count} verwijderen"
+      },
+      "mergeModal": {
+        "title": "Entiteiten samenvoegen",
+        "description": "Selecteer welke entiteit je wilt behouden. De andere worden erin samengevoegd en verwijderd."
+      }
+    }
+  },
+  "views": {
+    "entity": {
+      "book": "Boek",
+      "collection": "Collectie",
+      "library": "Bibliotheek",
+      "smartScope": "SmartScope"
+    },
+    "common": {
+      "retry": "Opnieuw proberen"
+    },
+    "bookView": {
+      "sort": "Sorteren",
+      "sortOn": "Aan",
+      "resetSort": "Sortering herstellen naar standaard",
+      "filters": "Filters",
+      "clear": "Wissen",
+      "clearAllFilters": "Alle filters wissen",
+      "expandSeries": "Reeks uitklappen",
+      "collapseSeries": "Reeks inklappen",
+      "expanded": "Uitgeklapt",
+      "exportMetadata": "Metadata exporteren",
+      "export": "Exporteren",
+      "searchPlaceholder": "Zoek op titel, auteur, reeks, verteller...",
+      "allBooksLoaded": "Alle {count} boeken geladen"
+    },
+    "notFound": {
+      "title": "Pagina niet gevonden",
+      "description": "De pagina die je zoekt bestaat niet.",
+      "goHome": "Naar startpagina"
+    },
+    "dashboard": {
+      "customize": "Dashboard aanpassen",
+      "allShelvesHidden": "Alle planken zijn verborgen.",
+      "greeting": {
+        "morning": "Goedemorgen,",
+        "afternoon": "Goedemiddag,",
+        "evening": "Goedenavond,",
+        "fallbackName": "daar"
+      }
+    },
+    "bookDetail": {
+      "title": "Boek",
+      "titleWithId": "Boek #{id}",
+      "pageTitle": {
+        "book": "Boek · {base}",
+        "editMetadata": "Metadata bewerken · {base}",
+        "edit": "Bewerken · {base}",
+        "files": "Bestanden · {base}",
+        "readingLog": "Leeslogboek · {base}",
+        "highlights": "Markeringen · {base}"
+      }
+    },
+    "bookDock": {
+      "title": "Book Dock",
+      "newFilesDetected": "Nieuwe bestanden gevonden",
+      "reconnecting": "Opnieuw verbinden",
+      "rescanFailed": "Opnieuw scannen mislukt",
+      "totalInDock": "{size} in Book Dock",
+      "dropFiles": "Sleep bestanden naar Book Dock",
+      "supportedFormats": "Ondersteund: {formats}",
+      "empty": {
+        "noSearchMatch": "Geen bestanden komen overeen met \"{query}\"",
+        "noStatusFiles": "Geen {status} bestanden",
+        "uploadPrompt": "Upload bestanden of zet ze in de Book Dock-map"
+      },
+      "retry": {
+        "noneToRetry": "Geen bestanden met fouten om opnieuw te proberen",
+        "retrying": "Eén bestand opnieuw proberen | Eén bestand opnieuw proberen | {count} bestanden opnieuw proberen"
+      },
+      "applyFetched": {
+        "applied": "Op geen bestanden toegepast | Op één bestand toegepast | Op {count} bestanden toegepast",
+        "skippedEdited": "één bestand overgeslagen omdat het handmatige bewerkingen bevat | één bestand overgeslagen omdat het handmatige bewerkingen bevat | {count} bestanden overgeslagen omdat ze handmatige bewerkingen bevatten",
+        "skippedNoMetadata": "één bestand overgeslagen omdat het geen opgehaalde metadata heeft | één bestand overgeslagen omdat het geen opgehaalde metadata heeft | {count} bestanden overgeslagen omdat ze geen opgehaalde metadata hebben",
+        "noneApplied": "Geen bestanden toegepast; {reasons}",
+        "noneSelected": "Geen bestanden geselecteerd"
+      }
+    },
+    "collection": {
+      "title": "Collectie",
+      "pageTitle": "Collectie · {name}",
+      "pageTitleWithId": "Collectie #{id}",
+      "editCollection": "Collectie bewerken",
+      "loadError": "Kan deze collectie niet laden",
+      "toast": {
+        "removed": "Geen boeken uit collectie verwijderd | Eén boek uit collectie verwijderd | {count} boeken uit collectie verwijderd",
+        "removeFailed": "Boeken verwijderen uit collectie mislukt"
+      },
+      "empty": {
+        "noSearchMatch": "Geen boeken komen overeen met deze zoekopdracht",
+        "noSearchMatchHint": "Probeer een andere zoekterm of wis de zoekopdracht.",
+        "noBooks": "Geen boeken in deze collectie",
+        "noBooksHint": "Selecteer boeken uit je bibliotheek en voeg ze hier toe."
+      }
+    },
+    "library": {
+      "title": "Bibliotheek",
+      "pageTitle": "Bibliotheek · {name}",
+      "pageTitleWithId": "Bibliotheek #{id}",
+      "filterRules": "Filterregels",
+      "saveAsSmartScope": "Opslaan als Smart Scope",
+      "saveScope": "Scope opslaan",
+      "saveAsSmartScopeTooltip": "Sla dit filter op als een benoemde Smart Scope",
+      "saved": "Opgeslagen",
+      "saveFilter": "Filter opslaan",
+      "filterSaved": "Filter opgeslagen",
+      "saveFilterTooltip": "Filter opslaan voor deze bibliotheek",
+      "removeSavedFilter": "Opgeslagen filter verwijderen",
+      "empty": {
+        "noFilterMatch": "Geen boeken komen overeen met je filters",
+        "noFilterMatchHint": "Pas je filters aan of wis ze om meer boeken te zien.",
+        "clearFilters": "Filters wissen",
+        "scanning": "Je bibliotheek scannen...",
+        "scanningHint": "Boeken verschijnen hier zodra ze worden ontdekt.",
+        "emptyLibrary": "Je bibliotheek is leeg",
+        "emptyLibraryHint": "Zodra je boeken aan deze bibliotheek toevoegt, verschijnen ze hier."
+      },
+      "querySelection": {
+        "loadedSelected": "{selected} van {total} geladen boeken geselecteerd.",
+        "selectAllMatching": "Selecteer alle {total} overeenkomende boeken"
+      }
+    },
+    "smartScope": {
+      "title": "SmartScope",
+      "pageTitle": "SmartScope · {name}",
+      "pageTitleWithId": "SmartScope #{id}",
+      "defaultName": "Smart scope",
+      "filter": "Filter",
+      "hideFilter": "Filter verbergen",
+      "showFilter": "Filter tonen",
+      "confirmDelete": "Bevestigen?",
+      "loadError": "Kan deze SmartScope niet laden",
+      "toast": {
+        "deleted": "\"{name}\" verwijderd",
+        "deleteFailed": "Verwijderen van \"{name}\" mislukt"
+      },
+      "empty": {
+        "noRules": "Geen regels ingesteld",
+        "noRulesHint": "Open de editor om met filters en sorteerregels te bepalen welke boeken in deze smartScope verschijnen.",
+        "configure": "SmartScope configureren",
+        "noMatch": "Geen boeken komen overeen met deze smartScope",
+        "noMatchHint": "Probeer de filterregels aan te passen.",
+        "edit": "SmartScope bewerken"
+      }
+    }
+  },
+  "whatsNew": {
+    "title": "Wat is er nieuw",
+    "subtitle": "Alles wat is uitgebracht, nieuwste eerst.",
+    "versionPrefix": "Versie {version}",
+    "newUpdates": "geen nieuwe updates | één nieuwe update | {count} nieuwe updates",
+    "remindLater": "Later herinneren",
+    "gotIt": "Begrepen",
+    "latest": "Nieuwste",
+    "fullChangelog": "Volledige changelog",
+    "seeAllReleases": "Alle releases bekijken",
+    "versions": "Versies",
+    "currentVersion": "Huidige versie",
+    "youreHere": "Je bent hier",
+    "searchPlaceholder": "Releases zoeken…",
+    "noReleasesFound": "Geen releases gevonden.",
+    "noHighlights": "Geen hoogtepunten voor deze release.",
+    "showChangelog": "Volledige changelog tonen",
+    "hideChangelog": "Volledige changelog verbergen",
+    "openOnGitHub": "Openen op GitHub",
+    "loadMore": "Meer laden",
+    "loadingMore": "Laden…",
+    "loadFailed": "Laden van releases mislukt",
+    "loadMoreFailed": "Kon niet meer releases laden. Probeer het opnieuw.",
+    "loadErrorHint": "Kon releases niet laden. Controleer je verbinding en probeer het opnieuw.",
+    "retry": "Opnieuw proberen",
+    "imageViewer": "Afbeeldingsviewer",
+    "closeImage": "Afbeelding sluiten",
+    "previousImage": "Vorige afbeelding",
+    "nextImage": "Volgende afbeelding"
   }
 }

--- a/client/src/locales/nl.json
+++ b/client/src/locales/nl.json
@@ -309,6 +309,13 @@
           "delete": "Pictogram verwijderen mislukt",
           "bulkDelete": "Pictogrammen verwijderen mislukt"
         }
+      },
+      "tabs": {
+        "theme": "Thema",
+        "book-covers": "Boekomslagen",
+        "icons": "Pictogrammen",
+        "layout": "Indeling",
+        "behavior": "Gedrag"
       }
     },
     "account": {
@@ -954,6 +961,11 @@
         "recalcStarted": "Herberekening van scores gestart op de achtergrond",
         "recalcFailed": "Herberekening mislukt",
         "resetToDefaults": "Gewichten teruggezet naar standaardwaarden. Sla op om toe te passen."
+      },
+      "tabs": {
+        "users": "Gebruikers",
+        "magic-links": "Magische links",
+        "oidc": "OIDC / SSO"
       }
     },
     "common": {
@@ -1279,6 +1291,33 @@
         "clear": "Wissen",
         "noLibraries": "Nog geen bibliotheken beschikbaar.",
         "allLibraries": "Alle bibliotheken"
+      },
+      "tabs": {
+        "providers": "Providers",
+        "field-rules": "Veldregels",
+        "custom-fields": "Aangepaste velden",
+        "genre-blocklist": "Genre-blokkeerlijst",
+        "score": "Score",
+        "auto-fetch": "Boeken",
+        "authors": "Auteurs"
+      },
+      "tabTitles": {
+        "providers": "Providers",
+        "field-rules": "Regels op veldniveau",
+        "custom-fields": "Aangepaste metadata",
+        "genre-blocklist": "Genre-blokkeerlijst",
+        "score": "Betrouwbaarheidsscore",
+        "auto-fetch": "Boeken automatisch ophalen",
+        "authors": "Auteurs automatisch ophalen"
+      },
+      "tabSubtitles": {
+        "providers": "Schakel externe metadatabronnen in en configureer hun inloggegevens.",
+        "field-rules": "Bepaal welke provider elk metadataveld levert en hoe waarden worden samengevoegd in je bibliotheken.",
+        "custom-fields": "Definieer aangepaste metadatavelden en kies welke bibliotheken ze gebruiken.",
+        "genre-blocklist": "Voorkom dat ongewenste genrewaarden van providers naar boeken worden geschreven.",
+        "score": "Ken gewichten toe aan metadatavelden om te berekenen hoeveel vertrouwen opgehaalde resultaten verdienen.",
+        "auto-fetch": "Haal automatisch omslagen, beschrijvingen en andere details op wanneer nieuwe boeken aan je bibliotheek worden toegevoegd.",
+        "authors": "Haal automatisch biografieën en profielfoto's op wanneer nieuwe auteurs in je bibliotheek verschijnen."
       }
     },
     "reader": {
@@ -1780,6 +1819,22 @@
         "deleteUserFailed": "Kan OPDS-gebruiker niet verwijderen",
         "labelCopied": "{label} gekopieerd",
         "copyLabelFailed": "Kan {label} niet kopiëren"
+      },
+      "tabs": {
+        "general": "Algemeen",
+        "ebook": "eBook",
+        "pdf": "PDF",
+        "comics": "Strips",
+        "audio": "Luisterboek",
+        "fonts": "Lettertypen"
+      }
+    },
+    "system": {
+      "tabs": {
+        "file-naming": "Bestandsnaamgeving",
+        "book-dock": "Book Dock",
+        "maintenance": "Onderhoud",
+        "audit-log": "Auditlogboek"
       }
     }
   },
@@ -5579,5 +5634,84 @@
     "closeImage": "Afbeelding sluiten",
     "previousImage": "Vorige afbeelding",
     "nextImage": "Volgende afbeelding"
+  },
+  "titles": {
+    "dashboard": "Dashboard",
+    "libraries": "Bibliotheken",
+    "opds": "OPDS",
+    "koboSync": "Kobo-synchronisatie",
+    "koreaderSync": "KOReader-synchronisatie",
+    "bookDock": "Book Dock",
+    "whatsNew": "Nieuw",
+    "annotations": "Annotaties",
+    "achievements": "Prestaties",
+    "statistics": "Statistieken",
+    "authors": "Auteurs",
+    "series": "Reeksen",
+    "entityManager": "Entiteitenbeheer",
+    "bulkRename": "Bulksgewijs hernoemen",
+    "notFound": "Niet gevonden",
+    "signIn": "Inloggen",
+    "initialSetup": "Eerste installatie",
+    "forgotPassword": "Wachtwoord vergeten",
+    "resetPassword": "Wachtwoord opnieuw instellen",
+    "completingSignIn": "Inloggen voltooien",
+    "magicLinkLogin": "Inloggen via magische link",
+    "readPrefix": "Lezen",
+    "emailSuffix": "E-mail",
+    "library": "Bibliotheek",
+    "smartScope": "SmartScope",
+    "collection": "Collectie",
+    "author": "Auteur",
+    "book": "Boek",
+    "seriesItem": "Reeks",
+    "appearance": {
+      "theme": "Weergave",
+      "book-covers": "Boekomslagen",
+      "icons": "Pictogrammen",
+      "layout": "Weergave-indeling",
+      "behavior": "Bibliotheekgedrag"
+    },
+    "reader": {
+      "general": "Lezerinstellingen",
+      "ebook": "eBook-lezer",
+      "pdf": "PDF-lezer",
+      "comics": "Stripboeklezer",
+      "audio": "Luisterboekspeler",
+      "fonts": "Lezerlettertypen"
+    },
+    "email": {
+      "providers": "Providers",
+      "recipients": "Ontvangers",
+      "groups": "Groepen",
+      "templates": "Sjablonen",
+      "preferences": "Voorkeuren",
+      "history": "Geschiedenis"
+    },
+    "metadata": {
+      "providers": "Providers",
+      "field-rules": "Regels op veldniveau",
+      "custom-fields": "Aangepaste metadata",
+      "genre-blocklist": "Genre-blokkeerlijst",
+      "score": "Betrouwbaarheidsscore",
+      "auto-fetch": "Boeken automatisch ophalen",
+      "authors": "Auteurs automatisch ophalen"
+    },
+    "admin": {
+      "users": "Gebruikers",
+      "magic-links": "Magische links",
+      "oidc": "OIDC / SSO"
+    },
+    "system": {
+      "file-naming": "Bestandsnaamgeving",
+      "book-dock": "Book Dock",
+      "maintenance": "Onderhoud",
+      "audit-log": "Auditlogboek"
+    },
+    "account": {
+      "profile": "Account",
+      "notifications": "Meldingen",
+      "restrictions": "Inhoudsbeperkingen"
+    }
   }
 }

--- a/client/src/locales/nl.json
+++ b/client/src/locales/nl.json
@@ -1,0 +1,26 @@
+{
+  "common": {
+    "save": "Opslaan",
+    "cancel": "Annuleren",
+    "delete": "Verwijderen",
+    "edit": "Bewerken",
+    "close": "Sluiten",
+    "confirm": "Bevestigen",
+    "loading": "Laden...",
+    "search": "Zoeken",
+    "back": "Terug",
+    "next": "Volgende",
+    "previous": "Vorige",
+    "yes": "Ja",
+    "no": "Nee"
+  },
+  "settings": {
+    "appearance": {
+      "language": {
+        "title": "Taal",
+        "description": "Kies de taal die in de hele interface wordt gebruikt.",
+        "label": "Interfacetaal"
+      }
+    }
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -6,6 +6,8 @@ import { createPinia } from 'pinia'
 
 import App from './App.vue'
 import router from './router'
+import { i18n } from './i18n'
+import { useLocaleStore } from './stores/locale'
 import { useAuth } from './features/auth/composables/useAuth'
 import { useSetupStatus } from './features/auth/composables/useSetupStatus'
 
@@ -36,6 +38,12 @@ ariaHiddenObserver.observe(document.body, {
 const app = createApp(App)
 
 app.use(createPinia())
+app.use(i18n)
+
+// Load and apply the initial locale (stored preference or browser language) before mount
+// so the first paint is already localized. Server-synced locale is applied later during auth.
+const localeStore = useLocaleStore()
+await localeStore.setLocale(localeStore.locale)
 
 // Resolve setup status/auth before installing router.
 // app.use(router) triggers initial navigation and guard execution.

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,13 +1,16 @@
 import { createRouter, createWebHistory, type RouteLocationNormalizedLoaded, type RouteRecordRaw } from 'vue-router'
-import { EMAIL_TAB_LABELS, normalizeEmailTab } from '@/features/email/lib/email-tabs'
-import { METADATA_TAB_INFO, normalizeMetadataTab } from '@/features/settings/lib/metadata-tabs'
-import { READER_TAB_TITLE_LABELS, normalizeReaderTab } from '@/features/settings/lib/reader-tabs'
-import { ADMIN_TAB_INFO, normalizeAdminTab } from '@/features/settings/lib/admin-tabs'
-import { SYSTEM_TAB_INFO, normalizeSystemTab } from '@/features/settings/lib/system-tabs'
-import { ACCOUNT_TAB_INFO, normalizeAccountTab } from '@/features/settings/lib/account-tabs'
-import { APPEARANCE_TAB_TITLE_LABELS, normalizeAppearanceTab } from '@/features/settings/lib/appearance-tabs'
+import { i18n } from '@/i18n'
+import { normalizeEmailTab } from '@/features/email/lib/email-tabs'
+import { normalizeMetadataTab } from '@/features/settings/lib/metadata-tabs'
+import { normalizeReaderTab } from '@/features/settings/lib/reader-tabs'
+import { normalizeAdminTab } from '@/features/settings/lib/admin-tabs'
+import { normalizeSystemTab } from '@/features/settings/lib/system-tabs'
+import { normalizeAccountTab } from '@/features/settings/lib/account-tabs'
+import { normalizeAppearanceTab } from '@/features/settings/lib/appearance-tabs'
 import { registerAuthGuard } from './guards/auth.guard'
 import { registerRouteTitleHook } from './title-resolver'
+
+const t = i18n.global.t
 
 function firstText(value: unknown): string | null {
   if (Array.isArray(value)) return firstText(value[0])
@@ -23,47 +26,48 @@ function numericParam(to: RouteLocationNormalizedLoaded, key: string): number | 
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null
 }
 
-function fallbackById(prefix: string, id: number | null): string {
+function fallbackById(prefixKey: string, id: number | null): string {
+  const prefix = t(prefixKey)
   return id === null ? prefix : `${prefix} #${id}`
 }
 
 function resolveReaderTitle(to: RouteLocationNormalizedLoaded): string {
   const tab = normalizeReaderTab(to.query.tab)
-  return READER_TAB_TITLE_LABELS[tab]
+  return t(`titles.reader.${tab}`)
 }
 
 function resolveAppearanceTitle(to: RouteLocationNormalizedLoaded): string {
   const tab = normalizeAppearanceTab(to.query.tab)
-  return APPEARANCE_TAB_TITLE_LABELS[tab]
+  return t(`titles.appearance.${tab}`)
 }
 
 function resolveEmailTitle(to: RouteLocationNormalizedLoaded): string {
   const tab = normalizeEmailTab(to.query.tab)
-  return `${EMAIL_TAB_LABELS[tab]} · Email`
+  return `${t(`titles.email.${tab}`)} · ${t('titles.emailSuffix')}`
 }
 
 function resolveMetadataTitle(to: RouteLocationNormalizedLoaded): string {
   const tab = normalizeMetadataTab(to.query.tab)
-  return METADATA_TAB_INFO[tab].titleLabel
+  return t(`titles.metadata.${tab}`)
 }
 
 function resolveAdminTitle(to: RouteLocationNormalizedLoaded): string {
   const tab = normalizeAdminTab(to.query.tab)
-  return ADMIN_TAB_INFO[tab].titleLabel
+  return t(`titles.admin.${tab}`)
 }
 
 function resolveSystemTitle(to: RouteLocationNormalizedLoaded): string {
   const tab = normalizeSystemTab(to.query.tab)
-  return SYSTEM_TAB_INFO[tab].titleLabel
+  return t(`titles.system.${tab}`)
 }
 
 function resolveAccountTitle(to: RouteLocationNormalizedLoaded): string {
   const tab = normalizeAccountTab(to.query.tab)
-  return ACCOUNT_TAB_INFO[tab].titleLabel
+  return t(`titles.account.${tab}`)
 }
 
 function resolveStatisticsTitle(): string {
-  return 'Statistics'
+  return t('titles.statistics')
 }
 
 function resolveLegacyIntegrationsRoute(tab: unknown): string {
@@ -87,7 +91,7 @@ export const routes: RouteRecordRaw[] = [
         path: '',
         name: 'dashboard',
         component: () => import('@/views/DashboardView.vue'),
-        meta: { title: 'Dashboard' },
+        meta: { title: () => t('titles.dashboard') },
       },
       {
         path: '/settings',
@@ -109,7 +113,7 @@ export const routes: RouteRecordRaw[] = [
             path: 'libraries',
             name: 'settings-libraries',
             component: () => import('@/features/settings/LibrariesSettings.vue'),
-            meta: { maxWidth: 'max-w-[52rem]', title: 'Libraries' },
+            meta: { maxWidth: 'max-w-[52rem]', title: () => t('titles.libraries') },
           },
           {
             path: 'appearance',
@@ -121,7 +125,7 @@ export const routes: RouteRecordRaw[] = [
             path: 'opds',
             name: 'settings-opds',
             component: () => import('@/features/settings/OpdsSettings.vue'),
-            meta: { title: 'OPDS' },
+            meta: { title: () => t('titles.opds') },
           },
           {
             path: 'integrations',
@@ -132,13 +136,13 @@ export const routes: RouteRecordRaw[] = [
             path: 'kobo',
             name: 'settings-kobo',
             component: () => import('@/features/settings/KoboSettings.vue'),
-            meta: { maxWidth: 'max-w-4xl', title: 'Kobo Sync' },
+            meta: { maxWidth: 'max-w-4xl', title: () => t('titles.koboSync') },
           },
           {
             path: 'koreader',
             name: 'settings-koreader',
             component: () => import('@/features/settings/KoreaderSettings.vue'),
-            meta: { maxWidth: 'max-w-4xl', title: 'KOReader Sync' },
+            meta: { maxWidth: 'max-w-4xl', title: () => t('titles.koreaderSync') },
           },
           {
             path: 'hardcover',
@@ -238,19 +242,19 @@ export const routes: RouteRecordRaw[] = [
         path: '/book-dock',
         name: 'book-dock',
         component: () => import('@/views/BookDockView.vue'),
-        meta: { title: 'Book Dock' },
+        meta: { title: () => t('titles.bookDock') },
       },
       {
         path: '/whats-new',
         name: 'whats-new',
         component: () => import('@/features/whats-new/WhatsNewView.vue'),
-        meta: { title: "What's New" },
+        meta: { title: () => t('titles.whatsNew') },
       },
       {
         path: '/annotations',
         name: 'annotations',
         component: () => import('@/features/annotations/views/AnnotationsHubView.vue'),
-        meta: { title: 'Annotations' },
+        meta: { title: () => t('titles.annotations') },
       },
       {
         path: '/statistics',
@@ -267,49 +271,49 @@ export const routes: RouteRecordRaw[] = [
         path: '/achievements',
         name: 'achievements',
         component: () => import('@/views/AchievementsView.vue'),
-        meta: { title: 'Achievements' },
+        meta: { title: () => t('titles.achievements') },
       },
       {
         path: '/library/:id',
         name: 'library',
         component: () => import('@/views/HomeView.vue'),
-        meta: { title: (to) => fallbackById('Library', numericParam(to, 'id')) },
+        meta: { title: (to) => fallbackById('titles.library', numericParam(to, 'id')) },
       },
       {
         path: '/smart-scope/:id',
         name: 'smartScope',
         component: () => import('@/views/SmartScopeView.vue'),
-        meta: { title: (to) => fallbackById('SmartScope', numericParam(to, 'id')) },
+        meta: { title: (to) => fallbackById('titles.smartScope', numericParam(to, 'id')) },
       },
       {
         path: '/collection/:id',
         name: 'collection',
         component: () => import('@/views/CollectionView.vue'),
-        meta: { title: (to) => fallbackById('Collection', numericParam(to, 'id')) },
+        meta: { title: (to) => fallbackById('titles.collection', numericParam(to, 'id')) },
       },
       {
         path: '/authors',
         name: 'authors',
         component: () => import('@/features/author/views/AuthorsView.vue'),
-        meta: { title: 'Authors' },
+        meta: { title: () => t('titles.authors') },
       },
       {
         path: '/authors/:id',
         name: 'author-detail',
         component: () => import('@/features/author/views/AuthorDetailView.vue'),
-        meta: { title: (to) => fallbackById('Author', numericParam(to, 'id')) },
+        meta: { title: (to) => fallbackById('titles.author', numericParam(to, 'id')) },
       },
       {
         path: '/series',
         name: 'series',
         component: () => import('@/features/series/views/SeriesView.vue'),
-        meta: { title: 'Series' },
+        meta: { title: () => t('titles.series') },
       },
       {
         path: '/series/:seriesId',
         name: 'series-detail',
         component: () => import('@/features/series/views/SeriesDetailView.vue'),
-        meta: { title: (to) => fallbackById('Series', numericParam(to, 'seriesId')) },
+        meta: { title: (to) => fallbackById('titles.seriesItem', numericParam(to, 'seriesId')) },
       },
       {
         path: '/tools',
@@ -320,13 +324,13 @@ export const routes: RouteRecordRaw[] = [
             path: 'entity-manager',
             name: 'tools-entity-manager',
             component: () => import('@/features/tools/entity-manager/views/EntityManagerView.vue'),
-            meta: { title: 'Entity Manager' },
+            meta: { title: () => t('titles.entityManager') },
           },
           {
             path: 'bulk-rename',
             name: 'tools-bulk-rename',
             component: () => import('@/features/tools/bulk-rename/views/BulkRenameView.vue'),
-            meta: { title: 'Bulk Rename' },
+            meta: { title: () => t('titles.bulkRename') },
           },
           { path: ':pathMatch(.*)*', redirect: { name: 'tools-entity-manager' } },
         ],
@@ -335,7 +339,7 @@ export const routes: RouteRecordRaw[] = [
         path: '/book/:bookId',
         name: 'book-detail',
         component: () => import('@/views/BookDetailView.vue'),
-        meta: { title: (to) => fallbackById('Book', numericParam(to, 'bookId')) },
+        meta: { title: (to) => fallbackById('titles.book', numericParam(to, 'bookId')) },
         beforeEnter: (to) => {
           if (!to.query.tab) {
             return { ...to, query: { ...to.query, tab: 'details' } }
@@ -350,50 +354,50 @@ export const routes: RouteRecordRaw[] = [
         path: '/book/:bookId/edit',
         redirect: (to) => ({ name: 'book-detail', params: to.params, query: { tab: 'edit' } }),
       },
-      { path: ':pathMatch(.*)*', component: () => import('@/views/NotFoundView.vue'), meta: { title: 'Not Found' } },
+      { path: ':pathMatch(.*)*', component: () => import('@/views/NotFoundView.vue'), meta: { title: () => t('titles.notFound') } },
     ],
   },
   {
     path: '/read/:bookId/:fileId',
     name: 'reader',
     component: () => import('@/features/reader/ReaderView.vue'),
-    meta: { title: (to) => `Read · ${fallbackById('Book', numericParam(to, 'bookId'))}` },
+    meta: { title: (to) => `${t('titles.readPrefix')} · ${fallbackById('titles.book', numericParam(to, 'bookId'))}` },
   },
   {
     path: '/login',
     name: 'login',
     component: () => import('@/features/auth/LoginPage.vue'),
-    meta: { public: true, title: 'Sign In' },
+    meta: { public: true, title: () => t('titles.signIn') },
   },
   {
     path: '/setup',
     name: 'setup',
     component: () => import('@/features/auth/SetupPage.vue'),
-    meta: { public: true, title: 'Initial Setup' },
+    meta: { public: true, title: () => t('titles.initialSetup') },
   },
   {
     path: '/forgot-password',
     name: 'forgot-password',
     component: () => import('@/features/auth/ForgotPasswordPage.vue'),
-    meta: { public: true, title: 'Forgot Password' },
+    meta: { public: true, title: () => t('titles.forgotPassword') },
   },
   {
     path: '/reset-password',
     name: 'reset-password',
     component: () => import('@/features/auth/ResetPasswordPage.vue'),
-    meta: { public: true, title: 'Reset Password' },
+    meta: { public: true, title: () => t('titles.resetPassword') },
   },
   {
     path: '/oauth2-callback',
     name: 'oidc-callback',
     component: () => import('@/features/auth/OidcCallbackPage.vue'),
-    meta: { public: true, title: 'Completing Sign In' },
+    meta: { public: true, title: () => t('titles.completingSignIn') },
   },
   {
     path: '/magic',
     name: 'magic-link-login',
     component: () => import('@/features/auth/MagicLinkLoginView.vue'),
-    meta: { public: true, title: 'Magic Link Login' },
+    meta: { public: true, title: () => t('titles.magicLinkLogin') },
   },
   { path: '/:pathMatch(.*)*', redirect: '/' },
 ]

--- a/client/src/stores/locale.ts
+++ b/client/src/stores/locale.ts
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { DEFAULT_LOCALE, isSupportedLocale, type Locale } from '@bookorbit/types'
+import { storage } from '@/services/storage'
+import { setI18nLocale } from '@/i18n'
+
+const STORAGE_KEY = 'locale'
+
+/** Resolve the initial locale: stored preference, then browser language, then default. */
+export function detectInitialLocale(): Locale {
+  const stored = storage.get<string>(STORAGE_KEY, '')
+  if (isSupportedLocale(stored)) return stored
+
+  if (typeof navigator !== 'undefined' && typeof navigator.language === 'string') {
+    const base = navigator.language.split('-')[0]
+    if (isSupportedLocale(base)) return base
+  }
+
+  return DEFAULT_LOCALE
+}
+
+export const useLocaleStore = defineStore('locale', () => {
+  const locale = ref<Locale>(detectInitialLocale())
+
+  /** Apply a locale to vue-i18n and, unless applying server prefs, persist it locally. */
+  async function setLocale(next: Locale, persist = true): Promise<void> {
+    locale.value = next
+    await setI18nLocale(next)
+    if (persist) storage.set(STORAGE_KEY, next)
+  }
+
+  return { locale, setLocale }
+})

--- a/client/src/test-setup.ts
+++ b/client/src/test-setup.ts
@@ -1,0 +1,6 @@
+import { config } from '@vue/test-utils'
+import { i18n } from '@/i18n'
+
+// Install vue-i18n globally for all component tests so useI18n()/t() resolve real
+// English messages (matching existing English text assertions) instead of throwing.
+config.global.plugins = [...(config.global.plugins ?? []), i18n]

--- a/client/src/views/BookDetailView.vue
+++ b/client/src/views/BookDetailView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, defineAsyncComponent, provide, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import type { BookDetail, BookMetadataLockField } from '@bookorbit/types'
 import BookDetailLayout from '@/features/book/components/detail/BookDetailLayout.vue'
 import DetailsTab from '@/features/book/components/detail/tabs/DetailsTab.vue'
@@ -19,6 +20,7 @@ import EntityNotFound from '@/components/EntityNotFound.vue'
 const ReadingLogTab = defineAsyncComponent(() => import('@/features/book/components/detail/tabs/ReadingLogTab.vue'))
 const HighlightsTab = defineAsyncComponent(() => import('@/features/book/components/detail/tabs/HighlightsTab.vue'))
 
+const { t } = useI18n()
 const route = useRoute()
 const { hasPermission } = usePermissions()
 const { libraries } = useLibraries()
@@ -38,12 +40,12 @@ const tab = computed(() => normalizeBookDetailTab(route.query.tab))
 const { detail, loading, notFound, fetch } = useBookDetail()
 const pageTitle = computed(() => {
   const title = detail.value?.title?.trim()
-  const base = title || (Number.isFinite(bookId.value) ? `Book #${bookId.value}` : 'Book')
-  if (tab.value === 'edit') return `Edit Metadata · ${base}`
-  if (tab.value === 'files') return `Files · ${base}`
-  if (tab.value === 'reading-log') return `Reading Log · ${base}`
-  if (tab.value === 'highlights') return `Highlights · ${base}`
-  return `Book · ${base}`
+  const base = title || (Number.isFinite(bookId.value) ? t('views.bookDetail.titleWithId', { id: bookId.value }) : t('views.bookDetail.title'))
+  if (tab.value === 'edit') return t('views.bookDetail.pageTitle.editMetadata', { base })
+  if (tab.value === 'files') return t('views.bookDetail.pageTitle.files', { base })
+  if (tab.value === 'reading-log') return t('views.bookDetail.pageTitle.readingLog', { base })
+  if (tab.value === 'highlights') return t('views.bookDetail.pageTitle.highlights', { base })
+  return t('views.bookDetail.pageTitle.book', { base })
 })
 usePageTitle(pageTitle)
 
@@ -157,7 +159,7 @@ function onCoverChanged(source: 'extracted' | 'custom' | null) {
       </div>
 
       <div v-else-if="notFound" key="not-found">
-        <EntityNotFound entity="Book" />
+        <EntityNotFound :entity="t('views.entity.book')" />
       </div>
     </Transition>
   </BookDetailLayout>

--- a/client/src/views/BookDockView.vue
+++ b/client/src/views/BookDockView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { PackageOpen, CheckCircle2, AlertCircle } from '@lucide/vue'
 import type { BookDockFile } from '@bookorbit/types'
 import { api } from '@/lib/api'
@@ -22,6 +23,8 @@ type ApplyFetchedResult = {
   skipped: number
   skippedEdited: number
 }
+
+const { t } = useI18n()
 
 const {
   items,
@@ -126,9 +129,9 @@ const errorCount = computed(() => {
 })
 
 const emptyMessage = computed(() => {
-  if (filters.search) return `No files match "${filters.search}"`
-  if (filters.status) return `No ${filters.status} files`
-  return 'Upload files or drop them in the Book Dock folder'
+  if (filters.search) return t('views.bookDock.empty.noSearchMatch', { query: filters.search })
+  if (filters.status) return t('views.bookDock.empty.noStatusFiles', { status: filters.status })
+  return t('views.bookDock.empty.uploadPrompt')
 })
 
 async function handleBulkDiscard() {
@@ -206,24 +209,18 @@ async function handleInlineApplyFetched(fileId: number) {
   }
 }
 
-function pluralizeFiles(count: number): string {
-  return `${count} file${count === 1 ? '' : 's'}`
-}
-
 function applyFetchedResultMessage(result: ApplyFetchedResult): string {
   const reasons: string[] = []
-  if (result.skippedEdited > 0)
-    reasons.push(`skipped ${pluralizeFiles(result.skippedEdited)} because ${result.skippedEdited === 1 ? 'it has' : 'they have'} manual edits`)
-  if (result.skipped > 0)
-    reasons.push(`skipped ${pluralizeFiles(result.skipped)} because ${result.skipped === 1 ? 'it has' : 'they have'} no fetched metadata`)
+  if (result.skippedEdited > 0) reasons.push(t('views.bookDock.applyFetched.skippedEdited', { count: result.skippedEdited }, result.skippedEdited))
+  if (result.skipped > 0) reasons.push(t('views.bookDock.applyFetched.skippedNoMetadata', { count: result.skipped }, result.skipped))
 
   if (result.applied > 0) {
-    const base = `Applied to ${pluralizeFiles(result.applied)}`
+    const base = t('views.bookDock.applyFetched.applied', { count: result.applied }, result.applied)
     return reasons.length ? `${base}; ${reasons.join('; ')}` : base
   }
 
-  if (reasons.length) return `No files applied; ${reasons.join('; ')}`
-  return 'No files selected'
+  if (reasons.length) return t('views.bookDock.applyFetched.noneApplied', { reasons: reasons.join('; ') })
+  return t('views.bookDock.applyFetched.noneSelected')
 }
 
 function handleRescanError() {
@@ -363,7 +360,7 @@ onUnmounted(() => {
           <div class="flex items-center justify-center size-9 rounded-lg bg-primary/10">
             <PackageOpen class="size-4.5 text-primary" />
           </div>
-          <h1 class="text-xl font-semibold text-foreground tracking-tight">Book Dock</h1>
+          <h1 class="text-xl font-semibold text-foreground tracking-tight">{{ t('views.bookDock.title') }}</h1>
           <span
             v-if="summary.total > 0"
             class="ml-1 inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-primary/15 text-primary text-xs font-semibold tabular-nums"
@@ -376,7 +373,7 @@ onUnmounted(() => {
               class="ml-2 inline-flex items-center gap-1.5 h-6 px-2.5 rounded-full bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 text-xs font-medium"
             >
               <span class="size-1.5 rounded-full bg-current animate-pulse" />
-              New files detected
+              {{ t('views.bookDock.newFilesDetected') }}
             </span>
           </Transition>
           <Transition name="fade">
@@ -394,7 +391,11 @@ onUnmounted(() => {
               class="ml-2 inline-flex items-center gap-1.5 h-6 px-2.5 rounded-full bg-primary/15 text-primary text-xs font-medium"
             >
               <CheckCircle2 class="size-3.5" />
-              {{ retryQueued === 0 ? 'No error files to retry' : `Retrying ${retryQueued} file${retryQueued !== 1 ? 's' : ''}` }}
+              {{
+                retryQueued === 0
+                  ? t('views.bookDock.retry.noneToRetry')
+                  : t('views.bookDock.retry.retrying', { count: retryQueued }, retryQueued ?? 0)
+              }}
             </span>
           </Transition>
           <Transition name="fade">
@@ -403,7 +404,7 @@ onUnmounted(() => {
               class="ml-2 inline-flex items-center gap-1.5 h-6 px-2.5 rounded-full bg-muted text-muted-foreground text-xs font-medium"
             >
               <span class="size-1.5 rounded-full bg-muted-foreground animate-pulse" />
-              Reconnecting
+              {{ t('views.bookDock.reconnecting') }}
             </span>
           </Transition>
           <Transition name="fade">
@@ -412,7 +413,7 @@ onUnmounted(() => {
               class="ml-2 inline-flex items-center gap-1.5 h-6 px-2.5 rounded-full bg-red-500/15 text-red-600 dark:text-red-400 text-xs font-medium"
             >
               <AlertCircle class="size-3.5" />
-              Rescan failed
+              {{ t('views.bookDock.rescanFailed') }}
             </span>
           </Transition>
         </div>
@@ -438,7 +439,7 @@ onUnmounted(() => {
 
         <!-- Statistics bar -->
         <div v-if="statistics && statistics.byFormat.length > 0" class="flex items-center gap-3 flex-wrap text-xs text-muted-foreground">
-          <span class="font-medium text-foreground">{{ formatBytes(statistics.totalSizeBytes) }} in Book Dock</span>
+          <span class="font-medium text-foreground">{{ t('views.bookDock.totalInDock', { size: formatBytes(statistics.totalSizeBytes) }) }}</span>
           <span
             v-for="f in statistics.byFormat"
             :key="f.format"
@@ -459,8 +460,10 @@ onUnmounted(() => {
                 <PackageOpen class="size-8 text-primary" />
               </div>
               <div class="text-center">
-                <p class="text-sm font-medium text-foreground">Drop files into Book Dock</p>
-                <p class="text-xs text-muted-foreground mt-1">Supported: {{ SUPPORTED_FORMATS.join(', ') }}</p>
+                <p class="text-sm font-medium text-foreground">{{ t('views.bookDock.dropFiles') }}</p>
+                <p class="text-xs text-muted-foreground mt-1">
+                  {{ t('views.bookDock.supportedFormats', { formats: SUPPORTED_FORMATS.join(', ') }) }}
+                </p>
               </div>
             </div>
           </div>

--- a/client/src/views/BookEditMetadataView.vue
+++ b/client/src/views/BookEditMetadataView.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import type { BookDetail } from '@bookorbit/types'
 import BookDetailLayout from '@/features/book/components/detail/BookDetailLayout.vue'
 import EditMetadataTab from '@/features/book/components/detail/tabs/EditMetadataTab.vue'
 import { useBookDetail } from '@/features/book/composables/useBookDetail'
 import { usePageTitle } from '@/composables/usePageTitle'
 
+const { t } = useI18n()
 const route = useRoute()
 
 const bookId = computed(() => Number(route.params.bookId))
@@ -14,8 +16,8 @@ const bookId = computed(() => Number(route.params.bookId))
 const { detail, loading, fetch } = useBookDetail()
 const pageTitle = computed(() => {
   const title = detail.value?.title?.trim()
-  const base = title || (Number.isFinite(bookId.value) ? `Book #${bookId.value}` : 'Book')
-  return `Edit · ${base}`
+  const base = title || (Number.isFinite(bookId.value) ? t('views.bookDetail.titleWithId', { id: bookId.value }) : t('views.bookDetail.title'))
+  return t('views.bookDetail.pageTitle.edit', { base })
 })
 usePageTitle(pageTitle)
 

--- a/client/src/views/BookFilesView.vue
+++ b/client/src/views/BookFilesView.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import BookDetailLayout from '@/features/book/components/detail/BookDetailLayout.vue'
 import FilesTab from '@/features/book/components/detail/tabs/FilesTab.vue'
 import { useBookDetail } from '@/features/book/composables/useBookDetail'
 import { usePageTitle } from '@/composables/usePageTitle'
 
+const { t } = useI18n()
 const route = useRoute()
 
 const bookId = computed(() => Number(route.params.bookId))
@@ -13,8 +15,8 @@ const bookId = computed(() => Number(route.params.bookId))
 const { detail, loading, fetch } = useBookDetail()
 const pageTitle = computed(() => {
   const title = detail.value?.title?.trim()
-  const base = title || (Number.isFinite(bookId.value) ? `Book #${bookId.value}` : 'Book')
-  return `Files · ${base}`
+  const base = title || (Number.isFinite(bookId.value) ? t('views.bookDetail.titleWithId', { id: bookId.value }) : t('views.bookDetail.title'))
+  return t('views.bookDetail.pageTitle.files', { base })
 })
 usePageTitle(pageTitle)
 

--- a/client/src/views/CollectionView.vue
+++ b/client/src/views/CollectionView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, shallowRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { AlertTriangle, CheckSquare, FileSpreadsheet, FolderOpen, Layers, Pencil, Search, SlidersHorizontal, Square, X } from '@lucide/vue'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
@@ -41,6 +42,7 @@ import type { BulkEditFields } from '@/features/book/composables/useBulkEditMeta
 import type { BookCard } from '@bookorbit/types'
 import EntityNotFound from '@/components/EntityNotFound.vue'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { viewMode, effectiveViewMode } = useEffectiveViewMode()
@@ -55,8 +57,8 @@ const { collections, loaded: collectionsLoaded, error: collectionsError, fetchCo
 const collectionNotFound = ref(false)
 const collection = computed(() => collections.value.find((c) => c.id === collectionId.value))
 const pageTitle = computed(() => {
-  if (collection.value?.name) return `Collection · ${collection.value.name}`
-  return Number.isFinite(collectionId.value) ? `Collection #${collectionId.value}` : 'Collection'
+  if (collection.value?.name) return t('views.collection.pageTitle', { name: collection.value.name })
+  return Number.isFinite(collectionId.value) ? t('views.collection.pageTitleWithId', { id: collectionId.value }) : t('views.collection.title')
 })
 usePageTitle(pageTitle)
 
@@ -231,9 +233,9 @@ async function handleRemoveFromCollection() {
     resetBooks()
     refreshBuckets()
     exitSelectionMode()
-    toast.success(`Removed ${ids.length} book${ids.length === 1 ? '' : 's'} from collection`)
+    toast.success(t('views.collection.toast.removed', { count: ids.length }, ids.length))
   } catch {
-    toast.error('Failed to remove books from collection')
+    toast.error(t('views.collection.toast.removeFailed'))
   } finally {
     removingInProgress = false
   }
@@ -425,7 +427,7 @@ defineOptions({ name: 'CollectionView' })
 
     <section class="flex flex-1 flex-col min-h-0">
       <ViewHeader
-        :title="collection?.name ?? 'Collection'"
+        :title="collection?.name ?? t('views.collection.title')"
         :icon="collection?.icon || 'FolderOpen'"
         fallback-icon="FolderOpen"
         :total="total"
@@ -453,7 +455,7 @@ defineOptions({ name: 'CollectionView' })
                 <Layers :size="14" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>{{ collapseEnabledRef ? 'Expand series' : 'Collapse series' }}</TooltipContent>
+            <TooltipContent>{{ collapseEnabledRef ? t('views.bookView.expandSeries') : t('views.bookView.collapseSeries') }}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -466,7 +468,7 @@ defineOptions({ name: 'CollectionView' })
                 <FileSpreadsheet :size="14" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Export metadata</TooltipContent>
+            <TooltipContent>{{ t('views.bookView.exportMetadata') }}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -479,7 +481,7 @@ defineOptions({ name: 'CollectionView' })
                 <Pencil :size="14" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Edit collection</TooltipContent>
+            <TooltipContent>{{ t('views.collection.editCollection') }}</TooltipContent>
           </Tooltip>
 
           <button
@@ -493,7 +495,7 @@ defineOptions({ name: 'CollectionView' })
           <DropdownMenuItem @click="handleToggleCollapse">
             <CheckSquare v-if="collapseEnabledRef" :size="14" class="mr-2" />
             <Square v-else :size="14" class="mr-2" />
-            Collapse series
+            {{ t('views.bookView.collapseSeries') }}
           </DropdownMenuItem>
         </template>
         <template v-if="effectiveViewMode === 'table'" #columns>
@@ -531,7 +533,7 @@ defineOptions({ name: 'CollectionView' })
           <input
             v-model="searchQuery"
             type="search"
-            placeholder="Search title, author, series, narrator..."
+            :placeholder="t('views.bookView.searchPlaceholder')"
             class="mobile-search-input h-full w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/85"
           />
           <button v-if="searchQuery.trim()" class="ml-1 text-muted-foreground/85 transition-colors hover:text-foreground" @click="clearSearch">
@@ -550,7 +552,7 @@ defineOptions({ name: 'CollectionView' })
             @click="handleToggleCollapse"
           >
             <Layers :size="13" />
-            <span>{{ collapseEnabledRef ? 'Expanded' : 'Collapse series' }}</span>
+            <span>{{ collapseEnabledRef ? t('views.bookView.expanded') : t('views.bookView.collapseSeries') }}</span>
           </button>
           <button
             v-if="hasPermission('library_download') && !isDemoRestrictedAccount"
@@ -558,7 +560,7 @@ defineOptions({ name: 'CollectionView' })
             @click="openMetadataExport"
           >
             <FileSpreadsheet :size="13" />
-            <span>Export</span>
+            <span>{{ t('views.bookView.export') }}</span>
           </button>
           <button
             v-if="collection"
@@ -566,14 +568,14 @@ defineOptions({ name: 'CollectionView' })
             @click="openCollectionEditor"
           >
             <Pencil :size="13" />
-            <span>Edit</span>
+            <span>{{ t('common.edit') }}</span>
           </button>
           <button
             class="flex h-8 items-center gap-1.5 rounded-md border border-input px-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             @click="closeMobileControls"
           >
             <X :size="13" />
-            <span>Close</span>
+            <span>{{ t('common.close') }}</span>
           </button>
         </div>
       </section>
@@ -583,25 +585,27 @@ defineOptions({ name: 'CollectionView' })
           <div class="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10 text-destructive">
             <AlertTriangle :size="28" />
           </div>
-          <p class="text-sm font-medium text-foreground">Could not load this collection</p>
+          <p class="text-sm font-medium text-foreground">{{ t('views.collection.loadError') }}</p>
           <p class="max-w-md text-xs text-muted-foreground">{{ collectionLoadError }}</p>
           <button
             class="rounded-md border border-input px-3 py-2 text-sm text-foreground transition-colors hover:bg-muted"
             @click="retryCollectionLoad"
           >
-            Retry
+            {{ t('views.common.retry') }}
           </button>
         </div>
 
-        <EntityNotFound v-else-if="collectionNotFound" entity="Collection" />
+        <EntityNotFound v-else-if="collectionNotFound" :entity="t('views.entity.collection')" />
 
         <div v-else-if="booksInitialized && !loading && books.length === 0" class="flex flex-col items-center justify-center gap-3 py-24 text-center">
           <div class="h-16 w-16 rounded-full bg-muted flex items-center justify-center">
             <FolderOpen :size="28" class="text-muted-foreground/70" />
           </div>
-          <p class="text-sm font-medium text-foreground">{{ debouncedQuery ? 'No books match this search' : 'No books in this collection' }}</p>
+          <p class="text-sm font-medium text-foreground">
+            {{ debouncedQuery ? t('views.collection.empty.noSearchMatch') : t('views.collection.empty.noBooks') }}
+          </p>
           <p class="text-xs text-muted-foreground">
-            {{ debouncedQuery ? 'Try a different search term or clear the search.' : 'Select books from your library and add them here.' }}
+            {{ debouncedQuery ? t('views.collection.empty.noSearchMatchHint') : t('views.collection.empty.noBooksHint') }}
           </p>
         </div>
 
@@ -657,10 +661,10 @@ defineOptions({ name: 'CollectionView' })
         />
 
         <div v-if="effectiveViewMode === 'list'" ref="sentinel" class="h-8 mt-4 flex items-center justify-center">
-          <span v-if="loading" class="text-xs text-muted-foreground">Loading...</span>
-          <span v-else-if="!hasMorePrefix && contiguousPrefix.length > 0" class="text-xs text-muted-foreground"
-            >All {{ total.toLocaleString() }} books loaded</span
-          >
+          <span v-if="loading" class="text-xs text-muted-foreground">{{ t('common.loading') }}</span>
+          <span v-else-if="!hasMorePrefix && contiguousPrefix.length > 0" class="text-xs text-muted-foreground">{{
+            t('views.bookView.allBooksLoaded', { count: total.toLocaleString() })
+          }}</span>
         </div>
 
         <JumpRail

--- a/client/src/views/DashboardView.vue
+++ b/client/src/views/DashboardView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Settings2, Sparkles } from '@lucide/vue'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
@@ -14,6 +15,7 @@ import { useDashboardConfig } from '@/features/dashboard/composables/useDashboar
 import { useOnboardingTour } from '@/features/onboarding/composables/useOnboardingTour'
 import { useSmartScopes } from '@/features/smart-scope/composables/useSmartScopes'
 
+const { t } = useI18n()
 const { hasPermission } = usePermissions()
 const { user } = useAuth()
 const { libraries, loading: librariesLoading, fetchLibraries } = useLibraries()
@@ -28,16 +30,16 @@ const enabledScrollers = computed(() =>
 )
 
 const hasNoLibraries = computed(() => !librariesLoading.value && libraries.value.length === 0)
-const greetingLabel = computed(() => {
+const greetingText = computed(() => {
   const hour = new Date().getHours()
-  if (hour < 12) return 'morning'
-  if (hour < 18) return 'afternoon'
-  return 'evening'
+  if (hour < 12) return t('views.dashboard.greeting.morning')
+  if (hour < 18) return t('views.dashboard.greeting.afternoon')
+  return t('views.dashboard.greeting.evening')
 })
 const greetingName = computed(() => {
   const fullName = user.value?.name?.trim()
   if (fullName) return fullName.split(/\s+/)[0] ?? fullName
-  return user.value?.username?.trim() || 'there'
+  return user.value?.username?.trim() || t('views.dashboard.greeting.fallbackName')
 })
 
 watch(
@@ -76,7 +78,7 @@ onMounted(() => {
                 <Settings2 :size="18" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="left" align="center">Customize dashboard</TooltipContent>
+            <TooltipContent side="left" align="center">{{ t('views.dashboard.customize') }}</TooltipContent>
           </Tooltip>
         </div>
       </div>
@@ -88,7 +90,7 @@ onMounted(() => {
           <div class="animate-fade-up flex items-center gap-2 px-1" style="animation-delay: 40ms">
             <Sparkles :size="16" class="shrink-0 text-primary/85" />
             <p class="text-[1.05rem] font-medium leading-tight tracking-[-0.01em] text-foreground/90 sm:text-[1.18rem]">
-              <span class="text-foreground/88">Good {{ greetingLabel }},</span>
+              <span class="text-foreground/88">{{ greetingText }}</span>
               <span class="ml-1 font-semibold text-primary">{{ greetingName }}</span>
             </p>
           </div>
@@ -105,8 +107,8 @@ onMounted(() => {
             :style="{ animationDelay: `${index * 100}ms` }"
           />
           <div v-if="enabledScrollers.length === 0" class="px-2 py-12 text-center">
-            <p class="text-sm text-muted-foreground">All shelves are hidden.</p>
-            <button class="mt-2 text-sm text-primary hover:underline" @click="settingsOpen = true">Customize dashboard</button>
+            <p class="text-sm text-muted-foreground">{{ t('views.dashboard.allShelvesHidden') }}</p>
+            <button class="mt-2 text-sm text-primary hover:underline" @click="settingsOpen = true">{{ t('views.dashboard.customize') }}</button>
           </div>
         </template>
       </div>

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onUnmounted, provide, ref, shallowRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import {
   ArrowUpDown,
   Bookmark,
@@ -65,6 +66,7 @@ import type { GroupRule, Rule, SortSpec } from '@bookorbit/types'
 import EntityNotFound from '@/components/EntityNotFound.vue'
 import { type QuerySelectionState } from '@/features/book/composables/useBookBulkActions'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { viewMode, effectiveViewMode } = useEffectiveViewMode()
@@ -77,11 +79,11 @@ const currentCoverAspectRatio = computed(() => currentLibrary.value?.coverAspect
 const { coverSize, gridGap } = useViewDisplaySettings('library', libraryId, currentCoverAspectRatio)
 
 const libraryNotFound = computed(() => librariesLoaded.value && libraryId.value !== null && !currentLibrary.value)
-const title = computed(() => currentLibrary.value?.name ?? 'Library')
+const title = computed(() => currentLibrary.value?.name ?? t('views.library.title'))
 const libraryIcon = computed(() => currentLibrary.value?.icon ?? 'BookOpen')
 const pageTitle = computed(() => {
-  if (currentLibrary.value?.name) return `Library · ${currentLibrary.value.name}`
-  return libraryId.value === null ? 'Library' : `Library #${libraryId.value}`
+  if (currentLibrary.value?.name) return t('views.library.pageTitle', { name: currentLibrary.value.name })
+  return libraryId.value === null ? t('views.library.title') : t('views.library.pageTitleWithId', { id: libraryId.value })
 })
 usePageTitle(pageTitle)
 
@@ -582,7 +584,7 @@ defineOptions({ name: 'HomeView' })
                   <ArrowUpDown :size="13" />
                   <span class="hidden lg:inline">{{ sortSummary }}</span>
                   <span class="lg:hidden"
-                    >Sort<template v-if="!isDefaultSort"> ({{ sort.length }})</template></span
+                    >{{ t('views.bookView.sort') }}<template v-if="!isDefaultSort"> ({{ sort.length }})</template></span
                   >
                 </button>
               </PopoverTrigger>
@@ -600,7 +602,7 @@ defineOptions({ name: 'HomeView' })
                   <X :size="13" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Reset sort to default</TooltipContent>
+              <TooltipContent>{{ t('views.bookView.resetSort') }}</TooltipContent>
             </Tooltip>
           </div>
           <div class="hidden sm:block w-px h-5 bg-border shrink-0" />
@@ -618,7 +620,7 @@ defineOptions({ name: 'HomeView' })
                 <Layers :size="14" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>{{ collapseEnabledRef ? 'Expand series' : 'Collapse series' }}</TooltipContent>
+            <TooltipContent>{{ collapseEnabledRef ? t('views.bookView.expandSeries') : t('views.bookView.collapseSeries') }}</TooltipContent>
           </Tooltip>
           <Tooltip>
             <TooltipTrigger as-child>
@@ -630,7 +632,7 @@ defineOptions({ name: 'HomeView' })
                 <FileSpreadsheet :size="14" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Export metadata</TooltipContent>
+            <TooltipContent>{{ t('views.bookView.exportMetadata') }}</TooltipContent>
           </Tooltip>
           <button
             @click="toggleFilterPanel"
@@ -642,7 +644,7 @@ defineOptions({ name: 'HomeView' })
             "
           >
             <Filter :size="13" />
-            <span>Filters</span>
+            <span>{{ t('views.bookView.filters') }}</span>
             <span v-if="activeFilterCount > 0" class="text-xs font-semibold">({{ activeFilterCount }})</span>
           </button>
           <Tooltip>
@@ -653,10 +655,10 @@ defineOptions({ name: 'HomeView' })
                 class="hidden sm:flex items-center gap-1 h-8 px-2 rounded-md text-sm text-muted-foreground hover:text-destructive transition-colors"
               >
                 <X :size="13" />
-                Clear
+                {{ t('views.bookView.clear') }}
               </button>
             </TooltipTrigger>
-            <TooltipContent>Clear all filters</TooltipContent>
+            <TooltipContent>{{ t('views.bookView.clearAllFilters') }}</TooltipContent>
           </Tooltip>
 
           <button
@@ -681,7 +683,7 @@ defineOptions({ name: 'HomeView' })
           <DropdownMenuItem @click="handleToggleCollapse">
             <CheckSquare v-if="collapseEnabledRef" :size="14" class="mr-2" />
             <Square v-else :size="14" class="mr-2" />
-            Collapse series
+            {{ t('views.bookView.collapseSeries') }}
           </DropdownMenuItem>
         </template>
         <template v-if="effectiveViewMode === 'table'" #columns>
@@ -719,7 +721,7 @@ defineOptions({ name: 'HomeView' })
           <input
             v-model="searchQuery"
             type="search"
-            placeholder="Search title, author, series, narrator..."
+            :placeholder="t('views.bookView.searchPlaceholder')"
             class="mobile-search-input h-full w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/85"
           />
           <button v-if="searchQuery.trim()" class="ml-1 text-muted-foreground/85 transition-colors hover:text-foreground" @click="clearSearch">
@@ -739,8 +741,10 @@ defineOptions({ name: 'HomeView' })
                 "
               >
                 <ArrowUpDown :size="13" />
-                <span>Sort</span>
-                <span v-if="!isDefaultSort" class="rounded-full border border-primary/40 px-1 py-0.5 text-[10px] font-semibold leading-none">On</span>
+                <span>{{ t('views.bookView.sort') }}</span>
+                <span v-if="!isDefaultSort" class="rounded-full border border-primary/40 px-1 py-0.5 text-[10px] font-semibold leading-none">{{
+                  t('views.bookView.sortOn')
+                }}</span>
               </button>
             </PopoverTrigger>
             <PopoverContent align="start" class="w-80 p-3">
@@ -766,7 +770,7 @@ defineOptions({ name: 'HomeView' })
             "
           >
             <Filter :size="13" />
-            <span>Filters</span>
+            <span>{{ t('views.bookView.filters') }}</span>
             <span v-if="activeFilterCount > 0" class="rounded-full bg-primary/10 px-1 py-0.5 text-[10px] font-semibold leading-none">
               {{ activeFilterCount }}
             </span>
@@ -778,7 +782,7 @@ defineOptions({ name: 'HomeView' })
             @click="openMetadataExport('all-matching')"
           >
             <FileSpreadsheet :size="13" />
-            <span>Export</span>
+            <span>{{ t('views.bookView.export') }}</span>
           </button>
 
           <button
@@ -786,7 +790,7 @@ defineOptions({ name: 'HomeView' })
             @click="clearFilters"
             class="h-8 rounded-md px-2 text-sm text-muted-foreground transition-colors hover:text-destructive"
           >
-            Clear
+            {{ t('views.bookView.clear') }}
           </button>
         </div>
       </section>
@@ -794,7 +798,7 @@ defineOptions({ name: 'HomeView' })
       <!-- Filter builder panel rendered outside <main> so it stays anchored when the list is scrolled -->
       <div v-if="filterOpen && !libraryNotFound" class="mb-4 p-3 rounded-md border border-border bg-card">
         <div class="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <span class="text-xs font-medium text-muted-foreground sm:shrink-0">Filter rules</span>
+          <span class="text-xs font-medium text-muted-foreground sm:shrink-0">{{ t('views.library.filterRules') }}</span>
           <div class="flex w-full flex-wrap items-center gap-1.5 sm:w-auto sm:flex-nowrap">
             <Tooltip>
               <TooltipTrigger as-child>
@@ -804,11 +808,11 @@ defineOptions({ name: 'HomeView' })
                   class="flex min-h-7 items-center gap-1.5 rounded-md border border-input bg-background px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <Telescope :size="13" />
-                  <span class="hidden sm:inline whitespace-nowrap">Save as Smart Scope</span>
-                  <span class="sm:hidden whitespace-nowrap">Save Scope</span>
+                  <span class="hidden sm:inline whitespace-nowrap">{{ t('views.library.saveAsSmartScope') }}</span>
+                  <span class="sm:hidden whitespace-nowrap">{{ t('views.library.saveScope') }}</span>
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Save this filter as a named Smart Scope</TooltipContent>
+              <TooltipContent>{{ t('views.library.saveAsSmartScopeTooltip') }}</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger as-child>
@@ -824,10 +828,10 @@ defineOptions({ name: 'HomeView' })
                 >
                   <BookmarkCheck v-if="isFilterSaved" :size="13" />
                   <Bookmark v-else :size="13" />
-                  {{ isFilterSaved ? 'Saved' : 'Save filter' }}
+                  {{ isFilterSaved ? t('views.library.saved') : t('views.library.saveFilter') }}
                 </button>
               </TooltipTrigger>
-              <TooltipContent>{{ isFilterSaved ? 'Filter saved' : 'Save filter for this library' }}</TooltipContent>
+              <TooltipContent>{{ isFilterSaved ? t('views.library.filterSaved') : t('views.library.saveFilterTooltip') }}</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger as-child>
@@ -839,13 +843,13 @@ defineOptions({ name: 'HomeView' })
                   <X :size="11" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Remove saved filter</TooltipContent>
+              <TooltipContent>{{ t('views.library.removeSavedFilter') }}</TooltipContent>
             </Tooltip>
             <button
               class="min-h-7 whitespace-nowrap rounded-md border border-input px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               @click="closeFilterPanel"
             >
-              Close
+              {{ t('common.close') }}
             </button>
           </div>
         </div>
@@ -853,7 +857,7 @@ defineOptions({ name: 'HomeView' })
       </div>
 
       <main ref="mainRef" :class="effectiveViewMode === 'table' ? 'flex-1 min-h-0 flex flex-col overflow-hidden' : 'flex-1 min-h-0 overflow-y-auto'">
-        <EntityNotFound v-if="libraryNotFound" entity="Library" />
+        <EntityNotFound v-if="libraryNotFound" :entity="t('views.entity.library')" />
 
         <template v-else>
           <div v-if="error" class="text-sm text-destructive mb-4">{{ error }}</div>
@@ -865,9 +869,9 @@ defineOptions({ name: 'HomeView' })
             v-if="booksInitialized && !loading && books.length === 0 && activeFilterCount > 0"
             class="flex flex-col items-center justify-center py-24 gap-3 text-center"
           >
-            <p class="text-sm font-medium text-foreground">No books match your filters</p>
-            <p class="text-xs text-muted-foreground">Try adjusting or clearing your filters to see more books.</p>
-            <button @click="clearFilters" class="text-xs text-primary hover:underline">Clear filters</button>
+            <p class="text-sm font-medium text-foreground">{{ t('views.library.empty.noFilterMatch') }}</p>
+            <p class="text-xs text-muted-foreground">{{ t('views.library.empty.noFilterMatchHint') }}</p>
+            <button @click="clearFilters" class="text-xs text-primary hover:underline">{{ t('views.library.empty.clearFilters') }}</button>
           </div>
 
           <!-- Empty state: no books in library -->
@@ -879,12 +883,12 @@ defineOptions({ name: 'HomeView' })
               <BookOpen :size="28" class="text-muted-foreground/70" />
             </div>
             <div v-if="libraryId !== null && isScanning(libraryId)" class="flex flex-col gap-1">
-              <p class="text-sm font-medium text-foreground">Scanning your library...</p>
-              <p class="text-xs text-muted-foreground max-w-xs">Books will appear here as they are discovered.</p>
+              <p class="text-sm font-medium text-foreground">{{ t('views.library.empty.scanning') }}</p>
+              <p class="text-xs text-muted-foreground max-w-xs">{{ t('views.library.empty.scanningHint') }}</p>
             </div>
             <div v-else class="flex flex-col gap-1">
-              <p class="text-sm font-medium text-foreground">Your library is empty</p>
-              <p class="text-xs text-muted-foreground max-w-xs">Once you add books to this library, they will appear here.</p>
+              <p class="text-sm font-medium text-foreground">{{ t('views.library.empty.emptyLibrary') }}</p>
+              <p class="text-xs text-muted-foreground max-w-xs">{{ t('views.library.empty.emptyLibraryHint') }}</p>
             </div>
           </div>
 
@@ -947,10 +951,10 @@ defineOptions({ name: 'HomeView' })
           />
 
           <div v-if="effectiveViewMode === 'list'" ref="sentinel" class="h-8 mt-4 flex items-center justify-center">
-            <span v-if="loading" class="text-xs text-muted-foreground">Loading...</span>
-            <span v-else-if="!hasMorePrefix && contiguousPrefix.length > 0" class="text-xs text-muted-foreground"
-              >All {{ total.toLocaleString() }} books loaded</span
-            >
+            <span v-if="loading" class="text-xs text-muted-foreground">{{ t('common.loading') }}</span>
+            <span v-else-if="!hasMorePrefix && contiguousPrefix.length > 0" class="text-xs text-muted-foreground">{{
+              t('views.bookView.allBooksLoaded', { count: total.toLocaleString() })
+            }}</span>
           </div>
 
           <JumpRail
@@ -983,9 +987,11 @@ defineOptions({ name: 'HomeView' })
         v-if="showQuerySelectionBanner && !querySelection"
         class="fixed bottom-16 left-1/2 z-40 -translate-x-1/2 flex items-center gap-3 rounded-lg border border-primary/30 bg-background px-4 py-2.5 text-sm shadow-lg"
       >
-        <span class="text-muted-foreground"> {{ selectedCount.toLocaleString() }} of {{ total.toLocaleString() }} loaded books selected. </span>
+        <span class="text-muted-foreground">
+          {{ t('views.library.querySelection.loadedSelected', { selected: selectedCount.toLocaleString(), total: total.toLocaleString() }) }}
+        </span>
         <button class="font-medium text-primary underline-offset-2 hover:underline" @click="activateQuerySelection">
-          Select all {{ total.toLocaleString() }} matching books
+          {{ t('views.library.querySelection.selectAllMatching', { total: total.toLocaleString() }) }}
         </button>
         <button class="text-muted-foreground hover:text-foreground" @click="dismissQuerySelectionBanner">
           <X :size="14" />

--- a/client/src/views/NotFoundView.vue
+++ b/client/src/views/NotFoundView.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { House } from '@lucide/vue'
 
+const { t } = useI18n()
 const router = useRouter()
 
 function goHome() {
@@ -18,8 +20,8 @@ function goHome() {
       404
     </p>
     <div class="space-y-1 animate-fade-up" style="animation-delay: 150ms">
-      <h1 class="text-xl font-semibold text-foreground">Page not found</h1>
-      <p class="text-sm text-muted-foreground">The page you're looking for doesn't exist.</p>
+      <h1 class="text-xl font-semibold text-foreground">{{ t('views.notFound.title') }}</h1>
+      <p class="text-sm text-muted-foreground">{{ t('views.notFound.description') }}</p>
     </div>
     <button
       class="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors mt-2 animate-fade-up"
@@ -27,7 +29,7 @@ function goHome() {
       @click="goHome"
     >
       <House :size="15" />
-      Go home
+      {{ t('views.notFound.goHome') }}
     </button>
   </div>
 </template>

--- a/client/src/views/SmartScopeView.vue
+++ b/client/src/views/SmartScopeView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, shallowRef, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import {
   AlertTriangle,
   Settings2,
@@ -51,6 +52,7 @@ import type { BulkEditFields } from '@/features/book/composables/useBulkEditMeta
 import type { BookCard, GroupRule, SortField } from '@bookorbit/types'
 import EntityNotFound from '@/components/EntityNotFound.vue'
 
+const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const { viewMode, effectiveViewMode } = useEffectiveViewMode()
@@ -105,8 +107,8 @@ const smartScopeLoadError = computed(() => smartScopesError.value ?? booksError.
 
 const smartScope = computed(() => smartScopes.value.find((l) => l.id === smartScopeId.value))
 const pageTitle = computed(() => {
-  if (smartScope.value?.name) return `SmartScope · ${smartScope.value.name}`
-  return Number.isFinite(smartScopeId.value) ? `SmartScope #${smartScopeId.value}` : 'SmartScope'
+  if (smartScope.value?.name) return t('views.smartScope.pageTitle', { name: smartScope.value.name })
+  return Number.isFinite(smartScopeId.value) ? t('views.smartScope.pageTitleWithId', { id: smartScopeId.value }) : t('views.smartScope.title')
 })
 usePageTitle(pageTitle)
 
@@ -266,13 +268,13 @@ async function handleDelete() {
     return
   }
   deleting.value = true
-  const name = smartScope.value?.name ?? 'Smart scope'
+  const name = smartScope.value?.name ?? t('views.smartScope.defaultName')
   try {
     await deleteSmartScope(smartScopeId.value)
-    toast.success(`"${name}" deleted`)
+    toast.success(t('views.smartScope.toast.deleted', { name }))
     router.push({ name: 'dashboard' })
   } catch {
-    toast.error(`Failed to delete "${name}"`)
+    toast.error(t('views.smartScope.toast.deleteFailed', { name }))
   } finally {
     deleting.value = false
     confirmSmartScopeDelete.value = false
@@ -437,7 +439,7 @@ defineOptions({ name: 'SmartScopeView' })
 
     <section class="flex flex-1 flex-col min-h-0">
       <ViewHeader
-        :title="smartScope?.name ?? 'SmartScope'"
+        :title="smartScope?.name ?? t('views.smartScope.title')"
         :icon="smartScope?.icon ?? undefined"
         fallback-icon="Aperture"
         :total="total"
@@ -462,10 +464,10 @@ defineOptions({ name: 'SmartScopeView' })
             v-if="smartScope?.filter || sortChip"
             @click="filterExpanded = !filterExpanded"
             class="hidden md:flex items-center gap-1.5 h-8 px-3 rounded-md border border-input text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-            :title="filterExpanded ? 'Hide filter' : 'Show filter'"
+            :title="filterExpanded ? t('views.smartScope.hideFilter') : t('views.smartScope.showFilter')"
           >
             <component :is="filterExpanded ? ChevronUp : ChevronDown" :size="13" />
-            <span>Filter</span>
+            <span>{{ t('views.smartScope.filter') }}</span>
           </button>
           <button
             v-if="hasPermission('library_download') && !isDemoRestrictedAccount"
@@ -473,14 +475,14 @@ defineOptions({ name: 'SmartScopeView' })
             class="hidden md:flex items-center gap-1.5 h-8 px-3 rounded-md border border-input text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
             <FileSpreadsheet :size="13" />
-            <span>Export</span>
+            <span>{{ t('views.bookView.export') }}</span>
           </button>
           <button
             @click="openEditor"
             class="hidden md:flex items-center gap-1.5 h-8 px-3 rounded-md border border-input text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
             <Settings2 :size="13" />
-            <span>Edit</span>
+            <span>{{ t('common.edit') }}</span>
           </button>
           <button
             @click="handleDelete"
@@ -493,7 +495,7 @@ defineOptions({ name: 'SmartScopeView' })
             "
           >
             <Trash2 :size="13" />
-            <span>{{ confirmSmartScopeDelete ? 'Confirm?' : 'Delete' }}</span>
+            <span>{{ confirmSmartScopeDelete ? t('views.smartScope.confirmDelete') : t('common.delete') }}</span>
           </button>
         </template>
         <template v-if="effectiveViewMode === 'table'" #columns>
@@ -531,7 +533,7 @@ defineOptions({ name: 'SmartScopeView' })
           <input
             v-model="searchQuery"
             type="search"
-            placeholder="Search title, author, series, narrator..."
+            :placeholder="t('views.bookView.searchPlaceholder')"
             class="mobile-search-input h-full w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/85"
           />
           <button v-if="searchQuery.trim()" class="ml-1 text-muted-foreground/85 transition-colors hover:text-foreground" @click="clearSearch">
@@ -546,7 +548,7 @@ defineOptions({ name: 'SmartScopeView' })
             class="flex h-8 items-center gap-1.5 rounded-md border border-input px-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
             <component :is="filterExpanded ? ChevronUp : ChevronDown" :size="13" />
-            <span>{{ filterExpanded ? 'Hide Filter' : 'Show Filter' }}</span>
+            <span>{{ filterExpanded ? t('views.smartScope.hideFilter') : t('views.smartScope.showFilter') }}</span>
           </button>
           <button
             v-if="hasPermission('library_download') && !isDemoRestrictedAccount"
@@ -554,14 +556,14 @@ defineOptions({ name: 'SmartScopeView' })
             class="flex h-8 items-center gap-1.5 rounded-md border border-input px-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
             <FileSpreadsheet :size="13" />
-            <span>Export</span>
+            <span>{{ t('views.bookView.export') }}</span>
           </button>
           <button
             @click="openEditor"
             class="flex h-8 items-center gap-1.5 rounded-md border border-input px-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
             <Settings2 :size="13" />
-            <span>Edit</span>
+            <span>{{ t('common.edit') }}</span>
           </button>
           <button
             @click="handleDelete"
@@ -574,14 +576,14 @@ defineOptions({ name: 'SmartScopeView' })
             "
           >
             <Trash2 :size="13" />
-            <span>{{ confirmSmartScopeDelete ? 'Confirm?' : 'Delete' }}</span>
+            <span>{{ confirmSmartScopeDelete ? t('views.smartScope.confirmDelete') : t('common.delete') }}</span>
           </button>
           <button
             class="flex h-8 items-center gap-1.5 rounded-md border border-input px-2.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             @click="closeMobileControls"
           >
             <X :size="13" />
-            <span>Close</span>
+            <span>{{ t('common.close') }}</span>
           </button>
         </div>
       </section>
@@ -591,17 +593,17 @@ defineOptions({ name: 'SmartScopeView' })
           <div class="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10 text-destructive">
             <AlertTriangle :size="28" />
           </div>
-          <p class="text-sm font-medium text-foreground">Could not load this SmartScope</p>
+          <p class="text-sm font-medium text-foreground">{{ t('views.smartScope.loadError') }}</p>
           <p class="max-w-md text-xs text-muted-foreground">{{ smartScopeLoadError }}</p>
           <button
             class="rounded-md border border-input px-3 py-2 text-sm text-foreground transition-colors hover:bg-muted"
             @click="retrySmartScopeLoad"
           >
-            Retry
+            {{ t('views.common.retry') }}
           </button>
         </div>
 
-        <EntityNotFound v-else-if="smartScopeNotFound" entity="SmartScope" />
+        <EntityNotFound v-else-if="smartScopeNotFound" :entity="t('views.entity.smartScope')" />
 
         <template v-else>
           <!-- Filter summary -->
@@ -614,7 +616,7 @@ defineOptions({ name: 'SmartScopeView' })
             <span v-if="sortChip" class="inline-flex items-center text-xs rounded-md border border-border/60 overflow-hidden">
               <span class="inline-flex items-center gap-1 px-2 py-0.5 bg-muted text-muted-foreground border-r border-border/60">
                 <ArrowUpDown :size="10" class="shrink-0" />
-                <span class="font-semibold">Sort</span>
+                <span class="font-semibold">{{ t('views.bookView.sort') }}</span>
               </span>
               <span class="px-2 py-0.5 bg-muted/40 text-foreground font-medium">{{ sortChip }}</span>
             </span>
@@ -629,16 +631,16 @@ defineOptions({ name: 'SmartScopeView' })
               <Settings2 :size="28" class="text-muted-foreground/70" />
             </div>
             <div class="flex flex-col gap-1">
-              <p class="text-sm font-medium text-foreground">No rules configured</p>
+              <p class="text-sm font-medium text-foreground">{{ t('views.smartScope.empty.noRules') }}</p>
               <p class="text-xs text-muted-foreground max-w-xs">
-                Open the editor to define which books appear in this smartScope using filters and sort rules.
+                {{ t('views.smartScope.empty.noRulesHint') }}
               </p>
             </div>
             <button
               @click="editorOpen = true"
               class="h-9 px-5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
             >
-              Configure SmartScope
+              {{ t('views.smartScope.empty.configure') }}
             </button>
           </div>
 
@@ -650,9 +652,9 @@ defineOptions({ name: 'SmartScopeView' })
             <div class="h-16 w-16 rounded-full bg-muted flex items-center justify-center">
               <Aperture :size="28" class="text-muted-foreground/70" />
             </div>
-            <p class="text-sm font-medium text-foreground">No books match this smartScope</p>
-            <p class="text-xs text-muted-foreground">Try adjusting the filter rules.</p>
-            <button @click="editorOpen = true" class="text-xs text-primary hover:underline">Edit SmartScope</button>
+            <p class="text-sm font-medium text-foreground">{{ t('views.smartScope.empty.noMatch') }}</p>
+            <p class="text-xs text-muted-foreground">{{ t('views.smartScope.empty.noMatchHint') }}</p>
+            <button @click="editorOpen = true" class="text-xs text-primary hover:underline">{{ t('views.smartScope.empty.edit') }}</button>
           </div>
 
           <!-- Grid view -->
@@ -709,9 +711,9 @@ defineOptions({ name: 'SmartScopeView' })
           />
 
           <div v-if="effectiveViewMode === 'list'" ref="sentinel" class="h-8 mt-4 flex items-center justify-center">
-            <span v-if="loading" class="text-xs text-muted-foreground">Loading...</span>
+            <span v-if="loading" class="text-xs text-muted-foreground">{{ t('common.loading') }}</span>
             <span v-else-if="!hasMorePrefix && contiguousPrefix.length > 0" class="text-xs text-muted-foreground">
-              All {{ total.toLocaleString() }} books loaded
+              {{ t('views.bookView.allBooksLoaded', { count: total.toLocaleString() }) }}
             </span>
           </div>
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
+import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -12,6 +13,10 @@ export default defineConfig({
     vue(),
     vueDevTools(),
     tailwindcss(),
+    VueI18nPlugin({
+      // Precompile the JSON message catalogs so no runtime message compiler (or eval) is needed.
+      include: [fileURLToPath(new URL('./src/locales/**', import.meta.url))],
+    }),
     VitePWA({
       registerType: 'autoUpdate',
       injectRegister: 'auto',

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
     VueI18nPlugin({
       // Precompile the JSON message catalogs so no runtime message compiler (or eval) is needed.
       include: [fileURLToPath(new URL('./src/locales/**', import.meta.url))],
+      // Some messages intentionally contain inline HTML (<strong>/<code>) rendered via v-html or
+      // <i18n-t>; allow it instead of failing compilation.
+      strictMessage: false,
+      escapeHtml: false,
     }),
     VitePWA({
       registerType: 'autoUpdate',

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -7,6 +7,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       environment: 'jsdom',
+      setupFiles: ['./src/test-setup.ts'],
       exclude: [...configDefaults.exclude, 'e2e/**'],
       root: fileURLToPath(new URL('./', import.meta.url)),
       coverage: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@ export * from "./audit";
 export * from "./auth";
 export * from "./theme";
 export * from "./display-preferences";
+export * from "./locale";
 export * from "./permissions";
 export * from "./content-filter";
 export * from "./metadata-preferences";

--- a/packages/types/src/locale.ts
+++ b/packages/types/src/locale.ts
@@ -1,0 +1,18 @@
+export const SUPPORTED_LOCALES = ["en", "nl"] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+export const DEFAULT_LOCALE: Locale = "en";
+
+/** Native display names for each supported locale, shown in the language picker. */
+export const LOCALE_LABELS: Record<Locale, string> = {
+  en: "English",
+  nl: "Nederlands",
+};
+
+export interface LocalePreferences {
+  locale: Locale;
+}
+
+export function isSupportedLocale(value: unknown): value is Locale {
+  return typeof value === "string" && (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       vue-echarts:
         specifier: 8.1.0-beta.2
         version: 8.1.0-beta.2(echarts@6.1.0)(vue@3.5.38(typescript@6.0.3))
+      vue-i18n:
+        specifier: ^11.4.6
+        version: 11.4.6(vue@3.5.38(typescript@6.0.3))
       vue-router:
         specifier: ^5.1.0
         version: 5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
@@ -153,6 +156,9 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4(vue@3.5.38(typescript@6.0.3))
     devDependencies:
+      "@intlify/unplugin-vue-i18n":
+        specifier: ^11.2.4
+        version: 11.2.4(@vue/compiler-dom@3.5.38)(eslint@10.5.0(jiti@2.7.0))(rollup@4.62.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-i18n@11.4.6(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
       "@tsconfig/node24":
         specifier: ^24.0.4
         version: 24.0.4
@@ -3795,6 +3801,89 @@ packages:
         integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==,
       }
 
+  "@intlify/bundle-utils@11.2.4":
+    resolution:
+      {
+        integrity: sha512-eE18yR9eM9k5n8snCkHIYp2MuVTxa19aF8z9OMyxXWv0frz2HlBZDGIPFjA38pP3OJ1IlRBXC/dW5GILeLMSCQ==,
+      }
+    engines: { node: ">= 22.13" }
+    peerDependencies:
+      petite-vue-i18n: "*"
+      vue-i18n: "*"
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  "@intlify/core-base@11.4.6":
+    resolution:
+      {
+        integrity: sha512-EOeHO95XESK9IFHgHeZXunsM/WBAoCA0DlaWODvx14vKmetAuS97t+l6Xe9hTUqntPpF93vtVSjjUDafw3wXMw==,
+      }
+    engines: { node: ">= 22" }
+
+  "@intlify/devtools-types@11.4.6":
+    resolution:
+      {
+        integrity: sha512-wowQPpNem56b2d43IJmqbrzG2FeBKe5f/kUGlpNuBmXs6OSqncF8m1+1lxHuW8ISZJF0ma2RkW3iLkw0g0G4VA==,
+      }
+    engines: { node: ">= 22" }
+
+  "@intlify/message-compiler@11.4.6":
+    resolution:
+      {
+        integrity: sha512-5nj3jULqeTAC1WovwMs1LQWgatTa2pM/rXN9T3XW8rdOtXW9ZF6/GLSNFTKDQmPLwclhPdgUWLJ/4w3fMeeC/Q==,
+      }
+    engines: { node: ">= 22" }
+
+  "@intlify/shared@11.4.6":
+    resolution:
+      {
+        integrity: sha512-m1p1HHAMLhqSpTRH7VnXdrN0CQ4y+9vunFkpLkbD8soIuBsnQdawZXqMCgvwI2UVF9Ww7sVaw7g9tV2VO7shoA==,
+      }
+    engines: { node: ">= 22" }
+
+  "@intlify/unplugin-vue-i18n@11.2.4":
+    resolution:
+      {
+        integrity: sha512-bY0ZOaVUvWTyvy4bRGCUKw4Brx5uH/ojjVKsZ1aWzY2drFKIJbeP8DpGMD2QZT8aLpZSUsHtiJlRGLQSZenrvw==,
+      }
+    engines: { node: ">= 22.13" }
+    peerDependencies:
+      petite-vue-i18n: "*"
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
+      vue-i18n: "*"
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vite:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  "@intlify/vue-i18n-extensions@8.0.0":
+    resolution:
+      {
+        integrity: sha512-w0+70CvTmuqbskWfzeYhn0IXxllr6mU+IeM2MU0M+j9OW64jkrvqY+pYFWrUnIIC9bEdij3NICruicwd5EgUuQ==,
+      }
+    engines: { node: ">= 18" }
+    peerDependencies:
+      "@intlify/shared": ^9.0.0 || ^10.0.0 || ^11.0.0
+      "@vue/compiler-dom": ^3.0.0
+      vue: ^3.0.0
+      vue-i18n: ^9.0.0 || ^10.0.0 || ^11.0.0
+    peerDependenciesMeta:
+      "@intlify/shared":
+        optional: true
+      "@vue/compiler-dom":
+        optional: true
+      vue:
+        optional: true
+      vue-i18n:
+        optional: true
+
   "@isaacs/cliui@8.0.2":
     resolution:
       {
@@ -6401,6 +6490,12 @@ packages:
         integrity: sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==,
       }
 
+  "@vue/devtools-api@6.6.4":
+    resolution:
+      {
+        integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==,
+      }
+
   "@vue/devtools-api@7.7.9":
     resolution:
       {
@@ -8763,6 +8858,14 @@ packages:
       }
     engines: { node: ">=12" }
 
+  escodegen@2.1.0:
+    resolution:
+      {
+        integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==,
+      }
+    engines: { node: ">=6.0" }
+    hasBin: true
+
   eslint-config-prettier@10.1.8:
     resolution:
       {
@@ -8881,6 +8984,13 @@ packages:
         integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==,
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
+
+  espree@9.6.1:
+    resolution:
+      {
+        integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
   esprima@4.0.1:
     resolution:
@@ -9473,6 +9583,7 @@ packages:
         integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==,
       }
     engines: { node: ">=18" }
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -10485,6 +10596,13 @@ packages:
       }
     engines: { node: ">=6" }
     hasBin: true
+
+  jsonc-eslint-parser@2.4.2:
+    resolution:
+      {
+        integrity: sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
   jsonc-parser@3.3.1:
     resolution:
@@ -14144,6 +14262,13 @@ packages:
       }
     engines: { node: ">=20.19.0" }
 
+  unplugin@2.3.11:
+    resolution:
+      {
+        integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==,
+      }
+    engines: { node: ">=18.12.0" }
+
   unplugin@3.0.0:
     resolution:
       {
@@ -14431,6 +14556,15 @@ packages:
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+
+  vue-i18n@11.4.6:
+    resolution:
+      {
+        integrity: sha512-l0gE7Rfy0phCa5ChKYkOq543Wgd39BCK6hkktfr1Ed4D99oRkgPK9ffShASZdeC8OJxGfdWmpYoAaAH6iLEuIg==,
+      }
+    engines: { node: ">= 22" }
+    peerDependencies:
+      vue: ^3.0.0
 
   vue-router@5.1.0:
     resolution:
@@ -14896,6 +15030,13 @@ packages:
       {
         integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
       }
+
+  yaml-eslint-parser@1.3.2:
+    resolution:
+      {
+        integrity: sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==,
+      }
+    engines: { node: ^14.17.0 || >=16.0.0 }
 
   yaml@2.9.0:
     resolution:
@@ -17182,6 +17323,72 @@ snapshots:
     dependencies:
       "@swc/helpers": 0.5.23
 
+  "@intlify/bundle-utils@11.2.4(vue-i18n@11.4.6(vue@3.5.38(typescript@6.0.3)))":
+    dependencies:
+      "@intlify/message-compiler": 11.4.6
+      "@intlify/shared": 11.4.6
+      acorn: 8.17.0
+      esbuild: 0.25.12
+      escodegen: 2.1.0
+      estree-walker: 2.0.2
+      jsonc-eslint-parser: 2.4.2
+      source-map-js: 1.2.1
+      yaml-eslint-parser: 1.3.2
+    optionalDependencies:
+      vue-i18n: 11.4.6(vue@3.5.38(typescript@6.0.3))
+
+  "@intlify/core-base@11.4.6":
+    dependencies:
+      "@intlify/devtools-types": 11.4.6
+      "@intlify/message-compiler": 11.4.6
+      "@intlify/shared": 11.4.6
+
+  "@intlify/devtools-types@11.4.6":
+    dependencies:
+      "@intlify/core-base": 11.4.6
+      "@intlify/shared": 11.4.6
+
+  "@intlify/message-compiler@11.4.6":
+    dependencies:
+      "@intlify/shared": 11.4.6
+      source-map-js: 1.2.1
+
+  "@intlify/shared@11.4.6": {}
+
+  "@intlify/unplugin-vue-i18n@11.2.4(@vue/compiler-dom@3.5.38)(eslint@10.5.0(jiti@2.7.0))(rollup@4.62.2)(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-i18n@11.4.6(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))":
+    dependencies:
+      "@eslint-community/eslint-utils": 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      "@intlify/bundle-utils": 11.2.4(vue-i18n@11.4.6(vue@3.5.38(typescript@6.0.3)))
+      "@intlify/shared": 11.4.6
+      "@intlify/vue-i18n-extensions": 8.0.0(@intlify/shared@11.4.6)(@vue/compiler-dom@3.5.38)(vue-i18n@11.4.6(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
+      "@rollup/pluginutils": 5.4.0(rollup@4.62.2)
+      "@typescript-eslint/scope-manager": 8.61.1
+      "@typescript-eslint/typescript-estree": 8.61.1(typescript@6.0.3)
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      unplugin: 2.3.11
+      vue: 3.5.38(typescript@6.0.3)
+    optionalDependencies:
+      vite: 8.0.16(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vue-i18n: 11.4.6(vue@3.5.38(typescript@6.0.3))
+    transitivePeerDependencies:
+      - "@vue/compiler-dom"
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  "@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.4.6)(@vue/compiler-dom@3.5.38)(vue-i18n@11.4.6(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))":
+    dependencies:
+      "@babel/parser": 7.29.7
+    optionalDependencies:
+      "@intlify/shared": 11.4.6
+      "@vue/compiler-dom": 3.5.38
+      vue: 3.5.38(typescript@6.0.3)
+      vue-i18n: 11.4.6(vue@3.5.38(typescript@6.0.3))
+
   "@isaacs/cliui@8.0.2":
     dependencies:
       string-width: 5.1.2
@@ -18744,6 +18951,8 @@ snapshots:
       "@vue/compiler-dom": 3.5.38
       "@vue/shared": 3.5.38
 
+  "@vue/devtools-api@6.6.4": {}
+
   "@vue/devtools-api@7.7.9":
     dependencies:
       "@vue/devtools-kit": 7.7.9
@@ -19050,6 +19259,10 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
+
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
 
   acorn-walk@8.3.5:
     dependencies:
@@ -20214,6 +20427,14 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
   eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       eslint: 10.5.0(jiti@2.7.0)
@@ -20314,6 +20535,12 @@ snapshots:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
 
@@ -21237,6 +21464,13 @@ snapshots:
   json-with-bigint@3.5.8: {}
 
   json5@2.2.3: {}
+
+  jsonc-eslint-parser@2.4.2:
+    dependencies:
+      acorn: 8.17.0
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      semver: 7.8.5
 
   jsonc-parser@3.3.1: {}
 
@@ -23450,6 +23684,13 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
 
+  unplugin@2.3.11:
+    dependencies:
+      "@jridgewell/remapping": 2.3.5
+      acorn: 8.17.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
   unplugin@3.0.0:
     dependencies:
       "@jridgewell/remapping": 2.3.5
@@ -23631,6 +23872,14 @@ snapshots:
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
+
+  vue-i18n@11.4.6(vue@3.5.38(typescript@6.0.3)):
+    dependencies:
+      "@intlify/core-base": 11.4.6
+      "@intlify/devtools-types": 11.4.6
+      "@intlify/shared": 11.4.6
+      "@vue/devtools-api": 6.6.4
+      vue: 3.5.38(typescript@6.0.3)
 
   vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
@@ -23996,6 +24245,11 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml-eslint-parser@1.3.2:
+    dependencies:
+      eslint-visitor-keys: 3.4.3
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 

--- a/server/src/modules/user-preferences/user-preferences.controller.test.ts
+++ b/server/src/modules/user-preferences/user-preferences.controller.test.ts
@@ -1,5 +1,5 @@
 import type { Mocked } from 'vitest';
-import { EMPTY_CONTENT_FILTER_RULES, type DisplayPreferences, type ThemePreferences } from '@bookorbit/types';
+import { EMPTY_CONTENT_FILTER_RULES, type DisplayPreferences, type LocalePreferences, type ThemePreferences } from '@bookorbit/types';
 
 import type { RequestUser } from '../../common/types/request-user';
 import { UserPreferencesController } from './user-preferences.controller';
@@ -56,6 +56,10 @@ const validDisplayPreferences: DisplayPreferences = {
   thumbnailClickAction: 'reader',
 };
 
+const validLocalePreferences: LocalePreferences = {
+  locale: 'nl',
+};
+
 describe('UserPreferencesController', () => {
   let service: Mocked<UserPreferencesService>;
   let controller: UserPreferencesController;
@@ -64,8 +68,10 @@ describe('UserPreferencesController', () => {
     service = {
       getThemePreferences: vi.fn(),
       getDisplayPreferences: vi.fn(),
+      getLocalePreferences: vi.fn(),
       upsertThemePreferences: vi.fn(),
       upsertDisplayPreferences: vi.fn(),
+      upsertLocalePreferences: vi.fn(),
     } as unknown as Mocked<UserPreferencesService>;
 
     controller = new UserPreferencesController(service);
@@ -127,5 +133,34 @@ describe('UserPreferencesController', () => {
     await controller.upsertDisplayPreferences({ settings: validDisplayPreferences as unknown as Record<string, unknown> }, user);
 
     expect(service.upsertDisplayPreferences).toHaveBeenCalledWith(99, validDisplayPreferences);
+  });
+
+  it('GET /locale returns null settings when no saved preferences exist', async () => {
+    service.getLocalePreferences.mockResolvedValueOnce(null);
+
+    await expect(controller.getLocalePreferences(makeUser({ id: 11 }))).resolves.toEqual({ settings: null });
+    expect(service.getLocalePreferences).toHaveBeenCalledWith(11);
+  });
+
+  it('GET /locale returns saved settings when present', async () => {
+    service.getLocalePreferences.mockResolvedValueOnce(validLocalePreferences);
+
+    await expect(controller.getLocalePreferences(makeUser())).resolves.toEqual({ settings: validLocalePreferences });
+  });
+
+  it('PUT /locale delegates valid payloads to the service and returns 204', async () => {
+    const user = makeUser({ id: 42 });
+    const dto = { settings: validLocalePreferences as unknown as Record<string, unknown> };
+
+    await expect(controller.upsertLocalePreferences(dto, user)).resolves.toBeUndefined();
+    expect(service.upsertLocalePreferences).toHaveBeenCalledWith(42, validLocalePreferences);
+  });
+
+  it('PUT /locale forwards the current user id to the service', async () => {
+    const user = makeUser({ id: 99 });
+
+    await controller.upsertLocalePreferences({ settings: validLocalePreferences as unknown as Record<string, unknown> }, user);
+
+    expect(service.upsertLocalePreferences).toHaveBeenCalledWith(99, validLocalePreferences);
   });
 });

--- a/server/src/modules/user-preferences/user-preferences.controller.ts
+++ b/server/src/modules/user-preferences/user-preferences.controller.ts
@@ -33,6 +33,18 @@ export class UserPreferencesController {
     await this.userPreferencesService.upsertDisplayPreferences(user.id, dto.settings);
   }
 
+  @Get('locale')
+  async getLocalePreferences(@CurrentUser() user: RequestUser) {
+    const settings = await this.userPreferencesService.getLocalePreferences(user.id);
+    return { settings };
+  }
+
+  @Put('locale')
+  @HttpCode(204)
+  async upsertLocalePreferences(@Body() dto: UpsertUserPreferenceDto, @CurrentUser() user: RequestUser) {
+    await this.userPreferencesService.upsertLocalePreferences(user.id, dto.settings);
+  }
+
   @Get('whats-new')
   async getWhatsNewPreferences(@CurrentUser() user: RequestUser) {
     const settings = await this.userPreferencesService.getWhatsNewPreferences(user.id);

--- a/server/src/modules/user-preferences/user-preferences.service.test.ts
+++ b/server/src/modules/user-preferences/user-preferences.service.test.ts
@@ -1,6 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { DisplayPreferences, ThemePreferences } from '@bookorbit/types';
+import type { DisplayPreferences, LocalePreferences, ThemePreferences } from '@bookorbit/types';
 
 import { UserPreferencesRepository } from './user-preferences.repository';
 import { UserPreferencesService } from './user-preferences.service';
@@ -38,8 +38,12 @@ const validDisplayPreferences: DisplayPreferences = {
   thumbnailClickAction: 'reader',
 };
 
+const validLocalePreferences: LocalePreferences = {
+  locale: 'nl',
+};
+
 const repo = {
-  findByCategory: vi.fn<(...args: [number, string]) => Promise<{ data: ThemePreferences | DisplayPreferences } | undefined>>(),
+  findByCategory: vi.fn<(...args: [number, string]) => Promise<{ data: ThemePreferences | DisplayPreferences | LocalePreferences } | undefined>>(),
   upsert: vi.fn<(...args: [number, string, Record<string, unknown>]) => Promise<void>>(),
   delete: vi.fn<(...args: [number, string]) => Promise<void>>(),
 };
@@ -74,6 +78,34 @@ describe('UserPreferencesService', () => {
     repo.findByCategory.mockResolvedValueOnce({ data: validDisplayPreferences });
 
     await expect(service.getDisplayPreferences(7)).resolves.toEqual(validDisplayPreferences);
+  });
+
+  it('getLocalePreferences returns null when repository has no row', async () => {
+    await expect(service.getLocalePreferences(7)).resolves.toBeNull();
+    expect(repo.findByCategory).toHaveBeenCalledWith(7, 'locale');
+  });
+
+  it('getLocalePreferences returns saved locale settings when row exists', async () => {
+    repo.findByCategory.mockResolvedValueOnce({ data: validLocalePreferences });
+
+    await expect(service.getLocalePreferences(7)).resolves.toEqual(validLocalePreferences);
+  });
+
+  it('upsertLocalePreferences persists validated settings', async () => {
+    await expect(service.upsertLocalePreferences(11, validLocalePreferences)).resolves.toBeUndefined();
+    expect(repo.upsert).toHaveBeenCalledWith(11, 'locale', validLocalePreferences);
+  });
+
+  it('upsertLocalePreferences rejects unsupported locale', async () => {
+    await expect(service.upsertLocalePreferences(11, { locale: 'de' } as never)).rejects.toBeInstanceOf(BadRequestException);
+    expect(repo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('upsertLocalePreferences rejects extra unknown fields', async () => {
+    await expect(
+      service.upsertLocalePreferences(11, { ...validLocalePreferences, unexpected: true } as Record<string, unknown>),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(repo.upsert).not.toHaveBeenCalled();
   });
 
   it('upsertThemePreferences persists validated settings', async () => {

--- a/server/src/modules/user-preferences/user-preferences.service.ts
+++ b/server/src/modules/user-preferences/user-preferences.service.ts
@@ -13,9 +13,11 @@ import {
   GRID_CARD_LABEL_FIELDS,
   RADIUS_IDS,
   SERIES_CARD_COVER_MODES,
+  SUPPORTED_LOCALES,
   TABLE_DENSITIES,
   THEME_IDS,
   type DisplayPreferences,
+  type LocalePreferences,
   type ThemePreferences,
   type WhatsNewPreferences,
 } from '@bookorbit/types';
@@ -71,6 +73,12 @@ const DISPLAY_PREFERENCES_SCHEMA = z
     }
   });
 
+const LOCALE_PREFERENCES_SCHEMA = z
+  .object({
+    locale: z.enum(SUPPORTED_LOCALES),
+  })
+  .strict();
+
 const WHATS_NEW_PREFERENCES_SCHEMA = z
   .object({
     lastSeenVersion: z.string().min(1).max(50).optional(),
@@ -120,6 +128,38 @@ export class UserPreferencesService {
       const error = sanitizeLogValue(err instanceof Error ? err.message : String(err));
       this.logger.error(
         `[user_preferences.upsert_whats_new] [fail] userId=${userId} durationMs=${durationMs} errorClass=${errorClass} error="${error}" - upsert whats-new preferences failed`,
+      );
+      throw err;
+    }
+  }
+
+  async getLocalePreferences(userId: number): Promise<LocalePreferences | null> {
+    const row = await this.repo.findByCategory(userId, 'locale');
+    return row ? (row.data as LocalePreferences) : null;
+  }
+
+  async upsertLocalePreferences(userId: number, data: Record<string, unknown>): Promise<void> {
+    const start = Date.now();
+    this.logger.log(`[user_preferences.upsert_locale] [start] userId=${userId} - upsert locale preferences started`);
+
+    const result = LOCALE_PREFERENCES_SCHEMA.safeParse(data);
+    if (!result.success) {
+      const firstIssue = result.error.issues[0];
+      const issuePath = firstIssue?.path.length ? firstIssue.path.join('.') : 'settings';
+      const issueMessage = firstIssue?.message ?? 'Invalid settings payload';
+      throw new BadRequestException(`Invalid locale preferences at "${issuePath}": ${issueMessage}`);
+    }
+
+    try {
+      await this.repo.upsert(userId, 'locale', result.data);
+      const durationMs = Date.now() - start;
+      this.logger.log(`[user_preferences.upsert_locale] [end] userId=${userId} durationMs=${durationMs} - upsert locale preferences completed`);
+    } catch (err) {
+      const durationMs = Date.now() - start;
+      const errorClass = err instanceof Error ? err.constructor.name : 'UnknownError';
+      const error = sanitizeLogValue(err instanceof Error ? err.message : String(err));
+      this.logger.error(
+        `[user_preferences.upsert_locale] [fail] userId=${userId} durationMs=${durationMs} errorClass=${errorClass} error="${error}" - upsert locale preferences failed`,
       );
       throw err;
     }


### PR DESCRIPTION
## Summary

Adds multi-language (i18n) support to the client and ships a complete Dutch (nl) translation. This introduces the framework, so adding further languages (for example the Slovenian translation offered in #20) becomes a matter of dropping in one JSON catalog.

Addresses #20 (currently labeled `status:blocked`). This PR unblocks it by providing the translation infrastructure plus a first non-English locale.

## What's included

- **Library:** `vue-i18n@11` + `@intlify/unplugin-vue-i18n` (Vite plugin precompiles the JSON catalogs; non-default locales are lazy-loaded as separate chunks).
- **Extraction:** roughly 4,400 message keys covering every one of the 421 `.vue` components, plus router browser titles and settings tab bars. Pluralization uses vue-i18n plural forms; label collections are wrapped in `computed()` so they re-render on a language switch; dates and numbers use `Intl`.
- **Dutch catalog:** full `nl.json` for all keys, with a consistent glossary. Product and brand names (BookOrbit, Kobo, Hardcover, SmartScope, etc.) are left untranslated.
- **Language switcher:** Settings, Display, Behavior.
- **Locale persistence:** rides the existing theme/display preference mechanism (see the design note below).
- **Tests:** a vitest setup installs vue-i18n globally so component tests resolve real messages. Client type-check, lint, unit tests (3097), and the production build all pass.

## How locale is stored today

Locale follows the exact same model as theme and display preferences:

- Default: written to `localStorage` under `locale`, so it is per browser/device.
- Initial value when nothing is stored: `navigator.language`, falling back to English.
- Optional per-user, cross-device sync: only when the user picks "My account" storage in Settings, Display. That reuses the existing `syncThemePreferences` flag and stores the locale server-side under a new `locale` category on the generic `user_preferences` table (no schema migration needed; endpoints and tests added).

## Open decision: how should locale be persisted?

This is the main thing to decide before merge. Options:

1. **Keep the current approach** (browser-first, optional account sync via the existing toggle). Consistent with theme/display, no new UI, no forced DB writes for anonymous or pre-login users.
2. **Always persist per-user in the database.** Cross-device by default, but adds a required user setting and does not cover the pre-login screens (login, setup, OIDC callback), which still need a browser-level choice.
3. **Browser-only, plus a small language icon in the top bar** for quick switching (the idea raised in review). Simplest and most discoverable, but no cross-device follow.

Recommendation: keep option 1 as the storage model (it is already wired and tested) and optionally add the small top-bar language control from option 3 for discoverability. Happy to adjust based on maintainer preference.

## Still to do / known gaps

The sweep covered all `.vue` templates and scripts. A few `.ts`-sourced strings remain English and were intentionally left for a focused follow-up:

- Some option/label maps that live in `@bookorbit/types` (for example permission labels, metadata-score group labels) and a handful of thrown `Error` / toast fallback strings in composables and `api/*.ts`.
- ECharts-internal axis and tooltip strings in the statistics charts.
- Dashboard scroller and widget default labels. These are deliberately excluded: the `label` is user-editable and persisted, so replacing the default with `t()` would freeze the translation into stored config and be indistinguishable from a user rename. The correct fix is to persist only the stable `type` plus an optional custom label (null for defaults) and render `label ?? t(keyForType)` at display time. This deserves its own change with a read-time normalization for existing stored configs.
- Server-side email and notification templates (out of scope for this frontend PR).

## Testing

- `pnpm --filter client type-check`: 0 errors
- `pnpm --filter client lint:check`: clean
- `pnpm --filter client test:unit --run`: 262 files, 3097 tests passing
- `pnpm --filter client build`: succeeds (Dutch ships as a lazy chunk)
- Manual: switching to Nederlands updates the UI and browser tab titles immediately and persists across reloads.

## Notes for reviewers

- To add a language later: add `xx` to `SUPPORTED_LOCALES` and `LOCALE_LABELS` in `packages/types/src/locale.ts`, then add `client/src/locales/xx.json`. That is the whole checklist, which is what makes the Slovenian offer in #20 straightforward.
