### PR TITLE
feat(opds): OPDS-PSE (Page Streaming Extension) support

### DIFF
--- a/server/src/common/comic-page-counter.test.ts
+++ b/server/src/common/comic-page-counter.test.ts
@@ -1,0 +1,75 @@
+vi.mock('fs/promises', () => ({ readFile: vi.fn() }));
+vi.mock('node-unrar-js', () => ({ createExtractorFromData: vi.fn() }));
+vi.mock('./sevenzip', () => ({ getSevenZip: vi.fn() }));
+vi.mock('./comic-format-detect', () => ({
+  detectComicContainerFormat: vi.fn().mockImplementation((_path: string, fmt: string) => Promise.resolve(fmt)),
+}));
+vi.mock('./cbz-zip-reader', () => ({ readCbzZipIndex: vi.fn() }));
+
+import { readFile } from 'fs/promises';
+import { createExtractorFromData } from 'node-unrar-js';
+
+import { readCbzZipIndex } from './cbz-zip-reader';
+import { getSevenZip } from './sevenzip';
+import { countComicPages } from './comic-page-counter';
+
+const mockReadFile = readFile as MockedFunction<typeof readFile>;
+const mockReadCbzZipIndex = readCbzZipIndex as MockedFunction<typeof readCbzZipIndex>;
+const mockCreateExtractorFromData = createExtractorFromData as MockedFunction<typeof createExtractorFromData>;
+const mockGetSevenZip = getSevenZip as MockedFunction<typeof getSevenZip>;
+
+describe('countComicPages', () => {
+  it('counts only image entries in a cbz, skipping directories, hidden files, and non-image entries', async () => {
+    mockReadCbzZipIndex.mockResolvedValue({
+      comment: null,
+      entries: [
+        { name: 'page1.jpg', compression: 8, compressedSize: 100, uncompressedSize: 200, localHeaderOffset: 0, dataStart: 0 },
+        { name: 'page2.png', compression: 0, compressedSize: 100, uncompressedSize: 100, localHeaderOffset: 0, dataStart: 0 },
+        { name: 'folder/', compression: 0, compressedSize: 0, uncompressedSize: 0, localHeaderOffset: 0, dataStart: 0 },
+        { name: '.hidden/page.jpg', compression: 8, compressedSize: 100, uncompressedSize: 200, localHeaderOffset: 0, dataStart: 0 },
+        { name: 'ComicInfo.xml', compression: 8, compressedSize: 100, uncompressedSize: 200, localHeaderOffset: 0, dataStart: 0 },
+      ],
+    });
+
+    await expect(countComicPages(1, '/books/a.cbz', 'cbz')).resolves.toBe(2);
+  });
+
+  it('returns 0 for a cbz with no readable index', async () => {
+    mockReadCbzZipIndex.mockResolvedValue(null);
+    await expect(countComicPages(1, '/books/a.cbz', 'cbz')).resolves.toBe(0);
+  });
+
+  it('counts image files in a cbr file list without extracting', async () => {
+    mockReadFile.mockResolvedValue(Buffer.from('rar-bytes'));
+    mockCreateExtractorFromData.mockResolvedValue({
+      getFileList: () => ({
+        fileHeaders: [
+          { name: 'page1.jpg', flags: { directory: false } },
+          { name: 'page2.jpg', flags: { directory: false } },
+          { name: 'sub', flags: { directory: true } },
+          { name: 'notes.txt', flags: { directory: false } },
+        ],
+      }),
+      extract: vi.fn(),
+    } as never);
+
+    await expect(countComicPages(2, '/books/b.cbr', 'cbr')).resolves.toBe(2);
+  });
+
+  it('counts image files extracted from a cb7 archive', async () => {
+    const write = vi.fn();
+    const open = vi.fn().mockReturnValue(1);
+    const close = vi.fn();
+    const unlink = vi.fn();
+    const rmdir = vi.fn();
+    const mkdir = vi.fn();
+    const readdir = vi.fn().mockReturnValue(['.', '..', 'page1.jpg', 'page2.jpg', 'notes.txt']);
+    mockReadFile.mockResolvedValue(Buffer.from('7z-bytes'));
+    mockGetSevenZip.mockResolvedValue({
+      FS: { open, write, close, mkdir, readdir, readFile: vi.fn(), unlink, rmdir },
+      callMain: vi.fn(),
+    });
+
+    await expect(countComicPages(3, '/books/c.cb7', 'cb7')).resolves.toBe(2);
+  });
+});

--- a/server/src/common/comic-page-counter.ts
+++ b/server/src/common/comic-page-counter.ts
@@ -1,0 +1,77 @@
+import { readFile } from 'fs/promises';
+import { createExtractorFromData } from 'node-unrar-js';
+
+import { detectComicContainerFormat, type ComicContainerFormat } from './comic-format-detect';
+import { isHiddenPage, isImagePage } from './comic-page-utils';
+import { readCbzZipIndex } from './cbz-zip-reader';
+import { getSevenZip } from './sevenzip';
+
+// Buffer.buffer is a shared pool; slice out only the bytes for this buffer.
+function toArrayBuffer(buf: Buffer): ArrayBuffer {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}
+
+async function countCbzPages(absolutePath: string): Promise<number> {
+  const index = await readCbzZipIndex(absolutePath);
+  if (!index) return 0;
+  return index.entries.filter(
+    (entry) =>
+      !entry.name.endsWith('/') &&
+      !isHiddenPage(entry.name) &&
+      isImagePage(entry.name) &&
+      (entry.compression === 0 || entry.compression === 8) &&
+      entry.compressedSize > 0,
+  ).length;
+}
+
+async function countCbrPages(absolutePath: string): Promise<number> {
+  const buf = await readFile(absolutePath);
+  const extractor = await createExtractorFromData({ data: toArrayBuffer(buf) });
+  const { fileHeaders } = extractor.getFileList();
+  let count = 0;
+  for (const h of fileHeaders) {
+    if (!h.flags.directory && isImagePage(h.name) && !isHiddenPage(h.name)) count++;
+  }
+  return count;
+}
+
+async function countCb7Pages(fileId: number, absolutePath: string): Promise<number> {
+  const sz = await getSevenZip();
+  const archivePath = `/count${fileId}`;
+  const outDir = `/countOut${fileId}`;
+
+  const buf = await readFile(absolutePath);
+  const fd = sz.FS.open(archivePath, 'w+');
+  sz.FS.write(fd, buf, 0, buf.length);
+  sz.FS.close(fd);
+
+  try {
+    sz.FS.mkdir(outDir);
+  } catch {
+    // already exists from a previous run
+  }
+
+  try {
+    sz.callMain(['e', archivePath, `-o${outDir}`, '-y']);
+    const files = sz.FS.readdir(outDir);
+    return files.filter((f) => f !== '.' && f !== '..' && isImagePage(f) && !isHiddenPage(f)).length;
+  } finally {
+    sz.FS.unlink(archivePath);
+    for (const f of sz.FS.readdir(outDir)) {
+      if (f !== '.' && f !== '..') sz.FS.unlink(`${outDir}/${f}`);
+    }
+    sz.FS.rmdir(outDir);
+  }
+}
+
+/**
+ * Counts streamable image pages in a comic archive. Used to lazily populate
+ * `bookFiles.pageCount` for OPDS-PSE, independent of `CbzService` so callers
+ * that only hold an `OpdsRequestUser` (not a full `RequestUser`) can use it.
+ */
+export async function countComicPages(fileId: number, absolutePath: string, storedFormat: ComicContainerFormat): Promise<number> {
+  const format = await detectComicContainerFormat(absolutePath, storedFormat);
+  if (format === 'cbz') return countCbzPages(absolutePath);
+  if (format === 'cbr') return countCbrPages(absolutePath);
+  return countCb7Pages(fileId, absolutePath);
+}

--- a/server/src/common/comic-page-utils.ts
+++ b/server/src/common/comic-page-utils.ts
@@ -1,0 +1,14 @@
+const IMAGE_EXTS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp', '.avif']);
+
+export function isImagePage(name: string): boolean {
+  const dot = name.lastIndexOf('.');
+  return dot !== -1 && IMAGE_EXTS.has(name.substring(dot).toLowerCase());
+}
+
+export function isHiddenPage(name: string): boolean {
+  return name.split('/').some((p) => p.startsWith('.'));
+}
+
+export function naturalPageSort(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+}

--- a/server/src/common/pdf-page-count.test.ts
+++ b/server/src/common/pdf-page-count.test.ts
@@ -1,0 +1,20 @@
+vi.mock('fs/promises', () => ({ readFile: vi.fn() }));
+vi.mock('pdf-lib', () => ({ PDFDocument: { load: vi.fn() } }));
+
+import { readFile } from 'fs/promises';
+import { PDFDocument } from 'pdf-lib';
+
+import { getPdfPageCount } from './pdf-page-count';
+
+const mockReadFile = readFile as MockedFunction<typeof readFile>;
+const mockLoad = PDFDocument.load as MockedFunction<typeof PDFDocument.load>;
+
+describe('getPdfPageCount', () => {
+  it('reads the file and returns the page count from pdf-lib', async () => {
+    mockReadFile.mockResolvedValue(Buffer.from('%PDF-1.4'));
+    mockLoad.mockResolvedValue({ getPageCount: () => 42 } as never);
+
+    await expect(getPdfPageCount('/books/a.pdf')).resolves.toBe(42);
+    expect(mockLoad).toHaveBeenCalledWith(Buffer.from('%PDF-1.4'), { updateMetadata: false });
+  });
+});

--- a/server/src/common/pdf-page-count.ts
+++ b/server/src/common/pdf-page-count.ts
@@ -1,0 +1,8 @@
+import { readFile } from 'fs/promises';
+import { PDFDocument } from 'pdf-lib';
+
+export async function getPdfPageCount(absolutePath: string): Promise<number> {
+  const buf = await readFile(absolutePath);
+  const doc = await PDFDocument.load(buf, { updateMetadata: false });
+  return doc.getPageCount();
+}

--- a/server/src/db/migrations/0037_opds-pse-page-count.sql
+++ b/server/src/db/migrations/0037_opds-pse-page-count.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "book_files" ADD COLUMN "page_count" integer;--> statement-breakpoint
+ALTER TABLE "book_files" ADD CONSTRAINT "book_files_page_count_nonnegative_chk" CHECK ("book_files"."page_count" is null or "book_files"."page_count" >= 0);

--- a/server/src/db/migrations/meta/0037_snapshot.json
+++ b/server/src/db/migrations/meta/0037_snapshot.json
@@ -1,0 +1,12843 @@
+{
+  "id": "6c98e844-4dbc-458b-9e05-1e1b3a82c501",
+  "prevId": "9c539320-4049-43a1-a2fa-96ec6b657c7d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_user_id": {
+          "name": "idx_audit_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource": {
+          "name": "idx_audit_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_action": {
+          "name": "idx_audit_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_ip": {
+          "name": "idx_audit_ip",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_created_at": {
+          "name": "idx_audit_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.magic_access_tokens": {
+      "name": "magic_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_token": {
+          "name": "raw_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "magic_access_tokens_user_id_idx": {
+          "name": "magic_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_access_tokens_user_id_users_id_fk": {
+          "name": "magic_access_tokens_user_id_users_id_fk",
+          "tableFrom": "magic_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "magic_access_tokens_created_by_users_id_fk": {
+          "name": "magic_access_tokens_created_by_users_id_fk",
+          "tableFrom": "magic_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "magic_access_tokens_token_hash_unique": {
+          "name": "magic_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "magic_access_tokens_use_count_nonneg_chk": {
+          "name": "magic_access_tokens_use_count_nonneg_chk",
+          "value": "\"magic_access_tokens\".\"use_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_user_id_idx": {
+          "name": "password_reset_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_expires_at_idx": {
+          "name": "password_reset_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "password_reset_tokens_expires_after_created_chk": {
+          "name": "password_reset_tokens_expires_after_created_chk",
+          "value": "\"password_reset_tokens\".\"expires_at\" > \"password_reset_tokens\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_token_hash": {
+          "name": "replaced_by_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "refresh_tokens_expires_after_created_chk": {
+          "name": "refresh_tokens_expires_after_created_chk",
+          "value": "\"refresh_tokens\".\"expires_at\" > \"refresh_tokens\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_content_filter_genres": {
+      "name": "user_content_filter_genres",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "content_filter_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_content_filter_genres_genre_id_idx": {
+          "name": "user_content_filter_genres_genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_content_filter_genres_user_id_users_id_fk": {
+          "name": "user_content_filter_genres_user_id_users_id_fk",
+          "tableFrom": "user_content_filter_genres",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_content_filter_genres_genre_id_genres_id_fk": {
+          "name": "user_content_filter_genres_genre_id_genres_id_fk",
+          "tableFrom": "user_content_filter_genres",
+          "tableTo": "genres",
+          "columnsFrom": ["genre_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_content_filter_genres_user_id_filter_type_genre_id_pk": {
+          "name": "user_content_filter_genres_user_id_filter_type_genre_id_pk",
+          "columns": ["user_id", "filter_type", "genre_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_content_filter_tags": {
+      "name": "user_content_filter_tags",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "content_filter_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_content_filter_tags_tag_id_idx": {
+          "name": "user_content_filter_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_content_filter_tags_user_id_users_id_fk": {
+          "name": "user_content_filter_tags_user_id_users_id_fk",
+          "tableFrom": "user_content_filter_tags",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_content_filter_tags_tag_id_tags_id_fk": {
+          "name": "user_content_filter_tags_tag_id_tags_id_fk",
+          "tableFrom": "user_content_filter_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_content_filter_tags_user_id_filter_type_tag_id_pk": {
+          "name": "user_content_filter_tags_user_id_filter_type_tag_id_pk",
+          "columns": ["user_id", "filter_type", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_library_access": {
+      "name": "user_library_access",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "library_access_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        }
+      },
+      "indexes": {
+        "user_library_access_library_user_idx": {
+          "name": "user_library_access_library_user_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_library_access_user_id_users_id_fk": {
+          "name": "user_library_access_user_id_users_id_fk",
+          "tableFrom": "user_library_access",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_access_library_id_libraries_id_fk": {
+          "name": "user_library_access_library_id_libraries_id_fk",
+          "tableFrom": "user_library_access",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_library_access_user_id_library_id_pk": {
+          "name": "user_library_access_user_id_library_id_pk",
+          "columns": ["user_id", "library_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permissions": {
+      "name": "user_permissions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_name": {
+          "name": "permission_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_permissions_user_id_users_id_fk": {
+          "name": "user_permissions_user_id_users_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_permissions_user_id_permission_name_pk": {
+          "name": "user_permissions_user_id_permission_name_pk",
+          "columns": ["user_id", "permission_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_superuser": {
+          "name": "is_superuser",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_password": {
+          "name": "is_default_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_source": {
+          "name": "avatar_source",
+          "type": "user_avatar_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "avatar_version": {
+          "name": "avatar_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "provisioning_method": {
+          "name": "provisioning_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_username_lower_uidx": {
+          "name": "users_username_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_lower_uidx": {
+          "name": "users_email_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"email\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_oidc_subject_issuer_uidx": {
+          "name": "users_oidc_subject_issuer_uidx",
+          "columns": [
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"oidc_subject\" is not null and \"users\".\"oidc_issuer\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_provisioning_method_chk": {
+          "name": "users_provisioning_method_chk",
+          "value": "\"users\".\"provisioning_method\" in ('local', 'manual', 'oidc', 'shared')"
+        },
+        "users_token_version_nonnegative_chk": {
+          "name": "users_token_version_nonnegative_chk",
+          "value": "\"users\".\"token_version\" >= 0"
+        },
+        "users_failed_login_attempts_nonnegative_chk": {
+          "name": "users_failed_login_attempts_nonnegative_chk",
+          "value": "\"users\".\"failed_login_attempts\" >= 0"
+        },
+        "users_avatar_version_nonnegative_chk": {
+          "name": "users_avatar_version_nonnegative_chk",
+          "value": "\"users\".\"avatar_version\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comic_metadata": {
+      "name": "comic_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_name": {
+          "name": "volume_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pencillers": {
+          "name": "pencillers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inkers": {
+          "name": "inkers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colorists": {
+          "name": "colorists",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "letterers": {
+          "name": "letterers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_artists": {
+          "name": "cover_artists",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "characters": {
+          "name": "characters",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams": {
+          "name": "teams",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locations": {
+          "name": "locations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "story_arcs": {
+          "name": "story_arcs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comic_metadata_book_id_books_id_fk": {
+          "name": "comic_metadata_book_id_books_id_fk",
+          "tableFrom": "comic_metadata",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comic_metadata_book_id_unique": {
+          "name": "comic_metadata_book_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["book_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_custom_metadata_values": {
+      "name": "book_custom_metadata_values",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_boolean": {
+          "name": "value_boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_custom_metadata_values_field_idx": {
+          "name": "book_custom_metadata_values_field_idx",
+          "columns": [
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_custom_metadata_values_book_id_books_id_fk": {
+          "name": "book_custom_metadata_values_book_id_books_id_fk",
+          "tableFrom": "book_custom_metadata_values",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_custom_metadata_values_field_id_custom_metadata_fields_id_fk": {
+          "name": "book_custom_metadata_values_field_id_custom_metadata_fields_id_fk",
+          "tableFrom": "book_custom_metadata_values",
+          "tableTo": "custom_metadata_fields",
+          "columnsFrom": ["field_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_custom_metadata_values_book_id_field_id_pk": {
+          "name": "book_custom_metadata_values_book_id_field_id_pk",
+          "columns": ["book_id", "field_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_custom_metadata_values_single_value_chk": {
+          "name": "book_custom_metadata_values_single_value_chk",
+          "value": "(\n        (\"book_custom_metadata_values\".\"value_text\" is not null)::int +\n        (\"book_custom_metadata_values\".\"value_number\" is not null)::int +\n        (\"book_custom_metadata_values\".\"value_date\" is not null)::int +\n        (\"book_custom_metadata_values\".\"value_boolean\" is not null)::int\n      ) <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_metadata_fields": {
+      "name": "custom_metadata_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_metadata_fields_key_uidx": {
+          "name": "custom_metadata_fields_key_uidx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_metadata_fields_active_order_idx": {
+          "name": "custom_metadata_fields_active_order_idx",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_metadata_fields_type_chk": {
+          "name": "custom_metadata_fields_type_chk",
+          "value": "\"custom_metadata_fields\".\"type\" in ('text', 'url', 'number', 'date', 'boolean')"
+        },
+        "custom_metadata_fields_key_format_chk": {
+          "name": "custom_metadata_fields_key_format_chk",
+          "value": "\"custom_metadata_fields\".\"key\" ~ '^[a-z0-9][a-z0-9_]{0,99}$'"
+        },
+        "custom_metadata_fields_label_not_blank_chk": {
+          "name": "custom_metadata_fields_label_not_blank_chk",
+          "value": "length(btrim(\"custom_metadata_fields\".\"label\")) > 0"
+        },
+        "custom_metadata_fields_display_order_nonnegative_chk": {
+          "name": "custom_metadata_fields_display_order_nonnegative_chk",
+          "value": "\"custom_metadata_fields\".\"display_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_metadata_library_fields": {
+      "name": "custom_metadata_library_fields",
+      "schema": "",
+      "columns": {
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_metadata_library_fields_field_idx": {
+          "name": "custom_metadata_library_fields_field_idx",
+          "columns": [
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_metadata_library_fields_library_order_idx": {
+          "name": "custom_metadata_library_fields_library_order_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_metadata_library_fields_field_id_custom_metadata_fields_id_fk": {
+          "name": "custom_metadata_library_fields_field_id_custom_metadata_fields_id_fk",
+          "tableFrom": "custom_metadata_library_fields",
+          "tableTo": "custom_metadata_fields",
+          "columnsFrom": ["field_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_metadata_library_fields_library_id_libraries_id_fk": {
+          "name": "custom_metadata_library_fields_library_id_libraries_id_fk",
+          "tableFrom": "custom_metadata_library_fields",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "custom_metadata_library_fields_library_id_field_id_pk": {
+          "name": "custom_metadata_library_fields_library_id_field_id_pk",
+          "columns": ["library_id", "field_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_metadata_library_fields_display_order_nonnegative_chk": {
+          "name": "custom_metadata_library_fields_display_order_nonnegative_chk",
+          "value": "\"custom_metadata_library_fields\".\"display_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_icons": {
+      "name": "custom_icons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_name": {
+          "name": "stored_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_icons_slug_uidx": {
+          "name": "custom_icons_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_icons_slug_chk": {
+          "name": "custom_icons_slug_chk",
+          "value": "\"custom_icons\".\"slug\" ~ '^[a-z0-9][a-z0-9-]*[a-z0-9]$' or \"custom_icons\".\"slug\" ~ '^[a-z0-9]$'"
+        },
+        "custom_icons_file_size_positive_chk": {
+          "name": "custom_icons_file_size_positive_chk",
+          "value": "\"custom_icons\".\"file_size\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_plan_artifacts": {
+      "name": "migration_plan_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot_hash": {
+          "name": "source_snapshot_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_hash": {
+          "name": "profile_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_hash": {
+          "name": "plan_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_data": {
+          "name": "source_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_plan_artifacts_plan_hash_uidx": {
+          "name": "migration_plan_artifacts_plan_hash_uidx",
+          "columns": [
+            {
+              "expression": "plan_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_plan_artifacts_source_id_idx": {
+          "name": "migration_plan_artifacts_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_plan_artifacts_profile_id_idx": {
+          "name": "migration_plan_artifacts_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_plan_artifacts_source_id_migration_sources_id_fk": {
+          "name": "migration_plan_artifacts_source_id_migration_sources_id_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "migration_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_plan_artifacts_profile_id_migration_profiles_id_fk": {
+          "name": "migration_plan_artifacts_profile_id_migration_profiles_id_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "migration_profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_plan_artifacts_created_by_user_id_users_id_fk": {
+          "name": "migration_plan_artifacts_created_by_user_id_users_id_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "migration_plan_artifacts_profile_source_fk": {
+          "name": "migration_plan_artifacts_profile_source_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "migration_profiles",
+          "columnsFrom": ["profile_id", "source_id"],
+          "columnsTo": ["id", "source_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "migration_plan_artifacts_id_source_profile_unique": {
+          "name": "migration_plan_artifacts_id_source_profile_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "source_id", "profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_profiles": {
+      "name": "migration_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_mappings": {
+          "name": "user_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_mappings": {
+          "name": "path_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_profiles_source_name_version_uidx": {
+          "name": "migration_profiles_source_name_version_uidx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_profiles_source_id_idx": {
+          "name": "migration_profiles_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_profiles_source_id_migration_sources_id_fk": {
+          "name": "migration_profiles_source_id_migration_sources_id_fk",
+          "tableFrom": "migration_profiles",
+          "tableTo": "migration_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_profiles_created_by_user_id_users_id_fk": {
+          "name": "migration_profiles_created_by_user_id_users_id_fk",
+          "tableFrom": "migration_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "migration_profiles_id_source_id_unique": {
+          "name": "migration_profiles_id_source_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "source_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "migration_profiles_version_positive_chk": {
+          "name": "migration_profiles_version_positive_chk",
+          "value": "\"migration_profiles\".\"version\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_run_metrics": {
+      "name": "migration_run_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported": {
+          "name": "imported",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unresolved": {
+          "name": "unresolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_run_metrics_run_stage_entity_uidx": {
+          "name": "migration_run_metrics_run_stage_entity_uidx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_run_metrics_run_id_idx": {
+          "name": "migration_run_metrics_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_run_metrics_run_id_migration_runs_id_fk": {
+          "name": "migration_run_metrics_run_id_migration_runs_id_fk",
+          "tableFrom": "migration_run_metrics",
+          "tableTo": "migration_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_run_metrics_processed_nonnegative_chk": {
+          "name": "migration_run_metrics_processed_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"processed\" >= 0"
+        },
+        "migration_run_metrics_imported_nonnegative_chk": {
+          "name": "migration_run_metrics_imported_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"imported\" >= 0"
+        },
+        "migration_run_metrics_skipped_nonnegative_chk": {
+          "name": "migration_run_metrics_skipped_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"skipped\" >= 0"
+        },
+        "migration_run_metrics_unresolved_nonnegative_chk": {
+          "name": "migration_run_metrics_unresolved_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"unresolved\" >= 0"
+        },
+        "migration_run_metrics_failed_nonnegative_chk": {
+          "name": "migration_run_metrics_failed_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"failed\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_artifact_id": {
+          "name": "plan_artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bookorbit'"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_runs_source_target_state_idx": {
+          "name": "migration_runs_source_target_state_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_state_idx": {
+          "name": "migration_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_source_id_migration_sources_id_fk": {
+          "name": "migration_runs_source_id_migration_sources_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_profile_id_migration_profiles_id_fk": {
+          "name": "migration_runs_profile_id_migration_profiles_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_plan_artifact_id_migration_plan_artifacts_id_fk": {
+          "name": "migration_runs_plan_artifact_id_migration_plan_artifacts_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_plan_artifacts",
+          "columnsFrom": ["plan_artifact_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "migration_runs_triggered_by_user_id_users_id_fk": {
+          "name": "migration_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": ["triggered_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "migration_runs_profile_source_fk": {
+          "name": "migration_runs_profile_source_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_profiles",
+          "columnsFrom": ["profile_id", "source_id"],
+          "columnsTo": ["id", "source_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_plan_artifact_source_profile_fk": {
+          "name": "migration_runs_plan_artifact_source_profile_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_plan_artifacts",
+          "columnsFrom": ["plan_artifact_id", "source_id", "profile_id"],
+          "columnsTo": ["id", "source_id", "profile_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_state_chk": {
+          "name": "migration_runs_state_chk",
+          "value": "\"state\" IN ('draft', 'preflight_failed', 'dry_run_ready', 'running', 'failed', 'completed')"
+        },
+        "migration_runs_started_before_ended_chk": {
+          "name": "migration_runs_started_before_ended_chk",
+          "value": "\"migration_runs\".\"ended_at\" is null or \"migration_runs\".\"started_at\" is null or \"migration_runs\".\"ended_at\" >= \"migration_runs\".\"started_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_sources": {
+      "name": "migration_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_config": {
+          "name": "connection_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_sources_type_name_uidx": {
+          "name": "migration_sources_type_name_uidx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_sources_created_by_user_id_idx": {
+          "name": "migration_sources_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_sources_created_by_user_id_users_id_fk": {
+          "name": "migration_sources_created_by_user_id_users_id_fk",
+          "tableFrom": "migration_sources",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.libraries": {
+      "name": "libraries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cover_aspect_ratio": {
+          "name": "cover_aspect_ratio",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2/3'"
+        },
+        "watch": {
+          "name": "watch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_scan_cron_expression": {
+          "name": "auto_scan_cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_precedence": {
+          "name": "metadata_precedence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"folderStructure\",\"embedded\",\"nfoFile\",\"opfFile\",\"sidecar\"]'::jsonb"
+        },
+        "format_priority": {
+          "name": "format_priority",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"epub\",\"pdf\",\"cbz\",\"cbr\",\"cb7\",\"mobi\",\"azw3\",\"azw\",\"fb2\",\"m4b\",\"mp3\",\"m4a\",\"opus\",\"ogg\",\"flac\"]'::jsonb"
+        },
+        "allowed_formats": {
+          "name": "allowed_formats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "organization_mode": {
+          "name": "organization_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'book_per_folder'"
+        },
+        "exclude_patterns": {
+          "name": "exclude_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reading_threshold": {
+          "name": "reading_threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.25
+        },
+        "mark_as_finished_percent_complete": {
+          "name": "mark_as_finished_percent_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 98
+        },
+        "file_write_enabled": {
+          "name": "file_write_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_write_write_cover": {
+          "name": "file_write_write_cover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "file_write_epub_enabled": {
+          "name": "file_write_epub_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "file_write_epub_max_file_size_mb": {
+          "name": "file_write_epub_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "file_write_pdf_enabled": {
+          "name": "file_write_pdf_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "file_write_pdf_max_file_size_mb": {
+          "name": "file_write_pdf_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "file_write_cbx_enabled": {
+          "name": "file_write_cbx_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_write_cbx_max_file_size_mb": {
+          "name": "file_write_cbx_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "file_write_audio_enabled": {
+          "name": "file_write_audio_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_write_audio_max_file_size_mb": {
+          "name": "file_write_audio_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "file_rename_enabled": {
+          "name": "file_rename_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_naming_pattern": {
+          "name": "file_naming_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_fetch_preferences": {
+          "name": "metadata_fetch_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_metadata_fetch_config": {
+          "name": "book_metadata_fetch_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_metadata_fetch_last_run_at": {
+          "name": "book_metadata_fetch_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_metadata_fetch_last_queued_count": {
+          "name": "book_metadata_fetch_last_queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_mode": {
+          "name": "scan_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 300
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "libraries_name_lower_uidx": {
+          "name": "libraries_name_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "libraries_display_order_nonnegative_chk": {
+          "name": "libraries_display_order_nonnegative_chk",
+          "value": "\"libraries\".\"display_order\" >= 0"
+        },
+        "libraries_organization_mode_chk": {
+          "name": "libraries_organization_mode_chk",
+          "value": "\"libraries\".\"organization_mode\" in ('book_per_folder', 'book_per_file')"
+        },
+        "libraries_reading_threshold_range_chk": {
+          "name": "libraries_reading_threshold_range_chk",
+          "value": "\"libraries\".\"reading_threshold\" >= 0 and \"libraries\".\"reading_threshold\" <= 100"
+        },
+        "libraries_mark_finished_percent_range_chk": {
+          "name": "libraries_mark_finished_percent_range_chk",
+          "value": "\"libraries\".\"mark_as_finished_percent_complete\" >= 0 and \"libraries\".\"mark_as_finished_percent_complete\" <= 100"
+        },
+        "libraries_scan_mode_chk": {
+          "name": "libraries_scan_mode_chk",
+          "value": "\"libraries\".\"scan_mode\" in ('auto', 'manual')"
+        },
+        "libraries_poll_interval_nonnegative_chk": {
+          "name": "libraries_poll_interval_nonnegative_chk",
+          "value": "\"libraries\".\"poll_interval_seconds\" is null or \"libraries\".\"poll_interval_seconds\" >= 0"
+        },
+        "libraries_file_write_epub_max_size_chk": {
+          "name": "libraries_file_write_epub_max_size_chk",
+          "value": "\"libraries\".\"file_write_epub_max_file_size_mb\" >= 1"
+        },
+        "libraries_file_write_pdf_max_size_chk": {
+          "name": "libraries_file_write_pdf_max_size_chk",
+          "value": "\"libraries\".\"file_write_pdf_max_file_size_mb\" >= 1"
+        },
+        "libraries_file_write_cbx_max_size_chk": {
+          "name": "libraries_file_write_cbx_max_size_chk",
+          "value": "\"libraries\".\"file_write_cbx_max_file_size_mb\" >= 1"
+        },
+        "libraries_file_write_audio_max_size_chk": {
+          "name": "libraries_file_write_audio_max_size_chk",
+          "value": "\"libraries\".\"file_write_audio_max_file_size_mb\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.library_folders": {
+      "name": "library_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_folders_library_id_idx": {
+          "name": "library_folders_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_folders_library_path_uidx": {
+          "name": "library_folders_library_path_uidx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_folders_library_id_libraries_id_fk": {
+          "name": "library_folders_library_id_libraries_id_fk",
+          "tableFrom": "library_folders",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "library_folders_id_library_id_unique": {
+          "name": "library_folders_id_library_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "library_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_files": {
+      "name": "book_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_folder_id": {
+          "name": "library_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_path": {
+          "name": "absolute_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rel_path": {
+          "name": "rel_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ino": {
+          "name": "ino",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'content'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_files_absolute_path_uidx": {
+          "name": "book_files_absolute_path_uidx",
+          "columns": [
+            {
+              "expression": "absolute_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_book_id_idx": {
+          "name": "book_files_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_library_folder_id_idx": {
+          "name": "book_files_library_folder_id_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_file_hash_idx": {
+          "name": "book_files_file_hash_idx",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_ino_idx": {
+          "name": "book_files_ino_idx",
+          "columns": [
+            {
+              "expression": "ino",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_format_idx": {
+          "name": "book_files_format_idx",
+          "columns": [
+            {
+              "expression": "format",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_library_folder_file_hash_idx": {
+          "name": "book_files_library_folder_file_hash_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_library_folder_ino_idx": {
+          "name": "book_files_library_folder_ino_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ino",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_files_book_id_books_id_fk": {
+          "name": "book_files_book_id_books_id_fk",
+          "tableFrom": "book_files",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_files_library_folder_id_library_folders_id_fk": {
+          "name": "book_files_library_folder_id_library_folders_id_fk",
+          "tableFrom": "book_files",
+          "tableTo": "library_folders",
+          "columnsFrom": ["library_folder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_files_book_folder_consistency_fk": {
+          "name": "book_files_book_folder_consistency_fk",
+          "tableFrom": "book_files",
+          "tableTo": "books",
+          "columnsFrom": ["book_id", "library_folder_id"],
+          "columnsTo": ["id", "library_folder_id"],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_files_role_chk": {
+          "name": "book_files_role_chk",
+          "value": "\"book_files\".\"role\" in ('content', 'cover', 'metadata', 'supplement')"
+        },
+        "book_files_size_bytes_nonnegative_chk": {
+          "name": "book_files_size_bytes_nonnegative_chk",
+          "value": "\"book_files\".\"size_bytes\" is null or \"book_files\".\"size_bytes\" >= 0"
+        },
+        "book_files_duration_seconds_nonnegative_chk": {
+          "name": "book_files_duration_seconds_nonnegative_chk",
+          "value": "\"book_files\".\"duration_seconds\" is null or \"book_files\".\"duration_seconds\" >= 0"
+        },
+        "book_files_page_count_nonnegative_chk": {
+          "name": "book_files_page_count_nonnegative_chk",
+          "value": "\"book_files\".\"page_count\" is null or \"book_files\".\"page_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_folder_id": {
+          "name": "library_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_file_id": {
+          "name": "primary_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_author_sort_name": {
+          "name": "primary_author_sort_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_path": {
+          "name": "folder_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'present'"
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "books_library_id_folder_path_idx": {
+          "name": "books_library_id_folder_path_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folder_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_primary_file_id_idx": {
+          "name": "books_primary_file_id_idx",
+          "columns": [
+            {
+              "expression": "primary_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_status_idx": {
+          "name": "books_library_status_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_added_at_idx": {
+          "name": "books_library_added_at_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"added_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_visible_added_id_idx": {
+          "name": "books_library_visible_added_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"added_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"books\".\"status\" <> 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_author_sort_id_idx": {
+          "name": "books_library_author_sort_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"primary_author_sort_name\" asc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"books\".\"status\" <> 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_author_sort_desc_id_idx": {
+          "name": "books_library_author_sort_desc_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"primary_author_sort_name\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"books\".\"status\" <> 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_library_id_libraries_id_fk": {
+          "name": "books_library_id_libraries_id_fk",
+          "tableFrom": "books",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "books_library_folder_id_library_folders_id_fk": {
+          "name": "books_library_folder_id_library_folders_id_fk",
+          "tableFrom": "books",
+          "tableTo": "library_folders",
+          "columnsFrom": ["library_folder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "books_primary_file_id_book_files_id_fk": {
+          "name": "books_primary_file_id_book_files_id_fk",
+          "tableFrom": "books",
+          "tableTo": "book_files",
+          "columnsFrom": ["primary_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "books_library_folder_library_fk": {
+          "name": "books_library_folder_library_fk",
+          "tableFrom": "books",
+          "tableTo": "library_folders",
+          "columnsFrom": ["library_folder_id", "library_id"],
+          "columnsTo": ["id", "library_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "books_id_library_folder_id_unique": {
+          "name": "books_id_library_folder_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "library_folder_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "books_status_chk": {
+          "name": "books_status_chk",
+          "value": "\"books\".\"status\" in ('present', 'missing', 'processing')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collection_books": {
+      "name": "collection_books",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_books_book_id_idx": {
+          "name": "collection_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_books_collection_id_collections_id_fk": {
+          "name": "collection_books_collection_id_collections_id_fk",
+          "tableFrom": "collection_books",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_books_book_id_books_id_fk": {
+          "name": "collection_books_book_id_books_id_fk",
+          "tableFrom": "collection_books",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_books_collection_id_book_id_pk": {
+          "name": "collection_books_collection_id_book_id_pk",
+          "columns": ["collection_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_to_kobo": {
+          "name": "sync_to_kobo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_name_uidx": {
+          "name": "collections_user_name_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_user_display_name_idx": {
+          "name": "collections_user_display_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.smart_scopes": {
+      "name": "smart_scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_sort": {
+          "name": "default_sort",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "smart_scopes_user_id_users_id_fk": {
+          "name": "smart_scopes_user_id_users_id_fk",
+          "tableFrom": "smart_scopes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "smart_scopes_user_id_name_unique": {
+          "name": "smart_scopes_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_series": {
+      "name": "book_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_series_normalized_name_uidx": {
+          "name": "book_series_normalized_name_uidx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_series_name_trgm_idx": {
+          "name": "book_series_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "book_series_name_lower_idx": {
+          "name": "book_series_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_series_memberships": {
+      "name": "book_series_memberships",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_index": {
+          "name": "series_index",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_series_memberships_book_display_uidx": {
+          "name": "book_series_memberships_book_display_uidx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_series_memberships_series_index_book_idx": {
+          "name": "book_series_memberships_series_index_book_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "series_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_series_memberships_book_display_idx": {
+          "name": "book_series_memberships_book_display_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_series_memberships_book_id_books_id_fk": {
+          "name": "book_series_memberships_book_id_books_id_fk",
+          "tableFrom": "book_series_memberships",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_series_memberships_series_id_book_series_id_fk": {
+          "name": "book_series_memberships_series_id_book_series_id_fk",
+          "tableFrom": "book_series_memberships",
+          "tableTo": "book_series",
+          "columnsFrom": ["series_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_series_memberships_book_id_series_id_pk": {
+          "name": "book_series_memberships_book_id_series_id_pk",
+          "columns": ["book_id", "series_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_series_memberships_display_order_nonnegative_chk": {
+          "name": "book_series_memberships_display_order_nonnegative_chk",
+          "value": "\"book_series_memberships\".\"display_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.author_enrichment_queue": {
+      "name": "author_enrichment_queue",
+      "schema": "",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "author_enrichment_queue_status_next_attempt_idx": {
+          "name": "author_enrichment_queue_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "author_enrichment_queue_next_attempt_idx": {
+          "name": "author_enrichment_queue_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "author_enrichment_queue_single_processing_idx": {
+          "name": "author_enrichment_queue_single_processing_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"author_enrichment_queue\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "author_enrichment_queue_author_id_authors_id_fk": {
+          "name": "author_enrichment_queue_author_id_authors_id_fk",
+          "tableFrom": "author_enrichment_queue",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "author_enrichment_queue_status_chk": {
+          "name": "author_enrichment_queue_status_chk",
+          "value": "\"author_enrichment_queue\".\"status\" in ('queued', 'processing', 'rate_limited', 'failed', 'done')"
+        },
+        "author_enrichment_queue_reason_chk": {
+          "name": "author_enrichment_queue_reason_chk",
+          "value": "\"author_enrichment_queue\".\"reason\" in ('unknown', 'metadata_replace', 'manual_backfill', 'manual_backfill_all', 'author_rename', 'author_merge_target')"
+        },
+        "author_enrichment_queue_attempt_count_nonnegative_chk": {
+          "name": "author_enrichment_queue_attempt_count_nonnegative_chk",
+          "value": "\"author_enrichment_queue\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_photo": {
+          "name": "has_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_enriched_at": {
+          "name": "last_enriched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "authors_name_trgm_idx": {
+          "name": "authors_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authors_name_unique": {
+          "name": "authors_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_authors": {
+      "name": "book_authors",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "book_authors_author_id_idx": {
+          "name": "book_authors_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_authors_book_display_idx": {
+          "name": "book_authors_book_display_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_authors_book_display_author_idx": {
+          "name": "book_authors_book_display_author_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_authors_book_id_books_id_fk": {
+          "name": "book_authors_book_id_books_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_authors_author_id_authors_id_fk": {
+          "name": "book_authors_author_id_authors_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_authors_book_id_author_id_pk": {
+          "name": "book_authors_book_id_author_id_pk",
+          "columns": ["book_id", "author_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_community_ratings": {
+      "name": "book_community_ratings",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_count": {
+          "name": "rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_community_ratings_provider_idx": {
+          "name": "book_community_ratings_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_community_ratings_rating_book_idx": {
+          "name": "book_community_ratings_rating_book_idx",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_community_ratings_provider_rating_book_idx": {
+          "name": "book_community_ratings_provider_rating_book_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_community_ratings_book_id_books_id_fk": {
+          "name": "book_community_ratings_book_id_books_id_fk",
+          "tableFrom": "book_community_ratings",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_community_ratings_book_id_provider_pk": {
+          "name": "book_community_ratings_book_id_provider_pk",
+          "columns": ["book_id", "provider"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_community_ratings_rating_range_chk": {
+          "name": "book_community_ratings_rating_range_chk",
+          "value": "\"book_community_ratings\".\"rating\" >= 0 and \"book_community_ratings\".\"rating\" <= 5"
+        },
+        "book_community_ratings_count_nonnegative_chk": {
+          "name": "book_community_ratings_count_nonnegative_chk",
+          "value": "\"book_community_ratings\".\"rating_count\" is null or \"book_community_ratings\".\"rating_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_genres": {
+      "name": "book_genres",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_genres_genre_id_idx": {
+          "name": "book_genres_genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_genres_book_id_books_id_fk": {
+          "name": "book_genres_book_id_books_id_fk",
+          "tableFrom": "book_genres",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_genres_genre_id_genres_id_fk": {
+          "name": "book_genres_genre_id_genres_id_fk",
+          "tableFrom": "book_genres",
+          "tableTo": "genres",
+          "columnsFrom": ["genre_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_genres_book_id_genre_id_pk": {
+          "name": "book_genres_book_id_genre_id_pk",
+          "columns": ["book_id", "genre_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_metadata": {
+      "name": "book_metadata",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn10": {
+          "name": "isbn10",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn13": {
+          "name": "isbn13",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_name": {
+          "name": "series_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_index": {
+          "name": "series_index",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_source": {
+          "name": "cover_source",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_id": {
+          "name": "google_books_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goodreads_id": {
+          "name": "goodreads_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amazon_id": {
+          "name": "amazon_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_id": {
+          "name": "hardcover_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_edition_id": {
+          "name": "hardcover_edition_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_library_id": {
+          "name": "open_library_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itunes_id": {
+          "name": "itunes_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_id": {
+          "name": "kobo_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_score": {
+          "name": "metadata_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_metadata_fetch_at": {
+          "name": "last_metadata_fetch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_written_at": {
+          "name": "last_written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abridged": {
+          "name": "abridged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audible_id": {
+          "name": "audible_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comicvine_id": {
+          "name": "comicvine_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranobedb_id": {
+          "name": "ranobedb_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lubimyczytac_id": {
+          "name": "lubimyczytac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aladin_id": {
+          "name": "aladin_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_fields": {
+          "name": "locked_fields",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bm_title_trgm_idx": {
+          "name": "bm_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_title_lower_idx": {
+          "name": "bm_title_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"title\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_title_book_id_idx": {
+          "name": "bm_title_book_id_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_trgm_idx": {
+          "name": "bm_series_trgm_idx",
+          "columns": [
+            {
+              "expression": "series_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_series_id_idx": {
+          "name": "bm_series_id_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_id_index_book_id_idx": {
+          "name": "bm_series_id_index_book_id_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "series_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_name_lower_btrim_idx": {
+          "name": "bm_series_name_lower_btrim_idx",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"series_name\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_publisher_trgm_idx": {
+          "name": "bm_publisher_trgm_idx",
+          "columns": [
+            {
+              "expression": "publisher",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_language_idx": {
+          "name": "bm_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_language_trgm_idx": {
+          "name": "bm_language_trgm_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_published_year_idx": {
+          "name": "bm_published_year_idx",
+          "columns": [
+            {
+              "expression": "published_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_name_index_idx": {
+          "name": "bm_series_name_index_idx",
+          "columns": [
+            {
+              "expression": "series_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "series_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_isbn10_idx": {
+          "name": "bm_isbn10_idx",
+          "columns": [
+            {
+              "expression": "isbn10",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_isbn13_idx": {
+          "name": "bm_isbn13_idx",
+          "columns": [
+            {
+              "expression": "isbn13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_embedding_hnsw_cosine_idx": {
+          "name": "bm_embedding_hnsw_cosine_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_metadata_book_id_books_id_fk": {
+          "name": "book_metadata_book_id_books_id_fk",
+          "tableFrom": "book_metadata",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_metadata_series_id_book_series_id_fk": {
+          "name": "book_metadata_series_id_book_series_id_fk",
+          "tableFrom": "book_metadata",
+          "tableTo": "book_series",
+          "columnsFrom": ["series_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_metadata_rating_range_chk": {
+          "name": "book_metadata_rating_range_chk",
+          "value": "\"book_metadata\".\"rating\" is null or (\"book_metadata\".\"rating\" >= 1 and \"book_metadata\".\"rating\" <= 10)"
+        },
+        "book_metadata_published_year_range_chk": {
+          "name": "book_metadata_published_year_range_chk",
+          "value": "\"book_metadata\".\"published_year\" is null or (\"book_metadata\".\"published_year\" >= 1000 and \"book_metadata\".\"published_year\" <= 2200)"
+        },
+        "book_metadata_page_count_nonnegative_chk": {
+          "name": "book_metadata_page_count_nonnegative_chk",
+          "value": "\"book_metadata\".\"page_count\" is null or \"book_metadata\".\"page_count\" >= 0"
+        },
+        "book_metadata_duration_seconds_nonnegative_chk": {
+          "name": "book_metadata_duration_seconds_nonnegative_chk",
+          "value": "\"book_metadata\".\"duration_seconds\" is null or \"book_metadata\".\"duration_seconds\" >= 0"
+        },
+        "book_metadata_cover_source_chk": {
+          "name": "book_metadata_cover_source_chk",
+          "value": "\"book_metadata\".\"cover_source\" is null or \"book_metadata\".\"cover_source\" in ('extracted', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_metadata_fetch_queue": {
+      "name": "book_metadata_fetch_queue",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual_trigger'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bmfq_status_idx": {
+          "name": "bmfq_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bmfq_created_at_idx": {
+          "name": "bmfq_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bmfq_status_created_book_idx": {
+          "name": "bmfq_status_created_book_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_metadata_fetch_queue_book_id_books_id_fk": {
+          "name": "book_metadata_fetch_queue_book_id_books_id_fk",
+          "tableFrom": "book_metadata_fetch_queue",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_metadata_fetch_queue_status_chk": {
+          "name": "book_metadata_fetch_queue_status_chk",
+          "value": "\"book_metadata_fetch_queue\".\"status\" in ('queued', 'processing', 'failed')"
+        },
+        "book_metadata_fetch_queue_reason_chk": {
+          "name": "book_metadata_fetch_queue_reason_chk",
+          "value": "\"book_metadata_fetch_queue\".\"reason\" in ('event_import', 'manual_trigger', 'manual_retry')"
+        },
+        "book_metadata_fetch_queue_attempt_count_nonnegative_chk": {
+          "name": "book_metadata_fetch_queue_attempt_count_nonnegative_chk",
+          "value": "\"book_metadata_fetch_queue\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_id_idx": {
+          "name": "book_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_books_id_fk": {
+          "name": "book_tags_book_id_books_id_fk",
+          "tableFrom": "book_tags",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_tag_id_tags_id_fk": {
+          "name": "book_tags_tag_id_tags_id_fk",
+          "tableFrom": "book_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_book_id_tag_id_pk": {
+          "name": "book_tags_book_id_tag_id_pk",
+          "columns": ["book_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "genres_name_trgm_idx": {
+          "name": "genres_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_trgm_idx": {
+          "name": "tags_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_narrators": {
+      "name": "book_narrators",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrator_id": {
+          "name": "narrator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "book_narrators_narrator_id_idx": {
+          "name": "book_narrators_narrator_id_idx",
+          "columns": [
+            {
+              "expression": "narrator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_narrators_book_id_books_id_fk": {
+          "name": "book_narrators_book_id_books_id_fk",
+          "tableFrom": "book_narrators",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_narrators_narrator_id_narrators_id_fk": {
+          "name": "book_narrators_narrator_id_narrators_id_fk",
+          "tableFrom": "book_narrators",
+          "tableTo": "narrators",
+          "columnsFrom": ["narrator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_narrators_book_id_narrator_id_pk": {
+          "name": "book_narrators_book_id_narrator_id_pk",
+          "columns": ["book_id", "narrator_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.narrators": {
+      "name": "narrators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "narrators_name_trgm_idx": {
+          "name": "narrators_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "narrators_name_unique": {
+          "name": "narrators_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_dir_scan_state": {
+      "name": "library_dir_scan_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_folder_id": {
+          "name": "library_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dir_path": {
+          "name": "dir_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_mtime_ms": {
+          "name": "last_seen_mtime_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_dir_scan_state_folder_dir_uidx": {
+          "name": "library_dir_scan_state_folder_dir_uidx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dir_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_dir_scan_state_folder_idx": {
+          "name": "library_dir_scan_state_folder_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_dir_scan_state_library_folder_id_library_folders_id_fk": {
+          "name": "library_dir_scan_state_library_folder_id_library_folders_id_fk",
+          "tableFrom": "library_dir_scan_state",
+          "tableTo": "library_folders",
+          "columnsFrom": ["library_folder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_jobs": {
+      "name": "scan_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_count": {
+          "name": "added_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "missing_count": {
+          "name": "missing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scan_jobs_library_status_idx": {
+          "name": "scan_jobs_library_status_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_jobs_library_id_libraries_id_fk": {
+          "name": "scan_jobs_library_id_libraries_id_fk",
+          "tableFrom": "scan_jobs",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scan_jobs_status_chk": {
+          "name": "scan_jobs_status_chk",
+          "value": "\"scan_jobs\".\"status\" in ('running', 'completed', 'failed')"
+        },
+        "scan_jobs_triggered_by_chk": {
+          "name": "scan_jobs_triggered_by_chk",
+          "value": "\"scan_jobs\".\"triggered_by\" in ('manual', 'watcher', 'schedule')"
+        },
+        "scan_jobs_added_count_nonnegative_chk": {
+          "name": "scan_jobs_added_count_nonnegative_chk",
+          "value": "\"scan_jobs\".\"added_count\" >= 0"
+        },
+        "scan_jobs_updated_count_nonnegative_chk": {
+          "name": "scan_jobs_updated_count_nonnegative_chk",
+          "value": "\"scan_jobs\".\"updated_count\" >= 0"
+        },
+        "scan_jobs_missing_count_nonnegative_chk": {
+          "name": "scan_jobs_missing_count_nonnegative_chk",
+          "value": "\"scan_jobs\".\"missing_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.annotation_positions": {
+      "name": "annotation_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "annotation_id": {
+          "name": "annotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos0": {
+          "name": "pos0",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos1": {
+          "name": "pos1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exact'"
+        },
+        "converter_version": {
+          "name": "converter_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extras": {
+          "name": "extras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annotation_positions_annotation_format_uidx": {
+          "name": "annotation_positions_annotation_format_uidx",
+          "columns": [
+            {
+              "expression": "annotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "format",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_positions_user_idx": {
+          "name": "annotation_positions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_positions_format_status_idx": {
+          "name": "annotation_positions_format_status_idx",
+          "columns": [
+            {
+              "expression": "format",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "annotation_positions_annotation_id_annotations_id_fk": {
+          "name": "annotation_positions_annotation_id_annotations_id_fk",
+          "tableFrom": "annotation_positions",
+          "tableTo": "annotations",
+          "columnsFrom": ["annotation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "annotation_positions_user_id_users_id_fk": {
+          "name": "annotation_positions_user_id_users_id_fk",
+          "tableFrom": "annotation_positions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "annotation_positions_book_file_id_book_files_id_fk": {
+          "name": "annotation_positions_book_file_id_book_files_id_fk",
+          "tableFrom": "annotation_positions",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "annotation_positions_format_chk": {
+          "name": "annotation_positions_format_chk",
+          "value": "\"annotation_positions\".\"format\" in ('cfi', 'xpointer', 'pdf', 'kobo_span')"
+        },
+        "annotation_positions_status_chk": {
+          "name": "annotation_positions_status_chk",
+          "value": "\"annotation_positions\".\"status\" in ('exact', 'repaired', 'failed', 'pending')"
+        },
+        "annotation_positions_pos0_chk": {
+          "name": "annotation_positions_pos0_chk",
+          "value": "\"annotation_positions\".\"status\" in ('failed', 'pending') or \"annotation_positions\".\"pos0\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.annotation_sync_state": {
+      "name": "annotation_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "annotation_id": {
+          "name": "annotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_created_at": {
+          "name": "external_created_at",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_applied_version": {
+          "name": "last_applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "delete_acked_at": {
+          "name": "delete_acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annotation_sync_state_annotation_source_device_uidx": {
+          "name": "annotation_sync_state_annotation_source_device_uidx",
+          "columns": [
+            {
+              "expression": "annotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_sync_state_user_source_device_key_idx": {
+          "name": "annotation_sync_state_user_source_device_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_sync_state_user_key_idx": {
+          "name": "annotation_sync_state_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_sync_state_annotation_id_idx": {
+          "name": "annotation_sync_state_annotation_id_idx",
+          "columns": [
+            {
+              "expression": "annotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "annotation_sync_state_annotation_id_annotations_id_fk": {
+          "name": "annotation_sync_state_annotation_id_annotations_id_fk",
+          "tableFrom": "annotation_sync_state",
+          "tableTo": "annotations",
+          "columnsFrom": ["annotation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "annotation_sync_state_user_id_users_id_fk": {
+          "name": "annotation_sync_state_user_id_users_id_fk",
+          "tableFrom": "annotation_sync_state",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "annotation_sync_state_source_chk": {
+          "name": "annotation_sync_state_source_chk",
+          "value": "\"annotation_sync_state\".\"source\" in ('koreader', 'kobo')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.annotations": {
+      "name": "annotations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yellow'"
+        },
+        "style": {
+          "name": "style",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'highlight'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_title": {
+          "name": "chapter_title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_created_at": {
+          "name": "device_created_at",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_updated_at": {
+          "name": "device_updated_at",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annotations_user_id_idx": {
+          "name": "annotations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotations_user_book_idx": {
+          "name": "annotations_user_book_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotations_user_book_active_idx": {
+          "name": "annotations_user_book_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"annotations\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "annotations_user_id_users_id_fk": {
+          "name": "annotations_user_id_users_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "annotations_book_id_books_id_fk": {
+          "name": "annotations_book_id_books_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "annotations_style_chk": {
+          "name": "annotations_style_chk",
+          "value": "\"annotations\".\"style\" in ('highlight', 'underline', 'strikethrough', 'squiggly', 'invert')"
+        },
+        "annotations_origin_chk": {
+          "name": "annotations_origin_chk",
+          "value": "\"annotations\".\"origin\" in ('web', 'koreader', 'kobo')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audiobook_progress": {
+      "name": "audiobook_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_file_id": {
+          "name": "current_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "abp_user_id_idx": {
+          "name": "abp_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audiobook_progress_user_id_users_id_fk": {
+          "name": "audiobook_progress_user_id_users_id_fk",
+          "tableFrom": "audiobook_progress",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audiobook_progress_book_id_books_id_fk": {
+          "name": "audiobook_progress_book_id_books_id_fk",
+          "tableFrom": "audiobook_progress",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audiobook_progress_current_file_id_book_files_id_fk": {
+          "name": "audiobook_progress_current_file_id_book_files_id_fk",
+          "tableFrom": "audiobook_progress",
+          "tableTo": "book_files",
+          "columnsFrom": ["current_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audiobook_progress_user_id_book_id_pk": {
+          "name": "audiobook_progress_user_id_book_id_pk",
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audiobook_progress_percentage_range_chk": {
+          "name": "audiobook_progress_percentage_range_chk",
+          "value": "\"audiobook_progress\".\"percentage\" >= 0 and \"audiobook_progress\".\"percentage\" <= 100"
+        },
+        "audiobook_progress_position_seconds_nonnegative_chk": {
+          "name": "audiobook_progress_position_seconds_nonnegative_chk",
+          "value": "\"audiobook_progress\".\"position_seconds\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cfi": {
+          "name": "cfi",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_book_idx": {
+          "name": "bookmarks_user_book_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_user_book_cfi_uidx": {
+          "name": "bookmarks_user_book_cfi_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cfi",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bookmarks\".\"cfi\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_user_book_pos_uidx": {
+          "name": "bookmarks_user_book_pos_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position_seconds",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bookmarks\".\"position_seconds\" is not null and \"bookmarks\".\"cfi\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_book_id_books_id_fk": {
+          "name": "bookmarks_book_id_books_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reader_default_preferences": {
+      "name": "reader_default_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_group": {
+          "name": "format_group",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rdp_user_format_idx": {
+          "name": "rdp_user_format_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "format_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reader_default_preferences_user_id_users_id_fk": {
+          "name": "reader_default_preferences_user_id_users_id_fk",
+          "tableFrom": "reader_default_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reader_default_preferences_format_group_chk": {
+          "name": "reader_default_preferences_format_group_chk",
+          "value": "\"reader_default_preferences\".\"format_group\" in ('epub', 'pdf', 'cbx', 'audio')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reader_preferences": {
+      "name": "reader_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rp_user_file_idx": {
+          "name": "rp_user_file_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reader_preferences_user_id_users_id_fk": {
+          "name": "reader_preferences_user_id_users_id_fk",
+          "tableFrom": "reader_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reader_preferences_book_file_id_book_files_id_fk": {
+          "name": "reader_preferences_book_file_id_book_files_id_fk",
+          "tableFrom": "reader_preferences",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_progress": {
+      "name": "reading_progress",
+      "schema": "",
+      "columns": {
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cfi": {
+          "name": "cfi",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_number": {
+          "name": "page_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_location_source": {
+          "name": "kobo_location_source",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_location_type": {
+          "name": "kobo_location_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_location_value": {
+          "name": "kobo_location_value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_content_source_progress_percent": {
+          "name": "kobo_content_source_progress_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koreader_progress": {
+          "name": "koreader_progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_progress_user_id_idx": {
+          "name": "reading_progress_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reading_progress_user_updated_at_idx": {
+          "name": "reading_progress_user_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reading_progress_book_file_id_book_files_id_fk": {
+          "name": "reading_progress_book_file_id_book_files_id_fk",
+          "tableFrom": "reading_progress",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_progress_user_id_users_id_fk": {
+          "name": "reading_progress_user_id_users_id_fk",
+          "tableFrom": "reading_progress",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reading_progress_book_file_id_user_id_pk": {
+          "name": "reading_progress_book_file_id_user_id_pk",
+          "columns": ["book_file_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reading_progress_percentage_range_chk": {
+          "name": "reading_progress_percentage_range_chk",
+          "value": "\"reading_progress\".\"percentage\" >= 0 and \"reading_progress\".\"percentage\" <= 100"
+        },
+        "reading_progress_page_number_nonnegative_chk": {
+          "name": "reading_progress_page_number_nonnegative_chk",
+          "value": "\"reading_progress\".\"page_number\" is null or \"reading_progress\".\"page_number\" >= 0"
+        },
+        "reading_progress_position_seconds_nonnegative_chk": {
+          "name": "reading_progress_position_seconds_nonnegative_chk",
+          "value": "\"reading_progress\".\"position_seconds\" is null or \"reading_progress\".\"position_seconds\" >= 0"
+        },
+        "reading_progress_kobo_content_source_progress_range_chk": {
+          "name": "reading_progress_kobo_content_source_progress_range_chk",
+          "value": "\"reading_progress\".\"kobo_content_source_progress_percent\" is null or (\"reading_progress\".\"kobo_content_source_progress_percent\" >= 0 and \"reading_progress\".\"kobo_content_source_progress_percent\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reading_sessions": {
+      "name": "reading_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress_delta": {
+          "name": "progress_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_progress": {
+          "name": "end_progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rs_user_session_id_uidx": {
+          "name": "rs_user_session_id_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_user_started_at_idx": {
+          "name": "rs_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_book_file_started_at_idx": {
+          "name": "rs_book_file_started_at_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_user_book_file_idx": {
+          "name": "rs_user_book_file_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_user_book_started_at_idx": {
+          "name": "rs_user_book_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reading_sessions_user_id_users_id_fk": {
+          "name": "reading_sessions_user_id_users_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_sessions_book_file_id_book_files_id_fk": {
+          "name": "reading_sessions_book_file_id_book_files_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_sessions_book_id_books_id_fk": {
+          "name": "reading_sessions_book_id_books_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reading_sessions_source_chk": {
+          "name": "reading_sessions_source_chk",
+          "value": "\"reading_sessions\".\"source\" in ('web', 'koreader', 'manual', 'kobo')"
+        },
+        "reading_sessions_duration_seconds_nonnegative_chk": {
+          "name": "reading_sessions_duration_seconds_nonnegative_chk",
+          "value": "\"reading_sessions\".\"duration_seconds\" >= 0"
+        },
+        "reading_sessions_end_progress_range_chk": {
+          "name": "reading_sessions_end_progress_range_chk",
+          "value": "\"reading_sessions\".\"end_progress\" is null or (\"reading_sessions\".\"end_progress\" >= 0 and \"reading_sessions\".\"end_progress\" <= 100)"
+        },
+        "reading_sessions_ended_after_started_chk": {
+          "name": "reading_sessions_ended_after_started_chk",
+          "value": "\"reading_sessions\".\"ended_at\" >= \"reading_sessions\".\"started_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_book_ratings": {
+      "name": "user_book_ratings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ubr_user_id_idx": {
+          "name": "ubr_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubr_book_id_idx": {
+          "name": "ubr_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubr_book_user_rating_idx": {
+          "name": "ubr_book_user_rating_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_book_ratings_user_id_users_id_fk": {
+          "name": "user_book_ratings_user_id_users_id_fk",
+          "tableFrom": "user_book_ratings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_book_ratings_book_id_books_id_fk": {
+          "name": "user_book_ratings_book_id_books_id_fk",
+          "tableFrom": "user_book_ratings",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_book_ratings_user_id_book_id_pk": {
+          "name": "user_book_ratings_user_id_book_id_pk",
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_book_ratings_rating_range_chk": {
+          "name": "user_book_ratings_rating_range_chk",
+          "value": "\"user_book_ratings\".\"rating\" >= 1 and \"user_book_ratings\".\"rating\" <= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_book_status": {
+      "name": "user_book_status",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unread'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ubs_user_id_idx": {
+          "name": "ubs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubs_user_status_idx": {
+          "name": "ubs_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubs_book_user_idx": {
+          "name": "ubs_book_user_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_book_status_user_id_users_id_fk": {
+          "name": "user_book_status_user_id_users_id_fk",
+          "tableFrom": "user_book_status",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_book_status_book_id_books_id_fk": {
+          "name": "user_book_status_book_id_books_id_fk",
+          "tableFrom": "user_book_status",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_book_status_user_id_book_id_pk": {
+          "name": "user_book_status_user_id_book_id_pk",
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_book_status_status_chk": {
+          "name": "user_book_status_status_chk",
+          "value": "\"user_book_status\".\"status\" in ('unread', 'want_to_read', 'reading', 'on_hold', 'rereading', 'read', 'skimmed', 'abandoned')"
+        },
+        "user_book_status_source_chk": {
+          "name": "user_book_status_source_chk",
+          "value": "\"user_book_status\".\"source\" in ('auto', 'manual')"
+        },
+        "user_book_status_finished_after_started_chk": {
+          "name": "user_book_status_finished_after_started_chk",
+          "value": "\"user_book_status\".\"finished_at\" is null or \"user_book_status\".\"started_at\" is null or \"user_book_status\".\"finished_at\" >= \"user_book_status\".\"started_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_reading_daily_stats": {
+      "name": "user_reading_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reading_seconds": {
+          "name": "reading_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_delta": {
+          "name": "progress_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sessions_count": {
+          "name": "sessions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "urds_user_day_idx": {
+          "name": "urds_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_reading_daily_stats_user_id_users_id_fk": {
+          "name": "user_reading_daily_stats_user_id_users_id_fk",
+          "tableFrom": "user_reading_daily_stats",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_reading_daily_stats_library_id_libraries_id_fk": {
+          "name": "user_reading_daily_stats_library_id_libraries_id_fk",
+          "tableFrom": "user_reading_daily_stats",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_reading_daily_stats_user_id_library_id_day_pk": {
+          "name": "user_reading_daily_stats_user_id_library_id_day_pk",
+          "columns": ["user_id", "library_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_reading_daily_stats_reading_seconds_nonnegative_chk": {
+          "name": "user_reading_daily_stats_reading_seconds_nonnegative_chk",
+          "value": "\"user_reading_daily_stats\".\"reading_seconds\" >= 0"
+        },
+        "user_reading_daily_stats_sessions_count_nonnegative_chk": {
+          "name": "user_reading_daily_stats_sessions_count_nonnegative_chk",
+          "value": "\"user_reading_daily_stats\".\"sessions_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oidc_group_mappings": {
+      "name": "oidc_group_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_group_claim": {
+          "name": "oidc_group_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_name": {
+          "name": "permission_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_group_mappings_provider_claim_uidx": {
+          "name": "oidc_group_mappings_provider_claim_uidx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_group_claim",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_group_mappings_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_group_mappings_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_group_mappings",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_identities": {
+      "name": "oidc_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_identities_provider_subject_uidx": {
+          "name": "oidc_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_identities_user_provider_uidx": {
+          "name": "oidc_identities_user_provider_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_identities_issuer_subject_uidx": {
+          "name": "oidc_identities_issuer_subject_uidx",
+          "columns": [
+            {
+              "expression": "oidc_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_identities_user_id_idx": {
+          "name": "oidc_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_identities_user_id_users_id_fk": {
+          "name": "oidc_identities_user_id_users_id_fk",
+          "tableFrom": "oidc_identities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_identities_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_identities_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_identities",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_permission_grants": {
+      "name": "oidc_permission_grants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_name": {
+          "name": "permission_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oidc_permission_grants_user_id_users_id_fk": {
+          "name": "oidc_permission_grants_user_id_users_id_fk",
+          "tableFrom": "oidc_permission_grants",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_permission_grants_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_permission_grants_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_permission_grants",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oidc_permission_grants_user_id_provider_id_permission_name_pk": {
+          "name": "oidc_permission_grants_user_id_provider_id_permission_name_pk",
+          "columns": ["user_id", "provider_id", "permission_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issuer_uri": {
+          "name": "issuer_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openid profile email'"
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_mapping": {
+          "name": "claim_mapping",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"username\":\"preferred_username\",\"name\":\"name\",\"email\":\"email\",\"groups\":\"groups\"}'::jsonb"
+        },
+        "auto_provision": {
+          "name": "auto_provision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"enabled\":false,\"allowLocalLinking\":false,\"defaultPermissionNames\":[]}'::jsonb"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_providers_enabled_order_idx": {
+          "name": "oidc_providers_enabled_order_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oidc_providers_slug_unique": {
+          "name": "oidc_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "oidc_providers_issuer_uri_unique": {
+          "name": "oidc_providers_issuer_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": ["issuer_uri"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_sessions": {
+      "name": "oidc_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_session_id": {
+          "name": "oidc_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token_hint": {
+          "name": "id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_refresh_token": {
+          "name": "idp_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oidc_sessions_user_active_idx": {
+          "name": "oidc_sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"oidc_sessions\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_subject_issuer_idx": {
+          "name": "oidc_sessions_subject_issuer_idx",
+          "columns": [
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_sid_idx": {
+          "name": "oidc_sessions_sid_idx",
+          "columns": [
+            {
+              "expression": "oidc_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_expires_at_idx": {
+          "name": "oidc_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_provider_id_idx": {
+          "name": "oidc_sessions_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_sessions_user_id_users_id_fk": {
+          "name": "oidc_sessions_user_id_users_id_fk",
+          "tableFrom": "oidc_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_sessions_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_sessions_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_sessions",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_states": {
+      "name": "oidc_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_states_expires_at_idx": {
+          "name": "oidc_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_states_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_states_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_states",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_used_jtis": {
+      "name": "oidc_used_jtis",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oidc_used_jtis_expires_at_idx": {
+          "name": "oidc_used_jtis_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opds_users": {
+      "name": "opds_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "opds_sort_order",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recent'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opds_users_username_lower_uidx": {
+          "name": "opds_users_username_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opds_users_user_id_users_id_fk": {
+          "name": "opds_users_user_id_users_id_fk",
+          "tableFrom": "opds_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opds_users_username_unique": {
+          "name": "opds_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_book_entitlements": {
+      "name": "kobo_book_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needs_legacy_numeric_removal": {
+          "name": "needs_legacy_numeric_removal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kobo_book_entitlements_user_id_idx": {
+          "name": "kobo_book_entitlements_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kobo_book_entitlements_book_id_idx": {
+          "name": "kobo_book_entitlements_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_book_entitlements_user_id_users_id_fk": {
+          "name": "kobo_book_entitlements_user_id_users_id_fk",
+          "tableFrom": "kobo_book_entitlements",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_book_entitlements_book_id_books_id_fk": {
+          "name": "kobo_book_entitlements_book_id_books_id_fk",
+          "tableFrom": "kobo_book_entitlements",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_book_entitlements_user_book_unique": {
+          "name": "kobo_book_entitlements_user_book_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "book_id"]
+        },
+        "kobo_book_entitlements_user_entitlement_unique": {
+          "name": "kobo_book_entitlements_user_entitlement_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "entitlement_id"]
+        },
+        "kobo_book_entitlements_user_cover_unique": {
+          "name": "kobo_book_entitlements_user_cover_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "cover_image_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_devices": {
+      "name": "kobo_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_device_id": {
+          "name": "client_device_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kobo_devices_user_id_idx": {
+          "name": "kobo_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_devices_user_id_users_id_fk": {
+          "name": "kobo_devices_user_id_users_id_fk",
+          "tableFrom": "kobo_devices",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_devices_token_unique": {
+          "name": "kobo_devices_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        },
+        "kobo_devices_client_device_id_unique": {
+          "name": "kobo_devices_client_device_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_device_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_library_snapshots": {
+      "name": "kobo_library_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kobo_library_snapshots_user_id_users_id_fk": {
+          "name": "kobo_library_snapshots_user_id_users_id_fk",
+          "tableFrom": "kobo_library_snapshots",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_library_snapshots_user_id_unique": {
+          "name": "kobo_library_snapshots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_reading_states": {
+      "name": "kobo_reading_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_kobo": {
+          "name": "created_at_kobo",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_kobo": {
+          "name": "last_modified_kobo",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_timestamp": {
+          "name": "priority_timestamp",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bookmark": {
+          "name": "current_bookmark",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_info": {
+          "name": "status_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kobo_reading_states_user_id_users_id_fk": {
+          "name": "kobo_reading_states_user_id_users_id_fk",
+          "tableFrom": "kobo_reading_states",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_reading_states_book_id_books_id_fk": {
+          "name": "kobo_reading_states_book_id_books_id_fk",
+          "tableFrom": "kobo_reading_states",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_reading_states_user_id_book_id_unique": {
+          "name": "kobo_reading_states_user_id_book_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_snapshot_books": {
+      "name": "kobo_snapshot_books",
+      "schema": "",
+      "columns": {
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_delete": {
+          "name": "pending_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_by_device": {
+          "name": "removed_by_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_hash": {
+          "name": "delivery_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_hash": {
+          "name": "metadata_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kobo_snapshot_books_snapshot_synced_book_idx": {
+          "name": "kobo_snapshot_books_snapshot_synced_book_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "synced",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_snapshot_books_snapshot_id_kobo_library_snapshots_id_fk": {
+          "name": "kobo_snapshot_books_snapshot_id_kobo_library_snapshots_id_fk",
+          "tableFrom": "kobo_snapshot_books",
+          "tableTo": "kobo_library_snapshots",
+          "columnsFrom": ["snapshot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_snapshot_books_book_id_books_id_fk": {
+          "name": "kobo_snapshot_books_book_id_books_id_fk",
+          "tableFrom": "kobo_snapshot_books",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kobo_snapshot_books_snapshot_id_book_id_pk": {
+          "name": "kobo_snapshot_books_snapshot_id_book_id_pk",
+          "columns": ["snapshot_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_sync_history": {
+      "name": "kobo_sync_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts": {
+          "name": "counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kobo_sync_history_user_created_idx": {
+          "name": "kobo_sync_history_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kobo_sync_history_device_created_idx": {
+          "name": "kobo_sync_history_device_created_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_sync_history_user_id_users_id_fk": {
+          "name": "kobo_sync_history_user_id_users_id_fk",
+          "tableFrom": "kobo_sync_history",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_sync_history_device_id_kobo_devices_id_fk": {
+          "name": "kobo_sync_history_device_id_kobo_devices_id_fk",
+          "tableFrom": "kobo_sync_history",
+          "tableTo": "kobo_devices",
+          "columnsFrom": ["device_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kobo_sync_history_event_chk": {
+          "name": "kobo_sync_history_event_chk",
+          "value": "\"kobo_sync_history\".\"event\" in ('library_sync', 'book_download', 'progress_update', 'annotations_pull', 'annotations_push')"
+        },
+        "kobo_sync_history_status_chk": {
+          "name": "kobo_sync_history_status_chk",
+          "value": "\"kobo_sync_history\".\"status\" in ('success', 'failed')"
+        },
+        "kobo_sync_history_duration_nonnegative_chk": {
+          "name": "kobo_sync_history_duration_nonnegative_chk",
+          "value": "\"kobo_sync_history\".\"duration_ms\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kobo_sync_settings": {
+      "name": "kobo_sync_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reading_threshold": {
+          "name": "reading_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finished_threshold": {
+          "name": "finished_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 99
+        },
+        "convert_to_kepub": {
+          "name": "convert_to_kepub",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "force_enable_hyphenation": {
+          "name": "force_enable_hyphenation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "kepub_conversion_limit_mb": {
+          "name": "kepub_conversion_limit_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "two_way_progress_sync": {
+          "name": "two_way_progress_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_bookorbit_annotations_to_kobo": {
+          "name": "sync_bookorbit_annotations_to_kobo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kobo_sync_settings_user_id_users_id_fk": {
+          "name": "kobo_sync_settings_user_id_users_id_fk",
+          "tableFrom": "kobo_sync_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_sync_settings_user_id_unique": {
+          "name": "kobo_sync_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kobo_sync_settings_reading_threshold_range_chk": {
+          "name": "kobo_sync_settings_reading_threshold_range_chk",
+          "value": "\"kobo_sync_settings\".\"reading_threshold\" >= 0 and \"kobo_sync_settings\".\"reading_threshold\" <= 100"
+        },
+        "kobo_sync_settings_finished_threshold_range_chk": {
+          "name": "kobo_sync_settings_finished_threshold_range_chk",
+          "value": "\"kobo_sync_settings\".\"finished_threshold\" >= 0 and \"kobo_sync_settings\".\"finished_threshold\" <= 100"
+        },
+        "kobo_sync_settings_conversion_limit_nonnegative_chk": {
+          "name": "kobo_sync_settings_conversion_limit_nonnegative_chk",
+          "value": "\"kobo_sync_settings\".\"kepub_conversion_limit_mb\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_dock_files": {
+      "name": "book_dock_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_path": {
+          "name": "absolute_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "embedded_metadata": {
+          "name": "embedded_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_metadata": {
+          "name": "selected_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_metadata": {
+          "name": "fetched_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_path": {
+          "name": "cover_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_library_id": {
+          "name": "target_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_folder_id": {
+          "name": "target_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_metadata_sources": {
+          "name": "fetched_metadata_sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_edited_at": {
+          "name": "metadata_edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_dock_files_status_idx": {
+          "name": "book_dock_files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_dock_files_uploaded_by_idx": {
+          "name": "book_dock_files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_dock_files_target_library_id_libraries_id_fk": {
+          "name": "book_dock_files_target_library_id_libraries_id_fk",
+          "tableFrom": "book_dock_files",
+          "tableTo": "libraries",
+          "columnsFrom": ["target_library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_dock_files_target_folder_id_library_folders_id_fk": {
+          "name": "book_dock_files_target_folder_id_library_folders_id_fk",
+          "tableFrom": "book_dock_files",
+          "tableTo": "library_folders",
+          "columnsFrom": ["target_folder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_dock_files_uploaded_by_users_id_fk": {
+          "name": "book_dock_files_uploaded_by_users_id_fk",
+          "tableFrom": "book_dock_files",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "book_dock_files_absolute_path_unique": {
+          "name": "book_dock_files_absolute_path_unique",
+          "nullsNotDistinct": false,
+          "columns": ["absolute_path"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "book_dock_files_status_chk": {
+          "name": "book_dock_files_status_chk",
+          "value": "\"book_dock_files\".\"status\" in ('pending', 'extracting', 'fetching', 'ready', 'error')"
+        },
+        "book_dock_files_confidence_range_chk": {
+          "name": "book_dock_files_confidence_range_chk",
+          "value": "\"book_dock_files\".\"confidence\" is null or (\"book_dock_files\".\"confidence\" >= 0 and \"book_dock_files\".\"confidence\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.file_write_log": {
+      "name": "file_write_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fields_written": {
+          "name": "fields_written",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fwl_book_id_written_at_idx": {
+          "name": "fwl_book_id_written_at_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "written_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_write_log_book_id_books_id_fk": {
+          "name": "file_write_log_book_id_books_id_fk",
+          "tableFrom": "file_write_log",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_write_log_book_file_id_book_files_id_fk": {
+          "name": "file_write_log_book_file_id_book_files_id_fk",
+          "tableFrom": "file_write_log",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "file_write_log_user_id_users_id_fk": {
+          "name": "file_write_log_user_id_users_id_fk",
+          "tableFrom": "file_write_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_write_log_status_chk": {
+          "name": "file_write_log_status_chk",
+          "value": "\"file_write_log\".\"status\" in ('success', 'skipped', 'failed')"
+        },
+        "file_write_log_triggered_by_chk": {
+          "name": "file_write_log_triggered_by_chk",
+          "value": "\"file_write_log\".\"triggered_by\" in ('auto', 'sync')"
+        },
+        "file_write_log_duration_ms_nonnegative_chk": {
+          "name": "file_write_log_duration_ms_nonnegative_chk",
+          "value": "\"file_write_log\".\"duration_ms\" is null or \"file_write_log\".\"duration_ms\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_templates_one_default_per_user_uidx": {
+          "name": "email_templates_one_default_per_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"is_default\" = true and \"email_templates\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_templates_system_name_unique": {
+          "name": "email_templates_system_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"user_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_user_id_users_id_fk": {
+          "name": "email_templates_user_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_templates_user_id_name_unique": {
+          "name": "email_templates_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_providers": {
+      "name": "email_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_enc": {
+          "name": "password_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl": {
+          "name": "ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "start_tls": {
+          "name": "start_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_system_provider": {
+          "name": "is_system_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls_reject_unauthorized": {
+          "name": "tls_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_providers_one_default_per_user_uidx": {
+          "name": "email_providers_one_default_per_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_providers\".\"is_default\" = true and \"email_providers\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_providers_one_system_provider_uidx": {
+          "name": "email_providers_one_system_provider_uidx",
+          "columns": [
+            {
+              "expression": "is_system_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_providers\".\"is_system_provider\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_providers_user_id_users_id_fk": {
+          "name": "email_providers_user_id_users_id_fk",
+          "tableFrom": "email_providers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_providers_user_id_name_unique": {
+          "name": "email_providers_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name"]
+        },
+        "email_providers_id_user_id_unique": {
+          "name": "email_providers_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_providers_port_range_chk": {
+          "name": "email_providers_port_range_chk",
+          "value": "\"email_providers\".\"port\" >= 1 and \"email_providers\".\"port\" <= 65535"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_recipient_group_members": {
+      "name": "email_recipient_group_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_recipient_group_members_user_id_users_id_fk": {
+          "name": "email_recipient_group_members_user_id_users_id_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_group_id_email_recipient_groups_id_fk": {
+          "name": "email_recipient_group_members_group_id_email_recipient_groups_id_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipient_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_recipient_id_email_recipients_id_fk": {
+          "name": "email_recipient_group_members_recipient_id_email_recipients_id_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipients",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_group_user_fk": {
+          "name": "email_recipient_group_members_group_user_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipient_groups",
+          "columnsFrom": ["group_id", "user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_recipient_user_fk": {
+          "name": "email_recipient_group_members_recipient_user_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipients",
+          "columnsFrom": ["recipient_id", "user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_recipient_group_members_group_id_recipient_id_pk": {
+          "name": "email_recipient_group_members_group_id_recipient_id_pk",
+          "columns": ["group_id", "recipient_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_recipient_groups": {
+      "name": "email_recipient_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_template_id": {
+          "name": "default_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_recipient_groups_user_id_users_id_fk": {
+          "name": "email_recipient_groups_user_id_users_id_fk",
+          "tableFrom": "email_recipient_groups",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_groups_default_template_id_email_templates_id_fk": {
+          "name": "email_recipient_groups_default_template_id_email_templates_id_fk",
+          "tableFrom": "email_recipient_groups",
+          "tableTo": "email_templates",
+          "columnsFrom": ["default_template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_recipient_groups_user_id_name_unique": {
+          "name": "email_recipient_groups_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name"]
+        },
+        "email_recipient_groups_id_user_id_unique": {
+          "name": "email_recipient_groups_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_recipients": {
+      "name": "email_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_format": {
+          "name": "preferred_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_template_id": {
+          "name": "default_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_recipients_user_email_lower_uidx": {
+          "name": "email_recipients_user_email_lower_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_recipients_one_default_per_user_uidx": {
+          "name": "email_recipients_one_default_per_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_recipients\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_recipients_user_id_users_id_fk": {
+          "name": "email_recipients_user_id_users_id_fk",
+          "tableFrom": "email_recipients",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipients_default_template_id_email_templates_id_fk": {
+          "name": "email_recipients_default_template_id_email_templates_id_fk",
+          "tableFrom": "email_recipients",
+          "tableTo": "email_templates",
+          "columnsFrom": ["default_template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_recipients_user_id_email_unique": {
+          "name": "email_recipients_user_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "email"]
+        },
+        "email_recipients_id_user_id_unique": {
+          "name": "email_recipients_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_recipients_device_type_chk": {
+          "name": "email_recipients_device_type_chk",
+          "value": "\"email_recipients\".\"device_type\" is null or \"email_recipients\".\"device_type\" in ('kindle', 'kobo', 'other')"
+        },
+        "email_recipients_preferred_format_chk": {
+          "name": "email_recipients_preferred_format_chk",
+          "value": "\"email_recipients\".\"preferred_format\" is null or \"email_recipients\".\"preferred_format\" in ('epub', 'pdf', 'mobi', 'azw3', 'cbz', 'cbr')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_preferences": {
+      "name": "email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_provider_id": {
+          "name": "default_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_recipient_id": {
+          "name": "default_recipient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_template_id": {
+          "name": "default_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_preferences_user_id_users_id_fk": {
+          "name": "email_preferences_user_id_users_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_provider_id_email_providers_id_fk": {
+          "name": "email_preferences_default_provider_id_email_providers_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_providers",
+          "columnsFrom": ["default_provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_recipient_id_email_recipients_id_fk": {
+          "name": "email_preferences_default_recipient_id_email_recipients_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_recipients",
+          "columnsFrom": ["default_recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_template_id_email_templates_id_fk": {
+          "name": "email_preferences_default_template_id_email_templates_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_templates",
+          "columnsFrom": ["default_template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_recipient_owner_fk": {
+          "name": "email_preferences_default_recipient_owner_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_recipients",
+          "columnsFrom": ["default_recipient_id", "user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_preferences_user_id_unique": {
+          "name": "email_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_send_log": {
+      "name": "email_send_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_email": {
+          "name": "to_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_name": {
+          "name": "to_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_send_log_user_created_at_idx": {
+          "name": "email_send_log_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_send_log_created_at_idx": {
+          "name": "email_send_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_send_log_status_next_retry_idx": {
+          "name": "email_send_log_status_next_retry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_send_log_user_id_users_id_fk": {
+          "name": "email_send_log_user_id_users_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_send_log_book_id_books_id_fk": {
+          "name": "email_send_log_book_id_books_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_send_log_book_file_id_book_files_id_fk": {
+          "name": "email_send_log_book_file_id_book_files_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_send_log_provider_id_email_providers_id_fk": {
+          "name": "email_send_log_provider_id_email_providers_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "email_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_send_log_template_id_email_templates_id_fk": {
+          "name": "email_send_log_template_id_email_templates_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "email_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_send_log_status_chk": {
+          "name": "email_send_log_status_chk",
+          "value": "\"email_send_log\".\"status\" in ('pending', 'sent', 'failed')"
+        },
+        "email_send_log_attempt_count_nonnegative_chk": {
+          "name": "email_send_log_attempt_count_nonnegative_chk",
+          "value": "\"email_send_log\".\"attempt_count\" >= 0"
+        },
+        "email_send_log_sent_after_created_chk": {
+          "name": "email_send_log_sent_after_created_chk",
+          "value": "\"email_send_log\".\"sent_at\" is null or \"email_send_log\".\"sent_at\" >= \"email_send_log\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dismissed_duplicate_pairs": {
+      "name": "dismissed_duplicate_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_a": {
+          "name": "entity_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_b": {
+          "name": "entity_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by": {
+          "name": "dismissed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dismissed_duplicate_pairs_entity_a_idx": {
+          "name": "dismissed_duplicate_pairs_entity_a_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dismissed_duplicate_pairs_entity_b_idx": {
+          "name": "dismissed_duplicate_pairs_entity_b_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dismissed_duplicate_pairs_dismissed_by_users_id_fk": {
+          "name": "dismissed_duplicate_pairs_dismissed_by_users_id_fk",
+          "tableFrom": "dismissed_duplicate_pairs",
+          "tableTo": "users",
+          "columnsFrom": ["dismissed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dismissed_duplicate_pairs_unique": {
+          "name": "dismissed_duplicate_pairs_unique",
+          "nullsNotDistinct": false,
+          "columns": ["entity_type", "entity_id_a", "entity_id_b"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dismissed_inline_duplicate_pairs": {
+      "name": "dismissed_inline_duplicate_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_a": {
+          "name": "value_a",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_b": {
+          "name": "value_b",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by": {
+          "name": "dismissed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dismissed_inline_pairs_entity_a_idx": {
+          "name": "dismissed_inline_pairs_entity_a_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dismissed_inline_pairs_entity_b_idx": {
+          "name": "dismissed_inline_pairs_entity_b_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dismissed_inline_duplicate_pairs_dismissed_by_users_id_fk": {
+          "name": "dismissed_inline_duplicate_pairs_dismissed_by_users_id_fk",
+          "tableFrom": "dismissed_inline_duplicate_pairs",
+          "tableTo": "users",
+          "columnsFrom": ["dismissed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dismissed_inline_duplicate_pairs_unique": {
+          "name": "dismissed_inline_duplicate_pairs_unique",
+          "nullsNotDistinct": false,
+          "columns": ["entity_type", "value_a", "value_b"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_duplicate_candidates": {
+      "name": "entity_duplicate_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_a": {
+          "name": "entity_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_b": {
+          "name": "entity_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sim_score": {
+          "name": "sim_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_dup_candidates_type_sim_idx": {
+          "name": "entity_dup_candidates_type_sim_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sim_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_dup_candidates_entity_a_idx": {
+          "name": "entity_dup_candidates_entity_a_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_dup_candidates_entity_b_idx": {
+          "name": "entity_dup_candidates_entity_b_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_duplicate_candidates_unique": {
+          "name": "entity_duplicate_candidates_unique",
+          "nullsNotDistinct": false,
+          "columns": ["entity_type", "entity_id_a", "entity_id_b"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_duplicate_scan_status": {
+      "name": "entity_duplicate_scan_status",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_computing": {
+          "name": "is_computing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pairs": {
+          "name": "total_pairs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_count": {
+          "name": "processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fonts": {
+      "name": "user_fonts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_name": {
+          "name": "stored_file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 400
+        },
+        "style": {
+          "name": "style",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uf_user_hash_uidx": {
+          "name": "uf_user_hash_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uf_user_family_weight_style_uidx": {
+          "name": "uf_user_family_weight_style_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "family_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "style",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fonts_user_id_users_id_fk": {
+          "name": "user_fonts_user_id_users_id_fk",
+          "tableFrom": "user_fonts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_fonts_format_chk": {
+          "name": "user_fonts_format_chk",
+          "value": "\"user_fonts\".\"format\" in ('ttf', 'otf', 'woff', 'woff2')"
+        },
+        "user_fonts_weight_chk": {
+          "name": "user_fonts_weight_chk",
+          "value": "\"user_fonts\".\"weight\" >= 100 and \"user_fonts\".\"weight\" <= 900 and \"user_fonts\".\"weight\" % 100 = 0"
+        },
+        "user_fonts_style_chk": {
+          "name": "user_fonts_style_chk",
+          "value": "\"user_fonts\".\"style\" in ('normal', 'italic')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_file_chapters": {
+      "name": "book_file_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_index": {
+          "name": "chapter_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spine_index": {
+          "name": "spine_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "book_file_chapters_book_file_id_chapter_index_uidx": {
+          "name": "book_file_chapters_book_file_id_chapter_index_uidx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_file_chapters_book_file_id_idx": {
+          "name": "book_file_chapters_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_file_chapters_book_file_id_book_files_id_fk": {
+          "name": "book_file_chapters_book_file_id_book_files_id_fk",
+          "tableFrom": "book_file_chapters",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_file_hash_history": {
+      "name": "book_file_hash_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_file_hash_history_book_file_id_file_hash_idx": {
+          "name": "book_file_hash_history_book_file_id_file_hash_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_file_hash_history_file_hash_idx": {
+          "name": "book_file_hash_history_file_hash_idx",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_file_hash_history_book_file_id_book_files_id_fk": {
+          "name": "book_file_hash_history_book_file_id_book_files_id_fk",
+          "tableFrom": "book_file_hash_history",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_file_hash_history_reason_chk": {
+          "name": "book_file_hash_history_reason_chk",
+          "value": "\"book_file_hash_history\".\"reason\" in ('file_write', 'external_change', 'rescan')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_book_hash_links": {
+      "name": "koreader_book_hash_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "koreader_title": {
+          "name": "koreader_title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koreader_authors": {
+          "name": "koreader_authors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koreader_last_open": {
+          "name": "koreader_last_open",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_book_hash_links_user_hash_uidx": {
+          "name": "koreader_book_hash_links_user_hash_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_book_hash_links_user_updated_idx": {
+          "name": "koreader_book_hash_links_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_book_hash_links_book_file_id_idx": {
+          "name": "koreader_book_hash_links_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_book_hash_links_user_id_users_id_fk": {
+          "name": "koreader_book_hash_links_user_id_users_id_fk",
+          "tableFrom": "koreader_book_hash_links",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "koreader_book_hash_links_book_file_id_book_files_id_fk": {
+          "name": "koreader_book_hash_links_book_file_id_book_files_id_fk",
+          "tableFrom": "koreader_book_hash_links",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_book_hash_links_hash_chk": {
+          "name": "koreader_book_hash_links_hash_chk",
+          "value": "\"koreader_book_hash_links\".\"hash\" ~ '^[0-9a-f]{32}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_device_progress": {
+      "name": "koreader_device_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'KOReader'"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_index": {
+          "name": "chapter_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_timestamp": {
+          "name": "sync_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned": {
+          "name": "orphaned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "orphaned_hash": {
+          "name": "orphaned_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_device_progress_book_user_device_uidx": {
+          "name": "koreader_device_progress_book_user_device_uidx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"koreader_device_progress\".\"orphaned\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_device_progress_orphaned_hash_idx": {
+          "name": "koreader_device_progress_orphaned_hash_idx",
+          "columns": [
+            {
+              "expression": "orphaned_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"koreader_device_progress\".\"orphaned\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_device_progress_user_updated_at_idx": {
+          "name": "koreader_device_progress_user_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_device_progress_book_file_id_idx": {
+          "name": "koreader_device_progress_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"koreader_device_progress\".\"book_file_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_device_progress_book_file_id_book_files_id_fk": {
+          "name": "koreader_device_progress_book_file_id_book_files_id_fk",
+          "tableFrom": "koreader_device_progress",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "koreader_device_progress_user_id_users_id_fk": {
+          "name": "koreader_device_progress_user_id_users_id_fk",
+          "tableFrom": "koreader_device_progress",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_device_progress_percentage_range_chk": {
+          "name": "koreader_device_progress_percentage_range_chk",
+          "value": "\"koreader_device_progress\".\"percentage\" is null or (\"koreader_device_progress\".\"percentage\" >= 0 and \"koreader_device_progress\".\"percentage\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_device_sweeps": {
+      "name": "koreader_device_sweeps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_model": {
+          "name": "device_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'KOReader'"
+        },
+        "plugin_version": {
+          "name": "plugin_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sweep_at": {
+          "name": "last_sweep_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sweep_books_matched": {
+          "name": "last_sweep_books_matched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sweep_page_stats": {
+          "name": "last_sweep_page_stats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sweep_annotations": {
+          "name": "last_sweep_annotations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kds_user_id_idx": {
+          "name": "kds_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_device_sweeps_user_id_users_id_fk": {
+          "name": "koreader_device_sweeps_user_id_users_id_fk",
+          "tableFrom": "koreader_device_sweeps",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "koreader_device_sweeps_user_id_device_id_pk": {
+          "name": "koreader_device_sweeps_user_id_device_id_pk",
+          "columns": ["user_id", "device_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.koreader_page_stats": {
+      "name": "koreader_page_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_pages": {
+          "name": "total_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kps_user_file_device_page_start_uidx": {
+          "name": "kps_user_file_device_page_start_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kps_user_file_device_start_idx": {
+          "name": "kps_user_file_device_start_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kps_user_id_idx": {
+          "name": "kps_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_page_stats_user_id_users_id_fk": {
+          "name": "koreader_page_stats_user_id_users_id_fk",
+          "tableFrom": "koreader_page_stats",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "koreader_page_stats_book_file_id_book_files_id_fk": {
+          "name": "koreader_page_stats_book_file_id_book_files_id_fk",
+          "tableFrom": "koreader_page_stats",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_page_stats_duration_nonnegative_chk": {
+          "name": "koreader_page_stats_duration_nonnegative_chk",
+          "value": "\"koreader_page_stats\".\"duration_seconds\" >= 0"
+        },
+        "koreader_page_stats_page_nonnegative_chk": {
+          "name": "koreader_page_stats_page_nonnegative_chk",
+          "value": "\"koreader_page_stats\".\"page\" >= 0"
+        },
+        "koreader_page_stats_total_pages_positive_chk": {
+          "name": "koreader_page_stats_total_pages_positive_chk",
+          "value": "\"koreader_page_stats\".\"total_pages\" > 0"
+        },
+        "koreader_page_stats_start_time_positive_chk": {
+          "name": "koreader_page_stats_start_time_positive_chk",
+          "value": "\"koreader_page_stats\".\"start_time\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_unmatched_book_devices": {
+      "name": "koreader_unmatched_book_devices",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_unmatched_book_devices_user_device_idx": {
+          "name": "koreader_unmatched_book_devices_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_unmatched_book_devices_user_id_users_id_fk": {
+          "name": "koreader_unmatched_book_devices_user_id_users_id_fk",
+          "tableFrom": "koreader_unmatched_book_devices",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "koreader_unmatched_book_devices_user_hash_fk": {
+          "name": "koreader_unmatched_book_devices_user_hash_fk",
+          "tableFrom": "koreader_unmatched_book_devices",
+          "tableTo": "koreader_unmatched_books",
+          "columnsFrom": ["user_id", "hash"],
+          "columnsTo": ["user_id", "hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "koreader_unmatched_book_devices_user_id_hash_device_id_pk": {
+          "name": "koreader_unmatched_book_devices_user_id_hash_device_id_pk",
+          "columns": ["user_id", "hash", "device_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_unmatched_book_devices_hash_chk": {
+          "name": "koreader_unmatched_book_devices_hash_chk",
+          "value": "\"koreader_unmatched_book_devices\".\"hash\" ~ '^[0-9a-f]{32}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_unmatched_books": {
+      "name": "koreader_unmatched_books",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_open": {
+          "name": "last_open",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'statistics'"
+        },
+        "metadata_ambiguous": {
+          "name": "metadata_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_unmatched_books_user_seen_idx": {
+          "name": "koreader_unmatched_books_user_seen_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"last_seen_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_unmatched_books_user_id_users_id_fk": {
+          "name": "koreader_unmatched_books_user_id_users_id_fk",
+          "tableFrom": "koreader_unmatched_books",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "koreader_unmatched_books_user_id_hash_pk": {
+          "name": "koreader_unmatched_books_user_id_hash_pk",
+          "columns": ["user_id", "hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_unmatched_books_hash_chk": {
+          "name": "koreader_unmatched_books_hash_chk",
+          "value": "\"koreader_unmatched_books\".\"hash\" ~ '^[0-9a-f]{32}$'"
+        },
+        "koreader_unmatched_books_source_chk": {
+          "name": "koreader_unmatched_books_source_chk",
+          "value": "\"koreader_unmatched_books\".\"source\" in ('current_file', 'file', 'statistics')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_users": {
+      "name": "koreader_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_md5": {
+          "name": "password_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_enabled": {
+          "name": "sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_users_user_id_uidx": {
+          "name": "koreader_users_user_id_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_users_username_uidx": {
+          "name": "koreader_users_username_uidx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_users_user_id_users_id_fk": {
+          "name": "koreader_users_user_id_users_id_fk",
+          "tableFrom": "koreader_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "achievements_category_sort_idx": {
+          "name": "achievements_category_sort_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "achievements_group_key_idx": {
+          "name": "achievements_group_key_idx",
+          "columns": [
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "achievements_category_chk": {
+          "name": "achievements_category_chk",
+          "value": "\"achievements\".\"category\" in ('reading', 'library', 'exploration', 'dedication', 'devices')"
+        },
+        "achievements_rarity_chk": {
+          "name": "achievements_rarity_chk",
+          "value": "\"achievements\".\"rarity\" in ('common', 'rare', 'epic', 'legendary')"
+        },
+        "achievements_tier_chk": {
+          "name": "achievements_tier_chk",
+          "value": "\"achievements\".\"tier\" is null or (\"achievements\".\"tier\" >= 1 and \"achievements\".\"tier\" <= 4)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_key": {
+          "name": "achievement_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "context_json": {
+          "name": "context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_achievements_user_key_uidx": {
+          "name": "user_achievements_user_key_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "achievement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_user_id_idx": {
+          "name": "user_achievements_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_user_awarded_at_idx": {
+          "name": "user_achievements_user_awarded_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "awarded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_key_achievements_key_fk": {
+          "name": "user_achievements_achievement_key_achievements_key_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": ["achievement_key"],
+          "columnsTo": ["key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hardcover_book_state": {
+      "name": "hardcover_book_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hardcover_book_id": {
+          "name": "hardcover_book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_edition_id": {
+          "name": "hardcover_edition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_user_book_id": {
+          "name": "hardcover_user_book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_read_id": {
+          "name": "hardcover_read_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_error": {
+          "name": "match_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_status": {
+          "name": "last_synced_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_progress": {
+          "name": "last_synced_progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_rating": {
+          "name": "last_synced_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_started_at": {
+          "name": "last_synced_started_at",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_finished_at": {
+          "name": "last_synced_finished_at",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_override": {
+          "name": "sync_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_excluded": {
+          "name": "sync_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hardcover_book_state_user_id_users_id_fk": {
+          "name": "hardcover_book_state_user_id_users_id_fk",
+          "tableFrom": "hardcover_book_state",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hardcover_book_state_book_id_books_id_fk": {
+          "name": "hardcover_book_state_book_id_books_id_fk",
+          "tableFrom": "hardcover_book_state",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hardcover_book_state_user_book_uidx": {
+          "name": "hardcover_book_state_user_book_uidx",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hardcover_user_settings": {
+      "name": "hardcover_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_sync_mode": {
+          "name": "book_sync_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_eligible'"
+        },
+        "auto_sync_on_status_change": {
+          "name": "auto_sync_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_sync_on_progress_update": {
+          "name": "auto_sync_on_progress_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_sync_on_rating_change": {
+          "name": "auto_sync_on_rating_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_setting_id": {
+          "name": "privacy_setting_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hardcover_user_settings_user_id_users_id_fk": {
+          "name": "hardcover_user_settings_user_id_users_id_fk",
+          "tableFrom": "hardcover_user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hardcover_user_settings_user_id_unique": {
+          "name": "hardcover_user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "up_user_category_idx": {
+          "name": "up_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.content_filter_type": {
+      "name": "content_filter_type",
+      "schema": "public",
+      "values": ["include", "exclude"]
+    },
+    "public.library_access_level": {
+      "name": "library_access_level",
+      "schema": "public",
+      "values": ["viewer", "editor", "owner"]
+    },
+    "public.user_avatar_source": {
+      "name": "user_avatar_source",
+      "schema": "public",
+      "values": ["none", "external", "uploaded"]
+    },
+    "public.opds_sort_order": {
+      "name": "opds_sort_order",
+      "schema": "public",
+      "values": ["recent", "title_asc", "title_desc", "author_asc", "author_desc", "series_asc", "series_desc"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1783034396046,
       "tag": "0036_kobo-sync-history",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1783318242860,
+      "tag": "0037_opds-pse-page-count",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema/books.ts
+++ b/server/src/db/schema/books.ts
@@ -67,6 +67,7 @@ export const bookFiles = pgTable(
     role: varchar('role', { length: 20 }).notNull().default('content'),
     sortOrder: integer('sort_order'),
     durationSeconds: integer('duration_seconds'),
+    pageCount: integer('page_count'),
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true })
       .defaultNow()
@@ -90,6 +91,7 @@ export const bookFiles = pgTable(
     check('book_files_role_chk', sql`${t.role} in ('content', 'cover', 'metadata', 'supplement')`),
     check('book_files_size_bytes_nonnegative_chk', sql`${t.sizeBytes} is null or ${t.sizeBytes} >= 0`),
     check('book_files_duration_seconds_nonnegative_chk', sql`${t.durationSeconds} is null or ${t.durationSeconds} >= 0`),
+    check('book_files_page_count_nonnegative_chk', sql`${t.pageCount} is null or ${t.pageCount} >= 0`),
   ],
 );
 

--- a/server/src/modules/architecture/architecture-boundaries.test.ts
+++ b/server/src/modules/architecture/architecture-boundaries.test.ts
@@ -65,6 +65,7 @@ describe('Architecture boundaries', () => {
       'src/modules/metadata-preferences/provider-config.service.ts',
       'src/modules/migration/planner/matching.service.ts',
       'src/modules/opds/opds-book.service.ts',
+      'src/modules/opds/opds-page-count.service.ts',
       'src/modules/opds/opds-user.service.ts',
       'src/modules/scanner/file-watcher.service.ts',
       'src/modules/seed/cleanup.service.ts',

--- a/server/src/modules/opds/__tests__/opds-auth.guard.test.ts
+++ b/server/src/modules/opds/__tests__/opds-auth.guard.test.ts
@@ -142,6 +142,15 @@ describe('OpdsAuthGuard', () => {
     expect((request.opdsUser as OpdsRequestUser).userId).toBe(1);
   });
 
+  it('accepts token auth on the PSE image streaming route', async () => {
+    const guard = makeGuard();
+    const token = createCoverToken(1, TEST_SECRET);
+    const { context, request } = mockContext(undefined, token, '/api/v1/opds/42/image');
+    const result = await guard.canActivate(context);
+    expect(result).toBe(true);
+    expect((request.opdsUser as OpdsRequestUser).userId).toBe(1);
+  });
+
   it('rejects a same-length tampered cover token', async () => {
     const guard = makeGuard();
     const token = createCoverToken(1, TEST_SECRET);

--- a/server/src/modules/opds/__tests__/opds-book.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds-book.service.test.ts
@@ -147,19 +147,6 @@ describe('OpdsBookService', () => {
     expect(values).toContain('%100\\%\\_\\\\%');
   });
 
-  it('handles getRecentBooksPage empty-access and delegated paths', async () => {
-    const { service } = makeService();
-    const accessSpy = vi.spyOn(service, 'getAccessibleLibraryIds');
-    const paginatedSpy = vi.spyOn(testable(service), 'paginatedBookQuery');
-
-    accessSpy.mockResolvedValueOnce([]);
-    await expect(service.getRecentBooksPage(5, 1, 30)).resolves.toEqual({ entries: [], total: 0 });
-
-    accessSpy.mockResolvedValueOnce([2, 3]);
-    paginatedSpy.mockResolvedValueOnce({ entries: [{ id: 1 }], total: 1 });
-    await expect(service.getRecentBooksPage(5, 2, 15)).resolves.toEqual({ entries: [{ id: 1 }], total: 1 });
-  });
-
   it('handles getRandomBooks guard branches and randomized id selection', async () => {
     const { service, db } = makeService([[], [{ id: 11 }, { id: 10 }]]);
     const accessSpy = vi.spyOn(service, 'getAccessibleLibraryIds');
@@ -182,6 +169,48 @@ describe('OpdsBookService', () => {
     const orderBy = chains.at(-1)!['orderBy'] as ReturnType<typeof vi.fn>;
     const values = orderBy.mock.calls.flat().flatMap((arg: unknown) => collectValues(arg));
     expect(values).toContain('random()');
+  });
+
+  it('getRecentGroupedPage returns empty without touching the DB when the user has no accessible libraries', async () => {
+    const { service, db } = makeService();
+    vi.spyOn(service, 'getAccessibleLibraryIds').mockResolvedValueOnce([]);
+
+    await expect(service.getRecentGroupedPage(7, 1, 20)).resolves.toEqual({ items: [], total: 0 });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('getRecentGroupedPage folds series-owned books into one grouped entry and leaves standalone books as book entries', async () => {
+    const lastAddedAt = new Date('2026-01-03T00:00:00.000Z');
+    const { service } = makeService([
+      [{ total: 2 }],
+      [
+        { seriesId: 42, seriesName: 'Dune', bookCount: 3, lastAddedAt, latestBookId: 9 },
+        { seriesId: null, seriesName: null, bookCount: 1, lastAddedAt: new Date('2026-01-02'), latestBookId: 5 },
+      ],
+    ]);
+    vi.spyOn(service, 'getAccessibleLibraryIds').mockResolvedValueOnce([1]);
+    const fetchSpy = vi.spyOn(testable(service), 'fetchBookEntries').mockResolvedValue([{ id: 5, title: 'Standalone' }]);
+
+    await expect(service.getRecentGroupedPage(7, 1, 20)).resolves.toEqual({
+      total: 2,
+      items: [
+        { kind: 'series', seriesId: 42, seriesName: 'Dune', bookCount: 3, lastAddedAt },
+        { kind: 'book', book: { id: 5, title: 'Standalone' } },
+      ],
+    });
+    expect(fetchSpy).toHaveBeenCalledWith([5]);
+  });
+
+  it('getRecentGroupedPage falls back to "Untitled Series" when a series-owned group has no series name', async () => {
+    const lastAddedAt = new Date('2026-01-03T00:00:00.000Z');
+    const { service } = makeService([[{ total: 1 }], [{ seriesId: 42, seriesName: null, bookCount: 2, lastAddedAt, latestBookId: 9 }]]);
+    vi.spyOn(service, 'getAccessibleLibraryIds').mockResolvedValueOnce([1]);
+    vi.spyOn(testable(service), 'fetchBookEntries').mockResolvedValue([]);
+
+    await expect(service.getRecentGroupedPage(7, 1, 20)).resolves.toEqual({
+      total: 1,
+      items: [{ kind: 'series', seriesId: 42, seriesName: 'Untitled Series', bookCount: 2, lastAddedAt }],
+    });
   });
 
   it('returns distinct authors and membership-backed series with and without access', async () => {

--- a/server/src/modules/opds/__tests__/opds-book.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds-book.service.test.ts
@@ -1,6 +1,6 @@
 import { ForbiddenException } from '@nestjs/common';
 
-import { bookSeries, bookSeriesMemberships } from '../../../db/schema';
+import { bookMetadata, bookSeries, bookSeriesMemberships } from '../../../db/schema';
 import { OpdsBookService } from '../opds-book.service';
 
 type BookPageResult = { entries: unknown[]; total: number };
@@ -185,7 +185,7 @@ describe('OpdsBookService', () => {
   });
 
   it('returns distinct authors and membership-backed series with and without access', async () => {
-    const { service, db } = makeService([[{ name: 'Frank Herbert', bookCount: 2 }], [{ id: 42, name: 'Dune', bookCount: 2 }]]);
+    const { service, db } = makeService([[{ name: 'Frank Herbert', bookCount: 2 }], [{ id: 42, name: 'Dune', bookCount: 2, coverBookId: 7 }]]);
     const accessSpy = vi.spyOn(service, 'getAccessibleLibraryIds');
 
     accessSpy.mockResolvedValueOnce([]);
@@ -195,12 +195,13 @@ describe('OpdsBookService', () => {
     await expect(service.getDistinctAuthors(1)).resolves.toEqual([{ name: 'Frank Herbert', bookCount: 2 }]);
 
     accessSpy.mockResolvedValueOnce([1]);
-    await expect(service.getDistinctSeries(1)).resolves.toEqual([{ id: 42, name: 'Dune', bookCount: 2 }]);
+    await expect(service.getDistinctSeries(1)).resolves.toEqual([{ id: 42, name: 'Dune', bookCount: 2, coverBookId: 7 }]);
 
     const chains = (db.select as ReturnType<typeof vi.fn>).mock.results.map((r) => r.value as Record<string, unknown>);
     const seriesChain = chains.at(-1)!;
     expect(seriesChain.from).toHaveBeenCalledWith(bookSeries);
     expect(seriesChain.innerJoin).toHaveBeenCalledWith(bookSeriesMemberships, expect.anything());
+    expect(seriesChain.leftJoin).toHaveBeenCalledWith(bookMetadata, expect.anything());
   });
 
   it('returns user collections and smartScopes', async () => {

--- a/server/src/modules/opds/__tests__/opds-book.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds-book.service.test.ts
@@ -1,6 +1,6 @@
 import { ForbiddenException } from '@nestjs/common';
 
-import { bookSeries, bookSeriesMemberships } from '../../../db/schema';
+import { books, bookSeries, bookSeriesMemberships } from '../../../db/schema';
 import { OpdsBookService } from '../opds-book.service';
 
 type BookPageResult = { entries: unknown[]; total: number };
@@ -199,6 +199,22 @@ describe('OpdsBookService', () => {
       ],
     });
     expect(fetchSpy).toHaveBeenCalledWith([5]);
+  });
+
+  it("getRecentGroupedPage decodes the lastAddedAt aggregate through books.addedAt's own driver-value decoder", async () => {
+    // A raw sql`` fragment (needed here for max()) is opaque to Drizzle: unlike a plain
+    // column select, it never gets timestamptz->Date conversion on its own (see
+    // drizzle-orm/node-postgres/session.cjs, which disables pg's built-in parser for
+    // that OID so columns can decode it themselves). .mapWith(books.addedAt) reuses that
+    // column's decoder instead of hand-rolling `new Date(...)`, which could subtly
+    // diverge from Drizzle's own timezone handling.
+    const { service, db } = makeService([[{ total: 0 }], []]);
+    vi.spyOn(service, 'getAccessibleLibraryIds').mockResolvedValueOnce([1]);
+
+    await service.getRecentGroupedPage(7, 1, 20);
+
+    const rowsCall = (db.select as ReturnType<typeof vi.fn>).mock.calls[1] as [{ lastAddedAt: { decoder: unknown } }];
+    expect(rowsCall[0].lastAddedAt.decoder).toBe(books.addedAt);
   });
 
   it('getRecentGroupedPage falls back to "Untitled Series" when a series-owned group has no series name', async () => {

--- a/server/src/modules/opds/__tests__/opds-book.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds-book.service.test.ts
@@ -8,7 +8,7 @@ type BookPageResult = { entries: unknown[]; total: number };
 type TestableOpdsBookService = {
   buildCatalogSearchClause(q: string): unknown;
   buildReadStatusClause(userId: number, status: 'unread' | 'reading' | 'finished'): unknown;
-  fetchBookEntries(bookIds: number[], options?: unknown): Promise<unknown[]>;
+  fetchBookEntries(bookIds: number[], userId?: number, options?: unknown): Promise<unknown[]>;
   getBooksBySmartScope(
     userId: number,
     smartScopeId: number,
@@ -57,8 +57,9 @@ function makeService(selectQueue: unknown[] = [], queryBuilderOverrides: Record<
     buildWhere: vi.fn().mockReturnValue(undefined),
     ...queryBuilderOverrides,
   };
-  const service = new OpdsBookService(db as never, queryBuilder as never);
-  return { service, db, queryBuilder };
+  const pageCountService = { ensure: vi.fn().mockResolvedValue(null) };
+  const service = new OpdsBookService(db as never, queryBuilder as never, pageCountService as never);
+  return { service, db, queryBuilder, pageCountService };
 }
 
 function collectValues(value: unknown, seen = new WeakSet<object>()): unknown[] {
@@ -176,7 +177,7 @@ describe('OpdsBookService', () => {
     accessSpy.mockResolvedValueOnce([1]);
     fetchSpy.mockResolvedValueOnce([{ id: 11 }, { id: 10 }]);
     await expect(service.getRandomBooks(7, 2)).resolves.toEqual([{ id: 11 }, { id: 10 }]);
-    expect(fetchSpy).toHaveBeenCalledWith([11, 10]);
+    expect(fetchSpy).toHaveBeenCalledWith([11, 10], 7);
 
     const chains = (db.select as ReturnType<typeof vi.fn>).mock.results.map((r) => r.value as Record<string, unknown>);
     const orderBy = chains.at(-1)!['orderBy'] as ReturnType<typeof vi.fn>;
@@ -222,13 +223,15 @@ describe('OpdsBookService', () => {
   });
 
   it('resolves getBookFiles with fallback formatting and title values', async () => {
-    const { service } = makeService([[], [{ absolutePath: '/books/a.epub', format: null, title: null }], []]);
+    const { service } = makeService([[], [{ id: 55, absolutePath: '/books/a.epub', format: null, pageCount: null, title: null }], []]);
 
     await expect(service.getBookFiles(7, 42)).resolves.toBeNull();
 
     await expect(service.getBookFiles(7)).resolves.toEqual({
+      id: 55,
       absolutePath: '/books/a.epub',
       format: 'unknown',
+      pageCount: null,
       title: 'book-7',
       authorName: '',
     });
@@ -292,7 +295,7 @@ describe('OpdsBookService', () => {
       entries: [{ id: 3 }, { id: 1 }],
       total: 2,
     });
-    expect(fetchSpy).toHaveBeenCalledWith([3, 1], {});
+    expect(fetchSpy).toHaveBeenCalledWith([3, 1], undefined, {});
   });
 
   it('builds read-status, format, and id filters and forwards the user id to pagination', async () => {
@@ -482,8 +485,8 @@ describe('OpdsBookService', () => {
         hasCover: true,
         authors: ['Author One'],
         files: [
-          { id: 10, format: 'epub' },
-          { id: 11, format: 'mobi' },
+          { id: 10, format: 'epub', pageCount: undefined, lastReadPage: null, lastReadDate: null },
+          { id: 11, format: 'mobi', pageCount: undefined, lastReadPage: null, lastReadDate: null },
         ],
       }),
       expect.objectContaining({
@@ -491,7 +494,7 @@ describe('OpdsBookService', () => {
         title: 'second',
         hasCover: false,
         authors: ['Author Two'],
-        files: [{ id: 20, format: 'unknown' }],
+        files: [{ id: 20, format: 'unknown', pageCount: undefined, lastReadPage: null, lastReadDate: null }],
       }),
     ]);
 
@@ -523,7 +526,7 @@ describe('OpdsBookService', () => {
       [{ bookId: 1, seriesId: 42, seriesName: 'Secondary Arc', seriesIndex: 3 }],
     ]);
 
-    await expect(testable(service).fetchBookEntries([1], { contextSeries: { seriesId: 42 } })).resolves.toEqual([
+    await expect(testable(service).fetchBookEntries([1], undefined, { contextSeries: { seriesId: 42 } })).resolves.toEqual([
       expect.objectContaining({
         id: 1,
         seriesId: 42,

--- a/server/src/modules/opds/__tests__/opds-page-count.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds-page-count.service.test.ts
@@ -1,0 +1,61 @@
+vi.mock('../../../common/comic-page-counter', () => ({ countComicPages: vi.fn() }));
+vi.mock('../../../common/pdf-page-count', () => ({ getPdfPageCount: vi.fn() }));
+
+import { countComicPages } from '../../../common/comic-page-counter';
+import { getPdfPageCount } from '../../../common/pdf-page-count';
+import { OpdsPageCountService } from '../opds-page-count.service';
+
+const mockCountComicPages = countComicPages as MockedFunction<typeof countComicPages>;
+const mockGetPdfPageCount = getPdfPageCount as MockedFunction<typeof getPdfPageCount>;
+
+function makeService() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where });
+  const update = vi.fn().mockReturnValue({ set });
+  const db = { update };
+  const service = new OpdsPageCountService(db as never);
+  return { service, db, update, set, where };
+}
+
+describe('OpdsPageCountService', () => {
+  it('returns the cached page count without recomputing', async () => {
+    const { service, update } = makeService();
+    await expect(service.ensure({ id: 1, format: 'cbz', absolutePath: '/a.cbz', pageCount: 24 })).resolves.toBe(24);
+    expect(mockCountComicPages).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('returns null for non-streamable formats (epub) without touching the DB', async () => {
+    const { service, update } = makeService();
+    await expect(service.ensure({ id: 1, format: 'epub', absolutePath: '/a.epub', pageCount: null })).resolves.toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('computes and persists a comic page count on first access', async () => {
+    mockCountComicPages.mockResolvedValue(18);
+    const { service, update, set, where } = makeService();
+
+    await expect(service.ensure({ id: 5, format: 'cbz', absolutePath: '/a.cbz', pageCount: null })).resolves.toBe(18);
+    expect(mockCountComicPages).toHaveBeenCalledWith(5, '/a.cbz', 'cbz');
+    expect(update).toHaveBeenCalled();
+    expect(set).toHaveBeenCalledWith({ pageCount: 18 });
+    expect(where).toHaveBeenCalled();
+  });
+
+  it('computes and persists a pdf page count on first access', async () => {
+    mockGetPdfPageCount.mockResolvedValue(200);
+    const { service, set } = makeService();
+
+    await expect(service.ensure({ id: 6, format: 'pdf', absolutePath: '/a.pdf', pageCount: null })).resolves.toBe(200);
+    expect(mockGetPdfPageCount).toHaveBeenCalledWith('/a.pdf');
+    expect(set).toHaveBeenCalledWith({ pageCount: 200 });
+  });
+
+  it('returns null and does not persist when counting throws (corrupt archive)', async () => {
+    mockCountComicPages.mockRejectedValue(new Error('bad archive'));
+    const { service, update } = makeService();
+
+    await expect(service.ensure({ id: 7, format: 'cbr', absolutePath: '/a.cbr', pageCount: null })).resolves.toBeNull();
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/opds/__tests__/opds-page-stream.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds-page-stream.service.test.ts
@@ -1,0 +1,69 @@
+vi.mock('fs', () => ({ createReadStream: vi.fn() }));
+
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { createReadStream } from 'fs';
+
+import { OpdsPageStreamService } from '../opds-page-stream.service';
+
+const mockCreateReadStream = createReadStream as MockedFunction<typeof createReadStream>;
+
+function makeService(pageCount: number | null) {
+  const cbzService = { streamPage: vi.fn() };
+  const pdfPageService = { ensurePage: vi.fn(), invalidate: vi.fn() };
+  const pageCountService = { ensure: vi.fn().mockResolvedValue(pageCount) };
+  const service = new OpdsPageStreamService(cbzService as never, pdfPageService as never, pageCountService as never);
+  return { service, cbzService, pdfPageService, pageCountService };
+}
+
+const user = { id: 1 } as never;
+
+describe('OpdsPageStreamService', () => {
+  it('rejects negative page numbers before touching the page count', async () => {
+    const { service, pageCountService } = makeService(10);
+    await expect(service.streamPage({ id: 1, format: 'cbz', absolutePath: '/a.cbz', pageCount: 10 }, -1, user)).rejects.toThrow(BadRequestException);
+    expect(pageCountService.ensure).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundException when the page count cannot be determined', async () => {
+    const { service } = makeService(null);
+    await expect(service.streamPage({ id: 1, format: 'cbz', absolutePath: '/a.cbz', pageCount: null }, 0, user)).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects an out-of-range page number', async () => {
+    const { service } = makeService(5);
+    await expect(service.streamPage({ id: 1, format: 'cbz', absolutePath: '/a.cbz', pageCount: null }, 5, user)).rejects.toThrow(BadRequestException);
+  });
+
+  it('streams a comic page via CbzService', async () => {
+    const { service, cbzService } = makeService(5);
+    cbzService.streamPage.mockResolvedValue({ stream: 'cbz-stream', mimeType: 'image/jpeg' });
+
+    await expect(service.streamPage({ id: 1, format: 'cbz', absolutePath: '/a.cbz', pageCount: null }, 2, user)).resolves.toEqual({
+      stream: 'cbz-stream',
+      mimeType: 'image/jpeg',
+      totalPages: 5,
+    });
+    expect(cbzService.streamPage).toHaveBeenCalledWith(1, 2, user);
+  });
+
+  it('streams a rasterized pdf page from the on-disk cache', async () => {
+    const { service, pdfPageService } = makeService(100);
+    pdfPageService.ensurePage.mockResolvedValue('/cache/1/2.jpg');
+    mockCreateReadStream.mockReturnValue('pdf-stream' as never);
+
+    const result = await service.streamPage({ id: 1, format: 'pdf', absolutePath: '/a.pdf', pageCount: null }, 2, user);
+    expect(pdfPageService.ensurePage).toHaveBeenCalledWith(1, '/a.pdf', 2);
+    expect(mockCreateReadStream).toHaveBeenCalledWith('/cache/1/2.jpg');
+    expect(result).toEqual({ stream: 'pdf-stream', mimeType: 'image/jpeg', totalPages: 100 });
+  });
+
+  it('invalidateCache only clears the pdf page cache (CbzService self-heals via its in-memory maps)', async () => {
+    const { service, pdfPageService } = makeService(10);
+    await service.invalidateCache({ id: 4, format: 'pdf', absolutePath: '/a.pdf', pageCount: 10 });
+    expect(pdfPageService.invalidate).toHaveBeenCalledWith(4);
+
+    pdfPageService.invalidate.mockClear();
+    await service.invalidateCache({ id: 4, format: 'cbz', absolutePath: '/a.cbz', pageCount: 10 });
+    expect(pdfPageService.invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/opds/__tests__/opds-pdf-page.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds-pdf-page.service.test.ts
@@ -1,0 +1,57 @@
+vi.mock('child_process', () => ({ execFile: vi.fn() }));
+vi.mock('fs/promises', () => ({ mkdir: vi.fn(), rm: vi.fn(), stat: vi.fn() }));
+
+import { execFile } from 'child_process';
+import { mkdir, rm, stat } from 'fs/promises';
+
+import { OpdsPdfPageService } from '../opds-pdf-page.service';
+
+const mockExecFile = execFile as unknown as MockedFunction<(...args: unknown[]) => void>;
+const mockMkdir = mkdir as MockedFunction<typeof mkdir>;
+const mockRm = rm as MockedFunction<typeof rm>;
+const mockStat = stat as MockedFunction<typeof stat>;
+
+function makeService() {
+  const config = { get: vi.fn().mockReturnValue('/data') };
+  return new OpdsPdfPageService(config as never);
+}
+
+beforeEach(() => {
+  mockExecFile.mockImplementation((...args: unknown[]) => {
+    const cb = args[args.length - 1] as (err: unknown, out: { stdout: string; stderr: string }) => void;
+    cb(null, { stdout: '', stderr: '' });
+  });
+});
+
+describe('OpdsPdfPageService', () => {
+  it('returns the cached page path without invoking pdftoppm when it already exists', async () => {
+    mockStat.mockResolvedValue({} as never);
+    const service = makeService();
+
+    const path = await service.ensurePage(1, '/books/a.pdf', 3);
+    expect(path).toBe('/data/pse-cache/1/3.jpg');
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('renders the page via pdftoppm (1-based page number) when not cached', async () => {
+    mockStat.mockRejectedValue(new Error('ENOENT'));
+    const service = makeService();
+
+    const path = await service.ensurePage(1, '/books/a.pdf', 0);
+    expect(path).toBe('/data/pse-cache/1/0.jpg');
+    expect(mockMkdir).toHaveBeenCalledWith('/data/pse-cache/1', { recursive: true });
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'pdftoppm',
+      ['-jpeg', '-singlefile', '-r', '150', '-f', '1', '-l', '1', '/books/a.pdf', '/data/pse-cache/1/0'],
+      expect.any(Function),
+    );
+  });
+
+  it('invalidate removes the file cache directory for the file', async () => {
+    mockRm.mockResolvedValue(undefined);
+    const service = makeService();
+
+    await service.invalidate(9);
+    expect(mockRm).toHaveBeenCalledWith('/data/pse-cache/9', { recursive: true, force: true });
+  });
+});

--- a/server/src/modules/opds/__tests__/opds-xml.helpers.test.ts
+++ b/server/src/modules/opds/__tests__/opds-xml.helpers.test.ts
@@ -1,4 +1,4 @@
-import { esc, xmlEl, xmlLink, fileMimeType } from '../opds-xml.helpers';
+import { esc, xmlEl, xmlLink, fileMimeType, isPseStreamableFormat, xmlPseStreamLink, OPDS_PSE_STREAM_REL } from '../opds-xml.helpers';
 
 describe('esc', () => {
   it('escapes all five XML special characters', () => {
@@ -81,6 +81,56 @@ describe('xmlLink', () => {
   it('escapes href', () => {
     const result = xmlLink('self', '/feed?a=1&b=2', 'text/xml');
     expect(result).toContain('href="/feed?a=1&amp;b=2"');
+  });
+});
+
+describe('isPseStreamableFormat', () => {
+  it.each(['cbz', 'cbr', 'cb7', 'pdf', 'CBZ'])('accepts %s', (format) => {
+    expect(isPseStreamableFormat(format)).toBe(true);
+  });
+
+  it('rejects epub (HTML/CSS, not paginated images)', () => {
+    expect(isPseStreamableFormat('epub')).toBe(false);
+  });
+
+  it.each(['mobi', 'azw3', 'fb2', 'unknown'])('rejects %s', (format) => {
+    expect(isPseStreamableFormat(format)).toBe(false);
+  });
+});
+
+describe('xmlPseStreamLink', () => {
+  it('uses the exact OPDS-PSE stream rel', () => {
+    const result = xmlPseStreamLink('/opds/1/image?fileId=2&pageNumber={pageNumber}', 'image/jpeg', 24);
+    expect(result).toContain(`rel="${OPDS_PSE_STREAM_REL}"`);
+    expect(OPDS_PSE_STREAM_REL).toBe('http://vaemendis.net/opds-pse/stream');
+  });
+
+  it('leaves the {pageNumber} template token unencoded', () => {
+    const result = xmlPseStreamLink('/opds/1/image?fileId=2&pageNumber={pageNumber}', 'image/jpeg', 24);
+    expect(result).toContain('pageNumber={pageNumber}');
+    expect(result).not.toContain('%7BpageNumber%7D');
+  });
+
+  it('includes pse:count', () => {
+    const result = xmlPseStreamLink('/href', 'image/jpeg', 42);
+    expect(result).toContain('pse:count="42"');
+  });
+
+  it('omits pse:lastRead/pse:lastReadDate when no progress exists', () => {
+    const result = xmlPseStreamLink('/href', 'image/jpeg', 42);
+    expect(result).not.toContain('pse:lastRead');
+  });
+
+  it('includes pse:lastRead and pse:lastReadDate (ISO 8601) when progress exists', () => {
+    const date = new Date('2026-01-15T10:30:00.000Z');
+    const result = xmlPseStreamLink('/href', 'image/jpeg', 42, { page: 7, date });
+    expect(result).toContain('pse:lastRead="7"');
+    expect(result).toContain('pse:lastReadDate="2026-01-15T10:30:00.000Z"');
+  });
+
+  it('escapes the href', () => {
+    const result = xmlPseStreamLink('/href?a=1&b=2', 'image/jpeg', 1);
+    expect(result).toContain('href="/href?a=1&amp;b=2"');
   });
 });
 

--- a/server/src/modules/opds/__tests__/opds.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds.service.test.ts
@@ -1,13 +1,17 @@
 import { XMLParser } from 'fast-xml-parser';
 
 import { OpdsService } from '../opds.service';
-import type { OpdsBookEntry } from '../opds-book.service';
+import type { OpdsBookEntry, OpdsBookFileEntry } from '../opds-book.service';
 
 function makeService() {
   return new OpdsService();
 }
 
 const BASE = '/api/v1/opds';
+
+function pseFile(overrides: Partial<OpdsBookFileEntry> & Pick<OpdsBookFileEntry, 'id' | 'format'>): OpdsBookFileEntry {
+  return { pageCount: null, lastReadPage: null, lastReadDate: null, ...overrides };
+}
 
 function sampleBook(overrides?: Partial<OpdsBookEntry>): OpdsBookEntry {
   return {
@@ -25,7 +29,7 @@ function sampleBook(overrides?: Partial<OpdsBookEntry>): OpdsBookEntry {
     isbn13: '9780765311788',
     hasCover: true,
     authors: ['Brandon Sanderson'],
-    files: [{ id: 10, format: 'epub' }],
+    files: [pseFile({ id: 10, format: 'epub' })],
     ...overrides,
   };
 }
@@ -311,10 +315,7 @@ describe('OpdsService', () => {
     it('handles multiple file formats per book', () => {
       const service = makeService();
       const book = sampleBook({
-        files: [
-          { id: 10, format: 'epub' },
-          { id: 11, format: 'pdf' },
-        ],
+        files: [pseFile({ id: 10, format: 'epub' }), pseFile({ id: 11, format: 'pdf', pageCount: 24 })],
       });
       const xml = service.generateAcquisitionFeed(
         'Catalog',
@@ -331,6 +332,67 @@ describe('OpdsService', () => {
       expect(xml).toContain('application/pdf');
       expect(xml).toContain('fileId=10');
       expect(xml).toContain('fileId=11');
+    });
+  });
+
+  describe('OPDS-PSE', () => {
+    it('declares the pse namespace on every feed', () => {
+      const service = makeService();
+      const xml = service.generateAcquisitionFeed('Catalog', 'urn:bookorbit:catalog', [], 0, 1, 50, `${BASE}/catalog`, 'test-token');
+      expect(xml).toContain('xmlns:pse="http://vaemendis.net/opds-pse/ns"');
+    });
+
+    it('emits a pse:stream link for a streamable format with a known page count', () => {
+      const service = makeService();
+      const book = sampleBook({ files: [pseFile({ id: 10, format: 'cbz', pageCount: 24 })] });
+      const xml = service.generateAcquisitionFeed('Catalog', 'urn:bookorbit:catalog', [book], 1, 1, 50, `${BASE}/catalog`, 'test-token');
+
+      expect(xml).toContain('rel="http://vaemendis.net/opds-pse/stream"');
+      expect(xml).toContain('pse:count="24"');
+      expect(xml).toContain(`href="${BASE}/1/image?fileId=10&amp;pageNumber={pageNumber}&amp;t=test-token"`);
+    });
+
+    it('omits the pse:stream link for epub (not paginated images)', () => {
+      const service = makeService();
+      const book = sampleBook({ files: [pseFile({ id: 10, format: 'epub', pageCount: 300 })] });
+      const xml = service.generateAcquisitionFeed('Catalog', 'urn:bookorbit:catalog', [book], 1, 1, 50, `${BASE}/catalog`, 'test-token');
+
+      expect(xml).not.toContain('opds-pse/stream');
+    });
+
+    it('omits the pse:stream link when the page count is not yet known', () => {
+      const service = makeService();
+      const book = sampleBook({ files: [pseFile({ id: 10, format: 'cbz', pageCount: null })] });
+      const xml = service.generateAcquisitionFeed('Catalog', 'urn:bookorbit:catalog', [book], 1, 1, 50, `${BASE}/catalog`, 'test-token');
+
+      expect(xml).not.toContain('opds-pse/stream');
+    });
+
+    it('includes pse:lastRead/pse:lastReadDate only when progress exists', () => {
+      const service = makeService();
+      const date = new Date('2026-02-01T00:00:00.000Z');
+      const withProgress = sampleBook({
+        id: 1,
+        files: [pseFile({ id: 10, format: 'pdf', pageCount: 100, lastReadPage: 12, lastReadDate: date })],
+      });
+      const withoutProgress = sampleBook({ id: 2, files: [pseFile({ id: 11, format: 'pdf', pageCount: 100 })] });
+
+      const xml = service.generateAcquisitionFeed(
+        'Catalog',
+        'urn:bookorbit:catalog',
+        [withProgress, withoutProgress],
+        2,
+        1,
+        50,
+        `${BASE}/catalog`,
+        'test-token',
+      );
+
+      expect(xml).toContain('pse:lastRead="12"');
+      expect(xml).toContain('pse:lastReadDate="2026-02-01T00:00:00.000Z"');
+
+      const secondLinkIndex = xml.indexOf('fileId=11');
+      expect(xml.slice(secondLinkIndex, secondLinkIndex + 80)).not.toContain('pse:lastRead');
     });
   });
 
@@ -377,7 +439,7 @@ describe('OpdsService', () => {
         description: 'How AI was built',
         seriesName: null,
         seriesIndex: null,
-        files: [{ id: 9001, format: 'epub' }],
+        files: [pseFile({ id: 9001, format: 'epub' })],
       });
       const children = sampleBook({
         id: 500,
@@ -385,7 +447,7 @@ describe('OpdsService', () => {
         description: 'Book three of the Dune\u0000 Chronicles',
         seriesName: null,
         seriesIndex: null,
-        files: [{ id: 9000, format: 'epub' }],
+        files: [pseFile({ id: 9000, format: 'epub' })],
       });
 
       const xml = service.generateAcquisitionFeed(

--- a/server/src/modules/opds/__tests__/opds.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds.service.test.ts
@@ -334,6 +334,87 @@ describe('OpdsService', () => {
     });
   });
 
+  describe('generateRecentGroupedFeed', () => {
+    it('renders a series-grouped item as a subsection folder titled "Name (count)"', () => {
+      const service = makeService();
+      const xml = service.generateRecentGroupedFeed(
+        'Recent Books',
+        'urn:bookorbit:recent',
+        [{ kind: 'series', seriesId: 42, seriesName: 'Dune', bookCount: 3, lastAddedAt: new Date('2026-01-03T00:00:00.000Z') }],
+        1,
+        1,
+        50,
+        `${BASE}/recent?page=1&size=50`,
+        'test-token',
+      );
+
+      expect(xml).toContain('<title>Dune (3)</title>');
+      expect(xml).toContain(`href="${BASE}/catalog?seriesId=42"`);
+      expect(xml).toContain('rel="subsection"');
+      expect(xml).not.toContain('http://opds-spec.org/acquisition');
+    });
+
+    it('renders a standalone book item exactly like a normal acquisition entry', () => {
+      const service = makeService();
+      const book = sampleBook();
+      const xml = service.generateRecentGroupedFeed(
+        'Recent Books',
+        'urn:bookorbit:recent',
+        [{ kind: 'book', book }],
+        1,
+        1,
+        50,
+        `${BASE}/recent?page=1&size=50`,
+        'test-token',
+      );
+
+      expect(xml).toContain('<title>Mistborn: The Final Empire</title>');
+      expect(xml).toContain('http://opds-spec.org/acquisition');
+    });
+
+    it('mixes series and standalone-book entries in the given order', () => {
+      const service = makeService();
+      const book = sampleBook({ id: 99, title: 'Standalone Novel' });
+      const xml = service.generateRecentGroupedFeed(
+        'Recent Books',
+        'urn:bookorbit:recent',
+        [
+          { kind: 'series', seriesId: 1, seriesName: 'Dune', bookCount: 2, lastAddedAt: new Date('2026-01-03') },
+          { kind: 'book', book },
+        ],
+        2,
+        1,
+        50,
+        `${BASE}/recent?page=1&size=50`,
+        'test-token',
+      );
+
+      const duneIndex = xml.indexOf('Dune (2)');
+      const standaloneIndex = xml.indexOf('Standalone Novel');
+      expect(duneIndex).toBeGreaterThanOrEqual(0);
+      expect(standaloneIndex).toBeGreaterThan(duneIndex);
+    });
+
+    it('includes pagination links the same way generateAcquisitionFeed does', () => {
+      const service = makeService();
+      const xml = service.generateRecentGroupedFeed(
+        'Recent Books',
+        'urn:bookorbit:recent',
+        [],
+        100,
+        2,
+        10,
+        `${BASE}/recent?page=2&size=10`,
+        'test-token',
+      );
+
+      expect(xml).toContain('rel="previous"');
+      expect(xml).toContain('rel="next"');
+      expect(xml).toContain('rel="first"');
+      expect(xml).toContain('rel="last"');
+    });
+  });
+
   describe('generateOpenSearchDescription', () => {
     it('produces valid OpenSearch XML with search template', () => {
       const service = makeService();

--- a/server/src/modules/opds/__tests__/opds.service.test.ts
+++ b/server/src/modules/opds/__tests__/opds.service.test.ts
@@ -116,18 +116,50 @@ describe('OpdsService', () => {
   describe('generateSeriesNavigation', () => {
     it('URL-encodes series names', () => {
       const service = makeService();
-      const xml = service.generateSeriesNavigation([{ name: 'The Lord of the Rings', bookCount: 3 }]);
+      const xml = service.generateSeriesNavigation([{ name: 'The Lord of the Rings', bookCount: 3 }], 'test-token');
 
       expect(xml).toContain(encodeURIComponent('The Lord of the Rings'));
     });
 
     it('uses stable series ids when available', () => {
       const service = makeService();
-      const xml = service.generateSeriesNavigation([{ id: 42, name: 'The Lord of the Rings', bookCount: 3 }]);
+      const xml = service.generateSeriesNavigation([{ id: 42, name: 'The Lord of the Rings', bookCount: 3 }], 'test-token');
 
       expect(xml).toContain('urn:bookorbit:series:42');
       expect(xml).toContain(`${BASE}/catalog?seriesId=42`);
       expect(xml).not.toContain('catalog?series=The%20Lord%20of%20the%20Rings');
+    });
+
+    it('emits a cover and thumbnail link borrowed from the series cover book when known', () => {
+      const service = makeService();
+      const xml = service.generateSeriesNavigation([{ id: 42, name: 'Dragon Ball Super', bookCount: 24, coverBookId: 204 }], 'tok');
+
+      expect(xml).toContain(`${BASE}/204/cover?t=tok`);
+      expect(xml).toContain(`${BASE}/204/thumbnail?t=tok`);
+      expect(xml).toContain('rel="http://opds-spec.org/image"');
+      expect(xml).toContain('rel="http://opds-spec.org/image/thumbnail"');
+    });
+
+    it('omits the cover/thumbnail links when no book in the series has a cover', () => {
+      const service = makeService();
+      const xml = service.generateSeriesNavigation([{ id: 42, name: 'Dune', bookCount: 3, coverBookId: null }], 'tok');
+
+      expect(xml).not.toContain('http://opds-spec.org/image');
+    });
+
+    it('still emits the bare subsection entry when coverBookId is not provided at all', () => {
+      const service = makeService();
+      const xml = service.generateSeriesNavigation([{ id: 42, name: 'Dune', bookCount: 3 }], 'tok');
+
+      expect(xml).not.toContain('http://opds-spec.org/image');
+      expect(xml).toContain('rel="subsection"');
+    });
+
+    it('URL-encodes the cover token', () => {
+      const service = makeService();
+      const xml = service.generateSeriesNavigation([{ id: 1, name: 'Dune', bookCount: 1, coverBookId: 9 }], 'a b&c');
+
+      expect(xml).toContain(`t=${encodeURIComponent('a b&c')}`);
     });
   });
 

--- a/server/src/modules/opds/opds-auth.guard.ts
+++ b/server/src/modules/opds/opds-auth.guard.ts
@@ -32,7 +32,7 @@ function stripQuery(url: string): string {
 }
 
 function isTokenImagePath(requestPath: string): boolean {
-  return /(?:^|\/)(?:api\/v1\/)?opds\/\d+\/(cover|thumbnail)$/.test(requestPath.replace(/^\//, ''));
+  return /(?:^|\/)(?:api\/v1\/)?opds\/\d+\/(cover|thumbnail|image)$/.test(requestPath.replace(/^\//, ''));
 }
 
 function parseCoverToken(token: string, secret: string): number | null {

--- a/server/src/modules/opds/opds-book.service.ts
+++ b/server/src/modules/opds/opds-book.service.ts
@@ -329,7 +329,7 @@ export class OpdsBookService {
     userId: number,
     isSuperuser = false,
     contentFilters?: ContentFilterRules,
-  ): Promise<{ id: number; name: string; bookCount: number }[]> {
+  ): Promise<{ id: number; name: string; bookCount: number; coverBookId: number | null }[]> {
     const accessibleIds = await this.getAccessibleLibraryIds(userId, isSuperuser);
     if (accessibleIds.length === 0) return [];
 
@@ -340,10 +340,18 @@ export class OpdsBookService {
         id: bookSeries.id,
         name: bookSeries.name,
         bookCount: sql<number>`count(DISTINCT ${books.id})::int`,
+        // Earliest-in-series book that actually has a cover, mirroring the "series cover"
+        // candidate the web UI already picks (see BookRepository's series_first_volume CTE).
+        // Null when no book in the series has a cover.
+        coverBookId: sql<number | null>`
+          (array_agg(${books.id} ORDER BY ${bookSeriesMemberships.seriesIndex} ASC NULLS LAST, ${books.addedAt} ASC, ${books.id} ASC)
+            FILTER (WHERE ${bookMetadata.coverSource} IS NOT NULL))[1]
+        `,
       })
       .from(bookSeries)
       .innerJoin(bookSeriesMemberships, eq(bookSeriesMemberships.seriesId, bookSeries.id))
       .innerJoin(books, and(eq(books.id, bookSeriesMemberships.bookId), eq(books.status, 'present'), ...filterClauses))
+      .leftJoin(bookMetadata, eq(bookMetadata.bookId, books.id))
       .where(inArray(books.libraryId, accessibleIds))
       .groupBy(bookSeries.id, bookSeries.name)
       .orderBy(sql`${bookSeries.name} ASC`);

--- a/server/src/modules/opds/opds-book.service.ts
+++ b/server/src/modules/opds/opds-book.service.ts
@@ -14,6 +14,7 @@ import {
   books,
   collections,
   collectionBooks,
+  readingProgress,
   smartScopes,
   libraries,
   userBookStatus,
@@ -22,6 +23,8 @@ import {
 import { BookQueryBuilder } from '../book/book-query-builder.service';
 import type { ContentFilterRules, GroupRule } from '@bookorbit/types';
 import { buildContentFilterClauses } from '../../common/utils/content-filter-sql.utils';
+import { OpdsPageCountService } from './opds-page-count.service';
+import { isPseStreamableFormat } from './opds-xml.helpers';
 
 type Db = NodePgDatabase<typeof schema>;
 
@@ -104,7 +107,15 @@ export interface OpdsBookEntry {
   isbn13: string | null;
   hasCover: boolean;
   authors: string[];
-  files: { id: number; format: string }[];
+  files: OpdsBookFileEntry[];
+}
+
+export interface OpdsBookFileEntry {
+  id: number;
+  format: string;
+  pageCount: number | null;
+  lastReadPage: number | null;
+  lastReadDate: Date | null;
 }
 
 @Injectable()
@@ -112,6 +123,7 @@ export class OpdsBookService {
   constructor(
     @Inject(DB) private readonly db: Db,
     private readonly queryBuilder: BookQueryBuilder,
+    private readonly pageCountService: OpdsPageCountService,
   ) {}
 
   async getAccessibleLibraryIds(userId: number, isSuperuser = false): Promise<number[]> {
@@ -281,7 +293,7 @@ export class OpdsBookService {
       clauses.push(...buildContentFilterClauses(contentFilters, this.db));
     }
     const where = and(...clauses);
-    return this.paginatedBookQuery(where!, 'recent', page, size);
+    return this.paginatedBookQuery(where!, 'recent', page, size, userId);
   }
 
   async getRandomBooks(userId: number, count: number, isSuperuser = false, contentFilters?: ContentFilterRules): Promise<OpdsBookEntry[]> {
@@ -303,7 +315,7 @@ export class OpdsBookService {
 
     const ids = idRows.map((row) => row.id);
     if (ids.length === 0) return [];
-    return this.fetchBookEntries(ids);
+    return this.fetchBookEntries(ids, userId);
   }
 
   async getDistinctAuthors(userId: number, isSuperuser = false, contentFilters?: ContentFilterRules): Promise<{ name: string; bookCount: number }[]> {
@@ -463,11 +475,16 @@ export class OpdsBookService {
     }
   }
 
-  async getBookFiles(bookId: number, fileId?: number): Promise<{ absolutePath: string; format: string; title: string; authorName: string } | null> {
+  async getBookFiles(
+    bookId: number,
+    fileId?: number,
+  ): Promise<{ id: number; absolutePath: string; format: string; pageCount: number | null; title: string; authorName: string } | null> {
     const fileQuery = this.db
       .select({
+        id: bookFiles.id,
         absolutePath: bookFiles.absolutePath,
         format: bookFiles.format,
+        pageCount: bookFiles.pageCount,
         title: bookMetadata.title,
       })
       .from(bookFiles)
@@ -488,8 +505,10 @@ export class OpdsBookService {
       .limit(1);
 
     return {
+      id: file.id,
       absolutePath: file.absolutePath,
       format: file.format ?? 'unknown',
+      pageCount: file.pageCount,
       title: file.title ?? `book-${bookId}`,
       authorName: authorRow?.name ?? '',
     };
@@ -603,15 +622,16 @@ export class OpdsBookService {
 
     const entries = await this.fetchBookEntries(
       idRows.map((r) => r.id),
+      userId,
       options,
     );
     return { entries, total: Number(total) };
   }
 
-  private async fetchBookEntries(bookIds: number[], options: FetchBookEntriesOptions = {}): Promise<OpdsBookEntry[]> {
+  private async fetchBookEntries(bookIds: number[], userId?: number, options: FetchBookEntriesOptions = {}): Promise<OpdsBookEntry[]> {
     if (bookIds.length === 0) return [];
 
-    const [metaRows, authorRows, fileRows, contextSeriesRows] = await Promise.all([
+    const [metaRows, authorRows, fileRows, contextSeriesRows, progressRows] = await Promise.all([
       this.db
         .select({
           id: books.id,
@@ -638,12 +658,26 @@ export class OpdsBookService {
         .where(inArray(bookAuthors.bookId, bookIds))
         .orderBy(bookAuthors.displayOrder),
       this.db
-        .select({ bookId: books.id, id: bookFiles.id, format: bookFiles.format, role: bookFiles.role })
+        .select({
+          bookId: books.id,
+          id: bookFiles.id,
+          format: bookFiles.format,
+          role: bookFiles.role,
+          absolutePath: bookFiles.absolutePath,
+          pageCount: bookFiles.pageCount,
+        })
         .from(bookFiles)
         .innerJoin(books, eq(books.id, bookFiles.bookId))
         .where(and(inArray(bookFiles.bookId, bookIds), eq(bookFiles.role, 'content')))
         .orderBy(sql`case when ${bookFiles.id} = ${books.primaryFileId} then 0 else 1 end`, bookFiles.sortOrder, bookFiles.id),
       options.contextSeries ? this.fetchContextSeriesRows(bookIds, options.contextSeries) : Promise.resolve<ContextSeriesRow[]>([]),
+      userId !== undefined
+        ? this.db
+            .select({ bookFileId: readingProgress.bookFileId, pageNumber: readingProgress.pageNumber, updatedAt: readingProgress.updatedAt })
+            .from(readingProgress)
+            .innerJoin(bookFiles, eq(bookFiles.id, readingProgress.bookFileId))
+            .where(and(inArray(bookFiles.bookId, bookIds), eq(readingProgress.userId, userId)))
+        : Promise.resolve<{ bookFileId: number; pageNumber: number | null; updatedAt: Date }[]>([]),
     ]);
 
     const authorsByBook = new Map<number, string[]>();
@@ -653,13 +687,24 @@ export class OpdsBookService {
       authorsByBook.set(row.bookId, list);
     }
 
-    const filesByBook = new Map<number, { id: number; format: string }[]>();
+    const progressByFile = new Map(progressRows.filter((row) => row.pageNumber != null).map((row) => [row.bookFileId, row]));
+
+    const filesByBook = new Map<number, OpdsBookFileEntry[]>();
     for (const row of fileRows) {
       if (row.role !== 'content') continue;
+      const progress = progressByFile.get(row.id);
       const list = filesByBook.get(row.bookId) ?? [];
-      list.push({ id: row.id, format: row.format ?? 'unknown' });
+      list.push({
+        id: row.id,
+        format: row.format ?? 'unknown',
+        pageCount: row.pageCount,
+        lastReadPage: progress?.pageNumber ?? null,
+        lastReadDate: progress?.updatedAt ?? null,
+      });
       filesByBook.set(row.bookId, list);
     }
+
+    await this.fillMissingPageCounts(fileRows, filesByBook);
 
     const idOrder = new Map(bookIds.map((id, i) => [id, i]));
     const contextSeriesByBook = new Map(contextSeriesRows.map((row) => [row.bookId, row]));
@@ -686,6 +731,32 @@ export class OpdsBookService {
         };
       })
       .sort((a, b) => (idOrder.get(a.id) ?? 0) - (idOrder.get(b.id) ?? 0));
+  }
+
+  /**
+   * PSE requires `pse:count` on every stream link. For files never rendered
+   * in a feed before, compute it now (once) and cache it on `bookFiles.pageCount`.
+   */
+  private async fillMissingPageCounts(
+    fileRows: { id: number; format: string | null; absolutePath: string; pageCount: number | null }[],
+    filesByBook: Map<number, OpdsBookFileEntry[]>,
+  ): Promise<void> {
+    const entriesById = new Map<number, OpdsBookFileEntry>();
+    for (const entries of filesByBook.values()) {
+      for (const entry of entries) entriesById.set(entry.id, entry);
+    }
+
+    const pending = fileRows.filter((row) => row.pageCount == null && row.format && isPseStreamableFormat(row.format));
+    if (pending.length === 0) return;
+
+    await Promise.all(
+      pending.map(async (row) => {
+        const count = await this.pageCountService.ensure({ id: row.id, format: row.format!, absolutePath: row.absolutePath, pageCount: null });
+        if (count == null) return;
+        const entry = entriesById.get(row.id);
+        if (entry) entry.pageCount = count;
+      }),
+    );
   }
 
   private resolveSeriesFilter(filters?: OpdsBookFilters): SeriesFilter | undefined {

--- a/server/src/modules/opds/opds-book.service.ts
+++ b/server/src/modules/opds/opds-book.service.ts
@@ -307,7 +307,12 @@ export class OpdsBookService {
           seriesId: bookMetadata.seriesId,
           seriesName: bookMetadata.seriesName,
           bookCount: sql<number>`count(*)::int`,
-          lastAddedAt: sql<Date>`max(${books.addedAt})`,
+          // .mapWith(books.addedAt) reuses the column's own driver-value decoder: a raw
+          // sql`` fragment is opaque to Drizzle (drizzle-orm/node-postgres disables pg's
+          // built-in timestamptz→Date parsing so columns can decode it themselves — see
+          // node-postgres/session.cjs), so without this the aggregate comes back as a
+          // string despite the `sql<Date>` type annotation lying about it at compile time.
+          lastAddedAt: sql`max(${books.addedAt})`.mapWith(books.addedAt),
           latestBookId: sql<number>`(array_agg(${books.id} ORDER BY ${books.addedAt} DESC))[1]`,
         })
         .from(books)

--- a/server/src/modules/opds/opds-book.service.ts
+++ b/server/src/modules/opds/opds-book.service.ts
@@ -107,6 +107,10 @@ export interface OpdsBookEntry {
   files: { id: number; format: string }[];
 }
 
+export type OpdsRecentGroupItem =
+  | { kind: 'series'; seriesId: number; seriesName: string; bookCount: number; lastAddedAt: Date }
+  | { kind: 'book'; book: OpdsBookEntry };
+
 @Injectable()
 export class OpdsBookService {
   constructor(
@@ -267,21 +271,70 @@ export class OpdsBookService {
     return or(...clauses)!;
   }
 
-  async getRecentBooksPage(
+  /**
+   * "Recent" grouped by series, mirroring Kavita's recently-updated feed: a book
+   * belonging to a series is folded into a single "Series Name (N)" entry alongside
+   * its series-mates, while a standalone book (no series) stays its own entry.
+   *
+   * Grouping key is `COALESCE(seriesId, 'book_' || bookId)` — the same idiom
+   * BookRepository already uses for the "collapse by series" book listing — so a
+   * NULL seriesId never accidentally merges unrelated standalone books into one
+   * bucket (SQL GROUP BY treats all NULLs as equal, which COALESCE avoids here by
+   * giving every standalone book its own unique group key).
+   */
+  async getRecentGroupedPage(
     userId: number,
     page: number,
     size: number,
     isSuperuser = false,
     contentFilters?: ContentFilterRules,
-  ): Promise<{ entries: OpdsBookEntry[]; total: number }> {
+  ): Promise<{ items: OpdsRecentGroupItem[]; total: number }> {
     const accessibleIds = await this.getAccessibleLibraryIds(userId, isSuperuser);
-    if (accessibleIds.length === 0) return { entries: [], total: 0 };
-    const clauses: SQL[] = [inArray(books.libraryId, accessibleIds), eq(books.status, 'present')];
-    if (!isSuperuser && contentFilters) {
-      clauses.push(...buildContentFilterClauses(contentFilters, this.db));
-    }
-    const where = and(...clauses);
-    return this.paginatedBookQuery(where!, 'recent', page, size);
+    if (accessibleIds.length === 0) return { items: [], total: 0 };
+
+    const filterClauses = !isSuperuser && contentFilters ? buildContentFilterClauses(contentFilters, this.db) : [];
+    const where = and(inArray(books.libraryId, accessibleIds), eq(books.status, 'present'), ...filterClauses)!;
+    const groupKey = sql`COALESCE(${bookMetadata.seriesId}::text, 'book_' || ${books.id}::text)`;
+
+    const [[{ total }], rows] = await Promise.all([
+      this.db
+        .select({ total: sql<number>`count(DISTINCT ${groupKey})::int` })
+        .from(books)
+        .leftJoin(bookMetadata, eq(bookMetadata.bookId, books.id))
+        .where(where),
+      this.db
+        .select({
+          seriesId: bookMetadata.seriesId,
+          seriesName: bookMetadata.seriesName,
+          bookCount: sql<number>`count(*)::int`,
+          lastAddedAt: sql<Date>`max(${books.addedAt})`,
+          latestBookId: sql<number>`(array_agg(${books.id} ORDER BY ${books.addedAt} DESC))[1]`,
+        })
+        .from(books)
+        .leftJoin(bookMetadata, eq(bookMetadata.bookId, books.id))
+        .where(where)
+        .groupBy(groupKey, bookMetadata.seriesId, bookMetadata.seriesName)
+        .orderBy(sql`max(${books.addedAt}) DESC`)
+        .limit(size)
+        .offset((page - 1) * size),
+    ]);
+
+    const standaloneIds = rows.filter((r) => r.seriesId == null).map((r) => r.latestBookId);
+    const standaloneEntries = new Map((await this.fetchBookEntries(standaloneIds)).map((entry) => [entry.id, entry]));
+
+    const items: OpdsRecentGroupItem[] = rows.map((r) =>
+      r.seriesId != null
+        ? {
+            kind: 'series' as const,
+            seriesId: r.seriesId,
+            seriesName: r.seriesName ?? 'Untitled Series',
+            bookCount: r.bookCount,
+            lastAddedAt: r.lastAddedAt,
+          }
+        : { kind: 'book' as const, book: standaloneEntries.get(r.latestBookId)! },
+    );
+
+    return { items, total: Number(total) };
   }
 
   async getRandomBooks(userId: number, count: number, isSuperuser = false, contentFilters?: ContentFilterRules): Promise<OpdsBookEntry[]> {

--- a/server/src/modules/opds/opds-page-count.service.ts
+++ b/server/src/modules/opds/opds-page-count.service.ts
@@ -1,0 +1,57 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { DB } from '../../db';
+import * as schema from '../../db/schema';
+import { bookFiles } from '../../db/schema';
+import { countComicPages } from '../../common/comic-page-counter';
+import { getPdfPageCount } from '../../common/pdf-page-count';
+import { isPseStreamableFormat } from './opds-xml.helpers';
+
+type Db = NodePgDatabase<typeof schema>;
+
+export interface PseFile {
+  id: number;
+  format: string;
+  absolutePath: string;
+  pageCount: number | null;
+}
+
+/**
+ * Lazily computes and caches the streamable page count for OPDS-PSE.
+ *
+ * Page count is computed once per file (on first feed render or stream
+ * request that needs it) and persisted to `book_files.page_count`, rather
+ * than being threaded through the scan/ingestion pipeline: the count is
+ * immutable once a file lands on disk, so "compute once, reuse forever" is
+ * correct and keeps this feature scoped to the OPDS module.
+ */
+@Injectable()
+export class OpdsPageCountService {
+  private readonly logger = new Logger(OpdsPageCountService.name);
+
+  constructor(@Inject(DB) private readonly db: Db) {}
+
+  async ensure(file: PseFile): Promise<number | null> {
+    if (file.pageCount != null) return file.pageCount;
+    if (!isPseStreamableFormat(file.format)) return null;
+
+    let count: number;
+    try {
+      count =
+        file.format === 'pdf'
+          ? await getPdfPageCount(file.absolutePath)
+          : await countComicPages(file.id, file.absolutePath, file.format as 'cbz' | 'cbr' | 'cb7');
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.logger.warn(
+        `[opds.pse_page_count] [fail] fileId=${file.id} format=${file.format} error="${err.message}" - page count unavailable, PSE link omitted`,
+      );
+      return null;
+    }
+
+    await this.db.update(bookFiles).set({ pageCount: count }).where(eq(bookFiles.id, file.id));
+    return count;
+  }
+}

--- a/server/src/modules/opds/opds-page-stream.service.ts
+++ b/server/src/modules/opds/opds-page-stream.service.ts
@@ -1,0 +1,43 @@
+import { createReadStream } from 'fs';
+
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+
+import type { RequestUser } from '../../common/types/request-user';
+import { CbzService } from '../reader/cbz/cbz.service';
+import { OpdsPageCountService, type PseFile } from './opds-page-count.service';
+import { OpdsPdfPageService } from './opds-pdf-page.service';
+
+export interface StreamedPage {
+  stream: NodeJS.ReadableStream;
+  mimeType: string;
+  totalPages: number;
+}
+
+@Injectable()
+export class OpdsPageStreamService {
+  constructor(
+    private readonly cbzService: CbzService,
+    private readonly pdfPageService: OpdsPdfPageService,
+    private readonly pageCountService: OpdsPageCountService,
+  ) {}
+
+  async streamPage(file: PseFile, pageNumber: number, user: RequestUser): Promise<StreamedPage> {
+    if (pageNumber < 0) throw new BadRequestException('pageNumber must be >= 0');
+
+    const totalPages = await this.pageCountService.ensure(file);
+    if (totalPages == null) throw new NotFoundException(`Unable to determine page count for file ${file.id}`);
+    if (pageNumber >= totalPages) throw new BadRequestException(`pageNumber ${pageNumber} is out of range (0-${totalPages - 1})`);
+
+    if (file.format === 'pdf') {
+      const path = await this.pdfPageService.ensurePage(file.id, file.absolutePath, pageNumber);
+      return { stream: createReadStream(path), mimeType: 'image/jpeg', totalPages };
+    }
+
+    const { stream, mimeType } = await this.cbzService.streamPage(file.id, pageNumber, user);
+    return { stream, mimeType, totalPages };
+  }
+
+  async invalidateCache(file: PseFile): Promise<void> {
+    if (file.format === 'pdf') await this.pdfPageService.invalidate(file.id);
+  }
+}

--- a/server/src/modules/opds/opds-pdf-page.service.ts
+++ b/server/src/modules/opds/opds-pdf-page.service.ts
@@ -1,0 +1,66 @@
+import { execFile } from 'child_process';
+import { mkdir, rm, stat } from 'fs/promises';
+import { join } from 'path';
+import { promisify } from 'util';
+
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Rasterizes a single PDF page to JPEG via `pdftoppm` (poppler-utils, already
+ * a runtime dependency — see `metadata/lib/pdf-cover.ts`), cached to disk per
+ * page. Presence is checked per-page-file rather than per-directory: a cache
+ * dir that exists but is missing a given page (e.g. an interrupted previous
+ * run) is repaired by re-rendering just that page, instead of silently
+ * serving nothing (see Kavita#3477 for the bug this avoids).
+ */
+@Injectable()
+export class OpdsPdfPageService {
+  private readonly cacheRoot: string;
+
+  constructor(config: ConfigService) {
+    this.cacheRoot = join(config.get<string>('storage.appDataPath')!, 'pse-cache');
+  }
+
+  private cacheDir(fileId: number): string {
+    return join(this.cacheRoot, String(fileId));
+  }
+
+  async ensurePage(fileId: number, absolutePath: string, pageNumber: number): Promise<string> {
+    const dir = this.cacheDir(fileId);
+    const pagePath = join(dir, `${pageNumber}.jpg`);
+    if (await this.exists(pagePath)) return pagePath;
+
+    await mkdir(dir, { recursive: true });
+    const pdfPageNumber = pageNumber + 1; // pdftoppm pages are 1-based; PSE pageNumber is 0-based
+    const outPrefix = join(dir, String(pageNumber));
+    await execFileAsync('pdftoppm', [
+      '-jpeg',
+      '-singlefile',
+      '-r',
+      '150',
+      '-f',
+      String(pdfPageNumber),
+      '-l',
+      String(pdfPageNumber),
+      absolutePath,
+      outPrefix,
+    ]);
+    return pagePath;
+  }
+
+  async invalidate(fileId: number): Promise<void> {
+    await rm(this.cacheDir(fileId), { recursive: true, force: true });
+  }
+
+  private async exists(path: string): Promise<boolean> {
+    try {
+      await stat(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/server/src/modules/opds/opds-xml.helpers.ts
+++ b/server/src/modules/opds/opds-xml.helpers.ts
@@ -31,6 +31,34 @@ export function xmlLink(rel: string, href: string, type: string, title?: string)
   return `<link rel="${esc(rel)}" href="${esc(href)}" type="${esc(type)}"${t}/>`;
 }
 
+export const OPDS_PSE_NS = 'http://vaemendis.net/opds-pse/ns';
+export const OPDS_PSE_STREAM_REL = 'http://vaemendis.net/opds-pse/stream';
+
+const PSE_STREAMABLE_FORMATS = new Set(['cbz', 'cbr', 'cb7', 'pdf']);
+
+/** EPUB is HTML/CSS, not page images — PSE only applies to paginated-image content. */
+export function isPseStreamableFormat(format: string): boolean {
+  return PSE_STREAMABLE_FORMATS.has(format.toLowerCase());
+}
+
+export interface PseLastRead {
+  page: number;
+  date: Date;
+}
+
+/**
+ * `href` must already contain the literal `{pageNumber}` client-substitution
+ * token. `esc()` only XML-escapes `&`/`<`/`>`/`"`/`'`, so the token passes
+ * through unencoded, per the OPDS-PSE spec.
+ */
+export function xmlPseStreamLink(href: string, type: string, count: number, lastRead?: PseLastRead): string {
+  const attrs = [`rel="${esc(OPDS_PSE_STREAM_REL)}"`, `href="${esc(href)}"`, `type="${esc(type)}"`, `pse:count="${count}"`];
+  if (lastRead) {
+    attrs.push(`pse:lastRead="${lastRead.page}"`, `pse:lastReadDate="${esc(lastRead.date.toISOString())}"`);
+  }
+  return `<link ${attrs.join(' ')}/>`;
+}
+
 export function fileMimeType(format: string): string {
   switch (format.toLowerCase()) {
     case 'epub':

--- a/server/src/modules/opds/opds.controller.test.ts
+++ b/server/src/modules/opds/opds.controller.test.ts
@@ -43,20 +43,35 @@ function makeController() {
     getRandomBooks: vi.fn().mockResolvedValue([{ id: 3 }]),
     validateBookAccess: vi.fn().mockResolvedValue(undefined),
     getBookFiles: vi.fn().mockResolvedValue({
+      id: 99,
       absolutePath: '/books/library/book.epub',
       format: 'epub',
+      pageCount: null,
       title: 'Book Title',
       authorName: 'Author Name',
     }),
+  } as never;
+  const opdsPageStreamService = {
+    streamPage: vi.fn(),
+    invalidateCache: vi.fn(),
+  } as never;
+  const userService = {
+    findByIdWithPermissions: vi.fn(),
+  } as never;
+  const bookService = {
+    saveProgress: vi.fn(),
   } as never;
   const config = {
     get: vi.fn().mockReturnValue('/books'),
   } as never;
 
   return {
-    controller: new OpdsController(opdsService, opdsBookService, config),
+    controller: new OpdsController(opdsService, opdsBookService, opdsPageStreamService, userService, bookService, config),
     opdsService,
     opdsBookService,
+    opdsPageStreamService,
+    userService,
+    bookService,
   };
 }
 
@@ -349,5 +364,64 @@ describe('OpdsController', () => {
     opdsBookService.getBookFiles.mockResolvedValue(null);
 
     await expect(controller.download(88, 77, { userId: 2, isSuperuser: false } as never, makeReply())).rejects.toThrow(NotFoundException);
+  });
+
+  describe('image (OPDS-PSE streaming)', () => {
+    const opdsUser = { userId: 2, isSuperuser: false, contentFilters: undefined } as never;
+    const fullUser = { id: 2, username: 'reader' };
+
+    it('rejects negative page numbers before any lookup', async () => {
+      const { controller, opdsBookService } = makeController();
+      await expect(controller.image(1, 10, -1, true, opdsUser, makeReply())).rejects.toThrow(BadRequestException);
+      expect(opdsBookService.validateBookAccess).not.toHaveBeenCalled();
+    });
+
+    it('streams the page, saves progress, and sets long-lived cache headers', async () => {
+      const { controller, opdsBookService, opdsPageStreamService, userService, bookService } = makeController();
+      const stream = { kind: 'page-stream' };
+      opdsBookService.getBookFiles.mockResolvedValue({ id: 10, absolutePath: '/a.cbz', format: 'cbz', pageCount: 20, title: 't', authorName: 'a' });
+      userService.findByIdWithPermissions.mockResolvedValue(fullUser);
+      opdsPageStreamService.streamPage.mockResolvedValue({ stream, mimeType: 'image/jpeg', totalPages: 20 });
+      const reply = makeReply();
+
+      await controller.image(1, 10, 4, true, opdsUser, reply);
+
+      expect(opdsBookService.validateBookAccess).toHaveBeenCalledWith(1, 2, false, undefined);
+      expect(opdsPageStreamService.streamPage).toHaveBeenCalledWith(expect.objectContaining({ id: 10, format: 'cbz' }), 4, fullUser);
+      expect(bookService.saveProgress).toHaveBeenCalledWith(2, 10, { pageNumber: 4, percentage: 25 }, fullUser);
+      expect(reply.header).toHaveBeenCalledWith('Cache-Control', 'private, max-age=31536000, immutable');
+      expect(reply.type).toHaveBeenCalledWith('image/jpeg');
+      expect(reply.send).toHaveBeenCalledWith(stream);
+    });
+
+    it('does not save progress when saveProgress=false', async () => {
+      const { controller, opdsBookService, opdsPageStreamService, userService, bookService } = makeController();
+      opdsBookService.getBookFiles.mockResolvedValue({ id: 10, absolutePath: '/a.cbz', format: 'cbz', pageCount: 20, title: 't', authorName: 'a' });
+      userService.findByIdWithPermissions.mockResolvedValue(fullUser);
+      opdsPageStreamService.streamPage.mockResolvedValue({ stream: {}, mimeType: 'image/jpeg', totalPages: 20 });
+
+      await controller.image(1, 10, 0, false, opdsUser, makeReply());
+
+      expect(bookService.saveProgress).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when the file does not exist', async () => {
+      const { controller, opdsBookService } = makeController();
+      opdsBookService.getBookFiles.mockResolvedValue(null);
+
+      await expect(controller.image(1, 10, 0, true, opdsUser, makeReply())).rejects.toThrow(NotFoundException);
+    });
+
+    it('invalidates the page cache and rethrows when streaming fails', async () => {
+      const { controller, opdsBookService, opdsPageStreamService, userService } = makeController();
+      const file = { id: 10, absolutePath: '/a.cbz', format: 'cbz', pageCount: 20, title: 't', authorName: 'a' };
+      opdsBookService.getBookFiles.mockResolvedValue(file);
+      userService.findByIdWithPermissions.mockResolvedValue(fullUser);
+      const failure = new BadRequestException('pageNumber out of range');
+      opdsPageStreamService.streamPage.mockRejectedValue(failure);
+
+      await expect(controller.image(1, 10, 999, true, opdsUser, makeReply())).rejects.toThrow(failure);
+      expect(opdsPageStreamService.invalidateCache).toHaveBeenCalledWith(expect.objectContaining({ id: 10 }));
+    });
   });
 });

--- a/server/src/modules/opds/opds.controller.test.ts
+++ b/server/src/modules/opds/opds.controller.test.ts
@@ -27,6 +27,7 @@ function makeController() {
     generateAuthorsNavigation: vi.fn().mockReturnValue('<authors />'),
     generateSeriesNavigation: vi.fn().mockReturnValue('<series />'),
     generateAcquisitionFeed: vi.fn().mockReturnValue('<feed />'),
+    generateRecentGroupedFeed: vi.fn().mockReturnValue('<recent />'),
     generateOpenSearchDescription: vi.fn().mockReturnValue('<search />'),
   } as never;
   const opdsBookService = {
@@ -39,7 +40,7 @@ function makeController() {
       { name: 'Dune', bookCount: 2 },
     ]),
     getBooksPage: vi.fn().mockResolvedValue({ entries: [{ id: 1 }], total: 1 }),
-    getRecentBooksPage: vi.fn().mockResolvedValue({ entries: [{ id: 2 }], total: 1 }),
+    getRecentGroupedPage: vi.fn().mockResolvedValue({ items: [{ kind: 'book', book: { id: 2 } }], total: 1 }),
     getRandomBooks: vi.fn().mockResolvedValue([{ id: 3 }]),
     validateBookAccess: vi.fn().mockResolvedValue(undefined),
     getBookFiles: vi.fn().mockResolvedValue({
@@ -220,7 +221,17 @@ describe('OpdsController', () => {
     await controller.recent(user, 0, 1000, makeReply());
     await controller.surprise(user, makeReply());
 
-    expect(opdsBookService.getRecentBooksPage).toHaveBeenCalledWith(12, 1, 100, false, undefined);
+    expect(opdsBookService.getRecentGroupedPage).toHaveBeenCalledWith(12, 1, 100, false, undefined);
+    expect(opdsService.generateRecentGroupedFeed).toHaveBeenCalledWith(
+      'Recent Books',
+      'urn:bookorbit:recent',
+      [{ kind: 'book', book: { id: 2 } }],
+      1,
+      1,
+      100,
+      '/api/v1/opds/recent?page=1&size=100',
+      'cover-token',
+    );
     expect(opdsBookService.getRandomBooks).toHaveBeenCalledWith(12, 25, false, undefined);
     expect(opdsService.generateAcquisitionFeed).toHaveBeenCalledWith(
       'Random Books',

--- a/server/src/modules/opds/opds.controller.test.ts
+++ b/server/src/modules/opds/opds.controller.test.ts
@@ -106,7 +106,7 @@ describe('OpdsController', () => {
     expect(opdsBookService.getUserSmartScopes).toHaveBeenCalledWith(8);
     expect(opdsBookService.getDistinctAuthors).toHaveBeenCalledWith(8, false, undefined);
     expect(opdsBookService.getDistinctSeries).toHaveBeenCalledWith(8, false, undefined);
-    expect(opdsService.generateSeriesNavigation).toHaveBeenCalledWith([{ name: 'Dune', bookCount: 2 }]);
+    expect(opdsService.generateSeriesNavigation).toHaveBeenCalledWith([{ name: 'Dune', bookCount: 2 }], undefined);
   });
 
   it('catalog clamps pagination and passes parsed filters to the book service', async () => {

--- a/server/src/modules/opds/opds.controller.ts
+++ b/server/src/modules/opds/opds.controller.ts
@@ -6,9 +6,11 @@ import {
   Headers,
   NotFoundException,
   Param,
+  ParseBoolPipe,
   ParseIntPipe,
   Query,
   Res,
+  UnauthorizedException,
   UseGuards,
 } from '@nestjs/common';
 import { createReadStream } from 'fs';
@@ -21,10 +23,14 @@ import { bookCoverDirPath, bookThumbnailPath, findPreferredBookCoverFileName } f
 import { MAX_OFFSET_ROWS, isOffsetWithinLimit } from '../../common/constants/pagination.constants';
 import { Public } from '../../common/decorators/public.decorator';
 import { imageContentTypeFromPath } from '../../common/image-content-type';
+import { BookService } from '../book/book.service';
+import { UserService } from '../user/user.service';
+import type { SaveProgressDto } from '../book/dto/save-progress.dto';
 import { OPDS_MIME_ACQ, OPDS_MIME_NAV, OPDS_MIME_SEARCH, fileMimeType } from './opds-xml.helpers';
 import { OpdsAuthGuard } from './opds-auth.guard';
 import type { OpdsRequestUser } from './opds-auth.guard';
 import { OpdsEnabledGuard } from './opds-enabled.guard';
+import { OpdsPageStreamService } from './opds-page-stream.service';
 import { OpdsUser } from './opds-user.decorator';
 import { OpdsBookService } from './opds-book.service';
 import { OpdsService } from './opds.service';
@@ -38,6 +44,9 @@ export class OpdsController {
   constructor(
     private readonly opdsService: OpdsService,
     private readonly opdsBookService: OpdsBookService,
+    private readonly opdsPageStreamService: OpdsPageStreamService,
+    private readonly userService: UserService,
+    private readonly bookService: BookService,
     private readonly config: ConfigService,
   ) {
     this.appDataPath = this.config.get<string>('storage.appDataPath')!;
@@ -284,6 +293,42 @@ export class OpdsController {
     reply.header('Content-Length', fileSize);
     reply.type(mime);
     reply.send(createReadStream(absolutePath));
+  }
+
+  @Get(':bookId/image')
+  async image(
+    @Param('bookId', ParseIntPipe) bookId: number,
+    @Query('fileId', ParseIntPipe) fileId: number,
+    @Query('pageNumber', ParseIntPipe) pageNumber: number,
+    @Query('saveProgress', new DefaultValuePipe(true), ParseBoolPipe) saveProgress: boolean,
+    @OpdsUser() opdsUser: OpdsRequestUser,
+    @Res() reply: FastifyReply,
+  ) {
+    if (pageNumber < 0) throw new BadRequestException('pageNumber must be >= 0');
+
+    await this.opdsBookService.validateBookAccess(bookId, opdsUser.userId, opdsUser.isSuperuser, opdsUser.contentFilters);
+    const file = await this.opdsBookService.getBookFiles(bookId, fileId);
+    if (!file) throw new NotFoundException('File not found');
+
+    const user = await this.userService.findByIdWithPermissions(opdsUser.userId);
+    if (!user) throw new UnauthorizedException('Account not found');
+
+    try {
+      const { stream, mimeType, totalPages } = await this.opdsPageStreamService.streamPage(file, pageNumber, user);
+
+      if (saveProgress) {
+        const percentage = totalPages > 0 ? Math.min(100, ((pageNumber + 1) / totalPages) * 100) : 0;
+        const dto: SaveProgressDto = { pageNumber, percentage };
+        await this.bookService.saveProgress(opdsUser.userId, fileId, dto, user);
+      }
+
+      reply.header('Cache-Control', 'private, max-age=31536000, immutable');
+      reply.type(mimeType);
+      reply.send(stream);
+    } catch (err) {
+      await this.opdsPageStreamService.invalidateCache(file);
+      throw err;
+    }
   }
 
   private sendXml(reply: FastifyReply, xml: string, mimeType: string) {

--- a/server/src/modules/opds/opds.controller.ts
+++ b/server/src/modules/opds/opds.controller.ts
@@ -160,7 +160,7 @@ export class OpdsController {
     const clampedPage = Math.max(page, 1);
     this.assertPaginationWindow(clampedPage, clampedSize);
 
-    const { entries, total } = await this.opdsBookService.getRecentBooksPage(
+    const { items, total } = await this.opdsBookService.getRecentGroupedPage(
       user.userId,
       clampedPage,
       clampedSize,
@@ -168,10 +168,10 @@ export class OpdsController {
       user.contentFilters,
     );
     const selfPath = `/api/v1/opds/recent?page=${clampedPage}&size=${clampedSize}`;
-    const xml = this.opdsService.generateAcquisitionFeed(
+    const xml = this.opdsService.generateRecentGroupedFeed(
       'Recent Books',
       'urn:bookorbit:recent',
-      entries,
+      items,
       total,
       clampedPage,
       clampedSize,

--- a/server/src/modules/opds/opds.controller.ts
+++ b/server/src/modules/opds/opds.controller.ts
@@ -86,7 +86,10 @@ export class OpdsController {
   @Get('series')
   async series(@OpdsUser() user: OpdsRequestUser, @Res() reply: FastifyReply) {
     const items = await this.opdsBookService.getDistinctSeries(user.userId, user.isSuperuser, user.contentFilters);
-    const xml = this.opdsService.generateSeriesNavigation(items.filter((s): s is { id: number; name: string; bookCount: number } => s.name !== null));
+    const xml = this.opdsService.generateSeriesNavigation(
+      items.filter((s): s is { id: number; name: string; bookCount: number; coverBookId: number | null } => s.name !== null),
+      user.coverToken,
+    );
     this.sendXml(reply, xml, OPDS_MIME_NAV);
   }
 

--- a/server/src/modules/opds/opds.module.test.ts
+++ b/server/src/modules/opds/opds.module.test.ts
@@ -5,19 +5,23 @@ import { MODULE_METADATA } from '@nestjs/common/constants';
 import { CommonModule } from '../../common/common.module';
 import { AppSettingsModule } from '../app-settings/app-settings.module';
 import { BookModule } from '../book/book.module';
+import { CbzModule } from '../reader/cbz/cbz.module';
 import { UserModule } from '../user/user.module';
 import { OpdsAuthGuard } from './opds-auth.guard';
 import { OpdsBookService } from './opds-book.service';
 import { OpdsController } from './opds.controller';
 import { OpdsEnabledGuard } from './opds-enabled.guard';
 import { OpdsModule } from './opds.module';
+import { OpdsPageCountService } from './opds-page-count.service';
+import { OpdsPageStreamService } from './opds-page-stream.service';
+import { OpdsPdfPageService } from './opds-pdf-page.service';
 import { OpdsService } from './opds.service';
 import { OpdsUserController } from './opds-user.controller';
 import { OpdsUserService } from './opds-user.service';
 
 describe('OpdsModule', () => {
   it('registers expected module wiring', () => {
-    expect(Reflect.getMetadata(MODULE_METADATA.IMPORTS, OpdsModule)).toEqual([AppSettingsModule, BookModule, UserModule, CommonModule]);
+    expect(Reflect.getMetadata(MODULE_METADATA.IMPORTS, OpdsModule)).toEqual([AppSettingsModule, BookModule, CbzModule, UserModule, CommonModule]);
     expect(Reflect.getMetadata(MODULE_METADATA.CONTROLLERS, OpdsModule)).toEqual([OpdsController, OpdsUserController]);
     expect(Reflect.getMetadata(MODULE_METADATA.PROVIDERS, OpdsModule)).toEqual([
       OpdsService,
@@ -25,6 +29,9 @@ describe('OpdsModule', () => {
       OpdsUserService,
       OpdsAuthGuard,
       OpdsEnabledGuard,
+      OpdsPageCountService,
+      OpdsPageStreamService,
+      OpdsPdfPageService,
     ]);
   });
 });

--- a/server/src/modules/opds/opds.module.ts
+++ b/server/src/modules/opds/opds.module.ts
@@ -2,20 +2,33 @@ import { Module } from '@nestjs/common';
 
 import { AppSettingsModule } from '../app-settings/app-settings.module';
 import { BookModule } from '../book/book.module';
+import { CbzModule } from '../reader/cbz/cbz.module';
 import { UserModule } from '../user/user.module';
 import { CommonModule } from '../../common/common.module';
 import { OpdsAuthGuard } from './opds-auth.guard';
 import { OpdsBookService } from './opds-book.service';
 import { OpdsController } from './opds.controller';
 import { OpdsEnabledGuard } from './opds-enabled.guard';
+import { OpdsPageCountService } from './opds-page-count.service';
+import { OpdsPageStreamService } from './opds-page-stream.service';
+import { OpdsPdfPageService } from './opds-pdf-page.service';
 import { OpdsService } from './opds.service';
 import { OpdsUserController } from './opds-user.controller';
 import { OpdsUserService } from './opds-user.service';
 
 @Module({
-  imports: [AppSettingsModule, BookModule, UserModule, CommonModule],
+  imports: [AppSettingsModule, BookModule, CbzModule, UserModule, CommonModule],
   controllers: [OpdsController, OpdsUserController],
-  providers: [OpdsService, OpdsBookService, OpdsUserService, OpdsAuthGuard, OpdsEnabledGuard],
+  providers: [
+    OpdsService,
+    OpdsBookService,
+    OpdsUserService,
+    OpdsAuthGuard,
+    OpdsEnabledGuard,
+    OpdsPageCountService,
+    OpdsPageStreamService,
+    OpdsPdfPageService,
+  ],
   exports: [OpdsBookService],
 })
 export class OpdsModule {}

--- a/server/src/modules/opds/opds.service.ts
+++ b/server/src/modules/opds/opds.service.ts
@@ -71,17 +71,19 @@ export class OpdsService {
     return this.wrapFeed('Authors', 'urn:bookorbit:authors', now, [xmlLink('self', `${BASE}/authors`, OPDS_MIME_NAV)], entries);
   }
 
-  generateSeriesNavigation(items: { id?: number; name: string; bookCount: number }[]): string {
+  generateSeriesNavigation(items: { id?: number; name: string; bookCount: number; coverBookId?: number | null }[], coverToken: string): string {
     const now = new Date().toISOString();
-    const entries = items.map((s) =>
-      this.navEntry(
-        `urn:bookorbit:series:${s.id ?? encodeURIComponent(s.name)}`,
-        s.name,
-        `${s.bookCount} books`,
-        s.id != null ? `${BASE}/catalog?seriesId=${s.id}` : `${BASE}/catalog?series=${encodeURIComponent(s.name)}`,
-        now,
-      ),
-    );
+    const entries = items.map((s) => {
+      const href = s.id != null ? `${BASE}/catalog?seriesId=${s.id}` : `${BASE}/catalog?series=${encodeURIComponent(s.name)}`;
+      const coverLinks =
+        s.coverBookId != null
+          ? [
+              xmlLink('http://opds-spec.org/image', `${BASE}/${s.coverBookId}/cover?t=${encodeURIComponent(coverToken)}`, 'image/jpeg'),
+              xmlLink('http://opds-spec.org/image/thumbnail', `${BASE}/${s.coverBookId}/thumbnail?t=${encodeURIComponent(coverToken)}`, 'image/jpeg'),
+            ]
+          : [];
+      return this.navEntry(`urn:bookorbit:series:${s.id ?? encodeURIComponent(s.name)}`, s.name, `${s.bookCount} books`, href, now, coverLinks);
+    });
     return this.wrapFeed('Series', 'urn:bookorbit:series', now, [xmlLink('self', `${BASE}/series`, OPDS_MIME_NAV)], entries);
   }
 
@@ -189,7 +191,7 @@ export class OpdsService {
     return lines.join('\n');
   }
 
-  private navEntry(id: string, title: string, content: string, href: string, updated: string): string {
+  private navEntry(id: string, title: string, content: string, href: string, updated: string, extraLinks: string[] = []): string {
     return [
       '<entry>',
       `  ${xmlEl('title', title)}`,
@@ -197,6 +199,7 @@ export class OpdsService {
       `  ${xmlEl('updated', updated)}`,
       `  <content type="text">${esc(content)}</content>`,
       `  ${xmlLink('subsection', href, OPDS_MIME_NAV)}`,
+      ...extraLinks.map((link) => `  ${link}`),
       '</entry>',
     ].join('\n');
   }

--- a/server/src/modules/opds/opds.service.ts
+++ b/server/src/modules/opds/opds.service.ts
@@ -1,6 +1,16 @@
 import { Injectable } from '@nestjs/common';
 
-import { esc, fileMimeType, OPDS_MIME_ACQ, OPDS_MIME_NAV, OPDS_MIME_SEARCH, xmlEl, xmlLink } from './opds-xml.helpers';
+import {
+  esc,
+  fileMimeType,
+  isPseStreamableFormat,
+  OPDS_MIME_ACQ,
+  OPDS_MIME_NAV,
+  OPDS_MIME_SEARCH,
+  xmlEl,
+  xmlLink,
+  xmlPseStreamLink,
+} from './opds-xml.helpers';
 import type { OpdsBookEntry } from './opds-book.service';
 
 const BASE = '/api/v1/opds';
@@ -183,6 +193,12 @@ export class OpdsService {
       lines.push(
         `  ${xmlLink('http://opds-spec.org/acquisition', `${BASE}/${book.id}/download?fileId=${file.id}`, mime, file.format.toUpperCase())}`,
       );
+
+      if (isPseStreamableFormat(file.format) && file.pageCount != null) {
+        const href = `${BASE}/${book.id}/image?fileId=${file.id}&pageNumber={pageNumber}&t=${encodeURIComponent(coverToken)}`;
+        const lastRead = file.lastReadPage != null && file.lastReadDate ? { page: file.lastReadPage, date: file.lastReadDate } : undefined;
+        lines.push(`  ${xmlPseStreamLink(href, 'image/jpeg', file.pageCount, lastRead)}`);
+      }
     }
 
     lines.push('</entry>');
@@ -207,7 +223,8 @@ export class OpdsService {
       '<feed xmlns="http://www.w3.org/2005/Atom"',
       '      xmlns:dc="http://purl.org/dc/terms/"',
       '      xmlns:opds="http://opds-spec.org/2010/catalog"',
-      '      xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">',
+      '      xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/"',
+      '      xmlns:pse="http://vaemendis.net/opds-pse/ns">',
       `  ${xmlEl('title', title)}`,
       `  ${xmlEl('id', id)}`,
       `  ${xmlEl('updated', updated)}`,

--- a/server/src/modules/opds/opds.service.ts
+++ b/server/src/modules/opds/opds.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { esc, fileMimeType, OPDS_MIME_ACQ, OPDS_MIME_NAV, OPDS_MIME_SEARCH, xmlEl, xmlLink } from './opds-xml.helpers';
-import type { OpdsBookEntry } from './opds-book.service';
+import type { OpdsBookEntry, OpdsRecentGroupItem } from './opds-book.service';
 
 const BASE = '/api/v1/opds';
 
@@ -96,6 +96,43 @@ export class OpdsService {
     coverToken: string,
   ): string {
     const now = new Date().toISOString();
+    const links = this.paginationLinks(selfPath, page, size, total);
+    const entries = books.map((book) => this.bookEntry(book, coverToken));
+    return this.wrapFeed(title, feedId, now, links, entries, total);
+  }
+
+  /**
+   * "Recent" grouped by series (see OpdsBookService.getRecentGroupedPage): a series
+   * item renders as a plain subsection folder titled "Name (N)"; a standalone book
+   * renders exactly like a normal acquisition entry, side by side in the same feed.
+   */
+  generateRecentGroupedFeed(
+    title: string,
+    feedId: string,
+    items: OpdsRecentGroupItem[],
+    total: number,
+    page: number,
+    size: number,
+    selfPath: string,
+    coverToken: string,
+  ): string {
+    const now = new Date().toISOString();
+    const links = this.paginationLinks(selfPath, page, size, total);
+    const entries = items.map((item) =>
+      item.kind === 'book'
+        ? this.bookEntry(item.book, coverToken)
+        : this.navEntry(
+            `urn:bookorbit:series:${item.seriesId}`,
+            `${item.seriesName} (${item.bookCount})`,
+            `${item.bookCount} recently added`,
+            `${BASE}/catalog?seriesId=${item.seriesId}`,
+            item.lastAddedAt.toISOString(),
+          ),
+    );
+    return this.wrapFeed(title, feedId, now, links, entries, total);
+  }
+
+  private paginationLinks(selfPath: string, page: number, size: number, total: number): string[] {
     const totalPages = Math.max(1, Math.ceil(total / size));
     const links = [
       xmlLink('self', selfPath, OPDS_MIME_ACQ),
@@ -118,9 +155,7 @@ export class OpdsService {
       links.push(xmlLink('last', pageUrl(totalPages), OPDS_MIME_ACQ));
     }
 
-    const entries = books.map((book) => this.bookEntry(book, coverToken));
-
-    return this.wrapFeed(title, feedId, now, links, entries, total);
+    return links;
   }
 
   generateOpenSearchDescription(): string {

--- a/server/src/modules/reader/cbz/cbz.module.ts
+++ b/server/src/modules/reader/cbz/cbz.module.ts
@@ -7,5 +7,6 @@ import { CbzService } from './cbz.service';
   imports: [BookModule],
   controllers: [CbzController],
   providers: [CbzService],
+  exports: [CbzService],
 })
 export class CbzModule {}

--- a/server/src/modules/reader/cbz/cbz.service.ts
+++ b/server/src/modules/reader/cbz/cbz.service.ts
@@ -6,26 +6,12 @@ import { getSevenZip } from '../../../common/sevenzip';
 import { imageContentTypeFromPath } from '../../../common/image-content-type';
 import { detectComicContainerFormat } from '../../../common/comic-format-detect';
 import { createCbzZipEntryReadStream, readCbzZipIndex, type CbzZipEntry } from '../../../common/cbz-zip-reader';
+import { isHiddenPage as isHidden, isImagePage as isImage, naturalPageSort as naturalSort } from '../../../common/comic-page-utils';
 
 import type { RequestUser } from '../../../common/types/request-user';
 import { BookService } from '../../book/book.service';
 
 // ── Shared helpers ─────────────────────────────────────────────────────────────
-
-const IMAGE_EXTS = new Set(['.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp', '.avif']);
-
-function isImage(name: string): boolean {
-  const dot = name.lastIndexOf('.');
-  return dot !== -1 && IMAGE_EXTS.has(name.substring(dot).toLowerCase());
-}
-
-function isHidden(name: string): boolean {
-  return name.split('/').some((p) => p.startsWith('.'));
-}
-
-function naturalSort(a: string, b: string): number {
-  return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
-}
 
 function mimeForExt(name: string): string {
   return imageContentTypeFromPath(name);


### PR DESCRIPTION
## What does this PR do?

Implements OPDS-PSE (Page Streaming Extension) so clients like Panels can stream comic pages incrementally instead of downloading the whole file first.

Closes #592

## How did you test this?

- Added unit tests for the PSE feed generation, the streaming endpoint, and lazy page-count caching.
- Full server test suite passes (7706 tests).
- Built a Docker image from this branch and deployed it to a live instance; verified page-by-page streaming against real CBZ/CBR/PDF files and confirmed reading-progress attributes (`pse:lastRead`, `pse:lastReadDate`) render correctly in the feed.

## Screenshots

N/A — OPDS is a machine-readable feed consumed by client apps (Panels, etc.), not a UI surface in this repo.

## Anything non-obvious in the diff?

- Page counts are computed lazily and cached per file rather than eagerly during import, to avoid touching the several independent metadata-extraction entry points (CBZ/CBR/CB7/PDF) that already exist.
- `{pageNumber}` in the streaming link is a literal, unencoded client-substitution token per the OPDS-PSE spec — `esc()` only escapes XML special characters, so it passes through untouched by design, not by omission.

## Checklist

- [x] I've read through my own diff
- [x] This PR was discussed in an issue and has maintainer approval (for new features)
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added page streaming for supported comic and PDF books, including per-page access, progress tracking, and cached rendered pages.
  * Added page counts to book files and OPDS feeds, with support for recent items grouped by series.
  * Added OPDS-PSE stream links for eligible books and improved series cover/thumbnail handling.

* **Bug Fixes**
  * Improved handling of hidden, non-image, and unreadable archive entries when counting pages.
  * Added safer cleanup and fallback behavior when page counting or streaming fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->