### PR TITLE
fix(kobo): prevent reading state sync feedback loop

### DIFF
--- a/server/src/modules/book/book.repository.ts
+++ b/server/src/modules/book/book.repository.ts
@@ -1687,6 +1687,7 @@ export class BookRepository {
       WHERE snap.id = sb.snapshot_id
         AND snap.user_id = ${userId}
         AND sb.book_id = ${bookId}
+        AND sb.synced = true
         AND sb.pending_delete = false
         AND sb.removed_by_device = false
     `);

--- a/server/src/modules/kobo/kobo-sync.controller.test.ts
+++ b/server/src/modules/kobo/kobo-sync.controller.test.ts
@@ -383,6 +383,7 @@ describe('KoboSyncController', () => {
       1,
       99,
       true,
+      77,
     );
     expect(historyService.recordSuccess).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/server/src/modules/kobo/kobo-sync.controller.ts
+++ b/server/src/modules/kobo/kobo-sync.controller.ts
@@ -253,6 +253,7 @@ export class KoboSyncController {
         settings.readingThreshold,
         settings.finishedThreshold,
         settings.twoWayProgressSync,
+        device.deviceId,
       );
       await this.historyService.recordSuccess({
         userId: user.id,

--- a/server/src/modules/kobo/services/kobo-reading-state.service.test.ts
+++ b/server/src/modules/kobo/services/kobo-reading-state.service.test.ts
@@ -75,7 +75,7 @@ describe('KoboReadingStateService', () => {
     const db = makeDb();
     db.query.books.findFirst.mockResolvedValue(null);
 
-    await expect(makeService(db).upsertState(7, 99, {}, 1, 99, false)).resolves.toEqual({
+    await expect(makeService(db).upsertState(7, 99, {}, 1, 99, false, 70)).resolves.toEqual({
       RequestResult: 'Success',
       UpdateResults: [
         {
@@ -122,6 +122,7 @@ describe('KoboReadingStateService', () => {
       1,
       99,
       false,
+      30,
     );
 
     expect(stateInsert.values).toHaveBeenCalledWith(
@@ -182,6 +183,7 @@ describe('KoboReadingStateService', () => {
       1,
       99,
       false,
+      30,
     );
 
     expect(stateInsert.values).toHaveBeenCalledWith(
@@ -199,6 +201,105 @@ describe('KoboReadingStateService', () => {
         }),
       }),
     );
+    expect(db.select).not.toHaveBeenCalled();
+    expect(db.execute).not.toHaveBeenCalled();
+    expect(userBookStatusService.autoUpdate).not.toHaveBeenCalled();
+    expect(achievementEvents.emit).not.toHaveBeenCalled();
+  });
+
+  it('does not propagate or repeat side effects for an identical device echo', async () => {
+    const db = makeDb();
+    const stateInsert = makeInsertChain();
+    const bookmark = { LastModified: '2026-01-02T00:00:00.000Z', ProgressPercent: 42 };
+    const statistics = { LastModified: '2026-01-02T00:00:00.000Z', SpentReadingMinutes: 5 };
+    const statusInfo = { LastModified: '2026-01-02T00:00:00.000Z', Status: 'Reading' };
+    db.insert.mockReturnValue(stateInsert);
+    db.query.books.findFirst.mockResolvedValue({ id: 12 });
+    db.query.koboReadingStates.findFirst
+      .mockResolvedValueOnce({
+        entitlementId: 'entitlement-12',
+        createdAtKobo: '2026-01-01T00:00:00.000Z',
+        lastModifiedKobo: '2026-01-02T00:00:00.000Z',
+        priorityTimestamp: '2026-01-02T00:00:00.000Z',
+        currentBookmark: bookmark,
+        statistics,
+        statusInfo,
+      })
+      .mockResolvedValueOnce({
+        entitlementId: 'entitlement-12',
+        createdAtKobo: '2026-01-01T00:00:00.000Z',
+        lastModifiedKobo: '2026-01-02T00:00:00.000Z',
+        priorityTimestamp: '2026-01-02T00:00:00.000Z',
+        currentBookmark: bookmark,
+        statistics,
+        statusInfo,
+      });
+
+    await makeService(db).upsertState(
+      3,
+      12,
+      {
+        LastModified: '2026-01-02T00:00:00.000Z',
+        PriorityTimestamp: '2026-01-02T00:00:00.000Z',
+        CurrentBookmark: { ...bookmark },
+        Statistics: { ...statistics },
+        StatusInfo: { ...statusInfo },
+      },
+      1,
+      99,
+      true,
+      30,
+    );
+
+    expect(db.execute).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+    expect(progressBridge.koboBookmarkToCanonical).not.toHaveBeenCalled();
+    expect(userBookStatusService.autoUpdate).not.toHaveBeenCalled();
+    expect(achievementEvents.emit).not.toHaveBeenCalled();
+  });
+
+  it('does not propagate a stale lower-progress echo or treat it as reread evidence', async () => {
+    const db = makeDb();
+    const stateInsert = makeInsertChain();
+    const currentBookmark = { LastModified: '2026-01-02T00:00:00.000Z', ProgressPercent: 84.94 };
+    const currentStatus = { LastModified: '2026-01-02T00:00:00.000Z', Status: 'Reading', TimesStartedReading: 2 };
+    db.insert.mockReturnValue(stateInsert);
+    db.query.books.findFirst.mockResolvedValue({ id: 12 });
+    db.query.koboReadingStates.findFirst
+      .mockResolvedValueOnce({
+        entitlementId: 'entitlement-12',
+        lastModifiedKobo: '2026-01-02T00:00:00.000Z',
+        priorityTimestamp: '2026-01-02T00:00:00.000Z',
+        currentBookmark,
+        statistics: null,
+        statusInfo: currentStatus,
+      })
+      .mockResolvedValueOnce({
+        entitlementId: 'entitlement-12',
+        currentBookmark,
+        statistics: null,
+        statusInfo: currentStatus,
+      });
+
+    await makeService(db).upsertState(
+      3,
+      12,
+      {
+        LastModified: '2026-01-01T00:00:00.000Z',
+        CurrentBookmark: { LastModified: '2026-01-01T00:00:00.000Z', ProgressPercent: 21 },
+        StatusInfo: { LastModified: '2026-01-01T00:00:00.000Z', Status: 'Reading', TimesStartedReading: 1 },
+      },
+      1,
+      99,
+      true,
+      30,
+    );
+
+    expect(stateInsert.values).toHaveBeenCalledWith(expect.objectContaining({ currentBookmark, statusInfo: currentStatus }));
+    expect(db.execute).not.toHaveBeenCalled();
+    expect(db.select).not.toHaveBeenCalled();
+    expect(userBookStatusService.autoUpdate).not.toHaveBeenCalled();
+    expect(achievementEvents.emit).not.toHaveBeenCalled();
   });
 
   it('calls autoUpdate with merged percent and thresholds when bookmark has ProgressPercent', async () => {
@@ -228,6 +329,7 @@ describe('KoboReadingStateService', () => {
       1,
       99,
       true,
+      77,
     );
 
     expect(userBookStatusService.autoUpdate).toHaveBeenCalledWith(
@@ -270,6 +372,7 @@ describe('KoboReadingStateService', () => {
       1,
       99,
       true,
+      77,
     );
 
     expect(userBookStatusService.autoUpdate).not.toHaveBeenCalled();
@@ -303,6 +406,7 @@ describe('KoboReadingStateService', () => {
       1,
       99,
       false,
+      77,
     );
 
     expect(userBookStatusService.autoUpdate).toHaveBeenCalledWith(
@@ -345,7 +449,7 @@ describe('KoboReadingStateService', () => {
     userBookStatusService.autoUpdate.mockRejectedValueOnce(new Error('status update failed'));
 
     await expect(
-      makeService(db).upsertState(1, 5, { CurrentBookmark: { LastModified: '2026-01-01T00:00:00Z', ProgressPercent: 42.5 } }, 1, 99, false),
+      makeService(db).upsertState(1, 5, { CurrentBookmark: { LastModified: '2026-01-01T00:00:00Z', ProgressPercent: 42.5 } }, 1, 99, false, 77),
     ).resolves.toEqual(expect.objectContaining({ EntitlementId: 'entitlement-5' }));
 
     expect(userBookStatusService.autoUpdate).toHaveBeenCalledWith(
@@ -376,7 +480,7 @@ describe('KoboReadingStateService', () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ entitlementId: '6', currentBookmark: { ProgressPercent: 60 } });
 
-    await makeService(db).upsertState(1, 6, { CurrentBookmark: { LastModified: '2026-01-01T00:00:00.000Z', ProgressPercent: 60 } }, 1, 99, true);
+    await makeService(db).upsertState(1, 6, { CurrentBookmark: { LastModified: '2026-01-01T00:00:00.000Z', ProgressPercent: 60 } }, 1, 99, true, 77);
 
     expect(db.insert).toHaveBeenCalledTimes(1);
   });
@@ -388,7 +492,7 @@ describe('KoboReadingStateService', () => {
     db.query.books.findFirst.mockResolvedValue({ id: 7 });
     db.query.koboReadingStates.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({ entitlementId: '7' });
 
-    await makeService(db).upsertState(2, 7, { Statistics: { LastModified: '2026-01-01T00:00:00Z' } }, 1, 99, false);
+    await makeService(db).upsertState(2, 7, { Statistics: { LastModified: '2026-01-01T00:00:00Z' } }, 1, 99, false, 77);
 
     expect(userBookStatusService.autoUpdate).not.toHaveBeenCalled();
   });

--- a/server/src/modules/kobo/services/kobo-reading-state.service.ts
+++ b/server/src/modules/kobo/services/kobo-reading-state.service.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from 'node:util';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { NodePgDatabase } from 'drizzle-orm/node-postgres';
@@ -22,6 +23,9 @@ function mergeSubObject(incoming: JsonObj | null | undefined, existing: JsonObj 
   const a = incoming.LastModified as string | undefined;
   const b = existing.LastModified as string | undefined;
   if (!a || !b) return incoming;
+  const aMs = new Date(a).getTime();
+  const bMs = new Date(b).getTime();
+  if (!Number.isNaN(aMs) && !Number.isNaN(bMs)) return aMs >= bMs ? incoming : existing;
   return a >= b ? incoming : existing;
 }
 
@@ -66,6 +70,7 @@ export class KoboReadingStateService {
     readingThreshold: number,
     finishedThreshold: number,
     twoWayProgressSync: boolean,
+    sourceDeviceId: number,
   ) {
     const now = new Date().toISOString();
 
@@ -108,17 +113,22 @@ export class KoboReadingStateService {
     const previousBookmark = this.asJsonObj(existing?.currentBookmark ?? null);
     const previousStatus = this.asJsonObj(existing?.statusInfo ?? null);
     const previousPercent = this.extractPercent(previousBookmark);
-    const incomingPercent = this.extractPercent(incomingBookmark);
     const previousTimesStarted = typeof previousStatus?.TimesStartedReading === 'number' ? previousStatus.TimesStartedReading : null;
-    const incomingTimesStarted = typeof incomingStatus?.TimesStartedReading === 'number' ? incomingStatus.TimesStartedReading : null;
-    const strongRereadEvidence =
-      (incomingStatus?.Status === 'Reading' && previousStatus?.Status !== 'Reading') ||
-      (incomingTimesStarted !== null && previousTimesStarted !== null && incomingTimesStarted > previousTimesStarted) ||
-      (incomingPercent !== null && previousPercent !== null && previousPercent - incomingPercent >= 10);
 
     const mergedBookmark = mergeSubObject(incomingBookmark, existing?.currentBookmark as JsonObj | null);
     const mergedStats = mergeSubObject(incomingStats, existing?.statistics as JsonObj | null);
     const mergedStatus = mergeSubObject(incomingStatus, existing?.statusInfo as JsonObj | null);
+    const bookmarkChanged = !isDeepStrictEqual(mergedBookmark, previousBookmark);
+    const statisticsChanged = !isDeepStrictEqual(mergedStats, this.asJsonObj(existing?.statistics ?? null));
+    const statusChanged = !isDeepStrictEqual(mergedStatus, previousStatus);
+    const stateChanged = bookmarkChanged || statisticsChanged || statusChanged;
+
+    const mergedPercent = this.extractPercent(mergedBookmark);
+    const mergedTimesStarted = typeof mergedStatus?.TimesStartedReading === 'number' ? mergedStatus.TimesStartedReading : null;
+    const strongRereadEvidence =
+      (mergedStatus?.Status === 'Reading' && previousStatus?.Status !== 'Reading') ||
+      (mergedTimesStarted !== null && previousTimesStarted !== null && mergedTimesStarted > previousTimesStarted) ||
+      (mergedPercent !== null && previousPercent !== null && previousPercent - mergedPercent >= 10);
 
     const bookmarkModified = typeof mergedBookmark?.LastModified === 'string' ? mergedBookmark.LastModified : undefined;
     const effectiveLastModified = maxIsoTimestamp(lastModified, existing?.lastModifiedKobo, bookmarkModified) ?? lastModified;
@@ -150,8 +160,7 @@ export class KoboReadingStateService {
         },
       });
 
-    const percent = this.extractPercent(mergedBookmark);
-    if (percent !== null) {
+    if (bookmarkChanged && mergedPercent !== null) {
       const locationSource = this.extractKoboLocationSource(mergedBookmark);
       const locationType = this.extractKoboLocationType(mergedBookmark);
       const locationValue = this.extractKoboLocationValue(mergedBookmark);
@@ -166,7 +175,7 @@ export class KoboReadingStateService {
       await this.syncPercentToInternalProgress(
         userId,
         bookId,
-        percent,
+        mergedPercent,
         this.extractProgressModifiedAt(mergedBookmark, lastModified),
         locationSource,
         locationType,
@@ -174,17 +183,24 @@ export class KoboReadingStateService {
         this.extractContentSourceProgressPercent(mergedBookmark),
         precise,
       );
-      if (twoWayProgressSync) {
-        await this.markSnapshotBookUnsynced(userId, bookId);
-      }
-      await this.autoUpdateReadStatus(userId, bookId, percent, readingThreshold, finishedThreshold, {
+    }
+
+    if (twoWayProgressSync && stateChanged && mergedPercent !== null) {
+      await this.markSnapshotBookUnsyncedForOtherDevices(userId, bookId, sourceDeviceId);
+    }
+
+    if ((bookmarkChanged || statusChanged) && mergedPercent !== null) {
+      await this.autoUpdateReadStatus(userId, bookId, mergedPercent, readingThreshold, finishedThreshold, {
         occurredOn: effectiveLastModified.slice(0, 10),
         strongRereadEvidence,
       });
+    }
+
+    if (bookmarkChanged && mergedPercent !== null) {
       this.achievementEvents.emit(ACHIEVEMENT_EVENT_BOOK_PROGRESS_CHANGED, {
         userId,
         bookId,
-        progress: percent,
+        progress: mergedPercent,
         source: 'kobo',
       });
     }
@@ -457,7 +473,7 @@ export class KoboReadingStateService {
       });
   }
 
-  private async markSnapshotBookUnsynced(userId: number, bookId: number): Promise<void> {
+  private async markSnapshotBookUnsyncedForOtherDevices(userId: number, bookId: number, sourceDeviceId: number): Promise<void> {
     await this.db.execute(sql`
       UPDATE ${schema.koboSnapshotBooks} AS sb
       SET synced = false,
@@ -465,7 +481,9 @@ export class KoboReadingStateService {
       FROM ${schema.koboLibrarySnapshots} AS snap
       WHERE snap.id = sb.snapshot_id
         AND snap.user_id = ${userId}
+        AND snap.device_id <> ${sourceDeviceId}
         AND sb.book_id = ${bookId}
+        AND sb.synced = true
         AND sb.pending_delete = false
         AND sb.removed_by_device = false
     `);

--- a/server/test/kobo-multi-device-sync.e2e-spec.ts
+++ b/server/test/kobo-multi-device-sync.e2e-spec.ts
@@ -20,6 +20,7 @@ import {
 
 type KoboDevice = { id: number; token: string };
 type SyncResponse = { entries: unknown[]; hasMore: boolean; syncToken: string };
+type NewEntitlement = { BookEntitlement: { Id: string }; ReadingState: Record<string, unknown> };
 
 const MIGRATIONS_DIRECTORY = join(dirname(fileURLToPath(import.meta.url)), '../src/db/migrations');
 
@@ -46,6 +47,20 @@ function newEntitlementIds(entries: unknown[]): string[] {
     const value = entry as Record<string, Record<string, Record<string, string>>>;
     const bookEntitlement = value.NewEntitlement?.BookEntitlement;
     return bookEntitlement?.Id ? [bookEntitlement.Id] : [];
+  });
+}
+
+function newEntitlements(entries: unknown[]): NewEntitlement[] {
+  return entries.flatMap((entry) => {
+    const value = entry as { NewEntitlement?: NewEntitlement };
+    return value.NewEntitlement ? [value.NewEntitlement] : [];
+  });
+}
+
+function changedReadingStates(entries: unknown[]): Record<string, unknown>[] {
+  return entries.flatMap((entry) => {
+    const value = entry as { ChangedReadingState?: { ReadingState: Record<string, unknown> } };
+    return value.ChangedReadingState ? [value.ChangedReadingState.ReadingState] : [];
   });
 }
 
@@ -191,6 +206,27 @@ describe('Kobo multi-device library sync (e2e)', { timeout: 180_000 }, () => {
     return body;
   }
 
+  async function putReadingState(device: KoboDevice, entitlementId: string, readingState: Record<string, unknown>): Promise<void> {
+    const response = await ctx.app.inject({
+      method: 'PUT',
+      url: `/api/v1/kobo/${device.token}/v1/library/${entitlementId}/state`,
+      payload: { ReadingStates: [readingState] },
+    });
+    expect(response.statusCode).toBe(200);
+  }
+
+  async function snapshotState(bookId: number): Promise<Array<{ deviceId: number; synced: boolean; isNew: boolean }>> {
+    return ctx.db
+      .select({
+        deviceId: schema.koboLibrarySnapshots.deviceId,
+        synced: schema.koboSnapshotBooks.synced,
+        isNew: schema.koboSnapshotBooks.isNew,
+      })
+      .from(schema.koboSnapshotBooks)
+      .innerJoin(schema.koboLibrarySnapshots, eq(schema.koboLibrarySnapshots.id, schema.koboSnapshotBooks.snapshotId))
+      .where(and(eq(schema.koboLibrarySnapshots.userId, userId), eq(schema.koboSnapshotBooks.bookId, bookId)));
+  }
+
   beforeAll(async () => {
     ctx = await createReaderStateIsolationE2EContext();
     library = await createLibraryWithFolder(ctx, { name: `kobo-multi-device-${randomUUID()}` });
@@ -234,6 +270,46 @@ describe('Kobo multi-device library sync (e2e)', { timeout: 180_000 }, () => {
     if (ctx) await closeReaderStateIsolationE2EContext(ctx);
   });
 
+  it('finishes pagination when Kobo echoes first-page reading states before requesting the next page', async () => {
+    const settingsResponse = await ctx.app.inject({
+      method: 'PATCH',
+      url: '/api/v1/kobo/settings',
+      headers: authHeader(ctx.adminToken),
+      payload: { twoWayProgressSync: true },
+    });
+    expect(settingsResponse.statusCode).toBe(200);
+
+    const echoDevice = await createDevice('Kobo pagination echo');
+    const first = await sync(echoDevice);
+    const firstEntitlements = newEntitlements(first.entries);
+    expect(first.hasMore).toBe(true);
+    expect(firstEntitlements).toHaveLength(5);
+
+    for (const entitlement of firstEntitlements) {
+      await putReadingState(echoDevice, entitlement.BookEntitlement.Id, entitlement.ReadingState);
+    }
+
+    const second = await sync(echoDevice, first.syncToken);
+    const firstIds = entitlementIds(first.entries);
+    const secondIds = entitlementIds(second.entries);
+    const expectedIdentityRows = await ctx.db
+      .select({ entitlementId: schema.koboBookEntitlements.entitlementId })
+      .from(schema.koboBookEntitlements)
+      .where(and(eq(schema.koboBookEntitlements.userId, userId), inArray(schema.koboBookEntitlements.bookId, bookIds)));
+
+    expect(second.hasMore).toBe(false);
+    expect(secondIds).toHaveLength(1);
+    expect(secondIds.some((id) => firstIds.includes(id))).toBe(false);
+    expect([...firstIds, ...secondIds].sort()).toEqual(expectedIdentityRows.map((row) => row.entitlementId).sort());
+
+    const revokeResponse = await ctx.app.inject({
+      method: 'DELETE',
+      url: `/api/v1/kobo/devices/${echoDevice.id}`,
+      headers: authHeader(ctx.adminToken),
+    });
+    expect(revokeResponse.statusCode).toBe(204);
+  });
+
   it('delivers every initial page independently when two devices interleave', async () => {
     const aFirst = await sync(deviceA);
     const bFirst = await sync(deviceB);
@@ -243,9 +319,28 @@ describe('Kobo multi-device library sync (e2e)', { timeout: 180_000 }, () => {
     expect(entitlementIds(bFirst.entries)).toHaveLength(5);
 
     const aSecond = await sync(deviceA, aFirst.syncToken);
-    const bSecond = await sync(deviceB, bFirst.syncToken);
     expect(aSecond.hasMore).toBe(false);
+    const [remainingEntitlementId] = entitlementIds(aSecond.entries);
+    const [remainingIdentity] = await ctx.db
+      .select({ bookId: schema.koboBookEntitlements.bookId })
+      .from(schema.koboBookEntitlements)
+      .where(and(eq(schema.koboBookEntitlements.userId, userId), eq(schema.koboBookEntitlements.entitlementId, remainingEntitlementId!)));
+    await putReadingState(deviceA, remainingEntitlementId!, {
+      EntitlementId: remainingEntitlementId,
+      LastModified: '2026-11-01T00:00:00.000Z',
+      CurrentBookmark: { LastModified: '2026-11-01T00:00:00.000Z', ProgressPercent: 15 },
+      StatusInfo: { LastModified: '2026-11-01T00:00:00.000Z', Status: 'Reading' },
+    });
+    expect(await snapshotState(remainingIdentity!.bookId)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ deviceId: deviceA.id, synced: true }),
+        expect.objectContaining({ deviceId: deviceB.id, synced: false, isNew: true }),
+      ]),
+    );
+
+    const bSecond = await sync(deviceB, bFirst.syncToken);
     expect(bSecond.hasMore).toBe(false);
+    expect(newEntitlementIds(bSecond.entries)).toContain(remainingEntitlementId);
 
     const expectedIds = await ctx.db
       .select({ entitlementId: schema.koboBookEntitlements.entitlementId })
@@ -272,6 +367,47 @@ describe('Kobo multi-device library sync (e2e)', { timeout: 180_000 }, () => {
       );
     expect(rows).toHaveLength(12);
     expect(rows.every((row) => row.synced)).toBe(true);
+  });
+
+  it('fans genuine state changes to other devices without reopening either device on echo', async () => {
+    const targetBookId = bookIds[0]!;
+    const [identity] = await ctx.db
+      .select({ entitlementId: schema.koboBookEntitlements.entitlementId })
+      .from(schema.koboBookEntitlements)
+      .where(and(eq(schema.koboBookEntitlements.userId, userId), eq(schema.koboBookEntitlements.bookId, targetBookId)));
+    const readingState = {
+      EntitlementId: identity!.entitlementId,
+      LastModified: '2026-12-01T00:00:00.000Z',
+      PriorityTimestamp: '2026-12-01T00:00:00.000Z',
+      CurrentBookmark: { LastModified: '2026-12-01T00:00:00.000Z', ProgressPercent: 42 },
+      Statistics: { LastModified: '2026-12-01T00:00:00.000Z', SpentReadingMinutes: 12 },
+      StatusInfo: { LastModified: '2026-12-01T00:00:00.000Z', Status: 'Reading' },
+    };
+
+    await putReadingState(deviceA, identity!.entitlementId, readingState);
+
+    expect(await snapshotState(targetBookId)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ deviceId: deviceA.id, synced: true }),
+        expect.objectContaining({ deviceId: deviceB.id, synced: false, isNew: false }),
+      ]),
+    );
+
+    const sourceAfterOwnUpdate = await sync(deviceA);
+    expect(entitlementIds(sourceAfterOwnUpdate.entries)).toEqual([]);
+
+    const deliveredToB = await sync(deviceB);
+    const deliveredStates = changedReadingStates(deliveredToB.entries);
+    expect(entitlementIds(deliveredToB.entries)).toEqual([identity!.entitlementId]);
+    expect(deliveredStates).toHaveLength(1);
+    expect(deliveredStates[0]).toEqual(expect.objectContaining({ CurrentBookmark: expect.objectContaining({ ProgressPercent: 42 }) }));
+    expect((await snapshotState(targetBookId)).every((row) => row.synced)).toBe(true);
+
+    await putReadingState(deviceB, identity!.entitlementId, deliveredStates[0]!);
+
+    expect((await snapshotState(targetBookId)).every((row) => row.synced)).toBe(true);
+    const sourceAfterEcho = await sync(deviceA);
+    expect(entitlementIds(sourceAfterEcho.entries)).toEqual([]);
   });
 
   it('fans metadata and delivery changes out to every device independently', async () => {

--- a/server/test/reading-attempts.e2e-spec.ts
+++ b/server/test/reading-attempts.e2e-spec.ts
@@ -284,6 +284,7 @@ describe('Reading attempts main-flow simulation (docker e2e)', { timeout: TIMEOU
       1,
       98,
       false,
+      1,
     );
     await kobo.upsertState(
       adminUserId,
@@ -296,6 +297,7 @@ describe('Reading attempts main-flow simulation (docker e2e)', { timeout: TIMEOU
       1,
       98,
       false,
+      1,
     );
     const history = await listAttempts(book.bookId);
     expect(history.total).toBe(2);


### PR DESCRIPTION
## What does this PR do?

Prevent Kobo native sync from reopening the originating device snapshot whenever that device uploads reading state. Propagate genuine state changes only to other devices, ignore stale or identical echoes, and preserve pending new-entitlement delivery.

Closes #654

## How did you test this?

- Ran the complete server unit suite: 8,113 tests passed.
- Ran the Kobo multi-device E2E suite: 7 tests passed.
- Ran the reading-attempt E2E suite: 18 tests passed.
- Ran server type checking and ESLint.
- Reproduced the real six-book sequence: deliver five books, accept Kobo state PUT echoes, advance to the sixth book, and finish pagination.

## Screenshots

Not applicable. This change has no UI impact.

## Anything non-obvious in the diff?

Snapshot invalidation updates only rows already marked synced. Pending rows retain `is_new=true`, allowing their first delivery to remain a `NewEntitlement` with the latest reading state embedded.

## Checklist

- [x] I reviewed the complete diff.
- [x] The fix is linked to an existing issue.
- [x] Lint and tests pass locally.
- [x] No unintended files are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kobo multi-device reading-state synchronization.
  * Prevented unnecessary updates when reading states are unchanged.
  * Ensured updates are not echoed back to the originating device.
  * Improved handling of bookmark timestamps, progress changes, and automatic read-status updates.
  * Prevented already-synced snapshots from being unnecessarily marked unsynced.

* **Tests**
  * Added coverage for pagination, device interleaving, state propagation, and duplicate-update prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->