### PR TITLE
fix(koreader): Offline sync doesn't crash in offline mode

### DIFF
--- a/koreader-plugin/bookorbit.koplugin/bookorbit_main_menu.lua
+++ b/koreader-plugin/bookorbit.koplugin/bookorbit_main_menu.lua
@@ -166,7 +166,7 @@ function MainMenu:addToMainMenu(menu_items)
                 text = _("Skip auto-sync when offline"),
                 checked_func = function() return self.settings.skip_sync_when_offline end,
                 enabled_func = function() return self.settings.auto_sync end,
-                help_text = _([[When enabled, automatic sync on book open is skipped if the device is not already online. Prevents the e-reader from stalling while trying to connect to Wi-Fi.]]),
+                help_text = _([[When enabled, automatic sync (book open, resume, suspend, close, and periodic push) is skipped if the device is not already online. Prevents the e-reader from stalling while trying to connect to Wi-Fi.]]),
                 callback = function()
                     self.settings.skip_sync_when_offline = not self.settings.skip_sync_when_offline
                 end,
@@ -360,7 +360,7 @@ function MainMenu:setServerAddress()
 end
 
 function MainMenu:login(menu)
-    if NetworkMgr:willRerunWhenOnline(function() self:login(menu) end) then
+    if NetworkMgr:willRerunWhenConnected(function() self:login(menu) end) then
         return
     end
 

--- a/koreader-plugin/bookorbit.koplugin/bookorbit_main_menu.lua
+++ b/koreader-plugin/bookorbit.koplugin/bookorbit_main_menu.lua
@@ -166,7 +166,7 @@ function MainMenu:addToMainMenu(menu_items)
                 text = _("Skip auto-sync when offline"),
                 checked_func = function() return self.settings.skip_sync_when_offline end,
                 enabled_func = function() return self.settings.auto_sync end,
-                help_text = _([[When enabled, automatic sync (book open, resume, suspend, close, and periodic push) is skipped if the device is not already online. Prevents the e-reader from stalling while trying to connect to Wi-Fi.]]),
+                help_text = _([[When enabled, automatic sync (book open, resume, suspend, close, and periodic push) is skipped if the device is not already connected. Prevents the e-reader from stalling while trying to connect to Wi-Fi.]]),
                 callback = function()
                     self.settings.skip_sync_when_offline = not self.settings.skip_sync_when_offline
                 end,

--- a/koreader-plugin/bookorbit.koplugin/bookorbit_progress_sync.lua
+++ b/koreader-plugin/bookorbit.koplugin/bookorbit_progress_sync.lua
@@ -190,7 +190,7 @@ function ProgressSync:updateProgress(ensure_networking, interactive, on_suspend)
         return
     end
 
-    if ensure_networking and NetworkMgr:willRerunWhenOnline(function() self:updateProgress(ensure_networking, interactive, on_suspend) end) then
+    if ensure_networking and NetworkMgr:willRerunWhenConnected(function() self:updateProgress(ensure_networking, interactive, on_suspend) end) then
         return
     end
 
@@ -232,7 +232,7 @@ function ProgressSync:getProgress(ensure_networking, interactive)
         return
     end
 
-    if ensure_networking and NetworkMgr:willRerunWhenOnline(function() self:getProgress(ensure_networking, interactive) end) then
+    if ensure_networking and NetworkMgr:willRerunWhenConnected(function() self:getProgress(ensure_networking, interactive) end) then
         return
     end
 

--- a/koreader-plugin/bookorbit.koplugin/bookorbit_updater.lua
+++ b/koreader-plugin/bookorbit.koplugin/bookorbit_updater.lua
@@ -156,6 +156,7 @@ end
 
 function UpdateCheck:maybeCheckForUpdate(interactive)
     if not self:isLoggedIn() or self._checking_update or self._updating then return end
+    if not interactive and self:skipAutoSyncOffline() then return end
     if BookOrbitSweep.isRunning() or BookOrbitBookSync.isRunning() then return end
 
     local now = os.time()

--- a/koreader-plugin/bookorbit.koplugin/main.lua
+++ b/koreader-plugin/bookorbit.koplugin/main.lua
@@ -101,6 +101,7 @@ function BookOrbit:init()
     self.periodic_push_task = function()
         self.periodic_push_scheduled = false
         self.page_update_counter = 0
+        if self:skipAutoSyncOffline() then return end
         -- Push only, no pull, no network nagging: relies on the connection
         -- being already up, like the stock kosync periodic push.
         if self.settings.auto_sync and (self.settings.pages_before_update or 0) > 0 then
@@ -230,6 +231,10 @@ function BookOrbit:isLoggedIn()
     return self.settings.server_url ~= nil and self.settings.username ~= nil and self.settings.userkey ~= nil
 end
 
+function BookOrbit:skipAutoSyncOffline()
+    return self.settings.skip_sync_when_offline == true and not NetworkMgr:isConnected()
+end
+
 function BookOrbit:onStart()
     if PluginShare.bookorbit_auto_open_done then return end
     PluginShare.bookorbit_auto_open_done = true
@@ -279,14 +284,14 @@ end
 function BookOrbit:onReaderReady()
     if self.settings.auto_sync then
         UIManager:nextTick(function()
-            if self.settings.skip_sync_when_offline and not NetworkMgr:isOnline() then
+            if self:skipAutoSyncOffline() then
                 return
             end
             self:getProgress(true, false)
         end)
         if self.settings.annotation_sync then
             UIManager:scheduleIn(2, function()
-                if self.settings.skip_sync_when_offline and not NetworkMgr:isOnline() then
+                if self:skipAutoSyncOffline() then
                     return
                 end
                 self:exchangeAnnotationsForOpenBook()
@@ -395,7 +400,7 @@ function BookOrbit:startSweep()
             if not err then self:maybeCheckForUpdate(false) end
         end,
     }
-    if NetworkMgr:willRerunWhenOnline(function() BookOrbitSweep.run(sweep_opts) end) then
+    if NetworkMgr:willRerunWhenConnected(function() BookOrbitSweep.run(sweep_opts) end) then
         return
     end
     BookOrbitSweep.run(sweep_opts)
@@ -438,7 +443,7 @@ function BookOrbit:onBookOrbitSyncBook()
     local run = function()
         self:reconcileProgressBeforeBookSync(snap.digest, run_book_sync)
     end
-    if NetworkMgr:willRerunWhenOnline(run) then
+    if NetworkMgr:willRerunWhenConnected(run) then
         return
     end
     run()
@@ -457,6 +462,8 @@ function BookOrbit:_onCloseDocument()
         logger.dbg("BookOrbit: close sync skipped, another sync is running")
         return
     end
+
+    if self:skipAutoSyncOffline() then return end
 
     -- Snapshot now: reader objects die after this handler returns. ReaderUI
     -- already flushed the sidecar and statistics before broadcasting
@@ -492,6 +499,7 @@ function BookOrbit:_onResume()
         return
     end
     UIManager:scheduleIn(1, function()
+        if self:skipAutoSyncOffline() then return end
         self:getProgress(true, false)
     end)
 end
@@ -503,6 +511,7 @@ function BookOrbit:_onSuspend()
 
     if not self:isLoggedIn() then return end
     if BookOrbitSweep.isRunning() or BookOrbitBookSync.isRunning() then return end
+    if self:skipAutoSyncOffline() then return end
 
     local snap = BookOrbitBookSync.capture(self)
     if not snap then return end
@@ -522,7 +531,7 @@ function BookOrbit:_onSuspend()
             annotation_sync = self.settings.annotation_sync,
         }
     end
-    if NetworkMgr:willRerunWhenOnline(run) then
+    if NetworkMgr:willRerunWhenConnected(run) then
         return
     end
     run()
@@ -538,6 +547,7 @@ end
 
 function BookOrbit:_onNetworkDisconnecting()
     logger.dbg("BookOrbit: onNetworkDisconnecting")
+    if self:skipAutoSyncOffline() then return end
     self:updateProgress(false, false)
 end
 


### PR DESCRIPTION
## What does this PR do?

Stops the BookOrbit KOReader plugin from freezing or crashing the reader when the device is offline or has Wi-Fi off. Both automatic sync (book open, resume, suspend, close, periodic push, update check) and manual actions (Sync now, Push, Pull, Login) previously stalled the reader while probing for connectivity. Automatic sync now short-circuits to a no-op when offline and the opt-in guard is enabled; manual actions still connect on demand but no longer block the UI thread.

## How did you test this?

- `luajit -e "assert(loadfile(...))"` on every edited plugin file to confirm Lua still parses.
- Static audit: no automatic or manual sync path references the blocking connectivity check anymore; every automatic path is routed through a single offline guard, and every manual/interactive path uses the non-blocking connection gate.
- Cross-checked the behavior of KOReader's `NetworkMgr` against upstream `frontend/ui/network/manager.lua` to confirm which calls block and which do not.
- Manually tested on an Onyx boox Go Color 7 II, with wifi on and off, in and out of connectivity (faraday mylar bag). Tested both manual and automatic sync, sync on resume, and close document sync.

## Screenshots

N/A - no UI changes beyond a one-line help-text wording update.

## Anything non-obvious in the diff?

The core of this change is the distinction between two KOReader connectivity checks:

- **`isOnline()`** verifies *internet reachability* by performing a **blocking DNS lookup** (`canResolveHostnames()` -> `socket.dns.toip(...)`). With Wi-Fi off there is no interface to answer, so the lookup hangs and the reader's watchdog kills KOReader. This is what caused the freezes/crashes.
- **`isConnected()`** only reads *local link state* (cached sysfs), never touches the network, and returns immediately.

Everything here is a deliberate move from the `isOnline`-based path to the `isConnected`-based path: the offline guard and all connect-on-demand triggers now gate on local connectivity instead of a WAN probe.
For a self-hosted server, LAN-connected is the correct precondition anyway - connect-on-demand behavior is preserved, minus the blocking call. The one intentionally-blocking path left untouched is the close-document finalizer, which is already covered by an offline guard.

The offline auto-sync guard stays opt-in (default off), so users who never enable it keep existing behavior.

## Checklist

- [x] I've read through my own diff
- [ ] This PR was discussed in an issue and has maintainer approval (for new features)
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline handling so automatic syncs, progress retries, and update checks are skipped more consistently when the device is not connected.
  * Network retry now re-runs when connectivity is restored (not just when the device becomes online).
  * Updated the “skip auto-sync when offline” help text to clarify the timing across additional lifecycle events.

* **New Features**
  * Expanded the “skip auto-sync when offline” behavior by applying it to more reader and app lifecycle actions, including periodic pushes and close/resume/suspend flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->