### PR TITLE
feat(auth): accept extra OIDC redirect URIs (native clients + multi-host SSO)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,15 @@ NODE_MAX_OLD_SPACE_SIZE=2048
 # Default false. Enable only in trusted self-hosted networks.
 # OIDC_ALLOW_LOCAL_ISSUERS=false
 
+# Comma-separated allow-list of additional OIDC redirect URIs the login callback
+# will accept, on top of the implicit APP_URL + /oauth2-callback. Use it for:
+#   - native apps that redirect to a custom scheme (e.g. bookorbit://oauth2-callback)
+#   - instances reachable on more than one hostname (LAN, VPN/overlay, public) that
+#     each need to complete SSO
+# http(s) entries are matched by origin + path; custom-scheme entries are matched
+# exactly. Default: bookorbit://oauth2-callback
+# OIDC_EXTRA_REDIRECT_URIS=bookorbit://oauth2-callback,https://books.lan/oauth2-callback
+
 # Optional: allow Cloudflare Web Analytics beacon when using automatic setup.
 # Keep unset/false to preserve strict CSP (`script-src 'self'`).
 # CSP_ALLOW_CLOUDFLARE_INSIGHTS=false

--- a/docker-compose.oidc.yml
+++ b/docker-compose.oidc.yml
@@ -1,0 +1,10 @@
+services:
+  dex:
+    image: ghcr.io/dexidp/dex:v2.41.1
+    container_name: bookorbit-dex
+    ports:
+      - "5556:5556"
+    volumes:
+      - ./scripts/dex-config.yaml:/etc/dex/config.yaml:ro
+    command: ["dex", "serve", "/etc/dex/config.yaml"]
+    restart: unless-stopped

--- a/scripts/dex-config.yaml
+++ b/scripts/dex-config.yaml
@@ -1,0 +1,28 @@
+issuer: http://localhost:5556/dex
+
+storage:
+  type: memory
+
+web:
+  http: 0.0.0.0:5556
+
+# Dev only: http issuer, no approval screen, and username/password login via the static list below.
+oauth2:
+  skipApprovalScreen: true
+
+enablePasswordDB: true
+
+staticClients:
+  - id: bookorbit-mobile
+    name: BookOrbit Mobile
+    public: true
+    redirectURIs:
+      - bookorbit://oauth2-callback
+      - http://localhost:5173/oauth2-callback
+
+staticPasswords:
+  - email: "dev@bookorbit.local"
+    # bcrypt hash of "password" (cost 10)
+    hash: "$2b$10$0ZjmQ93OgxPgeTBArfHa9.VJIifcBBPqnjka/JnrG4GKwtNGtrFnC"
+    username: "dev"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/server/src/config/config.test.ts
+++ b/server/src/config/config.test.ts
@@ -10,6 +10,7 @@ function resetEnv(): void {
   delete process.env.APP_URL;
   delete process.env.APP_VERSION;
   delete process.env.OIDC_ALLOW_LOCAL_ISSUERS;
+  delete process.env.OIDC_EXTRA_REDIRECT_URIS;
   delete process.env.SWAGGER_ENABLED;
   delete process.env.KOBO_CLOUDSCRAPER_PYTHON;
   delete process.env.KOREADER_PLUGIN_PATH;
@@ -50,6 +51,7 @@ describe('config', () => {
       githubReleasesRepo: 'bookorbit/bookorbit',
       githubReleasesToken: undefined,
       oidcAllowLocalIssuers: false,
+      oidcExtraRedirectUris: ['bookorbit://oauth2-callback'],
       swaggerEnabled: false,
       koboCloudscraperPython: undefined,
       koreaderPluginSourcePath: undefined,
@@ -74,6 +76,7 @@ describe('config', () => {
       githubReleasesRepo: 'acme/app',
       githubReleasesToken: 'ghp_example',
       oidcAllowLocalIssuers: true,
+      oidcExtraRedirectUris: ['bookorbit://oauth2-callback'],
       swaggerEnabled: true,
       koboCloudscraperPython: '/opt/bookorbit-python/bin/python',
       koreaderPluginSourcePath: '/opt/koreader/bookorbit.koplugin',
@@ -83,6 +86,16 @@ describe('config', () => {
   it('falls back to false when OIDC_ALLOW_LOCAL_ISSUERS is invalid', () => {
     process.env.OIDC_ALLOW_LOCAL_ISSUERS = 'maybe';
     expect(appConfig().oidcAllowLocalIssuers).toBe(false);
+  });
+
+  it('parses OIDC_EXTRA_REDIRECT_URIS as a comma-separated list', () => {
+    process.env.OIDC_EXTRA_REDIRECT_URIS = 'bookorbit://oauth2-callback, https://books.lan/oauth2-callback';
+    expect(appConfig().oidcExtraRedirectUris).toEqual(['bookorbit://oauth2-callback', 'https://books.lan/oauth2-callback']);
+  });
+
+  it('falls back to the default when OIDC_EXTRA_REDIRECT_URIS has no usable entries', () => {
+    process.env.OIDC_EXTRA_REDIRECT_URIS = ' , ,';
+    expect(appConfig().oidcExtraRedirectUris).toEqual(['bookorbit://oauth2-callback']);
   });
 
   it('uses defaults for database, auth, email, and migration config', () => {

--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -1,6 +1,10 @@
 import { registerAs } from '@nestjs/config';
 import { join, resolve } from 'path';
 
+// Redirect URI accepted for native clients out of the box (matches the Android/iOS app's
+// custom scheme). Callers can extend the allow-list via OIDC_EXTRA_REDIRECT_URIS.
+export const DEFAULT_OIDC_EXTRA_REDIRECT_URI = 'bookorbit://oauth2-callback';
+
 export const appConfig = registerAs('app', () => ({
   nodeEnv: process.env.NODE_ENV ?? 'development',
   appUrl: process.env.APP_URL ?? 'http://localhost:5173',
@@ -8,6 +12,7 @@ export const appConfig = registerAs('app', () => ({
   githubReleasesRepo: process.env.GITHUB_RELEASES_REPO?.trim() || 'bookorbit/bookorbit',
   githubReleasesToken: process.env.GITHUB_RELEASES_TOKEN?.trim() || undefined,
   oidcAllowLocalIssuers: parseBooleanFlag(process.env.OIDC_ALLOW_LOCAL_ISSUERS, false),
+  oidcExtraRedirectUris: parseStringList(process.env.OIDC_EXTRA_REDIRECT_URIS, [DEFAULT_OIDC_EXTRA_REDIRECT_URI]),
   swaggerEnabled: parseBooleanFlag(process.env.SWAGGER_ENABLED, false),
   koboCloudscraperPython: process.env.KOBO_CLOUDSCRAPER_PYTHON?.trim() || undefined,
   koreaderPluginSourcePath: process.env.KOREADER_PLUGIN_PATH?.trim() || undefined,
@@ -58,6 +63,15 @@ export const oidcRuntimeConfig = registerAs('oidcRuntime', () => ({
   clockToleranceSecs: parsePositiveInteger(process.env.OIDC_CLOCK_TOLERANCE_SECS, 30),
   tokenExchangeTimeoutMs: parsePositiveInteger(process.env.OIDC_TOKEN_EXCHANGE_TIMEOUT_MS, 10_000),
 }));
+
+function parseStringList(value: string | undefined, fallback: string[]): string[] {
+  if (!value?.trim()) return fallback;
+  const parsed = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return parsed.length > 0 ? parsed : fallback;
+}
 
 function parsePositiveInteger(value: string | undefined, fallback: number): number {
   const parsed = Number(value);

--- a/server/src/config/env.validation.ts
+++ b/server/src/config/env.validation.ts
@@ -58,6 +58,7 @@ const envSchema = z.object({
   FILE_WRITE_MAX_CONCURRENT_WRITES: z.coerce.number().int().positive().optional(),
   CLIENT_URL: z.string().url().optional(),
   APP_URL: z.string().url().default('http://localhost:5173'),
+  OIDC_EXTRA_REDIRECT_URIS: z.string().optional(),
   TRUST_PROXY: z.string().optional(),
   EMAIL_ENCRYPTION_KEY: z.string().optional(),
   MIGRATION_ENCRYPTION_KEY: z.string().optional(),

--- a/server/src/modules/auth/oidc/oidc.service.test.ts
+++ b/server/src/modules/auth/oidc/oidc.service.test.ts
@@ -22,7 +22,7 @@ const PROVIDER = {
   updatedAt: new Date(),
 };
 
-function makeService() {
+function makeService(options: { extraRedirectUris?: string[] } = {}) {
   const providerService = {
     findBySlugOrFail: vi.fn().mockResolvedValue(PROVIDER),
     findByIdOrFail: vi.fn().mockResolvedValue(PROVIDER),
@@ -87,6 +87,7 @@ function makeService() {
   const configService = {
     get: vi.fn().mockImplementation((key: string) => {
       if (key === 'app.appUrl') return APP_URL;
+      if (key === 'app.oidcExtraRedirectUris') return options.extraRedirectUris;
       return undefined;
     }),
   };
@@ -185,6 +186,41 @@ describe('OidcService', () => {
       await expect(service.handleCallback({ ...BASE_CALLBACK, redirectUri: 'https://evil.example/callback' }, {} as never)).rejects.toThrow(
         BadRequestException,
       );
+    });
+
+    it('rejects an unknown custom-scheme redirect URI', async () => {
+      const { service } = makeService();
+      await expect(service.handleCallback({ ...BASE_CALLBACK, redirectUri: 'evil://oauth2-callback' }, {} as never)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('accepts the default native redirect URI (bookorbit://oauth2-callback)', async () => {
+      const { service, identityRepo, userService, authService } = makeService();
+      identityRepo.findByProviderAndSubject.mockResolvedValue({ userId: 5 });
+      userService.findById.mockResolvedValue({ id: 5, username: 'u1', active: true, permissions: [] });
+      await expect(service.handleCallback({ ...BASE_CALLBACK, redirectUri: 'bookorbit://oauth2-callback' }, {} as never)).resolves.toMatchObject({
+        mode: 'login',
+      });
+      expect(authService.issueTokensForUser).toHaveBeenCalled();
+    });
+
+    it('accepts a redirect URI with surrounding whitespace', async () => {
+      const { service, identityRepo, userService } = makeService();
+      identityRepo.findByProviderAndSubject.mockResolvedValue({ userId: 5 });
+      userService.findById.mockResolvedValue({ id: 5, username: 'u1', active: true, permissions: [] });
+      await expect(service.handleCallback({ ...BASE_CALLBACK, redirectUri: `  ${VALID_REDIRECT_URI}  ` }, {} as never)).resolves.toMatchObject({
+        mode: 'login',
+      });
+    });
+
+    it('accepts an extra web redirect URI configured via OIDC_EXTRA_REDIRECT_URIS', async () => {
+      const { service, identityRepo, userService } = makeService({ extraRedirectUris: ['https://books.vpn/oauth2-callback'] });
+      identityRepo.findByProviderAndSubject.mockResolvedValue({ userId: 5 });
+      userService.findById.mockResolvedValue({ id: 5, username: 'u1', active: true, permissions: [] });
+      await expect(
+        service.handleCallback({ ...BASE_CALLBACK, redirectUri: 'https://books.vpn/oauth2-callback' }, {} as never),
+      ).resolves.toMatchObject({ mode: 'login' });
     });
 
     it('rejects callback when extracted subject is missing', async () => {

--- a/server/src/modules/auth/oidc/oidc.service.ts
+++ b/server/src/modules/auth/oidc/oidc.service.ts
@@ -5,6 +5,7 @@ import type { FastifyReply } from 'fastify';
 import { AuditAction, AuditResource, OidcCallbackResponse, OidcErrorCode, Permission } from '@bookorbit/types';
 import type { OidcAutoProvision, OidcClaimMapping } from '@bookorbit/types';
 
+import { DEFAULT_OIDC_EXTRA_REDIRECT_URI } from '../../../config/config';
 import { AUDIT_EVENT, AuditEventsService } from '../../audit/audit-events.service';
 import { OidcProviderService } from '../../app-settings/oidc-provider.service';
 import { OidcIdentityRepository } from '../../user/oidc-identity.repository';
@@ -32,19 +33,11 @@ function toThrowable(error: unknown, fallbackMessage: string): Error {
   return error instanceof Error ? error : new UnauthorizedException(fallbackMessage);
 }
 
-function normalizeRedirectUri(raw: string): string {
-  try {
-    const u = new URL(raw);
-    return u.origin + u.pathname;
-  } catch {
-    return raw;
-  }
-}
-
 @Injectable()
 export class OidcService {
   private readonly logger = new Logger(OidcService.name);
   private readonly appUrl: string;
+  private readonly allowedRedirectUris: string[];
 
   constructor(
     private readonly providerService: OidcProviderService,
@@ -63,6 +56,28 @@ export class OidcService {
     private readonly configService: ConfigService,
   ) {
     this.appUrl = (this.configService.get<string>('app.appUrl') ?? 'http://localhost:5173').replace(/\/$/, '');
+    const extraUris = this.configService.get<string[]>('app.oidcExtraRedirectUris') ?? [DEFAULT_OIDC_EXTRA_REDIRECT_URI];
+    this.allowedRedirectUris = [`${this.appUrl}/oauth2-callback`, ...extraUris];
+  }
+
+  /**
+   * Whether [redirectUri] is on the allow-list (APP_URL callback + OIDC_EXTRA_REDIRECT_URIS).
+   * http/https URIs are compared by origin + pathname so a deployment reachable on several
+   * hostnames can list each; custom-scheme URIs (e.g. `bookorbit://oauth2-callback` from
+   * native clients) are compared as exact strings after trimming whitespace and trailing slashes.
+   */
+  private isRedirectUriAllowed(redirectUri: string): boolean {
+    const normalize = (raw: string): string => {
+      const trimmed = raw.trim();
+      try {
+        const u = new URL(trimmed);
+        return u.protocol === 'http:' || u.protocol === 'https:' ? u.origin + u.pathname : trimmed.replace(/\/+$/, '');
+      } catch {
+        return trimmed.replace(/\/+$/, '');
+      }
+    };
+    const target = normalize(redirectUri);
+    return this.allowedRedirectUris.some((allowed) => normalize(allowed) === target);
   }
 
   async generateState(providerSlug: string): Promise<{ state: string; authorizationEndpoint: string }> {
@@ -165,8 +180,7 @@ export class OidcService {
     const claimMapping = provider.claimMapping as OidcClaimMapping;
     const autoProvision = provider.autoProvision as OidcAutoProvision;
 
-    const allowedRedirectUri = `${this.appUrl}/oauth2-callback`;
-    if (normalizeRedirectUri(params.redirectUri) !== normalizeRedirectUri(allowedRedirectUri)) {
+    if (!this.isRedirectUriAllowed(params.redirectUri)) {
       throw new BadRequestException(`Redirect URI is not allowed: ${params.redirectUri}`);
     }
 


### PR DESCRIPTION
## Summary

The OIDC login callback only ever accepted `APP_URL` + `/oauth2-callback`. That
rejects two legitimate deployments:

- **Native clients** (e.g. [deranjer/bookorbit-android](https://github.com/deranjer/bookorbit-android))
  complete OIDC via a custom-scheme redirect such as `bookorbit://oauth2-callback`.
  The callback returned HTTP 400 (bookorbit-android#37).
- **Multi-hostname instances** — a single deployment reachable on a LAN name, a
  VPN/overlay name, and sometimes a public one. SSO only works from whichever
  hostname `APP_URL` happens to be, with no way to configure around it
  (raised by @raphi011 in #490).

Adds `OIDC_EXTRA_REDIRECT_URIS` (comma-separated, default
`bookorbit://oauth2-callback`). The callback validates the incoming redirect URI
against the combined allow-list — implicit `APP_URL` callback plus the configured
entries:

- **http/https** entries match by origin + pathname (so each extra hostname works)
- **custom-scheme** entries match by exact string after trimming whitespace and
  trailing slashes

Purely additive — the default preserves existing single-host web behavior. Also
adds an optional `docker-compose.oidc.yml` + Dex config for running a local OIDC
provider during development.

### Changed from the original PR

- Renamed `OIDC_MOBILE_REDIRECT_URIS` → `OIDC_EXTRA_REDIRECT_URIS` and let http(s)
  entries through, so the same setting fixes the multi-origin web SSO case per
  @raphi011's review on #490.
- **Dropped** the file-serve rate-limit exemption. `SensitiveEndpointThrottlerGuard`
  (added in `e4536184`, after this branch was cut) made throttling opt-in per
  endpoint via `@Throttle()`; `serveFile`/cover/thumbnail carry none, so they are
  already exempt and `@SkipThrottle()` would be a no-op. Left a note on #490.
- Rebased onto current `main` (branch history was ~560 commits stale).

## Test plan

- [x] `pnpm run verify:fast` (lint + typecheck, server + client) — passes
- [x] `pnpm --filter server test` for `config.test.ts` + `oidc.service.test.ts` — 38 pass
- [x] New `config.test.ts` cases: comma-separated parse, empty-entry fallback
- [x] New `oidc.service.test.ts` cases: native default URI accepted, whitespace
      tolerated, extra web host accepted, unknown custom scheme rejected
- [x] **End-to-end against a live Dex provider:**
  - pre-change: `POST /auth/oidc/callback` with `redirectUri=bookorbit://oauth2-callback`
    → **HTTP 400** `"Redirect URI is not allowed"`
  - post-change: same request → **HTTP 200**, `mode:login`, tokens issued, user
    auto-provisioned
  - the `bookorbit-android` app (fdroid-debug on an emulator) completes the full
    OIDC login and lands on the dashboard; its OkHttp log shows
    `<-- 200 OK .../api/v1/auth/oidc/callback`

Closes #490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional OIDC redirect URIs.
  * Native apps can now use custom-scheme callbacks, such as `bookorbit://oauth2-callback`.
  * Added a development OIDC provider setup for local authentication testing.

* **Bug Fixes**
  * Improved redirect URI validation for web and custom-scheme callbacks.
  * Invalid or unapproved redirect URIs are rejected while valid configured alternatives are accepted.

* **Documentation**
  * Documented the new optional redirect URI configuration and matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->