### PR TITLE
feat(i18n): Adds Portuguese (PT-BR) language localization

### DIFF
--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -4982,3 +4982,249 @@
     "failedToLoadBook": "Falha ao carregar livro",
     "chapterNumber": "Capítulo {number}",
     "peek": {
+{
+  "peek": {
+    "badge": "Espiando",
+    "startReading": "Começar a ler"
+  },
+  "toast": {
+    "linkedHighlightError": "Não foi possível abrir a posição do destaque vinculado",
+    "resumed": "Retomado em {pct}% - {label}"
+  },
+  "header": {
+    "goBack": "Voltar",
+    "tableOfContents": "Sumário",
+    "toggleBookmark": "Alternar favorito",
+    "cycleFooterMode": "Alternar modo de informações do rodapé",
+    "keyboardShortcutsHint": "Atalhos de teclado (?)",
+    "enterFullscreen": "Entrar em tela cheia",
+    "exitFullscreen": "Sair da tela cheia",
+    "footerMode": {
+      "pageProgress": "Info do rodapé: página + progresso",
+      "sessionTimeLeft": "Info do rodapé: sessão de leitura + tempo restante",
+      "chapterTimeLeft": "Info do rodapé: capítulo + tempo restante do capítulo"
+    }
+  },
+  "footer": {
+    "previousSection": "Seção anterior",
+    "nextSection": "Próxima seção",
+    "goToPlaceholder": "45 ou p123",
+    "jumpToLocation": "Pular para a localização",
+    "jumpTooltip": "Pular para % ou página (ex: 45 ou p123)",
+    "go": "Ir"
+  },
+  "settings": {
+    "title": "Configurações",
+    "ariaLabel": "Configurações do leitor",
+    "tabs": {
+      "appearance": "Aparência",
+      "text": "Texto",
+      "layout": "Layout"
+    },
+    "appearance": {
+      "mode": "Modo",
+      "light": "Claro",
+      "dark": "Escuro",
+      "colorTheme": "Tema de cor"
+    },
+    "text": {
+      "fontSize": "Tamanho da fonte",
+      "fontSizeRange": "Intervalo: 10-32px",
+      "lineHeight": "Altura da linha",
+      "lineHeightRange": "Intervalo: 0.8-3.0",
+      "fontFamily": "Família de fontes",
+      "fontFamilyDescription": "Escolha fontes embutidas ou enviadas para o corpo do texto.",
+      "builtIn": "Embutida",
+      "yourFonts": "Suas fontes"
+    },
+    "layout": {
+      "pageSpreads": "Páginas duplas",
+      "pageSpreadsDescription": "Escolha como este EPUB baseado em imagem emparelha as páginas.",
+      "bookDefault": "Padrão do livro",
+      "singlePage": "Página única",
+      "readingFlow": "Fluxo de leitura",
+      "readingFlowDescription": "Alternar entre paginado e rolagem contínua.",
+      "paginated": "Paginado",
+      "scrolled": "Rolagem",
+      "textColumns": "Colunas de texto",
+      "textColumnsRange": "Intervalo: 1-10",
+      "columnGap": "Espaçamento entre colunas",
+      "columnGapRange": "Intervalo: 0-50%",
+      "maxWidth": "Largura máxima",
+      "maxWidthRange": "Intervalo: 400-1600",
+      "justifyText": "Justificar texto",
+      "justifyTextDescription": "Habilitar alinhamento de parágrafo de largura total.",
+      "hyphenation": "Hifenização",
+      "hyphenationDescription": "Habilitar hifenização automática de quebra de palavra."
+    }
+  },
+  "search": {
+    "placeholder": "Pesquisar no livro (mín. {min} caracteres)...",
+    "searching": "Pesquisando...",
+    "tooShort": "Digite pelo menos {min} caracteres",
+    "noResults": "Nenhum resultado encontrado",
+    "prompt": "Digite para pesquisar",
+    "resultCount": "nenhum resultado | {count} resultado | {count} resultados"
+  },
+  "sidebar": {
+    "tabs": {
+      "chapters": "Capítulos",
+      "bookmarks": "Favoritos",
+      "highlights": "Destaques",
+      "toc": "Sumário",
+      "tocShort": "Sumário",
+      "marksShort": "Marcas",
+      "notesShort": "Notas"
+    },
+    "pin": "Fixar barra lateral",
+    "unpin": "Desafixar barra lateral",
+    "close": "Fechar barra lateral",
+    "noChapters": "Nenhum capítulo encontrado",
+    "noBookmarks": "Nenhum favorito ainda",
+    "noBookmarksMatch": "Nenhum favorito corresponde aos seus filtros",
+    "noHighlights": "Nenhum destaque ainda",
+    "noHighlightsMatch": "Nenhum destaque corresponde aos seus filtros",
+    "searchBookmarks": "Pesquisar favoritos...",
+    "searchHighlights": "Pesquisar destaques...",
+    "bookmarkFallback": "Favorito",
+    "locationUnavailable": "Localização indisponível",
+    "customColor": "Personalizado ({color})",
+    "allColors": "Todas as cores",
+    "allChapters": "Todos os capítulos",
+    "notesOnly": "Apenas notas",
+    "deleteBookmark": "Excluir favorito",
+    "deleteHighlight": "Excluir destaque",
+    "approximatePosition": "Sincronizado do dispositivo; posição exata indisponível, pula para o capítulo",
+    "sort": {
+      "readingOrder": "Ordem de leitura",
+      "newest": "Mais novos primeiro",
+      "oldest": "Mais antigos primeiro"
+    }
+  },
+  "selection": {
+    "copy": "Copiar",
+    "copied": "Copiado!",
+    "highlight": "Destaque",
+    "translate": "Traduzir",
+    "define": "Definir",
+    "deleteAnnotation": "Excluir anotação",
+    "apply": "Aplicar"
+  },
+  "note": {
+    "title": "Adicionar nota",
+    "placeholder": "Escreva sua nota..."
+  },
+  "dictionary": {
+    "noDefinition": "Nenhuma definição encontrada",
+    "loadError": "Não foi possível carregar a definição"
+  },
+  "translation": {
+    "original": "Original",
+    "translation": "Tradução",
+    "translating": "Traduzindo...",
+    "noTranslation": "Nenhuma tradução ainda",
+    "viaProvider": "via {provider}",
+    "copyTranslation": "Copiar tradução"
+  },
+  "shortcuts": {
+    "title": "Atalhos de Teclado",
+    "groups": {
+      "panels": "Painéis",
+      "reading": "Leitura",
+      "actions": "Ações"
+    },
+    "toggleToc": "Alternar sumário",
+    "toggleSearch": "Alternar pesquisa",
+    "toggleHelp": "Mostrar/ocultar esta ajuda",
+    "closePanel": "Fechar painel",
+    "prevNextPage": "Página anterior/próxima",
+    "goToStart": "Ir para o início do livro",
+    "goToEnd": "Ir para o final do livro",
+    "toggleBookmark": "Alternar favorito",
+    "toggleFullscreen": "Alternar tela cheia",
+    "cycleFooterMode": "Alternar modo de informações do rodapé"
+  },
+  "cbz": {
+    "tabs": {
+      "view": "Visualização",
+      "reading": "Leitura",
+      "layout": "Layout"
+    },
+    "fitMode": "Modo de ajuste",
+    "background": "Fundo",
+    "scrollMode": "Modo de rolagem",
+    "scrollModeHint": "Use \"Sem espaços\" para webtoons e tiras verticais.",
+    "readingDirection": "Direção de leitura",
+    "pageView": "Visualização de página",
+    "autoFallback": "Fallback automático",
+    "spreadAlignmentLabel": "Alinhamento de página dupla",
+    "spreadAlignmentHint": "O alinhamento de página dupla está indisponível no modo de fallback automático.",
+    "focusTwoPageToggle": "Alternar foco de duas páginas",
+    "forceTwoPage": "Forçar duas páginas",
+    "off": "Desativado",
+    "on": "Ativado",
+    "widePages": "Páginas largas",
+    "resetBookViewSettings": "Redefinir configurações de visualização do livro",
+    "resetConfirm": "Redefinir as configurações de visualização deste livro para os seus padrões globais?",
+    "firstPage": "Primeira página",
+    "lastPage": "Última página",
+    "fit": {
+      "page": "Ajustar à Página",
+      "width": "Ajustar à Largura",
+      "height": "Ajustar à Altura",
+      "actual": "Tamanho Real"
+    },
+    "view": {
+      "single": "Única",
+      "twoPage": "Duas páginas"
+    },
+    "scroll": {
+      "paged": "Paginado",
+      "infinite": "Infinito",
+      "noGaps": "Sem espaços"
+    },
+    "direction": {
+      "ltr": "E para D",
+      "rtl": "D para E"
+    },
+    "spreadAlignment": {
+      "normal": "Normal",
+      "shifted": "Deslocado"
+    },
+    "widePage": {
+      "auto": "Automático",
+      "inSpreads": "Em páginas duplas"
+    },
+    "bg": {
+      "black": "Preto",
+      "gray": "Cinza",
+      "white": "Branco"
+    }
+  },
+  "audiobook": {
+    "untitled": "Sem título",
+    "loading": "Carregando audiobook...",
+    "loadError": "Falha ao carregar audiobook",
+    "noAudioFiles": "Nenhum arquivo de áudio encontrado para este livro.",
+    "speed": "Velocidade",
+    "chapters": "Capítulos",
+    "bookmarks": "Favoritos",
+    "volume": "Volume",
+    "muted": "Sem áudio",
+    "sleep": "Sono",
+    "chapterAbbrev": "Cap.",
+    "sleepTimer": "Temporizador de sono",
+    "minutes": "{count} minutos",
+    "endOfChapter": "Fim do capítulo",
+    "noChaptersAvailable": "Nenhum capítulo disponível",
+    "extend15": "+ 15 minutos",
+    "timeLeft": "({time} restantes)",
+    "playbackSpeed": "Velocidade de reprodução",
+    "noChapters": "Nenhum capítulo disponível.",
+    "noBookmarks": "Nenhum favorito ainda.",
+    "noBookmarksHint": "Toque no ícone de favorito no topo para salvar sua posição atual.",
+    "playerSettings": "Configurações do reprodutor",
+    "skipBack": "Retroceder",
+    "skipForward": "Avançar"
+  }
+}

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1,0 +1,4984 @@
+{
+  "common": {
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "close": "Fechar",
+    "confirm": "Confirmar",
+    "loading": "Carregando...",
+    "search": "Pesquisar",
+    "back": "Voltar",
+    "next": "Próximo",
+    "previous": "Anterior",
+    "yes": "Sim",
+    "no": "Não"
+  },
+  "settings": {
+    "appearance": {
+      "language": {
+        "title": "Idioma",
+        "description": "Escolha o idioma usado em toda a interface.",
+        "label": "Idioma da interface"
+      },
+      "pageTitle": "Exibição",
+      "pageSubtitle": "Controle temas, capas, layout e como sua biblioteca é apresentada.",
+      "mobileSummary": "Tema: {theme} • Destaque: {accent} • Fundo: {background}",
+      "themeMode": {
+        "light": "Claro",
+        "dark": "Escuro"
+      },
+      "theme": {
+        "title": "Tema",
+        "colorScheme": {
+          "label": "Esquema de cores",
+          "hint": "Interface clara ou escura"
+        },
+        "accentColor": {
+          "label": "Cor de destaque",
+          "hint": "Controla destaques e elementos interativos"
+        },
+        "cornerRadius": {
+          "label": "Raio da borda",
+          "hint": "Arredondamento de cartões e elementos da interface"
+        },
+        "surfaceBrightness": {
+          "label": "Brilho da superfície",
+          "hint": "Clarear superfícies no modo escuro",
+          "reset": "Redefinir"
+        },
+        "libraryBackground": {
+          "title": "Fundo da Biblioteca",
+          "pattern": {
+            "label": "Padrão de fundo",
+            "hint": "Padrão exibido atrás da grade de livros"
+          }
+        },
+        "backgroundGroups": {
+          "fundamental": "Fundamental",
+          "structural": "Estrutural",
+          "ambient": "Ambiente",
+          "refractive": "Refrativo"
+        }
+      },
+      "storage": {
+        "title": "Onde salvar as preferências de aparência",
+        "active": "Ativo",
+        "notAvailable": "Não disponível",
+        "device": {
+          "title": "Apenas neste dispositivo",
+          "description": "As preferências permanecem no seu navegador. Ideal se você quiser um visual diferente em dispositivos diferentes."
+        },
+        "account": {
+          "title": "Minha conta",
+          "description": "As preferências são salvas na sua conta. Ideal se você quiser a mesma aparência em todos os dispositivos."
+        },
+        "toasts": {
+          "synced": "As preferências agora serão sincronizadas",
+          "local": "As preferências permanecerão neste dispositivo"
+        },
+        "errors": {
+          "demoRestricted": "Uma conta restrita de demonstração não pode alterar o modo de armazenamento de tema",
+          "update": "Falha ao atualizar o modo de armazenamento",
+          "generic": "Ocorreu um erro ao atualizar o modo de armazenamento"
+        }
+      },
+      "bookCovers": {
+        "title": "Capas de Livros",
+        "displayMode": {
+          "title": "Modo de exibição de capa",
+          "hint": "Controla como as capas reais se ajustam aos espaços dos livros quando as proporções diferem",
+          "blurredFit": {
+            "label": "Ajuste desfocado",
+            "hint": "Mostrar a capa inteira com um preenchimento desfocado atrás dela"
+          },
+          "fillCrop": {
+            "label": "Preencher cartão",
+            "hint": "Preencher todo o espaço cortando as bordas quando as proporções diferem"
+          },
+          "naturalBottom": {
+            "label": "Base natural",
+            "hint": "Manter a proporção original da capa e ancorar a capa na parte inferior"
+          }
+        },
+        "spine": {
+          "title": "Sobreposição de lombada do livro",
+          "hint": "Adiciona uma lombada estilizada e efeito de brilho aos cartões de capa",
+          "off": {
+            "label": "Desativado",
+            "hint": "Sem efeito de lombada/brilho nas capas"
+          },
+          "subtle": {
+            "label": "Sutil",
+            "hint": "Lombada e brilho leves, mais próximos do visual padrão"
+          },
+          "strong": {
+            "label": "Forte",
+            "hint": "Lombada e tratamento de brilho mais pronunciados"
+          }
+        },
+        "showSpineOnComics": {
+          "label": "Mostrar lombada em quadrinhos",
+          "hint": "Aplicar o efeito de lombada e brilho em capas de quadrinhos (cbz, cbr, cb7)"
+        },
+        "shadow": {
+          "title": "Intensidade da sombra da capa",
+          "hint": "Controla a profundidade sob as capas na grade, lista, tabela e miniaturas do painel",
+          "default": {
+            "label": "Padrão",
+            "hint": "Elevação e profundidade atuais"
+          },
+          "strong": {
+            "label": "Forte",
+            "hint": "Sombra projetada mais pesada, semelhante a uma prateleira, sob as capas"
+          }
+        },
+        "overlays": {
+          "title": "Sobreposições de cartão",
+          "hint": "Escolha os metadados mostrados diretamente nos cartões de capa de livro",
+          "progressBar": {
+            "label": "Barra de progresso",
+            "hint": "Linha fina colorida ao longo da borda inferior"
+          },
+          "format": {
+            "label": "Formato do arquivo",
+            "hint": "Distintivo colorido EPUB, PDF, CBZ no canto inferior direito"
+          },
+          "rating": {
+            "label": "Avaliação",
+            "hint": "Indicador de classificação por estrelas no canto inferior esquerdo"
+          },
+          "readStatus": {
+            "label": "Status de leitura",
+            "hint": "Ícone colorido mostrando o status de leitura atual no canto superior esquerdo"
+          },
+          "seriesPosition": {
+            "label": "Número da série",
+            "hint": "Distintivo mostrando a posição do livro em sua série no canto superior direito (ex: #3, #1.5)"
+          },
+          "lockStatus": {
+            "label": "Status de bloqueio",
+            "hint": "Ícone de cadeado de metadados no canto superior direito - laranja quando bloqueado, verde quando desbloqueado"
+          }
+        }
+      },
+      "layout": {
+        "coverSize": "Tamanho da capa",
+        "gridSpacing": "Espaçamento da grade",
+        "gridLayout": {
+          "title": "Layout da Grade da Biblioteca"
+        },
+        "coverSizeBehavior": {
+          "label": "Comportamento do tamanho da capa",
+          "hint": "Controle se os tamanhos de retrato/quadrado e o espaçamento da grade são compartilhados em todas as visualizações ou mantidos por visualização",
+          "perViewHint": "Modo por visualização: ajuste o tamanho da capa e o espaçamento no painel de Exibição de cada visualização.",
+          "syncAll": "Sincronizar todas as visualizações",
+          "perView": "Tamanhos por visualização"
+        },
+        "portraitCoverSize": {
+          "label": "Tamanho da capa em retrato",
+          "hint": "Usado para bibliotecas e visualizações em retrato"
+        },
+        "squareCoverSize": {
+          "label": "Tamanho da capa quadrada",
+          "hint": "Usado para bibliotecas e visualizações quadradas"
+        },
+        "portraitGridSpacing": {
+          "label": "Espaçamento da grade em retrato",
+          "hint": "Espaço entre capas em retrato"
+        },
+        "squareGridSpacing": {
+          "label": "Espaçamento da grade quadrada",
+          "hint": "Espaço entre capas quadradas"
+        },
+        "cardInfoMode": {
+          "label": "Modo de informações do cartão",
+          "hint": "Onde mostrar o título do livro e o autor nos cartões da grade",
+          "onHover": "Ao passar o mouse",
+          "belowCover": "Abaixo da capa",
+          "off": "Desativado"
+        },
+        "primaryCardLabel": {
+          "label": "Rótulo principal do cartão",
+          "hint": "Texto mostrado abaixo de cada capa de livro (primeira linha)"
+        },
+        "secondaryCardLabel": {
+          "label": "Rótulo secundário do cartão",
+          "hint": "Texto adicional abaixo do rótulo principal (segunda linha)"
+        },
+        "labelField": {
+          "hidden": "Oculto",
+          "bookTitle": "Título do livro",
+          "seriesTitle": "Título da série",
+          "seriesTitlePosition": "Título da série + posição",
+          "author": "Autor"
+        },
+        "seriesDisplay": {
+          "title": "Exibição de Série",
+          "collapsedCover": {
+            "label": "Capa de série recolhida",
+            "hint": "Escolha qual capa mostrar quando as séries estiverem recolhidas na grade de livros"
+          },
+          "stack": "Pilha",
+          "mosaic": "Mosaico",
+          "first": "Primeiro",
+          "latest": "Mais recente",
+          "firstUnread": "Primeiro não lido"
+        },
+        "authorGrid": {
+          "title": "Grade de Autores",
+          "coverSize": {
+            "label": "Tamanho da capa",
+            "hint": "Largura das capas dos autores na grade"
+          },
+          "coverShape": {
+            "label": "Formato da capa",
+            "hint": "Formato das capas dos autores na grade"
+          },
+          "circle": "Círculo",
+          "square": "Quadrado"
+        },
+        "listTableViews": {
+          "title": "Visualizações de Lista e Tabela"
+        },
+        "zebraStriping": {
+          "label": "Cores alternadas",
+          "hint": "Alternar cores de fundo das linhas para facilitar a leitura"
+        }
+      },
+      "behavior": {
+        "title": "Comportamento da Biblioteca",
+        "thumbnailClicks": {
+          "label": "Cliques em miniaturas",
+          "hint": "Escolha o que acontece ao abrir um livro das visualizações de grade e lista",
+          "readFirst": "Ler primeiro",
+          "readFirstHint": "Abrir o leitor quando existir um arquivo legível",
+          "openDetails": "Abrir detalhes",
+          "openDetailsHint": "Ir para a página de detalhes do livro a partir de miniaturas de grade e lista"
+        },
+        "filterPreview": {
+          "label": "Mostrar visualização de filtro por padrão",
+          "hint": "Expandir o filtro ativo e o resumo de classificação ao abrir um SmartScope"
+        },
+        "collapseSeries": {
+          "label": "Recolher séries por padrão",
+          "hint": "Agrupar livros da mesma série em um único cartão nas visualizações de biblioteca e coleção"
+        }
+      },
+      "icons": {
+        "title": "Ícones Personalizados",
+        "uploadIcons": "Enviar ícones",
+        "uploadedCount": "nenhum ícone enviado | {count} ícone enviado | {count} ícones enviados",
+        "searchPlaceholder": "Pesquisar ícones",
+        "sort": {
+          "newest": "Mais novos",
+          "name": "Nome"
+        },
+        "selectedCount": "{count} selecionado(s)",
+        "clear": "Limpar",
+        "deleteSelected": "Excluir selecionados",
+        "loading": "Carregando ícones...",
+        "emptySearch": "Nenhum ícone corresponde à sua pesquisa.",
+        "emptyNoIcons": "Nenhum ícone personalizado enviado ainda.",
+        "namePlaceholder": "Nome",
+        "checkingUsage": "Verificando uso...",
+        "usedBy": "Usado por {count}",
+        "notUsedYet": "Ainda não usado",
+        "rename": "Renomear",
+        "replace": "Substituir",
+        "usage": {
+          "libraries": "nenhuma biblioteca | {count} biblioteca | {count} bibliotecas",
+          "collections": "nenhuma coleção | {count} coleção | {count} coleções",
+          "smartScopes": "nenhum smart scope | {count} smart scope | {count} smart scopes"
+        },
+        "confirm": {
+          "deleteOne": "Excluir \"{name}\"? Os usos existentes voltarão ao ícone padrão.",
+          "deleteMany": "Excluir nenhum ícone? | Excluir {count} ícone? Os usos existentes voltarão ao ícone padrão. | Excluir {count} ícones? Os usos existentes voltarão ao ícone padrão."
+        },
+        "toasts": {
+          "saved": "Ícone salvo",
+          "updated": "Ícone atualizado",
+          "deleted": "Ícone excluído",
+          "bulkDeleted": "Nenhum ícone excluído | {count} ícone excluído | {count} ícones excluídos",
+          "bulkDeletePartial": "{deleted} excluídos, {failed} falharam"
+        },
+        "errors": {
+          "load": "Falha ao carregar ícones",
+          "save": "Falha ao salvar ícone",
+          "replace": "Falha ao substituir ícone",
+          "delete": "Falha ao excluir ícone",
+          "bulkDelete": "Falha ao excluir ícones"
+        }
+      },
+      "tabs": {
+        "theme": "Tema",
+        "book-covers": "Capas de Livros",
+        "icons": "Ícones",
+        "layout": "Layout",
+        "behavior": "Comportamento"
+      }
+    },
+    "account": {
+      "title": "Conta",
+      "subtitle": "Gerencie suas configurações de perfil pessoal.",
+      "subtitleAll": "Gerencie seu perfil e preferências de notificação.",
+      "tabs": {
+        "profile": "Perfil",
+        "notifications": "Notificações",
+        "restrictions": "Restrições"
+      },
+      "demoRestricted": {
+        "cannotEdit": "Conta restrita de demonstração não pode editar configurações de conta",
+        "notice": "Conta restrita de demonstração: a edição de perfil, senha, avatar e identidades vinculadas está desativada."
+      },
+      "feedback": {
+        "unsavedChanges": "Alterações não salvas",
+        "allSaved": "Todas as alterações salvas"
+      },
+      "profile": {
+        "securityHeading": "Perfil e Segurança",
+        "username": "Nome de usuário",
+        "fullName": "Nome completo",
+        "email": "E-mail",
+        "emailHint": "Contate um administrador para alterar seu endereço de e-mail.",
+        "save": "Salvar perfil",
+        "saving": "Salvando...",
+        "changePassword": "Alterar senha",
+        "accountType": "Tipo de conta:",
+        "accountTypeOidc": "OIDC / SSO",
+        "accountTypeShared": "Compartilhada",
+        "accountTypeLocal": "Local",
+        "nameRequired": "O nome é obrigatório",
+        "updateFailed": "Falha ao atualizar o perfil",
+        "updated": "Perfil atualizado"
+      },
+      "readingPreferences": {
+        "title": "Preferências de Leitura",
+        "timezoneHint": "O fuso horário é usado para conquistas sensíveis ao tempo, como Early Bird e All-nighter.",
+        "timezone": "Fuso horário",
+        "save": "Salvar preferências"
+      },
+      "preferences": {
+        "saveFailed": "Falha ao salvar preferências",
+        "saved": "Preferências salvas"
+      },
+      "avatar": {
+        "title": "Foto de Perfil",
+        "unknownUser": "Usuário desconhecido",
+        "formatHint": "PNG/JPEG/WEBP até {size} MB",
+        "upload": "Enviar foto",
+        "replace": "Substituir foto",
+        "uploading": "Enviando...",
+        "remove": "Remover foto",
+        "removing": "Removendo...",
+        "updated": "Foto de perfil atualizada",
+        "uploadFailed": "Falha ao enviar foto de perfil",
+        "removed": "Foto de perfil removida",
+        "removeFailed": "Falha ao remover foto de perfil",
+        "removeConfirm": {
+          "title": "Remover foto de perfil?",
+          "description": "Seu avatar será removido e substituído por iniciais.",
+          "confirm": "Remover"
+        }
+      },
+      "connectedAccounts": {
+        "title": "Contas Conectadas",
+        "unlink": "Desvincular",
+        "unlinking": "Desvinculando...",
+        "linkAdditional": "Vincular provedores adicionais:",
+        "linkProvider": "Vincular {provider}",
+        "redirecting": "Redirecionando...",
+        "noneConfigured": "Nenhum provedor OIDC está configurado. Peça a um administrador para configurar o SSO.",
+        "linkStateFailed": "Falha ao gerar estado de vínculo",
+        "startLinkFailed": "Falha ao iniciar vínculo OIDC",
+        "unlinkFailed": "Falha ao desvincular",
+        "unlinked": "Identidade desvinculada",
+        "unlinkIdentityFailed": "Falha ao desvincular identidade",
+        "unlinkDialog": {
+          "title": "Desvincular identidade {provider}?",
+          "description": "Insira sua senha para confirmar. Você não poderá mais fazer login com este provedor.",
+          "currentPassword": "Senha atual"
+        }
+      },
+      "tour": {
+        "title": "Tour Guiado",
+        "description": "Repita o passo a passo que destaca os principais recursos do aplicativo.",
+        "action": "Fazer o tour novamente"
+      },
+      "restrictions": {
+        "none": {
+          "title": "Sem restrições de conteúdo",
+          "description": "Sua conta tem acesso total a todo o conteúdo dentro de suas bibliotecas atribuídas."
+        },
+        "banner": "Sua conta possui restrições de conteúdo aplicadas por um administrador. Alguns livros podem não estar visíveis para você.",
+        "allowedTags": {
+          "title": "Tags permitidas",
+          "description": "Apenas livros que têm pelo menos uma dessas tags são mostrados a você."
+        },
+        "blockedTags": {
+          "title": "Tags bloqueadas",
+          "description": "Livros com qualquer uma dessas tags ficam ocultos para você."
+        },
+        "allowedGenres": {
+          "title": "Gêneros permitidos",
+          "description": "Apenas livros que têm pelo menos um desses gêneros são mostrados a você."
+        },
+        "blockedGenres": {
+          "title": "Gêneros bloqueados",
+          "description": "Livros com qualquer um desses gêneros ficam ocultos para você."
+        }
+      }
+    },
+    "magicLinks": {
+      "title": "Links Mágicos",
+      "subtitle": "Crie links de login compartilháveis para contas compartilhadas.",
+      "createLink": "Criar link",
+      "noSharedAccounts": "Nenhuma conta compartilhada encontrada",
+      "activeLinks": "Links ativos",
+      "inactiveLinks": "Links inativos",
+      "paused": "Pausado",
+      "deletedUser": "Usuário excluído",
+      "expiredPrefix": "Expirado ",
+      "never": "Nunca",
+      "noExpiry": "Sem expiração",
+      "expired": "Expirado",
+      "expiresOn": "Expira em {date}",
+      "revokedOn": "Revogado em {date}",
+      "expiredOn": "Expirado em {date}",
+      "usesCount": "nenhum uso | um uso | {count} usos",
+      "copied": "Copiado!",
+      "copyLink": "Copiar link",
+      "pause": "Pausar",
+      "resume": "Retomar",
+      "revoke": "Revogar",
+      "revoking": "Revogando...",
+      "emptyState": "Nenhum link mágico criado ainda. Clique em \"{action}\" para gerar uma URL de login compartilhável.",
+      "columns": {
+        "label": "Rótulo",
+        "account": "Conta",
+        "createdBy": "Criado por",
+        "expires": "Expira",
+        "uses": "Usos",
+        "lastUsed": "Último uso",
+        "created": "Criado",
+        "status": "Status",
+        "totalUses": "Total de usos"
+      },
+      "createDialog": {
+        "title": "Criar link mágico",
+        "description": "Gerar uma URL de login compartilhável para uma conta compartilhada.",
+        "sharedAccount": "Conta compartilhada",
+        "selectAccount": "Selecione uma conta compartilhada",
+        "label": "Rótulo",
+        "labelPlaceholder": "ex: Link de demonstração para conferência",
+        "expiresAt": "Expira em",
+        "optional": "(opcional)",
+        "create": "Criar",
+        "creating": "Criando..."
+      },
+      "revokeDialog": {
+        "title": "Revogar link mágico?",
+        "description": "Isso invalidará imediatamente o link e encerrará todas as sessões ativas da conta vinculada."
+      },
+      "errors": {
+        "create": "Falha ao criar",
+        "copy": "Falha ao copiar o link mágico",
+        "update": "Falha ao atualizar o link mágico",
+        "revoke": "Falha ao revogar"
+      },
+      "usersPage": "Página de usuários",
+      "emptyTitle": "Nenhum link mágico criado ainda",
+      "emptyHint": "Clique em \"{action}\" para gerar uma URL de login compartilhável.",
+      "noActiveTitle": "Nenhum link mágico ativo",
+      "noActiveHint": "Todos os links mágicos gerados para esta página expiraram ou foram revogados."
+    },
+    "oidc": {
+      "title": "OIDC / SSO",
+      "subtitle": "Gerencie provedores OpenID Connect para single sign-on.",
+      "providers": "Provedores",
+      "addProvider": "Adicionar Provedor",
+      "editProvider": "Editar Provedor",
+      "configureNew": "Configure um novo provedor OIDC.",
+      "editing": "Editando {slug}",
+      "enabled": "Ativado",
+      "disabled": "Desativado",
+      "empty": {
+        "title": "Nenhum provedor ainda",
+        "description": "Adicione um provedor OIDC para habilitar o single sign-on para seus usuários."
+      },
+      "form": {
+        "status": "Status",
+        "enableProvider": "Habilitar provedor",
+        "enableProviderHint": "Mostrar este provedor na página de login.",
+        "identity": "Identidade do Provedor",
+        "slug": "Slug",
+        "slugHint": "Identificador único (minúsculas, hifens). Não pode ser alterado posteriormente.",
+        "displayName": "Nome de Exibição",
+        "displayNameHint": "Mostrado no botão de login.",
+        "iconUrl": "URL do Ícone",
+        "iconUrlHint": "Logotipo opcional mostrado ao lado do botão de login.",
+        "iconPreviewAlt": "pré-visualização do ícone",
+        "connection": "Conexão",
+        "issuerUri": "URI do Emissor",
+        "issuerUriHint": "A URL base do provedor.",
+        "test": "Testar",
+        "testing": "Testando...",
+        "clientId": "Client ID",
+        "clientSecret": "Client Secret",
+        "clientSecretPlaceholder": "Deixe em branco para manter o existente",
+        "scopes": "Escopos",
+        "claimMapping": "Mapeamento de Claims",
+        "previewClaims": "Pré-visualizar claims",
+        "redirecting": "Redirecionando...",
+        "mappedClaims": "Claims mapeados",
+        "rawClaims": "Claims brutos",
+        "usernameClaim": "Claim de nome de usuário",
+        "nameClaim": "Claim de nome",
+        "emailClaim": "Claim de e-mail",
+        "groupsClaim": "Claim de grupos",
+        "autoProvisioning": "Autoprovisionamento",
+        "autoProvisionUsers": "Autoprovisionar usuários",
+        "autoProvisionUsersHint": "Criar contas no primeiro login OIDC se o usuário não existir.",
+        "allowLocalLinking": "Permitir vinculação de conta local",
+        "allowLocalLinkingHint": "Vincular identidade OIDC a uma conta local existente por correspondência de nome de usuário.",
+        "defaultPermissions": "Permissões padrão",
+        "defaultPermissionsHint": "Permissões concedidas a novos usuários no primeiro login OIDC.",
+        "createProvider": "Criar Provedor",
+        "saveChanges": "Salvar Alterações",
+        "saving": "Salvando...",
+        "deleteProvider": "Excluir Provedor",
+        "deleting": "Excluindo..."
+      },
+      "test": {
+        "connected": "Conectado - {issuer}",
+        "connectionFailed": "Falha na conexão",
+        "hide": "Ocultar",
+        "details": "Detalhes",
+        "supported": "suportado",
+        "notSupported": "não suportado"
+      },
+      "groupMappings": {
+        "title": "Mapeamentos de Grupo",
+        "description": "Mapeie os claims de grupo OIDC para permissões do BookOrbit. Sincronizado a cada login.",
+        "noPermission": "Sem permissão",
+        "empty": "Nenhum mapeamento de grupo configurado.",
+        "addMapping": "Adicionar mapeamento",
+        "claimPlaceholder": "Claim de grupo OIDC (ex: admins)",
+        "add": "Adicionar",
+        "adding": "Adicionando..."
+      },
+      "toasts": {
+        "providerCreated": "Provedor criado",
+        "providerSaved": "Provedor salvo",
+        "providerDeleted": "Provedor excluído",
+        "mappingAdded": "Mapeamento de grupo adicionado",
+        "mappingRemoved": "Mapeamento de grupo removido"
+      },
+      "errors": {
+        "loadProvider": "Falha ao carregar provedor",
+        "createProvider": "Falha ao criar provedor",
+        "save": "Falha ao salvar",
+        "delete": "Falha ao excluir",
+        "deleteProvider": "Falha ao excluir provedor",
+        "requestFailed": "Falha na solicitação",
+        "previewState": "Falha ao gerar estado de pré-visualização",
+        "startPreview": "Falha ao iniciar pré-visualização",
+        "addMapping": "Falha ao adicionar mapeamento",
+        "removeMapping": "Falha ao remover mapeamento de grupo"
+      }
+    },
+    "admin": {
+      "title": "Admin",
+      "subtitle": "Gerencie usuários e configurações de autenticação.",
+      "system": {
+        "title": "Sistema",
+        "subtitle": "Configurações de organização de arquivos, ingestão e manutenção."
+      },
+      "maintenance": {
+        "title": "Manutenção",
+        "subtitle": "Gerencie tarefas em segundo plano, índices do sistema e operações de manutenção.",
+        "importGroup": "Importar",
+        "recommendationsGroup": "Recomendações",
+        "achievementsGroup": "Conquistas",
+        "updatesGroup": "Atualizações",
+        "importFromBooklore": "Importar do Booklore",
+        "bookloreImportConfigured": "Importação do Booklore configurada",
+        "migrationRunning": "Migração em andamento",
+        "migrationCompleted": "Migração concluída",
+        "migrationFailed": "Falha na migração",
+        "importDescription": "Importação única de livros, metadados e progresso de leitura de uma instalação anterior do Booklore.",
+        "configuredDescription": "Origem: {name}. Nenhuma migração executada ainda - continue a configuração para executar a importação.",
+        "runningDescription": "Estágio: {stage} - iniciado em {started}",
+        "completedDescription": "De {name} - concluída em {date}",
+        "migrationErrorGeneric": "Ocorreu um erro durante a migração.",
+        "stageInitializing": "inicializando",
+        "recently": "recentemente",
+        "getStarted": "Começar",
+        "continueSetup": "Continuar Configuração",
+        "viewDetails": "Ver Detalhes",
+        "refreshRecommendationIndex": "Atualizar índice de recomendações",
+        "refreshRecommendationHint": "Atualiza o mecanismo de recomendações com as alterações mais recentes da sua biblioteca. Este processo é executado em segundo plano.",
+        "booksQueuedForProcessing": "nenhum livro na fila de processamento | {count} livro na fila de processamento | {count} livros na fila de processamento",
+        "run": "Executar",
+        "running": "Executando...",
+        "backfillAchievements": "Preenchimento retroativo de conquistas",
+        "backfillAchievementsHint": "Reavaliar conquistas para todos os usuários.",
+        "backfillResult": "Processados {users} usuários; concedidos {awards} prêmios.",
+        "runBackfill": "Executar Preenchimento Retroativo",
+        "checkForUpdates": "Verificar atualizações",
+        "checkForUpdatesHint": "Verifica automaticamente o GitHub por uma nova versão na inicialização e mostra um indicador na barra lateral quando uma estiver disponível.",
+        "updateChecksEnabled": "Verificação de atualizações ativada",
+        "updateChecksDisabled": "Verificação de atualizações desativada",
+        "updateSettingFailed": "Falha ao atualizar configuração",
+        "booksQueuedForEmbedding": "nenhum livro na fila de incorporação | {count} livro na fila de incorporação | {count} livros na fila de incorporação",
+        "failed": "Falhou",
+        "unknownError": "Erro desconhecido",
+        "rebuildEmbeddingsFailed": "Falha ao reconstruir incorporações: {error}",
+        "achievementBackfillConfirm": "Executar o preenchimento retroativo de conquistas para todas as conquistas em todos os usuários? Isso pode demorar um pouco.",
+        "achievementBackfillComplete": "Preenchimento retroativo de conquistas concluído: {count} prêmios concedidos",
+        "backfillRunFailed": "Falha ao executar preenchimento retroativo",
+        "achievementBackfillFailed": "Falha ao executar preenchimento retroativo de conquistas: {error}",
+        "uploadsGroup": "Uploads",
+        "maxUploadSize": "Limite máximo de tamanho de arquivo de upload",
+        "maxUploadSizeHint": "Configure o limite de tamanho máximo para uploads de arquivos em todo o sistema.",
+        "save": "Salvar",
+        "uploadSizeInvalid": "O limite de tamanho de upload deve ser maior que 0",
+        "uploadSizeUpdated": "Limite de tamanho de upload atualizado"
+      },
+      "migration": {
+        "title": "Migração",
+        "subtitle": "Importação única do Booklore: conecte a origem, mapeie usuários, teste, inicie a migração e exporte um relatório.",
+        "progress": "Progresso",
+        "stepSourceConnection": "Conexão de Origem",
+        "stepUserPathMapping": "Mapeamento de Usuário e Caminho",
+        "stepDryRun": "Teste (Dry-Run)",
+        "stepDryRunTitle": "Teste (Dry Run)",
+        "stepRunMigration": "Executar Migração",
+        "stepReport": "Relatório",
+        "stepReportTitle": "Relatório de Migração",
+        "subtitleSource": "Configure a conexão do banco de dados com a sua instância Booklore de origem.",
+        "subtitleMappings": "Mapeie usuários de origem para usuários de destino e traduza os caminhos dos arquivos.",
+        "subtitleDryRun": "Pré-visualize o que será importado antes de executar a migração definitiva.",
+        "subtitleRun": "Inicie a importação definitiva e monitore seu progresso.",
+        "subtitleReport": "Revise o que foi importado e exporte um relatório detalhado.",
+        "continueToMappings": "Continuar para Mapeamentos",
+        "continueToDryRun": "Continuar para o Teste",
+        "continueToMigration": "Continuar para Migração",
+        "viewReport": "Ver Relatório",
+        "badgeValidated": "Validado",
+        "badgeSaved": "Salvo",
+        "badgeUpToDate": "Atualizado",
+        "badgeCompleted": "Concluído",
+        "badgeRunning": "Executando",
+        "badgeFailed": "Falhou",
+        "mediaPathRequired": "Obrigatório para migração de capas de livros.",
+        "mediaPathAbsolute": "Use um caminho absoluto (exemplo: /books). Caminhos relativos não são suportados.",
+        "mediaPathConfigured": "Caminho de importação de capa configurado. Use Testar Conexão para verificar o acesso e a estrutura de pastas de imagens do Booklore.",
+        "issueSaveSource": "Salvar configurações de conexão de origem",
+        "issueValidateSource": "Validar conexão de origem",
+        "issueSaveMappings": "Salvar mapeamentos de usuário e caminho",
+        "issueSavePathMappings": "Salvar mapeamentos de caminho para validá-los",
+        "issueFreshDryRun": "Executar um novo teste",
+        "issueResolveDuplicates": "Resolver correspondências duplicadas de livros de destino no teste",
+        "issueWaitActiveRun": "Aguardar a execução ativa terminar",
+        "sourceRecordId": "ID do registro de origem #{id}",
+        "byAuthorWithId": "por {author} (ID: {id})",
+        "filePathWithId": "{path} (ID: {id})",
+        "bookloreSourceId": "ID de origem Booklore: {id}",
+        "libraryBookNum": "Livro da biblioteca #{id}",
+        "errorInitialize": "Falha ao inicializar configurações de migração",
+        "errorLoadSourceTypes": "Falha ao carregar tipos de origem de migração suportados",
+        "errorLoadTargetUsers": "Falha ao carregar usuários de destino",
+        "errorLoadLibraryFolders": "Falha ao carregar pastas da biblioteca de destino",
+        "noSourceUsersReturned": "Nenhum usuário de origem foi retornado",
+        "userMappingSuggestionsLoaded": "Sugestões de mapeamento de usuário carregadas",
+        "errorLoadSuggestions": "Falha ao carregar sugestões de mapeamento de usuário",
+        "requiredFields": "Host, usuário, banco de dados e nome de origem são obrigatórios",
+        "connectionTestPassedWithWarnings": "Teste de conexão concluído com avisos",
+        "connectionTestPassedWithCount": "Teste de conexão concluído com {count} aviso(s). Primeiro: {first}",
+        "connectionTestPassed": "Teste de conexão aprovado",
+        "connectionOkMissingTables": "Conexão ok, mas {count} tabela(s) obrigatória(s) estão ausentes",
+        "cannotTestMediaPathActiveRun": "Não é possível testar o caminho de mídia enquanto uma execução estiver ativa",
+        "mediaRootPathRequiredCover": "Caminho Raiz de Mídia é obrigatório para importação de capa.",
+        "useAbsolutePath": "Use um caminho absoluto (por exemplo: /books).",
+        "mediaPathVerified": "Caminho de mídia verificado.",
+        "mediaPathValidReadable": "O caminho de mídia é válido e legível",
+        "mediaPathValidationFailed": "A validação do caminho de mídia falhou.",
+        "connectionFailedBeforeMediaPath": "O teste de conexão falhou antes que a validação do caminho de mídia pudesse ser concluída.",
+        "cannotModifySourceActiveRun": "Não é possível modificar a origem enquanto uma execução estiver ativa",
+        "sourceSavedValidatedWarnings": "Origem salva e validada com {count} aviso(s)",
+        "sourceSavedValidated": "Origem salva e validada",
+        "errorSaveValidateSource": "Falha ao salvar ou validar origem",
+        "cannotSaveMappingsActiveRun": "Não é possível salvar mapeamentos enquanto uma execução estiver ativa",
+        "saveSourceFirst": "Salvar origem primeiro",
+        "mapAtLeastOneUser": "Mapeie pelo menos um usuário de origem para um usuário de destino",
+        "mapEveryUser": "Mapeie todos os usuários de origem antes de salvar",
+        "pathValidationFailedProfileSaved": "A validação do caminho falhou, mas o perfil ainda será salvo",
+        "mappingsSaved": "Mapeamentos salvos",
+        "errorSaveMappings": "Falha ao salvar mapeamentos",
+        "cannotRunDryRunActiveRun": "Não é possível executar o teste enquanto uma execução estiver ativa",
+        "saveMappingsFirst": "Salvar mapeamentos primeiro",
+        "dryRunCompleted": "Teste concluído: {matched} correspondências, {unresolved} não resolvidos",
+        "dryRunFailed": "Falha no teste",
+        "selectSourceForAllGroups": "Selecione um livro de origem para todos os {count} grupos duplicados",
+        "duplicatesResolved": "Correspondências duplicadas resolvidas",
+        "errorResolveDuplicates": "Falha ao resolver duplicatas",
+        "preflightNotReady": "Pré-verificação de migração não pronta",
+        "runDryRunFirst": "Execute o teste primeiro",
+        "runStarted": "Execução de migração iniciada",
+        "errorStartMigration": "Falha ao iniciar migração",
+        "runCancelled": "Execução de migração cancelada",
+        "errorCancelMigration": "Falha ao cancelar migração",
+        "runRetried": "Execução de migração repetida - retomando do último estágio concluído",
+        "errorRetryMigration": "Falha ao repetir migração",
+        "errorLoadRunProgress": "Falha ao carregar progresso da execução",
+        "startMigrationFirst": "Inicie a migração primeiro",
+        "reportRefreshed": "Relatório de execução atualizado",
+        "errorLoadReport": "Falha ao carregar relatório de execução",
+        "reportExported": "Relatório exportado como {format}",
+        "errorExportReport": "Falha ao exportar relatório de migração",
+        "reasonNoTitleAuthorMatch": "Nenhum livro correspondente encontrado por título ou autor",
+        "reasonNoFilePathMatch": "O caminho do arquivo não corresponde a nenhum livro nesta biblioteca",
+        "reasonNoFileHashMatch": "O hash do arquivo não corresponde a nenhum livro nesta biblioteca",
+        "reasonNoIsbnMatch": "O ISBN não corresponde a nenhum livro nesta biblioteca",
+        "reasonInsufficientSourceData": "Metadados insuficientes para tentar a correspondência",
+        "reasonAmbiguousIsbnMatch": "Múltiplos livros correspondem ao mesmo ISBN",
+        "reasonAmbiguousFileHashMatch": "Múltiplos livros correspondem ao mesmo hash de arquivo",
+        "reasonAmbiguousFilePathMatch": "Múltiplos livros correspondem ao mesmo caminho de arquivo",
+        "reasonAmbiguousTitleAuthorMatch": "Múltiplos livros correspondem ao mesmo título e autor",
+        "reasonUnknown": "Não foi possível determinar o motivo",
+        "strategyIsbn": "Correspondido por ISBN",
+        "strategyFileHash": "Correspondido por hash de arquivo",
+        "strategyPathMapping": "Correspondido por caminho de arquivo mapeado",
+        "strategyTitleAuthor": "Correspondido por título e autor",
+        "strategyUnavailable": "Estratégia de correspondência indisponível",
+        "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {bookmarks} favoritos, {annotations} anotações, {collections} entradas de coleção",
+        "connErrorUnreachable": "Não foi possível acessar o servidor de banco de dados. Verifique o host e a porta.",
+        "connErrorAuth": "Falha na autenticação. Verifique o nome de usuário e a senha.",
+        "connErrorUnknownDatabase": "Banco de dados não encontrado. Verifique o nome do banco de dados.",
+        "connErrorTimeout": "A conexão expirou. Verifique as configurações de host e firewall.",
+        "connErrorGeneric": "O teste de conexão falhou",
+        "sourceType": "Tipo de Origem",
+        "sourceName": "Nome de Origem",
+        "host": "Host",
+        "port": "Porta",
+        "user": "Usuário",
+        "password": "Senha",
+        "passwordSavedPlaceholder": "Salvo - deixe inalterado",
+        "passwordEmptyPlaceholder": "Nenhuma senha definida",
+        "database": "Banco de Dados",
+        "mediaRootPath": "Caminho Raiz de Mídia",
+        "pathOk": "Caminho OK",
+        "pathIssue": "Problema no Caminho",
+        "testPath": "Testar Caminho",
+        "useTls": "Usar TLS/SSL",
+        "testConnection": "Testar Conexão",
+        "saveAndValidate": "Salvar e Validar",
+        "sourceValidatedWithWarnings": "Origem validada com avisos",
+        "lastValidationSnapshot": "Último instantâneo de validação",
+        "sourceVersion": "Versão de origem: {version}",
+        "unknown": "Desconhecido",
+        "missingRequiredTables": "Tabelas obrigatórias ausentes: {tables}",
+        "suggestionsAutoLoad": "As sugestões de usuário são carregadas automaticamente após a validação da origem.",
+        "refresh": "Atualizar",
+        "sourceUser": "Usuário de Origem",
+        "targetUser": "Usuário de Destino",
+        "noSourceUsersLoaded": "Nenhum usuário de origem carregado ainda.",
+        "noActiveTargetUsers": "Nenhum usuário de destino ativo encontrado. Crie ou reative um usuário BookOrbit antes de mapear.",
+        "pathPrefixMappings": "Mapeamentos de Prefixo de Caminho",
+        "addMapping": "Adicionar Mapeamento",
+        "pathMappingsHelp1": "Os mapeamentos de caminho traduzem os caminhos dos arquivos de origem para os caminhos de destino, para que os livros possam ser correspondidos pelo local do arquivo. Por exemplo, se a sua biblioteca Booklore armazenou arquivos em",
+        "pathMappingsHelp2": "e os mesmos arquivos agora estão em",
+        "pathMappingsHelp3": ", adicione esse mapeamento aqui. Livros também são correspondidos por ISBN, hash de arquivo e título/autor independentemente dos mapeamentos de caminho - o mapeamento de caminho é apenas uma das quatro estratégias e não limita quais livros de origem são incluídos na migração.",
+        "noPrefixesFound": "Nenhum prefixo encontrado - valide a origem primeiro",
+        "selectSourcePrefix": "Selecione o prefixo de origem...",
+        "selectTargetFolder": "Selecione a pasta de destino...",
+        "remove": "Remover",
+        "pathValidation": "Validação de caminho",
+        "pathValidationMapped": "{mapped} de {total} livros de origem têm um caminho mapeado",
+        "pathValidationUnmatched": "{count} caminhos mapeados não encontrados no disco - esses livros recorrerão à correspondência de ISBN / título",
+        "pathValidationAllMatched": "Todos os {count} caminhos mapeados encontrados no disco",
+        "saveMappings": "Salvar Mapeamentos",
+        "runDryRun": "Executar Teste",
+        "matched": "Correspondidos:",
+        "unresolved": "Não resolvidos:",
+        "duplicateMatches": "Correspondências duplicadas:",
+        "unresolvedSummary": "Resumo de não resolvidos",
+        "resolveDuplicateMatches": "Resolver correspondências de destino duplicadas",
+        "resolveDuplicateHint": "Para cada livro de destino, escolha um livro de origem para manter. Opções recomendadas são pré-selecionadas quando há uma única correspondência mais forte.",
+        "remainingGroups": "Grupos restantes:",
+        "ofCount": "de {count}",
+        "targetBookNum": "Livro de destino #{id}",
+        "recommended": "Recomendado",
+        "resolveDuplicatesButton": "Resolver {count} duplicata | Resolver {count} duplicata | Resolver {count} duplicatas",
+        "preflightChecks": "Verificações de pré-voo",
+        "allChecksPassed": "Todas as verificações aprovadas - pronto para migrar",
+        "checkSourceValidated": "Origem validada",
+        "checkSaveValidateSource": "Salvar e validar conexão de origem",
+        "checkValidateSource": "Validar conexão de origem",
+        "checkMappingsSaved": "Mapeamentos salvos",
+        "checkSaveMappings": "Salvar mapeamentos de usuário e caminho",
+        "checkPathMappingsValidated": "Mapeamentos de caminho validados",
+        "checkSavePathMappings": "Salvar mapeamentos de caminho para validá-los",
+        "checkDryRunUpToDate": "Teste está atualizado",
+        "checkFreshDryRun": "Executar um novo teste",
+        "startConfirmPrompt": "Isso iniciará a migração definitiva. Tem certeza?",
+        "confirmStart": "Confirmar Início",
+        "startMigration": "Iniciar Migração",
+        "cancelRun": "Cancelar Execução",
+        "refreshStatus": "Atualizar Status",
+        "statusPollingStopped": "A sondagem de status parou devido a um erro.",
+        "retry": "Tentar novamente",
+        "stageLabel": "Estágio: {stage}",
+        "stageInitializing": "inicializando",
+        "endedLabel": "Terminou em {date}",
+        "stageCompleted": "Concluído",
+        "stageInit": "Inicializando",
+        "stageSharedOverlays": "Importando metadados",
+        "stageBookCovers": "Importando capas",
+        "stageUserState": "Importando dados do usuário",
+        "noRunYet": "Nenhuma execução de migração ainda. Conclua as etapas acima para iniciar.",
+        "runNum": "Execução #{id}",
+        "notStarted": "Não iniciada",
+        "reloadReport": "Recarregar Relatório",
+        "loadFullReport": "Carregar Relatório Completo",
+        "exportJson": "Exportar JSON",
+        "exportCsv": "Exportar CSV",
+        "migrationFailed": "Falha na migração",
+        "retryFromLastStage": "Tentar novamente a partir do último estágio concluído",
+        "booksCard": "Livros",
+        "metadataOverlaysApplied": "Sobreposições de metadados aplicadas",
+        "authorMappingsReplaced": "Mapeamentos de autor substituídos",
+        "narratorMappingsReplaced": "Mapeamentos de narrador substituídos",
+        "genreMappingsReplaced": "Mapeamentos de gênero substituídos",
+        "tagMappingsReplaced": "Mapeamentos de tag substituídos",
+        "coversImported": "Capas importadas",
+        "coverImportSkipped": "Importação de capa ignorada - o caminho raiz de mídia não está configurado na origem",
+        "couldNotMatch": "Não foi possível corresponder",
+        "userDataCard": "Dados do Usuário",
+        "readingStatuses": "Status de leitura",
+        "readingProgressEntries": "Entradas de progresso de leitura",
+        "audiobookProgressEntries": "Entradas de progresso de audiobook",
+        "bookmarksLabel": "Favoritos",
+        "annotationsLabel": "Anotações",
+        "collectionEntries": "Entradas de coleção",
+        "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência do teste no relatório exportado.",
+        "completedNoIssues": "A migração foi concluída sem livros não resolvidos ou falhas.",
+        "matchedBooksHeading": "Livros correspondidos ({count})",
+        "matchedBooksHint": "Estas correspondências do teste foram usadas para decidir quais livros da biblioteca receberam dados importados.",
+        "sourceBookFallback": "Livro de origem {id}",
+        "libraryBookFallback": "Livro da biblioteca {id}",
+        "unresolvedBooksHeading": "Livros não resolvidos ({count})",
+        "unresolvedBooksHint": "Estes livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
+        "mappedUsersHeading": "Usuários mapeados ({count})",
+        "mappedUsersHint": "Os totais por usuário vêm da pré-visualização do teste armazenada em cache com o plano de migração.",
+        "coverImportsFailed": "{count} importação(ões) de capa falhou(aram). As linhas de falha detalhadas não são armazenadas.",
+        "backToSetup": "Voltar à Configuração"
+      },
+      "libraries": {
+        "title": "Bibliotecas",
+        "subtitle": "Gerencie suas bibliotecas de mídia e acione verificações de conteúdo.",
+        "scanAll": "Verificar Tudo",
+        "scanning": "Verificando...",
+        "addLibrary": "Adicionar Biblioteca",
+        "scan": "Verificar",
+        "editLibrary": "Editar biblioteca",
+        "refreshCovers": "Atualizar capas",
+        "syncMetadataToFiles": "Sincronizar metadados para arquivos",
+        "deleteLibrary": "Excluir biblioteca",
+        "bookCount": "nenhum livro | {count} livro | {count} livros",
+        "addedDate": "Adicionado em {date}",
+        "fileMode": "Modo de arquivo",
+        "folderMode": "Modo de pasta",
+        "folderCount": "nenhuma pasta | {count} pasta | {count} pastas",
+        "watching": "Monitorando",
+        "fileWrite": "Gravação de arquivo",
+        "fileRename": "Renomeação de arquivo",
+        "emptyTitle": "Nenhuma biblioteca ainda",
+        "emptyHint": "Adicione uma biblioteca para começar a organizar seus livros.",
+        "addFirstLibrary": "Adicionar sua primeira biblioteca",
+        "deleteConfirmTitle": "Excluir \"{name}\"?",
+        "deleteConfirmBody": "Isto removerá permanentemente todos os livros, metadados, progresso de leitura, favoritos e anotações nesta biblioteca. Isto não pode ser desfeito.",
+        "deleteConfirmTypeName": "Digite o nome da biblioteca para confirmar:",
+        "deleting": "Excluindo...",
+        "deleteLibraryButton": "Excluir Biblioteca",
+        "syncConfirmTitle": "Sincronizar metadados para os arquivos?",
+        "syncConfirmBodyPrefix": "Isso substituirá os metadados dentro de todos os arquivos suportados em",
+        "syncConfirmBodySuffix": "diretamente no disco. Isto não pode ser desfeito.",
+        "syncFiles": "Sincronizar arquivos",
+        "metadataSynced": "Metadados sincronizados com os arquivos de \"{name}\"",
+        "fileWriteNotEnabled": "A gravação de arquivo de metadados não está habilitada para esta biblioteca. Habilite-a nas configurações da biblioteca.",
+        "fileSyncFailed": "A sincronização de arquivos falhou para \"{name}\"",
+        "scanStarted": "Verificação iniciada para \"{name}\"",
+        "scanStartFailed": "Falha ao iniciar verificação para \"{name}\"",
+        "refreshCoversFailed": "Falha ao atualizar as capas de \"{name}\"",
+        "scanStartedAll": "Verificação iniciada para todas as bibliotecas",
+        "librariesFailedToStart": "nenhuma biblioteca falhou ao iniciar | {count} biblioteca falhou ao iniciar | {count} bibliotecas falharam ao iniciar",
+        "scansStartFailed": "Falha ao iniciar verificações",
+        "libraryCreated": "Biblioteca \"{name}\" criada",
+        "libraryUpdated": "Biblioteca \"{name}\" atualizada",
+        "libraryDeleted": "\"{name}\" excluída",
+        "deleteFailed": "Falha ao excluir biblioteca",
+        "scanningProgress": "Verificando {pct}% ({processed}/{total})",
+        "scanDone": "Concluído - {added} adicionados, {updated} atualizados",
+        "scanFailedWithError": "Falhou: {error}",
+        "scanFailed": "A verificação falhou",
+        "refreshingCovers": "Atualizando capas {pct}% ({processed}/{total})",
+        "coversRefreshed": "Capas atualizadas ({count} processadas)"
+      },
+      "authorEnrichment": {
+        "configuration": "Configuração",
+        "saving": "Salvando...",
+        "running": "Executando...",
+        "runEligibleShort": "Executar p/ elegíveis",
+        "runAllShort": "Executar p/ todos",
+        "enableTitle": "Habilitar enriquecimento automático de autor",
+        "enableHint": "Busca automaticamente biografias e fotos de perfil de autores quando livros são adicionados ou atualizados.",
+        "updateStrategyTitle": "Estratégia de atualização",
+        "updateStrategyHint": "O que fazer quando um autor já tem uma biografia ou foto.",
+        "writeModeMissingOnly": "Apenas preencher dados ausentes (recomendado)",
+        "writeModeAlwaysRefetch": "Sempre atualizar dados existentes",
+        "triggerOnImportTitle": "Acionar na importação",
+        "triggerOnImportHint": "Colocar autores na fila para enriquecimento quando livros são adicionados pela primeira vez a uma biblioteca.",
+        "eligibilityTitle": "Condições de elegibilidade",
+        "eligibilityHint": "Um autor é elegível se corresponder a qualquer condição habilitada.",
+        "neverEnrichedTitle": "Nunca enriquecido",
+        "neverEnrichedHint": "Enriquecer autores que nunca tiveram um enriquecimento bem-sucedido.",
+        "missingBioTitle": "Biografia ausente",
+        "missingBioHint": "Enriquecer se o autor não tiver biografia.",
+        "missingPhotoTitle": "Foto ausente",
+        "missingPhotoHint": "Enriquecer se o autor não tiver foto de perfil.",
+        "runForEligibleAuthors": "Executar para autores elegíveis",
+        "eligibleCount": "~{count} elegíveis",
+        "runForAllAuthors": "Executar para todos os autores",
+        "saved": "Configurações de enriquecimento de autor salvas",
+        "saveFailed": "Falha ao salvar as configurações de enriquecimento de autor",
+        "noEligibleAuthors": "Nenhum autor elegível encontrado",
+        "noAuthorsToEnrich": "Nenhum autor para enriquecer",
+        "queueFailed": "Falha ao enfileirar preenchimento retroativo de autor"
+      },
+      "scoreWeights": {
+        "groupLabel": "Pesos de Pontuação",
+        "assignHintPrefix": "Atribua um peso a cada campo. Peso total:",
+        "areYouSure": "Você tem certeza?",
+        "resetToDefaultsButton": "Redefinir para os padrões",
+        "recalculateAll": "Recalcular tudo",
+        "confirmReset": "Confirmar redefinição",
+        "reset": "Redefinir",
+        "recalculate": "Recalcular",
+        "subtotal": "subtotal: {count}",
+        "savedRecalculating": "Pesos de pontuação salvos. Recalculando pontuações da biblioteca...",
+        "saveFailed": "Falha ao salvar pesos de pontuação",
+        "recalcStarted": "O recálculo de pontuação começou em segundo plano",
+        "recalcFailed": "O recálculo falhou",
+        "resetToDefaults": "Pesos redefinidos para os padrões. Salve para aplicar."
+      },
+      "tabs": {
+        "users": "Usuários",
+        "magic-links": "Links Mágicos",
+        "oidc": "OIDC / SSO"
+      }
+    },
+    "common": {
+      "nav": {
+        "libraries": "Bibliotecas",
+        "display": "Exibição",
+        "reader": "Leitor",
+        "metadata": "Metadados",
+        "email": "E-mail",
+        "opds": "OPDS",
+        "kobo": "Kobo",
+        "koreader": "KOReader",
+        "hardcover": "Hardcover",
+        "admin": "Admin",
+        "system": "Sistema",
+        "account": "Conta"
+      }
+    },
+    "metadata": {
+      "title": "Metadados",
+      "noPermission": "Você não tem permissão para gerenciar as configurações de metadados.",
+      "fields": {
+        "title": "Título",
+        "subtitle": "Subtítulo",
+        "description": "Descrição",
+        "cover": "Capa",
+        "authors": "Autores",
+        "publisher": "Editora",
+        "publishedYear": "Ano de publicação",
+        "language": "Idioma",
+        "pageCount": "Número de páginas",
+        "communityRating": "Avaliação da comunidade",
+        "seriesName": "Nome da série",
+        "seriesIndex": "Índice da série",
+        "genres": "Gêneros",
+        "narrators": "Narradores",
+        "duration": "Duração",
+        "abridged": "Resumido"
+      },
+      "mergeStrategy": {
+        "fillMissing": {
+          "label": "Preencher ausentes",
+          "description": "Apenas gravar se o campo estiver vazio"
+        },
+        "overwriteIfProvided": {
+          "label": "Sobrescrever se fornecido",
+          "description": "Gravar se o provedor retornou um valor"
+        },
+        "overwrite": {
+          "label": "Sempre sobrescrever",
+          "description": "Sempre substituir o valor existente"
+        }
+      },
+      "autoFetch": {
+        "globalSettings": "Configurações Globais",
+        "perLibraryOverrides": "Substituições por Biblioteca",
+        "saving": "Salvando...",
+        "running": "Executando...",
+        "runNow": "Executar agora",
+        "runForEligible": "Executar para livros elegíveis",
+        "enable": {
+          "label": "Habilitar busca automática",
+          "hint": "Busca automaticamente metadados para livros elegíveis."
+        },
+        "triggerOnImport": {
+          "label": "Acionar na importação",
+          "hint": "Colocar livros elegíveis na fila quando são adicionados pela primeira vez a uma biblioteca."
+        },
+        "status": {
+          "inQueuePaused": "{count} na fila - pausado",
+          "remaining": "{count} restantes",
+          "eligible": "~{count} elegíveis"
+        },
+        "trigger": {
+          "queued": "Enfileirado {count} livro | Enfileirados {count} livros",
+          "noneFound": "Nenhum livro elegível encontrado"
+        },
+        "lastRun": {
+          "justNow": "agora mesmo",
+          "minutesAgo": "{count}m atrás",
+          "hoursAgo": "{count}h atrás",
+          "yesterday": "ontem",
+          "daysAgo": "{count} dias atrás",
+          "label": "Última execução: {when}",
+          "labelQueued": "Última execução: {when} - {count} livros enfileirados",
+          "labelNoneEligible": "Última execução: {when} - nenhum livro elegível"
+        },
+        "conditions": {
+          "title": "Condições de elegibilidade",
+          "hint": "Um livro é elegível se corresponder a qualquer condição habilitada.",
+          "noneEnabled": "Nenhuma condição habilitada",
+          "neverFetched": {
+            "label": "Nunca buscado",
+            "hint": "Buscar livros que nunca tiveram uma tentativa de busca de metadados.",
+            "summary": "Nunca buscado"
+          },
+          "scoreThreshold": {
+            "label": "Pontuação de metadados baixa",
+            "hint": "Buscar se a pontuação de metadados estiver abaixo de um limite.",
+            "scoreBelow": "Pontuação abaixo de",
+            "summary": "Pontuação < {threshold}"
+          },
+          "missingFields": {
+            "label": "Campos ausentes",
+            "hint": "Buscar se qualquer um dos campos selecionados estiver vazio.",
+            "summary": "{count} campo ausente | {count} campos ausentes"
+          }
+        },
+        "library": {
+          "inheritingGlobal": "Herdando padrões globais",
+          "inheritFromGlobal": "Herdar do global",
+          "usingGlobalDefaults": "Usando padrões globais.",
+          "saveOverride": "Salvar substituição"
+        }
+      },
+      "providers": {
+        "availableSources": "Fontes Disponíveis",
+        "saveChanges": "Salvar Alterações",
+        "test": "Testar",
+        "testing": "Testando...",
+        "enabled": "Habilitado",
+        "retryIn": "Tentar novamente em {duration}",
+        "runTestBeforeEnabling": "Execute o Teste antes de habilitar",
+        "hardcoverEnableHint": "Execute o Teste com o token atual para desbloquear a chave de habilitação.",
+        "badge": {
+          "setupRequired": "Configuração Necessária",
+          "throttled": "Limitado",
+          "ready": "Pronto"
+        },
+        "fields": {
+          "apiKey": "Chave de API",
+          "region": "Região",
+          "cookie": "Cookie",
+          "coverResolution": "Resolução da Capa",
+          "country": "País",
+          "language": "Idioma",
+          "ttbKey": "Chave TTB"
+        },
+        "helpers": {
+          "googleApiKey": "Chave da API do Google Books do Google Cloud."
+        },
+        "hints": {
+          "google": "Ampla cobertura do índice de livros do Google. O Google Books agora exige uma chave de API antes que este provedor possa ser ativado.",
+          "amazon": "O cookie de sessão é recomendado. Cole apenas o valor do cookie (sem \"Cookie:\").",
+          "goodreads": "A maior comunidade de leitura da web. Nenhuma configuração necessária.",
+          "hardcover": "Uma alternativa moderna ao Goodreads. Token de hardcover.app/account/api. O prefixo \"Bearer \" é opcional.",
+          "openLibrary": "O catálogo de livros gratuito do Internet Archive. Nenhuma configuração necessária.",
+          "itunes": "Catálogo de livros digitais da Apple. Escolha se deseja buscar capas em alta resolução ou padrão.",
+          "kobo": "Busca informações nas páginas públicas de livros da Kobo. O país e o idioma devem corresponder aos caminhos de URL da Kobo; a proteção contra bots pode bloquear as solicitações.",
+          "audible": "Extrai metadados de audiobooks do Audible. Nenhuma configuração adicional é necessária.",
+          "audnexus": "Metadados de audiobook impulsionados pela comunidade. Nenhuma configuração necessária.",
+          "comicvine": "Metadados de quadrinhos do ComicVine. Uma chave de API gratuita é necessária em comicvine.gamespot.com.",
+          "ranobedb": "Metadados de light novels japonesas do RanobeDB. Nenhuma configuração necessária.",
+          "lubimyczytac": "Catálogo de livros polonês (lubimyczytac.pl). Busca informações nas páginas públicas de livros. Nenhuma configuração necessária.",
+          "aladin": "Metadados de livros coreanos da Aladin (알라딘). É necessária uma Chave TTB de aladin.co.kr."
+        },
+        "blocked": {
+          "google": "O Google Books requer uma chave de API antes de ser habilitado",
+          "hardcover": "O Hardcover requer uma chave de API antes de ser habilitado",
+          "hardcoverTest": "O token do Hardcover deve passar no Teste antes que possa ser habilitado",
+          "comicvine": "O ComicVine requer uma chave de API antes de ser habilitado",
+          "aladin": "A Aladin requer uma Chave TTB antes de ser habilitada"
+        }
+      },
+      "fieldRules": {
+        "clearAllProviders": "Limpar Todos os Provedores",
+        "clearAll": "Limpar Tudo",
+        "resetToDefault": "Redefinir para Padrão",
+        "reset": "Redefinir",
+        "dragProvidersHint": "Arraste os provedores daqui para qualquer campo para adicioná-los",
+        "dragProviderHere": "arraste um provedor aqui",
+        "howItWorks": {
+          "title": "Como as Regras de Campo Funcionam",
+          "priorityOrder": {
+            "title": "Ordem de Prioridade",
+            "body": "Arraste os provedores na lista para reordená-los. O provedor mais ao topo que retornar um resultado será a fonte principal para aquele campo."
+          },
+          "mergeStrategy": {
+            "title": "Estratégia de Mesclagem",
+            "fillMissingTerm": "Preencher ausentes:",
+            "fillMissingBody": "Apenas gravar se o valor atual estiver vazio.",
+            "overwriteTerm": "Sobrescrever:",
+            "overwriteBody": "Substituir sempre que um provedor tiver dados."
+          }
+        },
+        "libraryOverrides": {
+          "title": "Substituições da Biblioteca",
+          "hint": "Expanda uma biblioteca para personalizar campos individuais. Campos não substituídos herdam os padrões globais."
+        },
+        "global": {
+          "title": "Padrões Globais",
+          "hint": "Regras padrão aplicadas a todas as bibliotecas. Substitua por biblioteca abaixo.",
+          "saveDefaults": "Salvar Padrões",
+          "clearAllConfirm": "Remover todos os provedores ativos de todos os campos? Isso será salvo imediatamente e não pode ser desfeito.",
+          "resetConfirm": "Redefinir todas as regras de campo globais para os padrões do sistema? Isso substituirá sua configuração atual."
+        },
+        "advanced": {
+          "title": "Comportamento Avançado de Busca",
+          "combineGenres": {
+            "label": "Combinar gêneros de todos os provedores selecionados",
+            "hint": "Coletar e desduplicar gêneros de todos os provedores atribuídos ao campo Gêneros, em vez de parar no primeiro resultado."
+          },
+          "storeProviderIds": {
+            "label": "Armazenar IDs de provedores nos livros",
+            "hint": "Ao buscar metadados, salvar os IDs de provedor retornados (ISBN, ASIN, ID Goodreads, etc.) no registro do livro para pesquisas futuras mais precisas."
+          }
+        },
+        "library": {
+          "primary": "Principal:",
+          "overrideCount": "{count} Substituição | {count} Substituições",
+          "unsavedSuffix": "(não salvo)",
+          "unsavedChanges": "Alterações não salvas",
+          "globalDefaults": "Padrões Globais",
+          "overriding": "Substituindo: {fields}",
+          "inheritingAll": "Herdando todas as regras de metadados globais",
+          "subHint": "Campos não substituídos herdam os padrões globais.",
+          "resetTooltip": "Remover todas as substituições e herdar padrões globais",
+          "clearAllConfirm": "Remover todos os provedores ativos de todos os campos em \"{library}\"?",
+          "resetConfirm": "Redefinir \"{library}\" para os padrões globais? Todas as substituições da biblioteca serão removidas."
+        },
+        "groups": {
+          "core": "Núcleo",
+          "contributors": "Contribuidores",
+          "publication": "Publicação",
+          "series": "Série",
+          "classification": "Classificação",
+          "audiobook": "Audiobook"
+        },
+        "groupSummary": {
+          "base": "{fields} campos · {enabled} habilitados",
+          "withOverrides": "{base} · {overrides} substituições"
+        },
+        "table": {
+          "field": "Campo",
+          "activeProviders": "Provedores Ativos (ordenados por prioridade)",
+          "mergeStrategy": "Estratégia de Mesclagem",
+          "status": "Status"
+        },
+        "field": {
+          "noProviders": "Habilitado, mas sem provedores",
+          "empty": "Vazio",
+          "config": "Config",
+          "custom": "Personalizado",
+          "default": "Padrão",
+          "resetToDefault": "Redefinir para o padrão"
+        },
+        "reservoir": {
+          "disabled": "{provider} - desativado",
+          "notConfigured": "{provider} - não configurado",
+          "dragToAssign": "Arraste para atribuir {provider} a um campo"
+        },
+        "sheet": {
+          "subtitle": "Toque nos provedores para atribuir, use setas para reordenar",
+          "enableField": "Habilitar este campo durante a atualização",
+          "providers": "Provedores",
+          "statusDisabled": "desativado",
+          "statusNotConfigured": "não configurado",
+          "done": "Concluído"
+        }
+      },
+      "genreBlocklist": {
+        "heading": "Exclusões Globais de Gênero",
+        "hint": "Valores exatos de gênero nesta lista são removidos dos resultados do provedor antes que os metadados sejam gravados.",
+        "saving": "Salvando",
+        "genreValueLabel": "Valor do gênero",
+        "addPlaceholder": "Adicione um valor de gênero, por exemplo Audiobook",
+        "duplicate": "Este gênero já está bloqueado.",
+        "add": "Adicionar",
+        "filterPlaceholder": "Filtrar lista de bloqueio",
+        "entryCount": "{count} entrada | {count} entradas",
+        "filteredCount": "{shown} de {total}",
+        "noFilterMatch": "Nenhum gênero bloqueado corresponde ao filtro atual.",
+        "emptyTitle": "Nenhum gênero bloqueado",
+        "emptyHint": "Adicione valores exatos como Audiobook ou Adulto para mantê-los fora dos metadados buscados.",
+        "removeLabel": "Remover {genre}"
+      },
+      "customFields": {
+        "label": "Rótulo",
+        "labelPlaceholder": "ex: Título Original",
+        "labelTooLong": "O rótulo deve ter 255 caracteres ou menos",
+        "labelDuplicate": "Um campo com este rótulo já existe",
+        "type": "Tipo",
+        "usage": "Usado por {count} livro | Usado por {count} livros",
+        "newField": {
+          "title": "Novo Campo",
+          "hint": "Defina um campo de metadados personalizado e escolha quais bibliotecas o usam."
+        },
+        "previewToggle": "Visualize como este campo aparece ao editar um livro",
+        "untitledField": "Campo sem título",
+        "addField": "Adicionar campo",
+        "fields": "Campos",
+        "fieldsHint": "Arraste para reordenar, editar rótulos, alternar bibliotecas ou arquivar campos que você não precisa mais.",
+        "searchPlaceholder": "Pesquisar campos",
+        "searchAriaLabel": "Pesquisar campos personalizados",
+        "emptyTitle": "Nenhum campo personalizado ainda",
+        "emptyHint": "Use o formulário acima para definir seu primeiro campo de metadados personalizado.",
+        "noMatchTitle": "Nenhum campo corresponde a \"{query}\"",
+        "noMatchHint": "Tente um rótulo, chave ou tipo diferente.",
+        "clearSearchToReorder": "Limpar pesquisa para reordenar",
+        "dragToReorder": "Arraste para reordenar",
+        "dragToReorderField": "Arraste para reordenar campo",
+        "unsaved": "Não salvo",
+        "archive": "Arquivar",
+        "archivedFields": "Campos Arquivados",
+        "archivedSummary": "{count} campo arquivado - restaurar ou excluir permanentemente. | {count} campos arquivados - restaurar ou excluir permanentemente.",
+        "archivedAt": "Arquivado em {when}",
+        "restore": "Restaurar",
+        "deleteForever": "Excluir permanentemente",
+        "deleteDialog": {
+          "title": "Excluir campo permanentemente",
+          "bodyBefore": "Isso excluirá permanentemente",
+          "bodyMiddle": "e removerá seus valores armazenados de",
+          "bodyAfter": ". Isso não pode ser desfeito.",
+          "confirmBefore": "Digite",
+          "confirmAfter": "para confirmar",
+          "confirmPlaceholder": "Digite o rótulo do campo para confirmar"
+        },
+        "preview": "Pré-visualização",
+        "sampleValue": "Valor de exemplo",
+        "enabledLibraries": "Bibliotecas Habilitadas",
+        "countOf": "{selected} de {total}",
+        "selectAll": "Selecionar tudo",
+        "clear": "Limpar",
+        "noLibraries": "Nenhuma biblioteca disponível ainda.",
+        "allLibraries": "Todas as bibliotecas"
+      },
+      "tabs": {
+        "providers": "Provedores",
+        "field-rules": "Regras de Campo",
+        "custom-fields": "Campos Personalizados",
+        "genre-blocklist": "Lista de Bloqueio de Gênero",
+        "score": "Pontuação",
+        "auto-fetch": "Livros",
+        "authors": "Autores"
+      },
+      "tabTitles": {
+        "providers": "Provedores",
+        "field-rules": "Regras em Nível de Campo",
+        "custom-fields": "Metadados Personalizados",
+        "genre-blocklist": "Lista de Bloqueio de Gênero",
+        "score": "Pontuação de Confiança",
+        "auto-fetch": "Busca Automática de Livro",
+        "authors": "Busca Automática de Autor"
+      },
+      "tabSubtitles": {
+        "providers": "Habilite fontes de metadados externas e configure suas credenciais.",
+        "field-rules": "Controle qual provedor fornece cada campo de metadados e como os valores são mesclados em suas bibliotecas.",
+        "custom-fields": "Defina campos de metadados personalizados e escolha quais bibliotecas os utilizam.",
+        "genre-blocklist": "Impeça que valores de gênero indesejados do provedor sejam gravados nos livros.",
+        "score": "Atribua pesos aos campos de metadados para calcular o quanto confiar nos resultados buscados.",
+        "auto-fetch": "Busque automaticamente capas, descrições e outros detalhes quando novos livros forem adicionados à sua biblioteca.",
+        "authors": "Busque automaticamente biografias e fotos de perfil quando novos autores aparecerem na sua biblioteca."
+      }
+    },
+    "reader": {
+      "resetToDefaults": "Redefinir para padrões",
+      "all": {
+        "title": "Leitor",
+        "subtitle": "Configure padrões para todos os modos de leitura em um só lugar."
+      },
+      "general": {
+        "title": "Leitura",
+        "subtitle": "Comportamento geral que se aplica a todos os tipos de leitor.",
+        "storageLabel": "Onde salvar as preferências do leitor",
+        "deviceOnly": "Apenas neste dispositivo",
+        "deviceOnlyHint": "As preferências permanecem no seu navegador. Ideal se você sempre lê neste dispositivo ou deseja configurações diferentes por dispositivo.",
+        "myAccount": "Minha conta",
+        "myAccountHint": "As preferências são salvas na sua conta. Ideal se você faz login de vários dispositivos e deseja uma experiência consistente em todos os lugares.",
+        "active": "Ativo",
+        "notAvailable": "Não disponível",
+        "demoCannotChangeStorage": "Conta restrita de demonstração não pode alterar o modo de armazenamento do leitor",
+        "preferencesSynced": "As preferências agora serão sincronizadas",
+        "preferencesLocal": "As preferências permanecerão neste dispositivo",
+        "storageUpdateFailed": "Falha ao atualizar o modo de armazenamento",
+        "storageUpdateError": "Ocorreu um erro ao atualizar o modo de armazenamento"
+      },
+      "ebook": {
+        "title": "Leitor de eBook",
+        "subtitle": "Configurações padrão aplicadas ao abrir arquivos EPUB, MOBI, FB2 e TXT.",
+        "newBooks": "Novos Livros",
+        "applySettings": "Aplicar minhas configurações a novos livros",
+        "applySettingsHint": "Quando desativado, os novos livros abrem com as fontes e o layout da própria editora. Suas configurações só se aplicam quando você altera algo no leitor.",
+        "layout": "Layout",
+        "readingFlow": "Fluxo de leitura",
+        "readingFlowHint": "Paginado vira as páginas; rolado flui continuamente",
+        "paginated": "Paginado",
+        "scrolled": "Rolagem",
+        "fixedLayoutSpread": "Páginas duplas em layout fixo",
+        "fixedLayoutSpreadHint": "Padrão para mangás, quadrinhos e EPUBs baseados em imagens",
+        "bookDefault": "Padrão do livro",
+        "singlePage": "Página única",
+        "columns": "Colunas",
+        "columnsHint": "Número de colunas de texto por página",
+        "theme": "Tema",
+        "darkMode": "Modo escuro",
+        "darkModeHint": "Usar a variante escura do tema selecionado",
+        "typography": "Tipografia",
+        "font": "Fonte",
+        "fontHint": "Tipo de letra usada para o corpo do texto",
+        "builtInFonts": "Fontes embutidas",
+        "yourFonts": "Suas Fontes",
+        "fontSize": "Tamanho da fonte",
+        "fontSizeHint": "Tamanho base do texto em pixels",
+        "lineHeight": "Altura da linha",
+        "lineHeightHint": "Espaçamento vertical entre as linhas",
+        "justify": "Justificar texto",
+        "justifyHint": "Alinhar texto a ambas as margens",
+        "hyphenation": "Hifenização",
+        "hyphenationHint": "Quebrar automaticamente palavras longas com hifens",
+        "advanced": "Avançado",
+        "maxContentWidth": "Largura máxima do conteúdo",
+        "maxContentWidthHint": "Largura máxima da área de texto em pixels",
+        "columnGap": "Espaçamento entre colunas",
+        "columnGapHint": "Preenchimento horizontal em cada lado da área de texto"
+      },
+      "pdf": {
+        "title": "Leitor de PDF",
+        "subtitle": "Configurações padrão aplicadas ao abrir arquivos PDF.",
+        "layout": "Layout",
+        "scrollMode": "Modo de rolagem",
+        "scrollModeHint": "A página vira uma de cada vez; contínuo rola por todas as páginas",
+        "page": "Página",
+        "scrolled": "Contínuo",
+        "pageSpread": "Páginas duplas",
+        "pageSpreadHint": "Qual número de página começa à direita na visualização de duas páginas",
+        "spreadNone": "Nenhum",
+        "spreadOdd": "Ímpar",
+        "spreadEven": "Par",
+        "zoom": "Zoom",
+        "defaultFit": "Ajuste padrão",
+        "defaultFitHint": "Como as páginas são dimensionadas quando um PDF é aberto",
+        "fitPage": "Ajustar à Página",
+        "fitWidth": "Ajustar à Largura",
+        "custom": "Personalizado",
+        "zoomLevel": "Nível de zoom",
+        "zoomLevelHint": "Fator de escala para modo de zoom personalizado"
+      },
+      "comics": {
+        "title": "Leitor de Quadrinhos",
+        "subtitle": "Configurações padrão aplicadas ao abrir arquivos CBZ, CBR e CB7.",
+        "view": "Visualização",
+        "readingMode": "Modo de leitura",
+        "readingModeHint": "Como as páginas são navegadas - use \"Infinito (sem espaços)\" para webtoons",
+        "paginated": "Paginado",
+        "infiniteSpaced": "Infinito (com espaços)",
+        "infiniteNoGaps": "Infinito (sem espaços)",
+        "pageView": "Visualização de página",
+        "pageViewHint": "Mostrar uma ou duas páginas lado a lado",
+        "single": "Única",
+        "twoPage": "Duas páginas",
+        "fitMode": "Modo de ajuste",
+        "fitModeHint": "Como as páginas são redimensionadas para caber na tela",
+        "fitPage": "Página",
+        "fitWidth": "Largura",
+        "fitHeight": "Altura",
+        "fitActual": "Real",
+        "readingDirection": "Direção de leitura",
+        "readingDirectionHint": "Esquerda para direita para quadrinhos ocidentais; direita para esquerda para mangás",
+        "ltr": "E para D",
+        "rtl": "D para E",
+        "spreadAlignment": "Alinhamento de página dupla",
+        "spreadAlignmentHint": "Deslocar pareamento em uma página após a capa para digitalizações com desvio de uma",
+        "alignmentNormal": "Normal",
+        "alignmentShifted": "Deslocado",
+        "widePageHandling": "Tratamento de páginas largas",
+        "widePageHandlingHint": "Auto mostra páginas largas sozinhas no modo paginado de duas páginas",
+        "widePageAuto": "Automático",
+        "widePageDisable": "Desativar",
+        "forceTwoPage": "Forçar duas páginas em telas pequenas",
+        "forceTwoPageHint": "Ignorar o fallback automático móvel quando o modo paginado de duas páginas for selecionado",
+        "off": "Desativado",
+        "on": "Ativado",
+        "display": "Exibição",
+        "backgroundColor": "Cor de fundo",
+        "backgroundColorHint": "Cor da tela atrás das páginas",
+        "bgBlack": "Preto",
+        "bgGray": "Cinza",
+        "bgWhite": "Branco"
+      },
+      "audio": {
+        "title": "Reprodutor de Audiobook",
+        "subtitle": "Configurações padrão aplicadas ao reproduzir M4B, MP3 e outros formatos de áudio.",
+        "playback": "Reprodução",
+        "playbackSpeed": "Velocidade de reprodução padrão",
+        "playbackSpeedHint": "Multiplicador de velocidade aplicado ao abrir um novo audiobook",
+        "volume": "Volume padrão",
+        "volumeHint": "Nível de volume inicial (0 a 100%)",
+        "skipControls": "Controles de salto",
+        "skipBack": "Duração do retrocesso",
+        "skipBackHint": "Segundos retrocedidos ao pressionar pular para trás",
+        "skipForward": "Duração do avanço",
+        "skipForwardHint": "Segundos avançados ao pressionar pular para frente"
+      },
+      "fonts": {
+        "title": "Fontes",
+        "subtitle": "Envie fontes personalizadas para uso no leitor de eBook.",
+        "uploadFonts": "Enviar Fontes",
+        "notAvailableDemo": "Não disponível para contas de demonstração",
+        "uploading": "Enviando...",
+        "dropFilesHere": "Solte os arquivos aqui",
+        "dragFontsPrefix": "Arraste arquivos de fonte aqui, ou",
+        "browse": "procurar",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - máximo 10 MB cada",
+        "yourFonts": "Suas Fontes",
+        "fontsUsed": "{count} / {max} usadas",
+        "noFontsYet": "Nenhuma fonte enviada ainda",
+        "noFontsHint": "Arraste um arquivo de fonte acima para começar.",
+        "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+        "pangram": "A rápida raposa marrom salta sobre o cão preguiçoso",
+        "renameFamily": "Renomear família",
+        "deleteFamily": "Excluir família",
+        "editVariant": "Editar peso/estilo",
+        "deleteVariant": "Excluir variante",
+        "styleNormal": "Normal",
+        "styleItalic": "Itálico",
+        "weightThin": "Fino",
+        "weightExtraLight": "Extra Leve",
+        "weightLight": "Leve",
+        "weightRegular": "Regular",
+        "weightMedium": "Médio",
+        "weightSemiBold": "Seminegrito",
+        "weightBold": "Negrito",
+        "weightExtraBold": "Extra Negrito",
+        "weightBlack": "Preto",
+        "renameFamilyFailed": "Falha ao renomear família de fontes",
+        "renamedTo": "Renomeado para \"{name}\"",
+        "updateVariantFailed": "Falha ao atualizar variante da fonte",
+        "deleteFontFailed": "Falha ao excluir fonte",
+        "deleteFamilyFailed": "Falha ao excluir família de fontes",
+        "demoCannotManage": "Conta restrita de demonstração não pode gerenciar fontes",
+        "fileAdded": "\"{name}\" adicionado",
+        "uploadFailed": "Falha no envio"
+      },
+      "bookDock": {
+        "title": "Book Dock",
+        "subtitle": "Configure como os arquivos são processados quando entram no Book Dock.",
+        "dropFolder": "Pasta de recepção",
+        "containerPath": "Caminho do contêiner",
+        "containerPathHint": "Copie ou mova arquivos de livro para esta pasta e eles serão automaticamente coletados e processados pelo Book Dock. Subdiretórios são suportados.",
+        "changePathPrefix": "Para alterar este caminho, defina",
+        "changePathMiddle": "no seu arquivo",
+        "changePathSuffix": ".",
+        "metadata": "Metadados",
+        "autoFetch": "Buscar metadados de provedores automaticamente",
+        "autoFetchHint": "Buscar metadados automaticamente de provedores configurados (Google Books, iTunes, Open Library, etc.) após um arquivo ser adicionado ao Book Dock.",
+        "autoFinalize": "Finalizar automaticamente",
+        "enableAutoFinalize": "Habilitar finalização automática",
+        "enableAutoFinalizeHint": "Arquivos com uma pontuação de confiança de metadados igual ou superior ao limite serão finalizados automaticamente.",
+        "confidenceThreshold": "Limite de confiança: {value}%",
+        "thresholdIgnored": "(ignorado apenas no modo Embutido)",
+        "destinationLibrary": "Biblioteca de destino",
+        "selectLibrary": "Selecione uma biblioteca...",
+        "metadataMode": "Modo de metadados",
+        "metadataModeSafeMerge": "Mesclagem segura (recomendado)",
+        "metadataModeFetchedOnly": "Apenas buscados",
+        "metadataModeEmbeddedOnly": "Apenas embutidos",
+        "destinationFolder": "Pasta de destino",
+        "selectFolder": "Selecione uma pasta...",
+        "saveSettingFailed": "Falha ao salvar configuração",
+        "updateSettingFailed": "Falha ao atualizar configuração",
+        "autoFetchEnabled": "Busca automática ativada",
+        "autoFetchDisabled": "Busca automática desativada",
+        "autoFinalizeEnabled": "Finalização automática ativada",
+        "autoFinalizeDisabled": "Finalização automática desativada",
+        "destinationLibraryUpdated": "Biblioteca de destino atualizada",
+        "destinationFolderUpdated": "Pasta de destino atualizada",
+        "confidenceThresholdUpdated": "Limite de confiança atualizado",
+        "metadataModeUpdated": "Modo de metadados atualizado"
+      },
+      "fileNaming": {
+        "title": "Nomenclatura de Arquivos",
+        "subtitle": "Controle como os arquivos são organizados no disco quando enviados e como são nomeados quando baixados usando tokens de espaço reservado.",
+        "copy": "Copiar",
+        "previewLabel": "Pré-visualização:",
+        "fileAsBookPreview": "Pré-visualização Arquivo como Livro",
+        "folderAsBookPreview": "Pré-visualização Pasta como Livro",
+        "downloadPreview": "Pré-visualização de Download",
+        "globalDefaults": "Padrões Globais",
+        "crossPlatform": "Sanitização de caminho multiplataforma",
+        "crossPlatformHint": "Torna os nomes de arquivos e pastas gerados seguros no Windows substituindo caracteres inválidos e nomes reservados, e removendo pontos e espaços finais. Desative apenas para configurações exclusivas do Linux que mantêm esses caracteres intencionalmente.",
+        "fileAsBookDefault": "Padrão de Arquivo como Livro",
+        "fileAsBookDefaultHint": "Padrão de envio para bibliotecas usando o modo Arquivo como Livro. Cada arquivo é um livro.",
+        "folderAsBookDefault": "Padrão de Pasta como Livro",
+        "folderAsBookDefaultHint": "Padrão de envio para bibliotecas usando o modo Pasta como Livro. Cada livro deve estar em sua própria pasta.",
+        "downloadPattern": "Padrão de Download",
+        "downloadPatternHint": "Nomes de arquivo sugeridos para downloads de arquivo único e arquivos dentro de ZIPs de exportação.",
+        "libraryOverrides": "Substituições da Biblioteca",
+        "noLibraries": "Nenhuma biblioteca configurada. Crie uma nas configurações da Biblioteca para definir padrões de nomenclatura personalizados.",
+        "badgeCustom": "Personalizado",
+        "badgeDefault": "Padrão",
+        "orgFolderAsBook": "Pasta como Livro",
+        "orgFileAsBook": "Arquivo como Livro",
+        "resetToDefault": "Redefinir para o padrão",
+        "patternReference": "Referência de Padrão",
+        "placeholderReference": "Referência de Espaço Reservado",
+        "placeholderReferenceHint": "- guia para criar padrões de nomenclatura personalizados",
+        "tokens": "Tokens",
+        "tokensHint": "Copie os espaços reservados rapidamente",
+        "clickTokenHint": "Clique em qualquer token para copiá-lo para a área de transferência.",
+        "copyValue": "Copiar {value}",
+        "modifiers": "Modificadores",
+        "modifiersHint": "Transformar os valores do token",
+        "modifiersExplain": "Anexe um modificador dentro de um token para transformar seu valor:",
+        "modFirst": "Apenas o primeiro valor",
+        "modSort": "Formato Sobrenome, Nome",
+        "modInitial": "Apenas a primeira letra",
+        "folderOnlyPrefix": "Termine um padrão com",
+        "folderOnlySuffix": "para especificar apenas uma pasta. O nome do arquivo original será preservado dentro dela.",
+        "conditionalLogic": "Lógica Condicional",
+        "conditionalLogicHint": "Segmentos opcionais e alternativas",
+        "conditionalPart1": "Envolva em",
+        "conditionalPart2": "para ignorar um segmento quando seu token estiver vazio. Use",
+        "conditionalPart3": "para um valor padrão.",
+        "examples": "Exemplos",
+        "patternExamples": "Exemplos de Padrões",
+        "patternExamplesHint": "Padrões prontos para estilos de biblioteca comuns",
+        "copyPatternTooltip": "Copiar padrão para a área de transferência",
+        "exCalibre": "Padrão estilo Calibre",
+        "exSeriesReader": "Leitor de séries",
+        "exCleanDownload": "Nome de arquivo de download limpo",
+        "exAlphabetical": "Agrupamento alfabético com série",
+        "exSeriesFallback": "Série ou alternativa Independente",
+        "exOptionalSubtitle": "Download com subtítulo opcional",
+        "exMultilingual": "Biblioteca multilíngue",
+        "exPublisher": "Organizado por editora",
+        "exStacked": "Pastas opcionais empilhadas",
+        "exFolderDrop": "Recepção de pasta com nome de classificação",
+        "caseWithYear": "com ano",
+        "caseNoYear": "sem ano",
+        "caseInSeries": "na série",
+        "caseStandalone": "independente",
+        "caseNoSeries": "sem série",
+        "caseFull": "completo",
+        "caseMinimal": "mínimo",
+        "caseWithLanguage": "com idioma",
+        "caseNoLanguage": "sem idioma",
+        "caseWithPublisher": "com editora",
+        "caseNoPublisher": "sem editora",
+        "caseAllSet": "tudo definido",
+        "copiedToClipboard": "{value} copiado para a área de transferência",
+        "copyTokenFailed": "Falha ao copiar token",
+        "patternCopied": "Padrão copiado para a área de transferência",
+        "copyPatternFailed": "Falha ao copiar padrão",
+        "labelCopied": "{label} copiado para a área de transferência",
+        "copyLabelFailed": "Falha ao copiar {label}"
+      },
+      "kobo": {
+        "title": "Sincronização Kobo",
+        "subtitle": "Pareie seu dispositivo Kobo para sincronizar sua biblioteca.",
+        "copy": "Copiar",
+        "never": "Nunca",
+        "justNow": "Agora mesmo",
+        "minutesAgo": "{count}m atrás",
+        "hoursAgo": "{count}h atrás",
+        "daysAgo": "{count}d atrás",
+        "loadFailed": "Falha ao carregar",
+        "devicePaired": "Dispositivo pareado com sucesso",
+        "devicePairedHint": "Você está pronto para configurar o seu Kobo. Siga as instruções abaixo.",
+        "syncUrl": "URL de sincronização",
+        "urlNotShownAgain": "Esta URL não será exibida novamente. Mantenha-a privada.",
+        "registeredDevices": "Dispositivos Registrados",
+        "addDevice": "Adicionar dispositivo",
+        "deviceName": "Nome do dispositivo",
+        "deviceNamePlaceholder": "ex: Meu Kobo Libra",
+        "creating": "Criando...",
+        "createDevice": "Criar dispositivo",
+        "createDeviceFailed": "Falha ao criar dispositivo",
+        "deviceRegistered": "Dispositivo \"{name}\" registrado",
+        "noDevicesYet": "Nenhum dispositivo ainda",
+        "noDevicesHint": "Adicione um dispositivo para começar a sincronizar seus livros com o seu Kobo.",
+        "lastSync": "Última sincronização: {time}",
+        "renameDevice": "Renomear dispositivo",
+        "revokeAccess": "Revogar acesso",
+        "deviceRenamed": "Dispositivo renomeado",
+        "renameDeviceFailed": "Falha ao renomear dispositivo",
+        "revokeConfirm": "Revogar acesso para \"{name}\"? O dispositivo não poderá sincronizar até ser pareado novamente.",
+        "accessRevoked": "Acesso revogado para \"{name}\"",
+        "revokeFailed": "Falha ao revogar acesso",
+        "syncUrlCopied": "URL de sincronização copiada para a área de transferência",
+        "syncUrlCopyFailed": "Falha ao copiar URL de sincronização",
+        "syncPreferences": "Preferências de Sincronização",
+        "twoWaySync": "Sincronização bidirecional de progresso",
+        "twoWaySyncHint": "Sincroniza a posição de leitura entre BookOrbit e Kobo. Requer entrega em KEPUB para locais precisos e restauração de página confiável.",
+        "syncHighlights": "Sincronizar destaques do BookOrbit para Kobo",
+        "syncHighlightsHint": "Envia destaques feitos no BookOrbit ou KOReader para o seu Kobo. Os destaques do Kobo são importados para o BookOrbit mesmo com esta opção desativada. Anotações vinculadas sincronizam edições e exclusões nos dois sentidos. Requer entrega em KEPUB; o livro no Kobo deve ser o KEPUB baixado do BookOrbit.",
+        "convertKepub": "Converter para KEPUB",
+        "convertKepubHint": "Envia EPUBs elegíveis como KEPUB. Esta opção permanece ativada quando a sincronização de progresso ou de destaques do BookOrbit para Kobo estão ativadas. Na próxima sincronização do Kobo, os livros afetados serão oferecidos novamente como downloads KEPUB; remova qualquer cópia EPUB antiga se o Kobo continuar abrindo-a.",
+        "forceHyphenation": "Forçar hifenização",
+        "forceHyphenationHint": "Garante uma justificação de texto consistente. Isso irá regenerar os KEPUBs armazenados em cache.",
+        "progressThresholds": "Limites de Progresso",
+        "progressThresholdsHint": "Defina quando o progresso de leitura do Kobo atualiza o status da sua biblioteca.",
+        "markAsReading": "Marcar como Lendo",
+        "markAsReadingHint": "Porcentagem mínima para mover um livro para \"Lendo\".",
+        "markAsFinished": "Marcar como Concluído",
+        "markAsFinishedHint": "Porcentagem limite para marcar um livro como \"Lido\".",
+        "kepubLimit": "Limite de conversão KEPUB",
+        "kepubLimitHint": "Livros acima deste limite são enviados como EPUBs normais, então o BookOrbit não sincronizará sua posição de leitura de volta para o Kobo.",
+        "changesMustBeSaved": "As alterações devem ser salvas para entrarem em vigor.",
+        "saving": "Salvando...",
+        "saveSyncSettings": "Salvar Configurações",
+        "thresholdOrderError": "O limite de leitura deve ser menor que o limite de finalização",
+        "saveSettingsFailed": "Falha ao salvar configurações",
+        "settingsSaved": "Configurações de sincronização do Kobo salvas",
+        "saveFailed": "Falha ao salvar",
+        "activity": {
+          "waitingForActivity": "Aguardando atividade",
+          "needsAttention": "Requer atenção",
+          "syncHealthy": "Sincronização saudável",
+          "never": "Nunca",
+          "none": "Nenhum",
+          "unknown": "Desconhecido",
+          "failureCount": "{count} falha | {count} falhas",
+          "noActivityRecorded": "Nenhuma atividade de sincronização do Kobo foi registrada.",
+          "lastSuccess": "Último sucesso em {time}",
+          "lastFailure": "Última falha em {time}",
+          "noFailedActivity": "Nenhuma atividade falha do Kobo no histórico recente.",
+          "noActivityYet": "Nenhuma atividade do Kobo ainda.",
+          "event": {
+            "librarySync": "Biblioteca verificada por atualizações",
+            "bookDownload": "Livro baixado",
+            "progressUpdate": "Posição de leitura atualizada",
+            "annotationsPull": "Destaques enviados ao Kobo",
+            "annotationsPush": "Destaques recebidos do Kobo"
+          },
+          "outcome": {
+            "failed": "Falhou",
+            "noUpdates": "Sem atualizações",
+            "noChanges": "Sem alterações",
+            "pending": "Pendente",
+            "completed": "Concluído",
+            "downloaded": "Baixado",
+            "updated": "Atualizado",
+            "sent": "Enviado",
+            "imported": "Importado"
+          },
+          "failure": {
+            "librarySync": "A verificação da biblioteca não foi concluída",
+            "bookDownload": "O download não foi concluído",
+            "progressUpdate": "A posição de leitura não foi atualizada",
+            "annotationsPull": "Os destaques não foram enviados",
+            "annotationsPush": "Os destaques não foram importados"
+          },
+          "chip": {
+            "morePending": "Mais pendentes",
+            "noUpdatesPending": "Sem atualizações pendentes",
+            "bookCount": "{count} livro | {count} livros",
+            "deletedAnnotations": "{count} anotações excluídas",
+            "deviceAlreadyCurrent": "Dispositivo já atualizado",
+            "freshHighlightData": "Dados de destaque recentes",
+            "created": "{count} criados",
+            "updated": "{count} atualizados",
+            "deleted": "{count} excluídos",
+            "unchanged": "{count} inalterados"
+          },
+          "readingPositionSyncedTitle": "Posição de leitura sincronizada: {title}",
+          "readingPositionSynced": "Posição de leitura sincronizada",
+          "labelWithTitle": "{label}: {title}",
+          "updateCount": "{count} atualização | {count} atualizações",
+          "directionToKobo": "BookOrbit -> Kobo",
+          "directionToBookOrbit": "Kobo -> BookOrbit",
+          "twoWaySyncEnabled": "Sincronização bidirecional ativada",
+          "deviceProgressSaved": "Progresso do dispositivo salvo",
+          "summary": {
+            "noLibraryUpdatesPending": "Nenhuma atualização de biblioteca pendente para este dispositivo",
+            "libraryUpdatesPrepared": "{count} atualização de biblioteca preparada para o dispositivo | {count} atualizações de biblioteca preparadas para o dispositivo",
+            "bookDownloadedBy": "{title} foi baixado por {device}",
+            "booksDownloaded": "{count} livro baixado | {count} livros baixados",
+            "progressUpdatesSyncedFor": "{count} atualização de progresso sincronizada para {title} | {count} atualizações de progresso sincronizadas para {title}",
+            "progressUpdatesSynced": "{count} atualização de progresso sincronizada | {count} atualizações de progresso sincronizadas",
+            "newReadingPositionFor": "O Kobo relatou uma nova posição de leitura para {title}",
+            "newReadingPosition": "O Kobo relatou uma nova posição de leitura",
+            "noHighlightChangesNeededFor": "Nenhuma alteração de destaque necessária para {title}",
+            "noHighlightChangesNeeded": "Nenhuma alteração de destaque necessária",
+            "highlightsSentToKoboFor": "{count} destaque enviado ao Kobo para {title} | {count} destaques enviados ao Kobo para {title}",
+            "highlightsSentToKobo": "{count} destaque enviado ao Kobo | {count} destaques enviados ao Kobo",
+            "noKoboHighlightChangesFor": "Nenhuma alteração de destaque do Kobo para {title}",
+            "noKoboHighlightChanges": "Nenhuma alteração de destaque do Kobo",
+            "highlightsImportedFromKoboFor": "{count} destaque importado do Kobo para {title} | {count} destaques importados do Kobo para {title}",
+            "highlightsImportedFromKobo": "{count} destaque importado do Kobo | {count} destaques importados do Kobo"
+          },
+          "timeRange": "{from} até {to}",
+          "eventsGrouped": "{count} evento agrupado | {count} eventos agrupados",
+          "removedDevice": "Dispositivo removido",
+          "loadMoreFailed": "Falha ao carregar mais do histórico",
+          "historyRefreshed": "Histórico de sincronização do Kobo atualizado",
+          "refreshFailed": "Falha ao atualizar o histórico",
+          "recentActivity": "Atividade Recente do Kobo",
+          "filterAll": "Tudo",
+          "filterFailures": "Falhas",
+          "refresh": "Atualizar",
+          "loadingActivity": "Carregando atividade do Kobo...",
+          "noActivityHint": "Atividades de sincronização recentes aparecerão depois que um Kobo pareado entrar em contato com o BookOrbit.",
+          "error": "Erro",
+          "loading": "Carregando...",
+          "loadMore": "Carregar mais atividade"
+        },
+        "howBooksSynced": {
+          "title": "Como os livros são sincronizados"
+        },
+        "nextSteps": {
+          "title": "Próximos Passos",
+          "step1": "1. Configure seu dispositivo Kobo para sincronizar com a URL de Sincronização acima."
+        },
+        "syncToKobo": "Sincronizar com o Kobo",
+        "tabs": {
+          "syncSettings": "Configurações de Sincronização",
+          "activityLog": "Registro de Atividade"
+        }
+      },
+      "koreader": {
+        "title": "Sincronização KOReader",
+        "subtitle": "Navegue pelo catálogo do BookOrbit no KOReader e sincronize o progresso, atividades de leitura, destaques e alterações de anotações.",
+        "loadingSettings": "Carregando configurações do KOReader...",
+        "loadFailed": "Falha ao carregar as configurações do KOReader",
+        "never": "Nunca",
+        "justNow": "Agora mesmo",
+        "minutesAgo": "{count}m atrás",
+        "hoursAgo": "{count}h atrás",
+        "daysAgo": "{count}d atrás",
+        "unknown": "Desconhecido",
+        "updateAvailable": "Atualização disponível",
+        "upToDate": "Atualizado",
+        "versionUnknown": "Versão desconhecida",
+        "latestPlugin": "Plugin mais recente: v{version}",
+        "latestPluginUnavailable": "Plugin mais recente indisponível",
+        "notConfigured": "A sincronização do KOReader não está configurada",
+        "notConfiguredHint": "Crie um conjunto de credenciais de sincronização e, em seguida, use-as com o plugin BookOrbit para KOReader para navegação, downloads, progresso, eventos de leitura, destaques e exclusões.",
+        "createCredentials": "Criar credenciais",
+        "createFormTitle": "Criar Credenciais de Sincronização do KOReader",
+        "createFormHint": "Estas credenciais autenticam seus dispositivos KOReader com o BookOrbit.",
+        "username": "Nome de usuário",
+        "usernamePlaceholder": "ex: meuleitor",
+        "password": "Senha",
+        "passwordPlaceholder": "Mín. 6 caracteres",
+        "creating": "Criando...",
+        "create": "Criar",
+        "credentialsCreated": "Credenciais de sincronização do KOReader criadas",
+        "createCredentialsFailed": "Falha ao criar credenciais",
+        "status": "Status do KOReader",
+        "refresh": "Atualizar",
+        "progressSync": "Sincronização de progresso",
+        "progressSyncHint": "Permite que os dispositivos KOReader sincronizem o progresso, atividades de leitura, destaques e exclusões de anotações com o BookOrbit.",
+        "lastSync": "Última sincronização",
+        "syncedBooks": "Livros sincronizados",
+        "bookCount": "nenhum livro | {count} livro | {count} livros",
+        "devices": "Dispositivos",
+        "deviceCount": "nenhum dispositivo | {count} dispositivo | {count} dispositivos",
+        "credentialsCreatedLabel": "Credenciais criadas",
+        "setup": "Configuração",
+        "pluginServerUrl": "URL do servidor do plugin",
+        "copied": "Copiado",
+        "copyUrl": "Copiar URL",
+        "preconfiguredPlugin": "Plugin pré-configurado do BookOrbit",
+        "preconfiguredPluginHintPrefix": "Baixe um zip com a URL do servidor e seu login de sincronização já configurados. O plugin inclui navegação de catálogo e sincronização. Copie a pasta para",
+        "preconfiguredPluginHintSuffix": "e reinicie o KOReader.",
+        "latestPluginNote": "{label}. Atualizações de dispositivo são executadas no menu BookOrbit no KOReader.",
+        "preparing": "Preparando...",
+        "downloadPlugin": "Baixar Plugin",
+        "noDevicesSynced": "Nenhum dispositivo sincronizou ainda",
+        "noDevicesSyncedHint": "Instale o plugin BookOrbit para sincronização completa ou configure a sincronização de progresso nativa do KOReader para atualizações apenas de progresso.",
+        "lastSyncLabel": "Última sincronização:",
+        "lastBookLabel": "Último livro:",
+        "noneYet": "Nenhum ainda",
+        "pluginActivity": "Atividade do Plugin",
+        "noPluginActivity": "Nenhuma atividade de plugin relatada ainda.",
+        "lastFullSync": "Última sincronização completa: {time}",
+        "latestPluginSuffix": "- plugin mais recente v{version}",
+        "matchedBooks": "Livros correspondidos",
+        "readingEvents": "Eventos de leitura",
+        "highlights": "Destaques",
+        "syncedTotals": "Totais sincronizados",
+        "trashedHighlights": "Destaques na lixeira",
+        "pendingDeletes": "nenhum destaque excluído aguardando confirmação do plugin do KOReader. | {count} destaque excluído aguardando confirmação do plugin do KOReader. | {count} destaques excluídos aguardando confirmação do plugin do KOReader.",
+        "failedPositions": "nenhuma posição de destaque requer atenção. | {count} posição de destaque requer atenção. | {count} posições de destaque requerem atenção.",
+        "setupGuide": "Guia de Configuração",
+        "setupSteps": "Passos de configuração do KOReader",
+        "setupStepsHint": "Use o plugin BookOrbit para navegação de catálogo, downloads, progresso, eventos de leitura e destaques. Use o plugin nativo apenas para progresso.",
+        "pluginGuideTitle": "Plugin BookOrbit",
+        "pluginStep1": "Baixe o plugin pré-configurado acima.",
+        "pluginStep2Prefix": "Descompacte e copie",
+        "pluginStep2Middle": "para",
+        "pluginStep2Suffix": "no seu dispositivo.",
+        "pluginStep3": "Reinicie o KOReader. O servidor e o login são configurados automaticamente.",
+        "pluginStep4Prefix": "Abra",
+        "pluginStep4Suffix": "para pesquisar, baixar e vincular livros à sincronização.",
+        "stockGuideTitle": "Plugin nativo de sincronização de progresso",
+        "stockStep1Prefix": "No seu dispositivo KOReader, vá para",
+        "stockStep1Suffix": ".",
+        "stockStep2": "Defina o servidor de sincronização personalizado para a URL mostrada acima.",
+        "stockStep3": "Insira o nome de usuário e a senha que você criou e toque em Login.",
+        "locationNote": "O BookOrbit salva posições de EPUB compatíveis com o KOReader do leitor web. A restauração deve cair perto da mesma posição, embora a localização exata da linha possa variar por leitor e layout do EPUB.",
+        "dangerZone": "Zona de Perigo",
+        "deleteCredentials": "Excluir credenciais do KOReader",
+        "deleteCredentialsHint": "Remove credenciais de sincronização e desconecta todos os dispositivos. Os dados de progresso serão retidos.",
+        "credentialsDeleted": "Credenciais do KOReader excluídas",
+        "deleteCredentialsFailed": "Falha ao excluir credenciais",
+        "deleteConfirmTitle": "Excluir credenciais do KOReader?",
+        "deleteConfirmBody": "Isto removerá suas credenciais de sincronização e desconectará todos os dispositivos KOReader. Os dados de progresso existentes serão mantidos.",
+        "syncEnabled": "Sincronização do KOReader ativada",
+        "syncDisabled": "Sincronização do KOReader desativada",
+        "toggleSyncFailed": "Falha ao alternar sincronização",
+        "syncUrlCopied": "URL de sincronização copiada para a área de transferência",
+        "syncUrlCopyFailed": "Falha ao copiar URL de sincronização",
+        "statusRefreshed": "Status de sincronização atualizado",
+        "refreshFailed": "Falha ao atualizar",
+        "pluginDownloaded": "Plugin baixado. Copie bookorbit.koplugin do zip para koreader/plugins/ no seu dispositivo.",
+        "pluginDownloadFailed": "Falha ao baixar o plugin",
+        "hashLinks": {
+          "unmatchedTitle": "Livros do KOReader Não Correspondidos",
+          "unmatchedBooks": "Livros não correspondidos",
+          "manualTitle": "Links Manuais do KOReader",
+          "refresh": "Atualizar",
+          "link": "Vincular",
+          "change": "Alterar",
+          "unlink": "Desvincular",
+          "hash": "Hash:",
+          "lastOpened": "Última abertura:",
+          "firstSeen": "Visto pela primeira vez:",
+          "lastSeen": "Visto pela última vez:",
+          "linked": "Vinculado:",
+          "updated": "Atualizado:",
+          "linkedTo": "Vinculado a {title}",
+          "loadingUnmatched": "Carregando livros não correspondidos...",
+          "loadingManual": "Carregando links manuais...",
+          "noUnmatched": "Nenhum livro não correspondido no KOReader.",
+          "noManual": "Nenhum link manual do KOReader.",
+          "pageOf": "Página {page} de {total}",
+          "showingRange": "Mostrando {start}-{end} de {total}",
+          "unknownFile": "Arquivo KOReader desconhecido {hash}",
+          "unknownAuthor": "Autor desconhecido",
+          "noTitleOrAuthor": "Nenhum título ou autor relatado",
+          "bookNumber": "Livro BookOrbit #{id}",
+          "toast": {
+            "unmatchedRefreshed": "Livros não correspondidos atualizados",
+            "unmatchedRefreshFailed": "Falha ao atualizar livros não correspondidos",
+            "manualRefreshed": "Links manuais atualizados",
+            "manualRefreshFailed": "Falha ao atualizar links manuais",
+            "bookLinked": "Livro vinculado",
+            "linkUpdated": "Link atualizado",
+            "linkFailed": "Falha ao vincular o livro",
+            "linkRemoved": "Link removido",
+            "unlinkFailed": "Falha ao desvincular o livro",
+            "unmatchedDismissed": "Livro não correspondido ignorado",
+            "dismissFailed": "Falha ao ignorar livro não correspondido",
+            "allDismissed": "Nenhum livro ignorado | {count} livro ignorado | {count} livros ignorados",
+            "dismissAllFailed": "Falha ao ignorar todos os livros não correspondidos"
+          },
+          "modal": {
+            "linkTitle": "Vincular livro do KOReader",
+            "changeTitle": "Alterar link do KOReader",
+            "bookOrbitBook": "Livro BookOrbit",
+            "searchPlaceholder": "Pesquise na sua biblioteca do BookOrbit",
+            "minChars": "Digite pelo menos 2 caracteres.",
+            "searching": "Pesquisando...",
+            "noBooksFound": "Nenhum livro encontrado.",
+            "untitledBook": "Livro sem título",
+            "selected": "Selecionado",
+            "select": "Selecionar",
+            "loadMore": "Carregar mais",
+            "confirmTitle": "Confirmar link do KOReader",
+            "koreader": "KOReader",
+            "bookOrbit": "BookOrbit",
+            "bookId": "ID do Livro: {id}",
+            "syncedStatsNote": "As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
+            "chooseDifferent": "Escolher diferente",
+            "saving": "Salvando...",
+            "confirmLink": "Confirmar vínculo",
+            "unlinkTitle": "Desvincular livro do KOReader?",
+            "unlinkBody": "Sincronizações futuras para este hash não resolverão para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
+            "unlinking": "Desvinculando..."
+          },
+          "dismiss": "Ignorar",
+          "dismissAll": "Ignorar tudo",
+          "dismissing": "Ignorando...",
+          "unlinking": "Desvinculando...",
+          "unlinkConfirmTitle": "Desvincular livro do KOReader?",
+          "unlinkConfirmBody": "Sincronizações futuras para este hash não resolverão para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
+          "dismissConfirmTitle": "Ignorar {title}?",
+          "dismissConfirmBody": "Isso remove-o da sua lista de livros não correspondidos. Se qualquer dispositivo reportar este hash novamente, ele reaparecerá como uma nova entrada.",
+          "dismissAllConfirmTitle": "nenhum livro não correspondido | Ignorar {count} livro não correspondido? | Ignorar todos os {count} livros não correspondidos?",
+          "dismissAllConfirmBody": "Isto limpa toda a sua lista de livros não correspondidos, não apenas a página atual. Se qualquer dispositivo reportar um desses hashes novamente, ele reaparecerá como uma nova entrada.",
+          "changeLinkTitle": "Alterar link do KOReader",
+          "linkBookTitle": "Vincular livro do KOReader",
+          "bookOrbitBook": "Livro BookOrbit",
+          "searchLibraryPlaceholder": "Pesquise na sua biblioteca do BookOrbit",
+          "enterMinChars": "Digite pelo menos 2 caracteres.",
+          "searching": "Pesquisando...",
+          "noBooksFound": "Nenhum livro encontrado.",
+          "untitledBook": "Livro sem título",
+          "selected": "Selecionado",
+          "select": "Selecionar",
+          "loadMore": "Carregar mais",
+          "loadingMore": "Carregando...",
+          "confirmLinkTitle": "Confirmar vínculo do KOReader",
+          "bookId": "ID do Livro: {id}",
+          "syncedStatsNote": "As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
+          "chooseDifferent": "Escolher diferente",
+          "saving": "Salvando...",
+          "confirmLink": "Confirmar vínculo"
+        },
+        "remove": "Remover",
+        "removing": "Removendo...",
+        "unmatchedBooks": "Livros não correspondidos",
+        "deviceRemoved": "Dispositivo removido",
+        "removeDeviceFailed": "Falha ao remover dispositivo",
+        "removeDeviceConfirmTitle": "Remover {device}?",
+        "removeDeviceConfirmBody": "Isto exclui permanentemente o progresso sincronizado deste dispositivo, a atividade de leitura e quaisquer entradas de livros não correspondidos que não sejam mais reportadas por outro dispositivo. Se o dispositivo sincronizar novamente mais tarde, ele reaparecerá como uma nova entrada."
+      },
+      "opds": {
+        "title": "OPDS",
+        "subtitle": "Conecte aplicativos de leitura compatíveis com OPDS, como KOReader ou Thorium Reader, à sua biblioteca.",
+        "copy": "Copiar",
+        "loadFailed": "Falha ao carregar",
+        "server": "Servidor",
+        "catalogServer": "Servidor de Catálogo OPDS",
+        "catalogServerHint": "Permitir que clientes OPDS naveguem e baixem livros",
+        "endpoint": "Endpoint",
+        "accounts": "Contas OPDS",
+        "add": "Adicionar",
+        "addAccount": "Adicionar conta",
+        "username": "Nome de usuário",
+        "usernameLabel": "Nome de usuário",
+        "usernamePlaceholder": "ex: koreader",
+        "password": "Senha",
+        "passwordPlaceholder": "Mín. 8 caracteres",
+        "defaultSort": "Classificação Padrão",
+        "sortLabel": "Classificação",
+        "creating": "Criando...",
+        "create": "Criar",
+        "noAccounts": "Nenhuma conta OPDS ainda. Crie uma para começar a usar os clientes OPDS.",
+        "hideDetails": "Ocultar detalhes",
+        "showDetails": "Mostrar detalhes",
+        "copyUsername": "Copiar nome de usuário",
+        "notes": "Notas sobre OPDS",
+        "notesBody": "Use contas OPDS em aplicativos de leitura. Mantenha as credenciais privadas e rotacione as senhas se compartilhadas acidentalmente.",
+        "deleteConfirmTitle": "Excluir conta OPDS?",
+        "deleteConfirmBody": "Excluir \"{username}\". Esta ação não pode ser desfeita.",
+        "sortRecent": "Adicionado Recentemente",
+        "sortTitleAsc": "Título (A-Z)",
+        "sortTitleDesc": "Título (Z-A)",
+        "sortAuthorAsc": "Autor (A-Z)",
+        "sortAuthorDesc": "Autor (Z-A)",
+        "sortSeriesAsc": "Série (A-Z)",
+        "sortSeriesDesc": "Série (Z-A)",
+        "serverEnabled": "Servidor OPDS ativado",
+        "serverDisabled": "Servidor OPDS desativado",
+        "updateSettingsFailed": "Falha ao atualizar configurações de OPDS",
+        "urlCopied": "URL do OPDS copiada para a área de transferência",
+        "urlCopyFailed": "Falha ao copiar a URL do OPDS",
+        "createUserFailed": "Falha ao criar usuário OPDS",
+        "userCreated": "Usuário OPDS \"{username}\" criado",
+        "sortOrderUpdated": "Ordem de classificação atualizada para \"{username}\"",
+        "updateSortFailed": "Falha ao atualizar a ordem de classificação",
+        "userDeleted": "Usuário OPDS \"{username}\" excluído",
+        "deleteUserFailed": "Falha ao excluir usuário OPDS",
+        "labelCopied": "{label} copiado",
+        "copyLabelFailed": "Falha ao copiar {label}"
+      },
+      "tabs": {
+        "general": "Geral",
+        "ebook": "eBook",
+        "pdf": "PDF",
+        "comics": "Quadrinhos",
+        "audio": "Audiobook",
+        "fonts": "Fontes"
+      }
+    },
+    "system": {
+      "tabs": {
+        "file-naming": "Nomenclatura de Arquivos",
+        "book-dock": "Book Dock",
+        "maintenance": "Manutenção",
+        "audit-log": "Log de Auditoria"
+      }
+    }
+  },
+  "achievements": {
+    "title": "Conquistas",
+    "tiersCount": "{earned} / {total} níveis",
+    "loadFailed": "Falha ao carregar conquistas",
+    "tryAgain": "Tentar novamente",
+    "noMatchFilter": "Nenhuma conquista corresponde a este filtro",
+    "secretAchievement": "Conquista Secreta",
+    "earnedOn": "Conquistado em {date}",
+    "whileReading": "Ao ler “{title}”",
+    "tierProgress": "Nível {earned} de {total}",
+    "progressToNext": "{current} / {threshold} para {name}",
+    "rarity": {
+      "common": "Comum",
+      "rare": "Rara",
+      "epic": "Épica",
+      "legendary": "Lendária"
+    },
+    "filter": {
+      "all": "Tudo",
+      "earned": "Conquistadas ({count})",
+      "inProgress": "Em Andamento ({count})",
+      "locked": "Bloqueadas ({count})"
+    }
+  },
+  "adminFeature": {
+    "resetLink": {
+      "title": "Link de Redefinição de Senha",
+      "description": "Compartilhe este link com o usuário. Ele expira em 15 minutos.",
+      "copy": "Copiar",
+      "copied": "Copiado!",
+      "copyFailed": "Falha ao copiar",
+      "notShownAgain": "Este link não será exibido novamente."
+    },
+    "userForm": {
+      "editUser": "Editar Usuário",
+      "createUser": "Criar Usuário",
+      "createSharedAccount": "Criar Conta Compartilhada",
+      "sharedBadge": "Compartilhado",
+      "active": "Ativo",
+      "suspended": "Suspenso",
+      "tabs": {
+        "general": "geral",
+        "access": "acesso",
+        "restrictions": "restrições"
+      },
+      "sharedAccount": "Conta compartilhada",
+      "sharedAccountHint": "Sem senha. O acesso é concedido apenas via links mágicos.",
+      "sharedAccountManageHint": "Gerencie links de login em Configurações - Links Mágicos.",
+      "username": "Nome de usuário",
+      "fullName": "Nome completo",
+      "email": "E-mail",
+      "optional": "(opcional)",
+      "libraryAccess": "Acesso à Biblioteca",
+      "noLibrariesSelected": "Nenhuma biblioteca selecionada. O usuário não pode ver nenhum livro.",
+      "permissions": "Permissões",
+      "presetStandard": "Padrão",
+      "presetAdmin": "Admin",
+      "presetClearAll": "Limpar Tudo",
+      "permissionGroups": {
+        "content": "Conteúdo",
+        "devicesAccess": "Dispositivos e Acesso",
+        "email": "E-mail",
+        "administration": "Administração",
+        "restrictions": "Restrições"
+      },
+      "superuserTarget": "Alvo de Superusuário",
+      "superuserTargetHint": "Restrições de conteúdo não podem ser aplicadas a superusuários.",
+      "noRestrictions": "Sem restrições de conteúdo",
+      "noRestrictionsHint": "Este usuário tem acesso total a todos os livros nas suas bibliotecas atribuídas.",
+      "addRestrictions": "+ Adicionar Restrições de Conteúdo",
+      "contentRestrictions": "Restrições de Conteúdo",
+      "remove": "Remover",
+      "includeTags": "Incluir tags",
+      "includeTagsHint": "(mostrar apenas livros com estas tags)",
+      "excludeTags": "Excluir tags",
+      "excludeTagsHint": "(ocultar livros com estas tags)",
+      "includeGenres": "Incluir gêneros",
+      "includeGenresHint": "(mostrar apenas livros com estes gêneros)",
+      "excludeGenres": "Excluir gêneros",
+      "excludeGenresHint": "(ocultar livros com estes gêneros)",
+      "searchTagsPlaceholder": "Pesquisar tags...",
+      "searchGenresPlaceholder": "Pesquisar gêneros...",
+      "saving": "Salvando...",
+      "errors": {
+        "updateUser": "Falha ao atualizar o usuário",
+        "updatePermissions": "Falha ao atualizar as permissões",
+        "updateLibraryAccess": "Falha ao atualizar o acesso à biblioteca",
+        "updateContentFilters": "Falha ao atualizar os filtros de conteúdo",
+        "emailRequired": "E-mail é obrigatório",
+        "createSharedAccount": "Falha ao criar conta compartilhada",
+        "createUser": "Falha ao criar usuário"
+      }
+    },
+    "usersPage": {
+      "usersTitle": "Usuários",
+      "magicLinksTitle": "Links Mágicos",
+      "usersSubtitle": "Gerencie contas de usuário e atribuições de permissão.",
+      "magicLinksSubtitle": "Crie links de login compartilháveis para contas compartilhadas.",
+      "createUser": "Criar usuário",
+      "createLink": "Criar link",
+      "usersTab": "Usuários",
+      "magicLinksTab": "Links Mágicos",
+      "columns": {
+        "name": "Nome",
+        "username": "Nome de usuário",
+        "email": "E-mail",
+        "access": "Acesso",
+        "status": "Status"
+      },
+      "adminBadge": "Admin",
+      "permissionCount": "nenhuma permissão | uma permissão | {count} permissões",
+      "filteredBadge": "Filtrado",
+      "contentRestrictionsActive": "Restrições de conteúdo ativas",
+      "statusActive": "Ativo",
+      "statusInactive": "Inativo",
+      "resetPassword": "Redefinir senha",
+      "resetPasswordOidcHint": "Usuários OIDC redefinem senhas no seu provedor de identidade",
+      "resetPasswordSharedHint": "Contas compartilhadas não possuem senhas",
+      "resetPasswordOidcHintFull": "Usuários OIDC redefinem senhas em seu provedor de identidade.",
+      "resetPasswordSharedHintFull": "Contas compartilhadas não possuem senhas.",
+      "deleteUserAction": "Excluir usuário",
+      "deleteDialogTitle": "Excluir usuário?",
+      "deleteDialogBody": "Excluir usuário \"{username}\". Esta ação não pode ser desfeita.",
+      "deleting": "Excluindo...",
+      "errors": {
+        "loadData": "Falha ao carregar dados",
+        "load": "Falha ao carregar",
+        "deleteUser": "Falha ao excluir usuário"
+      },
+      "currentUsers": "Usuários Atuais",
+      "defaultLibraryAccess": {
+        "title": "Acesso Padrão à Biblioteca",
+        "subtitle": "Acesso de visualização concedido a usuários registrados automaticamente e provisionados via OIDC.",
+        "description": "Selecione as bibliotecas atribuídas automaticamente a novos usuários.",
+        "noLibraries": "Nenhuma biblioteca disponível.",
+        "save": "Salvar padrões",
+        "saving": "Salvando...",
+        "saved": "Acesso padrão à biblioteca salvo.",
+        "saveError": "Falha ao salvar acesso padrão à biblioteca"
+      }
+    }
+  },
+  "annotations": {
+    "unknownBook": "Livro desconhecido",
+    "styles": {
+      "highlight": "Destaque",
+      "underline": "Sublinhado",
+      "strike": "Tachado",
+      "squiggle": "Ondulado",
+      "invert": "Inverter"
+    },
+    "combobox": {
+      "filterByBook": "Filtrar por livro",
+      "allBooks": "Todos os livros",
+      "clearBookFilter": "Limpar filtro de livro",
+      "searching": "Pesquisando...",
+      "noBooksFound": "Nenhum livro encontrado"
+    },
+    "bulk": {
+      "countSelected": "{count} selecionado(s)",
+      "pageSelected": "Página selecionada",
+      "selectPage": "Selecionar página",
+      "clear": "Limpar",
+      "recolorTo": "Recolorir para {color}",
+      "restyleTo": "Reestilizar para {style}"
+    },
+    "chips": {
+      "active": "Ativo:",
+      "removeFilter": "Remover filtro {label}",
+      "clearAll": "Limpar tudo"
+    },
+    "filters": {
+      "colors": "Cores",
+      "dateRange": "Intervalo de datas",
+      "fromDate": "Data de início",
+      "toDate": "Data de término",
+      "to": "até",
+      "clearDateRange": "Limpar intervalo de datas",
+      "clearAll": "Limpar tudo"
+    },
+    "pagination": {
+      "showing": "Mostrando {start}-{end} de {total}",
+      "pageOf": "Página {page} de {totalPages}",
+      "firstPage": "Primeira página",
+      "previousPage": "Página anterior",
+      "nextPage": "Próxima página",
+      "lastPage": "Última página"
+    },
+    "sync": {
+      "loading": "Carregando detalhe de sincronização",
+      "positions": "Posições",
+      "devices": "Dispositivos",
+      "retryConversion": "Tentar novamente a conversão",
+      "noStoredPositions": "Nenhuma posição armazenada.",
+      "notSynced": "Não sincronizado a nenhum dispositivo ainda.",
+      "upToDate": "Atualizado",
+      "pendingVersion": "Pendente v{version}",
+      "syncedAt": "sincronizado em {date}",
+      "format": {
+        "webReader": "Leitor web",
+        "koreader": "KOReader",
+        "pdf": "PDF",
+        "kobo": "Kobo"
+      },
+      "status": {
+        "exact": "Exato",
+        "repaired": "Reparado",
+        "failed": "Falhou",
+        "pending": "Pendente"
+      }
+    },
+    "toolbar": {
+      "searchPlaceholder": "Pesquisar texto e notas",
+      "filters": "Filtros",
+      "sortOrder": "Ordem de classificação",
+      "switchToCompact": "Mudar para visualização compacta",
+      "switchToComfortable": "Mudar para visualização confortável",
+      "compactView": "Visualização compacta",
+      "comfortableView": "Visualização confortável"
+    },
+    "listItem": {
+      "pageNumber": "p. {page}",
+      "chapterNumber": "capítulo {chapter}",
+      "selectAnnotation": "Selecionar anotação",
+      "collapse": "Recolher",
+      "expand": "Expandir",
+      "hideSyncDetail": "Ocultar detalhe de sincronização",
+      "showSyncDetail": "Mostrar detalhe de sincronização",
+      "exactPositionUnavailable": "Posição exata no leitor indisponível",
+      "saving": "Salvando",
+      "bookDetails": "Detalhes do livro",
+      "openInReader": "Abrir no leitor",
+      "restore": "Restaurar",
+      "deleteForever": "Excluir permanentemente",
+      "editNote": "Editar nota",
+      "addNote": "Adicionar nota",
+      "colorAndStyle": "Cor e estilo",
+      "copied": "Copiado",
+      "copyText": "Copiar texto",
+      "trash": "Lixeira",
+      "moveToTrash": "Mover para a lixeira"
+    },
+    "hub": {
+      "title": "Anotações",
+      "totalCount": "{count} total",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "noteCount": "nenhuma nota | {count} nota | {count} notas",
+      "export": "Exportar",
+      "exportMarkdown": "Markdown",
+      "exportCsv": "CSV",
+      "exportJson": "JSON",
+      "notesOnly": "Apenas notas",
+      "style": "Estilo",
+      "source": "Origem",
+      "bulkTrash": "Mover para lixeira",
+      "bulkRestore": "Restaurar",
+      "tabs": {
+        "highlights": "Destaques",
+        "trash": "Lixeira"
+      },
+      "empty": {
+        "noMatch": "Nenhum destaque corresponde aos seus filtros.",
+        "resetFilters": "Redefinir filtros",
+        "trashEmpty": "A lixeira está vazia",
+        "noAnnotations": "Nenhuma anotação ainda. Destaques que você cria na web ou no seu e-reader aparecerão aqui."
+      },
+      "toast": {
+        "movedToTrash": "Movido para a lixeira",
+        "annotationRestored": "Anotação restaurada",
+        "annotationDeletedForever": "Anotação excluída permanentemente",
+        "failedToDelete": "Falha ao excluir",
+        "bulkTrashed": "Nenhuma anotação movida para a lixeira | {count} anotação movida para a lixeira | {count} anotações movidas para a lixeira",
+        "bulkRestored": "Nenhuma anotação restaurada | {count} anotação restaurada | {count} anotações restauradas",
+        "bulkRecolored": "Nenhuma anotação recolorida | {count} anotação recolorida | {count} anotações recoloridas",
+        "bulkRestyled": "Nenhuma anotação reestilizada | {count} anotação reestilizada | {count} anotações reestilizadas"
+      }
+    }
+  },
+  "audit": {
+    "pageTitle": "Log de Auditoria",
+    "pageSubtitle": "Um registro de ações administrativas significativas realizadas em todo o sistema.",
+    "filters": "Filtros",
+    "noActiveFilters": "Nenhum filtro ativo",
+    "clear": "Limpar",
+    "empty": "Nenhum log de auditoria encontrado",
+    "showMore": "Mostrar mais",
+    "showLess": "Mostrar menos",
+    "details": "Detalhes",
+    "hideDetails": "Ocultar detalhes",
+    "detailAction": "Ação: {value}",
+    "detailIp": "IP: {value}",
+    "showing": "Mostrando {from}-{to} de {total}",
+    "prev": "Ant",
+    "chips": {
+      "action": "Ação: {value}",
+      "user": "Usuário: {value}",
+      "from": "De: {value}",
+      "to": "Até: {value}"
+    },
+    "filterLabels": {
+      "action": "Ação",
+      "userId": "ID do Usuário",
+      "from": "De",
+      "to": "Até"
+    },
+    "filterPlaceholders": {
+      "action": "ex: auth.login",
+      "userId": "ex: 1"
+    },
+    "columns": {
+      "when": "Quando",
+      "user": "Usuário",
+      "action": "Ação",
+      "description": "Descrição",
+      "ip": "IP"
+    }
+  },
+  "auth": {
+    "backToSignIn": "Voltar para entrar",
+    "themePicker": {
+      "switchToLight": "Mudar para claro",
+      "switchToDark": "Mudar para escuro",
+      "changeRadius": "Alterar raio do canto",
+      "changeBackground": "Alterar fundo",
+      "changeAccent": "Alterar cor de destaque"
+    },
+    "fields": {
+      "username": "Nome de usuário",
+      "password": "Senha",
+      "email": "E-mail",
+      "emailAddress": "Endereço de e-mail",
+      "fullName": "Nome completo",
+      "newPassword": "Nova senha",
+      "confirmPassword": "Confirmar senha",
+      "confirmNewPassword": "Confirmar nova senha",
+      "currentPassword": "Senha atual",
+      "passwordHint": "Mín. de 8 caracteres com maiúscula, minúscula e um dígito"
+    },
+    "errors": {
+      "generic": "Algo deu errado. Por favor, tente novamente.",
+      "passwordsDoNotMatch": "As senhas não coincidem"
+    },
+    "login": {
+      "subtitle": "Entre na sua conta",
+      "signIn": "Entrar",
+      "signingIn": "Entrando...",
+      "orDivider": "ou",
+      "forgotPassword": "Esqueceu a senha?",
+      "errors": {
+        "invalidCredentials": "Nome de usuário ou senha inválidos",
+        "tooManyAttempts": "Muitas tentativas de login. Aguarde um minuto e tente novamente."
+      }
+    },
+    "oidc": {
+      "loginFailed": "O login OIDC falhou",
+      "redirecting": "Redirecionando...",
+      "signInWith": "Entrar com {provider}",
+      "completingSignIn": "Concluindo login...",
+      "tryAgain": "Tentar novamente",
+      "errors": {
+        "stateExpired": "Sua sessão de login expirou. Tente fazer login novamente.",
+        "tokenExchangeFailed": "Não foi possível concluir o login com o seu provedor. Tente novamente ou contate seu administrador.",
+        "userNotProvisioned": "Sua conta não foi configurada. Contate seu administrador para acesso.",
+        "userInactive": "Sua conta foi desativada. Contate seu administrador.",
+        "providerError": "Seu provedor de identidade retornou um erro. Tente novamente.",
+        "missingCodeOrState": "Falta parâmetro de código ou estado"
+      },
+      "providerErrors": {
+        "accessDenied": "O acesso foi negado pelo provedor de identidade.",
+        "loginRequired": "A autenticação é necessária. Por favor, faça login novamente.",
+        "interactionRequired": "Interação adicional do usuário é necessária."
+      }
+    },
+    "forgotPassword": {
+      "subtitle": "Redefinir sua senha",
+      "submitted": "Se uma conta com este e-mail existir, um link de redefinição foi enviado. Verifique sua caixa de entrada.",
+      "sending": "Enviando...",
+      "sendResetLink": "Enviar link de redefinição",
+      "errors": {
+        "emailUnavailable": "A redefinição de senha por e-mail não está disponível. Contate seu administrador."
+      }
+    },
+    "resetPassword": {
+      "subtitle": "Definir uma nova senha",
+      "saving": "Salvando...",
+      "setNewPassword": "Definir nova senha",
+      "errors": {
+        "invalidLink": "Link de redefinição inválido. Solicite um novo.",
+        "invalidOrExpired": "Link de redefinição inválido ou expirado. Solicite um novo."
+      }
+    },
+    "setup": {
+      "title": "Configuração inicial",
+      "subtitle": "Crie a primeira conta de administrador.",
+      "setupToken": "Token de configuração",
+      "setupTokenHint": "(obrigatório em produção)",
+      "creatingAccount": "Criando conta...",
+      "createAccount": "Criar conta de administrador",
+      "errors": {
+        "failed": "Falha ao concluir a configuração"
+      }
+    },
+    "changePassword": {
+      "title": "Alterar senha",
+      "saving": "Salvando…",
+      "forcedNotice": "Você deve definir uma nova senha antes de continuar.",
+      "errors": {
+        "failed": "Falha ao alterar senha"
+      }
+    },
+    "magicLink": {
+      "signingIn": "Entrando...",
+      "loginFailed": "Login falhou",
+      "goToLogin": "Ir para o login",
+      "errors": {
+        "noToken": "Nenhum token fornecido"
+      }
+    }
+  },
+  "author": {
+    "card": {
+      "portraitAlt": "Retrato de {name}",
+      "viewDetails": "Ver Detalhes do Autor",
+      "refreshMetadata": "Atualizar Metadados",
+      "deleteAuthor": "Excluir Autor"
+    },
+    "listRow": {
+      "noRecentAdditions": "Nenhuma adição recente",
+      "portraitAlt": "Retrato de {name}"
+    },
+    "filters": {
+      "title": "Filtros de Autor",
+      "clearAll": "Limpar tudo",
+      "allLibraries": "Todas as Bibliotecas",
+      "allAuthors": "Todos os autores",
+      "hasPhoto": "Tem foto",
+      "missingPhoto": "Falta foto",
+      "minBooks": "Mín. de livros",
+      "anyPlaceholder": "Qualquer"
+    },
+    "header": {
+      "never": "Nunca",
+      "portraitAlt": "Retrato de {name}",
+      "actions": "Ações",
+      "editAuthor": "Editar Autor",
+      "mergeAuthors": "Mesclar Autores",
+      "refreshing": "Atualizando...",
+      "refreshMetadata": "Atualizar Metadados",
+      "deleteAuthor": "Excluir Autor",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar mais",
+      "lookingUpMetadata": "Procurando metadados do autor...",
+      "noBiography": "Nenhuma biografia disponível. Use o menu para atualizar os metadados.",
+      "previewFrom": "Pré-visualização do {provider}. Salve os metadados para mantê-los.",
+      "booksLabel": "Livros",
+      "lastAdded": "Último Adicionado"
+    },
+    "list": {
+      "title": "Autores",
+      "searchPlaceholder": "Pesquisar autores",
+      "sortButton": "Ordenar",
+      "sortBy": "Ordenar por",
+      "ascending": "Crescente",
+      "descending": "Decrescente",
+      "asc": "Cres",
+      "desc": "Decr",
+      "filters": "Filtros",
+      "clear": "Limpar",
+      "allLoaded": "Todos os {total} autores carregados",
+      "sort": {
+        "name": "Nome",
+        "sortName": "Nome de Classificação",
+        "bookCount": "Contagem de Livros",
+        "recentAdditions": "Adições Recentes",
+        "lastEnriched": "Último Enriquecido"
+      },
+      "empty": {
+        "title": "Nenhum autor encontrado",
+        "hint": "Tente alterar o texto de pesquisa, ordenação ou filtro de biblioteca."
+      },
+      "deleteDialog": {
+        "titleOne": "Excluir autor?",
+        "titleMany": "Excluir {count} autores?",
+        "descriptionOne": "Isto remove o autor do catálogo e o desvincula dos livros associados. Esta ação não pode ser desfeita.",
+        "descriptionMany": "Isto remove os autores selecionados do catálogo e os desvincula dos livros associados. Esta ação não pode ser desfeita."
+      },
+      "selection": {
+        "selectVisible": "Selecionar visíveis",
+        "refreshMetadata": "Atualizar metadados",
+        "refreshingMetadata": "Atualizando metadados...",
+        "deleteSelected": "Excluir selecionados",
+        "deleting": "Excluindo...",
+        "exitSelection": "Sair da seleção",
+        "confirmDeleteCount": "Excluir {count} autor? | Excluir {count} autor? | Excluir {count} autores?"
+      },
+      "toast": {
+        "refreshed": "Metadados do autor atualizados",
+        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem de autor foi encontrada.",
+        "refreshFailed": "Falha ao atualizar metadados do autor",
+        "bulkRefreshPartial": "Atualizado(s) {updated} autor(es), {failed} falharam",
+        "bulkRefreshSuccess": "Metadados atualizados para {updated} autor(es)",
+        "bulkRefreshFailed": "Falha ao atualizar autores selecionados",
+        "deleteSuccess": "Excluiu {count} autor; afetou {books} livros | Excluiu {count} autor; afetou {books} livros | Excluiu {count} autores; afetou {books} livros",
+        "deleteFailed": "Falha ao excluir autor(es)"
+      }
+    },
+    "detail": {
+      "pageTitle": "Autor",
+      "pageTitleNamed": "Autor · {name}",
+      "pageTitleId": "Autor #{id}",
+      "entityName": "Autor",
+      "loadingAuthor": "Carregando autor...",
+      "previewError": "Não foi possível carregar a pré-visualização externa do autor no momento.",
+      "edit": {
+        "name": "Nome",
+        "sortName": "Nome de Classificação",
+        "description": "Descrição",
+        "image": "Imagem",
+        "uploading": "Enviando...",
+        "replaceImage": "Substituir imagem",
+        "uploadImage": "Enviar imagem",
+        "removing": "Removendo...",
+        "removeImage": "Remover imagem",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP até {size} MB",
+        "saving": "Salvando..."
+      },
+      "merge": {
+        "searchPlaceholder": "Pesquise autores para mesclar neste autor",
+        "searching": "Pesquisando...",
+        "bookCount": "nenhum livro | {count} livro | {count} livros",
+        "selectedSummary": "Selecionado(s) {count} autor(es), aprox. {books} livros afetados.",
+        "merging": "Mesclando...",
+        "mergeSelected": "Mesclar Selecionados",
+        "confirmLabel": "Mesclar"
+      },
+      "mergeDialog": {
+        "title": "Mesclar {count} autor(es) em \"{name}\"?",
+        "titleFallback": "Mesclar autores selecionados?",
+        "description": "Isso mesclará os autores selecionados no autor atual e revinculará os livros associados. Essa ação não pode ser desfeita.",
+        "descriptionEmpty": "Essa ação não pode ser desfeita."
+      },
+      "deleteDialog": {
+        "title": "Excluir autor?",
+        "description": "Isto remove o autor do catálogo e o desvincula dos livros associados. Esta ação não pode ser desfeita."
+      },
+      "books": {
+        "heading": "Livros",
+        "allLibraries": "Todas as Bibliotecas",
+        "asc": "Cres",
+        "desc": "Decr",
+        "ascending": "Crescente",
+        "descending": "Decrescente",
+        "allLoaded": "Todos os {total} livros carregados",
+        "sort": {
+          "recentlyAdded": "Adicionado Recentemente",
+          "title": "Título",
+          "publishedYear": "Ano de Publicação"
+        },
+        "empty": {
+          "title": "Nenhum livro encontrado para este autor",
+          "hint": "Tente alterar a ordenação ou selecionar outra biblioteca."
+        }
+      },
+      "toast": {
+        "refreshed": "Metadados do autor atualizados",
+        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem de autor foi encontrada.",
+        "refreshFailed": "Falha ao atualizar metadados do autor",
+        "nameRequired": "O nome do autor é obrigatório",
+        "updated": "Autor atualizado",
+        "updateFailed": "Falha ao atualizar autor",
+        "imageUpdated": "Imagem do autor atualizada",
+        "imageUploadFailed": "Falha ao enviar imagem do autor",
+        "imageRemoved": "Imagem do autor removida",
+        "imageRemoveFailed": "Falha ao remover imagem do autor",
+        "mergeSuccess": "Mesclado(s) {count} autor(es); afetou {books} livros",
+        "mergeFailed": "Falha ao mesclar autores",
+        "deleteSuccess": "Autor excluído; afetou {books} livros",
+        "deleteFailed": "Falha ao excluir autor"
+      }
+    }
+  },
+  "book": {
+    "untitled": "Sem título",
+    "unknownFormat": "desconhecido",
+    "card": {
+      "missing": "Ausente"
+    },
+    "file": {
+      "primary": "Principal",
+      "audiobook": "Audiobook"
+    },
+    "actions": {
+      "read": "Ler",
+      "listen": "Ouvir",
+      "peek": "Espiar",
+      "quickView": "Visualização Rápida",
+      "details": "Detalhes",
+      "bookDetails": "Detalhes do Livro",
+      "download": "Baixar",
+      "metadata": "Metadados",
+      "editMetadata": "Editar Metadados",
+      "refreshMetadata": "Atualizar Metadados",
+      "regenerateCover": "Regerar Capa",
+      "addToCollection": "Adicionar à Coleção",
+      "setStatus": "Definir Status",
+      "sendViaEmail": "Enviar por E-mail",
+      "rate": "Avaliar {star}",
+      "openAs": "Abrir como {format}"
+    },
+    "readStatus": {
+      "unread": "Não lido",
+      "wantToRead": "Quero Ler",
+      "reading": "Lendo",
+      "onHold": "Pausado",
+      "rereading": "Relendo",
+      "read": "Lido",
+      "skimmed": "Folheado",
+      "abandoned": "Abandonado"
+    },
+    "download": {
+      "action": "Baixar",
+      "audiobookZip": "Audiobook (ZIP)",
+      "allFormatsZip": "Todos os formatos (ZIP)",
+      "primaryOnlyZip": "Apenas principal (ZIP)"
+    },
+    "sort": {
+      "moveUp": "Mover para cima",
+      "moveDown": "Mover para baixo",
+      "ascending": "Crescente",
+      "descending": "Decrescente",
+      "remove": "Remover",
+      "emptyState": "Nenhuma ordenação configurada. Título ascendente será usado.",
+      "addLevel": "Adicionar nível de ordenação"
+    },
+    "filter": {
+      "match": "Corresponder a",
+      "all": "TODAS",
+      "any": "QUALQUER",
+      "ofFollowingRules": "das seguintes regras",
+      "anyProvider": "Qualquer provedor",
+      "communityRatingProvider": "Provedor de avaliação da comunidade",
+      "loadingLibraries": "Carregando bibliotecas...",
+      "noLibrariesAvailable": "Nenhuma biblioteca disponível",
+      "selectLibrary": "Selecione a biblioteca...",
+      "selectStatus": "Selecione o status...",
+      "withinLastPlaceholder": "ex: 7",
+      "unit": {
+        "days": "dias",
+        "weeks": "semanas",
+        "months": "meses"
+      },
+      "scorePreset": {
+        "outstanding": "Excelente",
+        "good": "Bom",
+        "fair": "Razoável",
+        "poor": "Pobre"
+      },
+      "scoreRangePlaceholder": "0-100",
+      "valuePlaceholder": "valor",
+      "maxPlaceholder": "máx",
+      "to": "até",
+      "group": "Grupo",
+      "addRule": "Adicionar regra",
+      "addGroup": "Adicionar grupo",
+      "typeToSearch": "Digite para pesquisar..."
+    },
+    "deleteDialog": {
+      "title": "Excluir livro?",
+      "description": "Isso excluirá permanentemente o livro e todos os seus metadados, arquivos, progresso de leitura e favoritos. Isso não pode ser desfeito."
+    },
+    "bulkEdit": {
+      "title": "Editar metadados - {count} livro | Editar metadados - {count} livro | Editar metadados - {count} livros",
+      "instructions": "Alterne os campos para editar e, em seguida, defina os valores. Apenas os campos alternados serão alterados.",
+      "invalidYear": "Insira um ano válido (apenas números)",
+      "clearWarning": "Isso removerá todos {field} dos livros selecionados.",
+      "searchPlaceholder": "Pesquisar {field}...",
+      "enterPlaceholder": "Inserir {field}",
+      "yearPlaceholder": "ex: 2024",
+      "leaveEmptyHint": "Deixe vazio para limpar este campo em todos os livros selecionados.",
+      "applying": "Aplicando...",
+      "apply": "Aplicar",
+      "mode": {
+        "add": "Adicionar",
+        "remove": "Remover",
+        "replace": "Substituir",
+        "clear": "Limpar"
+      }
+    },
+    "export": {
+      "title": "Exportar Metadados",
+      "scope": "Escopo",
+      "selectedRows": "Linhas selecionadas",
+      "currentlySelected": "{count} selecionados no momento",
+      "allMatchingRows": "Todas as linhas correspondentes",
+      "rowsInResult": "{count} linhas no resultado atual",
+      "format": "Formato",
+      "csvDescription": "Pronto para planilha, inclui UTF-8 BOM",
+      "jsonDescription": "Exportação estruturada com contexto de metadados",
+      "columns": "Colunas",
+      "canonicalSchema": "Esquema canônico estável",
+      "visibleColumns": "Colunas visíveis atuais",
+      "options": "Opções",
+      "includePersonalData": "Incluir dados pessoais de leitura",
+      "includeFilePaths": "Incluir caminhos de arquivo (avançado)",
+      "includeContextMeta": "Incluir metadados de contexto",
+      "preflight": "Pré-verificação",
+      "scopeLabel": "Escopo: {summary}",
+      "calculatingSize": "Calculando tamanho da exportação...",
+      "estimatedSize": "Tamanho estimado:",
+      "fileLabel": "Arquivo: {fileName}",
+      "exportAction": "Exportar",
+      "selectedRowsSummary": "{count} linha selecionada | {count} linha selecionada | {count} linhas selecionadas",
+      "matchingRowsSummary": "{count} linha correspondente | {count} linha correspondente | {count} linhas correspondentes",
+      "prepareFailed": "Falha ao preparar exportação",
+      "exportStarted": "Exportação de metadados iniciada: {fileName}",
+      "exportFailed": "A exportação de metadados falhou"
+    },
+    "columnPanel": {
+      "columnsHeading": "Colunas",
+      "reset": "Redefinir",
+      "tableDensity": "Densidade da tabela",
+      "density": {
+        "compact": "Compacta",
+        "comfortable": "Confortável",
+        "roomy": "Espaçosa"
+      },
+      "presets": "Predefinições",
+      "exportBackup": "Exportar predefinições e visualizações",
+      "importBackup": "Importar predefinições e visualizações",
+      "rename": "Renomear",
+      "renamePrompt": "Insira um novo nome",
+      "builtIn": "Integrado",
+      "saveCurrentPreset": "Salvar predefinição atual",
+      "savedViews": "Visualizações salvas",
+      "savedViewsEmpty": "Salve ordenação, layout e filtros específicos de visualização para reutilização rápida.",
+      "saveCurrentView": "Salvar visualização atual",
+      "pinnedLeft": "Fixado à esquerda",
+      "pinnedRight": "Fixado à direita",
+      "columns": {
+        "cover": "Capa",
+        "read": "Lido",
+        "actions": "Ações"
+      }
+    },
+    "shortcuts": {
+      "title": "Atalhos de Teclado",
+      "navigation": {
+        "title": "Navegação",
+        "moveFocusVertical": "Mover o foco para cima/baixo",
+        "moveFocusHorizontal": "Mover o foco para esquerda/direita",
+        "jumpFirstColumn": "Pular para a primeira coluna",
+        "jumpLastColumn": "Pular para a última coluna",
+        "jumpFirstRow": "Pular para a primeira linha",
+        "jumpLastRow": "Pular para a última linha"
+      },
+      "actions": {
+        "title": "Ações",
+        "editCell": "Editar a célula focada",
+        "cancelEditing": "Cancelar edição / Fechar sobreposição",
+        "toggleRowSelection": "Alternar seleção de linha",
+        "copyCell": "Copiar valor da célula",
+        "copyRow": "Copiar linha focada"
+      },
+      "general": {
+        "title": "Geral",
+        "toggleHelp": "Alternar esta sobreposição de ajuda"
+      }
+    },
+    "jumpRail": {
+      "jumpToSection": "Pular para a seção",
+      "jumpTo": "Pular para {label}"
+    },
+    "quickView": {
+      "title": "Visualização rápida de livro",
+      "titleFor": "Visualização rápida de {title}",
+      "description": "Visualize detalhes do livro e execute ações rápidas.",
+      "openIn": "Abrir em {provider}",
+      "pages": "{count} página | {count} página | {count} páginas",
+      "primaryFile": "Arquivo Principal",
+      "fileNumber": "Arquivo #{id}",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar mais",
+      "collections": "Coleções",
+      "noDescription": "Nenhuma descrição disponível.",
+      "openMetadataEditor": "Abrir editor de metadados",
+      "coverPreview": "Pré-visualização da capa",
+      "coverPreviewFor": "Pré-visualização da capa de {title}",
+      "coverPreviewDescription": "Caixa de diálogo de visualização da imagem da capa ampliada."
+    },
+    "tableView": {
+      "openBookDetails": "Abrir detalhes do livro",
+      "openSeries": "Abrir série",
+      "metadataRefreshFailed": "Falha ao atualizar metadados",
+      "booksSelected": "{count} livro selecionado | {count} livro selecionado | {count} livros selecionados",
+      "loadingMoreBooks": "Carregando mais livros",
+      "sort": "Ordenar",
+      "refreshingMetadata": "Atualizando metadados {processed} / {total}",
+      "failedCount": "{count} falhou",
+      "remainingCount": "{count} restantes",
+      "readOnlyNotice": "A edição da tabela está desativada em telas menores. Mude para lista ou grade para ações mais rápidas.",
+      "fetching": "Buscando...",
+      "updated": "Atualizado",
+      "failed": "Falhou",
+      "noBooks": "Nenhum livro para mostrar",
+      "scrollToTop": "Rolar para o topo",
+      "selectedStatus": "{count} selecionados",
+      "filtered": "Filtrado",
+      "loadedStatus": "{loaded} de {total} carregados",
+      "bookCount": "{count} livro | {count} livro | {count} livros",
+      "keyboardShortcutsTitle": "Atalhos de teclado (?)",
+      "showKeyboardShortcuts": "Mostrar atalhos de teclado da tabela",
+      "copyHint": "Copiar célula: Ctrl/Cmd+C · Copiar linha: Ctrl/Cmd+Shift+C"
+    },
+    "detail": {
+      "authorBooks": {
+        "alsoByAuthor": "Também deste autor",
+        "alsoByAuthors": "Também destes autores"
+      },
+      "header": {
+        "previousBook": "Livro anterior",
+        "nextBook": "Próximo livro"
+      },
+      "tabs": {
+        "details": "Detalhes",
+        "editMetadata": "Editar Metadados",
+        "files": "Arquivos",
+        "readingLog": "Registro de Leitura",
+        "highlights": "Destaques"
+      },
+      "discover": {
+        "moreInSeries": "Mais na Série",
+        "byAuthor": "Por Autor",
+        "similarBooks": "Livros Semelhantes"
+      },
+      "recommended": {
+        "moreLikeThis": "Mais Como Este"
+      },
+      "series": {
+        "moreInSeriesPrefix": "Mais na série",
+        "moreInSeriesSuffix": ""
+      },
+      "writeRename": {
+        "written": "nenhum campo gravado | Gravado (um campo) | Gravado ({count} campos)",
+        "writeFailed": "Falha na gravação",
+        "skipped": "Ignorado",
+        "renamedTo": "Renomeado para {name}",
+        "fileRenamed": "Arquivo renomeado",
+        "renameFailed": "Falha ao renomear",
+        "autoWriteAndRenameDisabled": "As gravações e renomeações automáticas estão desativadas nas configurações da biblioteca. As alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "autoWriteDisabled": "A gravação automática está desativada nas configurações da biblioteca. As alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "autoRenameDisabled": "A renomeação automática está desativada nas configurações da biblioteca. As alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "writeLabel": "Gravar:",
+        "renameLabel": "Renomear:"
+      },
+      "addFile": {
+        "uploading": "Enviando...",
+        "uploadComplete": "Envio concluído",
+        "title": "Adicionar Arquivo",
+        "dropzone": {
+          "title": "Solte os arquivos aqui ou clique para procurar",
+          "hint": "epub, pdf, mobi, cbz, m4b e mais - até {size} MB cada"
+        },
+        "addMore": "Adicionar mais arquivos",
+        "fileCount": "nenhum arquivo | um arquivo | {count} arquivos",
+        "clearAll": "Limpar tudo",
+        "done": "Concluído",
+        "retry": "Tentar novamente",
+        "filesAdded": "nenhum arquivo adicionado | um arquivo adicionado | {count} arquivos adicionados",
+        "uploadedFailed": "{done} enviados, {failed} falharam",
+        "uploadingProgress": "{done} de {total} enviando...",
+        "renameAfter": "Renomear todos os arquivos de livros após o upload",
+        "uploadCount": "Upload ({count})",
+        "upload": "Upload"
+      },
+      "addSession": {
+        "errors": {
+          "invalidDate": "Escolha uma data e hora válidas.",
+          "future": "A sessão não pode começar no futuro.",
+          "duration": "A duração deve ser entre 1 e 1440 minutos.",
+          "endProgress": "O progresso final deve ser entre 0 e 100."
+        },
+        "title": "Adicionar sessão de leitura",
+        "startedAt": "Iniciada em",
+        "duration": "Duração (minutos)",
+        "endProgress": "Progresso final %",
+        "optional": "Opcional",
+        "format": "Formato",
+        "noFormat": "Nenhum formato específico",
+        "saving": "Salvando...",
+        "submit": "Adicionar sessão"
+      },
+      "coverEditor": {
+        "unlockCover": "Desbloquear capa",
+        "lockCover": "Bloquear capa",
+        "fileTab": "Arquivo",
+        "urlTab": "URL",
+        "chooseImage": "Escolher imagem...",
+        "findCoverOnline": "Encontrar capa online",
+        "saving": "Salvando...",
+        "saveCover": "Salvar capa",
+        "revertToOriginal": "Reverter para o original",
+        "regenerateCover": "Regerar Capa"
+      },
+      "coverSearch": {
+        "title": "Pesquisa Online",
+        "subtitle": "Procurar capas de livros",
+        "titleField": "Título",
+        "authorField": "Autor",
+        "sourceField": "Origem",
+        "allSources": "Todas as Fontes",
+        "audiobookCovers": "Capas de audiobooks",
+        "squareHint": "(quadrado)",
+        "searching": "Pesquisando...",
+        "findCovers": "Encontrar capas",
+        "selectCover": "Selecionar Capa",
+        "noResultsTitle": "Nenhum resultado encontrado",
+        "noResultsHint": "Tente ajustar seus termos de pesquisa",
+        "readyTitle": "Pronto para pesquisar",
+        "readyHint": "Insira um título e autor acima",
+        "resolutionTip": "Dica: Capas de alta resolução estão marcadas em verde"
+      },
+      "details": {
+        "by": "por",
+        "narratedBy": "narrado por",
+        "ratingLocked": "A avaliação está bloqueada",
+        "rateStar": "Avaliar {star}",
+        "listen": "Ouvir",
+        "read": "Ler",
+        "chooseFormat": "Escolha o formato",
+        "audiobook": "Audiobook",
+        "primary": "Principal",
+        "peek": "Espiar",
+        "sendViaEmail": "Enviar por E-mail",
+        "editCover": "Editar capa",
+        "finished": "Concluído",
+        "resetFileProgress": "Redefinir o progresso do arquivo",
+        "resetting": "Redefinindo...",
+        "resetProgressConfirm": "Redefinir o progresso de leitura armazenado para {label}?",
+        "moreCount": "+{count} mais",
+        "untitled": "Sem título",
+        "metadataScore": "Pontuação de Metadados",
+        "primaryFormat": "Formato principal",
+        "openIn": "Abrir em {provider}",
+        "showLess": "Mostrar menos",
+        "showMore": "Mostrar mais",
+        "publisher": "Editora",
+        "published": "Publicado",
+        "language": "Idioma",
+        "pages": "Páginas",
+        "duration": "Duração",
+        "edition": "Edição",
+        "abridged": "Resumido",
+        "unabridged": "Não resumido",
+        "isbn": "ISBN",
+        "fileSize": "Tamanho do Arquivo",
+        "library": "Biblioteca",
+        "added": "Adicionado",
+        "dateStarted": "Data de Início",
+        "saving": "Salvando...",
+        "cancelDateStartedEdit": "Cancelar edição da data de início",
+        "editDateStarted": "Editar data de início",
+        "dateFinished": "Data de Conclusão",
+        "cancelDateFinishedEdit": "Cancelar edição da data de conclusão",
+        "editDateFinished": "Editar data de conclusão",
+        "customMetadata": "Metadados Personalizados",
+        "synopsis": "Sinopse",
+        "noDescription": "Nenhuma descrição disponível.",
+        "dateStartedFutureError": "A Data de Início não pode ser no futuro.",
+        "dateFinishedFutureError": "A Data de Conclusão não pode ser no futuro.",
+        "dateFinishedBeforeStartedError": "A Data de Conclusão deve ser igual ou posterior à Data de Início.",
+        "saveReadingDatesError": "Falha ao salvar as datas de leitura.",
+        "koboPendingDelete": "Exclusão pendente do dispositivo",
+        "koboPendingDeleteTooltip": "O Kobo o removerá na próxima sincronização.",
+        "koboRemovedByDevice": "Removido pelo dispositivo",
+        "koboRemovedByDeviceTooltip": "O Kobo relatou este livro como removido.",
+        "koboNotSynced": "Não sincronizado",
+        "koboNotSyncedTooltip": "Na fila para a próxima sincronização do Kobo.",
+        "filesNotFound": "Arquivos não encontrados",
+        "filesNotFoundDescription": "O(s) arquivo(s) deste livro não pode(m) mais ser encontrado(s) no disco. Os metadados ainda estão disponíveis. Execute uma verificação da biblioteca para confirmar ou remova o registro."
+      },
+      "editMetadata": {
+        "fieldCount": "nenhum campo | um campo | {count} campos",
+        "bookFilesTarget": "arquivos do livro",
+        "formatFilesTarget": "arquivos {formats}",
+        "noPrimaryFile": "Nenhum arquivo principal disponível",
+        "formatNotSupported": "Este formato de arquivo não suporta gravação",
+        "formatDisabled": "A gravação está desativada para este formato",
+        "fileExceedsSizeLimit": "Este arquivo excede o limite de tamanho para gravação",
+        "writing": "Gravando...",
+        "saveInProgress": "Salvamento em andamento",
+        "writeManualLibraryDisabled": "Gravar metadados no arquivo e renomear no disco; a gravação automática está desativada para esta biblioteca",
+        "writeManualTooltip": "Gravar {fields} em {target} e renomear no disco",
+        "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "Ignorou nenhum campo bloqueado | Ignorou um campo bloqueado | Ignorou {count} campos bloqueados",
+        "updatedFields": "atualizou nenhum campo | atualizou um campo | atualizou {count} campos",
+        "wroteFieldsToFile": "Gravou {fields} no arquivo",
+        "fileWriteFailedReason": "Falha ao gravar arquivo: {reason}",
+        "fileWriteFailed": "Falha ao gravar arquivo",
+        "fileWriteSkippedReason": "Gravação de arquivo ignorada: {reason}",
+        "fileWriteSkipped": "Gravação de arquivo ignorada",
+        "metadataSaved": "Metadados salvos",
+        "metadataWrittenToFile": "Metadados gravados no arquivo",
+        "savedButWriteFailedReason": "Metadados salvos, mas a gravação no arquivo falhou: {reason}",
+        "savedButWriteFailed": "Metadados salvos, mas a gravação no arquivo falhou",
+        "savedWriteSkippedReason": "Metadados salvos, gravação no arquivo ignorada: {reason}",
+        "savedWriteSkipped": "Metadados salvos, gravação no arquivo ignorada",
+        "loadFromFileFailed": "Falha ao carregar metadados do arquivo",
+        "loadedFieldsFromFile": "Carregou nenhum campo do arquivo | Carregou um campo do arquivo | Carregou {count} campos do arquivo",
+        "noMetadataInFile": "Nenhum metadado encontrado no arquivo",
+        "loadFromFile": "Carregar do arquivo",
+        "loadFromFileTooltip": "Carregar metadados do arquivo principal do livro",
+        "writeToFile": "Gravar no arquivo",
+        "autoFill": "Preencher automaticamente",
+        "fetchingMetadata": "Buscando metadados...",
+        "allFieldsLocked": "Todos os campos estão bloqueados",
+        "autoFillTooltip": "Preencher campos automaticamente usando suas preferências de metadados",
+        "lockAll": "Bloquear tudo",
+        "lockAllTooltip": "Bloquear todos os campos",
+        "unlockAll": "Desbloquear tudo",
+        "unlockAllTooltip": "Desbloquear todos os campos",
+        "saving": "Salvando...",
+        "fileWriteBackDetails": "Detalhes de gravação no arquivo",
+        "fileWriteBack": "Gravação de arquivo",
+        "enabled": "Ativado",
+        "saveWritesMetadata": "'Salvar' grava os metadados em {target}",
+        "formats": "Formatos",
+        "bookFiles": "Arquivos de livro",
+        "supportedFields": "Campos suportados",
+        "titleLabel": "Título",
+        "subtitleLabel": "Subtítulo",
+        "authorsLabel": "Autores",
+        "narratorsLabel": "Narradores",
+        "genresLabel": "Gêneros",
+        "tagsLabel": "Tags",
+        "ratingLabel": "Avaliação",
+        "rateStar": "Avaliar {star}",
+        "clear": "Limpar",
+        "communityRatingsLabel": "Avaliações da Comunidade",
+        "noProviderRatings": "Nenhuma avaliação de provedor",
+        "seriesLabel": "Série",
+        "publisherLabel": "Editora",
+        "languageLabel": "Idioma",
+        "yearLabel": "Ano",
+        "pageCountLabel": "Contagem de Páginas",
+        "isbn13Label": "ISBN-13",
+        "isbn10Label": "ISBN-10",
+        "durationLabel": "Duração (s)",
+        "abridgedLabel": "Resumido",
+        "providerIds": "IDs de Provedores",
+        "comicDetails": "Detalhes do Quadrinho",
+        "comicIssueNumberLabel": "Número da Edição",
+        "comicVolumeLabel": "Volume",
+        "comicStoryArcsLabel": "Arcos de História",
+        "comicPencillersLabel": "Desenhistas",
+        "comicInkersLabel": "Arte-finalistas",
+        "comicColoristsLabel": "Coloristas",
+        "comicLetterersLabel": "Letreiristas",
+        "comicCoverArtistsLabel": "Artistas da Capa",
+        "comicCharactersLabel": "Personagens",
+        "comicTeamsLabel": "Equipes",
+        "comicLocationsLabel": "Locais",
+        "customMetadata": "Metadados Personalizados",
+        "descriptionLabel": "Descrição",
+        "unlockField": "Desbloquear {field}",
+        "lockField": "Bloquear {field}",
+        "diffPanel": {
+          "untitled": "Sem título",
+          "noFieldsSelected": "Nenhum campo selecionado",
+          "fieldsSelected": "nenhum campo selecionado | um campo selecionado | {count} campos selecionados",
+          "results": "Resultados",
+          "providerMatches": "Correspondências no {provider}",
+          "selectedOf": "Selecionados {selected} de {total}",
+          "yearUnknown": "Ano desconhecido",
+          "indexOf": "{index} de {total}",
+          "switchedResult": "Resultado alterado. As seleções anteriores deste provedor foram limpas.",
+          "selectFieldsToApply": "Selecione campos para aplicar",
+          "copyMissing": "Copiar Ausentes",
+          "copyAll": "Copiar Tudo",
+          "hideUnchanged": "Ocultar inalterados",
+          "showUnchanged": "Mostrar inalterados",
+          "current": "Atual",
+          "noMetadata": "Nenhum metadado disponível desta fonte.",
+          "noChangedFields": "Nenhum campo alterado ou ausente. Use Mostrar inalterados para inspecionar tudo.",
+          "applyToForm": "Aplicar ao formulário"
+        },
+        "diff": {
+          "locked": "Bloqueado",
+          "previewAlt": "Pré-visualização",
+          "currentCoverAlt": "Capa atual",
+          "newCoverAlt": "Nova capa",
+          "pickCoverFromProvider": "Escolher capa de outro provedor",
+          "pickCoverSource": "Escolher origem da capa",
+          "pickFromProvider": "Escolher de outro provedor",
+          "pickSource": "Escolher origem",
+          "empty": "vazio",
+          "showLess": "Mostrar menos",
+          "showMore": "Mostrar mais",
+          "coverPreviewAlt": "Pré-visualização de capa"
+        },
+        "searchDrawer": {
+          "searchTitle": "Pesquisar Metadados",
+          "compareTitle": "Comparar Metadados",
+          "searchSubtitle": "Encontre a melhor correspondência de provedor para este livro.",
+          "compareSubtitle": "Revise as diferenças e aplique apenas o que desejar."
+        },
+        "searchPanel": {
+          "untitledQuery": "Consulta sem título",
+          "titlePlaceholder": "Título",
+          "authorPlaceholder": "Autor",
+          "isbnPlaceholder": "ISBN",
+          "searching": "Pesquisando...",
+          "activeQuery": "Consulta ativa",
+          "searchScope": "Escopo de pesquisa",
+          "allEnabled": "Todos os habilitados",
+          "all": "Tudo",
+          "fieldRules": "Regras de Campo",
+          "custom": "Personalizado",
+          "providerNotInFieldRules": "{provider} está habilitado, mas não nas Regras de Campo",
+          "notInFieldRulesLabel": "Não nas Regras de Campo:",
+          "notInFieldRulesText": "{providers}. Incluídos na busca manual com 'Todos os habilitados' ativo, mas não usados na busca automática de metadados.",
+          "noResults": "Nenhum resultado encontrado",
+          "noResultsHint": "Tente ajustar o título ou autor",
+          "searchPrompt": "Pesquise acima, depois clique em um resultado para começar a comparar os metadados."
+        },
+        "writeAndRename": "Gravar no Arquivo e Renomear",
+        "writeAndRenameShort": "Gravar e Renomear"
+      },
+      "files": {
+        "relative": {
+          "seconds": "{value}s atrás",
+          "minutes": "{value}m atrás",
+          "hours": "{value}h atrás",
+          "days": "{value}d atrás"
+        },
+        "renameFailed": "Falha ao renomear arquivo",
+        "deleteFailed": "Falha ao excluir arquivo",
+        "addFile": "Adicionar Arquivo",
+        "lastSynced": "Última sincronização: {time}",
+        "sort": {
+          "label": "Ordenar:",
+          "name": "Nome",
+          "format": "Formato",
+          "size": "Tamanho",
+          "date": "Data"
+        },
+        "hidePaths": "Ocultar caminhos",
+        "showPaths": "Mostrar caminhos",
+        "hideLog": "Ocultar log",
+        "viewSyncLog": "Ver log de sincronização",
+        "noWriteHistory": "Nenhum histórico de gravação ainda.",
+        "fieldsWritten": "nenhum campo | um campo | {count} campos",
+        "track": "Faixa {number}",
+        "primary": "Principal",
+        "read": "Ler",
+        "play": "Reproduzir",
+        "peek": "Espiar",
+        "download": "Baixar",
+        "moreActions": "Mais ações",
+        "rename": "Renomear",
+        "empty": {
+          "title": "Nenhum arquivo anexado",
+          "description": "Este livro não possui arquivos associados."
+        },
+        "renameModal": {
+          "title": "Renomear Arquivo",
+          "description": "Renomeie o arquivo físico no disco.",
+          "placeholder": "Novo nome de arquivo"
+        },
+        "saving": "Salvando...",
+        "deleteModal": {
+          "title": "Excluir arquivo?",
+          "description": "Tem certeza que deseja excluir \"{filename}\"? Esta ação não pode ser desfeita."
+        },
+        "deleting": "Excluindo..."
+      },
+      "highlights": {
+        "note": {
+          "placeholder": "Adicionar uma nota...",
+          "saving": "Salvando"
+        },
+        "export": {
+          "trigger": "Exportar",
+          "plainText": "Texto Simples",
+          "page": "Exportar página",
+          "selected": "Exportar selecionados"
+        },
+        "sort": {
+          "position": "Posição",
+          "newest": "Mais novos primeiro",
+          "oldest": "Mais antigos primeiro"
+        },
+        "summary": {
+          "highlights": "nenhum destaque | um destaque | {count} destaques",
+          "notes": "nenhuma nota | uma nota | {count} notas",
+          "chapters": "nenhum capítulo | um capítulo | {count} capítulos"
+        },
+        "filterByChapter": "Filtrar por capítulo",
+        "allChapters": "Todos os capítulos",
+        "untitled": "Sem título",
+        "trash": "Lixeira",
+        "empty": {
+          "noMatch": "Nenhum destaque corresponde aos seus filtros.",
+          "resetFilters": "Redefinir filtros",
+          "none": "Nenhum destaque ainda",
+          "hint": "Selecione o texto durante a leitura para criar destaques"
+        },
+        "uncategorized": "Sem categoria",
+        "paginationUnit": "destaques"
+      },
+      "readingLog": {
+        "export": {
+          "button": "Exportar"
+        },
+        "weekdays": {
+          "sun": "Dom",
+          "mon": "Seg",
+          "tue": "Ter",
+          "wed": "Qua",
+          "thu": "Qui",
+          "fri": "Sex",
+          "sat": "Sáb"
+        },
+        "months": {
+          "jan": "Jan",
+          "feb": "Fev",
+          "mar": "Mar",
+          "apr": "Abr",
+          "may": "Mai",
+          "jun": "Jun",
+          "jul": "Jul",
+          "aug": "Ago",
+          "sep": "Set",
+          "oct": "Out",
+          "nov": "Nov",
+          "dec": "Dez"
+        },
+        "heatmap": {
+          "subtitle": "{count} dia ativo · {ratio}% de consistência | {count} dia ativo · {ratio}% de consistência | {count} dias ativos · {ratio}% de consistência",
+          "minutesUnit": "min",
+          "title": "Atividade",
+          "empty": "Nenhuma atividade de leitura nesta janela."
+        },
+        "hero": {
+          "notSet": "Não definido",
+          "relative": {
+            "seconds": "{count}s atrás",
+            "minutes": "{count}m atrás",
+            "hours": "{count}h atrás",
+            "days": "{count}d atrás",
+            "months": "{count} mês atrás | {count} mês atrás | {count} meses atrás",
+            "years": "{count} ano atrás | {count} ano atrás | {count} anos atrás"
+          },
+          "noSessions": "Nenhuma sessão",
+          "dateErrors": {
+            "startFuture": "A data de início não pode ser no futuro.",
+            "finishFuture": "A data de término não pode ser no futuro.",
+            "finishBeforeStart": "A data de término deve ser posterior ou igual à data de início.",
+            "saveFailed": "Falha ao salvar as datas de leitura."
+          },
+          "eta": {
+            "max": "99h+ para terminar",
+            "minutes": "~{m}m para terminar",
+            "hours": "~{h}h para terminar",
+            "hoursMinutes": "~{h}h {m}m para terminar"
+          },
+          "momentum": {
+            "none": "Nenhuma atividade nas últimas duas semanas",
+            "new": "Nova atividade esta semana",
+            "up": "+{pct}% vs os 7 dias anteriores",
+            "down": "{pct}% vs os 7 dias anteriores",
+            "flat": "Inalterado vs os 7 dias anteriores"
+          },
+          "stats": {
+            "totalTime": "Tempo Total",
+            "sessions": "Sessões",
+            "avgSession": "Sessão Média",
+            "lastRead": "Última Leitura"
+          },
+          "firstRead": "Primeira Leitura",
+          "lastRead": "Última Leitura",
+          "dateStarted": "Data de Início",
+          "dateFinished": "Data de Conclusão",
+          "addSession": "Adicionar sessão"
+        },
+        "journey": {
+          "tooltipProgress": "Progresso",
+          "tooltipReading": "Lendo",
+          "minutesUnit": "min",
+          "title": "Jornada de progresso",
+          "empty": "Nenhum dado de progresso nesta janela."
+        },
+        "sourceSplit": {
+          "title": "Onde você leu este livro"
+        },
+        "untitled": "Sem título",
+        "addSessionFailed": "Falha ao adicionar sessão",
+        "filters": {
+          "allTime": "Todo o tempo",
+          "last30": "Últimos 30 dias",
+          "last90": "Últimos 90 dias",
+          "thisYear": "Este ano",
+          "allFormats": "Todos os formatos"
+        },
+        "table": {
+          "sourceWeb": "Web",
+          "sourceManual": "Manual",
+          "colDate": "Data",
+          "colDateMobile": "Data",
+          "colDuration": "Duração",
+          "colDurationMobile": "Duração",
+          "colProgressChange": "Mudança de Progresso",
+          "colProgressChangeMobile": "Delta",
+          "colEndProgress": "Progresso Final",
+          "colEndProgressMobile": "Fim",
+          "empty": "Nenhuma sessão de leitura registrada ainda.",
+          "colPace": "Ritmo",
+          "colSource": "Origem",
+          "colFormatMobile": "Fmt",
+          "colFormat": "Formato",
+          "cancelDelete": "Cancelar exclusão",
+          "cancelDeleteAria": "Cancelar exclusão de sessão",
+          "confirmDeleteTitle": "Clique novamente para confirmar a exclusão",
+          "confirmDeleteAria": "Confirmar exclusão da sessão",
+          "deleteAria": "Excluir sessão",
+          "loadMore": "Carregar mais",
+          "showing": "Mostrando {shown} de {total} sessões"
+        }
+      },
+      "richDescription": {
+        "linkProtocolError": "Use http, https ou mailto.",
+        "bold": "Negrito",
+        "italic": "Itálico",
+        "underline": "Sublinhado",
+        "strikethrough": "Tachado",
+        "bulletList": "Lista com marcadores",
+        "numberedList": "Lista numerada",
+        "outdentAria": "Diminuir recuo de item da lista",
+        "outdent": "Diminuir recuo",
+        "indentAria": "Aumentar recuo de item da lista",
+        "indent": "Aumentar recuo",
+        "quote": "Citação",
+        "editLink": "Editar link",
+        "link": "Link",
+        "removeLink": "Remover link",
+        "undo": "Desfazer",
+        "redo": "Refazer",
+        "clearFormatting": "Limpar formatação",
+        "previewDescription": "Pré-visualizar descrição",
+        "preview": "Pré-visualização",
+        "linkUrlLabel": "URL do link",
+        "applyLink": "Aplicar link",
+        "apply": "Aplicar",
+        "cancelLink": "Cancelar link",
+        "noDescription": "Nenhuma descrição disponível."
+      },
+      "seriesMembership": {
+        "addSeries": "Adicionar série",
+        "seriesPlaceholder": "Série",
+        "moveUp": "Mover para cima",
+        "moveDown": "Mover para baixo",
+        "removeSeries": "Remover série"
+      }
+    },
+    "table": {
+      "actions": {
+        "quickView": "Visualização Rápida",
+        "bookDetails": "Detalhes do Livro",
+        "editMetadata": "Editar Metadados",
+        "refreshMetadata": "Atualizar Metadados",
+        "addToCollection": "Adicionar à Coleção",
+        "sendToDevice": "Enviar para o Dispositivo"
+      },
+      "boolean": {
+        "ariaNotSet": "Não definido - clique para definir verdadeiro",
+        "ariaTrue": "Verdadeiro - clique para definir falso",
+        "ariaFalse": "Falso - clique para limpar"
+      },
+      "chips": {
+        "addPlaceholder": "Adicionar..."
+      },
+      "cover": {
+        "previewDescription": "Pré-visualização da capa do livro",
+        "editDescription": "Editar a capa do livro",
+        "editTitle": "Editar capa",
+        "editCover": "Editar Capa",
+        "view": "Visualizar capa"
+      },
+      "date": {
+        "justNow": "agora mesmo"
+      },
+      "format": {
+        "unknown": "desconhecido"
+      },
+      "header": {
+        "sortAscending": "Ordem Crescente",
+        "sortDescending": "Ordem Decrescente",
+        "clearSort": "Limpar Ordenação",
+        "hideColumn": "Ocultar Coluna",
+        "pinLeft": "Fixar à Esquerda",
+        "pinRight": "Fixar à Direita",
+        "unpinColumn": "Desafixar Coluna",
+        "autoFitWidth": "Ajuste Automático de Largura",
+        "autoFitAllColumns": "Ajuste Automático para Todas as Colunas",
+        "selectAllBooks": "Selecionar todos os livros",
+        "shiftClickSecondarySort": "Shift+clique para adicionar ordenação secundária",
+        "clickToSort": "Clique para ordenar"
+      },
+      "locks": {
+        "lockAll": "Bloquear todos os campos",
+        "unlockAll": "Desbloquear todos os campos",
+        "lockField": "Bloquear campo",
+        "unlockField": "Desbloquear campo",
+        "clickToLock": "Clique para bloquear",
+        "clickToUnlock": "Clique para desbloquear"
+      },
+      "progress": {
+        "complete": "{percent} concluído"
+      },
+      "rating": {
+        "label": "Avaliação",
+        "remove": "Remover avaliação",
+        "rate": "Avaliar {star} de 5"
+      },
+      "read": {
+        "play": "Reproduzir",
+        "read": "Ler",
+        "primary": "Principal",
+        "peekFormat": "Espiar {format}",
+        "chooseFormat": "Escolha o formato para ler ou reproduzir",
+        "fileFallback": "ARQUIVO"
+      },
+      "readStatus": {
+        "unread": "Não lido"
+      },
+      "series": {
+        "bookCount": "(nenhum livro) | ({count} livro) | ({count} livros)",
+        "readOfCount": "{read} de {total} lidos"
+      },
+      "text": {
+        "openDetails": "Abrir detalhes"
+      }
+    }
+  },
+  "bookMetadataFetch": {
+    "book": {
+      "title": "Busca de Metadados"
+    },
+    "author": {
+      "title": "Enriquecimento de Autor"
+    },
+    "stats": {
+      "queued": "Na fila",
+      "processing": "Processando",
+      "rateLimited": "Limite de taxa",
+      "failed": "Falhou"
+    },
+    "actions": {
+      "pause": "Pausar",
+      "resume": "Retomar",
+      "cancelQueued": "Cancelar fila"
+    },
+    "cancel": {
+      "processingWillFinish": "Os itens atualmente em processamento serão concluídos.",
+      "confirm": "Confirmar cancelamento",
+      "keepRunning": "Continuar executando"
+    },
+    "viewFailed": "Ver um que falhou | Ver {count} que falharam",
+    "card": {
+      "fetchingMetadata": "Buscando metadados",
+      "enrichingAuthors": "Enriquecendo autores"
+    },
+    "label": {
+      "paused": "Pausado",
+      "remaining": "{count} restantes",
+      "processing": "{count} processando",
+      "failed": "{count} falhou",
+      "rateLimited": "{count} limitados por taxa"
+    },
+    "report": {
+      "bookTitle": "Buscas de Metadados com Falha",
+      "authorTitle": "Enriquecimentos de Autor com Falha",
+      "noFailedItems": "Nenhum item com falha.",
+      "retryAllFailed": "Tentar novamente todos com falha",
+      "bookFallback": "Livro #{id}",
+      "authorFallback": "Autor #{id}",
+      "columns": {
+        "title": "Título",
+        "library": "Biblioteca",
+        "author": "Autor",
+        "error": "Erro",
+        "http": "HTTP"
+      }
+    },
+    "toast": {
+      "failedToPause": "Falha ao pausar",
+      "failedToResume": "Falha ao retomar",
+      "failedToCancel": "Falha ao cancelar",
+      "failedToRetry": "Falha ao tentar novamente",
+      "failedItemsRequeued": "Itens com falha re-enfileirados",
+      "bookComplete": "Busca de metadados concluída - {done} livros atualizados",
+      "bookDoneWithFailures": "Busca de metadados finalizada - {done} processados, {failed} falharam",
+      "authorComplete": "Enriquecimento de autor concluído - {done} autores atualizados",
+      "authorDoneWithFailures": "Enriquecimento de autor finalizado - {done} processados, {failed} falharam"
+    }
+  },
+  "bookDock": {
+    "apply": "Aplicar",
+    "done": "Concluído",
+    "discard": "Descartar",
+    "finalize": "Finalizar",
+    "rescan": "Reescanear",
+    "uploadAction": "Fazer upload",
+    "uploading": "Enviando...",
+    "searchPlaceholder": "Pesquisar arquivos...",
+    "setDestinationAction": "Definir Destino",
+    "bulkEditAction": "Edição em Massa",
+    "applyFetched": "Aplicar Buscados",
+    "retryErrors": "Tentar Erros Novamente",
+    "commaSeparated": "separados por vírgula",
+    "destinationLibrary": "Biblioteca de Destino",
+    "destinationFolder": "Pasta de Destino",
+    "nSelected": "nenhum arquivo selecionado | {count} selecionado | {count} selecionados",
+    "nFailed": "{count} falhou",
+    "updatedOfFiles": "Atualizou {updated} de {total} arquivos",
+    "errorStatus": "Erro {status}",
+    "applyFetchedTooltip": "Aplicar metadados do provedor buscados automaticamente a {count} arquivos | Aplicar metadados do provedor buscados automaticamente a {count} arquivo | Aplicar metadados do provedor buscados automaticamente a {count} arquivos",
+    "retryErrorsTooltip": "Tentar novamente a busca de metadados para {count} arquivos com erro | Tentar novamente a busca de metadados para {count} arquivo com erro | Tentar novamente a busca de metadados para {count} arquivos com erro",
+    "tab": {
+      "all": "Todos",
+      "pending": "Pendente",
+      "ready": "Pronto",
+      "error": "Erro"
+    },
+    "status": {
+      "pending": "Pendente",
+      "extracting": "Extraindo",
+      "fetching": "Buscando",
+      "ready": "Pronto",
+      "error": "Erro"
+    },
+    "field": {
+      "title": "Título",
+      "subtitle": "Subtítulo",
+      "authors": "Autores",
+      "authorsCommaSeparated": "Autores (separados por vírgula)",
+      "publisher": "Editora",
+      "year": "Ano",
+      "language": "Idioma",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "series": "Série",
+      "seriesIndex": "Índice da série",
+      "genres": "Gêneros",
+      "genresCommaSeparated": "Gêneros (separados por vírgula)",
+      "description": "Descrição"
+    },
+    "upload": {
+      "nDone": "{count} concluídos",
+      "nFailed": "{count} falharam",
+      "nTotal": "{count} total"
+    },
+    "fileList": {
+      "emptyTitle": "Nenhum arquivo no Book Dock",
+      "emptyMessageDefault": "Faça upload de arquivos ou solte-os na pasta do Book Dock",
+      "colCurrent": "Atual",
+      "colNew": "Novo",
+      "colFile": "Arquivo",
+      "colSize": "Tamanho",
+      "colFormat": "Formato",
+      "colMatch": "Correspondência",
+      "colApply": "Aplicar",
+      "colStatus": "Status",
+      "applyFetchedMetadata": "Aplicar metadados buscados",
+      "coverPreview": "Pré-visualização da capa",
+      "coverPreviewDescription": "Diálogo de visualização da imagem da capa ampliada.",
+      "currentCoverAlt": "Capa atual de {title}",
+      "newCoverAlt": "Nova capa de {title}",
+      "unknownLibrary": "Biblioteca desconhecida",
+      "unassigned": "Não atribuído",
+      "targetPath": "Destino: {library} · {path}",
+      "targetUnassigned": "Destino: Não atribuído",
+      "targetUnknownPath": "Destino: {library} · Caminho de destino desconhecido"
+    },
+    "sheet": {
+      "saved": "Salvo",
+      "providerMetadataFound": "Metadados de provedor encontrados",
+      "providerMetadataFoundEdited": "Metadados de provedor encontrados - aplicação em massa irá ignorar este arquivo (você possui edições)",
+      "review": "Revisar",
+      "added": "Adicionado em {date}",
+      "searchMetadata": "Pesquisar Metadados",
+      "results": "Resultados"
+    },
+    "bulkEdit": {
+      "title": "Editar em massa nenhum arquivo | Editar em massa {count} arquivo | Editar em massa {count} arquivos",
+      "resultTitle": "Resultados da Edição em Massa",
+      "instructions": "Alterne os campos que deseja atualizar. Apenas os campos ativados serão aplicados.",
+      "mergeArrays": "Mesclar arrays (adicionar aos valores existentes em vez de substituir)",
+      "failed": "A edição em massa falhou"
+    },
+    "setDestination": {
+      "title": "Definir Destino para nenhum arquivo | Definir Destino para {count} arquivo | Definir Destino para {count} arquivos",
+      "resultTitle": "Destino Atualizado",
+      "failed": "Falha ao definir o destino"
+    },
+    "finalizeDialog": {
+      "title": "Finalizar nenhum arquivo | Finalizar {count} arquivo | Finalizar {count} arquivos",
+      "resultTitle": "Resultados da Finalização",
+      "needDestination": "{without} de {count} arquivos selecionados precisam de um destino | {without} de {count} arquivo selecionado precisa de um destino | {without} de {count} arquivos selecionados precisam de um destino",
+      "allHaveDestination": "Todos os arquivos selecionados já possuem destino definido",
+      "defaultDestinationLibrary": "Biblioteca de Destino Padrão",
+      "defaultDestinationFolder": "Pasta de Destino Padrão",
+      "renamePreview": "Pré-visualização de renomeação",
+      "moreFiles": "+{count} mais arquivos",
+      "start": "Iniciar",
+      "filesFinalized": "{succeeded} de {total} arquivos finalizados",
+      "failedWithDuplicates": "{failed} falharam ({count} duplicatas) | {failed} falhou ({count} duplicata) | {failed} falharam ({count} duplicatas)",
+      "view": "Ver",
+      "viewExisting": "Ver existente",
+      "importAnyway": "Importar mesmo assim",
+      "hide": "Ocultar",
+      "details": "Detalhes",
+      "alreadyExistsSaveAs": "Já existe - salvar como:",
+      "renamePlaceholder": "ex: {name} (2)",
+      "import": "Importar"
+    }
+  },
+  "collection": {
+    "dialog": {
+      "name": "Nome",
+      "icon": "Ícone",
+      "iconPlaceholder": "Escolha um ícone...",
+      "nameRequired": "O nome é obrigatório",
+      "iconRequired": "Escolha um ícone",
+      "creating": "Criando...",
+      "createFailed": "Falha ao criar coleção"
+    },
+    "createDialog": {
+      "title": "Nova Coleção",
+      "namePlaceholder": "ex: Favoritos"
+    },
+    "editDialog": {
+      "title": "Editar Coleção",
+      "syncToKobo": "Sincronizar com Kobo",
+      "syncToKoboHint": "Os livros nesta coleção aparecerão no seu dispositivo Kobo",
+      "deleteCollection": "Excluir coleção",
+      "confirmDelete": "Confirmar?",
+      "deleting": "Excluindo...",
+      "saving": "Salvando...",
+      "deleted": "\"{name}\" excluída",
+      "updateFailed": "Falha ao atualizar coleção",
+      "deleteFailed": "Falha ao excluir coleção"
+    },
+    "addToSheet": {
+      "title": "Gerenciar Coleções",
+      "selectedCount": "nenhum livro selecionado | um livro selecionado | {count} livros selecionados",
+      "newCollection": "Nova Coleção",
+      "namePlaceholder": "Nome da coleção",
+      "create": "Criar",
+      "collections": "Coleções",
+      "empty": "Nenhuma coleção ainda. Crie uma acima.",
+      "done": "Concluído",
+      "added": "Adicionado",
+      "allAdded": "Todos os {total} adicionados",
+      "inCollection": "Nesta coleção",
+      "allInCollection": "Todos os {total} nesta coleção",
+      "partialInCollection": "{partial} de {total} nesta coleção",
+      "bookCount": "nenhum livro | um livro | {count} livros",
+      "loadFailed": "Falha ao carregar coleções",
+      "createdAndAdded": "Criada \"{name}\" e adicionado nenhum livro | Criada \"{name}\" e adicionado um livro | Criada \"{name}\" e adicionados {count} livros",
+      "createdButAddFailed": "Criada \"{name}\", mas falhou ao adicionar livros",
+      "createFailed": "Falha ao criar coleção",
+      "addedNewWithExisting": "Adicionado um livro novo a \"{name}\" ({alreadyHad} já lá) | Adicionado um livro novo a \"{name}\" ({alreadyHad} já lá) | Adicionados {count} novos livros a \"{name}\" ({alreadyHad} já lá)",
+      "addedToCollection": "Nenhum livro adicionado a \"{name}\" | Um livro adicionado a \"{name}\" | {count} livros adicionados a \"{name}\"",
+      "addFailed": "Falha ao adicionar à coleção",
+      "removedFromCollection": "Nenhum livro removido de \"{name}\" | Um livro removido de \"{name}\" | {count} livros removidos de \"{name}\"",
+      "removeFailed": "Falha ao remover da coleção"
+    }
+  },
+  "components": {
+    "appHeader": {
+      "searchAllBooks": "Pesquisar todos os livros...",
+      "searching": "Pesquisando...",
+      "noResults": "Sem resultados",
+      "loadingMore": "Carregando mais...",
+      "loadMore": "Carregar mais ({loaded}/{total})",
+      "allMatchesShown": "Todas as 1 correspondências mostradas | Toda a 1 correspondência mostrada | Todas as {count} correspondências mostradas",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+      "uploadedToast": "Enviado(s) {uploaded}",
+      "uploadFailedToast": "O envio falhou para {failed}",
+      "uploadPartialToast": "Enviado(s) {uploaded}, {failed} falharam",
+      "bookDock": "Book Dock",
+      "statistics": "Estatísticas",
+      "achievements": "Conquistas",
+      "annotations": "Anotações",
+      "uploadBooks": "Enviar livros",
+      "appearance": "Aparência",
+      "theme": "Tema",
+      "accent": "Destaque",
+      "radius": "Raio",
+      "background": "Fundo",
+      "settings": "Configurações",
+      "whatsNew": "O que há de novo",
+      "documentation": "Documentação",
+      "help": "Ajuda",
+      "starOnGithub": "Dê uma estrela no GitHub",
+      "new": "Novo",
+      "newReleaseNotes": "Novas notas de lançamento disponíveis",
+      "account": "Conta",
+      "changePassword": "Alterar Senha",
+      "signOut": "Sair",
+      "githubStar": {
+        "title": "Gostando do BookOrbit?",
+        "body": "Se o BookOrbit está ajudando com a sua biblioteca, por favor, considere dar uma estrela ao projeto no GitHub. Isso ajuda mais pessoas a descobrirem o aplicativo e apoia o desenvolvimento contínuo.",
+        "cta": "Dar estrela ao BookOrbit no GitHub"
+      }
+    },
+    "sidebar": {
+      "tagline": "Seu Espaço de Leitura",
+      "dashboard": "Painel",
+      "authors": "Autores",
+      "series": "Série",
+      "tools": "Ferramentas",
+      "libraries": "Bibliotecas",
+      "newLibrary": "Nova Biblioteca",
+      "libraryScanning": "{name} - Verificando {pct}%",
+      "scanProgress": "{processed} / {total} livros",
+      "smartScopes": "Smart Scopes",
+      "newSmartScope": "Novo Smart Scope",
+      "noSmartScopes": "Nenhum Smart Scope ainda",
+      "collections": "Coleções",
+      "newCollection": "Nova Coleção",
+      "noCollections": "Nenhuma coleção ainda",
+      "latest": "Mais recente {version}",
+      "newReleaseNotes": "Novas notas de lançamento disponíveis",
+      "sectionHeader": {
+        "add": "Adicionar",
+        "reorder": "Reordenar",
+        "doneReordering": "Reordenação concluída"
+      }
+    },
+    "selectionActionBar": {
+      "setReadingStatus": "Definir status de leitura",
+      "setRating": "Definir avaliação",
+      "openMetadataEditor": "Abrir editor de metadados",
+      "editIndividually": "Editar livros individualmente",
+      "addToCollection": "Adicionar à coleção",
+      "removeFromCollection": "Remover da coleção",
+      "sendViaEmail": "Enviar por e-mail",
+      "downloadFilesZip": "Baixar arquivos como ZIP",
+      "moreActions": "Mais ações",
+      "setField": "Definir campo",
+      "refreshMetadata": "Atualizar metadados",
+      "reExtractCover": "Reextrair capa",
+      "metadataLock": "Bloqueio de metadados",
+      "lockAll": "Bloquear tudo",
+      "unlockAll": "Desbloquear tudo",
+      "exportMetadata": "Exportar metadados",
+      "deleteSelected": "Excluir selecionados",
+      "exitSelection": "Sair da seleção",
+      "downloadFilesZipLabel": "Baixar arquivos como ZIP:",
+      "primaryOnly": "Apenas principal",
+      "allFormats": "Todos os formatos",
+      "audioOnly": "Apenas áudio",
+      "setRatingLabel": "Definir avaliação:",
+      "clear": "Limpar",
+      "setFieldLabel": "Definir campo:",
+      "apply": "Aplicar",
+      "fieldPlaceholder": "Deixe em branco para limpar",
+      "fieldPlaceholderArray": "Separado por vírgulas (deixe em branco para limpar)",
+      "deleteConfirm": "Excluir {count} livro? | Excluir {count} livro? | Excluir {count} livros?",
+      "typeDelete": "Digite DELETE"
+    },
+    "viewHeader": {
+      "select": "Selecionar",
+      "display": "Exibição",
+      "displayDescription": "Ajuste o tamanho da capa, o espaçamento da grade e as opções de exibição de visualização.",
+      "columnVisibilityHint": "Use o painel de visibilidade das colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
+      "columnVisibilityMobileHint": "A visibilidade das colunas pode ser gerenciada no cabeçalho da tabela.",
+      "searchPlaceholder": "Pesquisar título, autor, série, narrador...",
+      "mobileSearch": {
+        "description": "Pesquise itens por título, autor, série ou narrador.",
+        "done": "Concluído"
+      },
+      "mobileMenu": {
+        "grid": "Grade",
+        "list": "Lista",
+        "select": "Selecionar",
+        "exitSelect": "Sair da Seleção"
+      },
+      "displayControls": {
+        "display": "Exibição",
+        "coverSize": "Tamanho da capa",
+        "gridGap": "Espaçamento da grade",
+        "columnsHint": "Use o painel de visibilidade das colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
+        "coverShape": "Formato da capa",
+        "circle": "Círculo",
+        "square": "Quadrado"
+      }
+    },
+    "iconPicker": {
+      "searchLucide": "Pesquisar ícones Lucide...",
+      "searchCustom": "Pesquisar ícones personalizados...",
+      "chooseIcon": "Escolha um ícone...",
+      "selectIcon": "Selecionar ícone",
+      "customTab": "Personalizado",
+      "searching": "Pesquisando...",
+      "noIconsMatch": "Nenhum ícone corresponde a \"{query}\"",
+      "typeToSearch": "Digite para pesquisar todos os ícones",
+      "noCustomIcons": "Nenhum ícone personalizado enviado",
+      "noIconsAvailable": "Nenhum ícone disponível"
+    },
+    "entityNotFound": {
+      "title": "{entity} não encontrado",
+      "description": "Este {entity} não existe ou foi excluído.",
+      "goBack": "Voltar"
+    },
+    "themePicker": {
+      "light": "Claro",
+      "dark": "Escuro"
+    },
+    "userAvatar": {
+      "profilePicture": "Foto de perfil",
+      "profilePictureOf": "Foto de perfil de {name}"
+    },
+    "ui": {
+      "sidebar": {
+        "title": "Barra Lateral",
+        "mobileDescription": "Exibe a barra lateral móvel.",
+        "toggle": "Alternar Barra Lateral"
+      },
+      "chipInput": {
+        "typeAndEnter": "Digite e pressione Enter para adicionar",
+        "pressEnter": "Pressione Enter para adicionar"
+      }
+    }
+  },
+  "customIcons": {
+    "dialogTitle": "Enviar ícones personalizados",
+    "dialogDescription": "Revise os nomes antes de adicioná-los à sua biblioteca.",
+    "readingFiles": "Lendo arquivos...",
+    "dropPrompt": "Solte arquivos SVG ou clique para procurar",
+    "fileLimit": "Até {max} arquivos, 128 KB cada",
+    "namePlaceholder": "Nome",
+    "nameRequired": "O nome é obrigatório",
+    "invalidSvg": "SVG Inválido",
+    "invalidSvgFile": "Arquivo SVG inválido",
+    "identicalTo": "Idêntico a \"{name}\"",
+    "uploadAnyway": "Enviar mesmo assim",
+    "skipThisOne": "Ignorar este",
+    "readyToUpload": "{count} prontos para upload",
+    "noIconsStaged": "Nenhum ícone na fila de envio ainda",
+    "uploading": "Enviando...",
+    "upload": "Fazer upload",
+    "uploadCount": "Fazer upload de {count}",
+    "onlySvgSupported": "Apenas arquivos SVG são suportados",
+    "maxStaged": "Você pode enfileirar no máximo {max} ícones de uma vez",
+    "onlyMoreCanStage": "Nenhum ícone adicional pode ser enfileirado | Apenas {count} ícone adicional pode ser enfileirado | Apenas {count} ícones adicionais podem ser enfileirados",
+    "readFailed": "Falha ao ler os arquivos SVG",
+    "uploadedCount": "Nenhum ícone enviado | {count} ícone enviado | {count} ícones enviados",
+    "uploadedPartial": "{created} enviado(s), {failed} falharam",
+    "noIconsUploaded": "Nenhum ícone enviado",
+    "uploadFailed": "Falha ao enviar os ícones",
+    "uploadFailedEntry": "O envio falhou"
+  },
+  "dashboard": {
+    "common": {
+      "failedToLoad": "Falha ao carregar",
+      "retry": "Tentar novamente",
+      "untitled": "Sem título",
+      "cover": "Capa",
+      "bookCover": "Capa do livro"
+    },
+    "scroller": {
+      "failedToLoad": "Falha ao carregar.",
+      "empty": {
+        "continueReading": "Nenhum livro em andamento ainda. Comece a ler um para vê-lo aqui.",
+        "continueListening": "Nenhum audiobook em andamento ainda. Comece a ouvir um para vê-lo aqui.",
+        "wantToRead": "Nenhum livro marcado como 'quero ler' ainda.",
+        "upNextInSeries": "Nenhuma próxima escolha da série ainda. Termine um volume para sugerir o próximo.",
+        "recentlyAdded": "Nenhum livro na sua biblioteca ainda.",
+        "smartScope": "Nenhum livro corresponde a este smartScope.",
+        "default": "Nenhum livro encontrado."
+      }
+    },
+    "settings": {
+      "title": "Personalizar Painel",
+      "tabs": {
+        "widgets": "Widgets",
+        "shelves": "Prateleiras"
+      },
+      "reorderHintWidget": "Arraste para reordenar. Alterne para mostrar ou ocultar um widget.",
+      "reorderHintShelf": "Arraste para reordenar. Alterne para mostrar ou ocultar uma prateleira.",
+      "smartScope": "Smart Scope",
+      "noSmartScopes": "Nenhum Smart Scope ainda. Crie um na barra lateral.",
+      "addShelf": "Adicionar prateleira",
+      "resetToDefaults": "Redefinir para os padrões"
+    },
+    "welcome": {
+      "emptyTitle": "Sua biblioteca está vazia",
+      "noLibrariesTitle": "Nenhuma biblioteca ainda",
+      "emptyDescription": "Crie uma biblioteca para começar a organizar e ler seus livros. Aponte para uma pasta e ela fará o resto.",
+      "noLibrariesDescription": "Seu administrador não configurou nenhuma biblioteca ainda. Entre em contato com eles para começar.",
+      "createFirstLibrary": "Criar sua primeira biblioteca"
+    },
+    "widgets": {
+      "currentlyReading": {
+        "title": "Lendo Atualmente",
+        "empty": "Nenhum livro em andamento. Comece a ler um para vê-lo aqui.",
+        "continueReading": "Continuar a ler"
+      },
+      "diversityScore": {
+        "title": "Índice de Diversidade",
+        "notEnoughData": "Leia pelo menos 3 livros para ver seu índice de diversidade",
+        "booksAnalyzed": "nenhum livro analisado | {count} livro analisado | {count} livros analisados",
+        "subScores": {
+          "genre": "Gênero",
+          "author": "Autor",
+          "era": "Época",
+          "language": "Idioma"
+        }
+      },
+      "highlightOfTheDay": {
+        "title": "Destaque do Dia",
+        "empty": "Destaque passagens durante a leitura para vê-las aqui"
+      },
+      "libraryOverview": {
+        "title": "Visão Geral da Biblioteca",
+        "empty": "Sua biblioteca está vazia. Adicione alguns livros para começar.",
+        "addedThisYear": "+{count} adicionados este ano",
+        "stats": {
+          "books": "Livros",
+          "authors": "Autores",
+          "series": "Série",
+          "storage": "Armazenamento"
+        }
+      },
+      "longWait": {
+        "title": "A Longa Espera",
+        "empty": "Nenhum livro aguardando. Você já começou tudo!",
+        "daysWaiting": "dias de espera",
+        "pages": "nenhuma página | {count} página | {count} páginas",
+        "startReading": "Começar a Ler"
+      },
+      "monthlyChallenge": {
+        "title": "Desafio Mensal",
+        "complete": "Concluído!"
+      },
+      "neglectedGems": {
+        "title": "Joias Negligenciadas",
+        "empty": "Todos os seus livros com melhor classificação já foram lidos!",
+        "rating": "{rating}/5",
+        "daysWaiting": "{count}d esperando",
+        "queued": "Na fila",
+        "addToQueue": "Adicionar à fila",
+        "shuffle": "Embaralhar"
+      },
+      "readingDna": {
+        "title": "DNA de Leitura",
+        "notEnoughData": "Leia pelo menos 5 livros para desbloquear o seu DNA de Leitura",
+        "basedOn": "Com base em nenhum livro | Com base em {count} livro | Com base em {count} livros",
+        "traits": {
+          "length": "Tamanho",
+          "variety": "Variedade",
+          "rhythm": "Ritmo",
+          "time": "Tempo",
+          "speed": "Velocidade"
+        }
+      },
+      "readingGoal": {
+        "title": "Meta de Leitura {year}",
+        "setGoalPrompt": "Defina uma meta de leitura para acompanhar o seu progresso",
+        "setGoal": "Definir meta",
+        "booksPerYear": "Livros por ano",
+        "ofGoal": "de {goal}",
+        "percentComplete": "{percentage}% concluído",
+        "editGoal": "Editar meta"
+      },
+      "readingRhythm": {
+        "title": "Ritmo de Leitura",
+        "empty": "Comece a ler para ver o seu ritmo tomar forma",
+        "activeDays": "nenhum dia ativo | {count} dia ativo | {count} dias ativos",
+        "consistency": "{activeDays} · {percent}% de consistência",
+        "avgPerDay": "média de {time}/dia"
+      },
+      "readingStreak": {
+        "title": "Sequência de Leitura",
+        "empty": "Leia hoje para iniciar a sua sequência",
+        "streakLabel": "dia em sequência | dia em sequência | dias em sequência",
+        "best": "Melhor: {count} dia | Melhor: {count} dia | Melhor: {count} dias",
+        "lastSevenDays": "Últimos 7 dias"
+      },
+      "yearProjection": {
+        "title": "Projeção do Ano",
+        "books": "livros",
+        "trendUp": "Tendência de alta",
+        "trendDown": "Tendência de baixa",
+        "trendSteady": "Ritmo estável",
+        "pages": "páginas",
+        "hours": "horas",
+        "readCount": "{count} lido",
+        "daysLeft": "{count}d restantes"
+      }
+    }
+  },
+  "email": {
+    "title": "E-mail",
+    "subtitle": "Envie livros para o seu e-reader por e-mail.",
+    "loadFailed": "Falha ao carregar",
+    "saveFailed": "Falha ao salvar",
+    "deleteFailed": "Falha ao excluir",
+    "setDefaultFailed": "Falha ao definir padrão",
+    "setAsDefault": "Definir como padrão",
+    "saving": "Salvando...",
+    "update": "Atualizar",
+    "create": "Criar",
+    "deleteConfirm": "Excluir \"{name}\". Esta ação não pode ser desfeita.",
+    "badge": {
+      "default": "Padrão",
+      "shared": "Compartilhado",
+      "system": "Sistema"
+    },
+    "tabs": {
+      "providers": "Provedores",
+      "recipients": "Destinatários",
+      "groups": "Grupos",
+      "templates": "Modelos",
+      "preferences": "Preferências",
+      "history": "Histórico"
+    },
+    "providers": {
+      "heading": "Provedores SMTP",
+      "add": "Adicionar provedor",
+      "newTitle": "Novo Provedor",
+      "editTitle": "Editar Provedor",
+      "name": "Nome",
+      "namePlaceholder": "ex: Gmail",
+      "host": "Host",
+      "port": "Porta",
+      "username": "Nome de usuário",
+      "password": "Senha",
+      "passwordEdit": "Senha (deixe em branco para manter a atual)",
+      "fromName": "Nome do Remetente",
+      "fromNamePlaceholder": "Minha Biblioteca",
+      "fromAddress": "Endereço do Remetente",
+      "authentication": "Autenticação",
+      "verifyTls": "Verificar certificado TLS",
+      "tlsWarning": "A verificação TLS está desativada. O certificado do servidor não será validado - use apenas para servidores internos confiáveis.",
+      "noFromAddress": "sem endereço de remetente",
+      "emptyManage": "Nenhum provedor ainda. Adicione um provedor SMTP para começar a enviar e-mails.",
+      "emptyReadonly": "Nenhum provedor disponível. Peça a um administrador para adicionar um.",
+      "setSystemTooltip": "Definir como provedor de e-mail do sistema",
+      "removeSystemTooltip": "Remover como provedor de e-mail do sistema",
+      "testTooltip": "Testar conexão",
+      "toggleSharing": "Alternar compartilhamento",
+      "removeSystemBeforeDelete": "Remova a designação do sistema antes de excluir",
+      "notesHeading": "Notas do Provedor",
+      "notesBody": "O provedor do <strong>Sistema</strong> (apenas para superusuários) é usado para e-mails de redefinição de senha. O provedor <strong>Padrão</strong> é usado ao enviar livros sem nenhum provedor explícito selecionado. Os provedores marcados como <strong>Compartilhados</strong> estão disponíveis para todos os usuários.",
+      "deleteTitle": "Excluir provedor?",
+      "nameHostRequired": "Nome e host são obrigatórios",
+      "created": "Provedor criado",
+      "updated": "Provedor atualizado",
+      "deleted": "\"{name}\" excluído",
+      "setDefaultSuccess": "\"{name}\" definido como padrão",
+      "unshared": "Provedor descompartilhado",
+      "sharedWithAll": "Provedor compartilhado com todos os usuários",
+      "updateSharingFailed": "Falha ao atualizar compartilhamento",
+      "systemRemoved": "\"{name}\" removido como provedor de e-mail do sistema",
+      "systemSet": "\"{name}\" definido como provedor de e-mail do sistema",
+      "updateSystemFailed": "Falha ao atualizar o provedor do sistema",
+      "connectionSuccess": "Conexão bem-sucedida",
+      "connectionFailed": "Falha na conexão",
+      "testFailed": "Teste falhou"
+    },
+    "recipients": {
+      "heading": "Destinatários",
+      "add": "Adicionar destinatário",
+      "newTitle": "Novo Destinatário",
+      "editTitle": "Editar Destinatário",
+      "name": "Nome",
+      "namePlaceholder": "Meu Kindle",
+      "emailAddress": "Endereço de e-mail",
+      "deviceType": "Tipo de dispositivo",
+      "deviceNone": "Nenhum",
+      "deviceOther": "Outro",
+      "preferredFormat": "Formato preferido",
+      "formatAuto": "Automático",
+      "defaultTemplate": "Modelo padrão",
+      "useAccountDefault": "Usar padrão da conta",
+      "kindleNote": "Os destinatários Kindle recebem e-mails automaticamente com o assunto \"convert\" para acionar a conversão de formato.",
+      "empty": "Nenhum destinatário ainda.",
+      "prefersFormat": "prefere {format}",
+      "deleteTitle": "Excluir destinatário?",
+      "nameEmailRequired": "Nome e e-mail são obrigatórios",
+      "created": "Destinatário criado",
+      "updated": "Destinatário atualizado",
+      "deleted": "\"{name}\" excluído",
+      "setDefaultSuccess": "\"{name}\" definido como padrão"
+    },
+    "groups": {
+      "heading": "Grupos de Destinatários",
+      "create": "Criar grupo",
+      "newTitle": "Novo Grupo",
+      "name": "Nome do grupo",
+      "namePlaceholder": "ex: Clube do Livro",
+      "creating": "Criando...",
+      "empty": "Nenhum grupo ainda. Crie um grupo para enviar para vários destinatários de uma vez.",
+      "memberCount": "nenhum membro | um membro | {count} membros",
+      "deleteTooltip": "Excluir grupo",
+      "noMembers": "Nenhum membro ainda.",
+      "removeMember": "Remover",
+      "selectRecipient": "Selecione o destinatário...",
+      "add": "Adicionar",
+      "addMember": "Adicionar membro",
+      "allRecipientsInGroup": "Todos os destinatários já estão neste grupo.",
+      "deleteTitle": "Excluir grupo?",
+      "created": "Grupo criado",
+      "createFailed": "Falha ao criar o grupo",
+      "deleted": "\"{name}\" excluído",
+      "memberAdded": "Membro adicionado",
+      "addMemberFailed": "Falha ao adicionar membro",
+      "memberRemoved": "Membro removido",
+      "removeMemberFailed": "Falha ao remover membro"
+    },
+    "templates": {
+      "heading": "Modelos de E-mail",
+      "new": "Novo modelo",
+      "newTitle": "Novo Modelo",
+      "editTitle": "Editar Modelo",
+      "name": "Nome",
+      "namePlaceholder": "Padrão",
+      "subject": "Assunto",
+      "body": "Corpo da Mensagem",
+      "availableVariables": "Variáveis disponíveis",
+      "editTemplate": "Editar modelo",
+      "empty": "Nenhum modelo ainda.",
+      "notesHeading": "Notas do Modelo",
+      "notesBody": "Os modelos do sistema não podem ser excluídos. Os administradores podem editá-los. Use variáveis como <code class=\"font-mono text-foreground/80\">&#123;&#123;title&#125;&#125;</code> nos assuntos e no corpo da mensagem - elas são substituídas pelos detalhes do livro no momento do envio.",
+      "deleteTitle": "Excluir modelo?",
+      "nameSubjectRequired": "Nome e assunto são obrigatórios",
+      "created": "Modelo criado",
+      "updated": "Modelo atualizado",
+      "deleted": "\"{name}\" excluído",
+      "setDefaultSuccess": "\"{name}\" definido como padrão"
+    },
+    "preferences": {
+      "heading": "Preferências de E-mail",
+      "defaultProvider": "Provedor padrão",
+      "defaultProviderHint": "Usado quando nenhum provedor for especificado. Se vazio, o padrão da conta será usado.",
+      "noneAccountDefault": "Nenhum (usar padrão da conta)",
+      "defaultRecipient": "Destinatário padrão",
+      "defaultRecipientHint": "Usado para envio rápido. Deve ser configurado para usar a ação de envio rápido nos cartões de livro.",
+      "none": "Nenhum",
+      "defaultTemplate": "Modelo padrão",
+      "defaultTemplateHint": "Usado quando nenhum modelo for especificado. Retorna ao padrão do sistema se estiver vazio.",
+      "noneSystemDefault": "Nenhum (usar padrão do sistema)",
+      "save": "Salvar preferências",
+      "saved": "Preferências salvas"
+    },
+    "history": {
+      "heading": "Histórico de Envio",
+      "empty": "Nenhum e-mail enviado ainda.",
+      "noSubject": "(sem assunto)",
+      "loadMore": "Carregar mais",
+      "resend": "Reenviar",
+      "deleteTitle": "Excluir entrada do histórico?",
+      "entryDeleted": "Entrada excluída",
+      "queuedForResend": "Na fila para reenvio",
+      "resendFailed": "Falha ao reenviar",
+      "statusSent": "Enviado",
+      "statusFailed": "Falhou",
+      "statusQueued": "Na fila",
+      "statusPending": "Pendente"
+    },
+    "send": {
+      "title": "Enviar por E-mail",
+      "bookCount": "nenhum livro | um livro | {count} livros",
+      "recipients": "Destinatários",
+      "noRecipients": "Nenhum destinatário configurado. Adicione um nas configurações de E-mail.",
+      "groups": "Grupos",
+      "options": "Opções",
+      "fileFormat": "Formato de arquivo",
+      "autoRecipientPreference": "Automático (usar a preferência do destinatário)",
+      "unknownFormat": "Desconhecido",
+      "primarySuffix": "(principal)",
+      "provider": "Provedor",
+      "template": "Modelo",
+      "default": "Padrão",
+      "send": "Enviar",
+      "sending": "Enviando...",
+      "queued": "nenhum e-mail enfileirado | um e-mail enfileirado | {count} e-mails enfileirados",
+      "failed": "Falha no envio"
+    }
+  },
+  "hardcover": {
+    "settings": {
+      "subtitle": "Sincronize seu progresso de leitura, status e avaliações com o Hardcover."
+    },
+    "bookSync": {
+      "label": "Sincronização com o Hardcover",
+      "toggleAriaLabel": "Sincronizar este livro com o Hardcover",
+      "syncNow": "Sincronizar agora"
+    },
+    "connection": {
+      "title": "Conexão",
+      "description": "Conecte sua conta do Hardcover para sincronizar os dados de leitura.",
+      "connected": "Conectado",
+      "apiToken": "Token da API",
+      "tokenPlaceholder": "Cole o token da API do Hardcover",
+      "show": "Mostrar",
+      "hide": "Ocultar",
+      "findTokenAt": "Encontre o seu token em",
+      "validateToken": "Validar token",
+      "valid": "Válido ({username})",
+      "invalidToken": "Token inválido",
+      "syncOptions": "Opções de sincronização",
+      "syncInfo": "A sincronização só é executada para livros que não estão não lidos. Isso se aplica aos acionadores de status, progresso e avaliação. Esses interruptores controlam quando a sincronização é executada.",
+      "syncScope": {
+        "title": "Escopo de sincronização de livros",
+        "allEligible": {
+          "label": "Todos os livros elegíveis",
+          "description": "Sincroniza tudo, a menos que você exclua um livro."
+        },
+        "selectedOnly": {
+          "label": "Apenas livros selecionados",
+          "description": "Sincroniza apenas os livros que você inclui explicitamente."
+        }
+      },
+      "enableSync": {
+        "title": "Habilitar sincronização",
+        "description": "Pause toda a sincronização com o Hardcover sem desconectar."
+      },
+      "syncOnStatus": {
+        "title": "Sincronizar na mudança de status",
+        "description": "Envia as atualizações quando você marca um livro como lendo, lido, etc."
+      },
+      "syncOnProgress": {
+        "title": "Sincronizar na atualização de progresso",
+        "description": "Envia o progresso de leitura e as datas quando o progresso no BookOrbit ou KOReader muda."
+      },
+      "syncOnRating": {
+        "title": "Sincronizar na mudança de avaliação",
+        "description": "Envia a sua avaliação de estrelas para o Hardcover."
+      },
+      "privacy": {
+        "title": "Privacidade",
+        "description": "Visibilidade padrão para livros sincronizados no Hardcover.",
+        "public": "Público",
+        "followersOnly": "Apenas seguidores",
+        "private": "Privado"
+      },
+      "disconnect": "Desconectar",
+      "toast": {
+        "enterToken": "Insira o token da sua API do Hardcover primeiro",
+        "saved": "Configurações do Hardcover salvas",
+        "saveFailed": "Falha ao salvar as configurações",
+        "disconnected": "Hardcover desconectado"
+      }
+    },
+    "sync": {
+      "title": "Sincronização manual",
+      "description": "Envie seus {scope} para o Hardcover agora.",
+      "scope": {
+        "selected": "livros selecionados",
+        "eligible": "livros elegíveis"
+      },
+      "checkingPending": "Verificando itens pendentes...",
+      "pendingOf": "{pending} pendentes de {total} livros.",
+      "noBooksInScope": "Nenhum livro no escopo de sincronização.",
+      "allSynced": "Todos os livros já estão sincronizados.",
+      "lastSyncedLabel": "Última sincronização",
+      "lastSuccessfulSync": "Última sincronização bem-sucedida",
+      "syncing": "Sincronizando...",
+      "progressCount": "{synced} / {total} livros",
+      "unavailable": {
+        "permissionDenied": "Você não tem permissão para usar a sincronização com o Hardcover.",
+        "userDisabled": "A sincronização está pausada nas suas configurações do Hardcover."
+      },
+      "button": {
+        "unavailable": "Sincronização indisponível",
+        "syncNow": "Sincronizar agora",
+        "syncNowCount": "Sincronizar agora ({count})"
+      },
+      "lastSynced": {
+        "justNow": "Agora mesmo",
+        "minutesAgo": "{count} min atrás",
+        "hoursAgo": "{count} hora atrás | {count} hora atrás | {count} horas atrás",
+        "daysAgo": "{count} dia atrás | {count} dia atrás | {count} dias atrás"
+      }
+    },
+    "import": {
+      "title": "Importar status de leitura",
+      "description": "Revise as correspondências do Hardcover antes de preencher os status vazios do BookOrbit.",
+      "clear": "Limpar",
+      "preview": "Pré-visualizar",
+      "importProgress": "Progresso de importação",
+      "reviewMatches": "Revisar correspondências",
+      "importReady": "Pronto para importar",
+      "exactMatches": "nenhuma correspondência exata pode ser importada sem revisão | {count} correspondência exata pode ser importada sem revisão | {count} correspondências exatas podem ser importadas sem revisão",
+      "progressAvailable": "nenhuma atualização de progresso disponível | {count} atualização de progresso disponível | {count} atualizações de progresso disponíveis",
+      "progressConflicts": "nenhum conflito | {count} conflito | {count} conflitos",
+      "unavailable": {
+        "permissionDenied": "Você não tem permissão para usar a sincronização com o Hardcover.",
+        "missingToken": "Conecte o Hardcover antes de importar.",
+        "userDisabled": "A sincronização está pausada nas suas configurações do Hardcover."
+      },
+      "summary": {
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflicts": "Conflitos",
+        "unmatched": "Não Correspondido",
+        "skipped": "Ignorado"
+      },
+      "result": {
+        "summary": "{applied} importados{progress}, {failed} falharam",
+        "progressUpdated": "{count} progresso atualizado"
+      },
+      "toast": {
+        "importFailed": "Falha ao importar o status de leitura do Hardcover",
+        "imported": "nenhum status de leitura importado{progress} | {count} status de leitura importado{progress} | {count} status de leitura importados{progress}",
+        "progressUpdates": "nenhuma atualização de progresso | {count} atualização de progresso | {count} atualizações de progresso"
+      }
+    },
+    "review": {
+      "title": "Revisão de importação do Hardcover",
+      "subtitle": "{total} livros no Hardcover, {matched} correspondidos.",
+      "closeAriaLabel": "Fechar revisão de importação",
+      "searchPlaceholder": "Pesquisar título ou autor",
+      "importProgress": "Progresso de importação",
+      "untitled": "Sem título",
+      "blank": "em branco",
+      "noRows": "Nenhuma linha corresponde aos filtros atuais.",
+      "selectRowAriaLabel": "Selecionar {title}",
+      "selectionSummary": "{count} selecionados: {ready} prontos, {reviewed} revisados.",
+      "selectedProgress": "nenhuma atualização de progresso | {count} atualização de progresso | {count} atualizações de progresso",
+      "selectReady": "Selecionar prontos",
+      "selectPage": "Selecionar página",
+      "clearPage": "Limpar página",
+      "clearSelection": "Limpar seleção",
+      "importSelected": "Importar selecionados",
+      "previousPage": "Página anterior",
+      "nextPage": "Próxima página",
+      "pageRange": "{start}-{end} de {total}",
+      "tabs": {
+        "all": "Tudo",
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflicts": "Conflitos",
+        "unmatched": "Não Correspondido",
+        "skipped": "Ignorado"
+      },
+      "summary": {
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflicts": "Conflitos",
+        "unmatched": "Não Correspondido",
+        "skipped": "Ignorado"
+      },
+      "matchOptions": {
+        "all": "Todos os tipos de correspondência"
+      },
+      "matchMethod": {
+        "hardcoverId": "ID do Hardcover",
+        "isbn": "ISBN",
+        "titleAuthor": "Título + autor"
+      },
+      "outcome": {
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflict": "Conflito",
+        "unmatched": "Não Correspondido",
+        "skipped": "Ignorado"
+      },
+      "column": {
+        "progress": "Progresso"
+      }
+    }
+  },
+  "library": {
+    "creator": {
+      "createTitle": "Criar Biblioteca",
+      "editTitle": "Editar: {name}",
+      "stepOf": "Passo {current} de {total}",
+      "sections": {
+        "details": "Detalhes",
+        "folders": "Pastas",
+        "scanner": "Scanner",
+        "metadata": "Metadados",
+        "fileWrite": "Gravação de Arquivo",
+        "reading": "Leitura",
+        "schedule": "Agendamento",
+        "access": "Acesso"
+      },
+      "actions": {
+        "saving": "Salvando...",
+        "saveChanges": "Salvar alterações",
+        "creating": "Criando...",
+        "createLibrary": "Criar biblioteca"
+      },
+      "details": {
+        "libraryName": "Nome da biblioteca",
+        "namePlaceholder": "Minha Biblioteca",
+        "coverStyle": {
+          "title": "Estilo de capa",
+          "portrait": "Retrato",
+          "square": "Quadrado",
+          "hint": "Retrato para e-books ou bibliotecas mistas. Quadrado para bibliotecas apenas de audiobooks."
+        },
+        "icon": {
+          "label": "Ícone",
+          "placeholder": "Escolha um ícone...",
+          "selected": "Selecionado"
+        }
+      },
+      "folders": {
+        "title": "Pastas de verificação",
+        "description": "Adicione um ou mais diretórios para procurar livros.",
+        "browseAdd": "Procurar e adicionar uma pasta",
+        "manualEntry": "Ou digite um caminho manualmente:",
+        "pathPlaceholder": "/caminho/para/livros",
+        "test": "Testar",
+        "add": "Adicionar",
+        "pathNotAccessible": "O caminho não está acessível no servidor.",
+        "pathAccessible": "O caminho está acessível.",
+        "pathNotAccessibleShort": "Caminho não acessível",
+        "bookFilesFound": "nenhum arquivo de livro encontrado | {count} arquivo de livro encontrado | {count} arquivos de livro encontrados",
+        "overlapsWith": "Sobrepõe-se a \"{library}\"",
+        "noneAdded": "Nenhuma pasta adicionada ainda",
+        "totalFilesFound": "nenhum arquivo de livro encontrado | {count} arquivo de livro encontrado - o número real de livros pode ser menor se houver vários formatos do mesmo livro | {count} arquivos de livro encontrados - o número real de livros pode ser menor se houver vários formatos do mesmo livro",
+        "runPrescanHint": "Execute uma pré-verificação para validar os caminhos antes de salvar.",
+        "scanning": "Verificando...",
+        "prescan": "Pré-verificação"
+      },
+      "scanner": {
+        "scanMode": {
+          "title": "Modo de verificação",
+          "lockedAria": "O modo de organização está bloqueado",
+          "lockTooltip": "O modo de organização é fixado após a criação da biblioteca porque alterá-lo pode criar entradas de livro duplicadas ou ausentes. Para usar um modo diferente, crie uma nova biblioteca e faça uma nova verificação.",
+          "recommended": "Recomendado",
+          "folderAsBook": {
+            "title": "Pasta como Livro",
+            "hint": "Todos os arquivos em uma pasta são agrupados em um livro. Funciona bem quando você mantém vários formatos, como EPUB e MOBI, juntos."
+          },
+          "fileAsBook": {
+            "title": "Arquivo como Livro",
+            "hint": "Trata cada arquivo como um livro individual. Mais adequado para bibliotecas com um formato por título. Evite se os seus audiobooks abrangerem vários arquivos."
+          }
+        },
+        "allowedFormats": {
+          "title": "Formatos permitidos",
+          "allowAll": "Permitir todos",
+          "allAllowed": "Todos os formatos são permitidos.",
+          "onlySelected": "Apenas os formatos selecionados serão importados.",
+          "warning": "Livros em outros formatos que já estão na biblioteca serão marcados como ausentes na próxima verificação."
+        },
+        "excludePatterns": {
+          "title": "Padrões de exclusão",
+          "hintBefore": "Padrões glob para ignorar durante a verificação (ex: ",
+          "hintAfter": ").",
+          "add": "Adicionar",
+          "empty": "Nenhum padrão adicionado."
+        }
+      },
+      "metadata": {
+        "sourcePrecedence": {
+          "title": "Precedência da fonte",
+          "hint": "A fonte mais alta na lista é preferida quando várias estão disponíveis."
+        },
+        "formatPriority": {
+          "title": "Prioridade do formato",
+          "hint": "Quando um livro tem vários formatos, o formato mais alto na lista é o preferido."
+        }
+      },
+      "fileWrite": {
+        "maxFileSizeMb": "Tamanho máx. do arquivo (MB)",
+        "rename": {
+          "title": "Renomear arquivos na atualização de metadados",
+          "hint": "Quando ativado, atualizar título, autor, série ou ano renomeará o arquivo físico usando o padrão de nomenclatura da biblioteca."
+        },
+        "write": {
+          "title": "Gravar metadados nos arquivos",
+          "hint": "Quando ativado, salvar os metadados também gravará as alterações de volta no arquivo físico no disco."
+        },
+        "cover": {
+          "title": "Incluir imagem da capa",
+          "hint": "Grava a capa armazenada de volta em formatos de arquivo suportados."
+        },
+        "epub": {
+          "title": "EPUB",
+          "hint": "Grava os metadados no arquivo OPF dentro do arquivo EPUB."
+        },
+        "pdf": {
+          "title": "PDF",
+          "hint": "Incorpora metadados no dicionário Info do PDF e no fluxo XMP."
+        },
+        "cbx": {
+          "title": "Arquivos de quadrinhos (CBX)",
+          "hint": "Grava ComicInfo.xml dentro de arquivos CBZ e CB7."
+        },
+        "audio": {
+          "title": "Áudio",
+          "hint": "Incorpora a capa armazenada em arquivos M4B, M4A, MP3 e FLAC."
+        }
+      },
+      "reading": {
+        "readingStart": {
+          "title": "Início da leitura",
+          "hint": "Um livro é marcado como \"lendo\" assim que atinge esta porcentagem de progresso."
+        },
+        "markAsFinished": {
+          "title": "Marcar como finalizado",
+          "hint": "Um livro é marcado automaticamente como \"lido\" quando atinge esta porcentagem de progresso."
+        }
+      },
+      "schedule": {
+        "fileWatching": "Monitoramento de arquivos",
+        "autoScanSchedule": "Cronograma de verificação automática",
+        "cronExpression": "Expressão Cron",
+        "cronInvalid": "Expressão cron inválida.",
+        "cronFormat": "Formato: minuto hora dia mês dia_da_semana",
+        "watchFolders": {
+          "title": "Monitorar pastas",
+          "hint": "Detectar automaticamente novos arquivos adicionados às pastas da biblioteca."
+        },
+        "presets": {
+          "never": "Nunca",
+          "hourly": "A cada hora",
+          "every6Hours": "A cada 6 horas",
+          "every12Hours": "A cada 12 horas",
+          "daily": "Diariamente",
+          "weekly": "Semanalmente",
+          "custom": "Personalizado"
+        },
+        "human": {
+          "disabled": "Verificação automática desativada",
+          "hourly": "A cada hora",
+          "every6Hours": "A cada 6 horas",
+          "every12Hours": "A cada 12 horas",
+          "dailyMidnight": "Diariamente à meia-noite",
+          "weeklyMonday": "Semanalmente na segunda-feira à meia-noite",
+          "cron": "Cron: {cron}"
+        }
+      },
+      "access": {
+        "title": "Controle de acesso",
+        "description": "Superusuários sempre têm acesso total. Conceda acesso a outros usuários abaixo.",
+        "notYetCreated": "O acesso pode ser configurado depois que a biblioteca for criada.",
+        "selectUser": "Selecione um usuário...",
+        "grant": "Conceder",
+        "empty": "Nenhum acesso concedido a usuários ainda.",
+        "levels": {
+          "viewer": "Visualizador",
+          "editor": "Editor",
+          "owner": "Proprietário"
+        },
+        "columns": {
+          "user": "Usuário",
+          "accessLevel": "Nível de acesso"
+        },
+        "errors": {
+          "grant": "Falha ao conceder acesso",
+          "updateLevel": "Falha ao atualizar o nível de acesso",
+          "revoke": "Falha ao revogar acesso"
+        }
+      }
+    },
+    "folderPicker": {
+      "title": "Procurar pastas",
+      "newFolder": "Nova pasta",
+      "goUp": "Subir um nível",
+      "filterPlaceholder": "Filtrar pastas...",
+      "newFolderNamePlaceholder": "Nome da nova pasta",
+      "create": "Criar",
+      "noFolders": "Nenhuma pasta encontrada",
+      "selectFolder": "Selecionar esta pasta",
+      "errors": {
+        "readDirectory": "Não foi possível ler o diretório",
+        "connect": "Não foi possível conectar",
+        "invalidName": "Insira um único nome de pasta, sem barras ou pontos à esquerda",
+        "createFolder": "Não foi possível criar a pasta"
+      }
+    },
+    "upload": {
+      "library": "Biblioteca",
+      "selectLibrary": "Selecione uma biblioteca...",
+      "targetFolder": "Pasta de destino",
+      "addMoreFiles": "Adicionar mais arquivos",
+      "clearAll": "Limpar tudo",
+      "done": "Concluído",
+      "retry": "Tentar novamente",
+      "upload": "Upload",
+      "uploadWithCount": "Fazer Upload ({count})",
+      "viewInLibrary": "Ver na Biblioteca",
+      "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+      "booksAdded": "nenhum livro adicionado | {count} livro adicionado | {count} livros adicionados",
+      "uploadedFailed": "{done} enviados, {failed} falharam",
+      "progress": "{done} de {total} enviando...",
+      "header": {
+        "uploading": "Enviando...",
+        "complete": "Envio concluído",
+        "uploadTo": "Fazer upload para {library}",
+        "uploadBooks": "Fazer Upload de Livros"
+      },
+      "dropzone": {
+        "title": "Solte os arquivos aqui ou clique para procurar",
+        "hint": "{formats} - até {size} MB cada"
+      }
+    }
+  },
+  "metadataScore": {
+    "missingFields": "nenhum campo ausente - editar metadados | {count} campo ausente - editar metadados | {count} campos ausentes - editar metadados"
+  },
+  "migration": {
+    "sidebarTitle": "Importação do Booklore",
+    "status": {
+      "done": "Concluído",
+      "saved": "Salvo",
+      "running": "Executando",
+      "failed": "Falhou"
+    },
+    "badge": {
+      "validated": "Validado",
+      "upToDate": "Atualizado",
+      "completed": "Concluído"
+    },
+    "steps": {
+      "source": {
+        "short": "Conexão de Origem",
+        "title": "Conexão de Origem",
+        "subtitle": "Configure a conexão do banco de dados com a sua instância Booklore de origem."
+      },
+      "mappings": {
+        "short": "Mapeamento de Usuário e Caminho",
+        "title": "Mapeamento de Usuário e Caminho",
+        "subtitle": "Mapeie usuários de origem para usuários de destino e traduza os caminhos dos arquivos."
+      },
+      "dryRun": {
+        "short": "Teste",
+        "title": "Teste (Dry Run)",
+        "subtitle": "Pré-visualize o que será importado antes de executar a migração definitiva."
+      },
+      "migration": {
+        "short": "Executar Migração",
+        "title": "Executar Migração",
+        "subtitle": "Inicie a importação definitiva e monitore seu progresso."
+      },
+      "report": {
+        "short": "Relatório",
+        "title": "Relatório de Migração",
+        "subtitle": "Revise o que foi importado e exporte um relatório detalhado."
+      }
+    },
+    "footer": {
+      "continueToMappings": "Continuar para Mapeamentos",
+      "continueToDryRun": "Continuar para o Teste",
+      "continueToMigration": "Continuar para Migração",
+      "viewReport": "Ver Relatório",
+      "resetSetup": "Redefinir Configuração",
+      "stepOf": "Passo {current} de {total}",
+      "backToSetup": "Voltar à Configuração"
+    },
+    "stages": {
+      "init": "Inicializando",
+      "sharedOverlays": "Importando metadados",
+      "bookCovers": "Importando capas",
+      "userState": "Importando dados do usuário"
+    },
+    "source": {
+      "testConnection": "Testar Conexão",
+      "saveAndValidate": "Salvar e Validar",
+      "validatedWithWarnings": "Origem validada com avisos",
+      "fields": {
+        "type": "Tipo de Origem",
+        "name": "Nome de Origem",
+        "host": "Host",
+        "port": "Porta",
+        "user": "Usuário",
+        "password": "Senha",
+        "passwordSaved": "Salva - deixe inalterada",
+        "passwordNotSet": "Nenhuma senha definida",
+        "database": "Banco de Dados",
+        "mediaRootPath": "Caminho Raiz de Mídia",
+        "ssl": "Usar TLS/SSL"
+      },
+      "mediaPath": {
+        "hintRequired": "Obrigatório para migração de capas de livros.",
+        "hintAbsolute": "Use um caminho absoluto (exemplo: /books). Caminhos relativos não são suportados.",
+        "hintConfigured": "Caminho de importação de capa configurado. Use Testar Conexão para verificar o acesso e a estrutura de pastas de imagens do Booklore.",
+        "buttonOk": "Caminho OK",
+        "buttonIssue": "Problema no Caminho",
+        "buttonTest": "Testar Caminho"
+      },
+      "compatibility": {
+        "title": "Compatibilidade testada",
+        "verifiedAgainst": "Verificado contra:",
+        "note": "Versões posteriores são provavelmente compatíveis, mas não foram verificadas. Execute um teste primeiro para confirmar antes de confirmar os dados."
+      },
+      "snapshot": {
+        "title": "Último instantâneo de validação",
+        "sourceVersion": "Versão de origem: {version}",
+        "unknown": "Desconhecido",
+        "missingTables": "Tabelas obrigatórias ausentes: {tables}"
+      }
+    },
+    "mappings": {
+      "suggestionsAutoLoad": "As sugestões de usuário são carregadas automaticamente após a validação da origem.",
+      "refresh": "Atualizar",
+      "sourceUser": "Usuário de Origem",
+      "targetUser": "Usuário de Destino",
+      "noSourceUsersLoaded": "Nenhum usuário de origem carregado ainda.",
+      "noActiveTargetUsers": "Nenhum usuário de destino ativo encontrado. Crie ou reative um usuário BookOrbit antes de mapear.",
+      "pathPrefixMappings": "Mapeamentos de Prefixo de Caminho",
+      "addMapping": "Adicionar Mapeamento",
+      "pathMappingsExplanation": "Os mapeamentos de caminho traduzem os caminhos dos arquivos de origem para os caminhos de destino, para que os livros possam ser correspondidos pelo local do arquivo. Os livros também são correspondidos por ISBN, hash de arquivo e título/autor independentemente dos mapeamentos de caminho.",
+      "noPrefixesFound": "Nenhum prefixo encontrado - valide a origem primeiro",
+      "selectSourcePrefix": "Selecione o prefixo de origem...",
+      "selectTargetFolder": "Selecione a pasta de destino...",
+      "remove": "Remover",
+      "saveMappings": "Salvar Mapeamentos",
+      "pathValidation": {
+        "title": "Validação de caminho",
+        "mappedSummary": "{mapped} de {total} livros de origem têm um caminho mapeado",
+        "unmatched": "{count} caminhos mapeados não encontrados no disco",
+        "allMatched": "Todos os {count} caminhos mapeados encontrados no disco"
+      }
+    },
+    "dryRun": {
+      "run": "Executar Teste",
+      "matched": "Correspondidos:",
+      "unresolved": "Não resolvidos:",
+      "duplicates": "Duplicatas:",
+      "unresolvedSummary": "Resumo de não resolvidos"
+    },
+    "duplicates": {
+      "title": "Resolver correspondências de destino duplicadas",
+      "explanation": "Para cada livro de destino, escolha um livro de origem para manter. Opções recomendadas são pré-selecionadas quando há uma única correspondência mais forte.",
+      "remainingGroups": "Grupos restantes:",
+      "ofCount": "de {total}",
+      "targetBookId": "Livro de destino #{id}",
+      "recommended": "Recomendado",
+      "resolveButton": "Resolver {count} duplicata | Resolver {count} duplicata | Resolver {count} duplicatas",
+      "sourceRecordId": "ID do registro de origem #{id}",
+      "byAuthor": "por {author} (ID: {id})",
+      "byFilePath": "{filePath} (ID: {id})",
+      "bookloreSourceId": "ID de origem Booklore: {id}",
+      "libraryBookId": "Livro da biblioteca #{id}"
+    },
+    "preflight": {
+      "title": "Verificações de pré-voo",
+      "allPassed": "Todas as verificações aprovadas - pronto para migrar",
+      "sourceValidated": "Origem validada",
+      "saveAndValidateSource": "Salvar e validar conexão de origem",
+      "validateSourceConnection": "Validar conexão de origem",
+      "mappingsSaved": "Mapeamentos salvos",
+      "saveUserAndPathMappings": "Salvar mapeamentos de usuário e caminho",
+      "pathMappingsValidated": "Mapeamentos de caminho validados",
+      "savePathMappingsToValidate": "Salvar mapeamentos de caminho para validá-los",
+      "dryRunUpToDate": "O teste está atualizado",
+      "runFreshDryRun": "Executar um novo teste",
+      "issues": {
+        "saveSource": "Salvar configurações de conexão de origem",
+        "validateSource": "Validar conexão de origem",
+        "saveMappings": "Salvar mapeamentos de usuário e caminho",
+        "savePathMappings": "Salvar mapeamentos de caminho para validá-los",
+        "freshDryRun": "Executar um novo teste",
+        "resolveDuplicates": "Resolver correspondências duplicadas de livros de destino no teste",
+        "waitForRun": "Aguardar a execução ativa terminar"
+      }
+    },
+    "run": {
+      "confirmPrompt": "Isso iniciará a migração definitiva. Tem certeza?",
+      "confirmStart": "Confirmar Início",
+      "startMigration": "Iniciar Migração",
+      "cancelRun": "Cancelar Execução",
+      "refreshStatus": "Atualizar Status",
+      "pollingStopped": "A sondagem de status parou devido a um erro.",
+      "retry": "Tentar novamente",
+      "stage": "Estágio: {stage}",
+      "initializing": "inicializando",
+      "ended": "Terminou em {time}"
+    },
+    "report": {
+      "noRunYet": "Nenhuma execução de migração ainda. Conclua as etapas acima para iniciar.",
+      "runNumber": "Execução #{id}",
+      "notStarted": "Não iniciada",
+      "reloadReport": "Recarregar Relatório",
+      "loadFullReport": "Carregar Relatório Completo",
+      "exportJson": "Exportar JSON",
+      "exportCsv": "Exportar CSV",
+      "migrationFailed": "Falha na migração",
+      "retryFromLastStage": "Tentar novamente a partir do último estágio concluído",
+      "booksSection": "Livros",
+      "metadataOverlays": "Sobreposições de metadados aplicadas",
+      "authorMappings": "Mapeamentos de autor substituídos",
+      "narratorMappings": "Mapeamentos de narrador substituídos",
+      "genreMappings": "Mapeamentos de gênero substituídos",
+      "tagMappings": "Mapeamentos de tag substituídos",
+      "coversImported": "Capas importadas",
+      "coverImportSkipped": "Importação de capa ignorada - caminho raiz de mídia não configurado",
+      "couldNotMatch": "Não foi possível corresponder",
+      "userDataSection": "Dados do Usuário",
+      "readingStatuses": "Status de leitura",
+      "readingProgressEntries": "Entradas de progresso de leitura",
+      "audiobookProgressEntries": "Entradas de progresso de audiobook",
+      "readingSessions": "Sessões de leitura",
+      "bookmarks": "Favoritos",
+      "annotations": "Anotações",
+      "collectionEntries": "Entradas de coleção",
+      "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência do teste no relatório exportado.",
+      "completedNoIssues": "Migração concluída sem livros não resolvidos ou falhas.",
+      "matchedBooks": "Livros correspondidos ({count})",
+      "matchedBooksExplanation": "Estas correspondências do teste foram usadas para decidir quais livros da biblioteca receberam dados importados.",
+      "sourceBook": "Livro de origem {id}",
+      "libraryBook": "Livro da biblioteca {id}",
+      "unresolvedBooks": "Livros não resolvidos ({count})",
+      "unresolvedBooksExplanation": "Estes livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
+      "mappedUsers": "Usuários mapeados ({count})",
+      "mappedUsersExplanation": "Os totais por usuário vêm da pré-visualização do teste armazenada em cache com o plano de migração.",
+      "coverFailures": "{count} importação(ões) de capa falhou(aram). As linhas de falha detalhadas não são armazenadas.",
+      "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {sessions} sessões de leitura, {bookmarks} favoritos, {annotations} anotações, {collections} entradas de coleção"
+    },
+    "unresolvedReason": {
+      "noTitleAuthorMatch": "Nenhum livro correspondente encontrado por título ou autor",
+      "noFilePathMatch": "O caminho do arquivo não corresponde a nenhum livro nesta biblioteca",
+      "noFileHashMatch": "O hash do arquivo não corresponde a nenhum livro nesta biblioteca",
+      "noIsbnMatch": "O ISBN não corresponde a nenhum livro nesta biblioteca",
+      "insufficientSourceData": "Metadados insuficientes para tentar a correspondência",
+      "ambiguousIsbnMatch": "Múltiplos livros correspondem ao mesmo ISBN",
+      "ambiguousFileHashMatch": "Múltiplos livros correspondem ao mesmo hash de arquivo",
+      "ambiguousFilePathMatch": "Múltiplos livros correspondem ao mesmo caminho de arquivo",
+      "ambiguousTitleAuthorMatch": "Múltiplos livros correspondem ao mesmo título e autor",
+      "unknown": "Não foi possível determinar o motivo"
+    },
+    "matchStrategy": {
+      "isbn": "Correspondido por ISBN",
+      "fileHash": "Correspondido por hash de arquivo",
+      "pathMapping": "Correspondido por caminho de arquivo mapeado",
+      "titleAuthor": "Correspondido por título e autor",
+      "unavailable": "Estratégia de correspondência indisponível"
+    },
+    "connectionError": {
+      "unreachable": "Não foi possível acessar o servidor de banco de dados. Verifique o host e a porta.",
+      "authFailed": "Falha na autenticação. Verifique o nome de usuário e a senha.",
+      "databaseNotFound": "Banco de dados não encontrado. Verifique o nome do banco de dados.",
+      "timeout": "A conexão expirou. Verifique as configurações de host e firewall.",
+      "generic": "O teste de conexão falhou"
+    },
+    "userSelect": {
+      "placeholder": "Selecionar usuário",
+      "noUsersFound": "Nenhum usuário encontrado"
+    },
+    "toast": {
+      "initFailed": "Falha ao inicializar configurações de migração",
+      "loadSupportedTypesFailed": "Falha ao carregar tipos de origem de migração suportados",
+      "loadTargetUsersFailed": "Falha ao carregar usuários de destino",
+      "loadTargetFoldersFailed": "Falha ao carregar pastas da biblioteca de destino",
+      "noSourceUsers": "Nenhum usuário de origem foi retornado",
+      "suggestionsLoaded": "Sugestões de mapeamento de usuário carregadas",
+      "loadSuggestionsFailed": "Falha ao carregar sugestões de mapeamento de usuário",
+      "sourceFieldsRequired": "Host, usuário, banco de dados e nome de origem são obrigatórios",
+      "connectionPassedWithWarnings": "Teste de conexão concluído com avisos",
+      "connectionPassedWithWarningCount": "Teste de conexão concluído com {count} aviso(s). Primeiro: {warning}",
+      "connectionPassed": "Teste de conexão aprovado",
+      "connectionMissingTables": "Conexão ok, mas {count} tabela(s) obrigatória(s) estão ausentes",
+      "cannotTestMediaWhileRunning": "Não é possível testar o caminho de mídia enquanto uma execução estiver ativa",
+      "mediaPathRequired": "Caminho Raiz de Mídia é obrigatório para importação de capa.",
+      "mediaPathAbsolute": "Use um caminho absoluto (por exemplo: /books).",
+      "mediaPathVerified": "Caminho de mídia verificado.",
+      "mediaPathValid": "O caminho de mídia é válido e legível",
+      "mediaPathValidationFailed": "A validação do caminho de mídia falhou.",
+      "connectionFailedBeforeMedia": "O teste de conexão falhou antes que a validação do caminho de mídia pudesse ser concluída.",
+      "cannotModifySourceWhileRunning": "Não é possível modificar a origem enquanto uma execução estiver ativa",
+      "sourceSavedWithWarnings": "Origem salva e validada com {count} aviso(s)",
+      "sourceSaved": "Origem salva e validada",
+      "saveSourceFailed": "Falha ao salvar ou validar origem",
+      "cannotSaveMappingsWhileRunning": "Não é possível salvar mapeamentos enquanto uma execução estiver ativa",
+      "saveSourceFirst": "Salvar origem primeiro",
+      "mapAtLeastOneUser": "Mapeie pelo menos um usuário de origem para um usuário de destino",
+      "mapEveryUser": "Mapeie todos os usuários de origem antes de salvar",
+      "pathValidationFailedButSaved": "A validação do caminho falhou, mas o perfil ainda será salvo",
+      "mappingsSaved": "Mapeamentos salvos",
+      "saveMappingsFailed": "Falha ao salvar mapeamentos",
+      "cannotDryRunWhileRunning": "Não é possível executar o teste enquanto uma execução estiver ativa",
+      "saveMappingsFirst": "Salvar mapeamentos primeiro",
+      "dryRunCompleted": "Teste concluído: {matched} correspondências, {unresolved} não resolvidos",
+      "dryRunFailed": "Falha no teste",
+      "selectSourceForDuplicates": "Selecione um livro de origem para todos os {count} grupos duplicados",
+      "duplicatesResolved": "Correspondências duplicadas resolvidas",
+      "resolveDuplicatesFailed": "Falha ao resolver duplicatas",
+      "preflightNotReady": "Pré-verificação de migração não pronta",
+      "runDryRunFirst": "Execute o teste primeiro",
+      "runStarted": "Execução de migração iniciada",
+      "startFailed": "Falha ao iniciar migração",
+      "runCancelled": "Execução de migração cancelada",
+      "cancelFailed": "Falha ao cancelar migração",
+      "runRetried": "Execução de migração repetida - retomando do último estágio concluído",
+      "retryFailed": "Falha ao repetir migração",
+      "loadProgressFailed": "Falha ao carregar progresso da execução",
+      "startMigrationFirst": "Inicie a migração primeiro",
+      "reportRefreshed": "Relatório de execução atualizado",
+      "loadReportFailed": "Falha ao carregar relatório de execução",
+      "reportExported": "Relatório exportado como {format}",
+      "exportFailed": "Falha ao exportar relatório de migração"
+    }
+  },
+  "notifications": {
+    "title": "Notificações",
+    "markAllRead": "Marcar tudo como lido",
+    "clear": "Limpar",
+    "empty": "Nenhuma notificação ainda",
+    "loadMore": "Carregar mais notificações",
+    "preferences": {
+      "title": "Notificações",
+      "subtitle": "Escolha quais categorias de notificação você deseja receber.",
+      "saving": "Salvando...",
+      "unsavedChanges": "Alterações não salvas",
+      "saved": "Preferências de notificação salvas",
+      "saveFailed": "Falha ao salvar preferências",
+      "savePreferenceFailed": "Falha ao salvar preferência",
+      "whatsNewToggle": "Mostrar \"O que há de novo\" após atualizações",
+      "whatsNewToggleHint": "Um pop-up destacando novos recursos após a atualização do aplicativo. O arquivo continua disponível de qualquer maneira."
+    }
+  },
+  "reader": {
+    "retry": "Tentar novamente",
+    "loadingBook": "Carregando livro...",
+    "failedToLoadBook": "Falha ao carregar livro",
+    "chapterNumber": "Capítulo {number}",
+    "peek": {

--- a/packages/types/src/locale.ts
+++ b/packages/types/src/locale.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_LOCALES = ["en", "de", "nl", "sl"] as const;
+export const SUPPORTED_LOCALES = ["en", "de", "nl", "pt", "sl"] as const;
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 
 export const DEFAULT_LOCALE: Locale = "en";
@@ -8,6 +8,7 @@ export const LOCALE_LABELS: Record<Locale, string> = {
   en: "English",
   de: "Deutsch",
   nl: "Nederlands",
+  pt: "Português",
   sl: "Slovenščina",
 };
 
@@ -15,6 +16,7 @@ export const LOCALE_DIRECTIONS: Record<Locale, "ltr" | "rtl"> = {
   en: "ltr",
   de: "ltr",
   nl: "ltr",
+  pt: "ltr",
   sl: "ltr",
 };
 


### PR DESCRIPTION
What does this PR do?
Adds Portuguese (PT-BR) language localization files and integrates them into the project.
Closes #673

How did you test this?
Changes were made via the GitHub Web UI. Verified the JSON syntax of the new translation files and ensured the keys perfectly match the existing English localization structure.

Screenshots
N/A - Translation files and basic UI selector update.

Anything non-obvious in the diff?
No. Standard localization mapping.

Checklist
[x] I've read through my own diff
[x] This PR was discussed in an issue and has maintainer approval (for new features)
[x] Lint and tests pass locally
[x] No unintended files included (build artifacts, .env, personal configs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Portuguese language support across the application.
  * Expanded Portuguese translations for settings, account management, authentication, administration, reading, metadata, integrations, and other interface areas.
  * Added Portuguese to the language selector as “Português.”
  * Portuguese interfaces use the standard left-to-right layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->