### PR TITLE
feat(series): display multiple series memberships

### DIFF
--- a/client/src/features/book/components/detail/tabs/DetailsTab.vue
+++ b/client/src/features/book/components/detail/tabs/DetailsTab.vue
@@ -81,6 +81,12 @@ type ProviderLink = {
   fallback: string
 }
 
+type SeriesDisplayLink = {
+  key: string
+  seriesId: number | null
+  label: string
+}
+
 const props = defineProps<{ book: BookDetail }>()
 const emit = defineEmits<{ saved: [BookDetail] }>()
 const router = useRouter()
@@ -797,10 +803,34 @@ const koboAnomaly = computed(() => {
   return null
 })
 
-const seriesLine = computed(() => {
-  if (!props.book.seriesName) return null
-  const idx = props.book.seriesIndex
-  return idx != null ? `${props.book.seriesName} #${idx % 1 === 0 ? Math.floor(idx) : idx}` : props.book.seriesName
+function formatSeriesLabel(seriesName: string, seriesIndex: number | null): string {
+  if (seriesIndex == null) return seriesName
+  const formattedIndex = seriesIndex % 1 === 0 ? Math.floor(seriesIndex) : seriesIndex
+  return `${seriesName} #${formattedIndex}`
+}
+
+const seriesLinks = computed<SeriesDisplayLink[]>(() => {
+  const memberships = props.book.seriesMemberships ?? []
+  if (memberships.length > 0) {
+    return memberships
+      .filter((membership) => membership.seriesName.trim().length > 0)
+      .slice()
+      .sort((a, b) => a.displayOrder - b.displayOrder || a.seriesId - b.seriesId)
+      .map((membership) => ({
+        key: `${membership.seriesId}-${membership.displayOrder}`,
+        seriesId: membership.seriesId,
+        label: formatSeriesLabel(membership.seriesName, membership.seriesIndex),
+      }))
+  }
+
+  if (!props.book.seriesName) return []
+  return [
+    {
+      key: `primary-${props.book.seriesId ?? 'unknown'}`,
+      seriesId: props.book.seriesId ?? null,
+      label: formatSeriesLabel(props.book.seriesName, props.book.seriesIndex),
+    },
+  ]
 })
 
 function formatDateTime(iso: string): string {
@@ -1116,13 +1146,17 @@ watch(
             <span class="text-muted-foreground">narrated by</span>
             <span class="ml-1 font-medium text-foreground">{{ narratorLine }}</span>
           </p>
-          <RouterLink
-            v-if="seriesLine && book.seriesId != null"
-            :to="{ name: 'series-detail', params: { seriesId: book.seriesId } }"
-            class="inline-block text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground transition-colors"
-            >{{ seriesLine }}</RouterLink
-          >
-          <span v-else-if="seriesLine" class="inline-block text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground">{{ seriesLine }}</span>
+          <div v-if="seriesLinks.length" class="flex flex-wrap gap-1">
+            <template v-for="series in seriesLinks" :key="series.key">
+              <RouterLink
+                v-if="series.seriesId != null"
+                :to="{ name: 'series-detail', params: { seriesId: series.seriesId } }"
+                class="inline-block text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground transition-colors"
+                >{{ series.label }}</RouterLink
+              >
+              <span v-else class="inline-block text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground">{{ series.label }}</span>
+            </template>
+          </div>
         </div>
         <!-- Stars: own row -->
         <div class="mt-2 flex items-center gap-0.5" @mouseleave="hoverRating = null">
@@ -1564,15 +1598,19 @@ watch(
             <span class="text-muted-foreground">narrated by</span>
             <span class="ml-1 font-medium text-foreground">{{ narratorLine }}</span>
           </p>
-          <template v-if="seriesLine">
+          <template v-if="seriesLinks.length">
             <span class="text-muted-foreground/60 text-xs">·</span>
-            <RouterLink
-              v-if="book.seriesId != null"
-              :to="{ name: 'series-detail', params: { seriesId: book.seriesId } }"
-              class="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground transition-colors"
-              >{{ seriesLine }}</RouterLink
-            >
-            <span v-else class="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground">{{ seriesLine }}</span>
+            <span class="inline-flex flex-wrap items-center gap-1">
+              <template v-for="series in seriesLinks" :key="series.key">
+                <RouterLink
+                  v-if="series.seriesId != null"
+                  :to="{ name: 'series-detail', params: { seriesId: series.seriesId } }"
+                  class="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground transition-colors"
+                  >{{ series.label }}</RouterLink
+                >
+                <span v-else class="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground">{{ series.label }}</span>
+              </template>
+            </span>
           </template>
         </div>
 

--- a/client/src/features/book/components/detail/tabs/__tests__/DetailsTab.spec.ts
+++ b/client/src/features/book/components/detail/tabs/__tests__/DetailsTab.spec.ts
@@ -265,6 +265,51 @@ describe('DetailsTab cover surface', () => {
     expect(wrapper.text()).toContain('Author One, Author Two')
   })
 
+  it('links every series membership to its series detail page', async () => {
+    const wrapper = mountDetails(
+      makeBook({
+        seriesId: 20,
+        seriesName: 'Mistborn Era 2',
+        seriesIndex: 4,
+        seriesMemberships: [
+          { seriesId: 22, seriesName: 'Cosmere', seriesIndex: null, displayOrder: 2 },
+          { seriesId: 20, seriesName: 'Mistborn Era 2', seriesIndex: 4, displayOrder: 0 },
+          { seriesId: 21, seriesName: 'Mistborn Saga', seriesIndex: 7.5, displayOrder: 1 },
+        ],
+      }),
+    )
+    await flushPromises()
+
+    const expectedLinks = [
+      { text: 'Mistborn Era 2 #4', to: { name: 'series-detail', params: { seriesId: 20 } } },
+      { text: 'Mistborn Saga #7.5', to: { name: 'series-detail', params: { seriesId: 21 } } },
+      { text: 'Cosmere', to: { name: 'series-detail', params: { seriesId: 22 } } },
+    ]
+    const seriesLinks = wrapper.findAllComponents(RouterLinkStub).filter((link) => expectedLinks.some((expected) => expected.text === link.text()))
+
+    expect(seriesLinks).toHaveLength(6)
+    expect(seriesLinks.map((link) => ({ text: link.text(), to: link.props('to') }))).toEqual([...expectedLinks, ...expectedLinks])
+  })
+
+  it('falls back to primary series fields when memberships are absent', async () => {
+    const wrapper = mountDetails(
+      makeBook({
+        seriesId: 20,
+        seriesName: 'Mistborn Era 2',
+        seriesIndex: 4,
+      }),
+    )
+    await flushPromises()
+
+    const seriesLinks = wrapper.findAllComponents(RouterLinkStub).filter((link) => link.text() === 'Mistborn Era 2 #4')
+
+    expect(seriesLinks).toHaveLength(2)
+    expect(seriesLinks.map((link) => link.props('to'))).toEqual([
+      { name: 'series-detail', params: { seriesId: 20 } },
+      { name: 'series-detail', params: { seriesId: 20 } },
+    ])
+  })
+
   it('renders community rating badges with score and tooltip per provider', async () => {
     const wrapper = mountDetails(
       makeBook({


### PR DESCRIPTION
## Before you submit

> **New feature?** Please open an issue first and get approval from the maintainers before writing any code.
> PRs that introduce features without a prior discussion will be closed.
>
> **Used AI assistance?** That's fine - but make sure you've read and understood every line of the diff
> before submitting. PRs that show no sign of self-review will be closed without detailed feedback.
>
> **Keep it focused.** One thing per PR. Don't bundle a bug fix with a refactor or unrelated cleanup.
> If it's not ready, open it as a draft instead.

---

## What does this PR do?

Displays every stored series membership on the book details tab instead of showing only the primary series fields.

- Adds a sorted series link list from `seriesMemberships`
- Links each membership to its series detail page when a series id is available
- Keeps the existing primary series fields as a fallback when memberships are absent
- Covers both detail header layouts with focused component tests

Closes #595

## How did you test this?

- `pnpm exec vitest run src/features/book/components/detail/tabs/__tests__/DetailsTab.spec.ts`
  - Result: passed, 10 tests
- `pnpm exec eslint src/features/book/components/detail/tabs/DetailsTab.vue src/features/book/components/detail/tabs/__tests__/DetailsTab.spec.ts --max-warnings 0`
  - Result: passed

## Screenshots

UI change is limited to rendering additional series links in the existing book details header. Screenshots can be added on GitHub with a book that has multiple series memberships.

## Anything non-obvious in the diff?

The book details tab renders the series links in two responsive header layouts, so the test expects each series link to appear twice.

## Checklist

- [x] I've read through my own diff
- [x] This PR was discussed in an issue and has maintainer approval (for new features)
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Book details now show multiple series memberships when available, instead of only a single series entry.
  * Series entries can link directly to their corresponding series pages when an ID is present.
  * If multiple series aren’t available, the app still displays the primary series information as before.

* **Bug Fixes**
  * Improved series display consistency across mobile and desktop views.
  * Series labels now show index information in a clearer format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->