### PR TITLE
feat(i18n): Adds Portuguese (PT-BR) language localization

### DIFF
--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -4982,3 +4982,249 @@
     "failedToLoadBook": "Falha ao carregar livro",
     "chapterNumber": "Capítulo {number}",
     "peek": {
+{
+  "peek": {
+    "badge": "Espiando",
+    "startReading": "Começar a ler"
+  },
+  "toast": {
+    "linkedHighlightError": "Não foi possível abrir a posição do destaque vinculado",
+    "resumed": "Retomado em {pct}% - {label}"
+  },
+  "header": {
+    "goBack": "Voltar",
+    "tableOfContents": "Sumário",
+    "toggleBookmark": "Alternar favorito",
+    "cycleFooterMode": "Alternar modo de informações do rodapé",
+    "keyboardShortcutsHint": "Atalhos de teclado (?)",
+    "enterFullscreen": "Entrar em tela cheia",
+    "exitFullscreen": "Sair da tela cheia",
+    "footerMode": {
+      "pageProgress": "Info do rodapé: página + progresso",
+      "sessionTimeLeft": "Info do rodapé: sessão de leitura + tempo restante",
+      "chapterTimeLeft": "Info do rodapé: capítulo + tempo restante do capítulo"
+    }
+  },
+  "footer": {
+    "previousSection": "Seção anterior",
+    "nextSection": "Próxima seção",
+    "goToPlaceholder": "45 ou p123",
+    "jumpToLocation": "Pular para a localização",
+    "jumpTooltip": "Pular para % ou página (ex: 45 ou p123)",
+    "go": "Ir"
+  },
+  "settings": {
+    "title": "Configurações",
+    "ariaLabel": "Configurações do leitor",
+    "tabs": {
+      "appearance": "Aparência",
+      "text": "Texto",
+      "layout": "Layout"
+    },
+    "appearance": {
+      "mode": "Modo",
+      "light": "Claro",
+      "dark": "Escuro",
+      "colorTheme": "Tema de cor"
+    },
+    "text": {
+      "fontSize": "Tamanho da fonte",
+      "fontSizeRange": "Intervalo: 10-32px",
+      "lineHeight": "Altura da linha",
+      "lineHeightRange": "Intervalo: 0.8-3.0",
+      "fontFamily": "Família de fontes",
+      "fontFamilyDescription": "Escolha fontes embutidas ou enviadas para o corpo do texto.",
+      "builtIn": "Embutida",
+      "yourFonts": "Suas fontes"
+    },
+    "layout": {
+      "pageSpreads": "Páginas duplas",
+      "pageSpreadsDescription": "Escolha como este EPUB baseado em imagem emparelha as páginas.",
+      "bookDefault": "Padrão do livro",
+      "singlePage": "Página única",
+      "readingFlow": "Fluxo de leitura",
+      "readingFlowDescription": "Alternar entre paginado e rolagem contínua.",
+      "paginated": "Paginado",
+      "scrolled": "Rolagem",
+      "textColumns": "Colunas de texto",
+      "textColumnsRange": "Intervalo: 1-10",
+      "columnGap": "Espaçamento entre colunas",
+      "columnGapRange": "Intervalo: 0-50%",
+      "maxWidth": "Largura máxima",
+      "maxWidthRange": "Intervalo: 400-1600",
+      "justifyText": "Justificar texto",
+      "justifyTextDescription": "Habilitar alinhamento de parágrafo de largura total.",
+      "hyphenation": "Hifenização",
+      "hyphenationDescription": "Habilitar hifenização automática de quebra de palavra."
+    }
+  },
+  "search": {
+    "placeholder": "Pesquisar no livro (mín. {min} caracteres)...",
+    "searching": "Pesquisando...",
+    "tooShort": "Digite pelo menos {min} caracteres",
+    "noResults": "Nenhum resultado encontrado",
+    "prompt": "Digite para pesquisar",
+    "resultCount": "nenhum resultado | {count} resultado | {count} resultados"
+  },
+  "sidebar": {
+    "tabs": {
+      "chapters": "Capítulos",
+      "bookmarks": "Favoritos",
+      "highlights": "Destaques",
+      "toc": "Sumário",
+      "tocShort": "Sumário",
+      "marksShort": "Marcas",
+      "notesShort": "Notas"
+    },
+    "pin": "Fixar barra lateral",
+    "unpin": "Desafixar barra lateral",
+    "close": "Fechar barra lateral",
+    "noChapters": "Nenhum capítulo encontrado",
+    "noBookmarks": "Nenhum favorito ainda",
+    "noBookmarksMatch": "Nenhum favorito corresponde aos seus filtros",
+    "noHighlights": "Nenhum destaque ainda",
+    "noHighlightsMatch": "Nenhum destaque corresponde aos seus filtros",
+    "searchBookmarks": "Pesquisar favoritos...",
+    "searchHighlights": "Pesquisar destaques...",
+    "bookmarkFallback": "Favorito",
+    "locationUnavailable": "Localização indisponível",
+    "customColor": "Personalizado ({color})",
+    "allColors": "Todas as cores",
+    "allChapters": "Todos os capítulos",
+    "notesOnly": "Apenas notas",
+    "deleteBookmark": "Excluir favorito",
+    "deleteHighlight": "Excluir destaque",
+    "approximatePosition": "Sincronizado do dispositivo; posição exata indisponível, pula para o capítulo",
+    "sort": {
+      "readingOrder": "Ordem de leitura",
+      "newest": "Mais novos primeiro",
+      "oldest": "Mais antigos primeiro"
+    }
+  },
+  "selection": {
+    "copy": "Copiar",
+    "copied": "Copiado!",
+    "highlight": "Destaque",
+    "translate": "Traduzir",
+    "define": "Definir",
+    "deleteAnnotation": "Excluir anotação",
+    "apply": "Aplicar"
+  },
+  "note": {
+    "title": "Adicionar nota",
+    "placeholder": "Escreva sua nota..."
+  },
+  "dictionary": {
+    "noDefinition": "Nenhuma definição encontrada",
+    "loadError": "Não foi possível carregar a definição"
+  },
+  "translation": {
+    "original": "Original",
+    "translation": "Tradução",
+    "translating": "Traduzindo...",
+    "noTranslation": "Nenhuma tradução ainda",
+    "viaProvider": "via {provider}",
+    "copyTranslation": "Copiar tradução"
+  },
+  "shortcuts": {
+    "title": "Atalhos de Teclado",
+    "groups": {
+      "panels": "Painéis",
+      "reading": "Leitura",
+      "actions": "Ações"
+    },
+    "toggleToc": "Alternar sumário",
+    "toggleSearch": "Alternar pesquisa",
+    "toggleHelp": "Mostrar/ocultar esta ajuda",
+    "closePanel": "Fechar painel",
+    "prevNextPage": "Página anterior/próxima",
+    "goToStart": "Ir para o início do livro",
+    "goToEnd": "Ir para o final do livro",
+    "toggleBookmark": "Alternar favorito",
+    "toggleFullscreen": "Alternar tela cheia",
+    "cycleFooterMode": "Alternar modo de informações do rodapé"
+  },
+  "cbz": {
+    "tabs": {
+      "view": "Visualização",
+      "reading": "Leitura",
+      "layout": "Layout"
+    },
+    "fitMode": "Modo de ajuste",
+    "background": "Fundo",
+    "scrollMode": "Modo de rolagem",
+    "scrollModeHint": "Use \"Sem espaços\" para webtoons e tiras verticais.",
+    "readingDirection": "Direção de leitura",
+    "pageView": "Visualização de página",
+    "autoFallback": "Fallback automático",
+    "spreadAlignmentLabel": "Alinhamento de página dupla",
+    "spreadAlignmentHint": "O alinhamento de página dupla está indisponível no modo de fallback automático.",
+    "focusTwoPageToggle": "Alternar foco de duas páginas",
+    "forceTwoPage": "Forçar duas páginas",
+    "off": "Desativado",
+    "on": "Ativado",
+    "widePages": "Páginas largas",
+    "resetBookViewSettings": "Redefinir configurações de visualização do livro",
+    "resetConfirm": "Redefinir as configurações de visualização deste livro para os seus padrões globais?",
+    "firstPage": "Primeira página",
+    "lastPage": "Última página",
+    "fit": {
+      "page": "Ajustar à Página",
+      "width": "Ajustar à Largura",
+      "height": "Ajustar à Altura",
+      "actual": "Tamanho Real"
+    },
+    "view": {
+      "single": "Única",
+      "twoPage": "Duas páginas"
+    },
+    "scroll": {
+      "paged": "Paginado",
+      "infinite": "Infinito",
+      "noGaps": "Sem espaços"
+    },
+    "direction": {
+      "ltr": "E para D",
+      "rtl": "D para E"
+    },
+    "spreadAlignment": {
+      "normal": "Normal",
+      "shifted": "Deslocado"
+    },
+    "widePage": {
+      "auto": "Automático",
+      "inSpreads": "Em páginas duplas"
+    },
+    "bg": {
+      "black": "Preto",
+      "gray": "Cinza",
+      "white": "Branco"
+    }
+  },
+  "audiobook": {
+    "untitled": "Sem título",
+    "loading": "Carregando audiobook...",
+    "loadError": "Falha ao carregar audiobook",
+    "noAudioFiles": "Nenhum arquivo de áudio encontrado para este livro.",
+    "speed": "Velocidade",
+    "chapters": "Capítulos",
+    "bookmarks": "Favoritos",
+    "volume": "Volume",
+    "muted": "Sem áudio",
+    "sleep": "Sono",
+    "chapterAbbrev": "Cap.",
+    "sleepTimer": "Temporizador de sono",
+    "minutes": "{count} minutos",
+    "endOfChapter": "Fim do capítulo",
+    "noChaptersAvailable": "Nenhum capítulo disponível",
+    "extend15": "+ 15 minutos",
+    "timeLeft": "({time} restantes)",
+    "playbackSpeed": "Velocidade de reprodução",
+    "noChapters": "Nenhum capítulo disponível.",
+    "noBookmarks": "Nenhum favorito ainda.",
+    "noBookmarksHint": "Toque no ícone de favorito no topo para salvar sua posição atual.",
+    "playerSettings": "Configurações do reprodutor",
+    "skipBack": "Retroceder",
+    "skipForward": "Avançar"
+  }
+}

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "resetSortAria": "Restaurar ordenação padrão",
     "save": "Salvar",
     "cancel": "Cancelar",
     "delete": "Excluir",
@@ -7,19 +8,75 @@
     "close": "Fechar",
     "confirm": "Confirmar",
     "loading": "Carregando...",
-    "search": "Pesquisar",
+    "search": "Buscar",
     "back": "Voltar",
     "next": "Próximo",
     "previous": "Anterior",
+    "retry": "Tentar novamente",
     "yes": "Sim",
     "no": "Não"
   },
   "settings": {
+    "privacySharing": {
+      "title": "Privacidade e Compartilhamento",
+      "subtitle": "Controle se os administradores podem ver um resumo identificável da sua atividade de leitura.",
+      "levelLegend": "Nível de compartilhamento de insights de leitura",
+      "current": "Configuração atual",
+      "levels": {
+        "private": { "title": "Privado", "description": "Apenas você pode ver suas estatísticas de leitura." },
+        "summary": { "title": "Compartilhar resumo", "description": "Compartilhar hábitos agregados sem títulos de livros, autores, séries ou narradores." },
+        "detailed": { "title": "Compartilhar insights detalhados", "description": "Compartilhar também livros, autores, séries, gêneros e narradores recentes e mais lidos." }
+      },
+      "fields": {
+        "frequency": "Frequência de leitura e dias ativos",
+        "completion": "Total de livros iniciados e concluídos",
+        "formats": "Distribuição de formatos",
+        "genres": "Distribuição geral de gêneros",
+        "trend": "Tendência geral de leitura",
+        "books": "Títulos de livros atuais, recentes e mais lidos",
+        "authors": "Principais autores",
+        "series": "Principais séries",
+        "narrators": "Principais narradores"
+      },
+      "confirm": {
+        "shareTitle": "Ativar {level}?",
+        "shareDescription": "Administradores com permissão poderão ver as seguintes informações.",
+        "stopTitle": "Parar de compartilhar insights de leitura?",
+        "stopDescription": "O acesso do administrador será bloqueado imediatamente. Os registros de acesso existentes permanecem no seu histórico.",
+        "recordedNotice": "Cada visualização do perfil por um administrador é registrada e aparece no seu histórico de acesso."
+      },
+      "preview": {
+        "title": "Pré-visualizar seu perfil compartilhado",
+        "description": "Veja as informações atualmente disponíveis para administradores autorizados.",
+        "action": "Carregar pré-visualização",
+        "readingTime": "Tempo de leitura",
+        "activeDays": "Dias ativos",
+        "started": "Livros iniciados",
+        "completed": "Livros concluídos",
+        "topBooks": "Livros mais lidos"
+      },
+      "history": {
+        "title": "Histórico de acesso ao perfil",
+        "description": "Visualizações recentes do seu perfil de leitura compartilhado por administradores.",
+        "empty": "Nenhum administrador visualizou seu perfil de leitura compartilhado.",
+        "paginationLabel": "Páginas do histórico de acesso ao perfil"
+      },
+      "durationMinutes": "{count} minuto | {count} minutos",
+      "durationHours": "{count} horas",
+      "unknownTitle": "Livro sem título",
+      "errors": {
+        "load": "Falha ao carregar configurações de compartilhamento.",
+        "save": "Falha ao atualizar configurações de compartilhamento.",
+        "preview": "Falha ao carregar a pré-visualização do perfil compartilhado."
+      }
+    },
     "appearance": {
       "language": {
         "title": "Idioma",
         "description": "Escolha o idioma usado em toda a interface.",
-        "label": "Idioma da interface"
+        "label": "Idioma da interface",
+        "loadError": "Falha ao carregar o idioma selecionado",
+        "saveError": "Falha ao salvar preferência de idioma"
       },
       "pageTitle": "Exibição",
       "pageSubtitle": "Controle temas, capas, layout e como sua biblioteca é apresentada.",
@@ -36,16 +93,16 @@
         },
         "accentColor": {
           "label": "Cor de destaque",
-          "hint": "Controla destaques e elementos interativos"
+          "hint": "Controla realces e elementos interativos"
         },
         "cornerRadius": {
-          "label": "Raio da borda",
+          "label": "Arredondamento das bordas",
           "hint": "Arredondamento de cartões e elementos da interface"
         },
         "surfaceBrightness": {
           "label": "Brilho da superfície",
           "hint": "Clarear superfícies no modo escuro",
-          "reset": "Redefinir"
+          "reset": "Restaurar"
         },
         "libraryBackground": {
           "title": "Fundo da Biblioteca",
@@ -67,7 +124,7 @@
         "notAvailable": "Não disponível",
         "device": {
           "title": "Apenas neste dispositivo",
-          "description": "As preferências permanecem no seu navegador. Ideal se você quiser um visual diferente em dispositivos diferentes."
+          "description": "As preferências ficam no seu navegador. Ideal se você quiser uma aparência diferente em dispositivos diferentes."
         },
         "account": {
           "title": "Minha conta",
@@ -78,27 +135,27 @@
           "local": "As preferências permanecerão neste dispositivo"
         },
         "errors": {
-          "demoRestricted": "Uma conta restrita de demonstração não pode alterar o modo de armazenamento de tema",
+          "demoRestricted": "A conta restrita de demonstração não pode alterar o modo de armazenamento do tema",
           "update": "Falha ao atualizar o modo de armazenamento",
           "generic": "Ocorreu um erro ao atualizar o modo de armazenamento"
         }
       },
       "bookCovers": {
-        "title": "Capas de Livros",
+        "title": "Capas dos Livros",
         "displayMode": {
-          "title": "Modo de exibição de capa",
-          "hint": "Controla como as capas reais se ajustam aos espaços dos livros quando as proporções diferem",
+          "title": "Modo de exibição da capa",
+          "hint": "Controle como as capas reais se encaixam nos espaços dos livros quando as proporções são diferentes",
           "blurredFit": {
-            "label": "Ajuste desfocado",
-            "hint": "Mostrar a capa inteira com um preenchimento desfocado atrás dela"
+            "label": "Ajuste com desfoque",
+            "hint": "Exibir a capa inteira com um preenchimento desfocado ao fundo"
           },
           "fillCrop": {
             "label": "Preencher cartão",
-            "hint": "Preencher todo o espaço cortando as bordas quando as proporções diferem"
+            "hint": "Preencher todo o espaço cortando as bordas quando as proporções forem diferentes"
           },
           "naturalBottom": {
             "label": "Base natural",
-            "hint": "Manter a proporção original da capa e ancorar a capa na parte inferior"
+            "hint": "Manter a proporção original da capa e fixá-la na parte inferior"
           }
         },
         "spine": {
@@ -114,51 +171,51 @@
           },
           "strong": {
             "label": "Forte",
-            "hint": "Lombada e tratamento de brilho mais pronunciados"
+            "hint": "Tratamento de lombada e brilho mais pronunciado"
           }
         },
         "showSpineOnComics": {
-          "label": "Mostrar lombada em quadrinhos",
+          "label": "Exibir lombada em quadrinhos",
           "hint": "Aplicar o efeito de lombada e brilho em capas de quadrinhos (cbz, cbr, cb7)"
         },
         "shadow": {
           "title": "Intensidade da sombra da capa",
-          "hint": "Controla a profundidade sob as capas na grade, lista, tabela e miniaturas do painel",
+          "hint": "Controle a profundidade sob as capas na grade, lista, tabela e miniaturas do painel",
           "default": {
             "label": "Padrão",
             "hint": "Elevação e profundidade atuais"
           },
           "strong": {
             "label": "Forte",
-            "hint": "Sombra projetada mais pesada, semelhante a uma prateleira, sob as capas"
+            "hint": "Sombra projetada mais pesada, estilo prateleira, sob as capas"
           }
         },
         "overlays": {
-          "title": "Sobreposições de cartão",
-          "hint": "Escolha os metadados mostrados diretamente nos cartões de capa de livro",
+          "title": "Sobreposições nos cartões",
+          "hint": "Escolha os metadados exibidos diretamente nos cartões de capa dos livros",
           "progressBar": {
             "label": "Barra de progresso",
-            "hint": "Linha fina colorida ao longo da borda inferior"
+            "hint": "Linha colorida fina ao longo da borda inferior"
           },
           "format": {
             "label": "Formato do arquivo",
-            "hint": "Distintivo colorido EPUB, PDF, CBZ no canto inferior direito"
+            "hint": "Emblema codificado por cores (EPUB, PDF, CBZ) no canto inferior direito"
           },
           "rating": {
             "label": "Avaliação",
-            "hint": "Indicador de classificação por estrelas no canto inferior esquerdo"
+            "hint": "Indicador de avaliação por estrelas no canto inferior esquerdo"
           },
           "readStatus": {
             "label": "Status de leitura",
             "hint": "Ícone colorido mostrando o status de leitura atual no canto superior esquerdo"
           },
           "seriesPosition": {
-            "label": "Número da série",
-            "hint": "Distintivo mostrando a posição do livro em sua série no canto superior direito (ex: #3, #1.5)"
+            "label": "Número na série",
+            "hint": "Emblema mostrando a posição do livro na série no canto superior direito (ex: #3, #1.5)"
           },
           "lockStatus": {
             "label": "Status de bloqueio",
-            "hint": "Ícone de cadeado de metadados no canto superior direito - laranja quando bloqueado, verde quando desbloqueado"
+            "hint": "Ícone de bloqueio de metadados no canto superior direito - laranja quando bloqueado, verde quando desbloqueado"
           }
         }
       },
@@ -170,41 +227,41 @@
         },
         "coverSizeBehavior": {
           "label": "Comportamento do tamanho da capa",
-          "hint": "Controle se os tamanhos de retrato/quadrado e o espaçamento da grade são compartilhados em todas as visualizações ou mantidos por visualização",
-          "perViewHint": "Modo por visualização: ajuste o tamanho da capa e o espaçamento no painel de Exibição de cada visualização.",
+          "hint": "Controle se os tamanhos retrato/quadrado e o espaçamento da grade são compartilhados entre todas as visualizações ou mantidos por visualização",
+          "perViewHint": "Modo por visualização: ajuste o tamanho da capa e o espaçamento em cada painel de Exibição da visualização.",
           "syncAll": "Sincronizar todas as visualizações",
           "perView": "Tamanhos por visualização"
         },
         "portraitCoverSize": {
-          "label": "Tamanho da capa em retrato",
-          "hint": "Usado para bibliotecas e visualizações em retrato"
+          "label": "Tamanho da capa retrato",
+          "hint": "Usado para bibliotecas e visualizações em modo retrato"
         },
         "squareCoverSize": {
           "label": "Tamanho da capa quadrada",
-          "hint": "Usado para bibliotecas e visualizações quadradas"
+          "hint": "Usado para bibliotecas e visualizações em modo quadrado"
         },
         "portraitGridSpacing": {
-          "label": "Espaçamento da grade em retrato",
-          "hint": "Espaço entre capas em retrato"
+          "label": "Espaçamento da grade retrato",
+          "hint": "Espaço entre capas retrato"
         },
         "squareGridSpacing": {
           "label": "Espaçamento da grade quadrada",
           "hint": "Espaço entre capas quadradas"
         },
         "cardInfoMode": {
-          "label": "Modo de informações do cartão",
-          "hint": "Onde mostrar o título do livro e o autor nos cartões da grade",
+          "label": "Modo de informação do cartão",
+          "hint": "Onde exibir o título e o autor do livro nos cartões da grade",
           "onHover": "Ao passar o mouse",
           "belowCover": "Abaixo da capa",
           "off": "Desativado"
         },
         "primaryCardLabel": {
-          "label": "Rótulo principal do cartão",
-          "hint": "Texto mostrado abaixo de cada capa de livro (primeira linha)"
+          "label": "Rótulo primário do cartão",
+          "hint": "Texto exibido abaixo de cada capa de livro (primeira linha)"
         },
         "secondaryCardLabel": {
           "label": "Rótulo secundário do cartão",
-          "hint": "Texto adicional abaixo do rótulo principal (segunda linha)"
+          "hint": "Texto adicional abaixo do rótulo primário (segunda linha)"
         },
         "labelField": {
           "hidden": "Oculto",
@@ -214,10 +271,10 @@
           "author": "Autor"
         },
         "seriesDisplay": {
-          "title": "Exibição de Série",
+          "title": "Exibição de Séries",
           "collapsedCover": {
-            "label": "Capa de série recolhida",
-            "hint": "Escolha qual capa mostrar quando as séries estiverem recolhidas na grade de livros"
+            "label": "Capa da série recolhida",
+            "hint": "Escolha qual capa exibir quando as séries estiverem recolhidas na grade de livros"
           },
           "stack": "Pilha",
           "mosaic": "Mosaico",
@@ -239,26 +296,26 @@
           "square": "Quadrado"
         },
         "listTableViews": {
-          "title": "Visualizações de Lista e Tabela"
+          "title": "Visualizações em Lista e Tabela"
         },
         "zebraStriping": {
-          "label": "Cores alternadas",
+          "label": "Linhas zebradas",
           "hint": "Alternar cores de fundo das linhas para facilitar a leitura"
         }
       },
       "behavior": {
         "title": "Comportamento da Biblioteca",
         "thumbnailClicks": {
-          "label": "Cliques em miniaturas",
-          "hint": "Escolha o que acontece ao abrir um livro das visualizações de grade e lista",
+          "label": "Cliques na miniatura",
+          "hint": "Escolha o que acontece ao abrir um livro a partir das visualizações em grade e lista",
           "readFirst": "Ler primeiro",
           "readFirstHint": "Abrir o leitor quando existir um arquivo legível",
           "openDetails": "Abrir detalhes",
-          "openDetailsHint": "Ir para a página de detalhes do livro a partir de miniaturas de grade e lista"
+          "openDetailsHint": "Ir para a página de detalhes do livro a partir das miniaturas de grade e lista"
         },
         "filterPreview": {
-          "label": "Mostrar visualização de filtro por padrão",
-          "hint": "Expandir o filtro ativo e o resumo de classificação ao abrir um SmartScope"
+          "label": "Exibir pré-visualização do filtro por padrão",
+          "hint": "Expandir o resumo do filtro e ordenação ativos ao abrir um escopo inteligente (smartScope)"
         },
         "collapseSeries": {
           "label": "Recolher séries por padrão",
@@ -269,38 +326,38 @@
         "title": "Ícones Personalizados",
         "uploadIcons": "Enviar ícones",
         "uploadedCount": "nenhum ícone enviado | {count} ícone enviado | {count} ícones enviados",
-        "searchPlaceholder": "Pesquisar ícones",
+        "searchPlaceholder": "Buscar ícones",
         "sort": {
-          "newest": "Mais novos",
+          "newest": "Mais recentes",
           "name": "Nome"
         },
         "selectedCount": "{count} selecionado(s)",
         "clear": "Limpar",
         "deleteSelected": "Excluir selecionados",
         "loading": "Carregando ícones...",
-        "emptySearch": "Nenhum ícone corresponde à sua pesquisa.",
+        "emptySearch": "Nenhum ícone corresponde à sua busca.",
         "emptyNoIcons": "Nenhum ícone personalizado enviado ainda.",
         "namePlaceholder": "Nome",
         "checkingUsage": "Verificando uso...",
         "usedBy": "Usado por {count}",
-        "notUsedYet": "Ainda não usado",
+        "notUsedYet": "Não usado ainda",
         "rename": "Renomear",
         "replace": "Substituir",
         "usage": {
           "libraries": "nenhuma biblioteca | {count} biblioteca | {count} bibliotecas",
           "collections": "nenhuma coleção | {count} coleção | {count} coleções",
-          "smartScopes": "nenhum smart scope | {count} smart scope | {count} smart scopes"
+          "smartScopes": "nenhum escopo inteligente | {count} escopo inteligente | {count} escopos inteligentes"
         },
         "confirm": {
-          "deleteOne": "Excluir \"{name}\"? Os usos existentes voltarão ao ícone padrão.",
-          "deleteMany": "Excluir nenhum ícone? | Excluir {count} ícone? Os usos existentes voltarão ao ícone padrão. | Excluir {count} ícones? Os usos existentes voltarão ao ícone padrão."
+          "deleteOne": "Excluir \"{name}\"? Os usos existentes reverterão para o ícone padrão.",
+          "deleteMany": "Excluir nenhum ícone? | Excluir {count} ícone? Os usos existentes reverterão para o ícone padrão. | Excluir {count} ícones? Os usos existentes reverterão para o ícone padrão."
         },
         "toasts": {
           "saved": "Ícone salvo",
           "updated": "Ícone atualizado",
           "deleted": "Ícone excluído",
-          "bulkDeleted": "Nenhum ícone excluído | {count} ícone excluído | {count} ícones excluídos",
-          "bulkDeletePartial": "{deleted} excluídos, {failed} falharam"
+          "bulkDeleted": "Nenhum ícone excluído | Excluído {count} ícone | Excluídos {count} ícones",
+          "bulkDeletePartial": "Excluído(s) {deleted}, {failed} falhou(aram)"
         },
         "errors": {
           "load": "Falha ao carregar ícones",
@@ -312,7 +369,7 @@
       },
       "tabs": {
         "theme": "Tema",
-        "book-covers": "Capas de Livros",
+        "book-covers": "Capas dos Livros",
         "icons": "Ícones",
         "layout": "Layout",
         "behavior": "Comportamento"
@@ -320,27 +377,28 @@
     },
     "account": {
       "title": "Conta",
-      "subtitle": "Gerencie suas configurações de perfil pessoal.",
+      "subtitle": "Gerencie as configurações do seu perfil pessoal.",
       "subtitleAll": "Gerencie seu perfil e preferências de notificação.",
       "tabs": {
         "profile": "Perfil",
+        "privacy": "Privacidade e Compartilhamento",
         "notifications": "Notificações",
         "restrictions": "Restrições"
       },
       "demoRestricted": {
-        "cannotEdit": "Conta restrita de demonstração não pode editar configurações de conta",
+        "cannotEdit": "A conta restrita de demonstração não pode editar as configurações da conta",
         "notice": "Conta restrita de demonstração: a edição de perfil, senha, avatar e identidades vinculadas está desativada."
       },
       "feedback": {
         "unsavedChanges": "Alterações não salvas",
-        "allSaved": "Todas as alterações salvas"
+        "allSaved": "Todas as alterações foram salvas"
       },
       "profile": {
         "securityHeading": "Perfil e Segurança",
         "username": "Nome de usuário",
         "fullName": "Nome completo",
         "email": "E-mail",
-        "emailHint": "Contate um administrador para alterar seu endereço de e-mail.",
+        "emailHint": "Entre em contato com um administrador para alterar seu endereço de e-mail.",
         "save": "Salvar perfil",
         "saving": "Salvando...",
         "changePassword": "Alterar senha",
@@ -354,29 +412,31 @@
       },
       "readingPreferences": {
         "title": "Preferências de Leitura",
-        "timezoneHint": "O fuso horário é usado para conquistas sensíveis ao tempo, como Early Bird e All-nighter.",
+        "timezoneHint": "O fuso horário é usado para conquistas sensíveis ao tempo, como Madrugador e Corujão.",
         "timezone": "Fuso horário",
-        "save": "Salvar preferências"
+        "save": "Salvar preferências",
+        "enableAchievements": "Ativar conquistas",
+        "enableAchievementsHint": "Acompanhe o progresso das conquistas e exiba a interface relacionada a elas. Gerencie as notificações de conquistas separadamente em Notificações."
       },
       "preferences": {
         "saveFailed": "Falha ao salvar preferências",
         "saved": "Preferências salvas"
       },
       "avatar": {
-        "title": "Foto de Perfil",
+        "title": "Foto do Perfil",
         "unknownUser": "Usuário desconhecido",
-        "formatHint": "PNG/JPEG/WEBP até {size} MB",
+        "formatHint": "PNG/JPEG/WEBP de até {size} MB",
         "upload": "Enviar foto",
         "replace": "Substituir foto",
         "uploading": "Enviando...",
         "remove": "Remover foto",
         "removing": "Removendo...",
-        "updated": "Foto de perfil atualizada",
-        "uploadFailed": "Falha ao enviar foto de perfil",
-        "removed": "Foto de perfil removida",
-        "removeFailed": "Falha ao remover foto de perfil",
+        "updated": "Foto do perfil atualizada",
+        "uploadFailed": "Falha ao enviar a foto do perfil",
+        "removed": "Foto do perfil removida",
+        "removeFailed": "Falha ao remover a foto do perfil",
         "removeConfirm": {
-          "title": "Remover foto de perfil?",
+          "title": "Remover foto do perfil?",
           "description": "Seu avatar será removido e substituído por iniciais.",
           "confirm": "Remover"
         }
@@ -389,31 +449,31 @@
         "linkProvider": "Vincular {provider}",
         "redirecting": "Redirecionando...",
         "noneConfigured": "Nenhum provedor OIDC está configurado. Peça a um administrador para configurar o SSO.",
-        "linkStateFailed": "Falha ao gerar estado de vínculo",
-        "startLinkFailed": "Falha ao iniciar vínculo OIDC",
+        "linkStateFailed": "Falha ao gerar o estado de vinculação",
+        "startLinkFailed": "Falha ao iniciar a vinculação OIDC",
         "unlinkFailed": "Falha ao desvincular",
         "unlinked": "Identidade desvinculada",
         "unlinkIdentityFailed": "Falha ao desvincular identidade",
         "unlinkDialog": {
           "title": "Desvincular identidade {provider}?",
-          "description": "Insira sua senha para confirmar. Você não poderá mais fazer login com este provedor.",
+          "description": "Digite sua senha para confirmar. Você não poderá mais fazer login com este provedor.",
           "currentPassword": "Senha atual"
         }
       },
       "tour": {
         "title": "Tour Guiado",
-        "description": "Repita o passo a passo que destaca os principais recursos do aplicativo.",
+        "description": "Repita a apresentação que destaca os principais recursos do aplicativo.",
         "action": "Fazer o tour novamente"
       },
       "restrictions": {
         "none": {
           "title": "Sem restrições de conteúdo",
-          "description": "Sua conta tem acesso total a todo o conteúdo dentro de suas bibliotecas atribuídas."
+          "description": "Sua conta tem acesso total a todo o conteúdo dentro das bibliotecas atribuídas."
         },
-        "banner": "Sua conta possui restrições de conteúdo aplicadas por um administrador. Alguns livros podem não estar visíveis para você.",
+        "banner": "Sua conta possui restrições de conteúdo aplicadas por um administrador. Alguns livros podem não ficar visíveis para você.",
         "allowedTags": {
           "title": "Tags permitidas",
-          "description": "Apenas livros que têm pelo menos uma dessas tags são mostrados a você."
+          "description": "Apenas livros que possuem pelo menos uma dessas tags são exibidos para você."
         },
         "blockedTags": {
           "title": "Tags bloqueadas",
@@ -421,7 +481,7 @@
         },
         "allowedGenres": {
           "title": "Gêneros permitidos",
-          "description": "Apenas livros que têm pelo menos um desses gêneros são mostrados a você."
+          "description": "Apenas livros que possuem pelo menos um desses gêneros são exibidos para você."
         },
         "blockedGenres": {
           "title": "Gêneros bloqueados",
@@ -439,12 +499,12 @@
       "paused": "Pausado",
       "deletedUser": "Usuário excluído",
       "expiredPrefix": "Expirado ",
-      "never": "Nunca",
+      "never": "Nenhuma atividade registrada",
       "noExpiry": "Sem expiração",
       "expired": "Expirado",
       "expiresOn": "Expira em {date}",
       "revokedOn": "Revogado em {date}",
-      "expiredOn": "Expirado em {date}",
+      "expiredOn": "Expirou em {date}",
       "usesCount": "nenhum uso | um uso | {count} usos",
       "copied": "Copiado!",
       "copyLink": "Copiar link",
@@ -462,11 +522,11 @@
         "lastUsed": "Último uso",
         "created": "Criado",
         "status": "Status",
-        "totalUses": "Total de usos"
+        "totalUses": "Ocorrências totais"
       },
       "createDialog": {
         "title": "Criar link mágico",
-        "description": "Gerar uma URL de login compartilhável para uma conta compartilhada.",
+        "description": "Gere uma URL de login compartilhável para uma conta compartilhada.",
         "sharedAccount": "Conta compartilhada",
         "selectAccount": "Selecione uma conta compartilhada",
         "label": "Rótulo",
@@ -478,7 +538,7 @@
       },
       "revokeDialog": {
         "title": "Revogar link mágico?",
-        "description": "Isso invalidará imediatamente o link e encerrará todas as sessões ativas da conta vinculada."
+        "description": "Isso invalidará imediatamente o link e encerrará todas as sessões ativas para a conta vinculada."
       },
       "errors": {
         "create": "Falha ao criar",
@@ -494,7 +554,7 @@
     },
     "oidc": {
       "title": "OIDC / SSO",
-      "subtitle": "Gerencie provedores OpenID Connect para single sign-on.",
+      "subtitle": "Gerencie provedores OpenID Connect para logon único (SSO).",
       "providers": "Provedores",
       "addProvider": "Adicionar Provedor",
       "editProvider": "Editar Provedor",
@@ -504,40 +564,40 @@
       "disabled": "Desativado",
       "empty": {
         "title": "Nenhum provedor ainda",
-        "description": "Adicione um provedor OIDC para habilitar o single sign-on para seus usuários."
+        "description": "Adicione um provedor OIDC para permitir o logon único para seus usuários."
       },
       "form": {
         "status": "Status",
-        "enableProvider": "Habilitar provedor",
-        "enableProviderHint": "Mostrar este provedor na página de login.",
+        "enableProvider": "Ativar provedor",
+        "enableProviderHint": "Exibir este provedor na página de login.",
         "identity": "Identidade do Provedor",
         "slug": "Slug",
-        "slugHint": "Identificador único (minúsculas, hifens). Não pode ser alterado posteriormente.",
+        "slugHint": "Identificador único (minúsculas, hífens). Não pode ser alterado posteriormente.",
         "displayName": "Nome de Exibição",
-        "displayNameHint": "Mostrado no botão de login.",
+        "displayNameHint": "Exibido no botão de login.",
         "iconUrl": "URL do Ícone",
-        "iconUrlHint": "Logotipo opcional mostrado ao lado do botão de login.",
+        "iconUrlHint": "Logo opcional exibido ao lado do botão de login.",
         "iconPreviewAlt": "pré-visualização do ícone",
         "connection": "Conexão",
-        "issuerUri": "URI do Emissor",
+        "issuerUri": "URI do Emissor (Issuer)",
         "issuerUriHint": "A URL base do provedor.",
         "test": "Testar",
         "testing": "Testando...",
-        "clientId": "Client ID",
-        "clientSecret": "Client Secret",
+        "clientId": "ID do Cliente (Client ID)",
+        "clientSecret": "Segredo do Cliente (Client Secret)",
         "clientSecretPlaceholder": "Deixe em branco para manter o existente",
-        "scopes": "Escopos",
+        "scopes": "Escopos (Scopes)",
         "claimMapping": "Mapeamento de Claims",
         "previewClaims": "Pré-visualizar claims",
         "redirecting": "Redirecionando...",
-        "mappedClaims": "Claims mapeados",
-        "rawClaims": "Claims brutos",
+        "mappedClaims": "Claims mapeadas",
+        "rawClaims": "Claims brutas",
         "usernameClaim": "Claim de nome de usuário",
         "nameClaim": "Claim de nome",
         "emailClaim": "Claim de e-mail",
         "groupsClaim": "Claim de grupos",
-        "autoProvisioning": "Autoprovisionamento",
-        "autoProvisionUsers": "Autoprovisionar usuários",
+        "autoProvisioning": "Provisionamento Automático",
+        "autoProvisionUsers": "Provisionar usuários automaticamente",
         "autoProvisionUsersHint": "Criar contas no primeiro login OIDC se o usuário não existir.",
         "allowLocalLinking": "Permitir vinculação de conta local",
         "allowLocalLinkingHint": "Vincular identidade OIDC a uma conta local existente por correspondência de nome de usuário.",
@@ -547,7 +607,7 @@
         "saveChanges": "Salvar Alterações",
         "saving": "Salvando...",
         "deleteProvider": "Excluir Provedor",
-        "deleting": "Excluindo..."
+        "deleting": "Exclundo..."
       },
       "test": {
         "connected": "Conectado - {issuer}",
@@ -558,9 +618,9 @@
         "notSupported": "não suportado"
       },
       "groupMappings": {
-        "title": "Mapeamentos de Grupo",
-        "description": "Mapeie os claims de grupo OIDC para permissões do BookOrbit. Sincronizado a cada login.",
-        "noPermission": "Sem permissão",
+        "title": "Mapeamento de Grupos",
+        "description": "Mapeie claims de grupo OIDC para permissões do BookOrbit. Sincronizado a cada login.",
+        "noPermission": "Nenhuma permissão",
         "empty": "Nenhum mapeamento de grupo configurado.",
         "addMapping": "Adicionar mapeamento",
         "claimPlaceholder": "Claim de grupo OIDC (ex: admins)",
@@ -575,12 +635,12 @@
         "mappingRemoved": "Mapeamento de grupo removido"
       },
       "errors": {
-        "loadProvider": "Falha ao carregar provedor",
-        "createProvider": "Falha ao criar provedor",
+        "loadProvider": "Falha ao carregar o provedor",
+        "createProvider": "Falha ao criar o provedor",
         "save": "Falha ao salvar",
         "delete": "Falha ao excluir",
-        "deleteProvider": "Falha ao excluir provedor",
-        "requestFailed": "Falha na solicitação",
+        "deleteProvider": "Falha ao excluir o provedor",
+        "requestFailed": "A requisição falhou",
         "previewState": "Falha ao gerar estado de pré-visualização",
         "startPreview": "Falha ao iniciar pré-visualização",
         "addMapping": "Falha ao adicionar mapeamento",
@@ -592,7 +652,7 @@
       "subtitle": "Gerencie usuários e configurações de autenticação.",
       "system": {
         "title": "Sistema",
-        "subtitle": "Configurações de organização de arquivos, ingestão e manutenção."
+        "subtitle": "Organização de arquivos, importação e configurações de manutenção."
       },
       "maintenance": {
         "title": "Manutenção",
@@ -603,12 +663,12 @@
         "updatesGroup": "Atualizações",
         "importFromBooklore": "Importar do Booklore",
         "bookloreImportConfigured": "Importação do Booklore configurada",
-        "migrationRunning": "Migração em andamento",
+        "migrationRunning": "Migração em execução",
         "migrationCompleted": "Migração concluída",
         "migrationFailed": "Falha na migração",
         "importDescription": "Importação única de livros, metadados e progresso de leitura de uma instalação anterior do Booklore.",
         "configuredDescription": "Origem: {name}. Nenhuma migração executada ainda - continue a configuração para executar a importação.",
-        "runningDescription": "Estágio: {stage} - iniciado em {started}",
+        "runningDescription": "Etapa: {stage} - iniciada em {started}",
         "completedDescription": "De {name} - concluída em {date}",
         "migrationErrorGeneric": "Ocorreu um erro durante a migração.",
         "stageInitializing": "inicializando",
@@ -617,52 +677,52 @@
         "continueSetup": "Continuar Configuração",
         "viewDetails": "Ver Detalhes",
         "refreshRecommendationIndex": "Atualizar índice de recomendações",
-        "refreshRecommendationHint": "Atualiza o mecanismo de recomendações com as alterações mais recentes da sua biblioteca. Este processo é executado em segundo plano.",
+        "refreshRecommendationHint": "Atualize o mecanismo de recomendações com as alterações mais recentes da sua biblioteca. Este processo roda em segundo plano.",
         "booksQueuedForProcessing": "nenhum livro na fila de processamento | {count} livro na fila de processamento | {count} livros na fila de processamento",
         "run": "Executar",
         "running": "Executando...",
         "backfillAchievements": "Preenchimento retroativo de conquistas",
         "backfillAchievementsHint": "Reavaliar conquistas para todos os usuários.",
-        "backfillResult": "Processados {users} usuários; concedidos {awards} prêmios.",
+        "backfillResult": "{users} usuários processados; {awards} prêmios concedidos.",
         "runBackfill": "Executar Preenchimento Retroativo",
         "checkForUpdates": "Verificar atualizações",
-        "checkForUpdatesHint": "Verifica automaticamente o GitHub por uma nova versão na inicialização e mostra um indicador na barra lateral quando uma estiver disponível.",
+        "checkForUpdatesHint": "Verificar automaticamente no GitHub se há uma nova versão ao iniciar e exibir um indicador na barra lateral quando houver uma disponível.",
         "updateChecksEnabled": "Verificação de atualizações ativada",
         "updateChecksDisabled": "Verificação de atualizações desativada",
         "updateSettingFailed": "Falha ao atualizar configuração",
         "booksQueuedForEmbedding": "nenhum livro na fila de incorporação | {count} livro na fila de incorporação | {count} livros na fila de incorporação",
         "failed": "Falhou",
         "unknownError": "Erro desconhecido",
-        "rebuildEmbeddingsFailed": "Falha ao reconstruir incorporações: {error}",
-        "achievementBackfillConfirm": "Executar o preenchimento retroativo de conquistas para todas as conquistas em todos os usuários? Isso pode demorar um pouco.",
+        "rebuildEmbeddingsFailed": "Falha ao reconstruir incorporações (embeddings): {error}",
+        "achievementBackfillConfirm": "Executar o preenchimento retroativo de todas as conquistas para todos os usuários? Isso pode demorar um pouco.",
         "achievementBackfillComplete": "Preenchimento retroativo de conquistas concluído: {count} prêmios concedidos",
-        "backfillRunFailed": "Falha ao executar preenchimento retroativo",
-        "achievementBackfillFailed": "Falha ao executar preenchimento retroativo de conquistas: {error}",
+        "backfillRunFailed": "Falha ao executar o preenchimento retroativo",
+        "achievementBackfillFailed": "Falha ao executar o preenchimento retroativo de conquistas: {error}",
         "uploadsGroup": "Uploads",
-        "maxUploadSize": "Limite máximo de tamanho de arquivo de upload",
-        "maxUploadSizeHint": "Configure o limite de tamanho máximo para uploads de arquivos em todo o sistema.",
+        "maxUploadSize": "Limite máximo de tamanho de arquivo para upload",
+        "maxUploadSizeHint": "Configure o limite máximo de tamanho para envio de arquivos em todo o sistema.",
         "save": "Salvar",
         "uploadSizeInvalid": "O limite de tamanho de upload deve ser maior que 0",
         "uploadSizeUpdated": "Limite de tamanho de upload atualizado"
       },
       "migration": {
         "title": "Migração",
-        "subtitle": "Importação única do Booklore: conecte a origem, mapeie usuários, teste, inicie a migração e exporte um relatório.",
+        "subtitle": "Importação única do Booklore: conecte a origem, mapeie usuários, faça a simulação (dry-run), inicie a migração e exporte um relatório.",
         "progress": "Progresso",
         "stepSourceConnection": "Conexão de Origem",
-        "stepUserPathMapping": "Mapeamento de Usuário e Caminho",
-        "stepDryRun": "Teste (Dry-Run)",
-        "stepDryRunTitle": "Teste (Dry Run)",
+        "stepUserPathMapping": "Mapeamento de Usuários e Caminhos",
+        "stepDryRun": "Simulação (Dry-Run)",
+        "stepDryRunTitle": "Simulação",
         "stepRunMigration": "Executar Migração",
         "stepReport": "Relatório",
         "stepReportTitle": "Relatório de Migração",
-        "subtitleSource": "Configure a conexão do banco de dados com a sua instância Booklore de origem.",
-        "subtitleMappings": "Mapeie usuários de origem para usuários de destino e traduza os caminhos dos arquivos.",
-        "subtitleDryRun": "Pré-visualize o que será importado antes de executar a migração definitiva.",
-        "subtitleRun": "Inicie a importação definitiva e monitore seu progresso.",
+        "subtitleSource": "Configure a conexão de banco de dados com sua instância de origem do Booklore.",
+        "subtitleMappings": "Mapeie usuários de origem para usuários de destino e traduza caminhos de arquivo.",
+        "subtitleDryRun": "Pré-visualize o que será importado antes de executar a migração real.",
+        "subtitleRun": "Inicie a importação real e acompanhe seu progresso.",
         "subtitleReport": "Revise o que foi importado e exporte um relatório detalhado.",
         "continueToMappings": "Continuar para Mapeamentos",
-        "continueToDryRun": "Continuar para o Teste",
+        "continueToDryRun": "Continuar para Simulação",
         "continueToMigration": "Continuar para Migração",
         "viewReport": "Ver Relatório",
         "badgeValidated": "Validado",
@@ -671,95 +731,95 @@
         "badgeCompleted": "Concluído",
         "badgeRunning": "Executando",
         "badgeFailed": "Falhou",
-        "mediaPathRequired": "Obrigatório para migração de capas de livros.",
-        "mediaPathAbsolute": "Use um caminho absoluto (exemplo: /books). Caminhos relativos não são suportados.",
-        "mediaPathConfigured": "Caminho de importação de capa configurado. Use Testar Conexão para verificar o acesso e a estrutura de pastas de imagens do Booklore.",
+        "mediaPathRequired": "Obrigatório para migrar capas de livros.",
+        "mediaPathAbsolute": "Use um caminho absoluto (por exemplo: /books). Caminhos relativos não são suportados.",
+        "mediaPathConfigured": "Caminho de importação de capas configurado. Use Testar Conexão para verificar o acesso e a estrutura da pasta de imagens do Booklore.",
         "issueSaveSource": "Salvar configurações de conexão de origem",
         "issueValidateSource": "Validar conexão de origem",
-        "issueSaveMappings": "Salvar mapeamentos de usuário e caminho",
+        "issueSaveMappings": "Salvar mapeamento de usuários e caminhos",
         "issueSavePathMappings": "Salvar mapeamentos de caminho para validá-los",
-        "issueFreshDryRun": "Executar um novo teste",
-        "issueResolveDuplicates": "Resolver correspondências duplicadas de livros de destino no teste",
+        "issueFreshDryRun": "Executar uma nova simulação",
+        "issueResolveDuplicates": "Resolver correspondências duplicatas de livros de destino na simulação",
         "issueWaitActiveRun": "Aguardar a execução ativa terminar",
         "sourceRecordId": "ID do registro de origem #{id}",
         "byAuthorWithId": "por {author} (ID: {id})",
         "filePathWithId": "{path} (ID: {id})",
-        "bookloreSourceId": "ID de origem Booklore: {id}",
+        "bookloreSourceId": "ID de origem do Booklore: {id}",
         "libraryBookNum": "Livro da biblioteca #{id}",
         "errorInitialize": "Falha ao inicializar configurações de migração",
         "errorLoadSourceTypes": "Falha ao carregar tipos de origem de migração suportados",
         "errorLoadTargetUsers": "Falha ao carregar usuários de destino",
         "errorLoadLibraryFolders": "Falha ao carregar pastas da biblioteca de destino",
         "noSourceUsersReturned": "Nenhum usuário de origem foi retornado",
-        "userMappingSuggestionsLoaded": "Sugestões de mapeamento de usuário carregadas",
-        "errorLoadSuggestions": "Falha ao carregar sugestões de mapeamento de usuário",
-        "requiredFields": "Host, usuário, banco de dados e nome de origem são obrigatórios",
-        "connectionTestPassedWithWarnings": "Teste de conexão concluído com avisos",
-        "connectionTestPassedWithCount": "Teste de conexão concluído com {count} aviso(s). Primeiro: {first}",
-        "connectionTestPassed": "Teste de conexão aprovado",
-        "connectionOkMissingTables": "Conexão ok, mas {count} tabela(s) obrigatória(s) estão ausentes",
-        "cannotTestMediaPathActiveRun": "Não é possível testar o caminho de mídia enquanto uma execução estiver ativa",
-        "mediaRootPathRequiredCover": "Caminho Raiz de Mídia é obrigatório para importação de capa.",
+        "userMappingSuggestionsLoaded": "Sugestões de mapeamento de usuários carregadas",
+        "errorLoadSuggestions": "Falha ao carregar sugestões de mapeamento de usuários",
+        "requiredFields": "Host, usuário, banco de dados e nome da origem são obrigatórios",
+        "connectionTestPassedWithWarnings": "O teste de conexão passou com avisos",
+        "connectionTestPassedWithCount": "O teste de conexão passou com {count} aviso(s). Primeiro: {first}",
+        "connectionTestPassed": "O teste de conexão passou",
+        "connectionOkMissingTables": "Conexão ok, mas {count} tabela(s) obrigatória(s) está(ão) ausente(s)",
+        "cannotTestMediaPathActiveRun": "Não é possível testar o caminho de mídia enquanto uma execução está ativa",
+        "mediaRootPathRequiredCover": "O Caminho Raiz de Mídia é obrigatório para importação de capas.",
         "useAbsolutePath": "Use um caminho absoluto (por exemplo: /books).",
         "mediaPathVerified": "Caminho de mídia verificado.",
         "mediaPathValidReadable": "O caminho de mídia é válido e legível",
-        "mediaPathValidationFailed": "A validação do caminho de mídia falhou.",
+        "mediaPathValidationFailed": "Falha na validação do caminho de mídia.",
         "connectionFailedBeforeMediaPath": "O teste de conexão falhou antes que a validação do caminho de mídia pudesse ser concluída.",
-        "cannotModifySourceActiveRun": "Não é possível modificar a origem enquanto uma execução estiver ativa",
+        "cannotModifySourceActiveRun": "Não é possível modificar a origem enquanto uma execução está ativa",
         "sourceSavedValidatedWarnings": "Origem salva e validada com {count} aviso(s)",
         "sourceSavedValidated": "Origem salva e validada",
-        "errorSaveValidateSource": "Falha ao salvar ou validar origem",
-        "cannotSaveMappingsActiveRun": "Não é possível salvar mapeamentos enquanto uma execução estiver ativa",
+        "errorSaveValidateSource": "Falha ao salvar ou validar a origem",
+        "cannotSaveMappingsActiveRun": "Não é possível salvar mapeamentos enquanto uma execução está ativa",
         "saveSourceFirst": "Salvar origem primeiro",
         "mapAtLeastOneUser": "Mapeie pelo menos um usuário de origem para um usuário de destino",
         "mapEveryUser": "Mapeie todos os usuários de origem antes de salvar",
-        "pathValidationFailedProfileSaved": "A validação do caminho falhou, mas o perfil ainda será salvo",
+        "pathValidationFailedProfileSaved": "Falha na validação do caminho, mas o perfil ainda será salvo",
         "mappingsSaved": "Mapeamentos salvos",
         "errorSaveMappings": "Falha ao salvar mapeamentos",
-        "cannotRunDryRunActiveRun": "Não é possível executar o teste enquanto uma execução estiver ativa",
+        "cannotRunDryRunActiveRun": "Não é possível executar uma simulação enquanto uma execução está ativa",
         "saveMappingsFirst": "Salvar mapeamentos primeiro",
-        "dryRunCompleted": "Teste concluído: {matched} correspondências, {unresolved} não resolvidos",
-        "dryRunFailed": "Falha no teste",
+        "dryRunCompleted": "Simulação concluída: {matched} correspondidos, {unresolved} não resolvidos",
+        "dryRunFailed": "Falha na simulação",
         "selectSourceForAllGroups": "Selecione um livro de origem para todos os {count} grupos duplicados",
         "duplicatesResolved": "Correspondências duplicadas resolvidas",
         "errorResolveDuplicates": "Falha ao resolver duplicatas",
-        "preflightNotReady": "Pré-verificação de migração não pronta",
-        "runDryRunFirst": "Execute o teste primeiro",
-        "runStarted": "Execução de migração iniciada",
+        "preflightNotReady": "As verificações pré-migração não estão prontas",
+        "runDryRunFirst": "Execute a simulação primeiro",
+        "runStarted": "Execução da migração iniciada",
         "errorStartMigration": "Falha ao iniciar migração",
-        "runCancelled": "Execução de migração cancelada",
+        "runCancelled": "Execução da migração cancelada",
         "errorCancelMigration": "Falha ao cancelar migração",
-        "runRetried": "Execução de migração repetida - retomando do último estágio concluído",
-        "errorRetryMigration": "Falha ao repetir migração",
+        "runRetried": "Execução da migração reiniciada - continuando da última etapa concluída",
+        "errorRetryMigration": "Falha ao tentar a migração novamente",
         "errorLoadRunProgress": "Falha ao carregar progresso da execução",
         "startMigrationFirst": "Inicie a migração primeiro",
         "reportRefreshed": "Relatório de execução atualizado",
-        "errorLoadReport": "Falha ao carregar relatório de execução",
+        "errorLoadReport": "Falha ao carregar relatório da execução",
         "reportExported": "Relatório exportado como {format}",
         "errorExportReport": "Falha ao exportar relatório de migração",
         "reasonNoTitleAuthorMatch": "Nenhum livro correspondente encontrado por título ou autor",
-        "reasonNoFilePathMatch": "O caminho do arquivo não corresponde a nenhum livro nesta biblioteca",
-        "reasonNoFileHashMatch": "O hash do arquivo não corresponde a nenhum livro nesta biblioteca",
-        "reasonNoIsbnMatch": "O ISBN não corresponde a nenhum livro nesta biblioteca",
+        "reasonNoFilePathMatch": "O caminho do arquivo não correspondeu a nenhum livro nesta biblioteca",
+        "reasonNoFileHashMatch": "O hash do arquivo não correspondeu a nenhum livro nesta biblioteca",
+        "reasonNoIsbnMatch": "O ISBN não correspondeu a nenhum livro nesta biblioteca",
         "reasonInsufficientSourceData": "Metadados insuficientes para tentar a correspondência",
-        "reasonAmbiguousIsbnMatch": "Múltiplos livros correspondem ao mesmo ISBN",
-        "reasonAmbiguousFileHashMatch": "Múltiplos livros correspondem ao mesmo hash de arquivo",
-        "reasonAmbiguousFilePathMatch": "Múltiplos livros correspondem ao mesmo caminho de arquivo",
-        "reasonAmbiguousTitleAuthorMatch": "Múltiplos livros correspondem ao mesmo título e autor",
+        "reasonAmbiguousIsbnMatch": "Múltiplos livros corresponderam ao mesmo ISBN",
+        "reasonAmbiguousFileHashMatch": "Múltiplos livros corresponderam ao mesmo hash de arquivo",
+        "reasonAmbiguousFilePathMatch": "Múltiplos livros corresponderam ao mesmo caminho de arquivo",
+        "reasonAmbiguousTitleAuthorMatch": "Múltiplos livros corresponderam ao mesmo título e autor",
         "reasonUnknown": "Não foi possível determinar o motivo",
         "strategyIsbn": "Correspondido por ISBN",
         "strategyFileHash": "Correspondido por hash de arquivo",
         "strategyPathMapping": "Correspondido por caminho de arquivo mapeado",
         "strategyTitleAuthor": "Correspondido por título e autor",
         "strategyUnavailable": "Estratégia de correspondência indisponível",
-        "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {bookmarks} favoritos, {annotations} anotações, {collections} entradas de coleção",
-        "connErrorUnreachable": "Não foi possível acessar o servidor de banco de dados. Verifique o host e a porta.",
+        "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {bookmarks} marcadores, {annotations} anotações, {collections} entradas de coleção",
+        "connErrorUnreachable": "Não foi possível conectar ao servidor de banco de dados. Verifique o host e a porta.",
         "connErrorAuth": "Falha na autenticação. Verifique o nome de usuário e a senha.",
         "connErrorUnknownDatabase": "Banco de dados não encontrado. Verifique o nome do banco de dados.",
         "connErrorTimeout": "A conexão expirou. Verifique as configurações de host e firewall.",
-        "connErrorGeneric": "O teste de conexão falhou",
+        "connErrorGeneric": "Falha no teste de conexão",
         "sourceType": "Tipo de Origem",
-        "sourceName": "Nome de Origem",
+        "sourceName": "Nome da Origem",
         "host": "Host",
         "port": "Porta",
         "user": "Usuário",
@@ -776,76 +836,76 @@
         "saveAndValidate": "Salvar e Validar",
         "sourceValidatedWithWarnings": "Origem validada com avisos",
         "lastValidationSnapshot": "Último instantâneo de validação",
-        "sourceVersion": "Versão de origem: {version}",
+        "sourceVersion": "Versão da origem: {version}",
         "unknown": "Desconhecido",
         "missingRequiredTables": "Tabelas obrigatórias ausentes: {tables}",
-        "suggestionsAutoLoad": "As sugestões de usuário são carregadas automaticamente após a validação da origem.",
+        "suggestionsAutoLoad": "Sugestões de usuários carregam automaticamente após a validação da origem.",
         "refresh": "Atualizar",
         "sourceUser": "Usuário de Origem",
         "targetUser": "Usuário de Destino",
         "noSourceUsersLoaded": "Nenhum usuário de origem carregado ainda.",
-        "noActiveTargetUsers": "Nenhum usuário de destino ativo encontrado. Crie ou reative um usuário BookOrbit antes de mapear.",
+        "noActiveTargetUsers": "Nenhum usuário de destino ativo encontrado. Crie ou reative um usuário no BookOrbit antes de mapear.",
         "pathPrefixMappings": "Mapeamentos de Prefixo de Caminho",
         "addMapping": "Adicionar Mapeamento",
-        "pathMappingsHelp1": "Os mapeamentos de caminho traduzem os caminhos dos arquivos de origem para os caminhos de destino, para que os livros possam ser correspondidos pelo local do arquivo. Por exemplo, se a sua biblioteca Booklore armazenou arquivos em",
+        "pathMappingsHelp1": "Os mapeamentos de caminho traduzem caminhos de arquivos da origem para caminhos de destino para que os livros possam ser correspondidos pelo local do arquivo. Por exemplo, se a sua biblioteca Booklore armazenou arquivos em",
         "pathMappingsHelp2": "e os mesmos arquivos agora estão em",
-        "pathMappingsHelp3": ", adicione esse mapeamento aqui. Livros também são correspondidos por ISBN, hash de arquivo e título/autor independentemente dos mapeamentos de caminho - o mapeamento de caminho é apenas uma das quatro estratégias e não limita quais livros de origem são incluídos na migração.",
+        "pathMappingsHelp3": ", adicione esse mapeamento aqui. Os livros também são correspondidos por ISBN, hash de arquivo e título/autor independentemente dos mapeamentos de caminho - o mapeamento de caminho é apenas uma das quatro estratégias e não limita quais livros de origem são incluídos na migração.",
         "noPrefixesFound": "Nenhum prefixo encontrado - valide a origem primeiro",
         "selectSourcePrefix": "Selecione o prefixo de origem...",
         "selectTargetFolder": "Selecione a pasta de destino...",
         "remove": "Remover",
         "pathValidation": "Validação de caminho",
         "pathValidationMapped": "{mapped} de {total} livros de origem têm um caminho mapeado",
-        "pathValidationUnmatched": "{count} caminhos mapeados não encontrados no disco - esses livros recorrerão à correspondência de ISBN / título",
-        "pathValidationAllMatched": "Todos os {count} caminhos mapeados encontrados no disco",
+        "pathValidationUnmatched": "{count} caminhos mapeados não foram encontrados no disco - esses livros reverterão para correspondência por ISBN / título",
+        "pathValidationAllMatched": "Todos os {count} caminhos mapeados foram encontrados no disco",
         "saveMappings": "Salvar Mapeamentos",
-        "runDryRun": "Executar Teste",
+        "runDryRun": "Executar Simulação",
         "matched": "Correspondidos:",
         "unresolved": "Não resolvidos:",
         "duplicateMatches": "Correspondências duplicadas:",
         "unresolvedSummary": "Resumo de não resolvidos",
-        "resolveDuplicateMatches": "Resolver correspondências de destino duplicadas",
+        "resolveDuplicateMatches": "Resolver correspondências duplicadas de destino",
         "resolveDuplicateHint": "Para cada livro de destino, escolha um livro de origem para manter. Opções recomendadas são pré-selecionadas quando há uma única correspondência mais forte.",
         "remainingGroups": "Grupos restantes:",
         "ofCount": "de {count}",
         "targetBookNum": "Livro de destino #{id}",
         "recommended": "Recomendado",
         "resolveDuplicatesButton": "Resolver {count} duplicata | Resolver {count} duplicata | Resolver {count} duplicatas",
-        "preflightChecks": "Verificações de pré-voo",
-        "allChecksPassed": "Todas as verificações aprovadas - pronto para migrar",
+        "preflightChecks": "Verificações pré-migração",
+        "allChecksPassed": "Todas as verificações passaram - pronto para migrar",
         "checkSourceValidated": "Origem validada",
         "checkSaveValidateSource": "Salvar e validar conexão de origem",
         "checkValidateSource": "Validar conexão de origem",
         "checkMappingsSaved": "Mapeamentos salvos",
-        "checkSaveMappings": "Salvar mapeamentos de usuário e caminho",
+        "checkSaveMappings": "Salvar mapeamento de usuários e caminhos",
         "checkPathMappingsValidated": "Mapeamentos de caminho validados",
         "checkSavePathMappings": "Salvar mapeamentos de caminho para validá-los",
-        "checkDryRunUpToDate": "Teste está atualizado",
-        "checkFreshDryRun": "Executar um novo teste",
-        "startConfirmPrompt": "Isso iniciará a migração definitiva. Tem certeza?",
+        "checkDryRunUpToDate": "A simulação está atualizada",
+        "checkFreshDryRun": "Executar uma nova simulação",
+        "startConfirmPrompt": "Isso iniciará a migração real. Tem certeza?",
         "confirmStart": "Confirmar Início",
         "startMigration": "Iniciar Migração",
         "cancelRun": "Cancelar Execução",
         "refreshStatus": "Atualizar Status",
-        "statusPollingStopped": "A sondagem de status parou devido a um erro.",
+        "statusPollingStopped": "A verificação contínua de status foi interrompida devido a um erro.",
         "retry": "Tentar novamente",
-        "stageLabel": "Estágio: {stage}",
+        "stageLabel": "Etapa: {stage}",
         "stageInitializing": "inicializando",
         "endedLabel": "Terminou em {date}",
         "stageCompleted": "Concluído",
         "stageInit": "Inicializando",
         "stageSharedOverlays": "Importando metadados",
         "stageBookCovers": "Importando capas",
-        "stageUserState": "Importando dados do usuário",
-        "noRunYet": "Nenhuma execução de migração ainda. Conclua as etapas acima para iniciar.",
+        "stageUserState": "Importando dados de usuário",
+        "noRunYet": "Nenhuma migração executada ainda. Conclua as etapas acima para iniciar.",
         "runNum": "Execução #{id}",
-        "notStarted": "Não iniciada",
+        "notStarted": "Não iniciado",
         "reloadReport": "Recarregar Relatório",
         "loadFullReport": "Carregar Relatório Completo",
         "exportJson": "Exportar JSON",
         "exportCsv": "Exportar CSV",
         "migrationFailed": "Falha na migração",
-        "retryFromLastStage": "Tentar novamente a partir do último estágio concluído",
+        "retryFromLastStage": "Tentar novamente a partir da última etapa concluída",
         "booksCard": "Livros",
         "metadataOverlaysApplied": "Sobreposições de metadados aplicadas",
         "authorMappingsReplaced": "Mapeamentos de autor substituídos",
@@ -853,128 +913,129 @@
         "genreMappingsReplaced": "Mapeamentos de gênero substituídos",
         "tagMappingsReplaced": "Mapeamentos de tag substituídos",
         "coversImported": "Capas importadas",
-        "coverImportSkipped": "Importação de capa ignorada - o caminho raiz de mídia não está configurado na origem",
+        "coverImportSkipped": "A importação de capas foi ignorada - o caminho raiz de mídia não está configurado na origem",
         "couldNotMatch": "Não foi possível corresponder",
         "userDataCard": "Dados do Usuário",
         "readingStatuses": "Status de leitura",
         "readingProgressEntries": "Entradas de progresso de leitura",
-        "audiobookProgressEntries": "Entradas de progresso de audiobook",
-        "bookmarksLabel": "Favoritos",
+        "audiobookProgressEntries": "Entradas de progresso de audiolivro",
+        "bookmarksLabel": "Marcadores",
         "annotationsLabel": "Anotações",
         "collectionEntries": "Entradas de coleção",
-        "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência do teste no relatório exportado.",
-        "completedNoIssues": "A migração foi concluída sem livros não resolvidos ou falhas.",
+        "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência da simulação no relatório exportado.",
+        "completedNoIssues": "Migração concluída sem livros não resolvidos ou falhas.",
         "matchedBooksHeading": "Livros correspondidos ({count})",
-        "matchedBooksHint": "Estas correspondências do teste foram usadas para decidir quais livros da biblioteca receberam dados importados.",
+        "matchedBooksHint": "Essas correspondências da simulação foram usadas para decidir quais livros da biblioteca receberam dados importados.",
         "sourceBookFallback": "Livro de origem {id}",
         "libraryBookFallback": "Livro da biblioteca {id}",
         "unresolvedBooksHeading": "Livros não resolvidos ({count})",
-        "unresolvedBooksHint": "Estes livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
+        "unresolvedBooksHint": "Esses livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
         "mappedUsersHeading": "Usuários mapeados ({count})",
-        "mappedUsersHint": "Os totais por usuário vêm da pré-visualização do teste armazenada em cache com o plano de migração.",
-        "coverImportsFailed": "{count} importação(ões) de capa falhou(aram). As linhas de falha detalhadas não são armazenadas.",
-        "backToSetup": "Voltar à Configuração"
+        "mappedUsersHint": "Os totais por usuário vêm da pré-visualização da simulação em cache com o plano de migração.",
+        "coverImportsFailed": "{count} importação(ões) de capa falhou(aram). As linhas detalhadas de falha não são armazenadas.",
+        "backToSetup": "Voltar para a Configuração"
       },
       "libraries": {
         "title": "Bibliotecas",
-        "subtitle": "Gerencie suas bibliotecas de mídia e acione verificações de conteúdo.",
-        "scanAll": "Verificar Tudo",
-        "scanning": "Verificando...",
+        "subtitle": "Gerencie suas bibliotecas de mídia e inicie verificações de conteúdo.",
+        "scanAll": "Escanear Todas",
+        "scanning": "Escaneando...",
         "addLibrary": "Adicionar Biblioteca",
-        "scan": "Verificar",
+        "scan": "Escanear",
         "editLibrary": "Editar biblioteca",
         "refreshCovers": "Atualizar capas",
-        "syncMetadataToFiles": "Sincronizar metadados para arquivos",
+        "syncMetadataToFiles": "Sincronizar metadados para os arquivos",
         "deleteLibrary": "Excluir biblioteca",
         "bookCount": "nenhum livro | {count} livro | {count} livros",
         "addedDate": "Adicionado em {date}",
-        "fileMode": "Modo de arquivo",
-        "folderMode": "Modo de pasta",
+        "fileMode": "Modo por arquivo",
+        "folderMode": "Modo por pasta",
         "folderCount": "nenhuma pasta | {count} pasta | {count} pastas",
         "watching": "Monitorando",
         "fileWrite": "Gravação de arquivo",
         "fileRename": "Renomeação de arquivo",
         "emptyTitle": "Nenhuma biblioteca ainda",
         "emptyHint": "Adicione uma biblioteca para começar a organizar seus livros.",
-        "addFirstLibrary": "Adicionar sua primeira biblioteca",
+        "addFirstLibrary": "Adicione sua primeira biblioteca",
         "deleteConfirmTitle": "Excluir \"{name}\"?",
-        "deleteConfirmBody": "Isto removerá permanentemente todos os livros, metadados, progresso de leitura, favoritos e anotações nesta biblioteca. Isto não pode ser desfeito.",
+        "deleteConfirmBody": "Isso removerá permanentemente todos os livros, metadados, progresso de leitura, marcadores e anotações nesta biblioteca. Isso não pode ser desfeito.",
         "deleteConfirmTypeName": "Digite o nome da biblioteca para confirmar:",
         "deleting": "Excluindo...",
         "deleteLibraryButton": "Excluir Biblioteca",
         "syncConfirmTitle": "Sincronizar metadados para os arquivos?",
-        "syncConfirmBodyPrefix": "Isso substituirá os metadados dentro de todos os arquivos suportados em",
-        "syncConfirmBodySuffix": "diretamente no disco. Isto não pode ser desfeito.",
+        "syncConfirmBodyPrefix": "Isso sobrescreverá os metadados dentro de cada arquivo suportado em",
+        "syncConfirmBodySuffix": "diretamente no disco. Isso não pode ser desfeito.",
         "syncFiles": "Sincronizar arquivos",
-        "metadataSynced": "Metadados sincronizados com os arquivos de \"{name}\"",
-        "fileWriteNotEnabled": "A gravação de arquivo de metadados não está habilitada para esta biblioteca. Habilite-a nas configurações da biblioteca.",
-        "fileSyncFailed": "A sincronização de arquivos falhou para \"{name}\"",
-        "scanStarted": "Verificação iniciada para \"{name}\"",
-        "scanStartFailed": "Falha ao iniciar verificação para \"{name}\"",
-        "refreshCoversFailed": "Falha ao atualizar as capas de \"{name}\"",
-        "scanStartedAll": "Verificação iniciada para todas as bibliotecas",
+        "metadataSynced": "Metadados sincronizados com os arquivos em \"{name}\"",
+        "fileWriteNotEnabled": "A gravação de arquivos de metadados não está ativada para esta biblioteca. Ative-a nas configurações da biblioteca.",
+        "fileSyncFailed": "Falha na sincronização de arquivos para \"{name}\"",
+        "scanStarted": "Escaneamento iniciado para \"{name}\"",
+        "scanStartFailed": "Falha ao iniciar escaneamento para \"{name}\"",
+        "refreshCoversFailed": "Falha ao atualizar capas para \"{name}\"",
+        "scanStartedAll": "Escaneamento iniciado para todas as bibliotecas",
         "librariesFailedToStart": "nenhuma biblioteca falhou ao iniciar | {count} biblioteca falhou ao iniciar | {count} bibliotecas falharam ao iniciar",
-        "scansStartFailed": "Falha ao iniciar verificações",
+        "scansStartFailed": "Falha ao iniciar escaneamentos",
         "libraryCreated": "Biblioteca \"{name}\" criada",
         "libraryUpdated": "Biblioteca \"{name}\" atualizada",
         "libraryDeleted": "\"{name}\" excluída",
         "deleteFailed": "Falha ao excluir biblioteca",
-        "scanningProgress": "Verificando {pct}% ({processed}/{total})",
-        "scanDone": "Concluído - {added} adicionados, {updated} atualizados",
+        "scanningProgress": "Escaneando {pct}% ({processed}/{total})",
+        "scanDone": "Concluído - {added} adicionado(s), {updated} atualizado(s)",
         "scanFailedWithError": "Falhou: {error}",
-        "scanFailed": "A verificação falhou",
+        "scanFailed": "Falha no escaneamento",
         "refreshingCovers": "Atualizando capas {pct}% ({processed}/{total})",
-        "coversRefreshed": "Capas atualizadas ({count} processadas)"
+        "coversRefreshed": "Capas atualizadas ({count} processada(s))"
       },
       "authorEnrichment": {
         "configuration": "Configuração",
         "saving": "Salvando...",
         "running": "Executando...",
-        "runEligibleShort": "Executar p/ elegíveis",
-        "runAllShort": "Executar p/ todos",
-        "enableTitle": "Habilitar enriquecimento automático de autor",
-        "enableHint": "Busca automaticamente biografias e fotos de perfil de autores quando livros são adicionados ou atualizados.",
+        "runEligibleShort": "Executar elegíveis",
+        "runAllShort": "Executar todos",
+        "enableTitle": "Ativar enriquecimento automático de autor",
+        "enableHint": "Buscar automaticamente biografias e fotos de perfil de autores quando livros forem adicionados ou atualizados.",
         "updateStrategyTitle": "Estratégia de atualização",
-        "updateStrategyHint": "O que fazer quando um autor já tem uma biografia ou foto.",
-        "writeModeMissingOnly": "Apenas preencher dados ausentes (recomendado)",
-        "writeModeAlwaysRefetch": "Sempre atualizar dados existentes",
-        "triggerOnImportTitle": "Acionar na importação",
-        "triggerOnImportHint": "Colocar autores na fila para enriquecimento quando livros são adicionados pela primeira vez a uma biblioteca.",
+        "updateStrategyHint": "O que fazer quando um autor já possui uma biografia ou foto.",
+        "writeModeMissingOnly": "Preencher apenas dados ausentes (recomendado)",
+        "writeModeAlwaysRefetch": "Sempre atualizar os dados existentes",
+        "triggerOnImportTitle": "Disparar na importação",
+        "triggerOnImportHint": "Colocar autores na fila para enriquecimento quando os livros forem adicionados pela primeira vez a uma biblioteca.",
         "eligibilityTitle": "Condições de elegibilidade",
-        "eligibilityHint": "Um autor é elegível se corresponder a qualquer condição habilitada.",
+        "eligibilityHint": "Um autor é elegível se corresponder a qualquer condição ativada.",
         "neverEnrichedTitle": "Nunca enriquecido",
         "neverEnrichedHint": "Enriquecer autores que nunca tiveram um enriquecimento bem-sucedido.",
-        "missingBioTitle": "Biografia ausente",
+        "missingBioTitle": "Sem biografia",
         "missingBioHint": "Enriquecer se o autor não tiver biografia.",
-        "missingPhotoTitle": "Foto ausente",
+        "missingPhotoTitle": "Sem foto",
         "missingPhotoHint": "Enriquecer se o autor não tiver foto de perfil.",
         "runForEligibleAuthors": "Executar para autores elegíveis",
         "eligibleCount": "~{count} elegíveis",
         "runForAllAuthors": "Executar para todos os autores",
         "saved": "Configurações de enriquecimento de autor salvas",
-        "saveFailed": "Falha ao salvar as configurações de enriquecimento de autor",
+        "saveFailed": "Falha ao salvar configurações de enriquecimento de autor",
         "noEligibleAuthors": "Nenhum autor elegível encontrado",
         "noAuthorsToEnrich": "Nenhum autor para enriquecer",
-        "queueFailed": "Falha ao enfileirar preenchimento retroativo de autor"
+        "queueFailed": "Falha ao colocar o enriquecimento de autor na fila"
       },
       "scoreWeights": {
-        "groupLabel": "Pesos de Pontuação",
+        "groupLabel": "Pesos das Pontuações",
         "assignHintPrefix": "Atribua um peso a cada campo. Peso total:",
-        "areYouSure": "Você tem certeza?",
-        "resetToDefaultsButton": "Redefinir para os padrões",
-        "recalculateAll": "Recalcular tudo",
+        "areYouSure": "Tem certeza?",
+        "resetToDefaultsButton": "Restaurar padrões",
+        "recalculateAll": "Recalcular todos",
         "confirmReset": "Confirmar redefinição",
-        "reset": "Redefinir",
+        "reset": "Restaurar",
         "recalculate": "Recalcular",
         "subtotal": "subtotal: {count}",
-        "savedRecalculating": "Pesos de pontuação salvos. Recalculando pontuações da biblioteca...",
-        "saveFailed": "Falha ao salvar pesos de pontuação",
-        "recalcStarted": "O recálculo de pontuação começou em segundo plano",
-        "recalcFailed": "O recálculo falhou",
-        "resetToDefaults": "Pesos redefinidos para os padrões. Salve para aplicar."
+        "savedRecalculating": "Pesos das pontuações salvos. Recalculando pontuações da biblioteca...",
+        "saveFailed": "Falha ao salvar pesos das pontuações",
+        "recalcStarted": "Recálculo de pontuação iniciado em segundo plano",
+        "recalcFailed": "Falha no recálculo",
+        "resetToDefaults": "Pesos restaurados para os padrões. Salve para aplicar."
       },
       "tabs": {
         "users": "Usuários",
+        "account-activity": "Atividade da Conta",
         "magic-links": "Links Mágicos",
         "oidc": "OIDC / SSO"
       }
@@ -1014,12 +1075,12 @@
         "genres": "Gêneros",
         "narrators": "Narradores",
         "duration": "Duração",
-        "abridged": "Resumido"
+        "abridged": "Abreviado / Resumido"
       },
       "mergeStrategy": {
         "fillMissing": {
           "label": "Preencher ausentes",
-          "description": "Apenas gravar se o campo estiver vazio"
+          "description": "Gravar apenas se o campo estiver vazio"
         },
         "overwriteIfProvided": {
           "label": "Sobrescrever se fornecido",
@@ -1038,43 +1099,43 @@
         "runNow": "Executar agora",
         "runForEligible": "Executar para livros elegíveis",
         "enable": {
-          "label": "Habilitar busca automática",
-          "hint": "Busca automaticamente metadados para livros elegíveis."
+          "label": "Ativar busca automática",
+          "hint": "Buscar metadados automaticamente para livros elegíveis."
         },
         "triggerOnImport": {
-          "label": "Acionar na importação",
-          "hint": "Colocar livros elegíveis na fila quando são adicionados pela primeira vez a uma biblioteca."
+          "label": "Disparar na importação",
+          "hint": "Colocar livros elegíveis na fila quando forem adicionados pela primeira vez a uma biblioteca."
         },
         "status": {
           "inQueuePaused": "{count} na fila - pausado",
-          "remaining": "{count} restantes",
+          "remaining": "{count} restante(s)",
           "eligible": "~{count} elegíveis"
         },
         "trigger": {
-          "queued": "Enfileirado {count} livro | Enfileirados {count} livros",
+          "queued": "{count} livro na fila | {count} livros na fila",
           "noneFound": "Nenhum livro elegível encontrado"
         },
         "lastRun": {
           "justNow": "agora mesmo",
-          "minutesAgo": "{count}m atrás",
-          "hoursAgo": "{count}h atrás",
+          "minutesAgo": "há {count}m",
+          "hoursAgo": "há {count}h",
           "yesterday": "ontem",
-          "daysAgo": "{count} dias atrás",
+          "daysAgo": "há {count} dias",
           "label": "Última execução: {when}",
-          "labelQueued": "Última execução: {when} - {count} livros enfileirados",
+          "labelQueued": "Última execução: {when} - {count} livro(s) na fila",
           "labelNoneEligible": "Última execução: {when} - nenhum livro elegível"
         },
         "conditions": {
           "title": "Condições de elegibilidade",
-          "hint": "Um livro é elegível se corresponder a qualquer condição habilitada.",
-          "noneEnabled": "Nenhuma condição habilitada",
+          "hint": "Um livro é elegível se corresponder a qualquer condição ativada.",
+          "noneEnabled": "Nenhuma condição ativada",
           "neverFetched": {
             "label": "Nunca buscado",
             "hint": "Buscar livros que nunca tiveram uma tentativa de busca de metadados.",
             "summary": "Nunca buscado"
           },
           "scoreThreshold": {
-            "label": "Pontuação de metadados baixa",
+            "label": "Pontuação baixa de metadados",
             "hint": "Buscar se a pontuação de metadados estiver abaixo de um limite.",
             "scoreBelow": "Pontuação abaixo de",
             "summary": "Pontuação < {threshold}"
@@ -1082,7 +1143,7 @@
           "missingFields": {
             "label": "Campos ausentes",
             "hint": "Buscar se qualquer um dos campos selecionados estiver vazio.",
-            "summary": "{count} campo ausente | {count} campos ausentes"
+            "summary": "Ausente em {count} campo | Ausente em {count} campos"
           }
         },
         "library": {
@@ -1097,13 +1158,13 @@
         "saveChanges": "Salvar Alterações",
         "test": "Testar",
         "testing": "Testando...",
-        "enabled": "Habilitado",
+        "enabled": "Ativado",
         "retryIn": "Tentar novamente em {duration}",
-        "runTestBeforeEnabling": "Execute o Teste antes de habilitar",
-        "hardcoverEnableHint": "Execute o Teste com o token atual para desbloquear a chave de habilitação.",
+        "runTestBeforeEnabling": "Execute o Teste antes de ativar",
+        "hardcoverEnableHint": "Execute o Teste com o token atual para desbloquear a chave de ativação.",
         "badge": {
           "setupRequired": "Configuração Necessária",
-          "throttled": "Limitado",
+          "throttled": "Limitado (Throttled)",
           "ready": "Pronto"
         },
         "fields": {
@@ -1116,97 +1177,97 @@
           "ttbKey": "Chave TTB"
         },
         "helpers": {
-          "googleApiKey": "Chave da API do Google Books do Google Cloud."
+          "googleApiKey": "Chave de API do Google Books do Google Cloud."
         },
         "hints": {
           "google": "Ampla cobertura do índice de livros do Google. O Google Books agora exige uma chave de API antes que este provedor possa ser ativado.",
           "amazon": "O cookie de sessão é recomendado. Cole apenas o valor do cookie (sem \"Cookie:\").",
-          "goodreads": "A maior comunidade de leitura da web. Nenhuma configuração necessária.",
-          "hardcover": "Uma alternativa moderna ao Goodreads. Token de hardcover.app/account/api. O prefixo \"Bearer \" é opcional.",
-          "openLibrary": "O catálogo de livros gratuito do Internet Archive. Nenhuma configuração necessária.",
-          "itunes": "Catálogo de livros digitais da Apple. Escolha se deseja buscar capas em alta resolução ou padrão.",
-          "kobo": "Busca informações nas páginas públicas de livros da Kobo. O país e o idioma devem corresponder aos caminhos de URL da Kobo; a proteção contra bots pode bloquear as solicitações.",
-          "audible": "Extrai metadados de audiobooks do Audible. Nenhuma configuração adicional é necessária.",
-          "audnexus": "Metadados de audiobook impulsionados pela comunidade. Nenhuma configuração necessária.",
+          "goodreads": "A maior comunidade de leitura na web. Nenhuma configuração é necessária.",
+          "hardcover": "Uma alternativa moderna ao Goodreads. Token obtido em hardcover.app/account/api. O prefixo \"Bearer \" é opcional.",
+          "openLibrary": "O catálogo gratuito de livros do Internet Archive. Nenhuma configuração é necessária.",
+          "itunes": "O catálogo digital de livros da Apple. Escolha se deseja buscar capas de alta resolução ou padrão.",
+          "kobo": "Coleta páginas públicas de livros da Kobo. O país e o idioma devem corresponder aos caminhos da URL da Kobo; proteções antibot podem bloquear requisições.",
+          "audible": "Extrai metadados de audiolivros do Audible. Nenhuma configuração adicional é necessária.",
+          "audnexus": "Metadados de audiolivros focados na comunidade. Nenhuma configuração é necessária.",
           "comicvine": "Metadados de quadrinhos do ComicVine. Uma chave de API gratuita é necessária em comicvine.gamespot.com.",
-          "ranobedb": "Metadados de light novels japonesas do RanobeDB. Nenhuma configuração necessária.",
-          "lubimyczytac": "Catálogo de livros polonês (lubimyczytac.pl). Busca informações nas páginas públicas de livros. Nenhuma configuração necessária.",
-          "aladin": "Metadados de livros coreanos da Aladin (알라딘). É necessária uma Chave TTB de aladin.co.kr."
+          "ranobedb": "Metadados de light novels japonesas do RanobeDB. Nenhuma configuração é necessária.",
+          "lubimyczytac": "Catálogo de livros polonês (lubimyczytac.pl). Coleta páginas públicas de livros. Nenhuma configuração é necessária.",
+          "aladin": "Metadados de livros coreanos do Aladin (알라딘). Uma Chave TTB de aladin.co.kr é necessária."
         },
         "blocked": {
-          "google": "O Google Books requer uma chave de API antes de ser habilitado",
-          "hardcover": "O Hardcover requer uma chave de API antes de ser habilitado",
-          "hardcoverTest": "O token do Hardcover deve passar no Teste antes que possa ser habilitado",
-          "comicvine": "O ComicVine requer uma chave de API antes de ser habilitado",
-          "aladin": "A Aladin requer uma Chave TTB antes de ser habilitada"
+          "google": "O Google Books requer uma chave de API antes de poder ser ativado",
+          "hardcover": "O Hardcover requer uma chave de API antes de poder ser ativado",
+          "hardcoverTest": "O token do Hardcover deve passar no Teste antes de poder ser ativado",
+          "comicvine": "O ComicVine requer uma chave de API antes de poder ser ativado",
+          "aladin": "O Aladin requer uma Chave TTB antes de poder ser ativado"
         }
       },
       "fieldRules": {
         "clearAllProviders": "Limpar Todos os Provedores",
         "clearAll": "Limpar Tudo",
-        "resetToDefault": "Redefinir para Padrão",
-        "reset": "Redefinir",
+        "resetToDefault": "Restaurar Padrão",
+        "reset": "Restaurar",
         "dragProvidersHint": "Arraste os provedores daqui para qualquer campo para adicioná-los",
-        "dragProviderHere": "arraste um provedor aqui",
+        "dragProviderHere": "arraste um provedor para cá",
         "howItWorks": {
-          "title": "Como as Regras de Campo Funcionam",
+          "title": "Como Funcionam as Regras de Campo",
           "priorityOrder": {
             "title": "Ordem de Prioridade",
-            "body": "Arraste os provedores na lista para reordená-los. O provedor mais ao topo que retornar um resultado será a fonte principal para aquele campo."
+            "body": "Arraste os provedores na lista para reordená-los. O provedor mais ao topo que retornar um resultado será a fonte principal para esse campo."
           },
           "mergeStrategy": {
             "title": "Estratégia de Mesclagem",
             "fillMissingTerm": "Preencher ausentes:",
-            "fillMissingBody": "Apenas gravar se o valor atual estiver vazio.",
+            "fillMissingBody": "Gravar apenas se o valor atual estiver vazio.",
             "overwriteTerm": "Sobrescrever:",
             "overwriteBody": "Substituir sempre que um provedor tiver dados."
           }
         },
         "libraryOverrides": {
           "title": "Substituições da Biblioteca",
-          "hint": "Expanda uma biblioteca para personalizar campos individuais. Campos não substituídos herdam os padrões globais."
+          "hint": "Expanda uma biblioteca para personalizar campos individuais. Os campos não substituídos herdam os padrões globais."
         },
         "global": {
           "title": "Padrões Globais",
           "hint": "Regras padrão aplicadas a todas as bibliotecas. Substitua por biblioteca abaixo.",
           "saveDefaults": "Salvar Padrões",
-          "clearAllConfirm": "Remover todos os provedores ativos de todos os campos? Isso será salvo imediatamente e não pode ser desfeito.",
-          "resetConfirm": "Redefinir todas as regras de campo globais para os padrões do sistema? Isso substituirá sua configuração atual."
+          "clearAllConfirm": "Remover todos os provedores ativos de todos os campos? Isso será salvo imediatamente e não poderá ser desfeito.",
+          "resetConfirm": "Restaurar todas as regras globais de campo para os padrões do sistema? Isso sobrescreverá sua configuração atual."
         },
         "advanced": {
           "title": "Comportamento Avançado de Busca",
           "combineGenres": {
             "label": "Combinar gêneros de todos os provedores selecionados",
-            "hint": "Coletar e desduplicar gêneros de todos os provedores atribuídos ao campo Gêneros, em vez de parar no primeiro resultado."
+            "hint": "Coletar e remover duplicatas de gêneros de cada provedor atribuído ao campo Gêneros, em vez de parar no primeiro resultado."
           },
           "storeProviderIds": {
             "label": "Armazenar IDs de provedores nos livros",
-            "hint": "Ao buscar metadados, salvar os IDs de provedor retornados (ISBN, ASIN, ID Goodreads, etc.) no registro do livro para pesquisas futuras mais precisas."
+            "hint": "Ao buscar metadados, salvar os IDs de provedores retornados (ISBN, ASIN, ID do Goodreads, etc.) no registro do livro para futuras consultas mais precisas."
           }
         },
         "library": {
-          "primary": "Principal:",
+          "primary": "Primário:",
           "overrideCount": "{count} Substituição | {count} Substituições",
           "unsavedSuffix": "(não salvo)",
           "unsavedChanges": "Alterações não salvas",
           "globalDefaults": "Padrões Globais",
           "overriding": "Substituindo: {fields}",
-          "inheritingAll": "Herdando todas as regras de metadados globais",
+          "inheritingAll": "Herdando todas as regras globais de metadados",
           "subHint": "Campos não substituídos herdam os padrões globais.",
           "resetTooltip": "Remover todas as substituições e herdar padrões globais",
           "clearAllConfirm": "Remover todos os provedores ativos de todos os campos em \"{library}\"?",
-          "resetConfirm": "Redefinir \"{library}\" para os padrões globais? Todas as substituições da biblioteca serão removidas."
+          "resetConfirm": "Restaurar \"{library}\" para os padrões globais? Todas as substituições da biblioteca serão removidas."
         },
         "groups": {
-          "core": "Núcleo",
-          "contributors": "Contribuidores",
+          "core": "Principal",
+          "contributors": "Colaboradores",
           "publication": "Publicação",
-          "series": "Série",
+          "series": "Séries",
           "classification": "Classificação",
-          "audiobook": "Audiobook"
+          "audiobook": "Audiolivro"
         },
         "groupSummary": {
-          "base": "{fields} campos · {enabled} habilitados",
+          "base": "{fields} campos · {enabled} ativados",
           "withOverrides": "{base} · {overrides} substituições"
         },
         "table": {
@@ -1216,12 +1277,12 @@
           "status": "Status"
         },
         "field": {
-          "noProviders": "Habilitado, mas sem provedores",
+          "noProviders": "Ativado, mas não possui provedores",
           "empty": "Vazio",
-          "config": "Config",
+          "config": "Configuração",
           "custom": "Personalizado",
           "default": "Padrão",
-          "resetToDefault": "Redefinir para o padrão"
+          "resetToDefault": "Restaurar para o padrão"
         },
         "reservoir": {
           "disabled": "{provider} - desativado",
@@ -1229,8 +1290,8 @@
           "dragToAssign": "Arraste para atribuir {provider} a um campo"
         },
         "sheet": {
-          "subtitle": "Toque nos provedores para atribuir, use setas para reordenar",
-          "enableField": "Habilitar este campo durante a atualização",
+          "subtitle": "Toque nos provedores para atribuir, use as setas para reordenar",
+          "enableField": "Ativar este campo durante a atualização",
           "providers": "Provedores",
           "statusDisabled": "desativado",
           "statusNotConfigured": "não configurado",
@@ -1239,10 +1300,10 @@
       },
       "genreBlocklist": {
         "heading": "Exclusões Globais de Gênero",
-        "hint": "Valores exatos de gênero nesta lista são removidos dos resultados do provedor antes que os metadados sejam gravados.",
+        "hint": "Valores exatos de gênero nesta lista são removidos dos resultados do provedor antes da gravação dos metadados.",
         "saving": "Salvando",
         "genreValueLabel": "Valor do gênero",
-        "addPlaceholder": "Adicione um valor de gênero, por exemplo Audiobook",
+        "addPlaceholder": "Adicione um valor de gênero, por exemplo: Audiolivro",
         "duplicate": "Este gênero já está bloqueado.",
         "add": "Adicionar",
         "filterPlaceholder": "Filtrar lista de bloqueio",
@@ -1250,7 +1311,7 @@
         "filteredCount": "{shown} de {total}",
         "noFilterMatch": "Nenhum gênero bloqueado corresponde ao filtro atual.",
         "emptyTitle": "Nenhum gênero bloqueado",
-        "emptyHint": "Adicione valores exatos como Audiobook ou Adulto para mantê-los fora dos metadados buscados.",
+        "emptyHint": "Adicione valores exatos como Audiolivro ou Adulto para mantê-los fora dos metadados buscados.",
         "removeLabel": "Remover {genre}"
       },
       "customFields": {
@@ -1262,26 +1323,26 @@
         "usage": "Usado por {count} livro | Usado por {count} livros",
         "newField": {
           "title": "Novo Campo",
-          "hint": "Defina um campo de metadados personalizado e escolha quais bibliotecas o usam."
+          "hint": "Defina um campo de metadado personalizado e escolha quais bibliotecas o utilizam."
         },
-        "previewToggle": "Visualize como este campo aparece ao editar um livro",
+        "previewToggle": "Pré-visualizar como este campo aparece ao editar um livro",
         "untitledField": "Campo sem título",
         "addField": "Adicionar campo",
         "fields": "Campos",
-        "fieldsHint": "Arraste para reordenar, editar rótulos, alternar bibliotecas ou arquivar campos que você não precisa mais.",
-        "searchPlaceholder": "Pesquisar campos",
-        "searchAriaLabel": "Pesquisar campos personalizados",
+        "fieldsHint": "Arraste para reordenar, edite rótulos, alterne bibliotecas ou arquive campos que não precisa mais.",
+        "searchPlaceholder": "Buscar campos",
+        "searchAriaLabel": "Buscar campos personalizados",
         "emptyTitle": "Nenhum campo personalizado ainda",
-        "emptyHint": "Use o formulário acima para definir seu primeiro campo de metadados personalizado.",
+        "emptyHint": "Use o formulário acima para definir seu primeiro campo de metadado personalizado.",
         "noMatchTitle": "Nenhum campo corresponde a \"{query}\"",
         "noMatchHint": "Tente um rótulo, chave ou tipo diferente.",
-        "clearSearchToReorder": "Limpar pesquisa para reordenar",
+        "clearSearchToReorder": "Limpe a busca para reordenar",
         "dragToReorder": "Arraste para reordenar",
-        "dragToReorderField": "Arraste para reordenar campo",
+        "dragToReorderField": "Arraste para reordenar o campo",
         "unsaved": "Não salvo",
         "archive": "Arquivar",
         "archivedFields": "Campos Arquivados",
-        "archivedSummary": "{count} campo arquivado - restaurar ou excluir permanentemente. | {count} campos arquivados - restaurar ou excluir permanentemente.",
+        "archivedSummary": "{count} campo arquivado - restaure ou exclua permanentemente. | {count} campos arquivados - restaure ou exclua permanentemente.",
         "archivedAt": "Arquivado em {when}",
         "restore": "Restaurar",
         "deleteForever": "Excluir permanentemente",
@@ -1294,11 +1355,11 @@
           "confirmAfter": "para confirmar",
           "confirmPlaceholder": "Digite o rótulo do campo para confirmar"
         },
-        "preview": "Pré-visualização",
+        "preview": "Pré-visualizar",
         "sampleValue": "Valor de exemplo",
-        "enabledLibraries": "Bibliotecas Habilitadas",
+        "enabledLibraries": "Bibliotecas Ativadas",
         "countOf": "{selected} de {total}",
-        "selectAll": "Selecionar tudo",
+        "selectAll": "Selecionar todos",
         "clear": "Limpar",
         "noLibraries": "Nenhuma biblioteca disponível ainda.",
         "allLibraries": "Todas as bibliotecas"
@@ -1307,47 +1368,47 @@
         "providers": "Provedores",
         "field-rules": "Regras de Campo",
         "custom-fields": "Campos Personalizados",
-        "genre-blocklist": "Lista de Bloqueio de Gênero",
+        "genre-blocklist": "Lista de Bloqueio de Gêneros",
         "score": "Pontuação",
         "auto-fetch": "Livros",
         "authors": "Autores"
       },
       "tabTitles": {
         "providers": "Provedores",
-        "field-rules": "Regras em Nível de Campo",
+        "field-rules": "Regras por Campo",
         "custom-fields": "Metadados Personalizados",
-        "genre-blocklist": "Lista de Bloqueio de Gênero",
+        "genre-blocklist": "Lista de Bloqueio de Gêneros",
         "score": "Pontuação de Confiança",
-        "auto-fetch": "Busca Automática de Livro",
-        "authors": "Busca Automática de Autor"
+        "auto-fetch": "Busca Automática de Livros",
+        "authors": "Busca Automática de Autores"
       },
       "tabSubtitles": {
-        "providers": "Habilite fontes de metadados externas e configure suas credenciais.",
+        "providers": "Ative fontes externas de metadados e configure suas credenciais.",
         "field-rules": "Controle qual provedor fornece cada campo de metadados e como os valores são mesclados em suas bibliotecas.",
         "custom-fields": "Defina campos de metadados personalizados e escolha quais bibliotecas os utilizam.",
-        "genre-blocklist": "Impeça que valores de gênero indesejados do provedor sejam gravados nos livros.",
+        "genre-blocklist": "Evite que valores indesejados de gêneros dos provedores sejam gravados nos livros.",
         "score": "Atribua pesos aos campos de metadados para calcular o quanto confiar nos resultados buscados.",
         "auto-fetch": "Busque automaticamente capas, descrições e outros detalhes quando novos livros forem adicionados à sua biblioteca.",
-        "authors": "Busque automaticamente biografias e fotos de perfil quando novos autores aparecerem na sua biblioteca."
+        "authors": "Busque automaticamente biografias e fotos de perfil quando novos autores aparecerem em sua biblioteca."
       }
     },
     "reader": {
-      "resetToDefaults": "Redefinir para padrões",
+      "resetToDefaults": "Restaurar padrões",
       "all": {
         "title": "Leitor",
         "subtitle": "Configure padrões para todos os modos de leitura em um só lugar."
       },
       "general": {
         "title": "Leitura",
-        "subtitle": "Comportamento geral que se aplica a todos os tipos de leitor.",
+        "subtitle": "Comportamento geral que se aplica a todos os tipos de leitores.",
         "storageLabel": "Onde salvar as preferências do leitor",
         "deviceOnly": "Apenas neste dispositivo",
-        "deviceOnlyHint": "As preferências permanecem no seu navegador. Ideal se você sempre lê neste dispositivo ou deseja configurações diferentes por dispositivo.",
+        "deviceOnlyHint": "As preferências ficam no seu navegador. Ideal se você lê sempre neste dispositivo ou quer configurações diferentes por dispositivo.",
         "myAccount": "Minha conta",
-        "myAccountHint": "As preferências são salvas na sua conta. Ideal se você faz login de vários dispositivos e deseja uma experiência consistente em todos os lugares.",
+        "myAccountHint": "As preferências são salvas na sua conta. Ideal se você faz login de vários dispositivos e quer uma experiência consistente em todos os lugares.",
         "active": "Ativo",
         "notAvailable": "Não disponível",
-        "demoCannotChangeStorage": "Conta restrita de demonstração não pode alterar o modo de armazenamento do leitor",
+        "demoCannotChangeStorage": "A conta restrita de demonstração não pode alterar o modo de armazenamento do leitor",
         "preferencesSynced": "As preferências agora serão sincronizadas",
         "preferencesLocal": "As preferências permanecerão neste dispositivo",
         "storageUpdateFailed": "Falha ao atualizar o modo de armazenamento",
@@ -1358,12 +1419,12 @@
         "subtitle": "Configurações padrão aplicadas ao abrir arquivos EPUB, MOBI, FB2 e TXT.",
         "newBooks": "Novos Livros",
         "applySettings": "Aplicar minhas configurações a novos livros",
-        "applySettingsHint": "Quando desativado, os novos livros abrem com as fontes e o layout da própria editora. Suas configurações só se aplicam quando você altera algo no leitor.",
+        "applySettingsHint": "Quando desativado, novos livros abrem com as fontes e layout da editora. Suas configurações só são aplicadas assim que você altera algo dentro do leitor.",
         "layout": "Layout",
         "readingFlow": "Fluxo de leitura",
-        "readingFlowHint": "Paginado vira as páginas; rolado flui continuamente",
+        "readingFlowHint": "Paginado vira páginas; rolado flui continuamente",
         "paginated": "Paginado",
-        "scrolled": "Rolagem",
+        "scrolled": "Rolado",
         "fixedLayoutSpread": "Páginas duplas em layout fixo",
         "fixedLayoutSpreadHint": "Padrão para mangás, quadrinhos e EPUBs baseados em imagens",
         "bookDefault": "Padrão do livro",
@@ -1375,7 +1436,7 @@
         "darkModeHint": "Usar a variante escura do tema selecionado",
         "typography": "Tipografia",
         "font": "Fonte",
-        "fontHint": "Tipo de letra usada para o corpo do texto",
+        "fontHint": "Tipo de letra usado no corpo do texto",
         "builtInFonts": "Fontes embutidas",
         "yourFonts": "Suas Fontes",
         "fontSize": "Tamanho da fonte",
@@ -1389,7 +1450,7 @@
         "advanced": "Avançado",
         "maxContentWidth": "Largura máxima do conteúdo",
         "maxContentWidthHint": "Largura máxima da área de texto em pixels",
-        "columnGap": "Espaçamento entre colunas",
+        "columnGap": "Espaço entre colunas",
         "columnGapHint": "Preenchimento horizontal em cada lado da área de texto"
       },
       "pdf": {
@@ -1397,10 +1458,10 @@
         "subtitle": "Configurações padrão aplicadas ao abrir arquivos PDF.",
         "layout": "Layout",
         "scrollMode": "Modo de rolagem",
-        "scrollModeHint": "A página vira uma de cada vez; contínuo rola por todas as páginas",
+        "scrollModeHint": "Página vira uma de cada vez; contínuo rola por todas as páginas",
         "page": "Página",
-        "scrolled": "Contínuo",
-        "pageSpread": "Páginas duplas",
+        "scrolled": "Rolado",
+        "pageSpread": "Exibição de página dupla",
         "pageSpreadHint": "Qual número de página começa à direita na visualização de duas páginas",
         "spreadNone": "Nenhum",
         "spreadOdd": "Ímpar",
@@ -1412,7 +1473,7 @@
         "fitWidth": "Ajustar à Largura",
         "custom": "Personalizado",
         "zoomLevel": "Nível de zoom",
-        "zoomLevelHint": "Fator de escala para modo de zoom personalizado"
+        "zoomLevelHint": "Fator de escala para o modo de zoom personalizado"
       },
       "comics": {
         "title": "Leitor de Quadrinhos",
@@ -1424,51 +1485,51 @@
         "infiniteSpaced": "Infinito (com espaços)",
         "infiniteNoGaps": "Infinito (sem espaços)",
         "pageView": "Visualização de página",
-        "pageViewHint": "Mostrar uma ou duas páginas lado a lado",
+        "pageViewHint": "Exibir uma ou duas páginas lado a lado",
         "single": "Única",
-        "twoPage": "Duas páginas",
+        "twoPage": "Página dupla",
         "fitMode": "Modo de ajuste",
-        "fitModeHint": "Como as páginas são redimensionadas para caber na tela",
+        "fitModeHint": "Como as páginas são dimensionadas para caber na tela",
         "fitPage": "Página",
         "fitWidth": "Largura",
         "fitHeight": "Altura",
         "fitActual": "Real",
         "readingDirection": "Direção de leitura",
-        "readingDirectionHint": "Esquerda para direita para quadrinhos ocidentais; direita para esquerda para mangás",
+        "readingDirectionHint": "Esquerda para a direita para quadrinhos ocidentais; direita para a esquerda para mangás",
         "ltr": "E para D",
         "rtl": "D para E",
         "spreadAlignment": "Alinhamento de página dupla",
-        "spreadAlignmentHint": "Deslocar pareamento em uma página após a capa para digitalizações com desvio de uma",
+        "spreadAlignmentHint": "Deslocar o pareamento em uma página após a capa para digitalizações com descompasso de página",
         "alignmentNormal": "Normal",
         "alignmentShifted": "Deslocado",
         "widePageHandling": "Tratamento de páginas largas",
-        "widePageHandlingHint": "Auto mostra páginas largas sozinhas no modo paginado de duas páginas",
+        "widePageHandlingHint": "Exibe automaticamente páginas largas sozinhas no modo paginado de duas páginas",
         "widePageAuto": "Automático",
         "widePageDisable": "Desativar",
-        "forceTwoPage": "Forçar duas páginas em telas pequenas",
-        "forceTwoPageHint": "Ignorar o fallback automático móvel quando o modo paginado de duas páginas for selecionado",
+        "forceTwoPage": "Forçar página dupla em telas pequenas",
+        "forceTwoPageHint": "Ignorar a reversão automática para mobile quando o modo paginado de duas páginas estiver selecionado",
         "off": "Desativado",
         "on": "Ativado",
         "display": "Exibição",
         "backgroundColor": "Cor de fundo",
-        "backgroundColorHint": "Cor da tela atrás das páginas",
+        "backgroundColorHint": "Cor do plano de fundo atrás das páginas",
         "bgBlack": "Preto",
         "bgGray": "Cinza",
         "bgWhite": "Branco"
       },
       "audio": {
-        "title": "Reprodutor de Audiobook",
-        "subtitle": "Configurações padrão aplicadas ao reproduzir M4B, MP3 e outros formatos de áudio.",
+        "title": "Reprodutor de Audiolivros",
+        "subtitle": "Configurações padrão aplicadas ao reproduzir arquivos M4B, MP3 e outros formatos de áudio.",
         "playback": "Reprodução",
         "playbackSpeed": "Velocidade de reprodução padrão",
-        "playbackSpeedHint": "Multiplicador de velocidade aplicado ao abrir um novo audiobook",
+        "playbackSpeedHint": "Multiplicador de velocidade aplicado ao abrir um novo audiolivro",
         "volume": "Volume padrão",
         "volumeHint": "Nível de volume inicial (0 a 100%)",
         "skipControls": "Controles de salto",
-        "skipBack": "Duração do retrocesso",
-        "skipBackHint": "Segundos retrocedidos ao pressionar pular para trás",
-        "skipForward": "Duração do avanço",
-        "skipForwardHint": "Segundos avançados ao pressionar pular para frente"
+        "skipBack": "Duração do salto para trás",
+        "skipBackHint": "Segundos retrocedidos ao pressionar o botão de salto para trás",
+        "skipForward": "Duração do salto para frente",
+        "skipForwardHint": "Segundos avançados ao pressionar o botão de salto para frente"
       },
       "fonts": {
         "title": "Fontes",
@@ -1477,11 +1538,11 @@
         "notAvailableDemo": "Não disponível para contas de demonstração",
         "uploading": "Enviando...",
         "dropFilesHere": "Solte os arquivos aqui",
-        "dragFontsPrefix": "Arraste arquivos de fonte aqui, ou",
-        "browse": "procurar",
-        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - máximo 10 MB cada",
+        "dragFontsPrefix": "Arraste os arquivos de fonte para cá ou",
+        "browse": "procure",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - máx. 10 MB cada",
         "yourFonts": "Suas Fontes",
-        "fontsUsed": "{count} / {max} usadas",
+        "fontsUsed": "{count} / {max} usado",
         "noFontsYet": "Nenhuma fonte enviada ainda",
         "noFontsHint": "Arraste um arquivo de fonte acima para começar.",
         "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
@@ -1492,41 +1553,41 @@
         "deleteVariant": "Excluir variante",
         "styleNormal": "Normal",
         "styleItalic": "Itálico",
-        "weightThin": "Fino",
+        "weightThin": "Fino (Thin)",
         "weightExtraLight": "Extra Leve",
         "weightLight": "Leve",
         "weightRegular": "Regular",
         "weightMedium": "Médio",
-        "weightSemiBold": "Seminegrito",
+        "weightSemiBold": "Semi Negrito",
         "weightBold": "Negrito",
         "weightExtraBold": "Extra Negrito",
-        "weightBlack": "Preto",
+        "weightBlack": "Preto (Black)",
         "renameFamilyFailed": "Falha ao renomear família de fontes",
-        "renamedTo": "Renomeado para \"{name}\"",
+        "renamedTo": "Renomeada para \"{name}\"",
         "updateVariantFailed": "Falha ao atualizar variante da fonte",
         "deleteFontFailed": "Falha ao excluir fonte",
         "deleteFamilyFailed": "Falha ao excluir família de fontes",
-        "demoCannotManage": "Conta restrita de demonstração não pode gerenciar fontes",
-        "fileAdded": "\"{name}\" adicionado",
+        "demoCannotManage": "A conta restrita de demonstração não pode gerenciar fontes",
+        "fileAdded": "\"{name}\" adicionada",
         "uploadFailed": "Falha no envio"
       },
       "bookDock": {
-        "title": "Book Dock",
-        "subtitle": "Configure como os arquivos são processados quando entram no Book Dock.",
-        "dropFolder": "Pasta de recepção",
+        "title": "Doca de Livros (Book Dock)",
+        "subtitle": "Configure como os arquivos são processados quando entram na Doca de Livros.",
+        "dropFolder": "Pasta de depósito",
         "containerPath": "Caminho do contêiner",
-        "containerPathHint": "Copie ou mova arquivos de livro para esta pasta e eles serão automaticamente coletados e processados pelo Book Dock. Subdiretórios são suportados.",
+        "containerPathHint": "Copie ou mova arquivos de livros para esta pasta e eles serão automaticamente coletados e processados pela Doca de Livros. Subdiretórios são suportados.",
         "changePathPrefix": "Para alterar este caminho, defina",
         "changePathMiddle": "no seu arquivo",
         "changePathSuffix": ".",
         "metadata": "Metadados",
         "autoFetch": "Buscar metadados de provedores automaticamente",
-        "autoFetchHint": "Buscar metadados automaticamente de provedores configurados (Google Books, iTunes, Open Library, etc.) após um arquivo ser adicionado ao Book Dock.",
-        "autoFinalize": "Finalizar automaticamente",
-        "enableAutoFinalize": "Habilitar finalização automática",
+        "autoFetchHint": "Buscar automaticamente metadados de provedores configurados (Google Books, iTunes, Open Library, etc.) após a adição de um arquivo à Doca de Livros.",
+        "autoFinalize": "Finalização automática",
+        "enableAutoFinalize": "Ativar finalização automática",
         "enableAutoFinalizeHint": "Arquivos com uma pontuação de confiança de metadados igual ou superior ao limite serão finalizados automaticamente.",
         "confidenceThreshold": "Limite de confiança: {value}%",
-        "thresholdIgnored": "(ignorado apenas no modo Embutido)",
+        "thresholdIgnored": "(ignorado no modo Apenas embutido)",
         "destinationLibrary": "Biblioteca de destino",
         "selectLibrary": "Selecione uma biblioteca...",
         "metadataMode": "Modo de metadados",
@@ -1547,67 +1608,67 @@
         "metadataModeUpdated": "Modo de metadados atualizado"
       },
       "fileNaming": {
-        "title": "Nomenclatura de Arquivos",
-        "subtitle": "Controle como os arquivos são organizados no disco quando enviados e como são nomeados quando baixados usando tokens de espaço reservado.",
+        "title": "Nomeação de Arquivos",
+        "subtitle": "Controle como os arquivos são organizados no disco ao serem enviados e como são nomeados ao serem baixados usando tokens de preenchimento.",
         "copy": "Copiar",
         "previewLabel": "Pré-visualização:",
         "fileAsBookPreview": "Pré-visualização Arquivo como Livro",
         "folderAsBookPreview": "Pré-visualização Pasta como Livro",
-        "downloadPreview": "Pré-visualização de Download",
+        "downloadPreview": "Pré-visualização de download",
         "globalDefaults": "Padrões Globais",
-        "crossPlatform": "Sanitização de caminho multiplataforma",
-        "crossPlatformHint": "Torna os nomes de arquivos e pastas gerados seguros no Windows substituindo caracteres inválidos e nomes reservados, e removendo pontos e espaços finais. Desative apenas para configurações exclusivas do Linux que mantêm esses caracteres intencionalmente.",
+        "crossPlatform": "Higienização de caminhos multiplataforma",
+        "crossPlatformHint": "Torne os nomes de arquivos e pastas gerados seguros para o Windows, substituindo caracteres inválidos e nomes reservados, e removendo pontos e espaços finais. Desative apenas para configurações exclusivas de Linux que mantêm intencionalmente esses caracteres.",
         "fileAsBookDefault": "Padrão de Arquivo como Livro",
-        "fileAsBookDefaultHint": "Padrão de envio para bibliotecas usando o modo Arquivo como Livro. Cada arquivo é um livro.",
+        "fileAsBookDefaultHint": "Padrão de envio para bibliotecas que usam o modo Arquivo como Livro. Cada arquivo é um livro.",
         "folderAsBookDefault": "Padrão de Pasta como Livro",
-        "folderAsBookDefaultHint": "Padrão de envio para bibliotecas usando o modo Pasta como Livro. Cada livro deve estar em sua própria pasta.",
+        "folderAsBookDefaultHint": "Padrão de envio para bibliotecas que usam o modo Pasta como Livro. Cada livro deve estar em sua própria pasta.",
         "downloadPattern": "Padrão de Download",
-        "downloadPatternHint": "Nomes de arquivo sugeridos para downloads de arquivo único e arquivos dentro de ZIPs de exportação.",
-        "libraryOverrides": "Substituições da Biblioteca",
-        "noLibraries": "Nenhuma biblioteca configurada. Crie uma nas configurações da Biblioteca para definir padrões de nomenclatura personalizados.",
+        "downloadPatternHint": "Nomes de arquivos sugeridos para downloads de um único arquivo e arquivos dentro de arquivos ZIP exportados.",
+        "libraryOverrides": "Substituições por Biblioteca",
+        "noLibraries": "Nenhuma biblioteca configurada. Crie uma nas configurações da Biblioteca para definir padrões de nomeação personalizados.",
         "badgeCustom": "Personalizado",
         "badgeDefault": "Padrão",
         "orgFolderAsBook": "Pasta como Livro",
         "orgFileAsBook": "Arquivo como Livro",
-        "resetToDefault": "Redefinir para o padrão",
-        "patternReference": "Referência de Padrão",
-        "placeholderReference": "Referência de Espaço Reservado",
-        "placeholderReferenceHint": "- guia para criar padrões de nomenclatura personalizados",
+        "resetToDefault": "Restaurar padrão",
+        "patternReference": "Referência de Padrões",
+        "placeholderReference": "Referência de Variáveis (Placeholders)",
+        "placeholderReferenceHint": "- guia para criar padrões de nomeação personalizados",
         "tokens": "Tokens",
-        "tokensHint": "Copie os espaços reservados rapidamente",
+        "tokensHint": "Copie variáveis rapidamente",
         "clickTokenHint": "Clique em qualquer token para copiá-lo para a área de transferência.",
         "copyValue": "Copiar {value}",
         "modifiers": "Modificadores",
-        "modifiersHint": "Transformar os valores do token",
-        "modifiersExplain": "Anexe um modificador dentro de um token para transformar seu valor:",
+        "modifiersHint": "Transforme os valores dos tokens",
+        "modifiersExplain": "Adicione um modificador dentro de um token para transformar seu valor:",
         "modFirst": "Apenas o primeiro valor",
         "modSort": "Formato Sobrenome, Nome",
         "modInitial": "Apenas a primeira letra",
         "folderOnlyPrefix": "Termine um padrão com",
-        "folderOnlySuffix": "para especificar apenas uma pasta. O nome do arquivo original será preservado dentro dela.",
+        "folderOnlySuffix": "para especificar apenas uma pasta. O nome original do arquivo será preservado dentro dela.",
         "conditionalLogic": "Lógica Condicional",
         "conditionalLogicHint": "Segmentos opcionais e alternativas",
         "conditionalPart1": "Envolva em",
-        "conditionalPart2": "para ignorar um segmento quando seu token estiver vazio. Use",
+        "conditionalPart2": "para pular um segmento quando seu token estiver vazio. Use",
         "conditionalPart3": "para um valor padrão.",
         "examples": "Exemplos",
         "patternExamples": "Exemplos de Padrões",
-        "patternExamplesHint": "Padrões prontos para estilos de biblioteca comuns",
+        "patternExamplesHint": "Padrões prontos para estilos comuns de biblioteca",
         "copyPatternTooltip": "Copiar padrão para a área de transferência",
         "exCalibre": "Padrão estilo Calibre",
-        "exSeriesReader": "Leitor de séries",
-        "exCleanDownload": "Nome de arquivo de download limpo",
-        "exAlphabetical": "Agrupamento alfabético com série",
-        "exSeriesFallback": "Série ou alternativa Independente",
+        "exSeriesReader": "Leitor por série",
+        "exCleanDownload": "Nome de arquivo limpo para download",
+        "exAlphabetical": "Agrupamento alfabético com séries",
+        "exSeriesFallback": "Alternativa entre série e livro avulso",
         "exOptionalSubtitle": "Download com subtítulo opcional",
         "exMultilingual": "Biblioteca multilíngue",
         "exPublisher": "Organizado por editora",
         "exStacked": "Pastas opcionais empilhadas",
-        "exFolderDrop": "Recepção de pasta com nome de classificação",
+        "exFolderDrop": "Depósito em pasta com nome de ordenação",
         "caseWithYear": "com ano",
         "caseNoYear": "sem ano",
         "caseInSeries": "na série",
-        "caseStandalone": "independente",
+        "caseStandalone": "livro avulso",
         "caseNoSeries": "sem série",
         "caseFull": "completo",
         "caseMinimal": "mínimo",
@@ -1615,7 +1676,7 @@
         "caseNoLanguage": "sem idioma",
         "caseWithPublisher": "com editora",
         "caseNoPublisher": "sem editora",
-        "caseAllSet": "tudo definido",
+        "caseAllSet": "tudo configurado",
         "copiedToClipboard": "{value} copiado para a área de transferência",
         "copyTokenFailed": "Falha ao copiar token",
         "patternCopied": "Padrão copiado para a área de transferência",
@@ -1625,18 +1686,18 @@
       },
       "kobo": {
         "title": "Sincronização Kobo",
-        "subtitle": "Pareie seu dispositivo Kobo para sincronizar sua biblioteca.",
+        "subtitle": "Emparelhe seu dispositivo Kobo para sincronizar sua biblioteca.",
         "copy": "Copiar",
         "never": "Nunca",
         "justNow": "Agora mesmo",
-        "minutesAgo": "{count}m atrás",
-        "hoursAgo": "{count}h atrás",
-        "daysAgo": "{count}d atrás",
+        "minutesAgo": "há {count}m",
+        "hoursAgo": "há {count}h",
+        "daysAgo": "há {count}d",
         "loadFailed": "Falha ao carregar",
-        "devicePaired": "Dispositivo pareado com sucesso",
+        "devicePaired": "Dispositivo emparelhado com sucesso",
         "devicePairedHint": "Você está pronto para configurar o seu Kobo. Siga as instruções abaixo.",
-        "syncUrl": "URL de sincronização",
-        "urlNotShownAgain": "Esta URL não será exibida novamente. Mantenha-a privada.",
+        "syncUrl": "URL de Sincronização",
+        "urlNotShownAgain": "Esta URL não será mostrada novamente. Mantenha-a em sigilo.",
         "registeredDevices": "Dispositivos Registrados",
         "addDevice": "Adicionar dispositivo",
         "deviceName": "Nome do dispositivo",
@@ -1652,53 +1713,53 @@
         "revokeAccess": "Revogar acesso",
         "deviceRenamed": "Dispositivo renomeado",
         "renameDeviceFailed": "Falha ao renomear dispositivo",
-        "revokeConfirm": "Revogar acesso para \"{name}\"? O dispositivo não poderá sincronizar até ser pareado novamente.",
+        "revokeConfirm": "Revogar acesso para \"{name}\"? O dispositivo não poderá sincronizar até ser emparelhado novamente.",
         "accessRevoked": "Acesso revogado para \"{name}\"",
         "revokeFailed": "Falha ao revogar acesso",
         "syncUrlCopied": "URL de sincronização copiada para a área de transferência",
         "syncUrlCopyFailed": "Falha ao copiar URL de sincronização",
         "syncPreferences": "Preferências de Sincronização",
-        "twoWaySync": "Sincronização bidirecional de progresso",
-        "twoWaySyncHint": "Sincroniza a posição de leitura entre BookOrbit e Kobo. Requer entrega em KEPUB para locais precisos e restauração de página confiável.",
-        "syncHighlights": "Sincronizar destaques do BookOrbit para Kobo",
-        "syncHighlightsHint": "Envia destaques feitos no BookOrbit ou KOReader para o seu Kobo. Os destaques do Kobo são importados para o BookOrbit mesmo com esta opção desativada. Anotações vinculadas sincronizam edições e exclusões nos dois sentidos. Requer entrega em KEPUB; o livro no Kobo deve ser o KEPUB baixado do BookOrbit.",
+        "twoWaySync": "Sincronização de progresso bilateral",
+        "twoWaySyncHint": "Sincronizar posição de leitura entre o BookOrbit e o Kobo. Requer envio no formato KEPUB para localizações precisas e restauração de página confiável.",
+        "syncHighlights": "Sincronizar destaques do BookOrbit com o Kobo",
+        "syncHighlightsHint": "Envie os destaques feitos no BookOrbit ou no KOReader para o seu Kobo. Os destaques do Kobo são importados para o BookOrbit mesmo com esta opção desativada. Anotações vinculadas sincronizam edições e exclusões nos dois sentidos. Requer envio de KEPUB; o livro no Kobo deve ser o KEPUB baixado do BookOrbit.",
         "convertKepub": "Converter para KEPUB",
-        "convertKepubHint": "Envia EPUBs elegíveis como KEPUB. Esta opção permanece ativada quando a sincronização de progresso ou de destaques do BookOrbit para Kobo estão ativadas. Na próxima sincronização do Kobo, os livros afetados serão oferecidos novamente como downloads KEPUB; remova qualquer cópia EPUB antiga se o Kobo continuar abrindo-a.",
+        "convertKepubHint": "Enviar EPUBs elegíveis como KEPUB. Esta opção permanece ativa quando a sincronização de progresso ou os destaques do BookOrbit para o Kobo estão ativados. Na próxima sincronização do Kobo, os livros afetados serão oferecidos novamente como downloads KEPUB; remova qualquer cópia EPUB antiga se o Kobo continuar abrindo ela.",
         "forceHyphenation": "Forçar hifenização",
-        "forceHyphenationHint": "Garante uma justificação de texto consistente. Isso irá regenerar os KEPUBs armazenados em cache.",
+        "forceHyphenationHint": "Garante um alinhamento justificado consistente de texto. Isso gerará novamente os KEPUBs em cache.",
         "progressThresholds": "Limites de Progresso",
-        "progressThresholdsHint": "Defina quando o progresso de leitura do Kobo atualiza o status da sua biblioteca.",
+        "progressThresholdsHint": "Defina quando o progresso de leitura do Kobo atualiza o status na sua biblioteca.",
         "markAsReading": "Marcar como Lendo",
         "markAsReadingHint": "Porcentagem mínima para mover um livro para \"Lendo\".",
         "markAsFinished": "Marcar como Concluído",
-        "markAsFinishedHint": "Porcentagem limite para marcar um livro como \"Lido\".",
+        "markAsFinishedHint": "Limite de porcentagem para marcar um livro como \"Concluído\".",
         "kepubLimit": "Limite de conversão KEPUB",
-        "kepubLimitHint": "Livros acima deste limite são enviados como EPUBs normais, então o BookOrbit não sincronizará sua posição de leitura de volta para o Kobo.",
+        "kepubLimitHint": "Livros acima desse limite são enviados como EPUBs normais, logo, o BookOrbit não sincronizará a posição de leitura deles de volta com o Kobo.",
         "changesMustBeSaved": "As alterações devem ser salvas para entrarem em vigor.",
         "saving": "Salvando...",
-        "saveSyncSettings": "Salvar Configurações",
-        "thresholdOrderError": "O limite de leitura deve ser menor que o limite de finalização",
+        "saveSyncSettings": "Salvar Configurações de Sincronização",
+        "thresholdOrderError": "O limite de leitura deve ser menor que o limite de conclusão",
         "saveSettingsFailed": "Falha ao salvar configurações",
         "settingsSaved": "Configurações de sincronização do Kobo salvas",
         "saveFailed": "Falha ao salvar",
         "activity": {
           "waitingForActivity": "Aguardando atividade",
-          "needsAttention": "Requer atenção",
-          "syncHealthy": "Sincronização saudável",
+          "needsAttention": "Precisa de atenção",
+          "syncHealthy": "Sincronização normal",
           "never": "Nunca",
-          "none": "Nenhum",
+          "none": "Nenhuma",
           "unknown": "Desconhecido",
           "failureCount": "{count} falha | {count} falhas",
           "noActivityRecorded": "Nenhuma atividade de sincronização do Kobo foi registrada.",
           "lastSuccess": "Último sucesso em {time}",
           "lastFailure": "Última falha em {time}",
-          "noFailedActivity": "Nenhuma atividade falha do Kobo no histórico recente.",
+          "noFailedActivity": "Nenhuma atividade do Kobo com falha no histórico recente.",
           "noActivityYet": "Nenhuma atividade do Kobo ainda.",
           "event": {
-            "librarySync": "Biblioteca verificada por atualizações",
+            "librarySync": "Biblioteca verificada quanto a atualizações",
             "bookDownload": "Livro baixado",
             "progressUpdate": "Posição de leitura atualizada",
-            "annotationsPull": "Destaques enviados ao Kobo",
+            "annotationsPull": "Destaques enviados para o Kobo",
             "annotationsPush": "Destaques recebidos do Kobo"
           },
           "outcome": {
@@ -1721,15 +1782,15 @@
           },
           "chip": {
             "morePending": "Mais pendentes",
-            "noUpdatesPending": "Sem atualizações pendentes",
+            "noUpdatesPending": "Nenhuma atualização pendente",
             "bookCount": "{count} livro | {count} livros",
             "deletedAnnotations": "{count} anotações excluídas",
             "deviceAlreadyCurrent": "Dispositivo já atualizado",
             "freshHighlightData": "Dados de destaque recentes",
-            "created": "{count} criados",
-            "updated": "{count} atualizados",
-            "deleted": "{count} excluídos",
-            "unchanged": "{count} inalterados"
+            "created": "{count} criado(s)",
+            "updated": "{count} atualizado(s)",
+            "deleted": "{count} excluído(s)",
+            "unchanged": "{count} inalterado(s)"
           },
           "readingPositionSyncedTitle": "Posição de leitura sincronizada: {title}",
           "readingPositionSynced": "Posição de leitura sincronizada",
@@ -1737,7 +1798,7 @@
           "updateCount": "{count} atualização | {count} atualizações",
           "directionToKobo": "BookOrbit -> Kobo",
           "directionToBookOrbit": "Kobo -> BookOrbit",
-          "twoWaySyncEnabled": "Sincronização bidirecional ativada",
+          "twoWaySyncEnabled": "Sincronização bilateral ativada",
           "deviceProgressSaved": "Progresso do dispositivo salvo",
           "summary": {
             "noLibraryUpdatesPending": "Nenhuma atualização de biblioteca pendente para este dispositivo",
@@ -1746,8 +1807,8 @@
             "booksDownloaded": "{count} livro baixado | {count} livros baixados",
             "progressUpdatesSyncedFor": "{count} atualização de progresso sincronizada para {title} | {count} atualizações de progresso sincronizadas para {title}",
             "progressUpdatesSynced": "{count} atualização de progresso sincronizada | {count} atualizações de progresso sincronizadas",
-            "newReadingPositionFor": "O Kobo relatou uma nova posição de leitura para {title}",
-            "newReadingPosition": "O Kobo relatou uma nova posição de leitura",
+            "newReadingPositionFor": "O Kobo informou uma nova posição de leitura para {title}",
+            "newReadingPosition": "O Kobo informou uma nova posição de leitura",
             "noHighlightChangesNeededFor": "Nenhuma alteração de destaque necessária para {title}",
             "noHighlightChangesNeeded": "Nenhuma alteração de destaque necessária",
             "highlightsSentToKoboFor": "{count} destaque enviado ao Kobo para {title} | {count} destaques enviados ao Kobo para {title}",
@@ -1760,7 +1821,7 @@
           "timeRange": "{from} até {to}",
           "eventsGrouped": "{count} evento agrupado | {count} eventos agrupados",
           "removedDevice": "Dispositivo removido",
-          "loadMoreFailed": "Falha ao carregar mais do histórico",
+          "loadMoreFailed": "Falha ao carregar mais histórico",
           "historyRefreshed": "Histórico de sincronização do Kobo atualizado",
           "refreshFailed": "Falha ao atualizar o histórico",
           "recentActivity": "Atividade Recente do Kobo",
@@ -1768,10 +1829,10 @@
           "filterFailures": "Falhas",
           "refresh": "Atualizar",
           "loadingActivity": "Carregando atividade do Kobo...",
-          "noActivityHint": "Atividades de sincronização recentes aparecerão depois que um Kobo pareado entrar em contato com o BookOrbit.",
+          "noActivityHint": "As atividades de sincronização recentes aparecerão depois que um Kobo emparelhado entrar em contato com o BookOrbit.",
           "error": "Erro",
           "loading": "Carregando...",
-          "loadMore": "Carregar mais atividade"
+          "loadMore": "Carregar mais atividades"
         },
         "howBooksSynced": {
           "title": "Como os livros são sincronizados"
@@ -1783,19 +1844,19 @@
         "syncToKobo": "Sincronizar com o Kobo",
         "tabs": {
           "syncSettings": "Configurações de Sincronização",
-          "activityLog": "Registro de Atividade"
+          "activityLog": "Registro de Atividades"
         }
       },
       "koreader": {
         "title": "Sincronização KOReader",
-        "subtitle": "Navegue pelo catálogo do BookOrbit no KOReader e sincronize o progresso, atividades de leitura, destaques e alterações de anotações.",
+        "subtitle": "Navegue pelo seu catálogo BookOrbit no KOReader e sincronize progresso, atividade de leitura, destaques e alterações nas anotações.",
         "loadingSettings": "Carregando configurações do KOReader...",
-        "loadFailed": "Falha ao carregar as configurações do KOReader",
+        "loadFailed": "Falha ao carregar configurações do KOReader",
         "never": "Nunca",
         "justNow": "Agora mesmo",
-        "minutesAgo": "{count}m atrás",
-        "hoursAgo": "{count}h atrás",
-        "daysAgo": "{count}d atrás",
+        "minutesAgo": "há {count}m",
+        "hoursAgo": "há {count}h",
+        "daysAgo": "há {count}d",
         "unknown": "Desconhecido",
         "updateAvailable": "Atualização disponível",
         "upToDate": "Atualizado",
@@ -1803,9 +1864,9 @@
         "latestPlugin": "Plugin mais recente: v{version}",
         "latestPluginUnavailable": "Plugin mais recente indisponível",
         "notConfigured": "A sincronização do KOReader não está configurada",
-        "notConfiguredHint": "Crie um conjunto de credenciais de sincronização e, em seguida, use-as com o plugin BookOrbit para KOReader para navegação, downloads, progresso, eventos de leitura, destaques e exclusões.",
+        "notConfiguredHint": "Crie um conjunto de credenciais de sincronização e use-as com o plugin BookOrbit para KOReader para navegação, downloads, progresso, eventos de leitura, destaques e exclusões.",
         "createCredentials": "Criar credenciais",
-        "createFormTitle": "Criar Credenciais de Sincronização do KOReader",
+        "createFormTitle": "Criar Credenciais de Sincronização KOReader",
         "createFormHint": "Estas credenciais autenticam seus dispositivos KOReader com o BookOrbit.",
         "username": "Nome de usuário",
         "usernamePlaceholder": "ex: meuleitor",
@@ -1813,12 +1874,12 @@
         "passwordPlaceholder": "Mín. 6 caracteres",
         "creating": "Criando...",
         "create": "Criar",
-        "credentialsCreated": "Credenciais de sincronização do KOReader criadas",
+        "credentialsCreated": "Credenciais de sincronização KOReader criadas",
         "createCredentialsFailed": "Falha ao criar credenciais",
         "status": "Status do KOReader",
         "refresh": "Atualizar",
         "progressSync": "Sincronização de progresso",
-        "progressSyncHint": "Permite que os dispositivos KOReader sincronizem o progresso, atividades de leitura, destaques e exclusões de anotações com o BookOrbit.",
+        "progressSyncHint": "Permitir que dispositivos KOReader sincronizem progresso, atividade de leitura, destaques e exclusão de anotações com o BookOrbit.",
         "lastSync": "Última sincronização",
         "syncedBooks": "Livros sincronizados",
         "bookCount": "nenhum livro | {count} livro | {count} livros",
@@ -1827,21 +1888,21 @@
         "credentialsCreatedLabel": "Credenciais criadas",
         "setup": "Configuração",
         "pluginServerUrl": "URL do servidor do plugin",
-        "copied": "Copiado",
+        "copied": "Copiada",
         "copyUrl": "Copiar URL",
-        "preconfiguredPlugin": "Plugin pré-configurado do BookOrbit",
-        "preconfiguredPluginHintPrefix": "Baixe um zip com a URL do servidor e seu login de sincronização já configurados. O plugin inclui navegação de catálogo e sincronização. Copie a pasta para",
+        "preconfiguredPlugin": "Plugin do BookOrbit pré-configurado",
+        "preconfiguredPluginHintPrefix": "Baixe um arquivo zip com a URL do servidor e seu login de sincronização já configurados. O plugin inclui navegação no catálogo e sincronização. Copie a pasta para",
         "preconfiguredPluginHintSuffix": "e reinicie o KOReader.",
-        "latestPluginNote": "{label}. Atualizações de dispositivo são executadas no menu BookOrbit no KOReader.",
+        "latestPluginNote": "{label}. Atualizações no dispositivo podem ser feitas a partir do menu BookOrbit no KOReader.",
         "preparing": "Preparando...",
         "downloadPlugin": "Baixar Plugin",
-        "noDevicesSynced": "Nenhum dispositivo sincronizou ainda",
-        "noDevicesSyncedHint": "Instale o plugin BookOrbit para sincronização completa ou configure a sincronização de progresso nativa do KOReader para atualizações apenas de progresso.",
+        "noDevicesSynced": "Nenhum dispositivo foi sincronizado ainda",
+        "noDevicesSyncedHint": "Instale o plugin BookOrbit para sincronização completa, ou configure a sincronização nativa de progresso do KOReader para atualizações apenas de progresso.",
         "lastSyncLabel": "Última sincronização:",
         "lastBookLabel": "Último livro:",
         "noneYet": "Nenhum ainda",
         "pluginActivity": "Atividade do Plugin",
-        "noPluginActivity": "Nenhuma atividade de plugin relatada ainda.",
+        "noPluginActivity": "Nenhuma atividade do plugin foi relatada ainda.",
         "lastFullSync": "Última sincronização completa: {time}",
         "latestPluginSuffix": "- plugin mais recente v{version}",
         "matchedBooks": "Livros correspondidos",
@@ -1849,45 +1910,45 @@
         "highlights": "Destaques",
         "syncedTotals": "Totais sincronizados",
         "trashedHighlights": "Destaques na lixeira",
-        "pendingDeletes": "nenhum destaque excluído aguardando confirmação do plugin do KOReader. | {count} destaque excluído aguardando confirmação do plugin do KOReader. | {count} destaques excluídos aguardando confirmação do plugin do KOReader.",
-        "failedPositions": "nenhuma posição de destaque requer atenção. | {count} posição de destaque requer atenção. | {count} posições de destaque requerem atenção.",
+        "pendingDeletes": "nenhum destaque excluído aguardando confirmação do plugin KOReader. | {count} destaque excluído aguardando confirmação do plugin KOReader. | {count} destaques excluídos aguardando confirmação do plugin KOReader.",
+        "failedPositions": "nenhuma posição de destaque precisa de atenção. | {count} posição de destaque precisa de atenção. | {count} posições de destaque precisam de atenção.",
         "setupGuide": "Guia de Configuração",
-        "setupSteps": "Passos de configuração do KOReader",
-        "setupStepsHint": "Use o plugin BookOrbit para navegação de catálogo, downloads, progresso, eventos de leitura e destaques. Use o plugin nativo apenas para progresso.",
+        "setupSteps": "Passos para configuração do KOReader",
+        "setupStepsHint": "Use o plugin do BookOrbit para navegação no catálogo, downloads, progresso, eventos de leitura e destaques. Use o plugin nativo apenas para progresso.",
         "pluginGuideTitle": "Plugin BookOrbit",
         "pluginStep1": "Baixe o plugin pré-configurado acima.",
-        "pluginStep2Prefix": "Descompacte e copie",
+        "pluginStep2Prefix": "Descompacte-o e copie",
         "pluginStep2Middle": "para",
         "pluginStep2Suffix": "no seu dispositivo.",
-        "pluginStep3": "Reinicie o KOReader. O servidor e o login são configurados automaticamente.",
+        "pluginStep3": "Reinicie o KOReader. O servidor e o login já estarão configurados automaticamente.",
         "pluginStep4Prefix": "Abra",
-        "pluginStep4Suffix": "para pesquisar, baixar e vincular livros à sincronização.",
+        "pluginStep4Suffix": "para buscar, baixar e vincular livros para sincronizar.",
         "stockGuideTitle": "Plugin nativo de sincronização de progresso",
-        "stockStep1Prefix": "No seu dispositivo KOReader, vá para",
+        "stockStep1Prefix": "No seu dispositivo KOReader, vá até",
         "stockStep1Suffix": ".",
-        "stockStep2": "Defina o servidor de sincronização personalizado para a URL mostrada acima.",
-        "stockStep3": "Insira o nome de usuário e a senha que você criou e toque em Login.",
-        "locationNote": "O BookOrbit salva posições de EPUB compatíveis com o KOReader do leitor web. A restauração deve cair perto da mesma posição, embora a localização exata da linha possa variar por leitor e layout do EPUB.",
+        "stockStep2": "Defina o servidor de sincronização personalizado como a URL exibida acima.",
+        "stockStep3": "Insira o nome de usuário e a senha que você criou, e depois toque em Entrar (Login).",
+        "locationNote": "O BookOrbit salva localizações de EPUB compatíveis com o KOReader a partir do leitor web. A restauração deve cair bem perto da mesma posição, embora a colocação exata da linha possa variar conforme o leitor e o layout do EPUB.",
         "dangerZone": "Zona de Perigo",
         "deleteCredentials": "Excluir credenciais do KOReader",
-        "deleteCredentialsHint": "Remove credenciais de sincronização e desconecta todos os dispositivos. Os dados de progresso serão retidos.",
+        "deleteCredentialsHint": "Remover credenciais de sincronização e desconectar todos os dispositivos. Os dados de progresso serão mantidos.",
         "credentialsDeleted": "Credenciais do KOReader excluídas",
         "deleteCredentialsFailed": "Falha ao excluir credenciais",
         "deleteConfirmTitle": "Excluir credenciais do KOReader?",
-        "deleteConfirmBody": "Isto removerá suas credenciais de sincronização e desconectará todos os dispositivos KOReader. Os dados de progresso existentes serão mantidos.",
-        "syncEnabled": "Sincronização do KOReader ativada",
-        "syncDisabled": "Sincronização do KOReader desativada",
-        "toggleSyncFailed": "Falha ao alternar sincronização",
+        "deleteConfirmBody": "Isso removerá suas credenciais de sincronização e desconectará todos os dispositivos KOReader. Os dados de progresso existentes serão mantidos.",
+        "syncEnabled": "Sincronização KOReader ativada",
+        "syncDisabled": "Sincronização KOReader desativada",
+        "toggleSyncFailed": "Falha ao alternar a sincronização",
         "syncUrlCopied": "URL de sincronização copiada para a área de transferência",
-        "syncUrlCopyFailed": "Falha ao copiar URL de sincronização",
+        "syncUrlCopyFailed": "Falha ao copiar a URL de sincronização",
         "statusRefreshed": "Status de sincronização atualizado",
         "refreshFailed": "Falha ao atualizar",
-        "pluginDownloaded": "Plugin baixado. Copie bookorbit.koplugin do zip para koreader/plugins/ no seu dispositivo.",
+        "pluginDownloaded": "Plugin baixado. Copie a pasta bookorbit.koplugin do arquivo zip para koreader/plugins/ no seu dispositivo.",
         "pluginDownloadFailed": "Falha ao baixar o plugin",
         "hashLinks": {
           "unmatchedTitle": "Livros do KOReader Não Correspondidos",
           "unmatchedBooks": "Livros não correspondidos",
-          "manualTitle": "Links Manuais do KOReader",
+          "manualTitle": "Vínculos Manuais do KOReader",
           "refresh": "Atualizar",
           "link": "Vincular",
           "change": "Alterar",
@@ -1900,70 +1961,70 @@
           "updated": "Atualizado:",
           "linkedTo": "Vinculado a {title}",
           "loadingUnmatched": "Carregando livros não correspondidos...",
-          "loadingManual": "Carregando links manuais...",
-          "noUnmatched": "Nenhum livro não correspondido no KOReader.",
-          "noManual": "Nenhum link manual do KOReader.",
+          "loadingManual": "Carregando vínculos manuais de hash...",
+          "noUnmatched": "Nenhum livro do KOReader sem correspondência.",
+          "noManual": "Nenhum vínculo manual do KOReader.",
           "pageOf": "Página {page} de {total}",
-          "showingRange": "Mostrando {start}-{end} de {total}",
-          "unknownFile": "Arquivo KOReader desconhecido {hash}",
+          "showingRange": "Exibindo {start}-{end} de {total}",
+          "unknownFile": "Arquivo desconhecido do KOReader {hash}",
           "unknownAuthor": "Autor desconhecido",
-          "noTitleOrAuthor": "Nenhum título ou autor relatado",
+          "noTitleOrAuthor": "Nenhum título ou autor informado",
           "bookNumber": "Livro BookOrbit #{id}",
           "toast": {
             "unmatchedRefreshed": "Livros não correspondidos atualizados",
             "unmatchedRefreshFailed": "Falha ao atualizar livros não correspondidos",
-            "manualRefreshed": "Links manuais atualizados",
-            "manualRefreshFailed": "Falha ao atualizar links manuais",
+            "manualRefreshed": "Vínculos manuais de hash atualizados",
+            "manualRefreshFailed": "Falha ao atualizar vínculos manuais de hash",
             "bookLinked": "Livro vinculado",
-            "linkUpdated": "Link atualizado",
+            "linkUpdated": "Vínculo atualizado",
             "linkFailed": "Falha ao vincular o livro",
-            "linkRemoved": "Link removido",
+            "linkRemoved": "Vínculo removido",
             "unlinkFailed": "Falha ao desvincular o livro",
-            "unmatchedDismissed": "Livro não correspondido ignorado",
-            "dismissFailed": "Falha ao ignorar livro não correspondido",
-            "allDismissed": "Nenhum livro ignorado | {count} livro ignorado | {count} livros ignorados",
-            "dismissAllFailed": "Falha ao ignorar todos os livros não correspondidos"
+            "unmatchedDismissed": "Livro não correspondido dispensado",
+            "dismissFailed": "Falha ao dispensar o livro não correspondido",
+            "allDismissed": "Nenhum livro dispensado | Dispensado {count} livro não correspondido | Dispensados {count} livros não correspondidos",
+            "dismissAllFailed": "Falha ao dispensar todos os livros não correspondidos"
           },
           "modal": {
             "linkTitle": "Vincular livro do KOReader",
-            "changeTitle": "Alterar link do KOReader",
-            "bookOrbitBook": "Livro BookOrbit",
-            "searchPlaceholder": "Pesquise na sua biblioteca do BookOrbit",
+            "changeTitle": "Alterar vínculo do KOReader",
+            "bookOrbitBook": "Livro do BookOrbit",
+            "searchPlaceholder": "Busque na sua biblioteca do BookOrbit",
             "minChars": "Digite pelo menos 2 caracteres.",
-            "searching": "Pesquisando...",
+            "searching": "Buscando...",
             "noBooksFound": "Nenhum livro encontrado.",
             "untitledBook": "Livro sem título",
             "selected": "Selecionado",
             "select": "Selecionar",
             "loadMore": "Carregar mais",
-            "confirmTitle": "Confirmar link do KOReader",
+            "confirmTitle": "Confirmar vínculo do KOReader",
             "koreader": "KOReader",
             "bookOrbit": "BookOrbit",
             "bookId": "ID do Livro: {id}",
-            "syncedStatsNote": "As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
-            "chooseDifferent": "Escolher diferente",
+            "syncedStatsNote": "Estatísticas já sincronizadas permanecerão em seu livro atual do BookOrbit.",
+            "chooseDifferent": "Escolher outro",
             "saving": "Salvando...",
             "confirmLink": "Confirmar vínculo",
             "unlinkTitle": "Desvincular livro do KOReader?",
-            "unlinkBody": "Sincronizações futuras para este hash não resolverão para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
+            "unlinkBody": "Sincronizações futuras para este hash deixarão de apontar para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no seu livro atual no BookOrbit.",
             "unlinking": "Desvinculando..."
           },
-          "dismiss": "Ignorar",
-          "dismissAll": "Ignorar tudo",
-          "dismissing": "Ignorando...",
+          "dismiss": "Dispensar",
+          "dismissAll": "Dispensar todos",
+          "dismissing": "Dispensando...",
           "unlinking": "Desvinculando...",
           "unlinkConfirmTitle": "Desvincular livro do KOReader?",
-          "unlinkConfirmBody": "Sincronizações futuras para este hash não resolverão para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
-          "dismissConfirmTitle": "Ignorar {title}?",
-          "dismissConfirmBody": "Isso remove-o da sua lista de livros não correspondidos. Se qualquer dispositivo reportar este hash novamente, ele reaparecerá como uma nova entrada.",
-          "dismissAllConfirmTitle": "nenhum livro não correspondido | Ignorar {count} livro não correspondido? | Ignorar todos os {count} livros não correspondidos?",
-          "dismissAllConfirmBody": "Isto limpa toda a sua lista de livros não correspondidos, não apenas a página atual. Se qualquer dispositivo reportar um desses hashes novamente, ele reaparecerá como uma nova entrada.",
-          "changeLinkTitle": "Alterar link do KOReader",
+          "unlinkConfirmBody": "Sincronizações futuras para este hash deixarão de apontar para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no seu livro atual no BookOrbit.",
+          "dismissConfirmTitle": "Dispensar {title}?",
+          "dismissConfirmBody": "Isso o remove da sua lista de livros não correspondidos. Se qualquer dispositivo informar este hash novamente no futuro, ele reaparecerá como uma nova entrada.",
+          "dismissAllConfirmTitle": "Nenhum livro | Dispensar todos os {count} livros não correspondidos? | Dispensar todos os {count} livros não correspondidos?",
+          "dismissAllConfirmBody": "Isso limpa toda a sua lista de livros não correspondidos, não apenas a página atual. Se algum dispositivo informar um desses hashes novamente, ele reaparecerá como uma nova entrada.",
+          "changeLinkTitle": "Alterar vínculo do KOReader",
           "linkBookTitle": "Vincular livro do KOReader",
-          "bookOrbitBook": "Livro BookOrbit",
-          "searchLibraryPlaceholder": "Pesquise na sua biblioteca do BookOrbit",
+          "bookOrbitBook": "Livro do BookOrbit",
+          "searchLibraryPlaceholder": "Busque na sua biblioteca do BookOrbit",
           "enterMinChars": "Digite pelo menos 2 caracteres.",
-          "searching": "Pesquisando...",
+          "searching": "Buscando...",
           "noBooksFound": "Nenhum livro encontrado.",
           "untitledBook": "Livro sem título",
           "selected": "Selecionado",
@@ -1972,8 +2033,8 @@
           "loadingMore": "Carregando...",
           "confirmLinkTitle": "Confirmar vínculo do KOReader",
           "bookId": "ID do Livro: {id}",
-          "syncedStatsNote": "As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
-          "chooseDifferent": "Escolher diferente",
+          "syncedStatsNote": "Estatísticas já sincronizadas permanecerão em seu livro atual do BookOrbit.",
+          "chooseDifferent": "Escolher outro",
           "saving": "Salvando...",
           "confirmLink": "Confirmar vínculo"
         },
@@ -1981,19 +2042,19 @@
         "removing": "Removendo...",
         "unmatchedBooks": "Livros não correspondidos",
         "deviceRemoved": "Dispositivo removido",
-        "removeDeviceFailed": "Falha ao remover dispositivo",
+        "removeDeviceFailed": "Falha ao remover o dispositivo",
         "removeDeviceConfirmTitle": "Remover {device}?",
-        "removeDeviceConfirmBody": "Isto exclui permanentemente o progresso sincronizado deste dispositivo, a atividade de leitura e quaisquer entradas de livros não correspondidos que não sejam mais reportadas por outro dispositivo. Se o dispositivo sincronizar novamente mais tarde, ele reaparecerá como uma nova entrada."
+        "removeDeviceConfirmBody": "Isso exclui permanentemente o progresso sincronizado deste dispositivo, a atividade de leitura e quaisquer entradas de livros não correspondidos que não sejam relatados por outro dispositivo. Se o dispositivo sincronizar novamente mais tarde, ele reaparecerá como uma nova entrada."
       },
       "opds": {
         "title": "OPDS",
-        "subtitle": "Conecte aplicativos de leitura compatíveis com OPDS, como KOReader ou Thorium Reader, à sua biblioteca.",
+        "subtitle": "Conecte aplicativos de leitura compatíveis com OPDS, como o KOReader ou Thorium Reader, à sua biblioteca.",
         "copy": "Copiar",
         "loadFailed": "Falha ao carregar",
         "server": "Servidor",
         "catalogServer": "Servidor de Catálogo OPDS",
         "catalogServerHint": "Permitir que clientes OPDS naveguem e baixem livros",
-        "endpoint": "Endpoint",
+        "endpoint": "Endereço (Endpoint)",
         "accounts": "Contas OPDS",
         "add": "Adicionar",
         "addAccount": "Adicionar conta",
@@ -2002,19 +2063,19 @@
         "usernamePlaceholder": "ex: koreader",
         "password": "Senha",
         "passwordPlaceholder": "Mín. 8 caracteres",
-        "defaultSort": "Classificação Padrão",
-        "sortLabel": "Classificação",
+        "defaultSort": "Ordenação Padrão",
+        "sortLabel": "Ordenação",
         "creating": "Criando...",
         "create": "Criar",
-        "noAccounts": "Nenhuma conta OPDS ainda. Crie uma para começar a usar os clientes OPDS.",
+        "noAccounts": "Nenhuma conta OPDS ainda. Crie uma para começar a usar clientes OPDS.",
         "hideDetails": "Ocultar detalhes",
-        "showDetails": "Mostrar detalhes",
+        "showDetails": "Exibir detalhes",
         "copyUsername": "Copiar nome de usuário",
-        "notes": "Notas sobre OPDS",
-        "notesBody": "Use contas OPDS em aplicativos de leitura. Mantenha as credenciais privadas e rotacione as senhas se compartilhadas acidentalmente.",
+        "notes": "Notas sobre o OPDS",
+        "notesBody": "Use contas OPDS em aplicativos de leitura. Mantenha as credenciais em sigilo e altere as senhas caso sejam compartilhadas por engano.",
         "deleteConfirmTitle": "Excluir conta OPDS?",
         "deleteConfirmBody": "Excluir \"{username}\". Esta ação não pode ser desfeita.",
-        "sortRecent": "Adicionado Recentemente",
+        "sortRecent": "Adicionados Recentes",
         "sortTitleAsc": "Título (A-Z)",
         "sortTitleDesc": "Título (Z-A)",
         "sortAuthorAsc": "Autor (A-Z)",
@@ -2023,16 +2084,16 @@
         "sortSeriesDesc": "Série (Z-A)",
         "serverEnabled": "Servidor OPDS ativado",
         "serverDisabled": "Servidor OPDS desativado",
-        "updateSettingsFailed": "Falha ao atualizar configurações de OPDS",
+        "updateSettingsFailed": "Falha ao atualizar configurações OPDS",
         "urlCopied": "URL do OPDS copiada para a área de transferência",
         "urlCopyFailed": "Falha ao copiar a URL do OPDS",
-        "createUserFailed": "Falha ao criar usuário OPDS",
+        "createUserFailed": "Falha ao criar o usuário OPDS",
         "userCreated": "Usuário OPDS \"{username}\" criado",
         "sortOrderUpdated": "Ordem de classificação atualizada para \"{username}\"",
         "updateSortFailed": "Falha ao atualizar a ordem de classificação",
         "userDeleted": "Usuário OPDS \"{username}\" excluído",
         "deleteUserFailed": "Falha ao excluir usuário OPDS",
-        "labelCopied": "{label} copiado",
+        "labelCopied": "{label} copiado(a)",
         "copyLabelFailed": "Falha ao copiar {label}"
       },
       "tabs": {
@@ -2040,16 +2101,16 @@
         "ebook": "eBook",
         "pdf": "PDF",
         "comics": "Quadrinhos",
-        "audio": "Audiobook",
+        "audio": "Audiolivro",
         "fonts": "Fontes"
       }
     },
     "system": {
       "tabs": {
-        "file-naming": "Nomenclatura de Arquivos",
-        "book-dock": "Book Dock",
+        "file-naming": "Nomeação de Arquivos",
+        "book-dock": "Doca de Livros",
         "maintenance": "Manutenção",
-        "audit-log": "Log de Auditoria"
+        "audit-log": "Registro de Auditoria"
       }
     }
   },
@@ -2071,15 +2132,107 @@
       "legendary": "Lendária"
     },
     "filter": {
-      "all": "Tudo",
+      "all": "Todas",
       "earned": "Conquistadas ({count})",
-      "inProgress": "Em Andamento ({count})",
+      "inProgress": "Em Progresso ({count})",
       "locked": "Bloqueadas ({count})"
     }
   },
   "adminFeature": {
+    "accountActivity": {
+      "title": "Atividade da Conta",
+      "subtitle": "Revise a atividade de autenticação da conta sem expor o histórico de leitura.",
+      "privacyNotice": "Esta página relata apenas logins e atualizações de autenticação. Ela não usa o histórico de leitura, progresso de livros ou atividades na biblioteca.",
+      "privacyLabel": "Sobre a privacidade das atividades da conta",
+      "never": "Nunca",
+      "openInsightsFor": "Abrir insights de leitura compartilhados para {name}",
+      "permissionLabel": "Ver atividade do usuário",
+      "states": { "recent": "Ativo recentemente", "dormant": "Inativo / Dormente", "never": "Nenhuma atividade registrada", "disabled": "Desativado" },
+      "filters": {
+        "search": "Buscar contas",
+        "searchPlaceholder": "Buscar por nome ou nome de usuário",
+        "state": "Estado de atividade",
+        "allStates": "Todos os estados de atividade",
+        "provisioning": "Método de autenticação",
+        "allMethods": "Todos os métodos de autenticação",
+        "sort": "Ordenar contas",
+        "mostRecent": "Atividade mais recente",
+        "leastRecent": "Atividade menos recente",
+        "lastLogin": "Login mais recente",
+        "newest": "Contas mais recentes",
+        "oldest": "Contas mais antigas",
+        "name": "Nome",
+        "apply": "Aplicar",
+        "clear": "Limpar"
+      },
+      "methods": { "local": "Local", "manual": "Criado pelo administrador", "oidc": "OIDC / SSO", "shared": "Link mágico compartilhado" },
+      "columns": {
+        "user": "Usuário",
+        "state": "Estado da conta",
+        "lastLogin": "Último login",
+        "lastAuthenticated": "Última autenticação",
+        "created": "Criada",
+        "readingInsights": "Insights de leitura"
+      },
+      "sharing": { "private": "Não compartilhado", "summary": "Resumo compartilhado", "detailed": "Detalhes compartilhados" },
+      "empty": { "title": "Nenhuma conta encontrada", "description": "Tente alterar ou limpar os filtros atuais." },
+      "pagination": { "label": "Páginas da atividade da conta", "page": "Página {page} de {totalPages}" },
+      "errors": { "load": "Falha ao carregar a atividade da conta." }
+    },
+    "sharedInsights": {
+      "title": "Insights de leitura compartilhados",
+      "subtitle": "Informações de leitura que este usuário escolheu voluntariamente compartilhar.",
+      "auditNotice": "O acesso a este perfil é registrado e fica visível para o usuário.",
+      "period": "Período do relatório",
+      "periodDays": "Últimos {count} dias",
+      "durationMinutes": "{count} minuto | {count} minutos",
+      "durationHours": "{count} horas",
+      "metrics": {
+        "sessions": "Sessões",
+        "readingTime": "Tempo de leitura",
+        "activeDays": "Dias ativos",
+        "started": "Livros iniciados",
+        "completed": "Livros concluídos"
+      },
+      "trend": "Tendência de leitura diária",
+      "emptyTitle": "Nenhuma atividade de leitura neste período",
+      "noData": "Nenhum dado de leitura registrado para este período.",
+      "sessionCount": "{count} sessão | {count} sessões",
+      "sourceNames": { "web": "Leitor web", "koreader": "KOReader", "manual": "Manual", "kobo": "Kobo", "unknown": "Desconhecido" },
+      "formats": "Formatos",
+      "genres": "Gêneros",
+      "broadGenres": {
+        "science_fiction": "Ficção científica",
+        "fantasy": "Fantasia",
+        "mystery_thriller": "Mistério e Suspense",
+        "romance": "Romance",
+        "horror": "Terror",
+        "history_biography": "História e Biografia",
+        "science_technology": "Ciência e Tecnologia",
+        "business_economics": "Negócios e Economia",
+        "self_development": "Desenvolvimento pessoal",
+        "society_culture": "Sociedade e Cultura",
+        "children_young_adult": "Infantil e Jovem Adulto",
+        "comics_graphic_novels": "Quadrinhos e Graphic Novels",
+        "poetry": "Poesia",
+        "other": "Outro"
+      },
+      "sources": "Fontes de dados",
+      "topBooks": "Livros mais lidos",
+      "recentBooks": "Lidos recentemente",
+      "unknownTitle": "Livro sem título",
+      "top": { "authors": "Principais autores", "genres": "Principais gêneros", "series": "Principais séries", "narrators": "Principais narradores" },
+      "errors": {
+        "READING_INSIGHTS_PRIVATE": "Este usuário não está compartilhando insights de leitura.",
+        "READING_INSIGHTS_SUMMARY_ONLY": "Este usuário compartilha apenas insights resumidos.",
+        "READING_INSIGHTS_VIEW_SESSION_REQUIRED": "Uma sessão de visualização do perfil é necessária.",
+        "READING_INSIGHTS_VIEW_SESSION_INVALID": "Esta visualização do perfil expirou ou não é mais válida.",
+        "LOAD_FAILED": "Não foi possível carregar os insights de leitura compartilhados.",
+        "cleared": "Nenhuma informação do perfil carregada anteriormente está sendo exibida."
+      }
+    },
     "resetLink": {
-      "title": "Link de Redefinição de Senha",
+      "title": "Link para Redefinição de Senha",
       "description": "Compartilhe este link com o usuário. Ele expira em 15 minutos.",
       "copy": "Copiar",
       "copied": "Copiado!",
@@ -2090,7 +2243,7 @@
       "editUser": "Editar Usuário",
       "createUser": "Criar Usuário",
       "createSharedAccount": "Criar Conta Compartilhada",
-      "sharedBadge": "Compartilhado",
+      "sharedBadge": "Compartilhada",
       "active": "Ativo",
       "suspended": "Suspenso",
       "tabs": {
@@ -2099,14 +2252,14 @@
         "restrictions": "restrições"
       },
       "sharedAccount": "Conta compartilhada",
-      "sharedAccountHint": "Sem senha. O acesso é concedido apenas via links mágicos.",
+      "sharedAccountHint": "Sem senha. O acesso é concedido apenas por meio de links mágicos.",
       "sharedAccountManageHint": "Gerencie links de login em Configurações - Links Mágicos.",
       "username": "Nome de usuário",
       "fullName": "Nome completo",
       "email": "E-mail",
       "optional": "(opcional)",
-      "libraryAccess": "Acesso à Biblioteca",
-      "noLibrariesSelected": "Nenhuma biblioteca selecionada. O usuário não pode ver nenhum livro.",
+      "libraryAccess": "Acesso a Bibliotecas",
+      "noLibrariesSelected": "Nenhuma biblioteca selecionada. O usuário não poderá ver nenhum livro.",
       "permissions": "Permissões",
       "presetStandard": "Padrão",
       "presetAdmin": "Admin",
@@ -2116,34 +2269,35 @@
         "devicesAccess": "Dispositivos e Acesso",
         "email": "E-mail",
         "administration": "Administração",
+        "notifications": "Notificações",
         "restrictions": "Restrições"
       },
-      "superuserTarget": "Alvo de Superusuário",
+      "superuserTarget": "Alvo Superusuário",
       "superuserTargetHint": "Restrições de conteúdo não podem ser aplicadas a superusuários.",
       "noRestrictions": "Sem restrições de conteúdo",
-      "noRestrictionsHint": "Este usuário tem acesso total a todos os livros nas suas bibliotecas atribuídas.",
+      "noRestrictionsHint": "Este usuário tem acesso total a todos os livros em suas bibliotecas atribuídas.",
       "addRestrictions": "+ Adicionar Restrições de Conteúdo",
       "contentRestrictions": "Restrições de Conteúdo",
       "remove": "Remover",
       "includeTags": "Incluir tags",
-      "includeTagsHint": "(mostrar apenas livros com estas tags)",
+      "includeTagsHint": "(exibir apenas livros com estas tags)",
       "excludeTags": "Excluir tags",
       "excludeTagsHint": "(ocultar livros com estas tags)",
       "includeGenres": "Incluir gêneros",
-      "includeGenresHint": "(mostrar apenas livros com estes gêneros)",
+      "includeGenresHint": "(exibir apenas livros com estes gêneros)",
       "excludeGenres": "Excluir gêneros",
       "excludeGenresHint": "(ocultar livros com estes gêneros)",
-      "searchTagsPlaceholder": "Pesquisar tags...",
-      "searchGenresPlaceholder": "Pesquisar gêneros...",
+      "searchTagsPlaceholder": "Buscar tags...",
+      "searchGenresPlaceholder": "Buscar gêneros...",
       "saving": "Salvando...",
       "errors": {
         "updateUser": "Falha ao atualizar o usuário",
         "updatePermissions": "Falha ao atualizar as permissões",
         "updateLibraryAccess": "Falha ao atualizar o acesso à biblioteca",
         "updateContentFilters": "Falha ao atualizar os filtros de conteúdo",
-        "emailRequired": "E-mail é obrigatório",
+        "emailRequired": "O e-mail é obrigatório",
         "createSharedAccount": "Falha ao criar conta compartilhada",
-        "createUser": "Falha ao criar usuário"
+        "createUser": "Falha ao criar o usuário"
       }
     },
     "usersPage": {
@@ -2169,29 +2323,29 @@
       "statusActive": "Ativo",
       "statusInactive": "Inativo",
       "resetPassword": "Redefinir senha",
-      "resetPasswordOidcHint": "Usuários OIDC redefinem senhas no seu provedor de identidade",
-      "resetPasswordSharedHint": "Contas compartilhadas não possuem senhas",
-      "resetPasswordOidcHintFull": "Usuários OIDC redefinem senhas em seu provedor de identidade.",
-      "resetPasswordSharedHintFull": "Contas compartilhadas não possuem senhas.",
+      "resetPasswordOidcHint": "Usuários OIDC redefinem suas senhas em seu provedor de identidade",
+      "resetPasswordSharedHint": "Contas compartilhadas não possuem senha",
+      "resetPasswordOidcHintFull": "Usuários OIDC redefinem suas senhas em seu provedor de identidade.",
+      "resetPasswordSharedHintFull": "Contas compartilhadas não possuem senha.",
       "deleteUserAction": "Excluir usuário",
       "deleteDialogTitle": "Excluir usuário?",
-      "deleteDialogBody": "Excluir usuário \"{username}\". Esta ação não pode ser desfeita.",
+      "deleteDialogBody": "Excluir o usuário \"{username}\". Esta ação não pode ser desfeita.",
       "deleting": "Excluindo...",
       "errors": {
-        "loadData": "Falha ao carregar dados",
+        "loadData": "Falha ao carregar os dados",
         "load": "Falha ao carregar",
-        "deleteUser": "Falha ao excluir usuário"
+        "deleteUser": "Falha ao excluir o usuário"
       },
       "currentUsers": "Usuários Atuais",
       "defaultLibraryAccess": {
-        "title": "Acesso Padrão à Biblioteca",
-        "subtitle": "Acesso de visualização concedido a usuários registrados automaticamente e provisionados via OIDC.",
+        "title": "Acesso Padrão às Bibliotecas",
+        "subtitle": "Acesso de visualizador concedido a usuários autorregistrados e provisionados via OIDC.",
         "description": "Selecione as bibliotecas atribuídas automaticamente a novos usuários.",
         "noLibraries": "Nenhuma biblioteca disponível.",
         "save": "Salvar padrões",
         "saving": "Salvando...",
-        "saved": "Acesso padrão à biblioteca salvo.",
-        "saveError": "Falha ao salvar acesso padrão à biblioteca"
+        "saved": "Acesso padrão às bibliotecas salvo.",
+        "saveError": "Falha ao salvar o acesso padrão às bibliotecas"
       }
     }
   },
@@ -2201,14 +2355,14 @@
       "highlight": "Destaque",
       "underline": "Sublinhado",
       "strike": "Tachado",
-      "squiggle": "Ondulado",
+      "squiggle": "Linha ondulada",
       "invert": "Inverter"
     },
     "combobox": {
       "filterByBook": "Filtrar por livro",
       "allBooks": "Todos os livros",
       "clearBookFilter": "Limpar filtro de livro",
-      "searching": "Pesquisando...",
+      "searching": "Buscando...",
       "noBooksFound": "Nenhum livro encontrado"
     },
     "bulk": {
@@ -2217,7 +2371,7 @@
       "selectPage": "Selecionar página",
       "clear": "Limpar",
       "recolorTo": "Recolorir para {color}",
-      "restyleTo": "Reestilizar para {style}"
+      "restyleTo": "Alterar estilo para {style}"
     },
     "chips": {
       "active": "Ativo:",
@@ -2226,15 +2380,15 @@
     },
     "filters": {
       "colors": "Cores",
-      "dateRange": "Intervalo de datas",
-      "fromDate": "Data de início",
-      "toDate": "Data de término",
+      "dateRange": "Período",
+      "fromDate": "A partir de",
+      "toDate": "Até a data",
       "to": "até",
-      "clearDateRange": "Limpar intervalo de datas",
+      "clearDateRange": "Limpar período",
       "clearAll": "Limpar tudo"
     },
     "pagination": {
-      "showing": "Mostrando {start}-{end} de {total}",
+      "showing": "Exibindo {start}-{end} de {total}",
       "pageOf": "Página {page} de {totalPages}",
       "firstPage": "Primeira página",
       "previousPage": "Página anterior",
@@ -2242,12 +2396,12 @@
       "lastPage": "Última página"
     },
     "sync": {
-      "loading": "Carregando detalhe de sincronização",
+      "loading": "Carregando detalhes da sincronização",
       "positions": "Posições",
       "devices": "Dispositivos",
-      "retryConversion": "Tentar novamente a conversão",
+      "retryConversion": "Tentar conversão novamente",
       "noStoredPositions": "Nenhuma posição armazenada.",
-      "notSynced": "Não sincronizado a nenhum dispositivo ainda.",
+      "notSynced": "Não sincronizado com nenhum dispositivo ainda.",
       "upToDate": "Atualizado",
       "pendingVersion": "Pendente v{version}",
       "syncedAt": "sincronizado em {date}",
@@ -2259,13 +2413,13 @@
       },
       "status": {
         "exact": "Exato",
-        "repaired": "Reparado",
+        "repaired": "Corrigido",
         "failed": "Falhou",
         "pending": "Pendente"
       }
     },
     "toolbar": {
-      "searchPlaceholder": "Pesquisar texto e notas",
+      "searchPlaceholder": "Buscar no texto e notas",
       "filters": "Filtros",
       "sortOrder": "Ordem de classificação",
       "switchToCompact": "Mudar para visualização compacta",
@@ -2279,9 +2433,9 @@
       "selectAnnotation": "Selecionar anotação",
       "collapse": "Recolher",
       "expand": "Expandir",
-      "hideSyncDetail": "Ocultar detalhe de sincronização",
-      "showSyncDetail": "Mostrar detalhe de sincronização",
-      "exactPositionUnavailable": "Posição exata no leitor indisponível",
+      "hideSyncDetail": "Ocultar detalhes da sincronização",
+      "showSyncDetail": "Exibir detalhes da sincronização",
+      "exactPositionUnavailable": "Posição exata do leitor indisponível",
       "saving": "Salvando",
       "bookDetails": "Detalhes do livro",
       "openInReader": "Abrir no leitor",
@@ -2297,7 +2451,7 @@
     },
     "hub": {
       "title": "Anotações",
-      "totalCount": "{count} total",
+      "totalCount": "{count} no total",
       "bookCount": "nenhum livro | {count} livro | {count} livros",
       "noteCount": "nenhuma nota | {count} nota | {count} notas",
       "export": "Exportar",
@@ -2306,8 +2460,8 @@
       "exportJson": "JSON",
       "notesOnly": "Apenas notas",
       "style": "Estilo",
-      "source": "Origem",
-      "bulkTrash": "Mover para lixeira",
+      "source": "Fonte",
+      "bulkTrash": "Excluir para lixeira",
       "bulkRestore": "Restaurar",
       "tabs": {
         "highlights": "Destaques",
@@ -2315,37 +2469,37 @@
       },
       "empty": {
         "noMatch": "Nenhum destaque corresponde aos seus filtros.",
-        "resetFilters": "Redefinir filtros",
+        "resetFilters": "Restaurar filtros",
         "trashEmpty": "A lixeira está vazia",
-        "noAnnotations": "Nenhuma anotação ainda. Destaques que você cria na web ou no seu e-reader aparecerão aqui."
+        "noAnnotations": "Nenhuma anotação ainda. Os destaques criados na web ou em seu e-reader aparecerão aqui."
       },
       "toast": {
         "movedToTrash": "Movido para a lixeira",
         "annotationRestored": "Anotação restaurada",
         "annotationDeletedForever": "Anotação excluída permanentemente",
         "failedToDelete": "Falha ao excluir",
-        "bulkTrashed": "Nenhuma anotação movida para a lixeira | {count} anotação movida para a lixeira | {count} anotações movidas para a lixeira",
-        "bulkRestored": "Nenhuma anotação restaurada | {count} anotação restaurada | {count} anotações restauradas",
-        "bulkRecolored": "Nenhuma anotação recolorida | {count} anotação recolorida | {count} anotações recoloridas",
-        "bulkRestyled": "Nenhuma anotação reestilizada | {count} anotação reestilizada | {count} anotações reestilizadas"
+        "bulkTrashed": "Nenhuma anotação movida para a lixeira | Movida {count} anotação para a lixeira | Movidas {count} anotações para a lixeira",
+        "bulkRestored": "Nenhuma anotação restaurada | Restaurada {count} anotação | Restauradas {count} anotações",
+        "bulkRecolored": "Nenhuma anotação recolorida | Recolorida {count} anotação | Recoloridas {count} anotações",
+        "bulkRestyled": "Estilo não alterado | Alterado o estilo de {count} anotação | Alterado o estilo de {count} anotações"
       }
     }
   },
   "audit": {
-    "pageTitle": "Log de Auditoria",
-    "pageSubtitle": "Um registro de ações administrativas significativas realizadas em todo o sistema.",
+    "pageTitle": "Registro de Auditoria",
+    "pageSubtitle": "Um histórico das ações administrativas relevantes realizadas em todo o sistema.",
     "filters": "Filtros",
     "noActiveFilters": "Nenhum filtro ativo",
     "clear": "Limpar",
-    "empty": "Nenhum log de auditoria encontrado",
-    "showMore": "Mostrar mais",
-    "showLess": "Mostrar menos",
+    "empty": "Nenhum registro de auditoria encontrado",
+    "showMore": "Exibir mais",
+    "showLess": "Exibir menos",
     "details": "Detalhes",
     "hideDetails": "Ocultar detalhes",
     "detailAction": "Ação: {value}",
     "detailIp": "IP: {value}",
-    "showing": "Mostrando {from}-{to} de {total}",
-    "prev": "Ant",
+    "showing": "Exibindo {from}-{to} de {total}",
+    "prev": "Anterior",
     "chips": {
       "action": "Ação: {value}",
       "user": "Usuário: {value}",
@@ -2363,7 +2517,7 @@
       "userId": "ex: 1"
     },
     "columns": {
-      "when": "Quando",
+      "when": "Data/Hora",
       "user": "Usuário",
       "action": "Ação",
       "description": "Descrição",
@@ -2371,11 +2525,11 @@
     }
   },
   "auth": {
-    "backToSignIn": "Voltar para entrar",
+    "backToSignIn": "Voltar para o login",
     "themePicker": {
-      "switchToLight": "Mudar para claro",
-      "switchToDark": "Mudar para escuro",
-      "changeRadius": "Alterar raio do canto",
+      "switchToLight": "Mudar para modo claro",
+      "switchToDark": "Mudar para modo escuro",
+      "changeRadius": "Alterar arredondamento das bordas",
       "changeBackground": "Alterar fundo",
       "changeAccent": "Alterar cor de destaque"
     },
@@ -2389,10 +2543,10 @@
       "confirmPassword": "Confirmar senha",
       "confirmNewPassword": "Confirmar nova senha",
       "currentPassword": "Senha atual",
-      "passwordHint": "Mín. de 8 caracteres com maiúscula, minúscula e um dígito"
+      "passwordHint": "Mín. de 8 caracteres com maiúscula, minúscula e um número"
     },
     "errors": {
-      "generic": "Algo deu errado. Por favor, tente novamente.",
+      "generic": "Ocorreu um erro. Por favor, tente novamente.",
       "passwordsDoNotMatch": "As senhas não coincidem"
     },
     "login": {
@@ -2403,45 +2557,45 @@
       "forgotPassword": "Esqueceu a senha?",
       "errors": {
         "invalidCredentials": "Nome de usuário ou senha inválidos",
-        "tooManyAttempts": "Muitas tentativas de login. Aguarde um minuto e tente novamente."
+        "tooManyAttempts": "Muitas tentativas de login. Por favor, aguarde um minuto e tente novamente."
       }
     },
     "oidc": {
-      "loginFailed": "O login OIDC falhou",
+      "loginFailed": "Falha no login OIDC",
       "redirecting": "Redirecionando...",
       "signInWith": "Entrar com {provider}",
-      "completingSignIn": "Concluindo login...",
+      "completingSignIn": "Concluindo o login...",
       "tryAgain": "Tentar novamente",
       "errors": {
-        "stateExpired": "Sua sessão de login expirou. Tente fazer login novamente.",
-        "tokenExchangeFailed": "Não foi possível concluir o login com o seu provedor. Tente novamente ou contate seu administrador.",
-        "userNotProvisioned": "Sua conta não foi configurada. Contate seu administrador para acesso.",
-        "userInactive": "Sua conta foi desativada. Contate seu administrador.",
-        "providerError": "Seu provedor de identidade retornou um erro. Tente novamente.",
-        "missingCodeOrState": "Falta parâmetro de código ou estado"
+        "stateExpired": "Sua sessão de login expirou. Por favor, tente entrar novamente.",
+        "tokenExchangeFailed": "Não foi possível concluir o login com seu provedor. Tente novamente ou entre em contato com um administrador.",
+        "userNotProvisioned": "Sua conta não foi configurada. Entre em contato com um administrador para obter acesso.",
+        "userInactive": "Sua conta foi desativada. Entre em contato com o seu administrador.",
+        "providerError": "Seu provedor de identidade retornou um erro. Por favor, tente novamente.",
+        "missingCodeOrState": "Código ou parâmetro de estado ausente"
       },
       "providerErrors": {
         "accessDenied": "O acesso foi negado pelo provedor de identidade.",
-        "loginRequired": "A autenticação é necessária. Por favor, faça login novamente.",
+        "loginRequired": "Autenticação é necessária. Por favor, faça login novamente.",
         "interactionRequired": "Interação adicional do usuário é necessária."
       }
     },
     "forgotPassword": {
-      "subtitle": "Redefinir sua senha",
+      "subtitle": "Redefina sua senha",
       "submitted": "Se uma conta com este e-mail existir, um link de redefinição foi enviado. Verifique sua caixa de entrada.",
       "sending": "Enviando...",
       "sendResetLink": "Enviar link de redefinição",
       "errors": {
-        "emailUnavailable": "A redefinição de senha por e-mail não está disponível. Contate seu administrador."
+        "emailUnavailable": "A redefinição de senha por e-mail não está disponível. Entre em contato com seu administrador."
       }
     },
     "resetPassword": {
-      "subtitle": "Definir uma nova senha",
+      "subtitle": "Crie uma nova senha",
       "saving": "Salvando...",
       "setNewPassword": "Definir nova senha",
       "errors": {
-        "invalidLink": "Link de redefinição inválido. Solicite um novo.",
-        "invalidOrExpired": "Link de redefinição inválido ou expirado. Solicite um novo."
+        "invalidLink": "Link de redefinição inválido. Por favor, solicite um novo.",
+        "invalidOrExpired": "Link de redefinição inválido ou expirado. Por favor, solicite um novo."
       }
     },
     "setup": {
@@ -2458,14 +2612,14 @@
     "changePassword": {
       "title": "Alterar senha",
       "saving": "Salvando…",
-      "forcedNotice": "Você deve definir uma nova senha antes de continuar.",
+      "forcedNotice": "Você precisa definir uma nova senha antes de continuar.",
       "errors": {
-        "failed": "Falha ao alterar senha"
+        "failed": "Falha ao alterar a senha"
       }
     },
     "magicLink": {
-      "signingIn": "Entrando...",
-      "loginFailed": "Login falhou",
+      "signingIn": "Conectando você...",
+      "loginFailed": "Falha no login",
       "goToLogin": "Ir para o login",
       "errors": {
         "noToken": "Nenhum token fornecido"
@@ -2484,13 +2638,13 @@
       "portraitAlt": "Retrato de {name}"
     },
     "filters": {
-      "title": "Filtros de Autor",
+      "title": "Filtros de Autores",
       "clearAll": "Limpar tudo",
       "allLibraries": "Todas as Bibliotecas",
       "allAuthors": "Todos os autores",
-      "hasPhoto": "Tem foto",
-      "missingPhoto": "Falta foto",
-      "minBooks": "Mín. de livros",
+      "hasPhoto": "Com foto",
+      "missingPhoto": "Sem foto",
+      "minBooks": "Mínimo de livros",
       "anyPlaceholder": "Qualquer"
     },
     "header": {
@@ -2502,42 +2656,43 @@
       "refreshing": "Atualizando...",
       "refreshMetadata": "Atualizar Metadados",
       "deleteAuthor": "Excluir Autor",
-      "showLess": "Mostrar menos",
-      "showMore": "Mostrar mais",
-      "lookingUpMetadata": "Procurando metadados do autor...",
+      "showLess": "Exibir menos",
+      "showMore": "Exibir mais",
+      "lookingUpMetadata": "Buscando metadados do autor...",
       "noBiography": "Nenhuma biografia disponível. Use o menu para atualizar os metadados.",
       "previewFrom": "Pré-visualização do {provider}. Salve os metadados para mantê-los.",
       "booksLabel": "Livros",
-      "lastAdded": "Último Adicionado"
+      "lastAdded": "Adicionado por Último"
     },
     "list": {
       "title": "Autores",
-      "searchPlaceholder": "Pesquisar autores",
+      "showControlsAria": "Exibir controles de autor",
+      "searchPlaceholder": "Buscar autores",
       "sortButton": "Ordenar",
       "sortBy": "Ordenar por",
       "ascending": "Crescente",
       "descending": "Decrescente",
-      "asc": "Cres",
-      "desc": "Decr",
+      "asc": "Cresc",
+      "desc": "Decresc",
       "filters": "Filtros",
       "clear": "Limpar",
       "allLoaded": "Todos os {total} autores carregados",
       "sort": {
         "name": "Nome",
-        "sortName": "Nome de Classificação",
-        "bookCount": "Contagem de Livros",
-        "recentAdditions": "Adições Recentes",
-        "lastEnriched": "Último Enriquecido"
+        "sortName": "Nome de Ordenação",
+        "bookCount": "Quantidade de Livros",
+        "recentAdditions": "Adicionados Recentemente",
+        "lastEnriched": "Último Enriquecimento"
       },
       "empty": {
         "title": "Nenhum autor encontrado",
-        "hint": "Tente alterar o texto de pesquisa, ordenação ou filtro de biblioteca."
+        "hint": "Tente alterar o texto de busca, ordenação ou filtro de biblioteca."
       },
       "deleteDialog": {
         "titleOne": "Excluir autor?",
         "titleMany": "Excluir {count} autores?",
-        "descriptionOne": "Isto remove o autor do catálogo e o desvincula dos livros associados. Esta ação não pode ser desfeita.",
-        "descriptionMany": "Isto remove os autores selecionados do catálogo e os desvincula dos livros associados. Esta ação não pode ser desfeita."
+        "descriptionOne": "Isso remove o autor do catálogo e desvincula os livros associados a ele. Esta ação não pode ser desfeita.",
+        "descriptionMany": "Isso remove os autores selecionados do catálogo e desvincula os livros associados a eles. Esta ação não pode ser desfeita."
       },
       "selection": {
         "selectVisible": "Selecionar visíveis",
@@ -2550,12 +2705,12 @@
       },
       "toast": {
         "refreshed": "Metadados do autor atualizados",
-        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem de autor foi encontrada.",
+        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem do autor foi encontrada.",
         "refreshFailed": "Falha ao atualizar metadados do autor",
-        "bulkRefreshPartial": "Atualizado(s) {updated} autor(es), {failed} falharam",
+        "bulkRefreshPartial": "Atualizado(s) {updated} autor(es), {failed} falhou(aram)",
         "bulkRefreshSuccess": "Metadados atualizados para {updated} autor(es)",
-        "bulkRefreshFailed": "Falha ao atualizar autores selecionados",
-        "deleteSuccess": "Excluiu {count} autor; afetou {books} livros | Excluiu {count} autor; afetou {books} livros | Excluiu {count} autores; afetou {books} livros",
+        "bulkRefreshFailed": "Falha ao atualizar os autores selecionados",
+        "deleteSuccess": "Excluído {count} autor; {books} livros afetados | Excluído {count} autor; {books} livros afetados | Excluídos {count} autores; {books} livros afetados",
         "deleteFailed": "Falha ao excluir autor(es)"
       }
     },
@@ -2565,10 +2720,10 @@
       "pageTitleId": "Autor #{id}",
       "entityName": "Autor",
       "loadingAuthor": "Carregando autor...",
-      "previewError": "Não foi possível carregar a pré-visualização externa do autor no momento.",
+      "previewError": "Não foi possível carregar a pré-visualização dos metadados externos do autor no momento.",
       "edit": {
         "name": "Nome",
-        "sortName": "Nome de Classificação",
+        "sortName": "Nome de Ordenação",
         "description": "Descrição",
         "image": "Imagem",
         "uploading": "Enviando...",
@@ -2576,12 +2731,12 @@
         "uploadImage": "Enviar imagem",
         "removing": "Removendo...",
         "removeImage": "Remover imagem",
-        "imageHint": "PNG/JPEG/WEBP/GIF/BMP até {size} MB",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP de até {size} MB",
         "saving": "Salvando..."
       },
       "merge": {
-        "searchPlaceholder": "Pesquise autores para mesclar neste autor",
-        "searching": "Pesquisando...",
+        "searchPlaceholder": "Busque autores para mesclar a este autor",
+        "searching": "Buscando...",
         "bookCount": "nenhum livro | {count} livro | {count} livros",
         "selectedSummary": "Selecionado(s) {count} autor(es), aprox. {books} livros afetados.",
         "merging": "Mesclando...",
@@ -2589,60 +2744,65 @@
         "confirmLabel": "Mesclar"
       },
       "mergeDialog": {
-        "title": "Mesclar {count} autor(es) em \"{name}\"?",
+        "title": "Mesclar {count} autor(es) com \"{name}\"?",
         "titleFallback": "Mesclar autores selecionados?",
-        "description": "Isso mesclará os autores selecionados no autor atual e revinculará os livros associados. Essa ação não pode ser desfeita.",
-        "descriptionEmpty": "Essa ação não pode ser desfeita."
+        "description": "Isso mesclará os autores selecionados com o autor atual e revinculará os livros associados. Esta ação não pode ser desfeita.",
+        "descriptionEmpty": "Esta ação não pode ser desfeita."
       },
       "deleteDialog": {
         "title": "Excluir autor?",
-        "description": "Isto remove o autor do catálogo e o desvincula dos livros associados. Esta ação não pode ser desfeita."
+        "description": "Isso remove o autor do catálogo e desvincula os livros associados a ele. Esta ação não pode ser desfeita."
       },
       "books": {
         "heading": "Livros",
         "allLibraries": "Todas as Bibliotecas",
-        "asc": "Cres",
-        "desc": "Decr",
+        "asc": "Cresc",
+        "desc": "Decresc",
         "ascending": "Crescente",
         "descending": "Decrescente",
         "allLoaded": "Todos os {total} livros carregados",
         "sort": {
-          "recentlyAdded": "Adicionado Recentemente",
+          "recentlyAdded": "Adicionados Recentemente",
           "title": "Título",
           "publishedYear": "Ano de Publicação"
         },
         "empty": {
           "title": "Nenhum livro encontrado para este autor",
-          "hint": "Tente alterar a ordenação ou selecionar outra biblioteca."
+          "hint": "Tente alterar a ordenação/ordem ou selecionar outra biblioteca."
         }
       },
       "toast": {
         "refreshed": "Metadados do autor atualizados",
-        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem de autor foi encontrada.",
+        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem do autor foi encontrada.",
         "refreshFailed": "Falha ao atualizar metadados do autor",
         "nameRequired": "O nome do autor é obrigatório",
         "updated": "Autor atualizado",
         "updateFailed": "Falha ao atualizar autor",
         "imageUpdated": "Imagem do autor atualizada",
-        "imageUploadFailed": "Falha ao enviar imagem do autor",
+        "imageUploadFailed": "Falha ao enviar a imagem do autor",
         "imageRemoved": "Imagem do autor removida",
-        "imageRemoveFailed": "Falha ao remover imagem do autor",
-        "mergeSuccess": "Mesclado(s) {count} autor(es); afetou {books} livros",
+        "imageRemoveFailed": "Falha ao remover a imagem do autor",
+        "mergeSuccess": "Mesclado(s) {count} autor(es); {books} livros afetados",
         "mergeFailed": "Falha ao mesclar autores",
-        "deleteSuccess": "Autor excluído; afetou {books} livros",
-        "deleteFailed": "Falha ao excluir autor"
+        "deleteSuccess": "Autor excluído; {books} livros afetados",
+        "deleteFailed": "Falha ao excluir o autor"
       }
     }
   },
   "book": {
     "untitled": "Sem título",
     "unknownFormat": "desconhecido",
+    "collapsedSeries": {
+      "label": "Série",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "readCount": "{count} lido(s)"
+    },
     "card": {
       "missing": "Ausente"
     },
     "file": {
-      "primary": "Principal",
-      "audiobook": "Audiobook"
+      "primary": "Primário",
+      "audiobook": "Audiolivro"
     },
     "actions": {
       "read": "Ler",
@@ -2655,7 +2815,7 @@
       "metadata": "Metadados",
       "editMetadata": "Editar Metadados",
       "refreshMetadata": "Atualizar Metadados",
-      "regenerateCover": "Regerar Capa",
+      "regenerateCover": "Gerar Capa Novamente",
       "addToCollection": "Adicionar à Coleção",
       "setStatus": "Definir Status",
       "sendViaEmail": "Enviar por E-mail",
@@ -2663,7 +2823,7 @@
       "openAs": "Abrir como {format}"
     },
     "readStatus": {
-      "unread": "Não lido",
+      "unread": "Não Lido",
       "wantToRead": "Quero Ler",
       "reading": "Lendo",
       "onHold": "Pausado",
@@ -2674,9 +2834,9 @@
     },
     "download": {
       "action": "Baixar",
-      "audiobookZip": "Audiobook (ZIP)",
+      "audiobookZip": "Audiolivro (ZIP)",
       "allFormatsZip": "Todos os formatos (ZIP)",
-      "primaryOnlyZip": "Apenas principal (ZIP)"
+      "primaryOnlyZip": "Apenas primário (ZIP)"
     },
     "sort": {
       "moveUp": "Mover para cima",
@@ -2684,11 +2844,11 @@
       "ascending": "Crescente",
       "descending": "Decrescente",
       "remove": "Remover",
-      "emptyState": "Nenhuma ordenação configurada. Título ascendente será usado.",
+      "emptyState": "Nenhuma ordenação configurada. Ordem alfabética por título (crescente) será utilizada.",
       "addLevel": "Adicionar nível de ordenação"
     },
     "filter": {
-      "match": "Corresponder a",
+      "match": "Corresponder",
       "all": "TODAS",
       "any": "QUALQUER",
       "ofFollowingRules": "das seguintes regras",
@@ -2705,10 +2865,10 @@
         "months": "meses"
       },
       "scorePreset": {
-        "outstanding": "Excelente",
+        "outstanding": "Excepcional",
         "good": "Bom",
         "fair": "Razoável",
-        "poor": "Pobre"
+        "poor": "Ruim"
       },
       "scoreRangePlaceholder": "0-100",
       "valuePlaceholder": "valor",
@@ -2717,19 +2877,19 @@
       "group": "Grupo",
       "addRule": "Adicionar regra",
       "addGroup": "Adicionar grupo",
-      "typeToSearch": "Digite para pesquisar..."
+      "typeToSearch": "Digite para buscar..."
     },
     "deleteDialog": {
       "title": "Excluir livro?",
-      "description": "Isso excluirá permanentemente o livro e todos os seus metadados, arquivos, progresso de leitura e favoritos. Isso não pode ser desfeito."
+      "description": "Isso excluirá permanentemente o livro e todos os seus metadados, arquivos, progresso de leitura e marcadores. Isso não pode ser desfeito."
     },
     "bulkEdit": {
       "title": "Editar metadados - {count} livro | Editar metadados - {count} livro | Editar metadados - {count} livros",
-      "instructions": "Alterne os campos para editar e, em seguida, defina os valores. Apenas os campos alternados serão alterados.",
-      "invalidYear": "Insira um ano válido (apenas números)",
-      "clearWarning": "Isso removerá todos {field} dos livros selecionados.",
-      "searchPlaceholder": "Pesquisar {field}...",
-      "enterPlaceholder": "Inserir {field}",
+      "instructions": "Alterne os campos para editar e, em seguida, configure os valores. Apenas os campos ativados serão alterados.",
+      "invalidYear": "Digite um ano válido (apenas números)",
+      "clearWarning": "Isso removerá todo o campo {field} dos livros selecionados.",
+      "searchPlaceholder": "Buscar {field}...",
+      "enterPlaceholder": "Digite {field}",
       "yearPlaceholder": "ex: 2024",
       "leaveEmptyHint": "Deixe vazio para limpar este campo em todos os livros selecionados.",
       "applying": "Aplicando...",
@@ -2745,11 +2905,11 @@
       "title": "Exportar Metadados",
       "scope": "Escopo",
       "selectedRows": "Linhas selecionadas",
-      "currentlySelected": "{count} selecionados no momento",
+      "currentlySelected": "{count} atualmente selecionada(s)",
       "allMatchingRows": "Todas as linhas correspondentes",
       "rowsInResult": "{count} linhas no resultado atual",
       "format": "Formato",
-      "csvDescription": "Pronto para planilha, inclui UTF-8 BOM",
+      "csvDescription": "Ideal para planilhas, inclui BOM UTF-8",
       "jsonDescription": "Exportação estruturada com contexto de metadados",
       "columns": "Colunas",
       "canonicalSchema": "Esquema canônico estável",
@@ -2758,7 +2918,7 @@
       "includePersonalData": "Incluir dados pessoais de leitura",
       "includeFilePaths": "Incluir caminhos de arquivo (avançado)",
       "includeContextMeta": "Incluir metadados de contexto",
-      "preflight": "Pré-verificação",
+      "preflight": "Verificações Prévias",
       "scopeLabel": "Escopo: {summary}",
       "calculatingSize": "Calculando tamanho da exportação...",
       "estimatedSize": "Tamanho estimado:",
@@ -2768,7 +2928,7 @@
       "matchingRowsSummary": "{count} linha correspondente | {count} linha correspondente | {count} linhas correspondentes",
       "prepareFailed": "Falha ao preparar exportação",
       "exportStarted": "Exportação de metadados iniciada: {fileName}",
-      "exportFailed": "A exportação de metadados falhou"
+      "exportFailed": "Falha na exportação de metadados"
     },
     "columnPanel": {
       "columnsHeading": "Colunas",
@@ -2780,14 +2940,14 @@
         "roomy": "Espaçosa"
       },
       "presets": "Predefinições",
-      "exportBackup": "Exportar predefinições e visualizações",
-      "importBackup": "Importar predefinições e visualizações",
+      "exportBackup": "Exportar predefinições e visualizações salvas",
+      "importBackup": "Importar predefinições e visualizações salvas",
       "rename": "Renomear",
       "renamePrompt": "Insira um novo nome",
-      "builtIn": "Integrado",
+      "builtIn": "Embutido",
       "saveCurrentPreset": "Salvar predefinição atual",
       "savedViews": "Visualizações salvas",
-      "savedViewsEmpty": "Salve ordenação, layout e filtros específicos de visualização para reutilização rápida.",
+      "savedViewsEmpty": "Salve ordenação, layout e filtros específicos da visualização para reutilização rápida.",
       "saveCurrentView": "Salvar visualização atual",
       "pinnedLeft": "Fixado à esquerda",
       "pinnedRight": "Fixado à direita",
@@ -2801,8 +2961,8 @@
       "title": "Atalhos de Teclado",
       "navigation": {
         "title": "Navegação",
-        "moveFocusVertical": "Mover o foco para cima/baixo",
-        "moveFocusHorizontal": "Mover o foco para esquerda/direita",
+        "moveFocusVertical": "Mover foco para cima/baixo",
+        "moveFocusHorizontal": "Mover foco para esquerda/direita",
         "jumpFirstColumn": "Pular para a primeira coluna",
         "jumpLastColumn": "Pular para a última coluna",
         "jumpFirstRow": "Pular para a primeira linha",
@@ -2810,11 +2970,11 @@
       },
       "actions": {
         "title": "Ações",
-        "editCell": "Editar a célula focada",
+        "editCell": "Editar célula em foco",
         "cancelEditing": "Cancelar edição / Fechar sobreposição",
         "toggleRowSelection": "Alternar seleção de linha",
         "copyCell": "Copiar valor da célula",
-        "copyRow": "Copiar linha focada"
+        "copyRow": "Copiar linha em foco"
       },
       "general": {
         "title": "Geral",
@@ -2826,39 +2986,39 @@
       "jumpTo": "Pular para {label}"
     },
     "quickView": {
-      "title": "Visualização rápida de livro",
+      "title": "Visualização rápida do livro",
       "titleFor": "Visualização rápida de {title}",
-      "description": "Visualize detalhes do livro e execute ações rápidas.",
+      "description": "Pré-visualize detalhes do livro e execute ações rápidas.",
       "openIn": "Abrir em {provider}",
       "pages": "{count} página | {count} página | {count} páginas",
-      "primaryFile": "Arquivo Principal",
+      "primaryFile": "Arquivo Primário",
       "fileNumber": "Arquivo #{id}",
       "showLess": "Mostrar menos",
       "showMore": "Mostrar mais",
       "collections": "Coleções",
       "noDescription": "Nenhuma descrição disponível.",
       "openMetadataEditor": "Abrir editor de metadados",
-      "coverPreview": "Pré-visualização da capa",
+      "coverPreview": "Pré-visualização da capa do livro",
       "coverPreviewFor": "Pré-visualização da capa de {title}",
-      "coverPreviewDescription": "Caixa de diálogo de visualização da imagem da capa ampliada."
+      "coverPreviewDescription": "Caixa de diálogo com pré-visualização ampliada da imagem da capa."
     },
     "tableView": {
       "openBookDetails": "Abrir detalhes do livro",
       "openSeries": "Abrir série",
-      "metadataRefreshFailed": "Falha ao atualizar metadados",
+      "metadataRefreshFailed": "Falha na atualização de metadados",
       "booksSelected": "{count} livro selecionado | {count} livro selecionado | {count} livros selecionados",
       "loadingMoreBooks": "Carregando mais livros",
       "sort": "Ordenar",
       "refreshingMetadata": "Atualizando metadados {processed} / {total}",
       "failedCount": "{count} falhou",
-      "remainingCount": "{count} restantes",
+      "remainingCount": "{count} restante(s)",
       "readOnlyNotice": "A edição da tabela está desativada em telas menores. Mude para lista ou grade para ações mais rápidas.",
       "fetching": "Buscando...",
       "updated": "Atualizado",
       "failed": "Falhou",
-      "noBooks": "Nenhum livro para mostrar",
+      "noBooks": "Nenhum livro para exibir",
       "scrollToTop": "Rolar para o topo",
-      "selectedStatus": "{count} selecionados",
+      "selectedStatus": "{count} selecionado(s)",
       "filtered": "Filtrado",
       "loadedStatus": "{loaded} de {total} carregados",
       "bookCount": "{count} livro | {count} livro | {count} livros",
@@ -2884,7 +3044,7 @@
       },
       "discover": {
         "moreInSeries": "Mais na Série",
-        "byAuthor": "Por Autor",
+        "byAuthor": "Pelo Autor",
         "similarBooks": "Livros Semelhantes"
       },
       "recommended": {
@@ -2895,24 +3055,24 @@
         "moreInSeriesSuffix": ""
       },
       "writeRename": {
-        "written": "nenhum campo gravado | Gravado (um campo) | Gravado ({count} campos)",
+        "written": "nenhum campo gravado | Gravado (um campo) | Gravados ({count} campos)",
         "writeFailed": "Falha na gravação",
         "skipped": "Ignorado",
         "renamedTo": "Renomeado para {name}",
         "fileRenamed": "Arquivo renomeado",
         "renameFailed": "Falha ao renomear",
-        "autoWriteAndRenameDisabled": "As gravações e renomeações automáticas estão desativadas nas configurações da biblioteca. As alterações não serão sincronizadas automaticamente em salvamentos futuros.",
-        "autoWriteDisabled": "A gravação automática está desativada nas configurações da biblioteca. As alterações não serão sincronizadas automaticamente em salvamentos futuros.",
-        "autoRenameDisabled": "A renomeação automática está desativada nas configurações da biblioteca. As alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "autoWriteAndRenameDisabled": "Gravação e renomeação automáticas estão desativadas nas configurações da biblioteca. Alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "autoWriteDisabled": "A gravação automática está desativada nas configurações da biblioteca. Alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "autoRenameDisabled": "A renomeação automática está desativada nas configurações da biblioteca. Alterações não serão sincronizadas automaticamente em salvamentos futuros.",
         "writeLabel": "Gravar:",
         "renameLabel": "Renomear:"
       },
       "addFile": {
         "uploading": "Enviando...",
-        "uploadComplete": "Envio concluído",
+        "uploadComplete": "Upload concluído",
         "title": "Adicionar Arquivo",
         "dropzone": {
-          "title": "Solte os arquivos aqui ou clique para procurar",
+          "title": "Arraste arquivos aqui ou clique para procurar",
           "hint": "epub, pdf, mobi, cbz, m4b e mais - até {size} MB cada"
         },
         "addMore": "Adicionar mais arquivos",
@@ -2923,9 +3083,9 @@
         "filesAdded": "nenhum arquivo adicionado | um arquivo adicionado | {count} arquivos adicionados",
         "uploadedFailed": "{done} enviados, {failed} falharam",
         "uploadingProgress": "{done} de {total} enviando...",
-        "renameAfter": "Renomear todos os arquivos de livros após o upload",
-        "uploadCount": "Upload ({count})",
-        "upload": "Upload"
+        "renameAfter": "Renomear todos os arquivos do livro após o upload",
+        "uploadCount": "Enviar ({count})",
+        "upload": "Enviar"
       },
       "addSession": {
         "errors": {
@@ -2935,12 +3095,12 @@
           "endProgress": "O progresso final deve ser entre 0 e 100."
         },
         "title": "Adicionar sessão de leitura",
-        "startedAt": "Iniciada em",
+        "startedAt": "Iniciado em",
         "duration": "Duração (minutos)",
         "endProgress": "Progresso final %",
         "optional": "Opcional",
         "format": "Formato",
-        "noFormat": "Nenhum formato específico",
+        "noFormat": "Sem formato específico",
         "saving": "Salvando...",
         "submit": "Adicionar sessão"
       },
@@ -2954,23 +3114,23 @@
         "saving": "Salvando...",
         "saveCover": "Salvar capa",
         "revertToOriginal": "Reverter para o original",
-        "regenerateCover": "Regerar Capa"
+        "regenerateCover": "Gerar Capa Novamente"
       },
       "coverSearch": {
-        "title": "Pesquisa Online",
-        "subtitle": "Procurar capas de livros",
+        "title": "Busca Online",
+        "subtitle": "Buscar capas de livros",
         "titleField": "Título",
         "authorField": "Autor",
-        "sourceField": "Origem",
+        "sourceField": "Fonte",
         "allSources": "Todas as Fontes",
-        "audiobookCovers": "Capas de audiobooks",
-        "squareHint": "(quadrado)",
-        "searching": "Pesquisando...",
+        "audiobookCovers": "Capas de audiolivros",
+        "squareHint": "(quadrada)",
+        "searching": "Buscando...",
         "findCovers": "Encontrar capas",
         "selectCover": "Selecionar Capa",
         "noResultsTitle": "Nenhum resultado encontrado",
-        "noResultsHint": "Tente ajustar seus termos de pesquisa",
-        "readyTitle": "Pronto para pesquisar",
+        "noResultsHint": "Tente ajustar seus termos de busca",
+        "readyTitle": "Pronto para buscar",
         "readyHint": "Insira um título e autor acima",
         "resolutionTip": "Dica: Capas de alta resolução estão marcadas em verde"
       },
@@ -2981,20 +3141,28 @@
         "rateStar": "Avaliar {star}",
         "listen": "Ouvir",
         "read": "Ler",
-        "chooseFormat": "Escolha o formato",
-        "audiobook": "Audiobook",
-        "primary": "Principal",
+        "chooseFormat": "Escolher formato",
+        "audiobook": "Audiolivro",
+        "primary": "Primário",
         "peek": "Espiar",
         "sendViaEmail": "Enviar por E-mail",
+        "personalReview": {
+          "title": "Revisão Pessoal",
+          "toggleAria": "Alternar revisão pessoal",
+          "editAria": "Editar revisão pessoal",
+          "placeholder": "Revisão privada",
+          "clearAria": "Limpar revisão pessoal",
+          "cancelEditAria": "Cancelar edição da revisão pessoal"
+        },
         "editCover": "Editar capa",
         "finished": "Concluído",
-        "resetFileProgress": "Redefinir o progresso do arquivo",
+        "resetFileProgress": "Redefinir progresso do arquivo",
         "resetting": "Redefinindo...",
-        "resetProgressConfirm": "Redefinir o progresso de leitura armazenado para {label}?",
+        "resetProgressConfirm": "Redefinir progresso de leitura armazenado para {label}?",
         "moreCount": "+{count} mais",
         "untitled": "Sem título",
         "metadataScore": "Pontuação de Metadados",
-        "primaryFormat": "Formato principal",
+        "primaryFormat": "Formato primário",
         "openIn": "Abrir em {provider}",
         "showLess": "Mostrar menos",
         "showMore": "Mostrar mais",
@@ -3005,7 +3173,7 @@
         "duration": "Duração",
         "edition": "Edição",
         "abridged": "Resumido",
-        "unabridged": "Não resumido",
+        "unabridged": "Integral",
         "isbn": "ISBN",
         "fileSize": "Tamanho do Arquivo",
         "library": "Biblioteca",
@@ -3014,58 +3182,58 @@
         "saving": "Salvando...",
         "cancelDateStartedEdit": "Cancelar edição da data de início",
         "editDateStarted": "Editar data de início",
-        "dateFinished": "Data de Conclusão",
-        "cancelDateFinishedEdit": "Cancelar edição da data de conclusão",
-        "editDateFinished": "Editar data de conclusão",
+        "dateFinished": "Data de Término",
+        "cancelDateFinishedEdit": "Cancelar edição da data de término",
+        "editDateFinished": "Editar data de término",
         "customMetadata": "Metadados Personalizados",
         "synopsis": "Sinopse",
         "noDescription": "Nenhuma descrição disponível.",
         "dateStartedFutureError": "A Data de Início não pode ser no futuro.",
-        "dateFinishedFutureError": "A Data de Conclusão não pode ser no futuro.",
-        "dateFinishedBeforeStartedError": "A Data de Conclusão deve ser igual ou posterior à Data de Início.",
-        "saveReadingDatesError": "Falha ao salvar as datas de leitura.",
-        "koboPendingDelete": "Exclusão pendente do dispositivo",
+        "dateFinishedFutureError": "A Data de Término não pode ser no futuro.",
+        "dateFinishedBeforeStartedError": "A Data de Término deve ser igual ou posterior à Data de Início.",
+        "saveReadingDatesError": "Falha ao salvar datas de leitura.",
+        "koboPendingDelete": "Exclusão pendente no dispositivo",
         "koboPendingDeleteTooltip": "O Kobo o removerá na próxima sincronização.",
         "koboRemovedByDevice": "Removido pelo dispositivo",
-        "koboRemovedByDeviceTooltip": "O Kobo relatou este livro como removido.",
+        "koboRemovedByDeviceTooltip": "O Kobo informou que este livro foi removido.",
         "koboNotSynced": "Não sincronizado",
         "koboNotSyncedTooltip": "Na fila para a próxima sincronização do Kobo.",
         "filesNotFound": "Arquivos não encontrados",
-        "filesNotFoundDescription": "O(s) arquivo(s) deste livro não pode(m) mais ser encontrado(s) no disco. Os metadados ainda estão disponíveis. Execute uma verificação da biblioteca para confirmar ou remova o registro."
+        "filesNotFoundDescription": "O(s) arquivo(s) deste livro não podem mais ser encontrados no disco. Os metadados ainda estão disponíveis. Execute um escaneamento da biblioteca para confirmar, ou remova o registro."
       },
       "editMetadata": {
         "fieldCount": "nenhum campo | um campo | {count} campos",
         "bookFilesTarget": "arquivos do livro",
         "formatFilesTarget": "arquivos {formats}",
-        "noPrimaryFile": "Nenhum arquivo principal disponível",
-        "formatNotSupported": "Este formato de arquivo não suporta gravação",
-        "formatDisabled": "A gravação está desativada para este formato",
-        "fileExceedsSizeLimit": "Este arquivo excede o limite de tamanho para gravação",
+        "noPrimaryFile": "Nenhum arquivo primário disponível",
+        "formatNotSupported": "Este formato de arquivo não suporta regravação",
+        "formatDisabled": "A regravação está desativada para este formato",
+        "fileExceedsSizeLimit": "Este arquivo excede o limite de tamanho de regravação",
         "writing": "Gravando...",
         "saveInProgress": "Salvamento em andamento",
-        "writeManualLibraryDisabled": "Gravar metadados no arquivo e renomear no disco; a gravação automática está desativada para esta biblioteca",
+        "writeManualLibraryDisabled": "Gravar metadados no arquivo e renomear no disco; a regravação automática está desativada para esta biblioteca",
         "writeManualTooltip": "Gravar {fields} em {target} e renomear no disco",
         "applyResult": "{skipped}, {updated}",
-        "skippedLockedFields": "Ignorou nenhum campo bloqueado | Ignorou um campo bloqueado | Ignorou {count} campos bloqueados",
-        "updatedFields": "atualizou nenhum campo | atualizou um campo | atualizou {count} campos",
-        "wroteFieldsToFile": "Gravou {fields} no arquivo",
-        "fileWriteFailedReason": "Falha ao gravar arquivo: {reason}",
-        "fileWriteFailed": "Falha ao gravar arquivo",
-        "fileWriteSkippedReason": "Gravação de arquivo ignorada: {reason}",
-        "fileWriteSkipped": "Gravação de arquivo ignorada",
+        "skippedLockedFields": "Nenhum campo bloqueado ignorado | Ignorado um campo bloqueado | Ignorados {count} campos bloqueados",
+        "updatedFields": "nenhum campo atualizado | um campo atualizado | {count} campos atualizados",
+        "wroteFieldsToFile": "Gravados {fields} no arquivo",
+        "fileWriteFailedReason": "Falha na gravação do arquivo: {reason}",
+        "fileWriteFailed": "Falha na gravação do arquivo",
+        "fileWriteSkippedReason": "Gravação do arquivo ignorada: {reason}",
+        "fileWriteSkipped": "Gravação do arquivo ignorada",
         "metadataSaved": "Metadados salvos",
         "metadataWrittenToFile": "Metadados gravados no arquivo",
-        "savedButWriteFailedReason": "Metadados salvos, mas a gravação no arquivo falhou: {reason}",
-        "savedButWriteFailed": "Metadados salvos, mas a gravação no arquivo falhou",
-        "savedWriteSkippedReason": "Metadados salvos, gravação no arquivo ignorada: {reason}",
-        "savedWriteSkipped": "Metadados salvos, gravação no arquivo ignorada",
+        "savedButWriteFailedReason": "Metadados salvos, mas a gravação do arquivo falhou: {reason}",
+        "savedButWriteFailed": "Metadados salvos, mas a gravação do arquivo falhou",
+        "savedWriteSkippedReason": "Metadados salvos, gravação do arquivo ignorada: {reason}",
+        "savedWriteSkipped": "Metadados salvos, gravação do arquivo ignorada",
         "loadFromFileFailed": "Falha ao carregar metadados do arquivo",
-        "loadedFieldsFromFile": "Carregou nenhum campo do arquivo | Carregou um campo do arquivo | Carregou {count} campos do arquivo",
+        "loadedFieldsFromFile": "Nenhum campo carregado do arquivo | Um campo carregado do arquivo | {count} campos carregados do arquivo",
         "noMetadataInFile": "Nenhum metadado encontrado no arquivo",
         "loadFromFile": "Carregar do arquivo",
-        "loadFromFileTooltip": "Carregar metadados do arquivo principal do livro",
+        "loadFromFileTooltip": "Carregar metadados do arquivo primário do livro",
         "writeToFile": "Gravar no arquivo",
-        "autoFill": "Preencher automaticamente",
+        "autoFill": "Preenchimento automático",
         "fetchingMetadata": "Buscando metadados...",
         "allFieldsLocked": "Todos os campos estão bloqueados",
         "autoFillTooltip": "Preencher campos automaticamente usando suas preferências de metadados",
@@ -3074,12 +3242,12 @@
         "unlockAll": "Desbloquear tudo",
         "unlockAllTooltip": "Desbloquear todos os campos",
         "saving": "Salvando...",
-        "fileWriteBackDetails": "Detalhes de gravação no arquivo",
-        "fileWriteBack": "Gravação de arquivo",
+        "fileWriteBackDetails": "Detalhes de regravação do arquivo",
+        "fileWriteBack": "Regravação de arquivo",
         "enabled": "Ativado",
-        "saveWritesMetadata": "'Salvar' grava os metadados em {target}",
+        "saveWritesMetadata": "'Salvar' grava metadados em {target}",
         "formats": "Formatos",
-        "bookFiles": "Arquivos de livro",
+        "bookFiles": "Arquivos do livro",
         "supportedFields": "Campos suportados",
         "titleLabel": "Título",
         "subtitleLabel": "Subtítulo",
@@ -3091,7 +3259,7 @@
         "rateStar": "Avaliar {star}",
         "clear": "Limpar",
         "communityRatingsLabel": "Avaliações da Comunidade",
-        "noProviderRatings": "Nenhuma avaliação de provedor",
+        "noProviderRatings": "Sem avaliações de provedores",
         "seriesLabel": "Série",
         "publisherLabel": "Editora",
         "languageLabel": "Idioma",
@@ -3101,7 +3269,7 @@
         "isbn10Label": "ISBN-10",
         "durationLabel": "Duração (s)",
         "abridgedLabel": "Resumido",
-        "providerIds": "IDs de Provedores",
+        "providerIds": "IDs do Provedor",
         "comicDetails": "Detalhes do Quadrinho",
         "comicIssueNumberLabel": "Número da Edição",
         "comicVolumeLabel": "Volume",
@@ -3109,8 +3277,8 @@
         "comicPencillersLabel": "Desenhistas",
         "comicInkersLabel": "Arte-finalistas",
         "comicColoristsLabel": "Coloristas",
-        "comicLetterersLabel": "Letreiristas",
-        "comicCoverArtistsLabel": "Artistas da Capa",
+        "comicLetterersLabel": "Letristas",
+        "comicCoverArtistsLabel": "Artistas de Capa",
         "comicCharactersLabel": "Personagens",
         "comicTeamsLabel": "Equipes",
         "comicLocationsLabel": "Locais",
@@ -3144,16 +3312,16 @@
           "currentCoverAlt": "Capa atual",
           "newCoverAlt": "Nova capa",
           "pickCoverFromProvider": "Escolher capa de outro provedor",
-          "pickCoverSource": "Escolher origem da capa",
+          "pickCoverSource": "Escolher fonte da capa",
           "pickFromProvider": "Escolher de outro provedor",
-          "pickSource": "Escolher origem",
+          "pickSource": "Escolher fonte",
           "empty": "vazio",
           "showLess": "Mostrar menos",
           "showMore": "Mostrar mais",
-          "coverPreviewAlt": "Pré-visualização de capa"
+          "coverPreviewAlt": "Pré-visualização da capa"
         },
         "searchDrawer": {
-          "searchTitle": "Pesquisar Metadados",
+          "searchTitle": "Buscar Metadados",
           "compareTitle": "Comparar Metadados",
           "searchSubtitle": "Encontre a melhor correspondência de provedor para este livro.",
           "compareSubtitle": "Revise as diferenças e aplique apenas o que desejar."
@@ -3163,29 +3331,35 @@
           "titlePlaceholder": "Título",
           "authorPlaceholder": "Autor",
           "isbnPlaceholder": "ISBN",
-          "searching": "Pesquisando...",
+          "searching": "Buscando...",
           "activeQuery": "Consulta ativa",
-          "searchScope": "Escopo de pesquisa",
-          "allEnabled": "Todos os habilitados",
-          "all": "Tudo",
+          "searchScope": "Escopo de busca",
+          "allEnabled": "Todos ativados",
+          "all": "Todos",
           "fieldRules": "Regras de Campo",
           "custom": "Personalizado",
-          "providerNotInFieldRules": "{provider} está habilitado, mas não nas Regras de Campo",
-          "notInFieldRulesLabel": "Não nas Regras de Campo:",
-          "notInFieldRulesText": "{providers}. Incluídos na busca manual com 'Todos os habilitados' ativo, mas não usados na busca automática de metadados.",
+          "providerNotInFieldRules": "{provider} está ativado mas não nas Regras de Campo",
+          "notInFieldRulesLabel": "Não está nas Regras de Campo:",
+          "notInFieldRulesText": "{providers}. Incluídos na busca manual com Todos ativados, mas não utilizados na busca automática de metadados.",
           "noResults": "Nenhum resultado encontrado",
           "noResultsHint": "Tente ajustar o título ou autor",
-          "searchPrompt": "Pesquise acima, depois clique em um resultado para começar a comparar os metadados."
+          "searchPrompt": "Busque acima, então clique em um resultado para começar a comparar os metadados."
         },
-        "writeAndRename": "Gravar no Arquivo e Renomear",
-        "writeAndRenameShort": "Gravar e Renomear"
+        "writeAndRename": "Gravar no Arquivo & Renomear",
+        "writeAndRenameShort": "Gravar & Renomear"
       },
       "files": {
+        "title": "Arquivos do livro",
+        "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+        "synced": "Sincronizado {time}",
+        "sortAria": "Ordenar arquivos",
+        "syncHistory": "Histórico de sincronização",
+        "metadataWriteBack": "Regravação de metadados",
         "relative": {
-          "seconds": "{value}s atrás",
-          "minutes": "{value}m atrás",
-          "hours": "{value}h atrás",
-          "days": "{value}d atrás"
+          "seconds": "há {value}s",
+          "minutes": "há {value}m",
+          "hours": "há {value}h",
+          "days": "há {value}d"
         },
         "renameFailed": "Falha ao renomear arquivo",
         "deleteFailed": "Falha ao excluir arquivo",
@@ -3198,16 +3372,16 @@
           "size": "Tamanho",
           "date": "Data"
         },
-        "hidePaths": "Ocultar caminhos",
+        "hidePaths": "Esconder caminhos",
         "showPaths": "Mostrar caminhos",
-        "hideLog": "Ocultar log",
+        "hideLog": "Esconder log",
         "viewSyncLog": "Ver log de sincronização",
         "noWriteHistory": "Nenhum histórico de gravação ainda.",
         "fieldsWritten": "nenhum campo | um campo | {count} campos",
         "track": "Faixa {number}",
-        "primary": "Principal",
+        "primary": "Primário",
         "read": "Ler",
-        "play": "Reproduzir",
+        "play": "Ouvir",
         "peek": "Espiar",
         "download": "Baixar",
         "moreActions": "Mais ações",
@@ -3218,8 +3392,8 @@
         },
         "renameModal": {
           "title": "Renomear Arquivo",
-          "description": "Renomeie o arquivo físico no disco.",
-          "placeholder": "Novo nome de arquivo"
+          "description": "Renomear o arquivo físico no disco.",
+          "placeholder": "Novo nome do arquivo"
         },
         "saving": "Salvando...",
         "deleteModal": {
@@ -3263,6 +3437,7 @@
         "paginationUnit": "destaques"
       },
       "readingLog": {
+        "moreActionsAria": "Mais ações do registro de leitura",
         "export": {
           "button": "Exportar"
         },
@@ -3290,27 +3465,29 @@
           "dec": "Dez"
         },
         "heatmap": {
-          "subtitle": "{count} dia ativo · {ratio}% de consistência | {count} dia ativo · {ratio}% de consistência | {count} dias ativos · {ratio}% de consistência",
+          "subtitle": "{count} dia ativo · {ratio}% consistência | {count} dia ativo · {ratio}% consistência | {count} dias ativos · {ratio}% consistência",
           "minutesUnit": "min",
           "title": "Atividade",
-          "empty": "Nenhuma atividade de leitura nesta janela."
+          "empty": "Nenhuma atividade de leitura nesta janela.",
+          "emptyHint": "Sessões registradas aqui construirão sua visão de consistência."
         },
         "hero": {
+          "summaryAria": "Resumo de leitura",
           "notSet": "Não definido",
           "relative": {
-            "seconds": "{count}s atrás",
-            "minutes": "{count}m atrás",
-            "hours": "{count}h atrás",
-            "days": "{count}d atrás",
-            "months": "{count} mês atrás | {count} mês atrás | {count} meses atrás",
-            "years": "{count} ano atrás | {count} ano atrás | {count} anos atrás"
+            "seconds": "há {count}s",
+            "minutes": "há {count}m",
+            "hours": "há {count}h",
+            "days": "há {count}d",
+            "months": "há {count} mês | há {count} mês | há {count} meses",
+            "years": "há {count} ano | há {count} ano | há {count} anos"
           },
-          "noSessions": "Nenhuma sessão",
+          "noSessions": "Sem sessões",
           "dateErrors": {
             "startFuture": "A data de início não pode ser no futuro.",
             "finishFuture": "A data de término não pode ser no futuro.",
-            "finishBeforeStart": "A data de término deve ser posterior ou igual à data de início.",
-            "saveFailed": "Falha ao salvar as datas de leitura."
+            "finishBeforeStart": "A data de término deve ser igual ou posterior à data de início.",
+            "saveFailed": "Falha ao salvar datas de leitura."
           },
           "eta": {
             "max": "99h+ para terminar",
@@ -3321,9 +3498,9 @@
           "momentum": {
             "none": "Nenhuma atividade nas últimas duas semanas",
             "new": "Nova atividade esta semana",
-            "up": "+{pct}% vs os 7 dias anteriores",
-            "down": "{pct}% vs os 7 dias anteriores",
-            "flat": "Inalterado vs os 7 dias anteriores"
+            "up": "+{pct}% em relação aos 7 dias anteriores",
+            "down": "{pct}% em relação aos 7 dias anteriores",
+            "flat": "Inalterado em relação aos 7 dias anteriores"
           },
           "stats": {
             "totalTime": "Tempo Total",
@@ -3334,7 +3511,7 @@
           "firstRead": "Primeira Leitura",
           "lastRead": "Última Leitura",
           "dateStarted": "Data de Início",
-          "dateFinished": "Data de Conclusão",
+          "dateFinished": "Data de Término",
           "addSession": "Adicionar sessão"
         },
         "journey": {
@@ -3342,21 +3519,26 @@
           "tooltipReading": "Lendo",
           "minutesUnit": "min",
           "title": "Jornada de progresso",
-          "empty": "Nenhum dado de progresso nesta janela."
+          "empty": "Nenhum dado de progresso nesta janela.",
+          "emptyHint": "O progresso aparecerá depois que uma sessão registrar uma posição de leitura."
         },
         "sourceSplit": {
-          "title": "Onde você leu este livro"
+          "title": "Fontes de leitura",
+          "shortTitle": "Fontes"
         },
         "untitled": "Sem título",
         "addSessionFailed": "Falha ao adicionar sessão",
         "filters": {
-          "allTime": "Todo o tempo",
+          "show": "Mostrar",
+          "dateRangeAria": "Período da sessão de leitura",
+          "allTime": "Todo o período",
           "last30": "Últimos 30 dias",
           "last90": "Últimos 90 dias",
           "thisYear": "Este ano",
           "allFormats": "Todos os formatos"
         },
         "table": {
+          "title": "Sessões",
           "sourceWeb": "Web",
           "sourceManual": "Manual",
           "colDate": "Data",
@@ -3368,30 +3550,31 @@
           "colEndProgress": "Progresso Final",
           "colEndProgressMobile": "Fim",
           "empty": "Nenhuma sessão de leitura registrada ainda.",
+          "emptyHint": "Adicione uma sessão para começar a construir o histórico de leitura deste livro.",
           "colPace": "Ritmo",
-          "colSource": "Origem",
+          "colSource": "Fonte",
           "colFormatMobile": "Fmt",
           "colFormat": "Formato",
           "cancelDelete": "Cancelar exclusão",
           "cancelDeleteAria": "Cancelar exclusão de sessão",
-          "confirmDeleteTitle": "Clique novamente para confirmar a exclusão",
-          "confirmDeleteAria": "Confirmar exclusão da sessão",
+          "confirmDeleteTitle": "Clique novamente para confirmar exclusão",
+          "confirmDeleteAria": "Confirmar exclusão de sessão",
           "deleteAria": "Excluir sessão",
           "loadMore": "Carregar mais",
-          "showing": "Mostrando {shown} de {total} sessões"
+          "showing": "Exibindo {shown} de {total} sessões"
         }
       },
       "richDescription": {
-        "linkProtocolError": "Use http, https ou mailto.",
+        "linkProtocolError": "Use http, https, ou mailto.",
         "bold": "Negrito",
         "italic": "Itálico",
         "underline": "Sublinhado",
         "strikethrough": "Tachado",
-        "bulletList": "Lista com marcadores",
+        "bulletList": "Lista de marcadores",
         "numberedList": "Lista numerada",
-        "outdentAria": "Diminuir recuo de item da lista",
+        "outdentAria": "Diminuir recuo do item da lista",
         "outdent": "Diminuir recuo",
-        "indentAria": "Aumentar recuo de item da lista",
+        "indentAria": "Aumentar recuo do item da lista",
         "indent": "Aumentar recuo",
         "quote": "Citação",
         "editLink": "Editar link",
@@ -3401,8 +3584,8 @@
         "redo": "Refazer",
         "clearFormatting": "Limpar formatação",
         "previewDescription": "Pré-visualizar descrição",
-        "preview": "Pré-visualização",
-        "linkUrlLabel": "URL do link",
+        "preview": "Pré-visualizar",
+        "linkUrlLabel": "URL do Link",
         "applyLink": "Aplicar link",
         "apply": "Aplicar",
         "cancelLink": "Cancelar link",
@@ -3426,8 +3609,8 @@
         "sendToDevice": "Enviar para o Dispositivo"
       },
       "boolean": {
-        "ariaNotSet": "Não definido - clique para definir verdadeiro",
-        "ariaTrue": "Verdadeiro - clique para definir falso",
+        "ariaNotSet": "Não definido - clique para definir como verdadeiro",
+        "ariaTrue": "Verdadeiro - clique para definir como falso",
         "ariaFalse": "Falso - clique para limpar"
       },
       "chips": {
@@ -3435,7 +3618,7 @@
       },
       "cover": {
         "previewDescription": "Pré-visualização da capa do livro",
-        "editDescription": "Editar a capa do livro",
+        "editDescription": "Editar capa do livro",
         "editTitle": "Editar capa",
         "editCover": "Editar Capa",
         "view": "Visualizar capa"
@@ -3454,8 +3637,8 @@
         "pinLeft": "Fixar à Esquerda",
         "pinRight": "Fixar à Direita",
         "unpinColumn": "Desafixar Coluna",
-        "autoFitWidth": "Ajuste Automático de Largura",
-        "autoFitAllColumns": "Ajuste Automático para Todas as Colunas",
+        "autoFitWidth": "Ajustar Largura Automaticamente",
+        "autoFitAllColumns": "Ajustar Todas as Colunas",
         "selectAllBooks": "Selecionar todos os livros",
         "shiftClickSecondarySort": "Shift+clique para adicionar ordenação secundária",
         "clickToSort": "Clique para ordenar"
@@ -3474,18 +3657,18 @@
       "rating": {
         "label": "Avaliação",
         "remove": "Remover avaliação",
-        "rate": "Avaliar {star} de 5"
+        "rate": "Avaliar com {star} de 5"
       },
       "read": {
-        "play": "Reproduzir",
+        "play": "Ouvir",
         "read": "Ler",
-        "primary": "Principal",
+        "primary": "Primário",
         "peekFormat": "Espiar {format}",
-        "chooseFormat": "Escolha o formato para ler ou reproduzir",
+        "chooseFormat": "Escolha o formato para ler ou ouvir",
         "fileFallback": "ARQUIVO"
       },
       "readStatus": {
-        "unread": "Não lido"
+        "unread": "Não Lido"
       },
       "series": {
         "bookCount": "(nenhum livro) | ({count} livro) | ({count} livros)",
@@ -3512,30 +3695,30 @@
     "actions": {
       "pause": "Pausar",
       "resume": "Retomar",
-      "cancelQueued": "Cancelar fila"
+      "cancelQueued": "Cancelar na fila"
     },
     "cancel": {
       "processingWillFinish": "Os itens atualmente em processamento serão concluídos.",
       "confirm": "Confirmar cancelamento",
       "keepRunning": "Continuar executando"
     },
-    "viewFailed": "Ver um que falhou | Ver {count} que falharam",
+    "viewFailed": "Ver um falhado | Ver {count} falhados",
     "card": {
       "fetchingMetadata": "Buscando metadados",
       "enrichingAuthors": "Enriquecendo autores"
     },
     "label": {
       "paused": "Pausado",
-      "remaining": "{count} restantes",
+      "remaining": "{count} restante(s)",
       "processing": "{count} processando",
       "failed": "{count} falhou",
-      "rateLimited": "{count} limitados por taxa"
+      "rateLimited": "{count} no limite de taxa"
     },
     "report": {
-      "bookTitle": "Buscas de Metadados com Falha",
-      "authorTitle": "Enriquecimentos de Autor com Falha",
-      "noFailedItems": "Nenhum item com falha.",
-      "retryAllFailed": "Tentar novamente todos com falha",
+      "bookTitle": "Buscas de Metadados Falhas",
+      "authorTitle": "Enriquecimentos de Autor Falhos",
+      "noFailedItems": "Nenhum item falhou.",
+      "retryAllFailed": "Tentar novamente todos os falhados",
       "bookFallback": "Livro #{id}",
       "authorFallback": "Autor #{id}",
       "columns": {
@@ -3551,7 +3734,7 @@
       "failedToResume": "Falha ao retomar",
       "failedToCancel": "Falha ao cancelar",
       "failedToRetry": "Falha ao tentar novamente",
-      "failedItemsRequeued": "Itens com falha re-enfileirados",
+      "failedItemsRequeued": "Itens falhados recolocados na fila",
       "bookComplete": "Busca de metadados concluída - {done} livros atualizados",
       "bookDoneWithFailures": "Busca de metadados finalizada - {done} processados, {failed} falharam",
       "authorComplete": "Enriquecimento de autor concluído - {done} autores atualizados",
@@ -3564,26 +3747,26 @@
     "discard": "Descartar",
     "finalize": "Finalizar",
     "rescan": "Reescanear",
-    "uploadAction": "Fazer upload",
+    "uploadAction": "Fazer Upload",
     "uploading": "Enviando...",
-    "searchPlaceholder": "Pesquisar arquivos...",
+    "searchPlaceholder": "Buscar arquivos...",
     "setDestinationAction": "Definir Destino",
     "bulkEditAction": "Edição em Massa",
     "applyFetched": "Aplicar Buscados",
     "retryErrors": "Tentar Erros Novamente",
-    "commaSeparated": "separados por vírgula",
+    "commaSeparated": "separado por vírgulas",
     "destinationLibrary": "Biblioteca de Destino",
     "destinationFolder": "Pasta de Destino",
     "nSelected": "nenhum arquivo selecionado | {count} selecionado | {count} selecionados",
-    "nFailed": "{count} falhou",
-    "updatedOfFiles": "Atualizou {updated} de {total} arquivos",
+    "nFailed": "{count} falharam",
+    "updatedOfFiles": "Atualizados {updated} de {total} arquivos",
     "errorStatus": "Erro {status}",
-    "applyFetchedTooltip": "Aplicar metadados do provedor buscados automaticamente a {count} arquivos | Aplicar metadados do provedor buscados automaticamente a {count} arquivo | Aplicar metadados do provedor buscados automaticamente a {count} arquivos",
-    "retryErrorsTooltip": "Tentar novamente a busca de metadados para {count} arquivos com erro | Tentar novamente a busca de metadados para {count} arquivo com erro | Tentar novamente a busca de metadados para {count} arquivos com erro",
+    "applyFetchedTooltip": "Aplicar metadados buscados automaticamente a {count} arquivos | Aplicar metadados buscados automaticamente a {count} arquivo | Aplicar metadados buscados automaticamente a {count} arquivos",
+    "retryErrorsTooltip": "Tentar buscar metadados novamente para {count} arquivos com erro | Tentar buscar metadados novamente para {count} arquivo com erro | Tentar buscar metadados novamente para {count} arquivos com erro",
     "tab": {
       "all": "Todos",
-      "pending": "Pendente",
-      "ready": "Pronto",
+      "pending": "Pendentes",
+      "ready": "Prontos",
       "error": "Erro"
     },
     "status": {
@@ -3597,16 +3780,17 @@
       "title": "Título",
       "subtitle": "Subtítulo",
       "authors": "Autores",
-      "authorsCommaSeparated": "Autores (separados por vírgula)",
+      "authorsCommaSeparated": "Autores (separados por vírgulas)",
       "publisher": "Editora",
+      "publishedDate": "Data de Publicação",
       "year": "Ano",
       "language": "Idioma",
       "isbn13": "ISBN-13",
       "isbn10": "ISBN-10",
       "series": "Série",
-      "seriesIndex": "Índice da série",
+      "seriesIndex": "Nº da Série",
       "genres": "Gêneros",
-      "genresCommaSeparated": "Gêneros (separados por vírgula)",
+      "genresCommaSeparated": "Gêneros (separados por vírgulas)",
       "description": "Descrição"
     },
     "upload": {
@@ -3615,8 +3799,8 @@
       "nTotal": "{count} total"
     },
     "fileList": {
-      "emptyTitle": "Nenhum arquivo no Book Dock",
-      "emptyMessageDefault": "Faça upload de arquivos ou solte-os na pasta do Book Dock",
+      "emptyTitle": "Nenhum arquivo na Doca de Livros",
+      "emptyMessageDefault": "Faça o upload de arquivos ou solte-os na pasta Doca de Livros",
       "colCurrent": "Atual",
       "colNew": "Novo",
       "colFile": "Arquivo",
@@ -3627,7 +3811,7 @@
       "colStatus": "Status",
       "applyFetchedMetadata": "Aplicar metadados buscados",
       "coverPreview": "Pré-visualização da capa",
-      "coverPreviewDescription": "Diálogo de visualização da imagem da capa ampliada.",
+      "coverPreviewDescription": "Caixa de diálogo com pré-visualização ampliada da imagem da capa.",
       "currentCoverAlt": "Capa atual de {title}",
       "newCoverAlt": "Nova capa de {title}",
       "unknownLibrary": "Biblioteca desconhecida",
@@ -3638,24 +3822,24 @@
     },
     "sheet": {
       "saved": "Salvo",
-      "providerMetadataFound": "Metadados de provedor encontrados",
-      "providerMetadataFoundEdited": "Metadados de provedor encontrados - aplicação em massa irá ignorar este arquivo (você possui edições)",
+      "providerMetadataFound": "Metadados do provedor encontrados",
+      "providerMetadataFoundEdited": "Metadados do provedor encontrados - a aplicação em massa irá ignorar este arquivo (você possui edições manuais)",
       "review": "Revisar",
-      "added": "Adicionado em {date}",
-      "searchMetadata": "Pesquisar Metadados",
+      "added": "Adicionado {date}",
+      "searchMetadata": "Buscar Metadados",
       "results": "Resultados"
     },
     "bulkEdit": {
-      "title": "Editar em massa nenhum arquivo | Editar em massa {count} arquivo | Editar em massa {count} arquivos",
+      "title": "Edição em Massa de nenhum arquivo | Edição em Massa de {count} arquivo | Edição em Massa de {count} arquivos",
       "resultTitle": "Resultados da Edição em Massa",
-      "instructions": "Alterne os campos que deseja atualizar. Apenas os campos ativados serão aplicados.",
-      "mergeArrays": "Mesclar arrays (adicionar aos valores existentes em vez de substituir)",
-      "failed": "A edição em massa falhou"
+      "instructions": "Alterne os campos que você deseja atualizar. Apenas os campos ativados serão aplicados.",
+      "mergeArrays": "Mesclar listas (adicionar aos valores existentes em vez de substituir)",
+      "failed": "Falha na edição em massa"
     },
     "setDestination": {
       "title": "Definir Destino para nenhum arquivo | Definir Destino para {count} arquivo | Definir Destino para {count} arquivos",
       "resultTitle": "Destino Atualizado",
-      "failed": "Falha ao definir o destino"
+      "failed": "Falha ao definir destino"
     },
     "finalizeDialog": {
       "title": "Finalizar nenhum arquivo | Finalizar {count} arquivo | Finalizar {count} arquivos",
@@ -3664,15 +3848,24 @@
       "allHaveDestination": "Todos os arquivos selecionados já possuem destino definido",
       "defaultDestinationLibrary": "Biblioteca de Destino Padrão",
       "defaultDestinationFolder": "Pasta de Destino Padrão",
-      "renamePreview": "Pré-visualização de renomeação",
+      "renamePreview": "Pré-visualização da renomeação",
       "moreFiles": "+{count} mais arquivos",
       "start": "Iniciar",
       "filesFinalized": "{succeeded} de {total} arquivos finalizados",
-      "failedWithDuplicates": "{failed} falharam ({count} duplicatas) | {failed} falhou ({count} duplicata) | {failed} falharam ({count} duplicatas)",
+      "checking": "Verificando arquivos selecionados...",
+      "readyCount": "nenhum arquivo pronto | {count} arquivo pronto | {count} arquivos prontos",
+      "duplicateCount": "nenhum já existe na biblioteca | {count} já existe na biblioteca | {count} já existem na biblioteca",
+      "conflictCount": "nenhum conflito de nome de arquivo | {count} conflito de nome de arquivo | {count} conflitos de nome de arquivo",
+      "missingDestinationCount": "nenhum destino ausente | {count} destino ausente | {count} destinos ausentes",
+      "blockedCount": "nenhum arquivo bloqueado | {count} arquivo bloqueado | {count} arquivos bloqueados",
+      "moreDuplicates": "+{count} mais já existentes na biblioteca",
+      "discardDuplicates": "Descartar duplicatas",
+      "failedCount": "nenhum arquivo falhou | {count} arquivo falhou | {count} arquivos falharam",
+      "failedWithDuplicates": "{failed} falhou ({count} duplicatas) | {failed} falhou ({count} duplicata) | {failed} falharam ({count} duplicatas)",
       "view": "Ver",
       "viewExisting": "Ver existente",
-      "importAnyway": "Importar mesmo assim",
-      "hide": "Ocultar",
+      "importAnyway": "Importar de qualquer forma",
+      "hide": "Esconder",
       "details": "Detalhes",
       "alreadyExistsSaveAs": "Já existe - salvar como:",
       "renamePlaceholder": "ex: {name} (2)",
@@ -3696,7 +3889,7 @@
     "editDialog": {
       "title": "Editar Coleção",
       "syncToKobo": "Sincronizar com Kobo",
-      "syncToKoboHint": "Os livros nesta coleção aparecerão no seu dispositivo Kobo",
+      "syncToKoboHint": "Livros nesta coleção aparecerão no seu dispositivo Kobo",
       "deleteCollection": "Excluir coleção",
       "confirmDelete": "Confirmar?",
       "deleting": "Excluindo...",
@@ -3724,7 +3917,7 @@
       "createdAndAdded": "Criada \"{name}\" e adicionado nenhum livro | Criada \"{name}\" e adicionado um livro | Criada \"{name}\" e adicionados {count} livros",
       "createdButAddFailed": "Criada \"{name}\", mas falhou ao adicionar livros",
       "createFailed": "Falha ao criar coleção",
-      "addedNewWithExisting": "Adicionado um livro novo a \"{name}\" ({alreadyHad} já lá) | Adicionado um livro novo a \"{name}\" ({alreadyHad} já lá) | Adicionados {count} novos livros a \"{name}\" ({alreadyHad} já lá)",
+      "addedNewWithExisting": "Adicionado um livro novo a \"{name}\" ({alreadyHad} já estavam lá) | Adicionado um livro novo a \"{name}\" ({alreadyHad} já estavam lá) | Adicionados {count} novos livros a \"{name}\" ({alreadyHad} já estavam lá)",
       "addedToCollection": "Nenhum livro adicionado a \"{name}\" | Um livro adicionado a \"{name}\" | {count} livros adicionados a \"{name}\"",
       "addFailed": "Falha ao adicionar à coleção",
       "removedFromCollection": "Nenhum livro removido de \"{name}\" | Um livro removido de \"{name}\" | {count} livros removidos de \"{name}\"",
@@ -3733,32 +3926,32 @@
   },
   "components": {
     "appHeader": {
-      "searchAllBooks": "Pesquisar todos os livros...",
-      "searching": "Pesquisando...",
-      "noResults": "Sem resultados",
+      "searchAllBooks": "Buscar em todos os livros...",
+      "searching": "Buscando...",
+      "noResults": "Nenhum resultado",
       "loadingMore": "Carregando mais...",
       "loadMore": "Carregar mais ({loaded}/{total})",
-      "allMatchesShown": "Todas as 1 correspondências mostradas | Toda a 1 correspondência mostrada | Todas as {count} correspondências mostradas",
+      "allMatchesShown": "Todo 1 resultado exibido | Todo 1 resultado exibido | Todos os {count} resultados exibidos",
       "bookCount": "nenhum livro | {count} livro | {count} livros",
       "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
       "uploadedToast": "Enviado(s) {uploaded}",
-      "uploadFailedToast": "O envio falhou para {failed}",
+      "uploadFailedToast": "Upload falhou para {failed}",
       "uploadPartialToast": "Enviado(s) {uploaded}, {failed} falharam",
-      "bookDock": "Book Dock",
+      "bookDock": "Doca de Livros",
       "statistics": "Estatísticas",
       "achievements": "Conquistas",
       "annotations": "Anotações",
-      "uploadBooks": "Enviar livros",
+      "uploadBooks": "Upload de livros",
       "appearance": "Aparência",
       "theme": "Tema",
       "accent": "Destaque",
-      "radius": "Raio",
+      "radius": "Arredondamento",
       "background": "Fundo",
       "settings": "Configurações",
       "whatsNew": "O que há de novo",
       "documentation": "Documentação",
       "help": "Ajuda",
-      "starOnGithub": "Dê uma estrela no GitHub",
+      "starOnGithub": "Dar estrela no GitHub",
       "new": "Novo",
       "newReleaseNotes": "Novas notas de lançamento disponíveis",
       "account": "Conta",
@@ -3766,7 +3959,7 @@
       "signOut": "Sair",
       "githubStar": {
         "title": "Gostando do BookOrbit?",
-        "body": "Se o BookOrbit está ajudando com a sua biblioteca, por favor, considere dar uma estrela ao projeto no GitHub. Isso ajuda mais pessoas a descobrirem o aplicativo e apoia o desenvolvimento contínuo.",
+        "body": "Se o BookOrbit está ajudando com sua biblioteca, por favor, considere dar uma estrela ao projeto no GitHub. Isso ajuda mais pessoas a descobrirem o aplicativo e apoia o desenvolvimento contínuo.",
         "cta": "Dar estrela ao BookOrbit no GitHub"
       }
     },
@@ -3774,24 +3967,27 @@
       "tagline": "Seu Espaço de Leitura",
       "dashboard": "Painel",
       "authors": "Autores",
-      "series": "Série",
+      "series": "Séries",
       "tools": "Ferramentas",
       "libraries": "Bibliotecas",
       "newLibrary": "Nova Biblioteca",
-      "libraryScanning": "{name} - Verificando {pct}%",
+      "libraryScanning": "{name} - Escaneando {pct}%",
       "scanProgress": "{processed} / {total} livros",
-      "smartScopes": "Smart Scopes",
-      "newSmartScope": "Novo Smart Scope",
-      "noSmartScopes": "Nenhum Smart Scope ainda",
+      "smartScopes": "SmartScopes",
+      "newSmartScope": "Novo SmartScope",
+      "noSmartScopes": "Nenhum SmartScope ainda",
       "collections": "Coleções",
       "newCollection": "Nova Coleção",
       "noCollections": "Nenhuma coleção ainda",
-      "latest": "Mais recente {version}",
+      "latest": "Última versão {version}",
       "newReleaseNotes": "Novas notas de lançamento disponíveis",
+      "support": "Apoie o BookOrbit",
+      "supportShort": "Apoiar",
+      "supportAria": "Apoie o BookOrbit no Ko-fi",
       "sectionHeader": {
         "add": "Adicionar",
         "reorder": "Reordenar",
-        "doneReordering": "Reordenação concluída"
+        "doneReordering": "Concluída a reordenação"
       }
     },
     "selectionActionBar": {
@@ -3806,7 +4002,7 @@
       "moreActions": "Mais ações",
       "setField": "Definir campo",
       "refreshMetadata": "Atualizar metadados",
-      "reExtractCover": "Reextrair capa",
+      "reExtractCover": "Extrair capa novamente",
       "metadataLock": "Bloqueio de metadados",
       "lockAll": "Bloquear tudo",
       "unlockAll": "Desbloquear tudo",
@@ -3814,7 +4010,7 @@
       "deleteSelected": "Excluir selecionados",
       "exitSelection": "Sair da seleção",
       "downloadFilesZipLabel": "Baixar arquivos como ZIP:",
-      "primaryOnly": "Apenas principal",
+      "primaryOnly": "Apenas primário",
       "allFormats": "Todos os formatos",
       "audioOnly": "Apenas áudio",
       "setRatingLabel": "Definir avaliação:",
@@ -3829,12 +4025,12 @@
     "viewHeader": {
       "select": "Selecionar",
       "display": "Exibição",
-      "displayDescription": "Ajuste o tamanho da capa, o espaçamento da grade e as opções de exibição de visualização.",
-      "columnVisibilityHint": "Use o painel de visibilidade das colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
+      "displayDescription": "Ajustar tamanho da capa, espaçamento da grade e opções de exibição da visualização.",
+      "columnVisibilityHint": "Use o painel de visibilidade de colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
       "columnVisibilityMobileHint": "A visibilidade das colunas pode ser gerenciada no cabeçalho da tabela.",
-      "searchPlaceholder": "Pesquisar título, autor, série, narrador...",
+      "searchPlaceholder": "Buscar título, autor, série, narrador...",
       "mobileSearch": {
-        "description": "Pesquise itens por título, autor, série ou narrador.",
+        "description": "Buscar itens por título, autor, série ou narrador.",
         "done": "Concluído"
       },
       "mobileMenu": {
@@ -3847,27 +4043,28 @@
         "display": "Exibição",
         "coverSize": "Tamanho da capa",
         "gridGap": "Espaçamento da grade",
-        "columnsHint": "Use o painel de visibilidade das colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
+        "columnsHint": "Use o painel de visibilidade de colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
         "coverShape": "Formato da capa",
         "circle": "Círculo",
         "square": "Quadrado"
       }
     },
     "iconPicker": {
-      "searchLucide": "Pesquisar ícones Lucide...",
-      "searchCustom": "Pesquisar ícones personalizados...",
+      "clearSelectionAria": "Limpar ícone selecionado",
+      "searchLucide": "Buscar ícones Lucide...",
+      "searchCustom": "Buscar ícones personalizados...",
       "chooseIcon": "Escolha um ícone...",
       "selectIcon": "Selecionar ícone",
       "customTab": "Personalizado",
-      "searching": "Pesquisando...",
+      "searching": "Buscando...",
       "noIconsMatch": "Nenhum ícone corresponde a \"{query}\"",
-      "typeToSearch": "Digite para pesquisar todos os ícones",
+      "typeToSearch": "Digite para buscar em todos os ícones",
       "noCustomIcons": "Nenhum ícone personalizado enviado",
       "noIconsAvailable": "Nenhum ícone disponível"
     },
     "entityNotFound": {
-      "title": "{entity} não encontrado",
-      "description": "Este {entity} não existe ou foi excluído.",
+      "title": "{entity} não encontrado(a)",
+      "description": "Este(a) {entity} não existe ou foi excluído(a).",
       "goBack": "Voltar"
     },
     "themePicker": {
@@ -3880,8 +4077,8 @@
     },
     "ui": {
       "sidebar": {
-        "title": "Barra Lateral",
-        "mobileDescription": "Exibe a barra lateral móvel.",
+        "title": "Barra lateral",
+        "mobileDescription": "Exibe a barra lateral em dispositivos móveis.",
         "toggle": "Alternar Barra Lateral"
       },
       "chipInput": {
@@ -3894,29 +4091,29 @@
     "dialogTitle": "Enviar ícones personalizados",
     "dialogDescription": "Revise os nomes antes de adicioná-los à sua biblioteca.",
     "readingFiles": "Lendo arquivos...",
-    "dropPrompt": "Solte arquivos SVG ou clique para procurar",
+    "dropPrompt": "Arraste arquivos SVG ou clique para procurar",
     "fileLimit": "Até {max} arquivos, 128 KB cada",
     "namePlaceholder": "Nome",
     "nameRequired": "O nome é obrigatório",
-    "invalidSvg": "SVG Inválido",
+    "invalidSvg": "SVG inválido",
     "invalidSvgFile": "Arquivo SVG inválido",
     "identicalTo": "Idêntico a \"{name}\"",
     "uploadAnyway": "Enviar mesmo assim",
-    "skipThisOne": "Ignorar este",
-    "readyToUpload": "{count} prontos para upload",
-    "noIconsStaged": "Nenhum ícone na fila de envio ainda",
+    "skipThisOne": "Pular este",
+    "readyToUpload": "{count} pronto(s) para enviar",
+    "noIconsStaged": "Nenhum ícone preparado ainda",
     "uploading": "Enviando...",
-    "upload": "Fazer upload",
-    "uploadCount": "Fazer upload de {count}",
+    "upload": "Enviar",
+    "uploadCount": "Enviar {count}",
     "onlySvgSupported": "Apenas arquivos SVG são suportados",
-    "maxStaged": "Você pode enfileirar no máximo {max} ícones de uma vez",
-    "onlyMoreCanStage": "Nenhum ícone adicional pode ser enfileirado | Apenas {count} ícone adicional pode ser enfileirado | Apenas {count} ícones adicionais podem ser enfileirados",
-    "readFailed": "Falha ao ler os arquivos SVG",
+    "maxStaged": "Você pode preparar no máximo {max} ícones por vez",
+    "onlyMoreCanStage": "Nenhum outro ícone pode ser preparado | Apenas mais {count} ícone pode ser preparado | Apenas mais {count} ícones podem ser preparados",
+    "readFailed": "Falha ao ler arquivos SVG",
     "uploadedCount": "Nenhum ícone enviado | {count} ícone enviado | {count} ícones enviados",
-    "uploadedPartial": "{created} enviado(s), {failed} falharam",
+    "uploadedPartial": "Enviado(s) {created}, {failed} falharam",
     "noIconsUploaded": "Nenhum ícone enviado",
     "uploadFailed": "Falha ao enviar os ícones",
-    "uploadFailedEntry": "O envio falhou"
+    "uploadFailedEntry": "Falha no envio"
   },
   "dashboard": {
     "common": {
@@ -3930,11 +4127,11 @@
       "failedToLoad": "Falha ao carregar.",
       "empty": {
         "continueReading": "Nenhum livro em andamento ainda. Comece a ler um para vê-lo aqui.",
-        "continueListening": "Nenhum audiobook em andamento ainda. Comece a ouvir um para vê-lo aqui.",
-        "wantToRead": "Nenhum livro marcado como 'quero ler' ainda.",
-        "upNextInSeries": "Nenhuma próxima escolha da série ainda. Termine um volume para sugerir o próximo.",
-        "recentlyAdded": "Nenhum livro na sua biblioteca ainda.",
-        "smartScope": "Nenhum livro corresponde a este smartScope.",
+        "continueListening": "Nenhum audiolivro em andamento ainda. Comece a ouvir um para vê-lo aqui.",
+        "wantToRead": "Nenhum livro marcado como quero ler ainda.",
+        "upNextInSeries": "Nenhuma escolha para a próxima série ainda. Termine um volume para sugerir o próximo.",
+        "recentlyAdded": "Nenhum livro em sua biblioteca ainda.",
+        "smartScope": "Nenhum livro corresponde a este SmartScope.",
         "default": "Nenhum livro encontrado."
       }
     },
@@ -3946,27 +4143,27 @@
       },
       "reorderHintWidget": "Arraste para reordenar. Alterne para mostrar ou ocultar um widget.",
       "reorderHintShelf": "Arraste para reordenar. Alterne para mostrar ou ocultar uma prateleira.",
-      "smartScope": "Smart Scope",
-      "noSmartScopes": "Nenhum Smart Scope ainda. Crie um na barra lateral.",
+      "smartScope": "SmartScope",
+      "noSmartScopes": "Nenhum SmartScope ainda. Crie um pela barra lateral.",
       "addShelf": "Adicionar prateleira",
-      "resetToDefaults": "Redefinir para os padrões"
+      "resetToDefaults": "Restaurar padrões"
     },
     "welcome": {
       "emptyTitle": "Sua biblioteca está vazia",
       "noLibrariesTitle": "Nenhuma biblioteca ainda",
-      "emptyDescription": "Crie uma biblioteca para começar a organizar e ler seus livros. Aponte para uma pasta e ela fará o resto.",
-      "noLibrariesDescription": "Seu administrador não configurou nenhuma biblioteca ainda. Entre em contato com eles para começar.",
+      "emptyDescription": "Crie uma biblioteca para começar a organizar e ler seus livros. Aponte-a para uma pasta e ela fará o resto.",
+      "noLibrariesDescription": "Seu administrador ainda não configurou nenhuma biblioteca. Entre em contato com ele para começar.",
       "createFirstLibrary": "Criar sua primeira biblioteca"
     },
     "widgets": {
       "currentlyReading": {
         "title": "Lendo Atualmente",
         "empty": "Nenhum livro em andamento. Comece a ler um para vê-lo aqui.",
-        "continueReading": "Continuar a ler"
+        "continueReading": "Continuar lendo"
       },
       "diversityScore": {
-        "title": "Índice de Diversidade",
-        "notEnoughData": "Leia pelo menos 3 livros para ver seu índice de diversidade",
+        "title": "Score de Diversidade",
+        "notEnoughData": "Leia pelo menos 3 livros para ver seu score de diversidade",
         "booksAnalyzed": "nenhum livro analisado | {count} livro analisado | {count} livros analisados",
         "subScores": {
           "genre": "Gênero",
@@ -3986,14 +4183,14 @@
         "stats": {
           "books": "Livros",
           "authors": "Autores",
-          "series": "Série",
+          "series": "Séries",
           "storage": "Armazenamento"
         }
       },
       "longWait": {
-        "title": "A Longa Espera",
-        "empty": "Nenhum livro aguardando. Você já começou tudo!",
-        "daysWaiting": "dias de espera",
+        "title": "O Longo Esperar",
+        "empty": "Nenhum livro na fila de espera. Você começou tudo!",
+        "daysWaiting": "dias em espera",
         "pages": "nenhuma página | {count} página | {count} páginas",
         "startReading": "Começar a Ler"
       },
@@ -4003,19 +4200,19 @@
       },
       "neglectedGems": {
         "title": "Joias Negligenciadas",
-        "empty": "Todos os seus livros com melhor classificação já foram lidos!",
+        "empty": "Todos os seus livros com melhor avaliação foram lidos!",
         "rating": "{rating}/5",
         "daysWaiting": "{count}d esperando",
         "queued": "Na fila",
         "addToQueue": "Adicionar à fila",
-        "shuffle": "Embaralhar"
+        "shuffle": "Misturar"
       },
       "readingDna": {
         "title": "DNA de Leitura",
-        "notEnoughData": "Leia pelo menos 5 livros para desbloquear o seu DNA de Leitura",
-        "basedOn": "Com base em nenhum livro | Com base em {count} livro | Com base em {count} livros",
+        "notEnoughData": "Leia pelo menos 5 livros para desbloquear seu DNA de Leitura",
+        "basedOn": "Baseado em nenhum livro | Baseado em {count} livro | Baseado em {count} livros",
         "traits": {
-          "length": "Tamanho",
+          "length": "Extensão",
           "variety": "Variedade",
           "rhythm": "Ritmo",
           "time": "Tempo",
@@ -4028,43 +4225,43 @@
         "setGoal": "Definir meta",
         "booksPerYear": "Livros por ano",
         "ofGoal": "de {goal}",
-        "percentComplete": "{percentage}% concluído",
+        "percentComplete": "{percentage}% concluída",
         "editGoal": "Editar meta"
       },
       "readingRhythm": {
         "title": "Ritmo de Leitura",
-        "empty": "Comece a ler para ver o seu ritmo tomar forma",
+        "empty": "Comece a ler para ver seu ritmo tomar forma",
         "activeDays": "nenhum dia ativo | {count} dia ativo | {count} dias ativos",
         "consistency": "{activeDays} · {percent}% de consistência",
         "avgPerDay": "média de {time}/dia"
       },
       "readingStreak": {
         "title": "Sequência de Leitura",
-        "empty": "Leia hoje para iniciar a sua sequência",
-        "streakLabel": "dia em sequência | dia em sequência | dias em sequência",
+        "empty": "Leia hoje para iniciar sua sequência",
+        "streakLabel": "dia de sequência | dia de sequência | dias de sequência",
         "best": "Melhor: {count} dia | Melhor: {count} dia | Melhor: {count} dias",
         "lastSevenDays": "Últimos 7 dias"
       },
       "yearProjection": {
-        "title": "Projeção do Ano",
+        "title": "Projeção Anual",
         "books": "livros",
         "trendUp": "Tendência de alta",
         "trendDown": "Tendência de baixa",
-        "trendSteady": "Ritmo estável",
+        "trendSteady": "Ritmo constante",
         "pages": "páginas",
         "hours": "horas",
-        "readCount": "{count} lido",
+        "readCount": "{count} lido(s)",
         "daysLeft": "{count}d restantes"
       }
     }
   },
   "email": {
     "title": "E-mail",
-    "subtitle": "Envie livros para o seu e-reader por e-mail.",
+    "subtitle": "Envie livros para o seu e-reader via e-mail.",
     "loadFailed": "Falha ao carregar",
     "saveFailed": "Falha ao salvar",
     "deleteFailed": "Falha ao excluir",
-    "setDefaultFailed": "Falha ao definir padrão",
+    "setDefaultFailed": "Falha ao definir como padrão",
     "setAsDefault": "Definir como padrão",
     "saving": "Salvando...",
     "update": "Atualizar",
@@ -4076,7 +4273,7 @@
       "system": "Sistema"
     },
     "tabs": {
-      "providers": "Provedores",
+      "providers": "Provedores SMTP",
       "recipients": "Destinatários",
       "groups": "Grupos",
       "templates": "Modelos",
@@ -4109,23 +4306,23 @@
       "testTooltip": "Testar conexão",
       "toggleSharing": "Alternar compartilhamento",
       "removeSystemBeforeDelete": "Remova a designação do sistema antes de excluir",
-      "notesHeading": "Notas do Provedor",
-      "notesBody": "O provedor do <strong>Sistema</strong> (apenas para superusuários) é usado para e-mails de redefinição de senha. O provedor <strong>Padrão</strong> é usado ao enviar livros sem nenhum provedor explícito selecionado. Os provedores marcados como <strong>Compartilhados</strong> estão disponíveis para todos os usuários.",
+      "notesHeading": "Notas sobre o Provedor",
+      "notesBody": "O provedor {system} (apenas para superusuário) é usado para e-mails de redefinição de senha. O provedor {defaultProvider} é usado ao enviar livros sem nenhum provedor explicitamente selecionado. Provedores marcados como {shared} estão disponíveis para todos os usuários.",
       "deleteTitle": "Excluir provedor?",
       "nameHostRequired": "Nome e host são obrigatórios",
       "created": "Provedor criado",
       "updated": "Provedor atualizado",
       "deleted": "\"{name}\" excluído",
       "setDefaultSuccess": "\"{name}\" definido como padrão",
-      "unshared": "Provedor descompartilhado",
+      "unshared": "Compartilhamento do provedor removido",
       "sharedWithAll": "Provedor compartilhado com todos os usuários",
       "updateSharingFailed": "Falha ao atualizar compartilhamento",
       "systemRemoved": "\"{name}\" removido como provedor de e-mail do sistema",
       "systemSet": "\"{name}\" definido como provedor de e-mail do sistema",
-      "updateSystemFailed": "Falha ao atualizar o provedor do sistema",
+      "updateSystemFailed": "Falha ao atualizar provedor do sistema",
       "connectionSuccess": "Conexão bem-sucedida",
       "connectionFailed": "Falha na conexão",
-      "testFailed": "Teste falhou"
+      "testFailed": "O teste falhou"
     },
     "recipients": {
       "heading": "Destinatários",
@@ -4142,7 +4339,7 @@
       "formatAuto": "Automático",
       "defaultTemplate": "Modelo padrão",
       "useAccountDefault": "Usar padrão da conta",
-      "kindleNote": "Os destinatários Kindle recebem e-mails automaticamente com o assunto \"convert\" para acionar a conversão de formato.",
+      "kindleNote": "Destinatários Kindle recebem automaticamente e-mails com o assunto \"convert\" para disparar a conversão de formato.",
       "empty": "Nenhum destinatário ainda.",
       "prefersFormat": "prefere {format}",
       "deleteTitle": "Excluir destinatário?",
@@ -4159,18 +4356,18 @@
       "name": "Nome do grupo",
       "namePlaceholder": "ex: Clube do Livro",
       "creating": "Criando...",
-      "empty": "Nenhum grupo ainda. Crie um grupo para enviar para vários destinatários de uma vez.",
+      "empty": "Nenhum grupo ainda. Crie um grupo para enviar a vários destinatários de uma vez.",
       "memberCount": "nenhum membro | um membro | {count} membros",
       "deleteTooltip": "Excluir grupo",
       "noMembers": "Nenhum membro ainda.",
       "removeMember": "Remover",
-      "selectRecipient": "Selecione o destinatário...",
+      "selectRecipient": "Selecionar destinatário...",
       "add": "Adicionar",
       "addMember": "Adicionar membro",
       "allRecipientsInGroup": "Todos os destinatários já estão neste grupo.",
       "deleteTitle": "Excluir grupo?",
       "created": "Grupo criado",
-      "createFailed": "Falha ao criar o grupo",
+      "createFailed": "Falha ao criar grupo",
       "deleted": "\"{name}\" excluído",
       "memberAdded": "Membro adicionado",
       "addMemberFailed": "Falha ao adicionar membro",
@@ -4185,12 +4382,12 @@
       "name": "Nome",
       "namePlaceholder": "Padrão",
       "subject": "Assunto",
-      "body": "Corpo da Mensagem",
+      "body": "Corpo",
       "availableVariables": "Variáveis disponíveis",
       "editTemplate": "Editar modelo",
       "empty": "Nenhum modelo ainda.",
       "notesHeading": "Notas do Modelo",
-      "notesBody": "Os modelos do sistema não podem ser excluídos. Os administradores podem editá-los. Use variáveis como <code class=\"font-mono text-foreground/80\">&#123;&#123;title&#125;&#125;</code> nos assuntos e no corpo da mensagem - elas são substituídas pelos detalhes do livro no momento do envio.",
+      "notesBody": "Modelos do sistema não podem ser excluídos. Administradores podem editá-los. Use variáveis como {variable} nos assuntos e corpos - elas são substituídas por detalhes do livro no momento do envio.",
       "deleteTitle": "Excluir modelo?",
       "nameSubjectRequired": "Nome e assunto são obrigatórios",
       "created": "Modelo criado",
@@ -4201,19 +4398,19 @@
     "preferences": {
       "heading": "Preferências de E-mail",
       "defaultProvider": "Provedor padrão",
-      "defaultProviderHint": "Usado quando nenhum provedor for especificado. Se vazio, o padrão da conta será usado.",
+      "defaultProviderHint": "Usado quando nenhum provedor é especificado. Se vazio, o padrão da conta será usado.",
       "noneAccountDefault": "Nenhum (usar padrão da conta)",
       "defaultRecipient": "Destinatário padrão",
-      "defaultRecipientHint": "Usado para envio rápido. Deve ser configurado para usar a ação de envio rápido nos cartões de livro.",
+      "defaultRecipientHint": "Usado para envio rápido. Deve ser configurado para usar a ação de envio rápido nos cartões dos livros.",
       "none": "Nenhum",
       "defaultTemplate": "Modelo padrão",
-      "defaultTemplateHint": "Usado quando nenhum modelo for especificado. Retorna ao padrão do sistema se estiver vazio.",
+      "defaultTemplateHint": "Usado quando nenhum modelo é especificado. Reverte para o padrão do sistema se estiver vazio.",
       "noneSystemDefault": "Nenhum (usar padrão do sistema)",
       "save": "Salvar preferências",
       "saved": "Preferências salvas"
     },
     "history": {
-      "heading": "Histórico de Envio",
+      "heading": "Histórico de Envios",
       "empty": "Nenhum e-mail enviado ainda.",
       "noSubject": "(sem assunto)",
       "loadMore": "Carregar mais",
@@ -4235,16 +4432,16 @@
       "groups": "Grupos",
       "options": "Opções",
       "fileFormat": "Formato de arquivo",
-      "autoRecipientPreference": "Automático (usar a preferência do destinatário)",
+      "autoRecipientPreference": "Automático (usar preferência do destinatário)",
       "unknownFormat": "Desconhecido",
-      "primarySuffix": "(principal)",
+      "primarySuffix": "(primário)",
       "provider": "Provedor",
       "template": "Modelo",
       "default": "Padrão",
       "send": "Enviar",
       "sending": "Enviando...",
-      "queued": "nenhum e-mail enfileirado | um e-mail enfileirado | {count} e-mails enfileirados",
-      "failed": "Falha no envio"
+      "queued": "nenhum e-mail na fila | um e-mail na fila | {count} e-mails na fila",
+      "failed": "Falha ao enviar"
     }
   },
   "hardcover": {
@@ -4252,7 +4449,7 @@
       "subtitle": "Sincronize seu progresso de leitura, status e avaliações com o Hardcover."
     },
     "bookSync": {
-      "label": "Sincronização com o Hardcover",
+      "label": "Sincronização Hardcover",
       "toggleAriaLabel": "Sincronizar este livro com o Hardcover",
       "syncNow": "Sincronizar agora"
     },
@@ -4260,42 +4457,42 @@
       "title": "Conexão",
       "description": "Conecte sua conta do Hardcover para sincronizar os dados de leitura.",
       "connected": "Conectado",
-      "apiToken": "Token da API",
-      "tokenPlaceholder": "Cole o token da API do Hardcover",
+      "apiToken": "Token de API",
+      "tokenPlaceholder": "Cole seu token de API do Hardcover",
       "show": "Mostrar",
-      "hide": "Ocultar",
-      "findTokenAt": "Encontre o seu token em",
+      "hide": "Esconder",
+      "findTokenAt": "Encontre seu token em",
       "validateToken": "Validar token",
       "valid": "Válido ({username})",
       "invalidToken": "Token inválido",
       "syncOptions": "Opções de sincronização",
-      "syncInfo": "A sincronização só é executada para livros que não estão não lidos. Isso se aplica aos acionadores de status, progresso e avaliação. Esses interruptores controlam quando a sincronização é executada.",
+      "syncInfo": "A sincronização ocorre apenas para livros que não estão como 'não lido'. Isso se aplica a gatilhos de status, progresso e avaliação. Esses interruptores controlam quando uma sincronização é executada.",
       "syncScope": {
         "title": "Escopo de sincronização de livros",
         "allEligible": {
           "label": "Todos os livros elegíveis",
-          "description": "Sincroniza tudo, a menos que você exclua um livro."
+          "description": "Sincronizar tudo, a menos que você exclua um livro."
         },
         "selectedOnly": {
           "label": "Apenas livros selecionados",
-          "description": "Sincroniza apenas os livros que você inclui explicitamente."
+          "description": "Sincronizar apenas livros que você incluir explicitamente."
         }
       },
       "enableSync": {
-        "title": "Habilitar sincronização",
-        "description": "Pause toda a sincronização com o Hardcover sem desconectar."
+        "title": "Ativar sincronização",
+        "description": "Pausar toda a sincronização com o Hardcover sem desconectar."
       },
       "syncOnStatus": {
-        "title": "Sincronizar na mudança de status",
-        "description": "Envia as atualizações quando você marca um livro como lendo, lido, etc."
+        "title": "Sincronizar na alteração de status",
+        "description": "Enviar atualizações quando você marcar um livro como lendo, lido, etc."
       },
       "syncOnProgress": {
         "title": "Sincronizar na atualização de progresso",
-        "description": "Envia o progresso de leitura e as datas quando o progresso no BookOrbit ou KOReader muda."
+        "description": "Enviar progresso de leitura e datas quando o progresso no BookOrbit ou KOReader for alterado."
       },
       "syncOnRating": {
-        "title": "Sincronizar na mudança de avaliação",
-        "description": "Envia a sua avaliação de estrelas para o Hardcover."
+        "title": "Sincronizar na alteração de avaliação",
+        "description": "Enviar suas avaliações de estrelas para o Hardcover."
       },
       "privacy": {
         "title": "Privacidade",
@@ -4306,21 +4503,21 @@
       },
       "disconnect": "Desconectar",
       "toast": {
-        "enterToken": "Insira o token da sua API do Hardcover primeiro",
+        "enterToken": "Insira seu token de API do Hardcover primeiro",
         "saved": "Configurações do Hardcover salvas",
-        "saveFailed": "Falha ao salvar as configurações",
+        "saveFailed": "Falha ao salvar configurações",
         "disconnected": "Hardcover desconectado"
       }
     },
     "sync": {
       "title": "Sincronização manual",
-      "description": "Envie seus {scope} para o Hardcover agora.",
+      "description": "Envie seu {scope} para o Hardcover agora.",
       "scope": {
         "selected": "livros selecionados",
         "eligible": "livros elegíveis"
       },
       "checkingPending": "Verificando itens pendentes...",
-      "pendingOf": "{pending} pendentes de {total} livros.",
+      "pendingOf": "{pending} pendente(s) de {total} livros.",
       "noBooksInScope": "Nenhum livro no escopo de sincronização.",
       "allSynced": "Todos os livros já estão sincronizados.",
       "lastSyncedLabel": "Última sincronização",
@@ -4328,7 +4525,7 @@
       "syncing": "Sincronizando...",
       "progressCount": "{synced} / {total} livros",
       "unavailable": {
-        "permissionDenied": "Você não tem permissão para usar a sincronização com o Hardcover.",
+        "permissionDenied": "Você não tem permissão para usar a sincronização do Hardcover.",
         "userDisabled": "A sincronização está pausada nas suas configurações do Hardcover."
       },
       "button": {
@@ -4338,52 +4535,52 @@
       },
       "lastSynced": {
         "justNow": "Agora mesmo",
-        "minutesAgo": "{count} min atrás",
-        "hoursAgo": "{count} hora atrás | {count} hora atrás | {count} horas atrás",
-        "daysAgo": "{count} dia atrás | {count} dia atrás | {count} dias atrás"
+        "minutesAgo": "há {count} min",
+        "hoursAgo": "há {count} hora | há {count} hora | há {count} horas",
+        "daysAgo": "há {count} dia | há {count} dia | há {count} dias"
       }
     },
     "import": {
-      "title": "Importar status de leitura",
-      "description": "Revise as correspondências do Hardcover antes de preencher os status vazios do BookOrbit.",
+      "title": "Puxar status de leitura",
+      "description": "Pré-visualize correspondências do Hardcover antes de preencher os status vazios do BookOrbit.",
       "clear": "Limpar",
       "preview": "Pré-visualizar",
-      "importProgress": "Progresso de importação",
+      "importProgress": "Importar progresso",
       "reviewMatches": "Revisar correspondências",
       "importReady": "Pronto para importar",
       "exactMatches": "nenhuma correspondência exata pode ser importada sem revisão | {count} correspondência exata pode ser importada sem revisão | {count} correspondências exatas podem ser importadas sem revisão",
       "progressAvailable": "nenhuma atualização de progresso disponível | {count} atualização de progresso disponível | {count} atualizações de progresso disponíveis",
       "progressConflicts": "nenhum conflito | {count} conflito | {count} conflitos",
       "unavailable": {
-        "permissionDenied": "Você não tem permissão para usar a sincronização com o Hardcover.",
-        "missingToken": "Conecte o Hardcover antes de importar.",
+        "permissionDenied": "Você não tem permissão para usar a sincronização do Hardcover.",
+        "missingToken": "Conecte-se ao Hardcover antes de importar.",
         "userDisabled": "A sincronização está pausada nas suas configurações do Hardcover."
       },
       "summary": {
         "ready": "Pronto",
         "review": "Revisar",
         "conflicts": "Conflitos",
-        "unmatched": "Não Correspondido",
-        "skipped": "Ignorado"
+        "unmatched": "Não correspondidos",
+        "skipped": "Ignorados"
       },
       "result": {
         "summary": "{applied} importados{progress}, {failed} falharam",
-        "progressUpdated": "{count} progresso atualizado"
+        "progressUpdated": "{count} progresso(s) atualizado(s)"
       },
       "toast": {
-        "importFailed": "Falha ao importar o status de leitura do Hardcover",
+        "importFailed": "Falha ao importar status de leitura do Hardcover",
         "imported": "nenhum status de leitura importado{progress} | {count} status de leitura importado{progress} | {count} status de leitura importados{progress}",
         "progressUpdates": "nenhuma atualização de progresso | {count} atualização de progresso | {count} atualizações de progresso"
       }
     },
     "review": {
-      "title": "Revisão de importação do Hardcover",
-      "subtitle": "{total} livros no Hardcover, {matched} correspondidos.",
-      "closeAriaLabel": "Fechar revisão de importação",
-      "searchPlaceholder": "Pesquisar título ou autor",
-      "importProgress": "Progresso de importação",
+      "title": "Revisão da importação do Hardcover",
+      "subtitle": "{total} livros do Hardcover, {matched} correspondidos.",
+      "closeAriaLabel": "Fechar revisão da importação",
+      "searchPlaceholder": "Buscar título ou autor",
+      "importProgress": "Importar progresso",
       "untitled": "Sem título",
-      "blank": "em branco",
+      "blank": "vazio",
       "noRows": "Nenhuma linha corresponde aos filtros atuais.",
       "selectRowAriaLabel": "Selecionar {title}",
       "selectionSummary": "{count} selecionados: {ready} prontos, {reviewed} revisados.",
@@ -4397,18 +4594,18 @@
       "nextPage": "Próxima página",
       "pageRange": "{start}-{end} de {total}",
       "tabs": {
-        "all": "Tudo",
-        "ready": "Pronto",
+        "all": "Todos",
+        "ready": "Prontos",
         "review": "Revisar",
         "conflicts": "Conflitos",
-        "unmatched": "Não Correspondido",
-        "skipped": "Ignorado"
+        "unmatched": "Não correspondidos",
+        "skipped": "Ignorados"
       },
       "summary": {
         "ready": "Pronto",
         "review": "Revisar",
         "conflicts": "Conflitos",
-        "unmatched": "Não Correspondido",
+        "unmatched": "Não correspondidos",
         "skipped": "Ignorado"
       },
       "matchOptions": {
@@ -4423,7 +4620,7 @@
         "ready": "Pronto",
         "review": "Revisar",
         "conflict": "Conflito",
-        "unmatched": "Não Correspondido",
+        "unmatched": "Não correspondido",
         "skipped": "Ignorado"
       },
       "column": {
@@ -4436,10 +4633,16 @@
       "createTitle": "Criar Biblioteca",
       "editTitle": "Editar: {name}",
       "stepOf": "Passo {current} de {total}",
+      "unsaved": "Não salvo",
+      "required": "Obrigatório",
+      "closeAria": "Fechar criador de biblioteca",
+      "progressAria": "Progresso da configuração da biblioteca",
+      "sectionsAria": "Seções de configurações da biblioteca",
+      "loadingAria": "Carregando configurações da biblioteca",
       "sections": {
         "details": "Detalhes",
         "folders": "Pastas",
-        "scanner": "Scanner",
+        "scanner": "Escâner",
         "metadata": "Metadados",
         "fileWrite": "Gravação de Arquivo",
         "reading": "Leitura",
@@ -4447,19 +4650,19 @@
         "access": "Acesso"
       },
       "actions": {
-        "saving": "Salvando...",
+        "saving": "Salvando…",
         "saveChanges": "Salvar alterações",
-        "creating": "Criando...",
+        "creating": "Criando…",
         "createLibrary": "Criar biblioteca"
       },
       "details": {
         "libraryName": "Nome da biblioteca",
         "namePlaceholder": "Minha Biblioteca",
         "coverStyle": {
-          "title": "Estilo de capa",
+          "title": "Estilo da capa",
           "portrait": "Retrato",
           "square": "Quadrado",
-          "hint": "Retrato para e-books ou bibliotecas mistas. Quadrado para bibliotecas apenas de audiobooks."
+          "hint": "Retrato para e-books ou bibliotecas mistas. Quadrado para bibliotecas exclusivas de audiolivros."
         },
         "icon": {
           "label": "Ícone",
@@ -4468,11 +4671,19 @@
         }
       },
       "folders": {
-        "title": "Pastas de verificação",
-        "description": "Adicione um ou mais diretórios para procurar livros.",
+        "title": "Pastas a escanear",
+        "description": "Adicione um ou mais diretórios para escanear por livros.",
         "browseAdd": "Procurar e adicionar uma pasta",
-        "manualEntry": "Ou digite um caminho manualmente:",
-        "pathPlaceholder": "/caminho/para/livros",
+        "browseTitle": "Procurar pastas no servidor",
+        "browseDescription": "Selecione uma ou mais pastas sem sair do navegador.",
+        "selectedTitle": "Pastas selecionadas",
+        "addFolders": "Adicionar pastas",
+        "manualEntry": "Inserir um caminho manualmente",
+        "absolutePath": "Caminho absoluto no servidor",
+        "addFolder": "Adicionar pasta",
+        "removeFolder": "Remover {folder}",
+        "manualCheckHint": "Caminhos manuais são verificados em conjunto com o restante das pastas selecionadas.",
+        "pathPlaceholder": "/caminho/para/os/livros",
         "test": "Testar",
         "add": "Adicionar",
         "pathNotAccessible": "O caminho não está acessível no servidor.",
@@ -4482,23 +4693,23 @@
         "overlapsWith": "Sobrepõe-se a \"{library}\"",
         "noneAdded": "Nenhuma pasta adicionada ainda",
         "totalFilesFound": "nenhum arquivo de livro encontrado | {count} arquivo de livro encontrado - o número real de livros pode ser menor se houver vários formatos do mesmo livro | {count} arquivos de livro encontrados - o número real de livros pode ser menor se houver vários formatos do mesmo livro",
-        "runPrescanHint": "Execute uma pré-verificação para validar os caminhos antes de salvar.",
-        "scanning": "Verificando...",
-        "prescan": "Pré-verificação"
+        "runPrescanHint": "Execute uma verificação prévia (prescan) para validar os caminhos antes de salvar.",
+        "scanning": "Escaneando…",
+        "prescan": "Verificação prévia"
       },
       "scanner": {
         "scanMode": {
-          "title": "Modo de verificação",
+          "title": "Modo de escaneamento",
           "lockedAria": "O modo de organização está bloqueado",
-          "lockTooltip": "O modo de organização é fixado após a criação da biblioteca porque alterá-lo pode criar entradas de livro duplicadas ou ausentes. Para usar um modo diferente, crie uma nova biblioteca e faça uma nova verificação.",
+          "lockTooltip": "O modo de organização é fixado após a criação da biblioteca porque alterá-lo pode criar entradas de livro duplicadas ou ausentes. Para usar um modo diferente, crie uma nova biblioteca e reescaneie.",
           "recommended": "Recomendado",
           "folderAsBook": {
             "title": "Pasta como Livro",
-            "hint": "Todos os arquivos em uma pasta são agrupados em um livro. Funciona bem quando você mantém vários formatos, como EPUB e MOBI, juntos."
+            "hint": "Todos os arquivos em uma pasta são agrupados em um único livro. Funciona bem quando você mantém vários formatos, como EPUB e MOBI, juntos."
           },
           "fileAsBook": {
             "title": "Arquivo como Livro",
-            "hint": "Trata cada arquivo como um livro individual. Mais adequado para bibliotecas com um formato por título. Evite se os seus audiobooks abrangerem vários arquivos."
+            "hint": "Trata cada arquivo como um livro individual. Mais adequado para bibliotecas com um formato por título. Evite se seus audiolivros abrangerem vários arquivos."
           }
         },
         "allowedFormats": {
@@ -4506,11 +4717,11 @@
           "allowAll": "Permitir todos",
           "allAllowed": "Todos os formatos são permitidos.",
           "onlySelected": "Apenas os formatos selecionados serão importados.",
-          "warning": "Livros em outros formatos que já estão na biblioteca serão marcados como ausentes na próxima verificação."
+          "warning": "Livros em outros formatos já presentes na biblioteca serão marcados como ausentes no próximo escaneamento."
         },
         "excludePatterns": {
           "title": "Padrões de exclusão",
-          "hintBefore": "Padrões glob para ignorar durante a verificação (ex: ",
+          "hintBefore": "Padrões Glob para pular durante a verificação (ex: ",
           "hintAfter": ").",
           "add": "Adicionar",
           "empty": "Nenhum padrão adicionado."
@@ -4518,19 +4729,20 @@
       },
       "metadata": {
         "sourcePrecedence": {
-          "title": "Precedência da fonte",
-          "hint": "A fonte mais alta na lista é preferida quando várias estão disponíveis."
+          "title": "Precedência de origem",
+          "hint": "A origem mais alta na lista é a preferida quando várias estiverem disponíveis."
         },
         "formatPriority": {
-          "title": "Prioridade do formato",
-          "hint": "Quando um livro tem vários formatos, o formato mais alto na lista é o preferido."
+          "title": "Prioridade de formato",
+          "hint": "Quando um livro possui vários formatos, o formato mais alto na lista é o preferido."
         }
       },
       "fileWrite": {
         "maxFileSizeMb": "Tamanho máx. do arquivo (MB)",
+        "formatLimits": "Limites por formato",
         "rename": {
-          "title": "Renomear arquivos na atualização de metadados",
-          "hint": "Quando ativado, atualizar título, autor, série ou ano renomeará o arquivo físico usando o padrão de nomenclatura da biblioteca."
+          "title": "Renomear arquivos após alterações de metadados",
+          "hint": "Renomeia arquivos físicos quando o título, autor, série ou ano muda, utilizando o padrão de nomenclatura da biblioteca."
         },
         "write": {
           "title": "Gravar metadados nos arquivos",
@@ -4538,44 +4750,48 @@
         },
         "cover": {
           "title": "Incluir imagem da capa",
-          "hint": "Grava a capa armazenada de volta em formatos de arquivo suportados."
+          "hint": "Grava a capa armazenada de volta nos formatos de arquivo compatíveis."
         },
         "epub": {
           "title": "EPUB",
-          "hint": "Grava os metadados no arquivo OPF dentro do arquivo EPUB."
+          "hint": "Grava os metadados no arquivo OPF dentro do arquivo EPUB.",
+          "toggleAria": "Gravar metadados no EPUB"
         },
         "pdf": {
           "title": "PDF",
-          "hint": "Incorpora metadados no dicionário Info do PDF e no fluxo XMP."
+          "hint": "Embutir metadados no dicionário Info do PDF e no fluxo XMP.",
+          "toggleAria": "Gravar metadados no PDF"
         },
         "cbx": {
           "title": "Arquivos de quadrinhos (CBX)",
-          "hint": "Grava ComicInfo.xml dentro de arquivos CBZ e CB7."
+          "hint": "Grava ComicInfo.xml dentro de arquivos CBZ e CB7.",
+          "toggleAria": "Gravar metadados em arquivos de quadrinhos"
         },
         "audio": {
           "title": "Áudio",
-          "hint": "Incorpora a capa armazenada em arquivos M4B, M4A, MP3 e FLAC."
+          "hint": "Embutir a capa armazenada nos arquivos M4B, M4A, MP3 e FLAC.",
+          "toggleAria": "Gravar capas de áudio"
         }
       },
       "reading": {
         "readingStart": {
           "title": "Início da leitura",
-          "hint": "Um livro é marcado como \"lendo\" assim que atinge esta porcentagem de progresso."
+          "hint": "Um livro é marcado como \"lendo\" assim que atingir esta porcentagem de progresso."
         },
         "markAsFinished": {
-          "title": "Marcar como finalizado",
-          "hint": "Um livro é marcado automaticamente como \"lido\" quando atinge esta porcentagem de progresso."
+          "title": "Marcar como concluído",
+          "hint": "Um livro é automaticamente marcado como \"lido\" quando atingir esta porcentagem de progresso."
         }
       },
       "schedule": {
         "fileWatching": "Monitoramento de arquivos",
-        "autoScanSchedule": "Cronograma de verificação automática",
+        "autoScanSchedule": "Agendamento de auto-escaneamento",
         "cronExpression": "Expressão Cron",
         "cronInvalid": "Expressão cron inválida.",
         "cronFormat": "Formato: minuto hora dia mês dia_da_semana",
         "watchFolders": {
-          "title": "Monitorar pastas",
-          "hint": "Detectar automaticamente novos arquivos adicionados às pastas da biblioteca."
+          "title": "Pastas monitoradas",
+          "hint": "Detecta automaticamente novos arquivos adicionados às pastas da biblioteca."
         },
         "presets": {
           "never": "Nunca",
@@ -4587,22 +4803,25 @@
           "custom": "Personalizado"
         },
         "human": {
-          "disabled": "Verificação automática desativada",
+          "disabled": "Auto-escaneamento desativado",
           "hourly": "A cada hora",
           "every6Hours": "A cada 6 horas",
           "every12Hours": "A cada 12 horas",
           "dailyMidnight": "Diariamente à meia-noite",
-          "weeklyMonday": "Semanalmente na segunda-feira à meia-noite",
+          "weeklyMonday": "Semanalmente às segundas-feiras à meia-noite",
           "cron": "Cron: {cron}"
         }
       },
       "access": {
         "title": "Controle de acesso",
         "description": "Superusuários sempre têm acesso total. Conceda acesso a outros usuários abaixo.",
-        "notYetCreated": "O acesso pode ser configurado depois que a biblioteca for criada.",
-        "selectUser": "Selecione um usuário...",
+        "notYetCreated": "O acesso pode ser configurado após a criação da biblioteca.",
+        "selectUser": "Selecione um usuário…",
         "grant": "Conceder",
         "empty": "Nenhum acesso concedido a usuários ainda.",
+        "loading": "Carregando configurações de acesso...",
+        "userSelectAria": "Usuário a receber acesso",
+        "levelSelectAria": "Nível de acesso a ser concedido",
         "levels": {
           "viewer": "Visualizador",
           "editor": "Editor",
@@ -4614,24 +4833,37 @@
         },
         "errors": {
           "grant": "Falha ao conceder acesso",
-          "updateLevel": "Falha ao atualizar o nível de acesso",
+          "updateLevel": "Falha ao atualizar nível de acesso",
           "revoke": "Falha ao revogar acesso"
         }
       }
     },
     "folderPicker": {
-      "title": "Procurar pastas",
+      "title": "Procurar pastas no servidor",
+      "description": "Selecione uma ou mais pastas para esta biblioteca.",
+      "closeAria": "Fechar navegador de pastas",
+      "currentFolderAria": "Pasta atual",
+      "parentFolder": "Ir para a pasta pai",
       "newFolder": "Nova pasta",
-      "goUp": "Subir um nível",
-      "filterPlaceholder": "Filtrar pastas...",
+      "goUp": "Subir",
+      "filterPlaceholder": "Filtrar pastas…",
+      "clearFilterAria": "Limpar filtro de pasta",
       "newFolderNamePlaceholder": "Nome da nova pasta",
       "create": "Criar",
+      "loading": "Carregando pastas...",
+      "selectCurrent": "Selecionar pasta atual",
+      "noMatches": "Nenhuma pasta correspondente",
+      "noMatchesHint": "Tente um filtro diferente.",
+      "empty": "Esta pasta está vazia",
+      "emptyHint": "Você pode selecionar a pasta atual ou criar uma nova.",
+      "openFolderAria": "Abrir {name}",
+      "selectedCount": "nenhuma pasta selecionada | {count} pasta selecionada | {count} pastas selecionadas",
       "noFolders": "Nenhuma pasta encontrada",
       "selectFolder": "Selecionar esta pasta",
       "errors": {
         "readDirectory": "Não foi possível ler o diretório",
         "connect": "Não foi possível conectar",
-        "invalidName": "Insira um único nome de pasta, sem barras ou pontos à esquerda",
+        "invalidName": "Insira o nome de uma única pasta, sem barras ou pontos iniciais",
         "createFolder": "Não foi possível criar a pasta"
       }
     },
@@ -4643,7 +4875,7 @@
       "clearAll": "Limpar tudo",
       "done": "Concluído",
       "retry": "Tentar novamente",
-      "upload": "Upload",
+      "upload": "Fazer Upload",
       "uploadWithCount": "Fazer Upload ({count})",
       "viewInLibrary": "Ver na Biblioteca",
       "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
@@ -4652,18 +4884,18 @@
       "progress": "{done} de {total} enviando...",
       "header": {
         "uploading": "Enviando...",
-        "complete": "Envio concluído",
+        "complete": "Upload concluído",
         "uploadTo": "Fazer upload para {library}",
         "uploadBooks": "Fazer Upload de Livros"
       },
       "dropzone": {
-        "title": "Solte os arquivos aqui ou clique para procurar",
+        "title": "Arraste os arquivos aqui ou clique para procurar",
         "hint": "{formats} - até {size} MB cada"
       }
     }
   },
   "metadataScore": {
-    "missingFields": "nenhum campo ausente - editar metadados | {count} campo ausente - editar metadados | {count} campos ausentes - editar metadados"
+    "missingFields": "nenhum campo faltando - editar metadados | {count} campo faltando - editar metadados | {count} campos faltando - editar metadados"
   },
   "migration": {
     "sidebarTitle": "Importação do Booklore",
@@ -4682,7 +4914,7 @@
       "source": {
         "short": "Conexão de Origem",
         "title": "Conexão de Origem",
-        "subtitle": "Configure a conexão do banco de dados com a sua instância Booklore de origem."
+        "subtitle": "Configure a conexão com o banco de dados da sua instância Booklore de origem."
       },
       "mappings": {
         "short": "Mapeamento de Usuário e Caminho",
@@ -4690,14 +4922,14 @@
         "subtitle": "Mapeie usuários de origem para usuários de destino e traduza os caminhos dos arquivos."
       },
       "dryRun": {
-        "short": "Teste",
-        "title": "Teste (Dry Run)",
-        "subtitle": "Pré-visualize o que será importado antes de executar a migração definitiva."
+        "short": "Simulação",
+        "title": "Simulação (Dry Run)",
+        "subtitle": "Pré-visualize o que será importado antes de executar a migração real."
       },
       "migration": {
         "short": "Executar Migração",
         "title": "Executar Migração",
-        "subtitle": "Inicie a importação definitiva e monitore seu progresso."
+        "subtitle": "Inicie a importação real e monitore seu progresso."
       },
       "report": {
         "short": "Relatório",
@@ -4707,12 +4939,12 @@
     },
     "footer": {
       "continueToMappings": "Continuar para Mapeamentos",
-      "continueToDryRun": "Continuar para o Teste",
-      "continueToMigration": "Continuar para Migração",
+      "continueToDryRun": "Continuar para a Simulação",
+      "continueToMigration": "Continuar para a Migração",
       "viewReport": "Ver Relatório",
       "resetSetup": "Redefinir Configuração",
       "stepOf": "Passo {current} de {total}",
-      "backToSetup": "Voltar à Configuração"
+      "backToSetup": "Voltar para a Configuração"
     },
     "stages": {
       "init": "Inicializando",
@@ -4722,33 +4954,33 @@
     },
     "source": {
       "testConnection": "Testar Conexão",
-      "saveAndValidate": "Salvar e Validar",
+      "saveAndValidate": "Salvar & Validar",
       "validatedWithWarnings": "Origem validada com avisos",
       "fields": {
         "type": "Tipo de Origem",
-        "name": "Nome de Origem",
+        "name": "Nome da Origem",
         "host": "Host",
         "port": "Porta",
         "user": "Usuário",
         "password": "Senha",
-        "passwordSaved": "Salva - deixe inalterada",
-        "passwordNotSet": "Nenhuma senha definida",
+        "passwordSaved": "Salva - deixe inalterado",
+        "passwordNotSet": "Sem senha definida",
         "database": "Banco de Dados",
         "mediaRootPath": "Caminho Raiz de Mídia",
         "ssl": "Usar TLS/SSL"
       },
       "mediaPath": {
-        "hintRequired": "Obrigatório para migração de capas de livros.",
-        "hintAbsolute": "Use um caminho absoluto (exemplo: /books). Caminhos relativos não são suportados.",
-        "hintConfigured": "Caminho de importação de capa configurado. Use Testar Conexão para verificar o acesso e a estrutura de pastas de imagens do Booklore.",
+        "hintRequired": "Obrigatório para migrar capas de livros.",
+        "hintAbsolute": "Use um caminho absoluto (exemplo: /livros). Caminhos relativos não são suportados.",
+        "hintConfigured": "Caminho de importação de capas configurado. Use 'Testar Conexão' para verificar o acesso e a estrutura da pasta de imagens do Booklore.",
         "buttonOk": "Caminho OK",
         "buttonIssue": "Problema no Caminho",
         "buttonTest": "Testar Caminho"
       },
       "compatibility": {
         "title": "Compatibilidade testada",
-        "verifiedAgainst": "Verificado contra:",
-        "note": "Versões posteriores são provavelmente compatíveis, mas não foram verificadas. Execute um teste primeiro para confirmar antes de confirmar os dados."
+        "verifiedAgainst": "Verificado em:",
+        "note": "As versões mais recentes provavelmente são compatíveis, mas não foram verificadas. Execute uma simulação (dry-run) primeiro para confirmar antes de confirmar os dados."
       },
       "snapshot": {
         "title": "Último instantâneo de validação",
@@ -4763,10 +4995,10 @@
       "sourceUser": "Usuário de Origem",
       "targetUser": "Usuário de Destino",
       "noSourceUsersLoaded": "Nenhum usuário de origem carregado ainda.",
-      "noActiveTargetUsers": "Nenhum usuário de destino ativo encontrado. Crie ou reative um usuário BookOrbit antes de mapear.",
+      "noActiveTargetUsers": "Nenhum usuário de destino ativo foi encontrado. Crie ou reative um usuário do BookOrbit antes de mapear.",
       "pathPrefixMappings": "Mapeamentos de Prefixo de Caminho",
       "addMapping": "Adicionar Mapeamento",
-      "pathMappingsExplanation": "Os mapeamentos de caminho traduzem os caminhos dos arquivos de origem para os caminhos de destino, para que os livros possam ser correspondidos pelo local do arquivo. Os livros também são correspondidos por ISBN, hash de arquivo e título/autor independentemente dos mapeamentos de caminho.",
+      "pathMappingsExplanation": "Os mapeamentos de caminho traduzem os caminhos de arquivo da origem para os caminhos de destino para que os livros possam ser correspondidos pelo local do arquivo. Os livros também são correspondidos por ISBN, hash de arquivo e título/autor, independentemente dos mapeamentos de caminho.",
       "noPrefixesFound": "Nenhum prefixo encontrado - valide a origem primeiro",
       "selectSourcePrefix": "Selecione o prefixo de origem...",
       "selectTargetFolder": "Selecione a pasta de destino...",
@@ -4774,35 +5006,35 @@
       "saveMappings": "Salvar Mapeamentos",
       "pathValidation": {
         "title": "Validação de caminho",
-        "mappedSummary": "{mapped} de {total} livros de origem têm um caminho mapeado",
-        "unmatched": "{count} caminhos mapeados não encontrados no disco",
-        "allMatched": "Todos os {count} caminhos mapeados encontrados no disco"
+        "mappedSummary": "{mapped} de {total} livros de origem possuem um caminho mapeado",
+        "unmatched": "{count} caminhos mapeados não foram encontrados no disco",
+        "allMatched": "Todos os {count} caminhos mapeados foram encontrados no disco"
       }
     },
     "dryRun": {
-      "run": "Executar Teste",
+      "run": "Executar Simulação",
       "matched": "Correspondidos:",
       "unresolved": "Não resolvidos:",
       "duplicates": "Duplicatas:",
       "unresolvedSummary": "Resumo de não resolvidos"
     },
     "duplicates": {
-      "title": "Resolver correspondências de destino duplicadas",
-      "explanation": "Para cada livro de destino, escolha um livro de origem para manter. Opções recomendadas são pré-selecionadas quando há uma única correspondência mais forte.",
+      "title": "Resolver correspondências duplicadas no destino",
+      "explanation": "Para cada livro de destino, escolha um livro de origem para manter. Opções recomendadas são pré-selecionadas quando há uma correspondência única e forte.",
       "remainingGroups": "Grupos restantes:",
       "ofCount": "de {total}",
       "targetBookId": "Livro de destino #{id}",
       "recommended": "Recomendado",
       "resolveButton": "Resolver {count} duplicata | Resolver {count} duplicata | Resolver {count} duplicatas",
-      "sourceRecordId": "ID do registro de origem #{id}",
+      "sourceRecordId": "ID de registro de origem #{id}",
       "byAuthor": "por {author} (ID: {id})",
       "byFilePath": "{filePath} (ID: {id})",
-      "bookloreSourceId": "ID de origem Booklore: {id}",
+      "bookloreSourceId": "ID de origem do Booklore: {id}",
       "libraryBookId": "Livro da biblioteca #{id}"
     },
     "preflight": {
-      "title": "Verificações de pré-voo",
-      "allPassed": "Todas as verificações aprovadas - pronto para migrar",
+      "title": "Verificações prévias",
+      "allPassed": "Todas as verificações passaram - pronto para migrar",
       "sourceValidated": "Origem validada",
       "saveAndValidateSource": "Salvar e validar conexão de origem",
       "validateSourceConnection": "Validar conexão de origem",
@@ -4810,40 +5042,40 @@
       "saveUserAndPathMappings": "Salvar mapeamentos de usuário e caminho",
       "pathMappingsValidated": "Mapeamentos de caminho validados",
       "savePathMappingsToValidate": "Salvar mapeamentos de caminho para validá-los",
-      "dryRunUpToDate": "O teste está atualizado",
-      "runFreshDryRun": "Executar um novo teste",
+      "dryRunUpToDate": "A simulação está atualizada",
+      "runFreshDryRun": "Executar uma nova simulação",
       "issues": {
-        "saveSource": "Salvar configurações de conexão de origem",
-        "validateSource": "Validar conexão de origem",
-        "saveMappings": "Salvar mapeamentos de usuário e caminho",
-        "savePathMappings": "Salvar mapeamentos de caminho para validá-los",
-        "freshDryRun": "Executar um novo teste",
-        "resolveDuplicates": "Resolver correspondências duplicadas de livros de destino no teste",
+        "saveSource": "Salvar as configurações de conexão da origem",
+        "validateSource": "Validar a conexão de origem",
+        "saveMappings": "Salvar os mapeamentos de usuário e caminho",
+        "savePathMappings": "Salvar os mapeamentos de caminho para validá-los",
+        "freshDryRun": "Executar uma nova simulação",
+        "resolveDuplicates": "Resolver as correspondências duplicadas de livros de destino na simulação",
         "waitForRun": "Aguardar a execução ativa terminar"
       }
     },
     "run": {
-      "confirmPrompt": "Isso iniciará a migração definitiva. Tem certeza?",
+      "confirmPrompt": "Isso iniciará a migração real. Tem certeza?",
       "confirmStart": "Confirmar Início",
       "startMigration": "Iniciar Migração",
       "cancelRun": "Cancelar Execução",
       "refreshStatus": "Atualizar Status",
-      "pollingStopped": "A sondagem de status parou devido a um erro.",
+      "pollingStopped": "A verificação de status foi interrompida devido a um erro.",
       "retry": "Tentar novamente",
-      "stage": "Estágio: {stage}",
+      "stage": "Etapa: {stage}",
       "initializing": "inicializando",
-      "ended": "Terminou em {time}"
+      "ended": "Terminou {time}"
     },
     "report": {
-      "noRunYet": "Nenhuma execução de migração ainda. Conclua as etapas acima para iniciar.",
+      "noRunYet": "Nenhuma migração foi executada ainda. Conclua as etapas acima para iniciar.",
       "runNumber": "Execução #{id}",
-      "notStarted": "Não iniciada",
+      "notStarted": "Não iniciado",
       "reloadReport": "Recarregar Relatório",
       "loadFullReport": "Carregar Relatório Completo",
       "exportJson": "Exportar JSON",
       "exportCsv": "Exportar CSV",
       "migrationFailed": "Falha na migração",
-      "retryFromLastStage": "Tentar novamente a partir do último estágio concluído",
+      "retryFromLastStage": "Tentar novamente a partir da última etapa concluída",
       "booksSection": "Livros",
       "metadataOverlays": "Sobreposições de metadados aplicadas",
       "authorMappings": "Mapeamentos de autor substituídos",
@@ -4851,380 +5083,1117 @@
       "genreMappings": "Mapeamentos de gênero substituídos",
       "tagMappings": "Mapeamentos de tag substituídos",
       "coversImported": "Capas importadas",
-      "coverImportSkipped": "Importação de capa ignorada - caminho raiz de mídia não configurado",
+      "coverImportSkipped": "A importação de capas foi ignorada - o caminho raiz de mídia não está configurado",
       "couldNotMatch": "Não foi possível corresponder",
       "userDataSection": "Dados do Usuário",
       "readingStatuses": "Status de leitura",
       "readingProgressEntries": "Entradas de progresso de leitura",
-      "audiobookProgressEntries": "Entradas de progresso de audiobook",
+      "audiobookProgressEntries": "Entradas de progresso de audiolivro",
       "readingSessions": "Sessões de leitura",
-      "bookmarks": "Favoritos",
+      "bookmarks": "Marcadores",
       "annotations": "Anotações",
       "collectionEntries": "Entradas de coleção",
-      "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência do teste no relatório exportado.",
-      "completedNoIssues": "Migração concluída sem livros não resolvidos ou falhas.",
+      "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência da simulação no relatório exportado.",
+      "completedNoIssues": "A migração foi concluída sem falhas ou livros não resolvidos.",
       "matchedBooks": "Livros correspondidos ({count})",
-      "matchedBooksExplanation": "Estas correspondências do teste foram usadas para decidir quais livros da biblioteca receberam dados importados.",
+      "matchedBooksExplanation": "Essas correspondências da simulação foram usadas para decidir quais livros da biblioteca receberam os dados importados.",
       "sourceBook": "Livro de origem {id}",
       "libraryBook": "Livro da biblioteca {id}",
       "unresolvedBooks": "Livros não resolvidos ({count})",
-      "unresolvedBooksExplanation": "Estes livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
+      "unresolvedBooksExplanation": "Esses livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
       "mappedUsers": "Usuários mapeados ({count})",
-      "mappedUsersExplanation": "Os totais por usuário vêm da pré-visualização do teste armazenada em cache com o plano de migração.",
-      "coverFailures": "{count} importação(ões) de capa falhou(aram). As linhas de falha detalhadas não são armazenadas.",
-      "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {sessions} sessões de leitura, {bookmarks} favoritos, {annotations} anotações, {collections} entradas de coleção"
+      "mappedUsersExplanation": "Os totais por usuário são provenientes da pré-visualização da simulação armazenada em cache com o plano de migração.",
+      "coverFailures": "{count} importação(ões) de capa falhou(aram). Linhas com detalhes de falhas não são armazenadas.",
+      "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {sessions} sessões de leitura, {bookmarks} marcadores, {annotations} anotações, {collections} entradas de coleção"
     },
     "unresolvedReason": {
       "noTitleAuthorMatch": "Nenhum livro correspondente encontrado por título ou autor",
-      "noFilePathMatch": "O caminho do arquivo não corresponde a nenhum livro nesta biblioteca",
-      "noFileHashMatch": "O hash do arquivo não corresponde a nenhum livro nesta biblioteca",
-      "noIsbnMatch": "O ISBN não corresponde a nenhum livro nesta biblioteca",
-      "insufficientSourceData": "Metadados insuficientes para tentar a correspondência",
-      "ambiguousIsbnMatch": "Múltiplos livros correspondem ao mesmo ISBN",
-      "ambiguousFileHashMatch": "Múltiplos livros correspondem ao mesmo hash de arquivo",
-      "ambiguousFilePathMatch": "Múltiplos livros correspondem ao mesmo caminho de arquivo",
-      "ambiguousTitleAuthorMatch": "Múltiplos livros correspondem ao mesmo título e autor",
+      "noFilePathMatch": "O caminho do arquivo não correspondeu a nenhum livro nesta biblioteca",
+      "noFileHashMatch": "O hash do arquivo não correspondeu a nenhum livro nesta biblioteca",
+      "noIsbnMatch": "O ISBN não correspondeu a nenhum livro nesta biblioteca",
+      "insufficientSourceData": "Metadados insuficientes para tentar correspondência",
+      "ambiguousIsbnMatch": "Vários livros corresponderam ao mesmo ISBN",
+      "ambiguousFileHashMatch": "Vários livros corresponderam ao mesmo hash de arquivo",
+      "ambiguousFilePathMatch": "Vários livros corresponderam ao mesmo caminho de arquivo",
+      "ambiguousTitleAuthorMatch": "Vários livros corresponderam ao mesmo título e autor",
       "unknown": "Não foi possível determinar o motivo"
     },
     "matchStrategy": {
       "isbn": "Correspondido por ISBN",
       "fileHash": "Correspondido por hash de arquivo",
-      "pathMapping": "Correspondido por caminho de arquivo mapeado",
+      "pathMapping": "Correspondido pelo caminho do arquivo mapeado",
       "titleAuthor": "Correspondido por título e autor",
       "unavailable": "Estratégia de correspondência indisponível"
     },
     "connectionError": {
-      "unreachable": "Não foi possível acessar o servidor de banco de dados. Verifique o host e a porta.",
-      "authFailed": "Falha na autenticação. Verifique o nome de usuário e a senha.",
+      "unreachable": "Não foi possível contatar o servidor do banco de dados. Verifique o host e a porta.",
+      "authFailed": "Falha na autenticação. Verifique o usuário e a senha.",
       "databaseNotFound": "Banco de dados não encontrado. Verifique o nome do banco de dados.",
-      "timeout": "A conexão expirou. Verifique as configurações de host e firewall.",
+      "timeout": "Tempo limite de conexão excedido. Verifique o host e as configurações do firewall.",
       "generic": "O teste de conexão falhou"
     },
     "userSelect": {
-      "placeholder": "Selecionar usuário",
+      "placeholder": "Selecione o usuário",
       "noUsersFound": "Nenhum usuário encontrado"
     },
     "toast": {
-      "initFailed": "Falha ao inicializar configurações de migração",
-      "loadSupportedTypesFailed": "Falha ao carregar tipos de origem de migração suportados",
+      "initFailed": "Falha ao inicializar as configurações de migração",
+      "loadSupportedTypesFailed": "Falha ao carregar tipos de fontes de migração suportados",
       "loadTargetUsersFailed": "Falha ao carregar usuários de destino",
-      "loadTargetFoldersFailed": "Falha ao carregar pastas da biblioteca de destino",
-      "noSourceUsers": "Nenhum usuário de origem foi retornado",
-      "suggestionsLoaded": "Sugestões de mapeamento de usuário carregadas",
+      "loadTargetFoldersFailed": "Falha ao carregar as pastas da biblioteca de destino",
+      "noSourceUsers": "Nenhum usuário de origem retornado",
+      "suggestionsLoaded": "Sugestões de mapeamento de usuários carregadas",
       "loadSuggestionsFailed": "Falha ao carregar sugestões de mapeamento de usuário",
       "sourceFieldsRequired": "Host, usuário, banco de dados e nome de origem são obrigatórios",
       "connectionPassedWithWarnings": "Teste de conexão concluído com avisos",
-      "connectionPassedWithWarningCount": "Teste de conexão concluído com {count} aviso(s). Primeiro: {warning}",
-      "connectionPassed": "Teste de conexão aprovado",
-      "connectionMissingTables": "Conexão ok, mas {count} tabela(s) obrigatória(s) estão ausentes",
-      "cannotTestMediaWhileRunning": "Não é possível testar o caminho de mídia enquanto uma execução estiver ativa",
-      "mediaPathRequired": "Caminho Raiz de Mídia é obrigatório para importação de capa.",
-      "mediaPathAbsolute": "Use um caminho absoluto (por exemplo: /books).",
-      "mediaPathVerified": "Caminho de mídia verificado.",
-      "mediaPathValid": "O caminho de mídia é válido e legível",
-      "mediaPathValidationFailed": "A validação do caminho de mídia falhou.",
+      "connectionPassedWithWarningCount": "O teste de conexão passou com {count} aviso(s). O primeiro foi: {warning}",
+      "connectionPassed": "O teste de conexão passou",
+      "connectionMissingTables": "Conexão ok, mas faltam {count} tabela(s) necessária(s)",
+      "cannotTestMediaWhileRunning": "Não é possível testar o caminho de mídia enquanto uma migração estiver em andamento",
+      "mediaPathRequired": "O Caminho Raiz da Mídia é obrigatório para a importação de capas.",
+      "mediaPathAbsolute": "Use um caminho absoluto (por exemplo: /livros).",
+      "mediaPathVerified": "Caminho da mídia verificado.",
+      "mediaPathValid": "O caminho da mídia é válido e está acessível",
+      "mediaPathValidationFailed": "Falha na validação do caminho da mídia.",
       "connectionFailedBeforeMedia": "O teste de conexão falhou antes que a validação do caminho de mídia pudesse ser concluída.",
-      "cannotModifySourceWhileRunning": "Não é possível modificar a origem enquanto uma execução estiver ativa",
+      "cannotModifySourceWhileRunning": "Não é possível modificar a origem enquanto houver uma migração em andamento",
       "sourceSavedWithWarnings": "Origem salva e validada com {count} aviso(s)",
-      "sourceSaved": "Origem salva e validada",
-      "saveSourceFailed": "Falha ao salvar ou validar origem",
-      "cannotSaveMappingsWhileRunning": "Não é possível salvar mapeamentos enquanto uma execução estiver ativa",
-      "saveSourceFirst": "Salvar origem primeiro",
+      "sourceSaved": "A origem foi salva e validada",
+      "saveSourceFailed": "Falha ao salvar ou validar a origem",
+      "cannotSaveMappingsWhileRunning": "Não é possível salvar os mapeamentos enquanto uma execução estiver ativa",
+      "saveSourceFirst": "Salve a origem primeiro",
       "mapAtLeastOneUser": "Mapeie pelo menos um usuário de origem para um usuário de destino",
       "mapEveryUser": "Mapeie todos os usuários de origem antes de salvar",
       "pathValidationFailedButSaved": "A validação do caminho falhou, mas o perfil ainda será salvo",
       "mappingsSaved": "Mapeamentos salvos",
-      "saveMappingsFailed": "Falha ao salvar mapeamentos",
-      "cannotDryRunWhileRunning": "Não é possível executar o teste enquanto uma execução estiver ativa",
-      "saveMappingsFirst": "Salvar mapeamentos primeiro",
-      "dryRunCompleted": "Teste concluído: {matched} correspondências, {unresolved} não resolvidos",
-      "dryRunFailed": "Falha no teste",
-      "selectSourceForDuplicates": "Selecione um livro de origem para todos os {count} grupos duplicados",
-      "duplicatesResolved": "Correspondências duplicadas resolvidas",
-      "resolveDuplicatesFailed": "Falha ao resolver duplicatas",
-      "preflightNotReady": "Pré-verificação de migração não pronta",
-      "runDryRunFirst": "Execute o teste primeiro",
-      "runStarted": "Execução de migração iniciada",
-      "startFailed": "Falha ao iniciar migração",
-      "runCancelled": "Execução de migração cancelada",
-      "cancelFailed": "Falha ao cancelar migração",
-      "runRetried": "Execução de migração repetida - retomando do último estágio concluído",
-      "retryFailed": "Falha ao repetir migração",
-      "loadProgressFailed": "Falha ao carregar progresso da execução",
+      "saveMappingsFailed": "Falha ao salvar os mapeamentos",
+      "cannotDryRunWhileRunning": "Não é possível executar a simulação enquanto houver uma migração em andamento",
+      "saveMappingsFirst": "Salve os mapeamentos primeiro",
+      "dryRunCompleted": "Simulação concluída: {matched} correspondências, {unresolved} não resolvidas",
+      "dryRunFailed": "Falha na simulação",
+      "selectSourceForDuplicates": "Selecione um livro de origem para todos os {count} grupos de duplicatas",
+      "duplicatesResolved": "As correspondências duplicadas foram resolvidas",
+      "resolveDuplicatesFailed": "Falha ao resolver as duplicatas",
+      "preflightNotReady": "As verificações prévias de migração não estão prontas",
+      "runDryRunFirst": "Execute a simulação (dry-run) primeiro",
+      "runStarted": "Migração iniciada",
+      "startFailed": "Falha ao iniciar a migração",
+      "runCancelled": "A execução da migração foi cancelada",
+      "cancelFailed": "Falha ao cancelar a migração",
+      "runRetried": "Migração reiniciada - retomando a partir da última etapa concluída",
+      "retryFailed": "Falha ao tentar a migração novamente",
+      "loadProgressFailed": "Falha ao carregar o progresso da execução",
       "startMigrationFirst": "Inicie a migração primeiro",
-      "reportRefreshed": "Relatório de execução atualizado",
-      "loadReportFailed": "Falha ao carregar relatório de execução",
-      "reportExported": "Relatório exportado como {format}",
-      "exportFailed": "Falha ao exportar relatório de migração"
+      "reportRefreshed": "Relatório da execução atualizado",
+      "loadReportFailed": "Falha ao carregar o relatório da execução",
+      "reportExported": "Relatório exportado no formato {format}",
+      "exportFailed": "Falha ao exportar o relatório da migração"
     }
   },
   "notifications": {
     "title": "Notificações",
-    "markAllRead": "Marcar tudo como lido",
+    "markAllRead": "Marcar todas como lidas",
     "clear": "Limpar",
     "empty": "Nenhuma notificação ainda",
     "loadMore": "Carregar mais notificações",
     "preferences": {
       "title": "Notificações",
-      "subtitle": "Escolha quais categorias de notificação você deseja receber.",
+      "subtitle": "Escolha quais categorias de notificação você quer receber.",
       "saving": "Salvando...",
       "unsavedChanges": "Alterações não salvas",
       "saved": "Preferências de notificação salvas",
-      "saveFailed": "Falha ao salvar preferências",
-      "savePreferenceFailed": "Falha ao salvar preferência",
-      "whatsNewToggle": "Mostrar \"O que há de novo\" após atualizações",
-      "whatsNewToggleHint": "Um pop-up destacando novos recursos após a atualização do aplicativo. O arquivo continua disponível de qualquer maneira."
+      "saveFailed": "Falha ao salvar as preferências",
+      "savePreferenceFailed": "Falha ao salvar a preferência",
+      "whatsNewToggle": "Mostrar \"O que há de novo\" depois das atualizações",
+      "whatsNewToggleHint": "Um pop-up destacando as novidades sempre que o aplicativo for atualizado. O arquivo continua disponível de qualquer maneira."
     }
   },
   "reader": {
     "retry": "Tentar novamente",
-    "loadingBook": "Carregando livro...",
-    "failedToLoadBook": "Falha ao carregar livro",
+    "pdf": {
+      "openError": "Não foi possível abrir este PDF",
+      "preparing": "Preparando o leitor de PDF",
+      "opening": "Abrindo PDF"
+    },
+    "loadingBook": "Carregando o livro…",
+    "failedToLoadBook": "Falha ao carregar o livro",
     "chapterNumber": "Capítulo {number}",
     "peek": {
-{
-  "peek": {
-    "badge": "Espiando",
-    "startReading": "Começar a ler"
-  },
-  "toast": {
-    "linkedHighlightError": "Não foi possível abrir a posição do destaque vinculado",
-    "resumed": "Retomado em {pct}% - {label}"
-  },
-  "header": {
-    "goBack": "Voltar",
-    "tableOfContents": "Sumário",
-    "toggleBookmark": "Alternar favorito",
-    "cycleFooterMode": "Alternar modo de informações do rodapé",
-    "keyboardShortcutsHint": "Atalhos de teclado (?)",
-    "enterFullscreen": "Entrar em tela cheia",
-    "exitFullscreen": "Sair da tela cheia",
-    "footerMode": {
-      "pageProgress": "Info do rodapé: página + progresso",
-      "sessionTimeLeft": "Info do rodapé: sessão de leitura + tempo restante",
-      "chapterTimeLeft": "Info do rodapé: capítulo + tempo restante do capítulo"
-    }
-  },
-  "footer": {
-    "previousSection": "Seção anterior",
-    "nextSection": "Próxima seção",
-    "goToPlaceholder": "45 ou p123",
-    "jumpToLocation": "Pular para a localização",
-    "jumpTooltip": "Pular para % ou página (ex: 45 ou p123)",
-    "go": "Ir"
-  },
-  "settings": {
-    "title": "Configurações",
-    "ariaLabel": "Configurações do leitor",
-    "tabs": {
-      "appearance": "Aparência",
-      "text": "Texto",
-      "layout": "Layout"
+      "badge": "Espiando",
+      "startReading": "Começar a ler"
     },
-    "appearance": {
-      "mode": "Modo",
-      "light": "Claro",
-      "dark": "Escuro",
-      "colorTheme": "Tema de cor"
+    "toast": {
+      "linkedHighlightError": "Não foi possível abrir a posição vinculada ao destaque",
+      "resumed": "Retomado em {pct}% - {label}"
     },
-    "text": {
-      "fontSize": "Tamanho da fonte",
-      "fontSizeRange": "Intervalo: 10-32px",
-      "lineHeight": "Altura da linha",
-      "lineHeightRange": "Intervalo: 0.8-3.0",
-      "fontFamily": "Família de fontes",
-      "fontFamilyDescription": "Escolha fontes embutidas ou enviadas para o corpo do texto.",
-      "builtIn": "Embutida",
-      "yourFonts": "Suas fontes"
+    "header": {
+      "goBack": "Voltar",
+      "tableOfContents": "Índice",
+      "toggleBookmark": "Alternar marcador",
+      "cycleFooterMode": "Alternar modo de informação do rodapé",
+      "keyboardShortcutsHint": "Atalhos de teclado (?)",
+      "enterFullscreen": "Entrar em tela cheia",
+      "exitFullscreen": "Sair da tela cheia",
+      "footerMode": {
+        "pageProgress": "Informação do rodapé: página + progresso",
+        "sessionTimeLeft": "Informação do rodapé: sessão de leitura + tempo restante",
+        "chapterTimeLeft": "Informação do rodapé: capítulo + tempo restante no capítulo"
+      }
     },
-    "layout": {
-      "pageSpreads": "Páginas duplas",
-      "pageSpreadsDescription": "Escolha como este EPUB baseado em imagem emparelha as páginas.",
-      "bookDefault": "Padrão do livro",
-      "singlePage": "Página única",
-      "readingFlow": "Fluxo de leitura",
-      "readingFlowDescription": "Alternar entre paginado e rolagem contínua.",
-      "paginated": "Paginado",
-      "scrolled": "Rolagem",
-      "textColumns": "Colunas de texto",
-      "textColumnsRange": "Intervalo: 1-10",
-      "columnGap": "Espaçamento entre colunas",
-      "columnGapRange": "Intervalo: 0-50%",
-      "maxWidth": "Largura máxima",
-      "maxWidthRange": "Intervalo: 400-1600",
-      "justifyText": "Justificar texto",
-      "justifyTextDescription": "Habilitar alinhamento de parágrafo de largura total.",
-      "hyphenation": "Hifenização",
-      "hyphenationDescription": "Habilitar hifenização automática de quebra de palavra."
-    }
-  },
-  "search": {
-    "placeholder": "Pesquisar no livro (mín. {min} caracteres)...",
-    "searching": "Pesquisando...",
-    "tooShort": "Digite pelo menos {min} caracteres",
-    "noResults": "Nenhum resultado encontrado",
-    "prompt": "Digite para pesquisar",
-    "resultCount": "nenhum resultado | {count} resultado | {count} resultados"
-  },
-  "sidebar": {
-    "tabs": {
+    "footer": {
+      "previousSection": "Seção anterior",
+      "nextSection": "Próxima seção",
+      "goToPlaceholder": "45 ou p123",
+      "jumpToLocation": "Pular para o local",
+      "jumpTooltip": "Pular para % ou página (ex. 45 ou p123)",
+      "go": "Ir"
+    },
+    "settings": {
+      "title": "Configurações",
+      "ariaLabel": "Configurações do Leitor",
+      "tabs": {
+        "appearance": "Aparência",
+        "text": "Texto",
+        "layout": "Layout"
+      },
+      "appearance": {
+        "mode": "Modo",
+        "light": "Claro",
+        "dark": "Escuro",
+        "colorTheme": "Tema de cor"
+      },
+      "text": {
+        "fontSize": "Tamanho da fonte",
+        "fontSizeRange": "Intervalo: 10-32px",
+        "lineHeight": "Altura da linha",
+        "lineHeightRange": "Intervalo: 0.8-3.0",
+        "fontFamily": "Família de fontes",
+        "fontFamilyDescription": "Escolha as fontes internas ou importadas para o corpo do texto.",
+        "builtIn": "Internas",
+        "yourFonts": "Suas fontes"
+      },
+      "layout": {
+        "pageSpreads": "Disposição das páginas",
+        "pageSpreadsDescription": "Escolha como esse EPUB baseado em imagem emparelha as páginas.",
+        "bookDefault": "Padrão do livro",
+        "singlePage": "Página única",
+        "readingFlow": "Fluxo de leitura",
+        "readingFlowDescription": "Alterne entre rolagem contínua e páginas separadas.",
+        "paginated": "Paginado",
+        "scrolled": "Rolar",
+        "textColumns": "Colunas de texto",
+        "textColumnsRange": "Intervalo: 1-10",
+        "columnGap": "Espaçamento das colunas",
+        "columnGapRange": "Intervalo: 0-50%",
+        "maxWidth": "Largura máxima",
+        "maxWidthRange": "Intervalo: 400-1600",
+        "justifyText": "Justificar texto",
+        "justifyTextDescription": "Habilitar alinhamento de parágrafos para a largura completa.",
+        "hyphenation": "Hifenização",
+        "hyphenationDescription": "Habilitar hifenização automática na quebra de linha."
+      }
+    },
+    "search": {
+      "placeholder": "Buscar no livro (mín. de {min} letras)...",
+      "searching": "Buscando…",
+      "tooShort": "Digite no mínimo {min} caracteres",
+      "noResults": "Nenhum resultado encontrado",
+      "prompt": "Digite para pesquisar",
+      "resultCount": "nenhum resultado | {count} resultado | {count} resultados"
+    },
+    "sidebar": {
+      "tabs": {
+        "chapters": "Capítulos",
+        "bookmarks": "Marcadores",
+        "highlights": "Destaques",
+        "toc": "Índice",
+        "tocShort": "Índice",
+        "marksShort": "Marcadores",
+        "notesShort": "Anotações"
+      },
+      "pin": "Fixar barra lateral",
+      "unpin": "Desafixar barra lateral",
+      "close": "Fechar barra lateral",
+      "noChapters": "Nenhum capítulo encontrado",
+      "noBookmarks": "Nenhum marcador ainda",
+      "noBookmarksMatch": "Nenhum marcador corresponde aos seus filtros",
+      "noHighlights": "Nenhum destaque ainda",
+      "noHighlightsMatch": "Nenhum destaque corresponde aos seus filtros",
+      "searchBookmarks": "Buscar marcadores...",
+      "searchHighlights": "Buscar destaques...",
+      "bookmarkFallback": "Marcador",
+      "locationUnavailable": "Local não disponível",
+      "customColor": "Personalizada ({color})",
+      "allColors": "Todas as cores",
+      "allChapters": "Todos os capítulos",
+      "notesOnly": "Apenas anotações",
+      "deleteBookmark": "Excluir marcador",
+      "deleteHighlight": "Excluir destaque",
+      "approximatePosition": "Sincronizado a partir do dispositivo; a posição exata não está disponível, pula para o capítulo",
+      "sort": {
+        "readingOrder": "Ordem de leitura",
+        "newest": "Mais novos primeiro",
+        "oldest": "Mais antigos primeiro"
+      }
+    },
+    "selection": {
+      "copy": "Copiar",
+      "copied": "Copiado!",
+      "highlight": "Destacar",
+      "translate": "Traduzir",
+      "define": "Definir",
+      "deleteAnnotation": "Excluir anotação",
+      "apply": "Aplicar"
+    },
+    "note": {
+      "title": "Adicionar nota",
+      "placeholder": "Escreva a sua nota…"
+    },
+    "dictionary": {
+      "noDefinition": "Nenhuma definição encontrada",
+      "loadError": "Não foi possível carregar a definição"
+    },
+    "translation": {
+      "original": "Original",
+      "translation": "Tradução",
+      "translating": "Traduzindo...",
+      "noTranslation": "Sem tradução ainda",
+      "viaProvider": "via {provider}",
+      "copyTranslation": "Copiar tradução"
+    },
+    "shortcuts": {
+      "title": "Atalhos de teclado",
+      "groups": {
+        "panels": "Painéis",
+        "reading": "Leitura",
+        "actions": "Ações"
+      },
+      "toggleToc": "Exibir/ocultar índice",
+      "toggleSearch": "Exibir/ocultar barra de busca",
+      "toggleHelp": "Exibir/ocultar esta ajuda",
+      "closePanel": "Fechar painel",
+      "prevNextPage": "Página anterior/próxima",
+      "goToStart": "Ir para o começo do livro",
+      "goToEnd": "Ir para o fim do livro",
+      "toggleBookmark": "Alternar o marcador",
+      "toggleFullscreen": "Alternar tela cheia",
+      "cycleFooterMode": "Alternar modo de rodapé"
+    },
+    "cbz": {
+      "tabs": {
+        "view": "Ver",
+        "reading": "Leitura",
+        "layout": "Layout"
+      },
+      "fitMode": "Modo de preenchimento",
+      "background": "Fundo",
+      "scrollMode": "Modo de rolagem",
+      "scrollModeHint": "Use \"Sem lacunas\" para webtoons e tiras verticais.",
+      "readingDirection": "Direção de leitura",
+      "pageView": "Visualização da página",
+      "autoFallback": "Preenchimento automático (fallback)",
+      "spreadAlignmentLabel": "Alinhamento das páginas",
+      "spreadAlignmentHint": "O alinhamento das páginas não está disponível no modo de fallback automático.",
+      "focusTwoPageToggle": "Alternar para focar em duas páginas",
+      "forceTwoPage": "Forçar duas páginas",
+      "off": "Desligado",
+      "on": "Ligado",
+      "widePages": "Páginas largas",
+      "resetBookViewSettings": "Redefinir configurações de exibição do livro",
+      "resetConfirm": "Redefinir as configurações de visualização deste livro para os seus padrões globais?",
+      "firstPage": "Primeira página",
+      "lastPage": "Última página",
+      "fit": {
+        "page": "Ajustar à página",
+        "width": "Ajustar à largura",
+        "height": "Ajustar à altura",
+        "actual": "Tamanho real"
+      },
+      "view": {
+        "single": "Única",
+        "twoPage": "Duas páginas"
+      },
+      "scroll": {
+        "paged": "Paginado",
+        "infinite": "Infinito",
+        "noGaps": "Sem lacunas"
+      },
+      "direction": {
+        "ltr": "E para D",
+        "rtl": "D para E"
+      },
+      "spreadAlignment": {
+        "normal": "Normal",
+        "shifted": "Deslocado"
+      },
+      "widePage": {
+        "auto": "Automático",
+        "inSpreads": "Em páginas duplas"
+      },
+      "bg": {
+        "black": "Preto",
+        "gray": "Cinza",
+        "white": "Branco"
+      }
+    },
+    "audiobook": {
+      "untitled": "Sem título",
+      "loading": "Carregando audiolivro...",
+      "loadError": "Falha ao carregar audiolivro",
+      "noAudioFiles": "Nenhum arquivo de áudio encontrado para este livro.",
+      "speed": "Velocidade",
       "chapters": "Capítulos",
-      "bookmarks": "Favoritos",
-      "highlights": "Destaques",
-      "toc": "Sumário",
-      "tocShort": "Sumário",
-      "marksShort": "Marcas",
-      "notesShort": "Notas"
-    },
-    "pin": "Fixar barra lateral",
-    "unpin": "Desafixar barra lateral",
-    "close": "Fechar barra lateral",
-    "noChapters": "Nenhum capítulo encontrado",
-    "noBookmarks": "Nenhum favorito ainda",
-    "noBookmarksMatch": "Nenhum favorito corresponde aos seus filtros",
-    "noHighlights": "Nenhum destaque ainda",
-    "noHighlightsMatch": "Nenhum destaque corresponde aos seus filtros",
-    "searchBookmarks": "Pesquisar favoritos...",
-    "searchHighlights": "Pesquisar destaques...",
-    "bookmarkFallback": "Favorito",
-    "locationUnavailable": "Localização indisponível",
-    "customColor": "Personalizado ({color})",
-    "allColors": "Todas as cores",
-    "allChapters": "Todos os capítulos",
-    "notesOnly": "Apenas notas",
-    "deleteBookmark": "Excluir favorito",
-    "deleteHighlight": "Excluir destaque",
-    "approximatePosition": "Sincronizado do dispositivo; posição exata indisponível, pula para o capítulo",
-    "sort": {
-      "readingOrder": "Ordem de leitura",
-      "newest": "Mais novos primeiro",
-      "oldest": "Mais antigos primeiro"
+      "bookmarks": "Marcadores",
+      "volume": "Volume",
+      "muted": "Mutado",
+      "sleep": "Pausa",
+      "chapterAbbrev": "Cap.",
+      "sleepTimer": "Temporizador de pausa",
+      "minutes": "{count} minutos",
+      "endOfChapter": "Fim do capítulo",
+      "noChaptersAvailable": "Nenhum capítulo disponível",
+      "extend15": "+ 15 minutos",
+      "timeLeft": "({time} restante)",
+      "playbackSpeed": "Velocidade de reprodução",
+      "noChapters": "Nenhum capítulo disponível.",
+      "noBookmarks": "Nenhum marcador ainda.",
+      "noBookmarksHint": "Toque no ícone de marcador na parte superior para salvar sua posição atual.",
+      "playerSettings": "Configurações do player",
+      "skipBack": "Pular para trás",
+      "skipForward": "Pular para frente"
     }
   },
-  "selection": {
-    "copy": "Copiar",
-    "copied": "Copiado!",
-    "highlight": "Destaque",
-    "translate": "Traduzir",
-    "define": "Definir",
-    "deleteAnnotation": "Excluir anotação",
-    "apply": "Aplicar"
+  "scanner": {
+    "filesProgress": "{processed}/{total} arquivos",
+    "booksFound": "nenhum livro encontrado | {count} livro encontrado | {count} livros encontrados"
   },
-  "note": {
-    "title": "Adicionar nota",
-    "placeholder": "Escreva sua nota..."
-  },
-  "dictionary": {
-    "noDefinition": "Nenhuma definição encontrada",
-    "loadError": "Não foi possível carregar a definição"
-  },
-  "translation": {
-    "original": "Original",
-    "translation": "Tradução",
-    "translating": "Traduzindo...",
-    "noTranslation": "Nenhuma tradução ainda",
-    "viaProvider": "via {provider}",
-    "copyTranslation": "Copiar tradução"
-  },
-  "shortcuts": {
-    "title": "Atalhos de Teclado",
-    "groups": {
-      "panels": "Painéis",
-      "reading": "Leitura",
-      "actions": "Ações"
+  "series": {
+    "completion": {
+      "readOfTotal": "{read} de {total} lido(s) ({percentage}%)"
     },
-    "toggleToc": "Alternar sumário",
-    "toggleSearch": "Alternar pesquisa",
-    "toggleHelp": "Mostrar/ocultar esta ajuda",
-    "closePanel": "Fechar painel",
-    "prevNextPage": "Página anterior/próxima",
-    "goToStart": "Ir para o início do livro",
-    "goToEnd": "Ir para o final do livro",
-    "toggleBookmark": "Alternar favorito",
-    "toggleFullscreen": "Alternar tela cheia",
-    "cycleFooterMode": "Alternar modo de informações do rodapé"
+    "gaps": {
+      "label": "Possíveis lacunas:"
+    },
+    "filters": {
+      "title": "Filtros de Séries",
+      "clearAll": "Limpar todos",
+      "allLibraries": "Todas as Bibliotecas",
+      "allCompletion": "Toda a conclusão",
+      "notStarted": "Não iniciada",
+      "inProgress": "Em progresso",
+      "complete": "Concluída"
+    },
+    "list": {
+      "title": "Séries",
+      "showControlsAria": "Exibir os controles de série",
+      "searchPlaceholder": "Buscar série ou autor",
+      "sortButton": "Ordenar",
+      "sortBy": "Ordenar por",
+      "ascending": "Crescente",
+      "descending": "Decrescente",
+      "ascShort": "Cresc",
+      "descShort": "Decresc",
+      "filters": "Filtros",
+      "clear": "Limpar",
+      "noMatch": "Nenhuma série corresponde aos seus filtros.",
+      "empty": "Nenhuma série foi encontrada em suas bibliotecas.",
+      "sort": {
+        "name": "Nome",
+        "bookCount": "Contagem de Livros",
+        "recentAdditions": "Adições Recentes",
+        "readingProgress": "Progresso de Leitura"
+      }
+    },
+    "detail": {
+      "pageTitle": "Série",
+      "pageTitleNamed": "Série · {name}",
+      "pageTitleWithId": "Série #{id}",
+      "entityName": "Série",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "byAuthors": "por {authors}",
+      "moreAuthors": "+{count} mais",
+      "preparingEditor": "Preparando editor...",
+      "editMetadata": "Editar Metadados",
+      "firstInSeries": "Primeiro da Série",
+      "untitled": "Sem título",
+      "loadingFirstBook": "Carregando a pré-visualização do primeiro livro...",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar mais",
+      "moreGenres": "+{count} mais",
+      "synopsis": "Sinopse",
+      "noDescription": "Nenhuma descrição disponível.",
+      "updatingPreview": "Atualizando a pré-visualização...",
+      "noBooksToPreview": "Não há livros disponíveis para pré-visualização.",
+      "loadingSeries": "Carregando série...",
+      "booksHeading": "Livros",
+      "allLibraries": "Todas as Bibliotecas",
+      "groupByMedia": "Agrupar por mídia",
+      "noBooksFound": "Nenhum livro foi encontrado nesta série",
+      "trySelectingLibrary": "Tente selecionar outra biblioteca.",
+      "allBooksLoaded": "Todos os {count} livros carregados",
+      "leadBookLoadError": "Falha ao carregar detalhes do livro principal",
+      "noBooksToEdit": "Esta série não tem livros para edição.",
+      "loadFullSeriesError": "Falha ao carregar a série completa para a edição.",
+      "sort": {
+        "seriesOrder": "Ordem da Série",
+        "title": "Título",
+        "recentlyAdded": "Adicionados Recentemente"
+      },
+      "order": {
+        "ascending": "Crescente",
+        "descending": "Decrescente"
+      }
+    }
   },
-  "cbz": {
+  "smartScope": {
+    "syncToKobo": "Sincronizar com o Kobo",
+    "syncToKoboHint": "Os livros que correspondem a este escopo aparecerão no seu dispositivo Kobo",
+    "dialog": {
+      "name": "Nome",
+      "namePlaceholder": "ex. Ficção Científica Não Lida",
+      "icon": "Ícone",
+      "iconPlaceholder": "Escolha um ícone...",
+      "nameRequired": "O nome é obrigatório",
+      "iconRequired": "Escolha um ícone",
+      "create": "Criar",
+      "creating": "Criando...",
+      "saving": "Salvando..."
+    },
+    "createDialog": {
+      "title": "Novo SmartScope",
+      "visibleToAll": "Visível a todos os usuários",
+      "createFailed": "Falha ao criar o SmartScope"
+    },
+    "saveAsDialog": {
+      "title": "Salvar como SmartScope",
+      "save": "Salvar SmartScope",
+      "saveFailed": "Falha ao salvar o SmartScope"
+    },
+    "editorPanel": {
+      "untitled": "SmartScope Sem Título",
+      "subtitle": "Configure as definições do SmartScope",
+      "counting": "contando...",
+      "bookCount": "nenhum livro | um livro | {count} livros",
+      "identity": "Identidade",
+      "filters": "Filtros",
+      "noFilters": "Nenhum filtro definido. Todos os livros acessíveis serão incluídos neste SmartScope.",
+      "buildFromScratch": "Construir do zero",
+      "replaceWithTemplate": "Substituir por modelo:",
+      "defaultSort": "Ordenação Padrão",
+      "saveChanges": "Salvar alterações",
+      "saveFailed": "Falha ao salvar",
+      "templates": {
+        "hasSeries": "Possui Série",
+        "addedRecently": "Adicionado Recentemente",
+        "pdfOnly": "Apenas PDF",
+        "noGenres": "Sem Gêneros",
+        "epubOnly": "Apenas EPUB"
+      }
+    }
+  },
+  "statistics": {
     "tabs": {
-      "view": "Visualização",
-      "reading": "Leitura",
-      "layout": "Layout"
+      "library": "Estatísticas da Biblioteca",
+      "user": "Minha Leitura"
     },
-    "fitMode": "Modo de ajuste",
-    "background": "Fundo",
-    "scrollMode": "Modo de rolagem",
-    "scrollModeHint": "Use \"Sem espaços\" para webtoons e tiras verticais.",
-    "readingDirection": "Direção de leitura",
-    "pageView": "Visualização de página",
-    "autoFallback": "Fallback automático",
-    "spreadAlignmentLabel": "Alinhamento de página dupla",
-    "spreadAlignmentHint": "O alinhamento de página dupla está indisponível no modo de fallback automático.",
-    "focusTwoPageToggle": "Alternar foco de duas páginas",
-    "forceTwoPage": "Forçar duas páginas",
-    "off": "Desativado",
-    "on": "Ativado",
-    "widePages": "Páginas largas",
-    "resetBookViewSettings": "Redefinir configurações de visualização do livro",
-    "resetConfirm": "Redefinir as configurações de visualização deste livro para os seus padrões globais?",
-    "firstPage": "Primeira página",
-    "lastPage": "Última página",
-    "fit": {
-      "page": "Ajustar à Página",
-      "width": "Ajustar à Largura",
-      "height": "Ajustar à Altura",
-      "actual": "Tamanho Real"
+    "filter": {
+      "allLibraries": "Todas as Bibliotecas",
+      "librarySelection": "{count} de {total} Bibliotecas"
     },
-    "view": {
-      "single": "Única",
-      "twoPage": "Duas páginas"
+    "config": {
+      "button": "Configurar",
+      "title": "Configurar Gráficos",
+      "description": "Arraste para reordenar, clique para mostrar ou esconder.",
+      "reset": "Redefinir padrões"
     },
-    "scroll": {
-      "paged": "Paginado",
-      "infinite": "Infinito",
-      "noGaps": "Sem espaços"
+    "summary": {
+      "books": "Livros",
+      "authors": "Autores",
+      "series": "Séries",
+      "publishers": "Editoras",
+      "storage": "Armazenamento",
+      "genres": "Gêneros",
+      "languages": "Idiomas",
+      "published": "Publicados",
+      "thisYear": "Neste Ano",
+      "started": "Iniciados",
+      "inProgress": "Em Progresso",
+      "completed": "Concluídos",
+      "avgProgress": "Progresso Médio"
     },
-    "direction": {
-      "ltr": "E para D",
-      "rtl": "D para E"
+    "card": {
+      "loadError": "Falha ao carregar os dados",
+      "emptyTitle": "Ainda não há dados",
+      "emptyDescription": "Nenhum dado disponível para este gráfico",
+      "unknownField": "nenhum dado para este campo | {count} livro sem dados para este campo | {count} livros sem dados para este campo"
     },
-    "spreadAlignment": {
-      "normal": "Normal",
-      "shifted": "Deslocado"
+    "breakdown": {
+      "ariaLabel": "Detalhamento por fonte ou formato"
     },
-    "widePage": {
-      "auto": "Automático",
-      "inSpreads": "Em páginas duplas"
+    "empty": {
+      "notEnoughData": "Dados insuficientes ainda"
     },
-    "bg": {
-      "black": "Preto",
-      "gray": "Cinza",
-      "white": "Branco"
+    "charts": {
+      "acquisitionLag": {
+        "title": "Atraso de Aquisição"
+      },
+      "booksAddedOverTime": {
+        "title": "Livros Adicionados ao Longo do Tempo",
+        "monthly": "Mensalmente",
+        "yearly": "Anualmente",
+        "allTime": "Todo o Período",
+        "last5Years": "Últimos 5 Anos",
+        "lastYear": "Último Ano"
+      },
+      "formatDistribution": {
+        "title": "Distribuição de Formatos"
+      },
+      "formatShareOverTime": {
+        "title": "Fatia de Formato ao Longo do Tempo"
+      },
+      "genreCooccurrence": {
+        "title": "Coocorrência de Gêneros"
+      },
+      "genreDistribution": {
+        "title": "Distribuição de Gêneros"
+      },
+      "languageDistribution": {
+        "title": "Distribuição de Idiomas"
+      },
+      "largestBooks": {
+        "title": "Top 50 Maiores Livros"
+      },
+      "libraryIntegrity": {
+        "title": "Integridade da Biblioteca"
+      },
+      "libraryMetadataCompleteness": {
+        "title": "Completude de Metadados da Biblioteca"
+      },
+      "metadataCompleteness": {
+        "title": "Completude de Metadados"
+      },
+      "metadataFreshness": {
+        "title": "Atualização dos Metadados"
+      },
+      "metadataScoreDistribution": {
+        "title": "Distribuição de Pontuação de Metadados"
+      },
+      "pageCountDistribution": {
+        "title": "Distribuição de Número de Páginas"
+      },
+      "publicationDecade": {
+        "title": "Década de Publicação"
+      },
+      "publicationYearTimeline": {
+        "title": "Linha do Tempo do Ano de Publicação"
+      },
+      "storageByFormat": {
+        "title": "Armazenamento por Formato"
+      },
+      "topAuthors": {
+        "title": "Top 25 Autores"
+      },
+      "topSeries": {
+        "title": "Top 50 Séries"
+      },
+      "booksCompleted": {
+        "title": "Livros Concluídos",
+        "notEnoughData": "Precisa de pelo menos {count} livros concluídos para este gráfico."
+      },
+      "completionLatency": {
+        "title": "Tempo até a Conclusão",
+        "notEnoughData": "Precisa de pelo menos {count} livros concluídos para este gráfico."
+      },
+      "completionTimeline": {
+        "title": "Linha do Tempo de Conclusão",
+        "notEnoughData": "Precisa de pelo menos {count} livros concluídos para este gráfico."
+      },
+      "favoriteReadingDays": {
+        "title": "Dias Favoritos de Leitura",
+        "notEnoughData": "Precisa de pelo menos {count} eventos de leitura para este gráfico."
+      },
+      "genreReadingTime": {
+        "title": "Tempo de Leitura por Gênero",
+        "notEnoughData": "Precisa de pelo menos {count} gêneros com tempo de leitura para este gráfico."
+      },
+      "goalTrajectory": {
+        "title": "Ritmo vs Meta",
+        "noCompletedTitle": "Ainda não há livros concluídos",
+        "noCompletedDescription": "Conclua um livro neste período para comparar o seu ritmo com a meta anual.",
+        "notEnoughData": "Precisa de pelo menos {count} livros concluídos para este gráfico."
+      },
+      "peakReadingHours": {
+        "title": "Horários de Pico de Leitura",
+        "notEnoughData": "Precisa de pelo menos {count} eventos de leitura para este gráfico."
+      },
+      "progressFunnel": {
+        "title": "Funil de Progresso",
+        "modePercent": "Porcentagem",
+        "modeCounts": "Contagens",
+        "modeDropoff": "Desistência",
+        "started": "Iniciados {count}",
+        "notEnoughData": "Precisa de pelo menos {count} livros iniciados para este gráfico.",
+        "noDropOffTitle": "Nenhuma desistência observada",
+        "noDropOffDescription": "Todos os livros iniciados progrediram em todos os estágios do funil neste período."
+      },
+      "readingClock": {
+        "title": "Relógio de Leitura",
+        "notEnoughData": "Precisa de pelo menos {count} sessões de leitura para este gráfico."
+      },
+      "readingHeatmap": {
+        "title": "Mapa de Calor de Leitura",
+        "notEnoughData": "Precisa de atividade em pelo menos {count} dias para este gráfico."
+      },
+      "readingPace": {
+        "title": "Ritmo de Leitura",
+        "notEnoughData": "Precisa de pelo menos {count} sessões com dados de progresso para este gráfico."
+      },
+      "readingSessionTimeline": {
+        "title": "Linha do Tempo da Sessão de Leitura",
+        "dragOn": "Arrastar: Ligado",
+        "dragOff": "Arrastar: Desligado",
+        "prev": "Anterior",
+        "next": "Próximo",
+        "week": "Semana {week}",
+        "dragHint": "Arraste as barras para mover as sessões. A duração é bloqueada e sessões sobrepostas são rejeitadas.",
+        "noSessionsTitle": "Nenhuma sessão nesta semana",
+        "noSessionsDescription": "Utilize Anterior/Próximo ou o seletor de semana para visualizar uma semana diferente.",
+        "overlapError": "A sessão se sobrepõe a outra sessão nesta janela",
+        "moveError": "Falha ao mover a sessão"
+      },
+      "sessionArchetypes": {
+        "title": "Arquétipos de Sessões"
+      },
+      "sourceDistribution": {
+        "title": "Onde Você Lê",
+        "emptyTitle": "Nenhuma atividade de leitura ainda",
+        "emptyDescription": "Leia na web, KOReader ou Kobo para ver sua distribuição de fontes."
+      }
     }
   },
-  "audiobook": {
-    "untitled": "Sem título",
-    "loading": "Carregando audiobook...",
-    "loadError": "Falha ao carregar audiobook",
-    "noAudioFiles": "Nenhum arquivo de áudio encontrado para este livro.",
-    "speed": "Velocidade",
-    "chapters": "Capítulos",
-    "bookmarks": "Favoritos",
-    "volume": "Volume",
-    "muted": "Sem áudio",
-    "sleep": "Sono",
-    "chapterAbbrev": "Cap.",
-    "sleepTimer": "Temporizador de sono",
-    "minutes": "{count} minutos",
-    "endOfChapter": "Fim do capítulo",
-    "noChaptersAvailable": "Nenhum capítulo disponível",
-    "extend15": "+ 15 minutos",
-    "timeLeft": "({time} restantes)",
-    "playbackSpeed": "Velocidade de reprodução",
-    "noChapters": "Nenhum capítulo disponível.",
-    "noBookmarks": "Nenhum favorito ainda.",
-    "noBookmarksHint": "Toque no ícone de favorito no topo para salvar sua posição atual.",
-    "playerSettings": "Configurações do reprodutor",
-    "skipBack": "Retroceder",
-    "skipForward": "Avançar"
+  "tools": {
+    "header": {
+      "entityManager": "Gerenciador de Entidades",
+      "bulkRename": "Renomeação em Massa"
+    },
+    "entityTypes": {
+      "authors": "Autores",
+      "genres": "Gêneros",
+      "tags": "Tags",
+      "narrators": "Narradores",
+      "publishers": "Editoras",
+      "languages": "Idiomas",
+      "series": "Séries"
+    },
+    "bulkRename": {
+      "library": "Biblioteca",
+      "selectLibraryPlaceholder": "Selecione uma biblioteca...",
+      "noEligibleLibraries": "Nenhuma biblioteca possui a renomeação de arquivos ativada. Ative isso em Configurações da Biblioteca.",
+      "refresh": "Atualizar",
+      "applyRename": "Aplicar Renomeação",
+      "showFullPaths": "Mostrar caminhos completos",
+      "columnsMenu": "Colunas",
+      "renamingInProgress": "Renomeando arquivos - você pode cancelar a qualquer momento.",
+      "executionFailed": "A renomeação em massa falhou",
+      "previewFailed": "Falha ao carregar a pré-visualização",
+      "noBooksMatch": "Nenhum livro corresponde ao filtro atual.",
+      "openBookDetails": "Abrir detalhes do livro",
+      "columns": {
+        "title": "Título",
+        "currentPath": "Caminho Atual",
+        "newPath": "Novo Caminho",
+        "status": "Status"
+      },
+      "status": {
+        "willRename": "Será Renomeado",
+        "unchanged": "Inalterado",
+        "collision": "Colisão",
+        "noPattern": "Sem Padrão",
+        "error": "Erro"
+      },
+      "filter": {
+        "all": "Todos"
+      },
+      "summary": {
+        "label": "Resumo",
+        "toRename": "{count} para renomear",
+        "unchanged": "{count} inalterado",
+        "collisions": "{count} colisão | {count} colisão | {count} colisões",
+        "errors": "{count} erro | {count} erro | {count} erros"
+      },
+      "empty": {
+        "title": "Escolha uma Biblioteca para Iniciar",
+        "description": "Selecione uma biblioteca acima para pré-visualizar alterações de nome, filtrar por status e aplicar a execução da renomeação em massa.",
+        "chooseLibrary": "Escolher Biblioteca"
+      },
+      "completed": {
+        "title": "Renomeação em massa concluída",
+        "stats": "{succeeded} renomeados, {failed} falharam, {skipped} ignorados ({processed} totais)"
+      },
+      "pagination": {
+        "showing": "Exibindo {from}-{to} de {total}"
+      },
+      "confirmDialog": {
+        "title": "Confirmar Renomeação em Massa",
+        "body": "Isto renomeará {count} livro no disco. Arquivos com colisões ou erros serão ignorados. Esta ação não pode ser desfeita. | Isto renomeará {count} livro no disco. Arquivos com colisões ou erros serão ignorados. Esta ação não pode ser desfeita. | Isto renomeará {count} livros no disco. Arquivos com colisões ou erros serão ignorados. Esta ação não pode ser desfeita.",
+        "renameButton": "Renomear {count} livro | Renomear {count} livro | Renomear {count} livros"
+      }
+    },
+    "entityManager": {
+      "unknown": "Desconhecido",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "sortPrefix": "· ordenação: {sortName}",
+      "selectTargetToKeep": "Selecione o destino que deseja manter",
+      "writeToFiles": "Gravar nos arquivos",
+      "writeChangesToFiles": "Gravar alterações nos arquivos",
+      "mergeIntoTarget": "Mesclar {count} no destino",
+      "modes": {
+        "browse": "Navegar & Gerenciar",
+        "duplicates": "Localizar Duplicatas"
+      },
+      "actions": {
+        "rename": "Renomear",
+        "split": "Dividir"
+      },
+      "duplicates": {
+        "similarity": "Similaridade:",
+        "scan": "Analisar",
+        "scanning": "Analisando...",
+        "computing": "Computando candidatos...",
+        "computedAt": "Candidatos computados {date}",
+        "recompute": "Recomputar",
+        "noneComputed": "Nenhum candidato computado ainda.",
+        "computeNow": "Computar agora",
+        "emptyTitle": "Encontrar entidades duplicadas",
+        "emptyDescription": "Ajuste o limite de similaridade e clique em Analisar para detectar possíveis duplicatas.",
+        "noneFoundTitle": "Nenhuma duplicata encontrada",
+        "noneFoundDescription": "Não foram detectadas possíveis duplicatas com as configurações atuais.",
+        "clustersFound": "nenhum cluster encontrado | {count} cluster encontrado | {count} clusters encontrados",
+        "plusOthers": "+ {count} outro | + {count} outro | + {count} outros",
+        "percentSimilar": "{percent}% similar",
+        "pairDetails": "Detalhes do par",
+        "dismissEntityTitle": "Ignorar todos os pares desta entidade",
+        "dismissPairTitle": "Ignorar este par"
+      },
+      "dismissed": {
+        "loading": "Carregando pares ignorados...",
+        "empty": "Nenhum par ignorado",
+        "restore": "Restaurar",
+        "restoreTitle": "Restaurar este par",
+        "hidePairs": "Ocultar pares ignorados",
+        "showPairs": "Mostrar pares ignorados"
+      },
+      "browse": {
+        "searchPlaceholder": "Pesquisar...",
+        "emptyOnly": "Somente vazias",
+        "clear": "Limpar",
+        "noEntities": "Nenhuma entidade encontrada",
+        "mergeCount": "Mesclar ({count})",
+        "deleteCount": "Excluir ({count})",
+        "totalCount": "{count} no total",
+        "sortLabel": "ordenação: {sortName}",
+        "sort": {
+          "nameAsc": "Nome A-Z",
+          "nameDesc": "Nome Z-A",
+          "fewestBooks": "Menos livros",
+          "mostBooks": "Mais livros"
+        }
+      },
+      "deleteMode": {
+        "label": "Modo de exclusão",
+        "softTitle": "Exclusão suave",
+        "softDescription": "Desvincular de todos os livros, mas manter o registro da entidade",
+        "softDescriptionPlural": "Desvincular de todos os livros, mas manter os registros das entidades",
+        "hardTitle": "Exclusão permanente",
+        "hardDescription": "Remover a entidade e todas as associações permanentemente",
+        "hardDescriptionPlural": "Remover as entidades e todas as associações permanentemente"
+      },
+      "renameModal": {
+        "title": "Renomear Entidade",
+        "currentName": "Nome atual",
+        "newName": "Novo nome"
+      },
+      "deleteModal": {
+        "title": "Excluir Entidade",
+        "confirm": "Tem certeza que quer excluir {name}?"
+      },
+      "splitModal": {
+        "title": "Dividir Entidade",
+        "splitting": "Dividindo",
+        "newNames": "Novos nomes (mín 2)",
+        "namePlaceholder": "Insira o nome...",
+        "addAnother": "Adicionar outro"
+      },
+      "bulkDeleteModal": {
+        "title": "Exclusão em Massa",
+        "confirm": "Tem certeza que quer excluir {count} entidade selecionada? | Tem certeza que quer excluir {count} entidade selecionada? | Tem certeza que quer excluir {count} entidades selecionadas?",
+        "deleteButton": "Excluir {count}"
+      },
+      "mergeModal": {
+        "title": "Mesclar Entidades",
+        "description": "Selecione qual entidade você deseja manter. As demais serão mescladas nela e em seguida removidas."
+      }
+    }
+  },
+  "views": {
+    "entity": {
+      "book": "Livro",
+      "collection": "Coleção",
+      "library": "Biblioteca",
+      "smartScope": "SmartScope"
+    },
+    "common": {
+      "retry": "Tentar novamente"
+    },
+    "bookView": {
+      "sort": "Ordenar",
+      "sortOn": "Em",
+      "resetSort": "Restaurar ordenação padrão",
+      "filters": "Filtros",
+      "clear": "Limpar",
+      "clearAllFilters": "Limpar todos os filtros",
+      "expandSeries": "Expandir séries",
+      "collapseSeries": "Recolher séries",
+      "expanded": "Expandida(s)",
+      "exportMetadata": "Exportar metadados",
+      "showControlsAria": "Exibir controles de biblioteca",
+      "export": "Exportar",
+      "searchPlaceholder": "Buscar título, autor, série, narrador...",
+      "allBooksLoaded": "Todos os {count} livros carregados"
+    },
+    "notFound": {
+      "title": "Página não encontrada",
+      "description": "A página que você está procurando não existe.",
+      "goHome": "Ir para o Início"
+    },
+    "dashboard": {
+      "customize": "Personalizar painel",
+      "allShelvesHidden": "Todas as prateleiras estão ocultas.",
+      "greeting": {
+        "night": "Boa noite,",
+        "morning": "Bom dia,",
+        "afternoon": "Boa tarde,",
+        "evening": "Boa noite,",
+        "fallbackName": "olá"
+      }
+    },
+    "bookDetail": {
+      "title": "Livro",
+      "titleWithId": "Livro #{id}",
+      "pageTitle": {
+        "book": "Livro · {base}",
+        "editMetadata": "Editar Metadados · {base}",
+        "edit": "Editar · {base}",
+        "files": "Arquivos · {base}",
+        "readingLog": "Registro de Leitura · {base}",
+        "highlights": "Destaques · {base}"
+      }
+    },
+    "bookDock": {
+      "title": "Doca de Livros",
+      "newFilesDetected": "Novos arquivos detectados",
+      "reconnecting": "Reconectando",
+      "rescanFailed": "O reescaneamento falhou",
+      "totalInDock": "{size} na Doca de Livros",
+      "dropFiles": "Arraste os arquivos para a Doca de Livros",
+      "supportedFormats": "Suportado: {formats}",
+      "empty": {
+        "noSearchMatch": "Nenhum arquivo corresponde a \"{query}\"",
+        "noStatusFiles": "Nenhum arquivo em {status}",
+        "uploadPrompt": "Faça o upload de arquivos ou arraste para a pasta Doca de Livros"
+      },
+      "retry": {
+        "noneToRetry": "Nenhum erro de arquivo para tentar novamente",
+        "retrying": "Tentando um arquivo novamente | Tentando um arquivo novamente | Tentando {count} arquivos novamente"
+      },
+      "applyFetched": {
+        "applied": "Aplicado a nenhum arquivo | Aplicado a um arquivo | Aplicado a {count} arquivos",
+        "skippedEdited": "ignorado um arquivo por ter edições manuais | ignorado um arquivo por ter edições manuais | ignorados {count} arquivos por terem edições manuais",
+        "skippedNoMetadata": "ignorado um arquivo por não ter metadados buscados | ignorado um arquivo por não ter metadados buscados | ignorados {count} arquivos por não terem metadados buscados",
+        "noneApplied": "Nenhum arquivo aplicado; {reasons}",
+        "noneSelected": "Nenhum arquivo selecionado"
+      }
+    },
+    "collection": {
+      "title": "Coleção",
+      "pageTitle": "Coleção · {name}",
+      "pageTitleWithId": "Coleção #{id}",
+      "editCollection": "Editar coleção",
+      "showControlsAria": "Exibir controles de coleção",
+      "loadError": "Não foi possível carregar esta coleção",
+      "toast": {
+        "removed": "Nenhum livro removido da coleção | Um livro removido da coleção | {count} livros removidos da coleção",
+        "removeFailed": "Falha ao remover livros da coleção"
+      },
+      "empty": {
+        "noSearchMatch": "Nenhum livro corresponde a esta pesquisa",
+        "noSearchMatchHint": "Tente um termo de pesquisa diferente ou limpe a pesquisa.",
+        "noBooks": "Nenhum livro nesta coleção",
+        "noBooksHint": "Selecione livros da sua biblioteca e adicione-os aqui."
+      }
+    },
+    "library": {
+      "title": "Biblioteca",
+      "pageTitle": "Biblioteca · {name}",
+      "pageTitleWithId": "Biblioteca #{id}",
+      "filterRules": "Regras de filtro",
+      "saveAsSmartScope": "Salvar como SmartScope",
+      "saveScope": "Salvar Escopo",
+      "saveAsSmartScopeTooltip": "Salvar este filtro como um SmartScope nomeado",
+      "saved": "Salvo",
+      "saveFilter": "Salvar filtro",
+      "filterSaved": "Filtro salvo",
+      "saveFilterTooltip": "Salvar filtro para esta biblioteca",
+      "removeSavedFilter": "Remover filtro salvo",
+      "empty": {
+        "noFilterMatch": "Nenhum livro corresponde aos seus filtros",
+        "noFilterMatchHint": "Tente ajustar ou limpar seus filtros para ver mais livros.",
+        "clearFilters": "Limpar filtros",
+        "scanning": "Escaneando sua biblioteca...",
+        "scanningHint": "Livros aparecerão aqui à medida que forem encontrados.",
+        "emptyLibrary": "A sua biblioteca está vazia",
+        "emptyLibraryHint": "Assim que adicionar livros à biblioteca, eles aparecerão aqui."
+      },
+      "querySelection": {
+        "loadedSelected": "{selected} de {total} livros carregados selecionados.",
+        "selectAllMatching": "Selecionar todos os {total} livros correspondentes"
+      }
+    },
+    "smartScope": {
+      "title": "SmartScope",
+      "pageTitle": "SmartScope · {name}",
+      "pageTitleWithId": "SmartScope #{id}",
+      "defaultName": "Escopo inteligente",
+      "filter": "Filtro",
+      "edit": "Editar SmartScope",
+      "showControlsAria": "Exibir controles do SmartScope",
+      "hideFilter": "Ocultar filtro",
+      "showFilter": "Mostrar filtro",
+      "confirmDelete": "Confirma?",
+      "loadError": "Não foi possível carregar este SmartScope",
+      "toast": {
+        "deleted": "\"{name}\" excluído(a)",
+        "deleteFailed": "Falha ao excluir \"{name}\""
+      },
+      "empty": {
+        "noRules": "Nenhuma regra configurada",
+        "noRulesHint": "Abra o editor para definir quais livros aparecerão neste SmartScope usando filtros e regras de classificação.",
+        "configure": "Configurar SmartScope",
+        "noMatch": "Nenhum livro corresponde a este SmartScope",
+        "noMatchHint": "Tente ajustar as regras de filtro.",
+        "edit": "Editar SmartScope"
+      }
+    }
+  },
+  "whatsNew": {
+    "title": "O que há de novo",
+    "subtitle": "Tudo o que foi lançado, do mais recente ao mais antigo.",
+    "versionPrefix": "Versão {version}",
+    "newUpdates": "nenhuma nova atualização | uma nova atualização | {count} novas atualizações",
+    "remindLater": "Lembrar mais tarde",
+    "gotIt": "Entendi",
+    "latest": "Última versão",
+    "fullChangelog": "Log de alterações completo",
+    "seeAllReleases": "Ver todos os lançamentos",
+    "versions": "Versões",
+    "currentVersion": "Versão atual",
+    "youreHere": "Você está aqui",
+    "searchPlaceholder": "Pesquisar lançamentos…",
+    "noReleasesFound": "Nenhum lançamento encontrado.",
+    "noHighlights": "Sem destaques para este lançamento.",
+    "showChangelog": "Exibir log de alterações completo",
+    "hideChangelog": "Ocultar log de alterações completo",
+    "openOnGitHub": "Abrir no GitHub",
+    "loadMore": "Carregar mais",
+    "loadingMore": "Carregando…",
+    "loadFailed": "Falha ao carregar lançamentos",
+    "loadMoreFailed": "Não foi possível carregar mais lançamentos. Por favor, tente novamente.",
+    "loadErrorHint": "Não conseguimos carregar os lançamentos. Verifique sua conexão e tente novamente.",
+    "retry": "Tentar novamente",
+    "imageViewer": "Visualizador de imagem",
+    "closeImage": "Fechar imagem",
+    "previousImage": "Imagem anterior",
+    "nextImage": "Próxima imagem"
+  },
+  "titles": {
+    "dashboard": "Painel",
+    "libraries": "Bibliotecas",
+    "opds": "OPDS",
+    "koboSync": "Sincronização Kobo",
+    "koreaderSync": "Sincronização KOReader",
+    "bookDock": "Doca de Livros",
+    "whatsNew": "O que há de novo",
+    "annotations": "Anotações",
+    "achievements": "Conquistas",
+    "statistics": "Estatísticas",
+    "authors": "Autores",
+    "series": "Séries",
+    "entityManager": "Gerenciador de Entidades",
+    "bulkRename": "Renomeação em Massa",
+    "notFound": "Não Encontrado",
+    "signIn": "Entrar",
+    "initialSetup": "Configuração Inicial",
+    "forgotPassword": "Esqueci a Senha",
+    "resetPassword": "Redefinir Senha",
+    "completingSignIn": "Concluindo o Login",
+    "magicLinkLogin": "Login via Link Mágico",
+    "readPrefix": "Ler",
+    "emailSuffix": "E-mail",
+    "library": "Biblioteca",
+    "smartScope": "SmartScope",
+    "collection": "Coleção",
+    "author": "Autor",
+    "book": "Livro",
+    "seriesItem": "Série",
+    "appearance": {
+      "theme": "Exibição",
+      "book-covers": "Capas de Livros",
+      "icons": "Ícones",
+      "layout": "Layout da Exibição",
+      "behavior": "Comportamento da Biblioteca"
+    },
+    "reader": {
+      "general": "Configurações do Leitor",
+      "ebook": "Leitor de eBook",
+      "pdf": "Leitor de PDF",
+      "comics": "Leitor de Quadrinhos",
+      "audio": "Reprodutor de Audiolivros",
+      "fonts": "Fontes do Leitor"
+    },
+    "email": {
+      "providers": "Provedores",
+      "recipients": "Destinatários",
+      "groups": "Grupos",
+      "templates": "Modelos",
+      "preferences": "Preferências",
+      "history": "Histórico"
+    },
+    "metadata": {
+      "providers": "Provedores",
+      "field-rules": "Regras por Campo",
+      "custom-fields": "Metadados Personalizados",
+      "genre-blocklist": "Lista de Bloqueio de Gêneros",
+      "score": "Pontuação de Confiança",
+      "auto-fetch": "Busca Automática de Livro",
+      "authors": "Busca Automática de Autor"
+    },
+    "admin": {
+      "users": "Usuários",
+      "account-activity": "Atividade da Conta",
+      "magic-links": "Links Mágicos",
+      "oidc": "OIDC / SSO"
+    },
+    "system": {
+      "file-naming": "Nomeação de Arquivos",
+      "book-dock": "Doca de Livros",
+      "maintenance": "Manutenção",
+      "audit-log": "Registro de Auditoria"
+    },
+    "account": {
+      "profile": "Conta",
+      "privacy": "Privacidade e Compartilhamento",
+      "notifications": "Notificações",
+      "restrictions": "Restrições de Conteúdo"
+    }
   }
 }

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1,0 +1,4984 @@
+{
+  "common": {
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "close": "Fechar",
+    "confirm": "Confirmar",
+    "loading": "Carregando...",
+    "search": "Pesquisar",
+    "back": "Voltar",
+    "next": "Próximo",
+    "previous": "Anterior",
+    "yes": "Sim",
+    "no": "Não"
+  },
+  "settings": {
+    "appearance": {
+      "language": {
+        "title": "Idioma",
+        "description": "Escolha o idioma usado em toda a interface.",
+        "label": "Idioma da interface"
+      },
+      "pageTitle": "Exibição",
+      "pageSubtitle": "Controle temas, capas, layout e como sua biblioteca é apresentada.",
+      "mobileSummary": "Tema: {theme} • Destaque: {accent} • Fundo: {background}",
+      "themeMode": {
+        "light": "Claro",
+        "dark": "Escuro"
+      },
+      "theme": {
+        "title": "Tema",
+        "colorScheme": {
+          "label": "Esquema de cores",
+          "hint": "Interface clara ou escura"
+        },
+        "accentColor": {
+          "label": "Cor de destaque",
+          "hint": "Controla destaques e elementos interativos"
+        },
+        "cornerRadius": {
+          "label": "Raio da borda",
+          "hint": "Arredondamento de cartões e elementos da interface"
+        },
+        "surfaceBrightness": {
+          "label": "Brilho da superfície",
+          "hint": "Clarear superfícies no modo escuro",
+          "reset": "Redefinir"
+        },
+        "libraryBackground": {
+          "title": "Fundo da Biblioteca",
+          "pattern": {
+            "label": "Padrão de fundo",
+            "hint": "Padrão exibido atrás da grade de livros"
+          }
+        },
+        "backgroundGroups": {
+          "fundamental": "Fundamental",
+          "structural": "Estrutural",
+          "ambient": "Ambiente",
+          "refractive": "Refrativo"
+        }
+      },
+      "storage": {
+        "title": "Onde salvar as preferências de aparência",
+        "active": "Ativo",
+        "notAvailable": "Não disponível",
+        "device": {
+          "title": "Apenas neste dispositivo",
+          "description": "As preferências permanecem no seu navegador. Ideal se você quiser um visual diferente em dispositivos diferentes."
+        },
+        "account": {
+          "title": "Minha conta",
+          "description": "As preferências são salvas na sua conta. Ideal se você quiser a mesma aparência em todos os dispositivos."
+        },
+        "toasts": {
+          "synced": "As preferências agora serão sincronizadas",
+          "local": "As preferências permanecerão neste dispositivo"
+        },
+        "errors": {
+          "demoRestricted": "Uma conta restrita de demonstração não pode alterar o modo de armazenamento de tema",
+          "update": "Falha ao atualizar o modo de armazenamento",
+          "generic": "Ocorreu um erro ao atualizar o modo de armazenamento"
+        }
+      },
+      "bookCovers": {
+        "title": "Capas de Livros",
+        "displayMode": {
+          "title": "Modo de exibição de capa",
+          "hint": "Controla como as capas reais se ajustam aos espaços dos livros quando as proporções diferem",
+          "blurredFit": {
+            "label": "Ajuste desfocado",
+            "hint": "Mostrar a capa inteira com um preenchimento desfocado atrás dela"
+          },
+          "fillCrop": {
+            "label": "Preencher cartão",
+            "hint": "Preencher todo o espaço cortando as bordas quando as proporções diferem"
+          },
+          "naturalBottom": {
+            "label": "Base natural",
+            "hint": "Manter a proporção original da capa e ancorar a capa na parte inferior"
+          }
+        },
+        "spine": {
+          "title": "Sobreposição de lombada do livro",
+          "hint": "Adiciona uma lombada estilizada e efeito de brilho aos cartões de capa",
+          "off": {
+            "label": "Desativado",
+            "hint": "Sem efeito de lombada/brilho nas capas"
+          },
+          "subtle": {
+            "label": "Sutil",
+            "hint": "Lombada e brilho leves, mais próximos do visual padrão"
+          },
+          "strong": {
+            "label": "Forte",
+            "hint": "Lombada e tratamento de brilho mais pronunciados"
+          }
+        },
+        "showSpineOnComics": {
+          "label": "Mostrar lombada em quadrinhos",
+          "hint": "Aplicar o efeito de lombada e brilho em capas de quadrinhos (cbz, cbr, cb7)"
+        },
+        "shadow": {
+          "title": "Intensidade da sombra da capa",
+          "hint": "Controla a profundidade sob as capas na grade, lista, tabela e miniaturas do painel",
+          "default": {
+            "label": "Padrão",
+            "hint": "Elevação e profundidade atuais"
+          },
+          "strong": {
+            "label": "Forte",
+            "hint": "Sombra projetada mais pesada, semelhante a uma prateleira, sob as capas"
+          }
+        },
+        "overlays": {
+          "title": "Sobreposições de cartão",
+          "hint": "Escolha os metadados mostrados diretamente nos cartões de capa de livro",
+          "progressBar": {
+            "label": "Barra de progresso",
+            "hint": "Linha fina colorida ao longo da borda inferior"
+          },
+          "format": {
+            "label": "Formato do arquivo",
+            "hint": "Distintivo colorido EPUB, PDF, CBZ no canto inferior direito"
+          },
+          "rating": {
+            "label": "Avaliação",
+            "hint": "Indicador de classificação por estrelas no canto inferior esquerdo"
+          },
+          "readStatus": {
+            "label": "Status de leitura",
+            "hint": "Ícone colorido mostrando o status de leitura atual no canto superior esquerdo"
+          },
+          "seriesPosition": {
+            "label": "Número da série",
+            "hint": "Distintivo mostrando a posição do livro em sua série no canto superior direito (ex: #3, #1.5)"
+          },
+          "lockStatus": {
+            "label": "Status de bloqueio",
+            "hint": "Ícone de cadeado de metadados no canto superior direito - laranja quando bloqueado, verde quando desbloqueado"
+          }
+        }
+      },
+      "layout": {
+        "coverSize": "Tamanho da capa",
+        "gridSpacing": "Espaçamento da grade",
+        "gridLayout": {
+          "title": "Layout da Grade da Biblioteca"
+        },
+        "coverSizeBehavior": {
+          "label": "Comportamento do tamanho da capa",
+          "hint": "Controle se os tamanhos de retrato/quadrado e o espaçamento da grade são compartilhados em todas as visualizações ou mantidos por visualização",
+          "perViewHint": "Modo por visualização: ajuste o tamanho da capa e o espaçamento no painel de Exibição de cada visualização.",
+          "syncAll": "Sincronizar todas as visualizações",
+          "perView": "Tamanhos por visualização"
+        },
+        "portraitCoverSize": {
+          "label": "Tamanho da capa em retrato",
+          "hint": "Usado para bibliotecas e visualizações em retrato"
+        },
+        "squareCoverSize": {
+          "label": "Tamanho da capa quadrada",
+          "hint": "Usado para bibliotecas e visualizações quadradas"
+        },
+        "portraitGridSpacing": {
+          "label": "Espaçamento da grade em retrato",
+          "hint": "Espaço entre capas em retrato"
+        },
+        "squareGridSpacing": {
+          "label": "Espaçamento da grade quadrada",
+          "hint": "Espaço entre capas quadradas"
+        },
+        "cardInfoMode": {
+          "label": "Modo de informações do cartão",
+          "hint": "Onde mostrar o título do livro e o autor nos cartões da grade",
+          "onHover": "Ao passar o mouse",
+          "belowCover": "Abaixo da capa",
+          "off": "Desativado"
+        },
+        "primaryCardLabel": {
+          "label": "Rótulo principal do cartão",
+          "hint": "Texto mostrado abaixo de cada capa de livro (primeira linha)"
+        },
+        "secondaryCardLabel": {
+          "label": "Rótulo secundário do cartão",
+          "hint": "Texto adicional abaixo do rótulo principal (segunda linha)"
+        },
+        "labelField": {
+          "hidden": "Oculto",
+          "bookTitle": "Título do livro",
+          "seriesTitle": "Título da série",
+          "seriesTitlePosition": "Título da série + posição",
+          "author": "Autor"
+        },
+        "seriesDisplay": {
+          "title": "Exibição de Série",
+          "collapsedCover": {
+            "label": "Capa de série recolhida",
+            "hint": "Escolha qual capa mostrar quando as séries estiverem recolhidas na grade de livros"
+          },
+          "stack": "Pilha",
+          "mosaic": "Mosaico",
+          "first": "Primeiro",
+          "latest": "Mais recente",
+          "firstUnread": "Primeiro não lido"
+        },
+        "authorGrid": {
+          "title": "Grade de Autores",
+          "coverSize": {
+            "label": "Tamanho da capa",
+            "hint": "Largura das capas dos autores na grade"
+          },
+          "coverShape": {
+            "label": "Formato da capa",
+            "hint": "Formato das capas dos autores na grade"
+          },
+          "circle": "Círculo",
+          "square": "Quadrado"
+        },
+        "listTableViews": {
+          "title": "Visualizações de Lista e Tabela"
+        },
+        "zebraStriping": {
+          "label": "Cores alternadas",
+          "hint": "Alternar cores de fundo das linhas para facilitar a leitura"
+        }
+      },
+      "behavior": {
+        "title": "Comportamento da Biblioteca",
+        "thumbnailClicks": {
+          "label": "Cliques em miniaturas",
+          "hint": "Escolha o que acontece ao abrir um livro das visualizações de grade e lista",
+          "readFirst": "Ler primeiro",
+          "readFirstHint": "Abrir o leitor quando existir um arquivo legível",
+          "openDetails": "Abrir detalhes",
+          "openDetailsHint": "Ir para a página de detalhes do livro a partir de miniaturas de grade e lista"
+        },
+        "filterPreview": {
+          "label": "Mostrar visualização de filtro por padrão",
+          "hint": "Expandir o filtro ativo e o resumo de classificação ao abrir um SmartScope"
+        },
+        "collapseSeries": {
+          "label": "Recolher séries por padrão",
+          "hint": "Agrupar livros da mesma série em um único cartão nas visualizações de biblioteca e coleção"
+        }
+      },
+      "icons": {
+        "title": "Ícones Personalizados",
+        "uploadIcons": "Enviar ícones",
+        "uploadedCount": "nenhum ícone enviado | {count} ícone enviado | {count} ícones enviados",
+        "searchPlaceholder": "Pesquisar ícones",
+        "sort": {
+          "newest": "Mais novos",
+          "name": "Nome"
+        },
+        "selectedCount": "{count} selecionado(s)",
+        "clear": "Limpar",
+        "deleteSelected": "Excluir selecionados",
+        "loading": "Carregando ícones...",
+        "emptySearch": "Nenhum ícone corresponde à sua pesquisa.",
+        "emptyNoIcons": "Nenhum ícone personalizado enviado ainda.",
+        "namePlaceholder": "Nome",
+        "checkingUsage": "Verificando uso...",
+        "usedBy": "Usado por {count}",
+        "notUsedYet": "Ainda não usado",
+        "rename": "Renomear",
+        "replace": "Substituir",
+        "usage": {
+          "libraries": "nenhuma biblioteca | {count} biblioteca | {count} bibliotecas",
+          "collections": "nenhuma coleção | {count} coleção | {count} coleções",
+          "smartScopes": "nenhum smart scope | {count} smart scope | {count} smart scopes"
+        },
+        "confirm": {
+          "deleteOne": "Excluir \"{name}\"? Os usos existentes voltarão ao ícone padrão.",
+          "deleteMany": "Excluir nenhum ícone? | Excluir {count} ícone? Os usos existentes voltarão ao ícone padrão. | Excluir {count} ícones? Os usos existentes voltarão ao ícone padrão."
+        },
+        "toasts": {
+          "saved": "Ícone salvo",
+          "updated": "Ícone atualizado",
+          "deleted": "Ícone excluído",
+          "bulkDeleted": "Nenhum ícone excluído | {count} ícone excluído | {count} ícones excluídos",
+          "bulkDeletePartial": "{deleted} excluídos, {failed} falharam"
+        },
+        "errors": {
+          "load": "Falha ao carregar ícones",
+          "save": "Falha ao salvar ícone",
+          "replace": "Falha ao substituir ícone",
+          "delete": "Falha ao excluir ícone",
+          "bulkDelete": "Falha ao excluir ícones"
+        }
+      },
+      "tabs": {
+        "theme": "Tema",
+        "book-covers": "Capas de Livros",
+        "icons": "Ícones",
+        "layout": "Layout",
+        "behavior": "Comportamento"
+      }
+    },
+    "account": {
+      "title": "Conta",
+      "subtitle": "Gerencie suas configurações de perfil pessoal.",
+      "subtitleAll": "Gerencie seu perfil e preferências de notificação.",
+      "tabs": {
+        "profile": "Perfil",
+        "notifications": "Notificações",
+        "restrictions": "Restrições"
+      },
+      "demoRestricted": {
+        "cannotEdit": "Conta restrita de demonstração não pode editar configurações de conta",
+        "notice": "Conta restrita de demonstração: a edição de perfil, senha, avatar e identidades vinculadas está desativada."
+      },
+      "feedback": {
+        "unsavedChanges": "Alterações não salvas",
+        "allSaved": "Todas as alterações salvas"
+      },
+      "profile": {
+        "securityHeading": "Perfil e Segurança",
+        "username": "Nome de usuário",
+        "fullName": "Nome completo",
+        "email": "E-mail",
+        "emailHint": "Contate um administrador para alterar seu endereço de e-mail.",
+        "save": "Salvar perfil",
+        "saving": "Salvando...",
+        "changePassword": "Alterar senha",
+        "accountType": "Tipo de conta:",
+        "accountTypeOidc": "OIDC / SSO",
+        "accountTypeShared": "Compartilhada",
+        "accountTypeLocal": "Local",
+        "nameRequired": "O nome é obrigatório",
+        "updateFailed": "Falha ao atualizar o perfil",
+        "updated": "Perfil atualizado"
+      },
+      "readingPreferences": {
+        "title": "Preferências de Leitura",
+        "timezoneHint": "O fuso horário é usado para conquistas sensíveis ao tempo, como Early Bird e All-nighter.",
+        "timezone": "Fuso horário",
+        "save": "Salvar preferências"
+      },
+      "preferences": {
+        "saveFailed": "Falha ao salvar preferências",
+        "saved": "Preferências salvas"
+      },
+      "avatar": {
+        "title": "Foto de Perfil",
+        "unknownUser": "Usuário desconhecido",
+        "formatHint": "PNG/JPEG/WEBP até {size} MB",
+        "upload": "Enviar foto",
+        "replace": "Substituir foto",
+        "uploading": "Enviando...",
+        "remove": "Remover foto",
+        "removing": "Removendo...",
+        "updated": "Foto de perfil atualizada",
+        "uploadFailed": "Falha ao enviar foto de perfil",
+        "removed": "Foto de perfil removida",
+        "removeFailed": "Falha ao remover foto de perfil",
+        "removeConfirm": {
+          "title": "Remover foto de perfil?",
+          "description": "Seu avatar será removido e substituído por iniciais.",
+          "confirm": "Remover"
+        }
+      },
+      "connectedAccounts": {
+        "title": "Contas Conectadas",
+        "unlink": "Desvincular",
+        "unlinking": "Desvinculando...",
+        "linkAdditional": "Vincular provedores adicionais:",
+        "linkProvider": "Vincular {provider}",
+        "redirecting": "Redirecionando...",
+        "noneConfigured": "Nenhum provedor OIDC está configurado. Peça a um administrador para configurar o SSO.",
+        "linkStateFailed": "Falha ao gerar estado de vínculo",
+        "startLinkFailed": "Falha ao iniciar vínculo OIDC",
+        "unlinkFailed": "Falha ao desvincular",
+        "unlinked": "Identidade desvinculada",
+        "unlinkIdentityFailed": "Falha ao desvincular identidade",
+        "unlinkDialog": {
+          "title": "Desvincular identidade {provider}?",
+          "description": "Insira sua senha para confirmar. Você não poderá mais fazer login com este provedor.",
+          "currentPassword": "Senha atual"
+        }
+      },
+      "tour": {
+        "title": "Tour Guiado",
+        "description": "Repita o passo a passo que destaca os principais recursos do aplicativo.",
+        "action": "Fazer o tour novamente"
+      },
+      "restrictions": {
+        "none": {
+          "title": "Sem restrições de conteúdo",
+          "description": "Sua conta tem acesso total a todo o conteúdo dentro de suas bibliotecas atribuídas."
+        },
+        "banner": "Sua conta possui restrições de conteúdo aplicadas por um administrador. Alguns livros podem não estar visíveis para você.",
+        "allowedTags": {
+          "title": "Tags permitidas",
+          "description": "Apenas livros que têm pelo menos uma dessas tags são mostrados a você."
+        },
+        "blockedTags": {
+          "title": "Tags bloqueadas",
+          "description": "Livros com qualquer uma dessas tags ficam ocultos para você."
+        },
+        "allowedGenres": {
+          "title": "Gêneros permitidos",
+          "description": "Apenas livros que têm pelo menos um desses gêneros são mostrados a você."
+        },
+        "blockedGenres": {
+          "title": "Gêneros bloqueados",
+          "description": "Livros com qualquer um desses gêneros ficam ocultos para você."
+        }
+      }
+    },
+    "magicLinks": {
+      "title": "Links Mágicos",
+      "subtitle": "Crie links de login compartilháveis para contas compartilhadas.",
+      "createLink": "Criar link",
+      "noSharedAccounts": "Nenhuma conta compartilhada encontrada",
+      "activeLinks": "Links ativos",
+      "inactiveLinks": "Links inativos",
+      "paused": "Pausado",
+      "deletedUser": "Usuário excluído",
+      "expiredPrefix": "Expirado ",
+      "never": "Nunca",
+      "noExpiry": "Sem expiração",
+      "expired": "Expirado",
+      "expiresOn": "Expira em {date}",
+      "revokedOn": "Revogado em {date}",
+      "expiredOn": "Expirado em {date}",
+      "usesCount": "nenhum uso | um uso | {count} usos",
+      "copied": "Copiado!",
+      "copyLink": "Copiar link",
+      "pause": "Pausar",
+      "resume": "Retomar",
+      "revoke": "Revogar",
+      "revoking": "Revogando...",
+      "emptyState": "Nenhum link mágico criado ainda. Clique em \"{action}\" para gerar uma URL de login compartilhável.",
+      "columns": {
+        "label": "Rótulo",
+        "account": "Conta",
+        "createdBy": "Criado por",
+        "expires": "Expira",
+        "uses": "Usos",
+        "lastUsed": "Último uso",
+        "created": "Criado",
+        "status": "Status",
+        "totalUses": "Total de usos"
+      },
+      "createDialog": {
+        "title": "Criar link mágico",
+        "description": "Gerar uma URL de login compartilhável para uma conta compartilhada.",
+        "sharedAccount": "Conta compartilhada",
+        "selectAccount": "Selecione uma conta compartilhada",
+        "label": "Rótulo",
+        "labelPlaceholder": "ex: Link de demonstração para conferência",
+        "expiresAt": "Expira em",
+        "optional": "(opcional)",
+        "create": "Criar",
+        "creating": "Criando..."
+      },
+      "revokeDialog": {
+        "title": "Revogar link mágico?",
+        "description": "Isso invalidará imediatamente o link e encerrará todas as sessões ativas da conta vinculada."
+      },
+      "errors": {
+        "create": "Falha ao criar",
+        "copy": "Falha ao copiar o link mágico",
+        "update": "Falha ao atualizar o link mágico",
+        "revoke": "Falha ao revogar"
+      },
+      "usersPage": "Página de usuários",
+      "emptyTitle": "Nenhum link mágico criado ainda",
+      "emptyHint": "Clique em \"{action}\" para gerar uma URL de login compartilhável.",
+      "noActiveTitle": "Nenhum link mágico ativo",
+      "noActiveHint": "Todos os links mágicos gerados para esta página expiraram ou foram revogados."
+    },
+    "oidc": {
+      "title": "OIDC / SSO",
+      "subtitle": "Gerencie provedores OpenID Connect para single sign-on.",
+      "providers": "Provedores",
+      "addProvider": "Adicionar Provedor",
+      "editProvider": "Editar Provedor",
+      "configureNew": "Configure um novo provedor OIDC.",
+      "editing": "Editando {slug}",
+      "enabled": "Ativado",
+      "disabled": "Desativado",
+      "empty": {
+        "title": "Nenhum provedor ainda",
+        "description": "Adicione um provedor OIDC para habilitar o single sign-on para seus usuários."
+      },
+      "form": {
+        "status": "Status",
+        "enableProvider": "Habilitar provedor",
+        "enableProviderHint": "Mostrar este provedor na página de login.",
+        "identity": "Identidade do Provedor",
+        "slug": "Slug",
+        "slugHint": "Identificador único (minúsculas, hifens). Não pode ser alterado posteriormente.",
+        "displayName": "Nome de Exibição",
+        "displayNameHint": "Mostrado no botão de login.",
+        "iconUrl": "URL do Ícone",
+        "iconUrlHint": "Logotipo opcional mostrado ao lado do botão de login.",
+        "iconPreviewAlt": "pré-visualização do ícone",
+        "connection": "Conexão",
+        "issuerUri": "URI do Emissor",
+        "issuerUriHint": "A URL base do provedor.",
+        "test": "Testar",
+        "testing": "Testando...",
+        "clientId": "Client ID",
+        "clientSecret": "Client Secret",
+        "clientSecretPlaceholder": "Deixe em branco para manter o existente",
+        "scopes": "Escopos",
+        "claimMapping": "Mapeamento de Claims",
+        "previewClaims": "Pré-visualizar claims",
+        "redirecting": "Redirecionando...",
+        "mappedClaims": "Claims mapeados",
+        "rawClaims": "Claims brutos",
+        "usernameClaim": "Claim de nome de usuário",
+        "nameClaim": "Claim de nome",
+        "emailClaim": "Claim de e-mail",
+        "groupsClaim": "Claim de grupos",
+        "autoProvisioning": "Autoprovisionamento",
+        "autoProvisionUsers": "Autoprovisionar usuários",
+        "autoProvisionUsersHint": "Criar contas no primeiro login OIDC se o usuário não existir.",
+        "allowLocalLinking": "Permitir vinculação de conta local",
+        "allowLocalLinkingHint": "Vincular identidade OIDC a uma conta local existente por correspondência de nome de usuário.",
+        "defaultPermissions": "Permissões padrão",
+        "defaultPermissionsHint": "Permissões concedidas a novos usuários no primeiro login OIDC.",
+        "createProvider": "Criar Provedor",
+        "saveChanges": "Salvar Alterações",
+        "saving": "Salvando...",
+        "deleteProvider": "Excluir Provedor",
+        "deleting": "Excluindo..."
+      },
+      "test": {
+        "connected": "Conectado - {issuer}",
+        "connectionFailed": "Falha na conexão",
+        "hide": "Ocultar",
+        "details": "Detalhes",
+        "supported": "suportado",
+        "notSupported": "não suportado"
+      },
+      "groupMappings": {
+        "title": "Mapeamentos de Grupo",
+        "description": "Mapeie os claims de grupo OIDC para permissões do BookOrbit. Sincronizado a cada login.",
+        "noPermission": "Sem permissão",
+        "empty": "Nenhum mapeamento de grupo configurado.",
+        "addMapping": "Adicionar mapeamento",
+        "claimPlaceholder": "Claim de grupo OIDC (ex: admins)",
+        "add": "Adicionar",
+        "adding": "Adicionando..."
+      },
+      "toasts": {
+        "providerCreated": "Provedor criado",
+        "providerSaved": "Provedor salvo",
+        "providerDeleted": "Provedor excluído",
+        "mappingAdded": "Mapeamento de grupo adicionado",
+        "mappingRemoved": "Mapeamento de grupo removido"
+      },
+      "errors": {
+        "loadProvider": "Falha ao carregar provedor",
+        "createProvider": "Falha ao criar provedor",
+        "save": "Falha ao salvar",
+        "delete": "Falha ao excluir",
+        "deleteProvider": "Falha ao excluir provedor",
+        "requestFailed": "Falha na solicitação",
+        "previewState": "Falha ao gerar estado de pré-visualização",
+        "startPreview": "Falha ao iniciar pré-visualização",
+        "addMapping": "Falha ao adicionar mapeamento",
+        "removeMapping": "Falha ao remover mapeamento de grupo"
+      }
+    },
+    "admin": {
+      "title": "Admin",
+      "subtitle": "Gerencie usuários e configurações de autenticação.",
+      "system": {
+        "title": "Sistema",
+        "subtitle": "Configurações de organização de arquivos, ingestão e manutenção."
+      },
+      "maintenance": {
+        "title": "Manutenção",
+        "subtitle": "Gerencie tarefas em segundo plano, índices do sistema e operações de manutenção.",
+        "importGroup": "Importar",
+        "recommendationsGroup": "Recomendações",
+        "achievementsGroup": "Conquistas",
+        "updatesGroup": "Atualizações",
+        "importFromBooklore": "Importar do Booklore",
+        "bookloreImportConfigured": "Importação do Booklore configurada",
+        "migrationRunning": "Migração em andamento",
+        "migrationCompleted": "Migração concluída",
+        "migrationFailed": "Falha na migração",
+        "importDescription": "Importação única de livros, metadados e progresso de leitura de uma instalação anterior do Booklore.",
+        "configuredDescription": "Origem: {name}. Nenhuma migração executada ainda - continue a configuração para executar a importação.",
+        "runningDescription": "Estágio: {stage} - iniciado em {started}",
+        "completedDescription": "De {name} - concluída em {date}",
+        "migrationErrorGeneric": "Ocorreu um erro durante a migração.",
+        "stageInitializing": "inicializando",
+        "recently": "recentemente",
+        "getStarted": "Começar",
+        "continueSetup": "Continuar Configuração",
+        "viewDetails": "Ver Detalhes",
+        "refreshRecommendationIndex": "Atualizar índice de recomendações",
+        "refreshRecommendationHint": "Atualiza o mecanismo de recomendações com as alterações mais recentes da sua biblioteca. Este processo é executado em segundo plano.",
+        "booksQueuedForProcessing": "nenhum livro na fila de processamento | {count} livro na fila de processamento | {count} livros na fila de processamento",
+        "run": "Executar",
+        "running": "Executando...",
+        "backfillAchievements": "Preenchimento retroativo de conquistas",
+        "backfillAchievementsHint": "Reavaliar conquistas para todos os usuários.",
+        "backfillResult": "Processados {users} usuários; concedidos {awards} prêmios.",
+        "runBackfill": "Executar Preenchimento Retroativo",
+        "checkForUpdates": "Verificar atualizações",
+        "checkForUpdatesHint": "Verifica automaticamente o GitHub por uma nova versão na inicialização e mostra um indicador na barra lateral quando uma estiver disponível.",
+        "updateChecksEnabled": "Verificação de atualizações ativada",
+        "updateChecksDisabled": "Verificação de atualizações desativada",
+        "updateSettingFailed": "Falha ao atualizar configuração",
+        "booksQueuedForEmbedding": "nenhum livro na fila de incorporação | {count} livro na fila de incorporação | {count} livros na fila de incorporação",
+        "failed": "Falhou",
+        "unknownError": "Erro desconhecido",
+        "rebuildEmbeddingsFailed": "Falha ao reconstruir incorporações: {error}",
+        "achievementBackfillConfirm": "Executar o preenchimento retroativo de conquistas para todas as conquistas em todos os usuários? Isso pode demorar um pouco.",
+        "achievementBackfillComplete": "Preenchimento retroativo de conquistas concluído: {count} prêmios concedidos",
+        "backfillRunFailed": "Falha ao executar preenchimento retroativo",
+        "achievementBackfillFailed": "Falha ao executar preenchimento retroativo de conquistas: {error}",
+        "uploadsGroup": "Uploads",
+        "maxUploadSize": "Limite máximo de tamanho de arquivo de upload",
+        "maxUploadSizeHint": "Configure o limite de tamanho máximo para uploads de arquivos em todo o sistema.",
+        "save": "Salvar",
+        "uploadSizeInvalid": "O limite de tamanho de upload deve ser maior que 0",
+        "uploadSizeUpdated": "Limite de tamanho de upload atualizado"
+      },
+      "migration": {
+        "title": "Migração",
+        "subtitle": "Importação única do Booklore: conecte a origem, mapeie usuários, teste, inicie a migração e exporte um relatório.",
+        "progress": "Progresso",
+        "stepSourceConnection": "Conexão de Origem",
+        "stepUserPathMapping": "Mapeamento de Usuário e Caminho",
+        "stepDryRun": "Teste (Dry-Run)",
+        "stepDryRunTitle": "Teste (Dry Run)",
+        "stepRunMigration": "Executar Migração",
+        "stepReport": "Relatório",
+        "stepReportTitle": "Relatório de Migração",
+        "subtitleSource": "Configure a conexão do banco de dados com a sua instância Booklore de origem.",
+        "subtitleMappings": "Mapeie usuários de origem para usuários de destino e traduza os caminhos dos arquivos.",
+        "subtitleDryRun": "Pré-visualize o que será importado antes de executar a migração definitiva.",
+        "subtitleRun": "Inicie a importação definitiva e monitore seu progresso.",
+        "subtitleReport": "Revise o que foi importado e exporte um relatório detalhado.",
+        "continueToMappings": "Continuar para Mapeamentos",
+        "continueToDryRun": "Continuar para o Teste",
+        "continueToMigration": "Continuar para Migração",
+        "viewReport": "Ver Relatório",
+        "badgeValidated": "Validado",
+        "badgeSaved": "Salvo",
+        "badgeUpToDate": "Atualizado",
+        "badgeCompleted": "Concluído",
+        "badgeRunning": "Executando",
+        "badgeFailed": "Falhou",
+        "mediaPathRequired": "Obrigatório para migração de capas de livros.",
+        "mediaPathAbsolute": "Use um caminho absoluto (exemplo: /books). Caminhos relativos não são suportados.",
+        "mediaPathConfigured": "Caminho de importação de capa configurado. Use Testar Conexão para verificar o acesso e a estrutura de pastas de imagens do Booklore.",
+        "issueSaveSource": "Salvar configurações de conexão de origem",
+        "issueValidateSource": "Validar conexão de origem",
+        "issueSaveMappings": "Salvar mapeamentos de usuário e caminho",
+        "issueSavePathMappings": "Salvar mapeamentos de caminho para validá-los",
+        "issueFreshDryRun": "Executar um novo teste",
+        "issueResolveDuplicates": "Resolver correspondências duplicadas de livros de destino no teste",
+        "issueWaitActiveRun": "Aguardar a execução ativa terminar",
+        "sourceRecordId": "ID do registro de origem #{id}",
+        "byAuthorWithId": "por {author} (ID: {id})",
+        "filePathWithId": "{path} (ID: {id})",
+        "bookloreSourceId": "ID de origem Booklore: {id}",
+        "libraryBookNum": "Livro da biblioteca #{id}",
+        "errorInitialize": "Falha ao inicializar configurações de migração",
+        "errorLoadSourceTypes": "Falha ao carregar tipos de origem de migração suportados",
+        "errorLoadTargetUsers": "Falha ao carregar usuários de destino",
+        "errorLoadLibraryFolders": "Falha ao carregar pastas da biblioteca de destino",
+        "noSourceUsersReturned": "Nenhum usuário de origem foi retornado",
+        "userMappingSuggestionsLoaded": "Sugestões de mapeamento de usuário carregadas",
+        "errorLoadSuggestions": "Falha ao carregar sugestões de mapeamento de usuário",
+        "requiredFields": "Host, usuário, banco de dados e nome de origem são obrigatórios",
+        "connectionTestPassedWithWarnings": "Teste de conexão concluído com avisos",
+        "connectionTestPassedWithCount": "Teste de conexão concluído com {count} aviso(s). Primeiro: {first}",
+        "connectionTestPassed": "Teste de conexão aprovado",
+        "connectionOkMissingTables": "Conexão ok, mas {count} tabela(s) obrigatória(s) estão ausentes",
+        "cannotTestMediaPathActiveRun": "Não é possível testar o caminho de mídia enquanto uma execução estiver ativa",
+        "mediaRootPathRequiredCover": "Caminho Raiz de Mídia é obrigatório para importação de capa.",
+        "useAbsolutePath": "Use um caminho absoluto (por exemplo: /books).",
+        "mediaPathVerified": "Caminho de mídia verificado.",
+        "mediaPathValidReadable": "O caminho de mídia é válido e legível",
+        "mediaPathValidationFailed": "A validação do caminho de mídia falhou.",
+        "connectionFailedBeforeMediaPath": "O teste de conexão falhou antes que a validação do caminho de mídia pudesse ser concluída.",
+        "cannotModifySourceActiveRun": "Não é possível modificar a origem enquanto uma execução estiver ativa",
+        "sourceSavedValidatedWarnings": "Origem salva e validada com {count} aviso(s)",
+        "sourceSavedValidated": "Origem salva e validada",
+        "errorSaveValidateSource": "Falha ao salvar ou validar origem",
+        "cannotSaveMappingsActiveRun": "Não é possível salvar mapeamentos enquanto uma execução estiver ativa",
+        "saveSourceFirst": "Salvar origem primeiro",
+        "mapAtLeastOneUser": "Mapeie pelo menos um usuário de origem para um usuário de destino",
+        "mapEveryUser": "Mapeie todos os usuários de origem antes de salvar",
+        "pathValidationFailedProfileSaved": "A validação do caminho falhou, mas o perfil ainda será salvo",
+        "mappingsSaved": "Mapeamentos salvos",
+        "errorSaveMappings": "Falha ao salvar mapeamentos",
+        "cannotRunDryRunActiveRun": "Não é possível executar o teste enquanto uma execução estiver ativa",
+        "saveMappingsFirst": "Salvar mapeamentos primeiro",
+        "dryRunCompleted": "Teste concluído: {matched} correspondências, {unresolved} não resolvidos",
+        "dryRunFailed": "Falha no teste",
+        "selectSourceForAllGroups": "Selecione um livro de origem para todos os {count} grupos duplicados",
+        "duplicatesResolved": "Correspondências duplicadas resolvidas",
+        "errorResolveDuplicates": "Falha ao resolver duplicatas",
+        "preflightNotReady": "Pré-verificação de migração não pronta",
+        "runDryRunFirst": "Execute o teste primeiro",
+        "runStarted": "Execução de migração iniciada",
+        "errorStartMigration": "Falha ao iniciar migração",
+        "runCancelled": "Execução de migração cancelada",
+        "errorCancelMigration": "Falha ao cancelar migração",
+        "runRetried": "Execução de migração repetida - retomando do último estágio concluído",
+        "errorRetryMigration": "Falha ao repetir migração",
+        "errorLoadRunProgress": "Falha ao carregar progresso da execução",
+        "startMigrationFirst": "Inicie a migração primeiro",
+        "reportRefreshed": "Relatório de execução atualizado",
+        "errorLoadReport": "Falha ao carregar relatório de execução",
+        "reportExported": "Relatório exportado como {format}",
+        "errorExportReport": "Falha ao exportar relatório de migração",
+        "reasonNoTitleAuthorMatch": "Nenhum livro correspondente encontrado por título ou autor",
+        "reasonNoFilePathMatch": "O caminho do arquivo não corresponde a nenhum livro nesta biblioteca",
+        "reasonNoFileHashMatch": "O hash do arquivo não corresponde a nenhum livro nesta biblioteca",
+        "reasonNoIsbnMatch": "O ISBN não corresponde a nenhum livro nesta biblioteca",
+        "reasonInsufficientSourceData": "Metadados insuficientes para tentar a correspondência",
+        "reasonAmbiguousIsbnMatch": "Múltiplos livros correspondem ao mesmo ISBN",
+        "reasonAmbiguousFileHashMatch": "Múltiplos livros correspondem ao mesmo hash de arquivo",
+        "reasonAmbiguousFilePathMatch": "Múltiplos livros correspondem ao mesmo caminho de arquivo",
+        "reasonAmbiguousTitleAuthorMatch": "Múltiplos livros correspondem ao mesmo título e autor",
+        "reasonUnknown": "Não foi possível determinar o motivo",
+        "strategyIsbn": "Correspondido por ISBN",
+        "strategyFileHash": "Correspondido por hash de arquivo",
+        "strategyPathMapping": "Correspondido por caminho de arquivo mapeado",
+        "strategyTitleAuthor": "Correspondido por título e autor",
+        "strategyUnavailable": "Estratégia de correspondência indisponível",
+        "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {bookmarks} favoritos, {annotations} anotações, {collections} entradas de coleção",
+        "connErrorUnreachable": "Não foi possível acessar o servidor de banco de dados. Verifique o host e a porta.",
+        "connErrorAuth": "Falha na autenticação. Verifique o nome de usuário e a senha.",
+        "connErrorUnknownDatabase": "Banco de dados não encontrado. Verifique o nome do banco de dados.",
+        "connErrorTimeout": "A conexão expirou. Verifique as configurações de host e firewall.",
+        "connErrorGeneric": "O teste de conexão falhou",
+        "sourceType": "Tipo de Origem",
+        "sourceName": "Nome de Origem",
+        "host": "Host",
+        "port": "Porta",
+        "user": "Usuário",
+        "password": "Senha",
+        "passwordSavedPlaceholder": "Salvo - deixe inalterado",
+        "passwordEmptyPlaceholder": "Nenhuma senha definida",
+        "database": "Banco de Dados",
+        "mediaRootPath": "Caminho Raiz de Mídia",
+        "pathOk": "Caminho OK",
+        "pathIssue": "Problema no Caminho",
+        "testPath": "Testar Caminho",
+        "useTls": "Usar TLS/SSL",
+        "testConnection": "Testar Conexão",
+        "saveAndValidate": "Salvar e Validar",
+        "sourceValidatedWithWarnings": "Origem validada com avisos",
+        "lastValidationSnapshot": "Último instantâneo de validação",
+        "sourceVersion": "Versão de origem: {version}",
+        "unknown": "Desconhecido",
+        "missingRequiredTables": "Tabelas obrigatórias ausentes: {tables}",
+        "suggestionsAutoLoad": "As sugestões de usuário são carregadas automaticamente após a validação da origem.",
+        "refresh": "Atualizar",
+        "sourceUser": "Usuário de Origem",
+        "targetUser": "Usuário de Destino",
+        "noSourceUsersLoaded": "Nenhum usuário de origem carregado ainda.",
+        "noActiveTargetUsers": "Nenhum usuário de destino ativo encontrado. Crie ou reative um usuário BookOrbit antes de mapear.",
+        "pathPrefixMappings": "Mapeamentos de Prefixo de Caminho",
+        "addMapping": "Adicionar Mapeamento",
+        "pathMappingsHelp1": "Os mapeamentos de caminho traduzem os caminhos dos arquivos de origem para os caminhos de destino, para que os livros possam ser correspondidos pelo local do arquivo. Por exemplo, se a sua biblioteca Booklore armazenou arquivos em",
+        "pathMappingsHelp2": "e os mesmos arquivos agora estão em",
+        "pathMappingsHelp3": ", adicione esse mapeamento aqui. Livros também são correspondidos por ISBN, hash de arquivo e título/autor independentemente dos mapeamentos de caminho - o mapeamento de caminho é apenas uma das quatro estratégias e não limita quais livros de origem são incluídos na migração.",
+        "noPrefixesFound": "Nenhum prefixo encontrado - valide a origem primeiro",
+        "selectSourcePrefix": "Selecione o prefixo de origem...",
+        "selectTargetFolder": "Selecione a pasta de destino...",
+        "remove": "Remover",
+        "pathValidation": "Validação de caminho",
+        "pathValidationMapped": "{mapped} de {total} livros de origem têm um caminho mapeado",
+        "pathValidationUnmatched": "{count} caminhos mapeados não encontrados no disco - esses livros recorrerão à correspondência de ISBN / título",
+        "pathValidationAllMatched": "Todos os {count} caminhos mapeados encontrados no disco",
+        "saveMappings": "Salvar Mapeamentos",
+        "runDryRun": "Executar Teste",
+        "matched": "Correspondidos:",
+        "unresolved": "Não resolvidos:",
+        "duplicateMatches": "Correspondências duplicadas:",
+        "unresolvedSummary": "Resumo de não resolvidos",
+        "resolveDuplicateMatches": "Resolver correspondências de destino duplicadas",
+        "resolveDuplicateHint": "Para cada livro de destino, escolha um livro de origem para manter. Opções recomendadas são pré-selecionadas quando há uma única correspondência mais forte.",
+        "remainingGroups": "Grupos restantes:",
+        "ofCount": "de {count}",
+        "targetBookNum": "Livro de destino #{id}",
+        "recommended": "Recomendado",
+        "resolveDuplicatesButton": "Resolver {count} duplicata | Resolver {count} duplicata | Resolver {count} duplicatas",
+        "preflightChecks": "Verificações de pré-voo",
+        "allChecksPassed": "Todas as verificações aprovadas - pronto para migrar",
+        "checkSourceValidated": "Origem validada",
+        "checkSaveValidateSource": "Salvar e validar conexão de origem",
+        "checkValidateSource": "Validar conexão de origem",
+        "checkMappingsSaved": "Mapeamentos salvos",
+        "checkSaveMappings": "Salvar mapeamentos de usuário e caminho",
+        "checkPathMappingsValidated": "Mapeamentos de caminho validados",
+        "checkSavePathMappings": "Salvar mapeamentos de caminho para validá-los",
+        "checkDryRunUpToDate": "Teste está atualizado",
+        "checkFreshDryRun": "Executar um novo teste",
+        "startConfirmPrompt": "Isso iniciará a migração definitiva. Tem certeza?",
+        "confirmStart": "Confirmar Início",
+        "startMigration": "Iniciar Migração",
+        "cancelRun": "Cancelar Execução",
+        "refreshStatus": "Atualizar Status",
+        "statusPollingStopped": "A sondagem de status parou devido a um erro.",
+        "retry": "Tentar novamente",
+        "stageLabel": "Estágio: {stage}",
+        "stageInitializing": "inicializando",
+        "endedLabel": "Terminou em {date}",
+        "stageCompleted": "Concluído",
+        "stageInit": "Inicializando",
+        "stageSharedOverlays": "Importando metadados",
+        "stageBookCovers": "Importando capas",
+        "stageUserState": "Importando dados do usuário",
+        "noRunYet": "Nenhuma execução de migração ainda. Conclua as etapas acima para iniciar.",
+        "runNum": "Execução #{id}",
+        "notStarted": "Não iniciada",
+        "reloadReport": "Recarregar Relatório",
+        "loadFullReport": "Carregar Relatório Completo",
+        "exportJson": "Exportar JSON",
+        "exportCsv": "Exportar CSV",
+        "migrationFailed": "Falha na migração",
+        "retryFromLastStage": "Tentar novamente a partir do último estágio concluído",
+        "booksCard": "Livros",
+        "metadataOverlaysApplied": "Sobreposições de metadados aplicadas",
+        "authorMappingsReplaced": "Mapeamentos de autor substituídos",
+        "narratorMappingsReplaced": "Mapeamentos de narrador substituídos",
+        "genreMappingsReplaced": "Mapeamentos de gênero substituídos",
+        "tagMappingsReplaced": "Mapeamentos de tag substituídos",
+        "coversImported": "Capas importadas",
+        "coverImportSkipped": "Importação de capa ignorada - o caminho raiz de mídia não está configurado na origem",
+        "couldNotMatch": "Não foi possível corresponder",
+        "userDataCard": "Dados do Usuário",
+        "readingStatuses": "Status de leitura",
+        "readingProgressEntries": "Entradas de progresso de leitura",
+        "audiobookProgressEntries": "Entradas de progresso de audiobook",
+        "bookmarksLabel": "Favoritos",
+        "annotationsLabel": "Anotações",
+        "collectionEntries": "Entradas de coleção",
+        "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência do teste no relatório exportado.",
+        "completedNoIssues": "A migração foi concluída sem livros não resolvidos ou falhas.",
+        "matchedBooksHeading": "Livros correspondidos ({count})",
+        "matchedBooksHint": "Estas correspondências do teste foram usadas para decidir quais livros da biblioteca receberam dados importados.",
+        "sourceBookFallback": "Livro de origem {id}",
+        "libraryBookFallback": "Livro da biblioteca {id}",
+        "unresolvedBooksHeading": "Livros não resolvidos ({count})",
+        "unresolvedBooksHint": "Estes livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
+        "mappedUsersHeading": "Usuários mapeados ({count})",
+        "mappedUsersHint": "Os totais por usuário vêm da pré-visualização do teste armazenada em cache com o plano de migração.",
+        "coverImportsFailed": "{count} importação(ões) de capa falhou(aram). As linhas de falha detalhadas não são armazenadas.",
+        "backToSetup": "Voltar à Configuração"
+      },
+      "libraries": {
+        "title": "Bibliotecas",
+        "subtitle": "Gerencie suas bibliotecas de mídia e acione verificações de conteúdo.",
+        "scanAll": "Verificar Tudo",
+        "scanning": "Verificando...",
+        "addLibrary": "Adicionar Biblioteca",
+        "scan": "Verificar",
+        "editLibrary": "Editar biblioteca",
+        "refreshCovers": "Atualizar capas",
+        "syncMetadataToFiles": "Sincronizar metadados para arquivos",
+        "deleteLibrary": "Excluir biblioteca",
+        "bookCount": "nenhum livro | {count} livro | {count} livros",
+        "addedDate": "Adicionado em {date}",
+        "fileMode": "Modo de arquivo",
+        "folderMode": "Modo de pasta",
+        "folderCount": "nenhuma pasta | {count} pasta | {count} pastas",
+        "watching": "Monitorando",
+        "fileWrite": "Gravação de arquivo",
+        "fileRename": "Renomeação de arquivo",
+        "emptyTitle": "Nenhuma biblioteca ainda",
+        "emptyHint": "Adicione uma biblioteca para começar a organizar seus livros.",
+        "addFirstLibrary": "Adicionar sua primeira biblioteca",
+        "deleteConfirmTitle": "Excluir \"{name}\"?",
+        "deleteConfirmBody": "Isto removerá permanentemente todos os livros, metadados, progresso de leitura, favoritos e anotações nesta biblioteca. Isto não pode ser desfeito.",
+        "deleteConfirmTypeName": "Digite o nome da biblioteca para confirmar:",
+        "deleting": "Excluindo...",
+        "deleteLibraryButton": "Excluir Biblioteca",
+        "syncConfirmTitle": "Sincronizar metadados para os arquivos?",
+        "syncConfirmBodyPrefix": "Isso substituirá os metadados dentro de todos os arquivos suportados em",
+        "syncConfirmBodySuffix": "diretamente no disco. Isto não pode ser desfeito.",
+        "syncFiles": "Sincronizar arquivos",
+        "metadataSynced": "Metadados sincronizados com os arquivos de \"{name}\"",
+        "fileWriteNotEnabled": "A gravação de arquivo de metadados não está habilitada para esta biblioteca. Habilite-a nas configurações da biblioteca.",
+        "fileSyncFailed": "A sincronização de arquivos falhou para \"{name}\"",
+        "scanStarted": "Verificação iniciada para \"{name}\"",
+        "scanStartFailed": "Falha ao iniciar verificação para \"{name}\"",
+        "refreshCoversFailed": "Falha ao atualizar as capas de \"{name}\"",
+        "scanStartedAll": "Verificação iniciada para todas as bibliotecas",
+        "librariesFailedToStart": "nenhuma biblioteca falhou ao iniciar | {count} biblioteca falhou ao iniciar | {count} bibliotecas falharam ao iniciar",
+        "scansStartFailed": "Falha ao iniciar verificações",
+        "libraryCreated": "Biblioteca \"{name}\" criada",
+        "libraryUpdated": "Biblioteca \"{name}\" atualizada",
+        "libraryDeleted": "\"{name}\" excluída",
+        "deleteFailed": "Falha ao excluir biblioteca",
+        "scanningProgress": "Verificando {pct}% ({processed}/{total})",
+        "scanDone": "Concluído - {added} adicionados, {updated} atualizados",
+        "scanFailedWithError": "Falhou: {error}",
+        "scanFailed": "A verificação falhou",
+        "refreshingCovers": "Atualizando capas {pct}% ({processed}/{total})",
+        "coversRefreshed": "Capas atualizadas ({count} processadas)"
+      },
+      "authorEnrichment": {
+        "configuration": "Configuração",
+        "saving": "Salvando...",
+        "running": "Executando...",
+        "runEligibleShort": "Executar p/ elegíveis",
+        "runAllShort": "Executar p/ todos",
+        "enableTitle": "Habilitar enriquecimento automático de autor",
+        "enableHint": "Busca automaticamente biografias e fotos de perfil de autores quando livros são adicionados ou atualizados.",
+        "updateStrategyTitle": "Estratégia de atualização",
+        "updateStrategyHint": "O que fazer quando um autor já tem uma biografia ou foto.",
+        "writeModeMissingOnly": "Apenas preencher dados ausentes (recomendado)",
+        "writeModeAlwaysRefetch": "Sempre atualizar dados existentes",
+        "triggerOnImportTitle": "Acionar na importação",
+        "triggerOnImportHint": "Colocar autores na fila para enriquecimento quando livros são adicionados pela primeira vez a uma biblioteca.",
+        "eligibilityTitle": "Condições de elegibilidade",
+        "eligibilityHint": "Um autor é elegível se corresponder a qualquer condição habilitada.",
+        "neverEnrichedTitle": "Nunca enriquecido",
+        "neverEnrichedHint": "Enriquecer autores que nunca tiveram um enriquecimento bem-sucedido.",
+        "missingBioTitle": "Biografia ausente",
+        "missingBioHint": "Enriquecer se o autor não tiver biografia.",
+        "missingPhotoTitle": "Foto ausente",
+        "missingPhotoHint": "Enriquecer se o autor não tiver foto de perfil.",
+        "runForEligibleAuthors": "Executar para autores elegíveis",
+        "eligibleCount": "~{count} elegíveis",
+        "runForAllAuthors": "Executar para todos os autores",
+        "saved": "Configurações de enriquecimento de autor salvas",
+        "saveFailed": "Falha ao salvar as configurações de enriquecimento de autor",
+        "noEligibleAuthors": "Nenhum autor elegível encontrado",
+        "noAuthorsToEnrich": "Nenhum autor para enriquecer",
+        "queueFailed": "Falha ao enfileirar preenchimento retroativo de autor"
+      },
+      "scoreWeights": {
+        "groupLabel": "Pesos de Pontuação",
+        "assignHintPrefix": "Atribua um peso a cada campo. Peso total:",
+        "areYouSure": "Você tem certeza?",
+        "resetToDefaultsButton": "Redefinir para os padrões",
+        "recalculateAll": "Recalcular tudo",
+        "confirmReset": "Confirmar redefinição",
+        "reset": "Redefinir",
+        "recalculate": "Recalcular",
+        "subtotal": "subtotal: {count}",
+        "savedRecalculating": "Pesos de pontuação salvos. Recalculando pontuações da biblioteca...",
+        "saveFailed": "Falha ao salvar pesos de pontuação",
+        "recalcStarted": "O recálculo de pontuação começou em segundo plano",
+        "recalcFailed": "O recálculo falhou",
+        "resetToDefaults": "Pesos redefinidos para os padrões. Salve para aplicar."
+      },
+      "tabs": {
+        "users": "Usuários",
+        "magic-links": "Links Mágicos",
+        "oidc": "OIDC / SSO"
+      }
+    },
+    "common": {
+      "nav": {
+        "libraries": "Bibliotecas",
+        "display": "Exibição",
+        "reader": "Leitor",
+        "metadata": "Metadados",
+        "email": "E-mail",
+        "opds": "OPDS",
+        "kobo": "Kobo",
+        "koreader": "KOReader",
+        "hardcover": "Hardcover",
+        "admin": "Admin",
+        "system": "Sistema",
+        "account": "Conta"
+      }
+    },
+    "metadata": {
+      "title": "Metadados",
+      "noPermission": "Você não tem permissão para gerenciar as configurações de metadados.",
+      "fields": {
+        "title": "Título",
+        "subtitle": "Subtítulo",
+        "description": "Descrição",
+        "cover": "Capa",
+        "authors": "Autores",
+        "publisher": "Editora",
+        "publishedYear": "Ano de publicação",
+        "language": "Idioma",
+        "pageCount": "Número de páginas",
+        "communityRating": "Avaliação da comunidade",
+        "seriesName": "Nome da série",
+        "seriesIndex": "Índice da série",
+        "genres": "Gêneros",
+        "narrators": "Narradores",
+        "duration": "Duração",
+        "abridged": "Resumido"
+      },
+      "mergeStrategy": {
+        "fillMissing": {
+          "label": "Preencher ausentes",
+          "description": "Apenas gravar se o campo estiver vazio"
+        },
+        "overwriteIfProvided": {
+          "label": "Sobrescrever se fornecido",
+          "description": "Gravar se o provedor retornou um valor"
+        },
+        "overwrite": {
+          "label": "Sempre sobrescrever",
+          "description": "Sempre substituir o valor existente"
+        }
+      },
+      "autoFetch": {
+        "globalSettings": "Configurações Globais",
+        "perLibraryOverrides": "Substituições por Biblioteca",
+        "saving": "Salvando...",
+        "running": "Executando...",
+        "runNow": "Executar agora",
+        "runForEligible": "Executar para livros elegíveis",
+        "enable": {
+          "label": "Habilitar busca automática",
+          "hint": "Busca automaticamente metadados para livros elegíveis."
+        },
+        "triggerOnImport": {
+          "label": "Acionar na importação",
+          "hint": "Colocar livros elegíveis na fila quando são adicionados pela primeira vez a uma biblioteca."
+        },
+        "status": {
+          "inQueuePaused": "{count} na fila - pausado",
+          "remaining": "{count} restantes",
+          "eligible": "~{count} elegíveis"
+        },
+        "trigger": {
+          "queued": "Enfileirado {count} livro | Enfileirados {count} livros",
+          "noneFound": "Nenhum livro elegível encontrado"
+        },
+        "lastRun": {
+          "justNow": "agora mesmo",
+          "minutesAgo": "{count}m atrás",
+          "hoursAgo": "{count}h atrás",
+          "yesterday": "ontem",
+          "daysAgo": "{count} dias atrás",
+          "label": "Última execução: {when}",
+          "labelQueued": "Última execução: {when} - {count} livros enfileirados",
+          "labelNoneEligible": "Última execução: {when} - nenhum livro elegível"
+        },
+        "conditions": {
+          "title": "Condições de elegibilidade",
+          "hint": "Um livro é elegível se corresponder a qualquer condição habilitada.",
+          "noneEnabled": "Nenhuma condição habilitada",
+          "neverFetched": {
+            "label": "Nunca buscado",
+            "hint": "Buscar livros que nunca tiveram uma tentativa de busca de metadados.",
+            "summary": "Nunca buscado"
+          },
+          "scoreThreshold": {
+            "label": "Pontuação de metadados baixa",
+            "hint": "Buscar se a pontuação de metadados estiver abaixo de um limite.",
+            "scoreBelow": "Pontuação abaixo de",
+            "summary": "Pontuação < {threshold}"
+          },
+          "missingFields": {
+            "label": "Campos ausentes",
+            "hint": "Buscar se qualquer um dos campos selecionados estiver vazio.",
+            "summary": "{count} campo ausente | {count} campos ausentes"
+          }
+        },
+        "library": {
+          "inheritingGlobal": "Herdando padrões globais",
+          "inheritFromGlobal": "Herdar do global",
+          "usingGlobalDefaults": "Usando padrões globais.",
+          "saveOverride": "Salvar substituição"
+        }
+      },
+      "providers": {
+        "availableSources": "Fontes Disponíveis",
+        "saveChanges": "Salvar Alterações",
+        "test": "Testar",
+        "testing": "Testando...",
+        "enabled": "Habilitado",
+        "retryIn": "Tentar novamente em {duration}",
+        "runTestBeforeEnabling": "Execute o Teste antes de habilitar",
+        "hardcoverEnableHint": "Execute o Teste com o token atual para desbloquear a chave de habilitação.",
+        "badge": {
+          "setupRequired": "Configuração Necessária",
+          "throttled": "Limitado",
+          "ready": "Pronto"
+        },
+        "fields": {
+          "apiKey": "Chave de API",
+          "region": "Região",
+          "cookie": "Cookie",
+          "coverResolution": "Resolução da Capa",
+          "country": "País",
+          "language": "Idioma",
+          "ttbKey": "Chave TTB"
+        },
+        "helpers": {
+          "googleApiKey": "Chave da API do Google Books do Google Cloud."
+        },
+        "hints": {
+          "google": "Ampla cobertura do índice de livros do Google. O Google Books agora exige uma chave de API antes que este provedor possa ser ativado.",
+          "amazon": "O cookie de sessão é recomendado. Cole apenas o valor do cookie (sem \"Cookie:\").",
+          "goodreads": "A maior comunidade de leitura da web. Nenhuma configuração necessária.",
+          "hardcover": "Uma alternativa moderna ao Goodreads. Token de hardcover.app/account/api. O prefixo \"Bearer \" é opcional.",
+          "openLibrary": "O catálogo de livros gratuito do Internet Archive. Nenhuma configuração necessária.",
+          "itunes": "Catálogo de livros digitais da Apple. Escolha se deseja buscar capas em alta resolução ou padrão.",
+          "kobo": "Busca informações nas páginas públicas de livros da Kobo. O país e o idioma devem corresponder aos caminhos de URL da Kobo; a proteção contra bots pode bloquear as solicitações.",
+          "audible": "Extrai metadados de audiobooks do Audible. Nenhuma configuração adicional é necessária.",
+          "audnexus": "Metadados de audiobook impulsionados pela comunidade. Nenhuma configuração necessária.",
+          "comicvine": "Metadados de quadrinhos do ComicVine. Uma chave de API gratuita é necessária em comicvine.gamespot.com.",
+          "ranobedb": "Metadados de light novels japonesas do RanobeDB. Nenhuma configuração necessária.",
+          "lubimyczytac": "Catálogo de livros polonês (lubimyczytac.pl). Busca informações nas páginas públicas de livros. Nenhuma configuração necessária.",
+          "aladin": "Metadados de livros coreanos da Aladin (알라딘). É necessária uma Chave TTB de aladin.co.kr."
+        },
+        "blocked": {
+          "google": "O Google Books requer uma chave de API antes de ser habilitado",
+          "hardcover": "O Hardcover requer uma chave de API antes de ser habilitado",
+          "hardcoverTest": "O token do Hardcover deve passar no Teste antes que possa ser habilitado",
+          "comicvine": "O ComicVine requer uma chave de API antes de ser habilitado",
+          "aladin": "A Aladin requer uma Chave TTB antes de ser habilitada"
+        }
+      },
+      "fieldRules": {
+        "clearAllProviders": "Limpar Todos os Provedores",
+        "clearAll": "Limpar Tudo",
+        "resetToDefault": "Redefinir para Padrão",
+        "reset": "Redefinir",
+        "dragProvidersHint": "Arraste os provedores daqui para qualquer campo para adicioná-los",
+        "dragProviderHere": "arraste um provedor aqui",
+        "howItWorks": {
+          "title": "Como as Regras de Campo Funcionam",
+          "priorityOrder": {
+            "title": "Ordem de Prioridade",
+            "body": "Arraste os provedores na lista para reordená-los. O provedor mais ao topo que retornar um resultado será a fonte principal para aquele campo."
+          },
+          "mergeStrategy": {
+            "title": "Estratégia de Mesclagem",
+            "fillMissingTerm": "Preencher ausentes:",
+            "fillMissingBody": "Apenas gravar se o valor atual estiver vazio.",
+            "overwriteTerm": "Sobrescrever:",
+            "overwriteBody": "Substituir sempre que um provedor tiver dados."
+          }
+        },
+        "libraryOverrides": {
+          "title": "Substituições da Biblioteca",
+          "hint": "Expanda uma biblioteca para personalizar campos individuais. Campos não substituídos herdam os padrões globais."
+        },
+        "global": {
+          "title": "Padrões Globais",
+          "hint": "Regras padrão aplicadas a todas as bibliotecas. Substitua por biblioteca abaixo.",
+          "saveDefaults": "Salvar Padrões",
+          "clearAllConfirm": "Remover todos os provedores ativos de todos os campos? Isso será salvo imediatamente e não pode ser desfeito.",
+          "resetConfirm": "Redefinir todas as regras de campo globais para os padrões do sistema? Isso substituirá sua configuração atual."
+        },
+        "advanced": {
+          "title": "Comportamento Avançado de Busca",
+          "combineGenres": {
+            "label": "Combinar gêneros de todos os provedores selecionados",
+            "hint": "Coletar e desduplicar gêneros de todos os provedores atribuídos ao campo Gêneros, em vez de parar no primeiro resultado."
+          },
+          "storeProviderIds": {
+            "label": "Armazenar IDs de provedores nos livros",
+            "hint": "Ao buscar metadados, salvar os IDs de provedor retornados (ISBN, ASIN, ID Goodreads, etc.) no registro do livro para pesquisas futuras mais precisas."
+          }
+        },
+        "library": {
+          "primary": "Principal:",
+          "overrideCount": "{count} Substituição | {count} Substituições",
+          "unsavedSuffix": "(não salvo)",
+          "unsavedChanges": "Alterações não salvas",
+          "globalDefaults": "Padrões Globais",
+          "overriding": "Substituindo: {fields}",
+          "inheritingAll": "Herdando todas as regras de metadados globais",
+          "subHint": "Campos não substituídos herdam os padrões globais.",
+          "resetTooltip": "Remover todas as substituições e herdar padrões globais",
+          "clearAllConfirm": "Remover todos os provedores ativos de todos os campos em \"{library}\"?",
+          "resetConfirm": "Redefinir \"{library}\" para os padrões globais? Todas as substituições da biblioteca serão removidas."
+        },
+        "groups": {
+          "core": "Núcleo",
+          "contributors": "Contribuidores",
+          "publication": "Publicação",
+          "series": "Série",
+          "classification": "Classificação",
+          "audiobook": "Audiobook"
+        },
+        "groupSummary": {
+          "base": "{fields} campos · {enabled} habilitados",
+          "withOverrides": "{base} · {overrides} substituições"
+        },
+        "table": {
+          "field": "Campo",
+          "activeProviders": "Provedores Ativos (ordenados por prioridade)",
+          "mergeStrategy": "Estratégia de Mesclagem",
+          "status": "Status"
+        },
+        "field": {
+          "noProviders": "Habilitado, mas sem provedores",
+          "empty": "Vazio",
+          "config": "Config",
+          "custom": "Personalizado",
+          "default": "Padrão",
+          "resetToDefault": "Redefinir para o padrão"
+        },
+        "reservoir": {
+          "disabled": "{provider} - desativado",
+          "notConfigured": "{provider} - não configurado",
+          "dragToAssign": "Arraste para atribuir {provider} a um campo"
+        },
+        "sheet": {
+          "subtitle": "Toque nos provedores para atribuir, use setas para reordenar",
+          "enableField": "Habilitar este campo durante a atualização",
+          "providers": "Provedores",
+          "statusDisabled": "desativado",
+          "statusNotConfigured": "não configurado",
+          "done": "Concluído"
+        }
+      },
+      "genreBlocklist": {
+        "heading": "Exclusões Globais de Gênero",
+        "hint": "Valores exatos de gênero nesta lista são removidos dos resultados do provedor antes que os metadados sejam gravados.",
+        "saving": "Salvando",
+        "genreValueLabel": "Valor do gênero",
+        "addPlaceholder": "Adicione um valor de gênero, por exemplo Audiobook",
+        "duplicate": "Este gênero já está bloqueado.",
+        "add": "Adicionar",
+        "filterPlaceholder": "Filtrar lista de bloqueio",
+        "entryCount": "{count} entrada | {count} entradas",
+        "filteredCount": "{shown} de {total}",
+        "noFilterMatch": "Nenhum gênero bloqueado corresponde ao filtro atual.",
+        "emptyTitle": "Nenhum gênero bloqueado",
+        "emptyHint": "Adicione valores exatos como Audiobook ou Adulto para mantê-los fora dos metadados buscados.",
+        "removeLabel": "Remover {genre}"
+      },
+      "customFields": {
+        "label": "Rótulo",
+        "labelPlaceholder": "ex: Título Original",
+        "labelTooLong": "O rótulo deve ter 255 caracteres ou menos",
+        "labelDuplicate": "Um campo com este rótulo já existe",
+        "type": "Tipo",
+        "usage": "Usado por {count} livro | Usado por {count} livros",
+        "newField": {
+          "title": "Novo Campo",
+          "hint": "Defina um campo de metadados personalizado e escolha quais bibliotecas o usam."
+        },
+        "previewToggle": "Visualize como este campo aparece ao editar um livro",
+        "untitledField": "Campo sem título",
+        "addField": "Adicionar campo",
+        "fields": "Campos",
+        "fieldsHint": "Arraste para reordenar, editar rótulos, alternar bibliotecas ou arquivar campos que você não precisa mais.",
+        "searchPlaceholder": "Pesquisar campos",
+        "searchAriaLabel": "Pesquisar campos personalizados",
+        "emptyTitle": "Nenhum campo personalizado ainda",
+        "emptyHint": "Use o formulário acima para definir seu primeiro campo de metadados personalizado.",
+        "noMatchTitle": "Nenhum campo corresponde a \"{query}\"",
+        "noMatchHint": "Tente um rótulo, chave ou tipo diferente.",
+        "clearSearchToReorder": "Limpar pesquisa para reordenar",
+        "dragToReorder": "Arraste para reordenar",
+        "dragToReorderField": "Arraste para reordenar campo",
+        "unsaved": "Não salvo",
+        "archive": "Arquivar",
+        "archivedFields": "Campos Arquivados",
+        "archivedSummary": "{count} campo arquivado - restaurar ou excluir permanentemente. | {count} campos arquivados - restaurar ou excluir permanentemente.",
+        "archivedAt": "Arquivado em {when}",
+        "restore": "Restaurar",
+        "deleteForever": "Excluir permanentemente",
+        "deleteDialog": {
+          "title": "Excluir campo permanentemente",
+          "bodyBefore": "Isso excluirá permanentemente",
+          "bodyMiddle": "e removerá seus valores armazenados de",
+          "bodyAfter": ". Isso não pode ser desfeito.",
+          "confirmBefore": "Digite",
+          "confirmAfter": "para confirmar",
+          "confirmPlaceholder": "Digite o rótulo do campo para confirmar"
+        },
+        "preview": "Pré-visualização",
+        "sampleValue": "Valor de exemplo",
+        "enabledLibraries": "Bibliotecas Habilitadas",
+        "countOf": "{selected} de {total}",
+        "selectAll": "Selecionar tudo",
+        "clear": "Limpar",
+        "noLibraries": "Nenhuma biblioteca disponível ainda.",
+        "allLibraries": "Todas as bibliotecas"
+      },
+      "tabs": {
+        "providers": "Provedores",
+        "field-rules": "Regras de Campo",
+        "custom-fields": "Campos Personalizados",
+        "genre-blocklist": "Lista de Bloqueio de Gênero",
+        "score": "Pontuação",
+        "auto-fetch": "Livros",
+        "authors": "Autores"
+      },
+      "tabTitles": {
+        "providers": "Provedores",
+        "field-rules": "Regras em Nível de Campo",
+        "custom-fields": "Metadados Personalizados",
+        "genre-blocklist": "Lista de Bloqueio de Gênero",
+        "score": "Pontuação de Confiança",
+        "auto-fetch": "Busca Automática de Livro",
+        "authors": "Busca Automática de Autor"
+      },
+      "tabSubtitles": {
+        "providers": "Habilite fontes de metadados externas e configure suas credenciais.",
+        "field-rules": "Controle qual provedor fornece cada campo de metadados e como os valores são mesclados em suas bibliotecas.",
+        "custom-fields": "Defina campos de metadados personalizados e escolha quais bibliotecas os utilizam.",
+        "genre-blocklist": "Impeça que valores de gênero indesejados do provedor sejam gravados nos livros.",
+        "score": "Atribua pesos aos campos de metadados para calcular o quanto confiar nos resultados buscados.",
+        "auto-fetch": "Busque automaticamente capas, descrições e outros detalhes quando novos livros forem adicionados à sua biblioteca.",
+        "authors": "Busque automaticamente biografias e fotos de perfil quando novos autores aparecerem na sua biblioteca."
+      }
+    },
+    "reader": {
+      "resetToDefaults": "Redefinir para padrões",
+      "all": {
+        "title": "Leitor",
+        "subtitle": "Configure padrões para todos os modos de leitura em um só lugar."
+      },
+      "general": {
+        "title": "Leitura",
+        "subtitle": "Comportamento geral que se aplica a todos os tipos de leitor.",
+        "storageLabel": "Onde salvar as preferências do leitor",
+        "deviceOnly": "Apenas neste dispositivo",
+        "deviceOnlyHint": "As preferências permanecem no seu navegador. Ideal se você sempre lê neste dispositivo ou deseja configurações diferentes por dispositivo.",
+        "myAccount": "Minha conta",
+        "myAccountHint": "As preferências são salvas na sua conta. Ideal se você faz login de vários dispositivos e deseja uma experiência consistente em todos os lugares.",
+        "active": "Ativo",
+        "notAvailable": "Não disponível",
+        "demoCannotChangeStorage": "Conta restrita de demonstração não pode alterar o modo de armazenamento do leitor",
+        "preferencesSynced": "As preferências agora serão sincronizadas",
+        "preferencesLocal": "As preferências permanecerão neste dispositivo",
+        "storageUpdateFailed": "Falha ao atualizar o modo de armazenamento",
+        "storageUpdateError": "Ocorreu um erro ao atualizar o modo de armazenamento"
+      },
+      "ebook": {
+        "title": "Leitor de eBook",
+        "subtitle": "Configurações padrão aplicadas ao abrir arquivos EPUB, MOBI, FB2 e TXT.",
+        "newBooks": "Novos Livros",
+        "applySettings": "Aplicar minhas configurações a novos livros",
+        "applySettingsHint": "Quando desativado, os novos livros abrem com as fontes e o layout da própria editora. Suas configurações só se aplicam quando você altera algo no leitor.",
+        "layout": "Layout",
+        "readingFlow": "Fluxo de leitura",
+        "readingFlowHint": "Paginado vira as páginas; rolado flui continuamente",
+        "paginated": "Paginado",
+        "scrolled": "Rolagem",
+        "fixedLayoutSpread": "Páginas duplas em layout fixo",
+        "fixedLayoutSpreadHint": "Padrão para mangás, quadrinhos e EPUBs baseados em imagens",
+        "bookDefault": "Padrão do livro",
+        "singlePage": "Página única",
+        "columns": "Colunas",
+        "columnsHint": "Número de colunas de texto por página",
+        "theme": "Tema",
+        "darkMode": "Modo escuro",
+        "darkModeHint": "Usar a variante escura do tema selecionado",
+        "typography": "Tipografia",
+        "font": "Fonte",
+        "fontHint": "Tipo de letra usada para o corpo do texto",
+        "builtInFonts": "Fontes embutidas",
+        "yourFonts": "Suas Fontes",
+        "fontSize": "Tamanho da fonte",
+        "fontSizeHint": "Tamanho base do texto em pixels",
+        "lineHeight": "Altura da linha",
+        "lineHeightHint": "Espaçamento vertical entre as linhas",
+        "justify": "Justificar texto",
+        "justifyHint": "Alinhar texto a ambas as margens",
+        "hyphenation": "Hifenização",
+        "hyphenationHint": "Quebrar automaticamente palavras longas com hifens",
+        "advanced": "Avançado",
+        "maxContentWidth": "Largura máxima do conteúdo",
+        "maxContentWidthHint": "Largura máxima da área de texto em pixels",
+        "columnGap": "Espaçamento entre colunas",
+        "columnGapHint": "Preenchimento horizontal em cada lado da área de texto"
+      },
+      "pdf": {
+        "title": "Leitor de PDF",
+        "subtitle": "Configurações padrão aplicadas ao abrir arquivos PDF.",
+        "layout": "Layout",
+        "scrollMode": "Modo de rolagem",
+        "scrollModeHint": "A página vira uma de cada vez; contínuo rola por todas as páginas",
+        "page": "Página",
+        "scrolled": "Contínuo",
+        "pageSpread": "Páginas duplas",
+        "pageSpreadHint": "Qual número de página começa à direita na visualização de duas páginas",
+        "spreadNone": "Nenhum",
+        "spreadOdd": "Ímpar",
+        "spreadEven": "Par",
+        "zoom": "Zoom",
+        "defaultFit": "Ajuste padrão",
+        "defaultFitHint": "Como as páginas são dimensionadas quando um PDF é aberto",
+        "fitPage": "Ajustar à Página",
+        "fitWidth": "Ajustar à Largura",
+        "custom": "Personalizado",
+        "zoomLevel": "Nível de zoom",
+        "zoomLevelHint": "Fator de escala para modo de zoom personalizado"
+      },
+      "comics": {
+        "title": "Leitor de Quadrinhos",
+        "subtitle": "Configurações padrão aplicadas ao abrir arquivos CBZ, CBR e CB7.",
+        "view": "Visualização",
+        "readingMode": "Modo de leitura",
+        "readingModeHint": "Como as páginas são navegadas - use \"Infinito (sem espaços)\" para webtoons",
+        "paginated": "Paginado",
+        "infiniteSpaced": "Infinito (com espaços)",
+        "infiniteNoGaps": "Infinito (sem espaços)",
+        "pageView": "Visualização de página",
+        "pageViewHint": "Mostrar uma ou duas páginas lado a lado",
+        "single": "Única",
+        "twoPage": "Duas páginas",
+        "fitMode": "Modo de ajuste",
+        "fitModeHint": "Como as páginas são redimensionadas para caber na tela",
+        "fitPage": "Página",
+        "fitWidth": "Largura",
+        "fitHeight": "Altura",
+        "fitActual": "Real",
+        "readingDirection": "Direção de leitura",
+        "readingDirectionHint": "Esquerda para direita para quadrinhos ocidentais; direita para esquerda para mangás",
+        "ltr": "E para D",
+        "rtl": "D para E",
+        "spreadAlignment": "Alinhamento de página dupla",
+        "spreadAlignmentHint": "Deslocar pareamento em uma página após a capa para digitalizações com desvio de uma",
+        "alignmentNormal": "Normal",
+        "alignmentShifted": "Deslocado",
+        "widePageHandling": "Tratamento de páginas largas",
+        "widePageHandlingHint": "Auto mostra páginas largas sozinhas no modo paginado de duas páginas",
+        "widePageAuto": "Automático",
+        "widePageDisable": "Desativar",
+        "forceTwoPage": "Forçar duas páginas em telas pequenas",
+        "forceTwoPageHint": "Ignorar o fallback automático móvel quando o modo paginado de duas páginas for selecionado",
+        "off": "Desativado",
+        "on": "Ativado",
+        "display": "Exibição",
+        "backgroundColor": "Cor de fundo",
+        "backgroundColorHint": "Cor da tela atrás das páginas",
+        "bgBlack": "Preto",
+        "bgGray": "Cinza",
+        "bgWhite": "Branco"
+      },
+      "audio": {
+        "title": "Reprodutor de Audiobook",
+        "subtitle": "Configurações padrão aplicadas ao reproduzir M4B, MP3 e outros formatos de áudio.",
+        "playback": "Reprodução",
+        "playbackSpeed": "Velocidade de reprodução padrão",
+        "playbackSpeedHint": "Multiplicador de velocidade aplicado ao abrir um novo audiobook",
+        "volume": "Volume padrão",
+        "volumeHint": "Nível de volume inicial (0 a 100%)",
+        "skipControls": "Controles de salto",
+        "skipBack": "Duração do retrocesso",
+        "skipBackHint": "Segundos retrocedidos ao pressionar pular para trás",
+        "skipForward": "Duração do avanço",
+        "skipForwardHint": "Segundos avançados ao pressionar pular para frente"
+      },
+      "fonts": {
+        "title": "Fontes",
+        "subtitle": "Envie fontes personalizadas para uso no leitor de eBook.",
+        "uploadFonts": "Enviar Fontes",
+        "notAvailableDemo": "Não disponível para contas de demonstração",
+        "uploading": "Enviando...",
+        "dropFilesHere": "Solte os arquivos aqui",
+        "dragFontsPrefix": "Arraste arquivos de fonte aqui, ou",
+        "browse": "procurar",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - máximo 10 MB cada",
+        "yourFonts": "Suas Fontes",
+        "fontsUsed": "{count} / {max} usadas",
+        "noFontsYet": "Nenhuma fonte enviada ainda",
+        "noFontsHint": "Arraste um arquivo de fonte acima para começar.",
+        "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+        "pangram": "A rápida raposa marrom salta sobre o cão preguiçoso",
+        "renameFamily": "Renomear família",
+        "deleteFamily": "Excluir família",
+        "editVariant": "Editar peso/estilo",
+        "deleteVariant": "Excluir variante",
+        "styleNormal": "Normal",
+        "styleItalic": "Itálico",
+        "weightThin": "Fino",
+        "weightExtraLight": "Extra Leve",
+        "weightLight": "Leve",
+        "weightRegular": "Regular",
+        "weightMedium": "Médio",
+        "weightSemiBold": "Seminegrito",
+        "weightBold": "Negrito",
+        "weightExtraBold": "Extra Negrito",
+        "weightBlack": "Preto",
+        "renameFamilyFailed": "Falha ao renomear família de fontes",
+        "renamedTo": "Renomeado para \"{name}\"",
+        "updateVariantFailed": "Falha ao atualizar variante da fonte",
+        "deleteFontFailed": "Falha ao excluir fonte",
+        "deleteFamilyFailed": "Falha ao excluir família de fontes",
+        "demoCannotManage": "Conta restrita de demonstração não pode gerenciar fontes",
+        "fileAdded": "\"{name}\" adicionado",
+        "uploadFailed": "Falha no envio"
+      },
+      "bookDock": {
+        "title": "Book Dock",
+        "subtitle": "Configure como os arquivos são processados quando entram no Book Dock.",
+        "dropFolder": "Pasta de recepção",
+        "containerPath": "Caminho do contêiner",
+        "containerPathHint": "Copie ou mova arquivos de livro para esta pasta e eles serão automaticamente coletados e processados pelo Book Dock. Subdiretórios são suportados.",
+        "changePathPrefix": "Para alterar este caminho, defina",
+        "changePathMiddle": "no seu arquivo",
+        "changePathSuffix": ".",
+        "metadata": "Metadados",
+        "autoFetch": "Buscar metadados de provedores automaticamente",
+        "autoFetchHint": "Buscar metadados automaticamente de provedores configurados (Google Books, iTunes, Open Library, etc.) após um arquivo ser adicionado ao Book Dock.",
+        "autoFinalize": "Finalizar automaticamente",
+        "enableAutoFinalize": "Habilitar finalização automática",
+        "enableAutoFinalizeHint": "Arquivos com uma pontuação de confiança de metadados igual ou superior ao limite serão finalizados automaticamente.",
+        "confidenceThreshold": "Limite de confiança: {value}%",
+        "thresholdIgnored": "(ignorado apenas no modo Embutido)",
+        "destinationLibrary": "Biblioteca de destino",
+        "selectLibrary": "Selecione uma biblioteca...",
+        "metadataMode": "Modo de metadados",
+        "metadataModeSafeMerge": "Mesclagem segura (recomendado)",
+        "metadataModeFetchedOnly": "Apenas buscados",
+        "metadataModeEmbeddedOnly": "Apenas embutidos",
+        "destinationFolder": "Pasta de destino",
+        "selectFolder": "Selecione uma pasta...",
+        "saveSettingFailed": "Falha ao salvar configuração",
+        "updateSettingFailed": "Falha ao atualizar configuração",
+        "autoFetchEnabled": "Busca automática ativada",
+        "autoFetchDisabled": "Busca automática desativada",
+        "autoFinalizeEnabled": "Finalização automática ativada",
+        "autoFinalizeDisabled": "Finalização automática desativada",
+        "destinationLibraryUpdated": "Biblioteca de destino atualizada",
+        "destinationFolderUpdated": "Pasta de destino atualizada",
+        "confidenceThresholdUpdated": "Limite de confiança atualizado",
+        "metadataModeUpdated": "Modo de metadados atualizado"
+      },
+      "fileNaming": {
+        "title": "Nomenclatura de Arquivos",
+        "subtitle": "Controle como os arquivos são organizados no disco quando enviados e como são nomeados quando baixados usando tokens de espaço reservado.",
+        "copy": "Copiar",
+        "previewLabel": "Pré-visualização:",
+        "fileAsBookPreview": "Pré-visualização Arquivo como Livro",
+        "folderAsBookPreview": "Pré-visualização Pasta como Livro",
+        "downloadPreview": "Pré-visualização de Download",
+        "globalDefaults": "Padrões Globais",
+        "crossPlatform": "Sanitização de caminho multiplataforma",
+        "crossPlatformHint": "Torna os nomes de arquivos e pastas gerados seguros no Windows substituindo caracteres inválidos e nomes reservados, e removendo pontos e espaços finais. Desative apenas para configurações exclusivas do Linux que mantêm esses caracteres intencionalmente.",
+        "fileAsBookDefault": "Padrão de Arquivo como Livro",
+        "fileAsBookDefaultHint": "Padrão de envio para bibliotecas usando o modo Arquivo como Livro. Cada arquivo é um livro.",
+        "folderAsBookDefault": "Padrão de Pasta como Livro",
+        "folderAsBookDefaultHint": "Padrão de envio para bibliotecas usando o modo Pasta como Livro. Cada livro deve estar em sua própria pasta.",
+        "downloadPattern": "Padrão de Download",
+        "downloadPatternHint": "Nomes de arquivo sugeridos para downloads de arquivo único e arquivos dentro de ZIPs de exportação.",
+        "libraryOverrides": "Substituições da Biblioteca",
+        "noLibraries": "Nenhuma biblioteca configurada. Crie uma nas configurações da Biblioteca para definir padrões de nomenclatura personalizados.",
+        "badgeCustom": "Personalizado",
+        "badgeDefault": "Padrão",
+        "orgFolderAsBook": "Pasta como Livro",
+        "orgFileAsBook": "Arquivo como Livro",
+        "resetToDefault": "Redefinir para o padrão",
+        "patternReference": "Referência de Padrão",
+        "placeholderReference": "Referência de Espaço Reservado",
+        "placeholderReferenceHint": "- guia para criar padrões de nomenclatura personalizados",
+        "tokens": "Tokens",
+        "tokensHint": "Copie os espaços reservados rapidamente",
+        "clickTokenHint": "Clique em qualquer token para copiá-lo para a área de transferência.",
+        "copyValue": "Copiar {value}",
+        "modifiers": "Modificadores",
+        "modifiersHint": "Transformar os valores do token",
+        "modifiersExplain": "Anexe um modificador dentro de um token para transformar seu valor:",
+        "modFirst": "Apenas o primeiro valor",
+        "modSort": "Formato Sobrenome, Nome",
+        "modInitial": "Apenas a primeira letra",
+        "folderOnlyPrefix": "Termine um padrão com",
+        "folderOnlySuffix": "para especificar apenas uma pasta. O nome do arquivo original será preservado dentro dela.",
+        "conditionalLogic": "Lógica Condicional",
+        "conditionalLogicHint": "Segmentos opcionais e alternativas",
+        "conditionalPart1": "Envolva em",
+        "conditionalPart2": "para ignorar um segmento quando seu token estiver vazio. Use",
+        "conditionalPart3": "para um valor padrão.",
+        "examples": "Exemplos",
+        "patternExamples": "Exemplos de Padrões",
+        "patternExamplesHint": "Padrões prontos para estilos de biblioteca comuns",
+        "copyPatternTooltip": "Copiar padrão para a área de transferência",
+        "exCalibre": "Padrão estilo Calibre",
+        "exSeriesReader": "Leitor de séries",
+        "exCleanDownload": "Nome de arquivo de download limpo",
+        "exAlphabetical": "Agrupamento alfabético com série",
+        "exSeriesFallback": "Série ou alternativa Independente",
+        "exOptionalSubtitle": "Download com subtítulo opcional",
+        "exMultilingual": "Biblioteca multilíngue",
+        "exPublisher": "Organizado por editora",
+        "exStacked": "Pastas opcionais empilhadas",
+        "exFolderDrop": "Recepção de pasta com nome de classificação",
+        "caseWithYear": "com ano",
+        "caseNoYear": "sem ano",
+        "caseInSeries": "na série",
+        "caseStandalone": "independente",
+        "caseNoSeries": "sem série",
+        "caseFull": "completo",
+        "caseMinimal": "mínimo",
+        "caseWithLanguage": "com idioma",
+        "caseNoLanguage": "sem idioma",
+        "caseWithPublisher": "com editora",
+        "caseNoPublisher": "sem editora",
+        "caseAllSet": "tudo definido",
+        "copiedToClipboard": "{value} copiado para a área de transferência",
+        "copyTokenFailed": "Falha ao copiar token",
+        "patternCopied": "Padrão copiado para a área de transferência",
+        "copyPatternFailed": "Falha ao copiar padrão",
+        "labelCopied": "{label} copiado para a área de transferência",
+        "copyLabelFailed": "Falha ao copiar {label}"
+      },
+      "kobo": {
+        "title": "Sincronização Kobo",
+        "subtitle": "Pareie seu dispositivo Kobo para sincronizar sua biblioteca.",
+        "copy": "Copiar",
+        "never": "Nunca",
+        "justNow": "Agora mesmo",
+        "minutesAgo": "{count}m atrás",
+        "hoursAgo": "{count}h atrás",
+        "daysAgo": "{count}d atrás",
+        "loadFailed": "Falha ao carregar",
+        "devicePaired": "Dispositivo pareado com sucesso",
+        "devicePairedHint": "Você está pronto para configurar o seu Kobo. Siga as instruções abaixo.",
+        "syncUrl": "URL de sincronização",
+        "urlNotShownAgain": "Esta URL não será exibida novamente. Mantenha-a privada.",
+        "registeredDevices": "Dispositivos Registrados",
+        "addDevice": "Adicionar dispositivo",
+        "deviceName": "Nome do dispositivo",
+        "deviceNamePlaceholder": "ex: Meu Kobo Libra",
+        "creating": "Criando...",
+        "createDevice": "Criar dispositivo",
+        "createDeviceFailed": "Falha ao criar dispositivo",
+        "deviceRegistered": "Dispositivo \"{name}\" registrado",
+        "noDevicesYet": "Nenhum dispositivo ainda",
+        "noDevicesHint": "Adicione um dispositivo para começar a sincronizar seus livros com o seu Kobo.",
+        "lastSync": "Última sincronização: {time}",
+        "renameDevice": "Renomear dispositivo",
+        "revokeAccess": "Revogar acesso",
+        "deviceRenamed": "Dispositivo renomeado",
+        "renameDeviceFailed": "Falha ao renomear dispositivo",
+        "revokeConfirm": "Revogar acesso para \"{name}\"? O dispositivo não poderá sincronizar até ser pareado novamente.",
+        "accessRevoked": "Acesso revogado para \"{name}\"",
+        "revokeFailed": "Falha ao revogar acesso",
+        "syncUrlCopied": "URL de sincronização copiada para a área de transferência",
+        "syncUrlCopyFailed": "Falha ao copiar URL de sincronização",
+        "syncPreferences": "Preferências de Sincronização",
+        "twoWaySync": "Sincronização bidirecional de progresso",
+        "twoWaySyncHint": "Sincroniza a posição de leitura entre BookOrbit e Kobo. Requer entrega em KEPUB para locais precisos e restauração de página confiável.",
+        "syncHighlights": "Sincronizar destaques do BookOrbit para Kobo",
+        "syncHighlightsHint": "Envia destaques feitos no BookOrbit ou KOReader para o seu Kobo. Os destaques do Kobo são importados para o BookOrbit mesmo com esta opção desativada. Anotações vinculadas sincronizam edições e exclusões nos dois sentidos. Requer entrega em KEPUB; o livro no Kobo deve ser o KEPUB baixado do BookOrbit.",
+        "convertKepub": "Converter para KEPUB",
+        "convertKepubHint": "Envia EPUBs elegíveis como KEPUB. Esta opção permanece ativada quando a sincronização de progresso ou de destaques do BookOrbit para Kobo estão ativadas. Na próxima sincronização do Kobo, os livros afetados serão oferecidos novamente como downloads KEPUB; remova qualquer cópia EPUB antiga se o Kobo continuar abrindo-a.",
+        "forceHyphenation": "Forçar hifenização",
+        "forceHyphenationHint": "Garante uma justificação de texto consistente. Isso irá regenerar os KEPUBs armazenados em cache.",
+        "progressThresholds": "Limites de Progresso",
+        "progressThresholdsHint": "Defina quando o progresso de leitura do Kobo atualiza o status da sua biblioteca.",
+        "markAsReading": "Marcar como Lendo",
+        "markAsReadingHint": "Porcentagem mínima para mover um livro para \"Lendo\".",
+        "markAsFinished": "Marcar como Concluído",
+        "markAsFinishedHint": "Porcentagem limite para marcar um livro como \"Lido\".",
+        "kepubLimit": "Limite de conversão KEPUB",
+        "kepubLimitHint": "Livros acima deste limite são enviados como EPUBs normais, então o BookOrbit não sincronizará sua posição de leitura de volta para o Kobo.",
+        "changesMustBeSaved": "As alterações devem ser salvas para entrarem em vigor.",
+        "saving": "Salvando...",
+        "saveSyncSettings": "Salvar Configurações",
+        "thresholdOrderError": "O limite de leitura deve ser menor que o limite de finalização",
+        "saveSettingsFailed": "Falha ao salvar configurações",
+        "settingsSaved": "Configurações de sincronização do Kobo salvas",
+        "saveFailed": "Falha ao salvar",
+        "activity": {
+          "waitingForActivity": "Aguardando atividade",
+          "needsAttention": "Requer atenção",
+          "syncHealthy": "Sincronização saudável",
+          "never": "Nunca",
+          "none": "Nenhum",
+          "unknown": "Desconhecido",
+          "failureCount": "{count} falha | {count} falhas",
+          "noActivityRecorded": "Nenhuma atividade de sincronização do Kobo foi registrada.",
+          "lastSuccess": "Último sucesso em {time}",
+          "lastFailure": "Última falha em {time}",
+          "noFailedActivity": "Nenhuma atividade falha do Kobo no histórico recente.",
+          "noActivityYet": "Nenhuma atividade do Kobo ainda.",
+          "event": {
+            "librarySync": "Biblioteca verificada por atualizações",
+            "bookDownload": "Livro baixado",
+            "progressUpdate": "Posição de leitura atualizada",
+            "annotationsPull": "Destaques enviados ao Kobo",
+            "annotationsPush": "Destaques recebidos do Kobo"
+          },
+          "outcome": {
+            "failed": "Falhou",
+            "noUpdates": "Sem atualizações",
+            "noChanges": "Sem alterações",
+            "pending": "Pendente",
+            "completed": "Concluído",
+            "downloaded": "Baixado",
+            "updated": "Atualizado",
+            "sent": "Enviado",
+            "imported": "Importado"
+          },
+          "failure": {
+            "librarySync": "A verificação da biblioteca não foi concluída",
+            "bookDownload": "O download não foi concluído",
+            "progressUpdate": "A posição de leitura não foi atualizada",
+            "annotationsPull": "Os destaques não foram enviados",
+            "annotationsPush": "Os destaques não foram importados"
+          },
+          "chip": {
+            "morePending": "Mais pendentes",
+            "noUpdatesPending": "Sem atualizações pendentes",
+            "bookCount": "{count} livro | {count} livros",
+            "deletedAnnotations": "{count} anotações excluídas",
+            "deviceAlreadyCurrent": "Dispositivo já atualizado",
+            "freshHighlightData": "Dados de destaque recentes",
+            "created": "{count} criados",
+            "updated": "{count} atualizados",
+            "deleted": "{count} excluídos",
+            "unchanged": "{count} inalterados"
+          },
+          "readingPositionSyncedTitle": "Posição de leitura sincronizada: {title}",
+          "readingPositionSynced": "Posição de leitura sincronizada",
+          "labelWithTitle": "{label}: {title}",
+          "updateCount": "{count} atualização | {count} atualizações",
+          "directionToKobo": "BookOrbit -> Kobo",
+          "directionToBookOrbit": "Kobo -> BookOrbit",
+          "twoWaySyncEnabled": "Sincronização bidirecional ativada",
+          "deviceProgressSaved": "Progresso do dispositivo salvo",
+          "summary": {
+            "noLibraryUpdatesPending": "Nenhuma atualização de biblioteca pendente para este dispositivo",
+            "libraryUpdatesPrepared": "{count} atualização de biblioteca preparada para o dispositivo | {count} atualizações de biblioteca preparadas para o dispositivo",
+            "bookDownloadedBy": "{title} foi baixado por {device}",
+            "booksDownloaded": "{count} livro baixado | {count} livros baixados",
+            "progressUpdatesSyncedFor": "{count} atualização de progresso sincronizada para {title} | {count} atualizações de progresso sincronizadas para {title}",
+            "progressUpdatesSynced": "{count} atualização de progresso sincronizada | {count} atualizações de progresso sincronizadas",
+            "newReadingPositionFor": "O Kobo relatou uma nova posição de leitura para {title}",
+            "newReadingPosition": "O Kobo relatou uma nova posição de leitura",
+            "noHighlightChangesNeededFor": "Nenhuma alteração de destaque necessária para {title}",
+            "noHighlightChangesNeeded": "Nenhuma alteração de destaque necessária",
+            "highlightsSentToKoboFor": "{count} destaque enviado ao Kobo para {title} | {count} destaques enviados ao Kobo para {title}",
+            "highlightsSentToKobo": "{count} destaque enviado ao Kobo | {count} destaques enviados ao Kobo",
+            "noKoboHighlightChangesFor": "Nenhuma alteração de destaque do Kobo para {title}",
+            "noKoboHighlightChanges": "Nenhuma alteração de destaque do Kobo",
+            "highlightsImportedFromKoboFor": "{count} destaque importado do Kobo para {title} | {count} destaques importados do Kobo para {title}",
+            "highlightsImportedFromKobo": "{count} destaque importado do Kobo | {count} destaques importados do Kobo"
+          },
+          "timeRange": "{from} até {to}",
+          "eventsGrouped": "{count} evento agrupado | {count} eventos agrupados",
+          "removedDevice": "Dispositivo removido",
+          "loadMoreFailed": "Falha ao carregar mais do histórico",
+          "historyRefreshed": "Histórico de sincronização do Kobo atualizado",
+          "refreshFailed": "Falha ao atualizar o histórico",
+          "recentActivity": "Atividade Recente do Kobo",
+          "filterAll": "Tudo",
+          "filterFailures": "Falhas",
+          "refresh": "Atualizar",
+          "loadingActivity": "Carregando atividade do Kobo...",
+          "noActivityHint": "Atividades de sincronização recentes aparecerão depois que um Kobo pareado entrar em contato com o BookOrbit.",
+          "error": "Erro",
+          "loading": "Carregando...",
+          "loadMore": "Carregar mais atividade"
+        },
+        "howBooksSynced": {
+          "title": "Como os livros são sincronizados"
+        },
+        "nextSteps": {
+          "title": "Próximos Passos",
+          "step1": "1. Configure seu dispositivo Kobo para sincronizar com a URL de Sincronização acima."
+        },
+        "syncToKobo": "Sincronizar com o Kobo",
+        "tabs": {
+          "syncSettings": "Configurações de Sincronização",
+          "activityLog": "Registro de Atividade"
+        }
+      },
+      "koreader": {
+        "title": "Sincronização KOReader",
+        "subtitle": "Navegue pelo catálogo do BookOrbit no KOReader e sincronize o progresso, atividades de leitura, destaques e alterações de anotações.",
+        "loadingSettings": "Carregando configurações do KOReader...",
+        "loadFailed": "Falha ao carregar as configurações do KOReader",
+        "never": "Nunca",
+        "justNow": "Agora mesmo",
+        "minutesAgo": "{count}m atrás",
+        "hoursAgo": "{count}h atrás",
+        "daysAgo": "{count}d atrás",
+        "unknown": "Desconhecido",
+        "updateAvailable": "Atualização disponível",
+        "upToDate": "Atualizado",
+        "versionUnknown": "Versão desconhecida",
+        "latestPlugin": "Plugin mais recente: v{version}",
+        "latestPluginUnavailable": "Plugin mais recente indisponível",
+        "notConfigured": "A sincronização do KOReader não está configurada",
+        "notConfiguredHint": "Crie um conjunto de credenciais de sincronização e, em seguida, use-as com o plugin BookOrbit para KOReader para navegação, downloads, progresso, eventos de leitura, destaques e exclusões.",
+        "createCredentials": "Criar credenciais",
+        "createFormTitle": "Criar Credenciais de Sincronização do KOReader",
+        "createFormHint": "Estas credenciais autenticam seus dispositivos KOReader com o BookOrbit.",
+        "username": "Nome de usuário",
+        "usernamePlaceholder": "ex: meuleitor",
+        "password": "Senha",
+        "passwordPlaceholder": "Mín. 6 caracteres",
+        "creating": "Criando...",
+        "create": "Criar",
+        "credentialsCreated": "Credenciais de sincronização do KOReader criadas",
+        "createCredentialsFailed": "Falha ao criar credenciais",
+        "status": "Status do KOReader",
+        "refresh": "Atualizar",
+        "progressSync": "Sincronização de progresso",
+        "progressSyncHint": "Permite que os dispositivos KOReader sincronizem o progresso, atividades de leitura, destaques e exclusões de anotações com o BookOrbit.",
+        "lastSync": "Última sincronização",
+        "syncedBooks": "Livros sincronizados",
+        "bookCount": "nenhum livro | {count} livro | {count} livros",
+        "devices": "Dispositivos",
+        "deviceCount": "nenhum dispositivo | {count} dispositivo | {count} dispositivos",
+        "credentialsCreatedLabel": "Credenciais criadas",
+        "setup": "Configuração",
+        "pluginServerUrl": "URL do servidor do plugin",
+        "copied": "Copiado",
+        "copyUrl": "Copiar URL",
+        "preconfiguredPlugin": "Plugin pré-configurado do BookOrbit",
+        "preconfiguredPluginHintPrefix": "Baixe um zip com a URL do servidor e seu login de sincronização já configurados. O plugin inclui navegação de catálogo e sincronização. Copie a pasta para",
+        "preconfiguredPluginHintSuffix": "e reinicie o KOReader.",
+        "latestPluginNote": "{label}. Atualizações de dispositivo são executadas no menu BookOrbit no KOReader.",
+        "preparing": "Preparando...",
+        "downloadPlugin": "Baixar Plugin",
+        "noDevicesSynced": "Nenhum dispositivo sincronizou ainda",
+        "noDevicesSyncedHint": "Instale o plugin BookOrbit para sincronização completa ou configure a sincronização de progresso nativa do KOReader para atualizações apenas de progresso.",
+        "lastSyncLabel": "Última sincronização:",
+        "lastBookLabel": "Último livro:",
+        "noneYet": "Nenhum ainda",
+        "pluginActivity": "Atividade do Plugin",
+        "noPluginActivity": "Nenhuma atividade de plugin relatada ainda.",
+        "lastFullSync": "Última sincronização completa: {time}",
+        "latestPluginSuffix": "- plugin mais recente v{version}",
+        "matchedBooks": "Livros correspondidos",
+        "readingEvents": "Eventos de leitura",
+        "highlights": "Destaques",
+        "syncedTotals": "Totais sincronizados",
+        "trashedHighlights": "Destaques na lixeira",
+        "pendingDeletes": "nenhum destaque excluído aguardando confirmação do plugin do KOReader. | {count} destaque excluído aguardando confirmação do plugin do KOReader. | {count} destaques excluídos aguardando confirmação do plugin do KOReader.",
+        "failedPositions": "nenhuma posição de destaque requer atenção. | {count} posição de destaque requer atenção. | {count} posições de destaque requerem atenção.",
+        "setupGuide": "Guia de Configuração",
+        "setupSteps": "Passos de configuração do KOReader",
+        "setupStepsHint": "Use o plugin BookOrbit para navegação de catálogo, downloads, progresso, eventos de leitura e destaques. Use o plugin nativo apenas para progresso.",
+        "pluginGuideTitle": "Plugin BookOrbit",
+        "pluginStep1": "Baixe o plugin pré-configurado acima.",
+        "pluginStep2Prefix": "Descompacte e copie",
+        "pluginStep2Middle": "para",
+        "pluginStep2Suffix": "no seu dispositivo.",
+        "pluginStep3": "Reinicie o KOReader. O servidor e o login são configurados automaticamente.",
+        "pluginStep4Prefix": "Abra",
+        "pluginStep4Suffix": "para pesquisar, baixar e vincular livros à sincronização.",
+        "stockGuideTitle": "Plugin nativo de sincronização de progresso",
+        "stockStep1Prefix": "No seu dispositivo KOReader, vá para",
+        "stockStep1Suffix": ".",
+        "stockStep2": "Defina o servidor de sincronização personalizado para a URL mostrada acima.",
+        "stockStep3": "Insira o nome de usuário e a senha que você criou e toque em Login.",
+        "locationNote": "O BookOrbit salva posições de EPUB compatíveis com o KOReader do leitor web. A restauração deve cair perto da mesma posição, embora a localização exata da linha possa variar por leitor e layout do EPUB.",
+        "dangerZone": "Zona de Perigo",
+        "deleteCredentials": "Excluir credenciais do KOReader",
+        "deleteCredentialsHint": "Remove credenciais de sincronização e desconecta todos os dispositivos. Os dados de progresso serão retidos.",
+        "credentialsDeleted": "Credenciais do KOReader excluídas",
+        "deleteCredentialsFailed": "Falha ao excluir credenciais",
+        "deleteConfirmTitle": "Excluir credenciais do KOReader?",
+        "deleteConfirmBody": "Isto removerá suas credenciais de sincronização e desconectará todos os dispositivos KOReader. Os dados de progresso existentes serão mantidos.",
+        "syncEnabled": "Sincronização do KOReader ativada",
+        "syncDisabled": "Sincronização do KOReader desativada",
+        "toggleSyncFailed": "Falha ao alternar sincronização",
+        "syncUrlCopied": "URL de sincronização copiada para a área de transferência",
+        "syncUrlCopyFailed": "Falha ao copiar URL de sincronização",
+        "statusRefreshed": "Status de sincronização atualizado",
+        "refreshFailed": "Falha ao atualizar",
+        "pluginDownloaded": "Plugin baixado. Copie bookorbit.koplugin do zip para koreader/plugins/ no seu dispositivo.",
+        "pluginDownloadFailed": "Falha ao baixar o plugin",
+        "hashLinks": {
+          "unmatchedTitle": "Livros do KOReader Não Correspondidos",
+          "unmatchedBooks": "Livros não correspondidos",
+          "manualTitle": "Links Manuais do KOReader",
+          "refresh": "Atualizar",
+          "link": "Vincular",
+          "change": "Alterar",
+          "unlink": "Desvincular",
+          "hash": "Hash:",
+          "lastOpened": "Última abertura:",
+          "firstSeen": "Visto pela primeira vez:",
+          "lastSeen": "Visto pela última vez:",
+          "linked": "Vinculado:",
+          "updated": "Atualizado:",
+          "linkedTo": "Vinculado a {title}",
+          "loadingUnmatched": "Carregando livros não correspondidos...",
+          "loadingManual": "Carregando links manuais...",
+          "noUnmatched": "Nenhum livro não correspondido no KOReader.",
+          "noManual": "Nenhum link manual do KOReader.",
+          "pageOf": "Página {page} de {total}",
+          "showingRange": "Mostrando {start}-{end} de {total}",
+          "unknownFile": "Arquivo KOReader desconhecido {hash}",
+          "unknownAuthor": "Autor desconhecido",
+          "noTitleOrAuthor": "Nenhum título ou autor relatado",
+          "bookNumber": "Livro BookOrbit #{id}",
+          "toast": {
+            "unmatchedRefreshed": "Livros não correspondidos atualizados",
+            "unmatchedRefreshFailed": "Falha ao atualizar livros não correspondidos",
+            "manualRefreshed": "Links manuais atualizados",
+            "manualRefreshFailed": "Falha ao atualizar links manuais",
+            "bookLinked": "Livro vinculado",
+            "linkUpdated": "Link atualizado",
+            "linkFailed": "Falha ao vincular o livro",
+            "linkRemoved": "Link removido",
+            "unlinkFailed": "Falha ao desvincular o livro",
+            "unmatchedDismissed": "Livro não correspondido ignorado",
+            "dismissFailed": "Falha ao ignorar livro não correspondido",
+            "allDismissed": "Nenhum livro ignorado | {count} livro ignorado | {count} livros ignorados",
+            "dismissAllFailed": "Falha ao ignorar todos os livros não correspondidos"
+          },
+          "modal": {
+            "linkTitle": "Vincular livro do KOReader",
+            "changeTitle": "Alterar link do KOReader",
+            "bookOrbitBook": "Livro BookOrbit",
+            "searchPlaceholder": "Pesquise na sua biblioteca do BookOrbit",
+            "minChars": "Digite pelo menos 2 caracteres.",
+            "searching": "Pesquisando...",
+            "noBooksFound": "Nenhum livro encontrado.",
+            "untitledBook": "Livro sem título",
+            "selected": "Selecionado",
+            "select": "Selecionar",
+            "loadMore": "Carregar mais",
+            "confirmTitle": "Confirmar link do KOReader",
+            "koreader": "KOReader",
+            "bookOrbit": "BookOrbit",
+            "bookId": "ID do Livro: {id}",
+            "syncedStatsNote": "As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
+            "chooseDifferent": "Escolher diferente",
+            "saving": "Salvando...",
+            "confirmLink": "Confirmar vínculo",
+            "unlinkTitle": "Desvincular livro do KOReader?",
+            "unlinkBody": "Sincronizações futuras para este hash não resolverão para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
+            "unlinking": "Desvinculando..."
+          },
+          "dismiss": "Ignorar",
+          "dismissAll": "Ignorar tudo",
+          "dismissing": "Ignorando...",
+          "unlinking": "Desvinculando...",
+          "unlinkConfirmTitle": "Desvincular livro do KOReader?",
+          "unlinkConfirmBody": "Sincronizações futuras para este hash não resolverão para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
+          "dismissConfirmTitle": "Ignorar {title}?",
+          "dismissConfirmBody": "Isso remove-o da sua lista de livros não correspondidos. Se qualquer dispositivo reportar este hash novamente, ele reaparecerá como uma nova entrada.",
+          "dismissAllConfirmTitle": "nenhum livro não correspondido | Ignorar {count} livro não correspondido? | Ignorar todos os {count} livros não correspondidos?",
+          "dismissAllConfirmBody": "Isto limpa toda a sua lista de livros não correspondidos, não apenas a página atual. Se qualquer dispositivo reportar um desses hashes novamente, ele reaparecerá como uma nova entrada.",
+          "changeLinkTitle": "Alterar link do KOReader",
+          "linkBookTitle": "Vincular livro do KOReader",
+          "bookOrbitBook": "Livro BookOrbit",
+          "searchLibraryPlaceholder": "Pesquise na sua biblioteca do BookOrbit",
+          "enterMinChars": "Digite pelo menos 2 caracteres.",
+          "searching": "Pesquisando...",
+          "noBooksFound": "Nenhum livro encontrado.",
+          "untitledBook": "Livro sem título",
+          "selected": "Selecionado",
+          "select": "Selecionar",
+          "loadMore": "Carregar mais",
+          "loadingMore": "Carregando...",
+          "confirmLinkTitle": "Confirmar vínculo do KOReader",
+          "bookId": "ID do Livro: {id}",
+          "syncedStatsNote": "As estatísticas já sincronizadas permanecerão no livro atual do BookOrbit.",
+          "chooseDifferent": "Escolher diferente",
+          "saving": "Salvando...",
+          "confirmLink": "Confirmar vínculo"
+        },
+        "remove": "Remover",
+        "removing": "Removendo...",
+        "unmatchedBooks": "Livros não correspondidos",
+        "deviceRemoved": "Dispositivo removido",
+        "removeDeviceFailed": "Falha ao remover dispositivo",
+        "removeDeviceConfirmTitle": "Remover {device}?",
+        "removeDeviceConfirmBody": "Isto exclui permanentemente o progresso sincronizado deste dispositivo, a atividade de leitura e quaisquer entradas de livros não correspondidos que não sejam mais reportadas por outro dispositivo. Se o dispositivo sincronizar novamente mais tarde, ele reaparecerá como uma nova entrada."
+      },
+      "opds": {
+        "title": "OPDS",
+        "subtitle": "Conecte aplicativos de leitura compatíveis com OPDS, como KOReader ou Thorium Reader, à sua biblioteca.",
+        "copy": "Copiar",
+        "loadFailed": "Falha ao carregar",
+        "server": "Servidor",
+        "catalogServer": "Servidor de Catálogo OPDS",
+        "catalogServerHint": "Permitir que clientes OPDS naveguem e baixem livros",
+        "endpoint": "Endpoint",
+        "accounts": "Contas OPDS",
+        "add": "Adicionar",
+        "addAccount": "Adicionar conta",
+        "username": "Nome de usuário",
+        "usernameLabel": "Nome de usuário",
+        "usernamePlaceholder": "ex: koreader",
+        "password": "Senha",
+        "passwordPlaceholder": "Mín. 8 caracteres",
+        "defaultSort": "Classificação Padrão",
+        "sortLabel": "Classificação",
+        "creating": "Criando...",
+        "create": "Criar",
+        "noAccounts": "Nenhuma conta OPDS ainda. Crie uma para começar a usar os clientes OPDS.",
+        "hideDetails": "Ocultar detalhes",
+        "showDetails": "Mostrar detalhes",
+        "copyUsername": "Copiar nome de usuário",
+        "notes": "Notas sobre OPDS",
+        "notesBody": "Use contas OPDS em aplicativos de leitura. Mantenha as credenciais privadas e rotacione as senhas se compartilhadas acidentalmente.",
+        "deleteConfirmTitle": "Excluir conta OPDS?",
+        "deleteConfirmBody": "Excluir \"{username}\". Esta ação não pode ser desfeita.",
+        "sortRecent": "Adicionado Recentemente",
+        "sortTitleAsc": "Título (A-Z)",
+        "sortTitleDesc": "Título (Z-A)",
+        "sortAuthorAsc": "Autor (A-Z)",
+        "sortAuthorDesc": "Autor (Z-A)",
+        "sortSeriesAsc": "Série (A-Z)",
+        "sortSeriesDesc": "Série (Z-A)",
+        "serverEnabled": "Servidor OPDS ativado",
+        "serverDisabled": "Servidor OPDS desativado",
+        "updateSettingsFailed": "Falha ao atualizar configurações de OPDS",
+        "urlCopied": "URL do OPDS copiada para a área de transferência",
+        "urlCopyFailed": "Falha ao copiar a URL do OPDS",
+        "createUserFailed": "Falha ao criar usuário OPDS",
+        "userCreated": "Usuário OPDS \"{username}\" criado",
+        "sortOrderUpdated": "Ordem de classificação atualizada para \"{username}\"",
+        "updateSortFailed": "Falha ao atualizar a ordem de classificação",
+        "userDeleted": "Usuário OPDS \"{username}\" excluído",
+        "deleteUserFailed": "Falha ao excluir usuário OPDS",
+        "labelCopied": "{label} copiado",
+        "copyLabelFailed": "Falha ao copiar {label}"
+      },
+      "tabs": {
+        "general": "Geral",
+        "ebook": "eBook",
+        "pdf": "PDF",
+        "comics": "Quadrinhos",
+        "audio": "Audiobook",
+        "fonts": "Fontes"
+      }
+    },
+    "system": {
+      "tabs": {
+        "file-naming": "Nomenclatura de Arquivos",
+        "book-dock": "Book Dock",
+        "maintenance": "Manutenção",
+        "audit-log": "Log de Auditoria"
+      }
+    }
+  },
+  "achievements": {
+    "title": "Conquistas",
+    "tiersCount": "{earned} / {total} níveis",
+    "loadFailed": "Falha ao carregar conquistas",
+    "tryAgain": "Tentar novamente",
+    "noMatchFilter": "Nenhuma conquista corresponde a este filtro",
+    "secretAchievement": "Conquista Secreta",
+    "earnedOn": "Conquistado em {date}",
+    "whileReading": "Ao ler “{title}”",
+    "tierProgress": "Nível {earned} de {total}",
+    "progressToNext": "{current} / {threshold} para {name}",
+    "rarity": {
+      "common": "Comum",
+      "rare": "Rara",
+      "epic": "Épica",
+      "legendary": "Lendária"
+    },
+    "filter": {
+      "all": "Tudo",
+      "earned": "Conquistadas ({count})",
+      "inProgress": "Em Andamento ({count})",
+      "locked": "Bloqueadas ({count})"
+    }
+  },
+  "adminFeature": {
+    "resetLink": {
+      "title": "Link de Redefinição de Senha",
+      "description": "Compartilhe este link com o usuário. Ele expira em 15 minutos.",
+      "copy": "Copiar",
+      "copied": "Copiado!",
+      "copyFailed": "Falha ao copiar",
+      "notShownAgain": "Este link não será exibido novamente."
+    },
+    "userForm": {
+      "editUser": "Editar Usuário",
+      "createUser": "Criar Usuário",
+      "createSharedAccount": "Criar Conta Compartilhada",
+      "sharedBadge": "Compartilhado",
+      "active": "Ativo",
+      "suspended": "Suspenso",
+      "tabs": {
+        "general": "geral",
+        "access": "acesso",
+        "restrictions": "restrições"
+      },
+      "sharedAccount": "Conta compartilhada",
+      "sharedAccountHint": "Sem senha. O acesso é concedido apenas via links mágicos.",
+      "sharedAccountManageHint": "Gerencie links de login em Configurações - Links Mágicos.",
+      "username": "Nome de usuário",
+      "fullName": "Nome completo",
+      "email": "E-mail",
+      "optional": "(opcional)",
+      "libraryAccess": "Acesso à Biblioteca",
+      "noLibrariesSelected": "Nenhuma biblioteca selecionada. O usuário não pode ver nenhum livro.",
+      "permissions": "Permissões",
+      "presetStandard": "Padrão",
+      "presetAdmin": "Admin",
+      "presetClearAll": "Limpar Tudo",
+      "permissionGroups": {
+        "content": "Conteúdo",
+        "devicesAccess": "Dispositivos e Acesso",
+        "email": "E-mail",
+        "administration": "Administração",
+        "restrictions": "Restrições"
+      },
+      "superuserTarget": "Alvo de Superusuário",
+      "superuserTargetHint": "Restrições de conteúdo não podem ser aplicadas a superusuários.",
+      "noRestrictions": "Sem restrições de conteúdo",
+      "noRestrictionsHint": "Este usuário tem acesso total a todos os livros nas suas bibliotecas atribuídas.",
+      "addRestrictions": "+ Adicionar Restrições de Conteúdo",
+      "contentRestrictions": "Restrições de Conteúdo",
+      "remove": "Remover",
+      "includeTags": "Incluir tags",
+      "includeTagsHint": "(mostrar apenas livros com estas tags)",
+      "excludeTags": "Excluir tags",
+      "excludeTagsHint": "(ocultar livros com estas tags)",
+      "includeGenres": "Incluir gêneros",
+      "includeGenresHint": "(mostrar apenas livros com estes gêneros)",
+      "excludeGenres": "Excluir gêneros",
+      "excludeGenresHint": "(ocultar livros com estes gêneros)",
+      "searchTagsPlaceholder": "Pesquisar tags...",
+      "searchGenresPlaceholder": "Pesquisar gêneros...",
+      "saving": "Salvando...",
+      "errors": {
+        "updateUser": "Falha ao atualizar o usuário",
+        "updatePermissions": "Falha ao atualizar as permissões",
+        "updateLibraryAccess": "Falha ao atualizar o acesso à biblioteca",
+        "updateContentFilters": "Falha ao atualizar os filtros de conteúdo",
+        "emailRequired": "E-mail é obrigatório",
+        "createSharedAccount": "Falha ao criar conta compartilhada",
+        "createUser": "Falha ao criar usuário"
+      }
+    },
+    "usersPage": {
+      "usersTitle": "Usuários",
+      "magicLinksTitle": "Links Mágicos",
+      "usersSubtitle": "Gerencie contas de usuário e atribuições de permissão.",
+      "magicLinksSubtitle": "Crie links de login compartilháveis para contas compartilhadas.",
+      "createUser": "Criar usuário",
+      "createLink": "Criar link",
+      "usersTab": "Usuários",
+      "magicLinksTab": "Links Mágicos",
+      "columns": {
+        "name": "Nome",
+        "username": "Nome de usuário",
+        "email": "E-mail",
+        "access": "Acesso",
+        "status": "Status"
+      },
+      "adminBadge": "Admin",
+      "permissionCount": "nenhuma permissão | uma permissão | {count} permissões",
+      "filteredBadge": "Filtrado",
+      "contentRestrictionsActive": "Restrições de conteúdo ativas",
+      "statusActive": "Ativo",
+      "statusInactive": "Inativo",
+      "resetPassword": "Redefinir senha",
+      "resetPasswordOidcHint": "Usuários OIDC redefinem senhas no seu provedor de identidade",
+      "resetPasswordSharedHint": "Contas compartilhadas não possuem senhas",
+      "resetPasswordOidcHintFull": "Usuários OIDC redefinem senhas em seu provedor de identidade.",
+      "resetPasswordSharedHintFull": "Contas compartilhadas não possuem senhas.",
+      "deleteUserAction": "Excluir usuário",
+      "deleteDialogTitle": "Excluir usuário?",
+      "deleteDialogBody": "Excluir usuário \"{username}\". Esta ação não pode ser desfeita.",
+      "deleting": "Excluindo...",
+      "errors": {
+        "loadData": "Falha ao carregar dados",
+        "load": "Falha ao carregar",
+        "deleteUser": "Falha ao excluir usuário"
+      },
+      "currentUsers": "Usuários Atuais",
+      "defaultLibraryAccess": {
+        "title": "Acesso Padrão à Biblioteca",
+        "subtitle": "Acesso de visualização concedido a usuários registrados automaticamente e provisionados via OIDC.",
+        "description": "Selecione as bibliotecas atribuídas automaticamente a novos usuários.",
+        "noLibraries": "Nenhuma biblioteca disponível.",
+        "save": "Salvar padrões",
+        "saving": "Salvando...",
+        "saved": "Acesso padrão à biblioteca salvo.",
+        "saveError": "Falha ao salvar acesso padrão à biblioteca"
+      }
+    }
+  },
+  "annotations": {
+    "unknownBook": "Livro desconhecido",
+    "styles": {
+      "highlight": "Destaque",
+      "underline": "Sublinhado",
+      "strike": "Tachado",
+      "squiggle": "Ondulado",
+      "invert": "Inverter"
+    },
+    "combobox": {
+      "filterByBook": "Filtrar por livro",
+      "allBooks": "Todos os livros",
+      "clearBookFilter": "Limpar filtro de livro",
+      "searching": "Pesquisando...",
+      "noBooksFound": "Nenhum livro encontrado"
+    },
+    "bulk": {
+      "countSelected": "{count} selecionado(s)",
+      "pageSelected": "Página selecionada",
+      "selectPage": "Selecionar página",
+      "clear": "Limpar",
+      "recolorTo": "Recolorir para {color}",
+      "restyleTo": "Reestilizar para {style}"
+    },
+    "chips": {
+      "active": "Ativo:",
+      "removeFilter": "Remover filtro {label}",
+      "clearAll": "Limpar tudo"
+    },
+    "filters": {
+      "colors": "Cores",
+      "dateRange": "Intervalo de datas",
+      "fromDate": "Data de início",
+      "toDate": "Data de término",
+      "to": "até",
+      "clearDateRange": "Limpar intervalo de datas",
+      "clearAll": "Limpar tudo"
+    },
+    "pagination": {
+      "showing": "Mostrando {start}-{end} de {total}",
+      "pageOf": "Página {page} de {totalPages}",
+      "firstPage": "Primeira página",
+      "previousPage": "Página anterior",
+      "nextPage": "Próxima página",
+      "lastPage": "Última página"
+    },
+    "sync": {
+      "loading": "Carregando detalhe de sincronização",
+      "positions": "Posições",
+      "devices": "Dispositivos",
+      "retryConversion": "Tentar novamente a conversão",
+      "noStoredPositions": "Nenhuma posição armazenada.",
+      "notSynced": "Não sincronizado a nenhum dispositivo ainda.",
+      "upToDate": "Atualizado",
+      "pendingVersion": "Pendente v{version}",
+      "syncedAt": "sincronizado em {date}",
+      "format": {
+        "webReader": "Leitor web",
+        "koreader": "KOReader",
+        "pdf": "PDF",
+        "kobo": "Kobo"
+      },
+      "status": {
+        "exact": "Exato",
+        "repaired": "Reparado",
+        "failed": "Falhou",
+        "pending": "Pendente"
+      }
+    },
+    "toolbar": {
+      "searchPlaceholder": "Pesquisar texto e notas",
+      "filters": "Filtros",
+      "sortOrder": "Ordem de classificação",
+      "switchToCompact": "Mudar para visualização compacta",
+      "switchToComfortable": "Mudar para visualização confortável",
+      "compactView": "Visualização compacta",
+      "comfortableView": "Visualização confortável"
+    },
+    "listItem": {
+      "pageNumber": "p. {page}",
+      "chapterNumber": "capítulo {chapter}",
+      "selectAnnotation": "Selecionar anotação",
+      "collapse": "Recolher",
+      "expand": "Expandir",
+      "hideSyncDetail": "Ocultar detalhe de sincronização",
+      "showSyncDetail": "Mostrar detalhe de sincronização",
+      "exactPositionUnavailable": "Posição exata no leitor indisponível",
+      "saving": "Salvando",
+      "bookDetails": "Detalhes do livro",
+      "openInReader": "Abrir no leitor",
+      "restore": "Restaurar",
+      "deleteForever": "Excluir permanentemente",
+      "editNote": "Editar nota",
+      "addNote": "Adicionar nota",
+      "colorAndStyle": "Cor e estilo",
+      "copied": "Copiado",
+      "copyText": "Copiar texto",
+      "trash": "Lixeira",
+      "moveToTrash": "Mover para a lixeira"
+    },
+    "hub": {
+      "title": "Anotações",
+      "totalCount": "{count} total",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "noteCount": "nenhuma nota | {count} nota | {count} notas",
+      "export": "Exportar",
+      "exportMarkdown": "Markdown",
+      "exportCsv": "CSV",
+      "exportJson": "JSON",
+      "notesOnly": "Apenas notas",
+      "style": "Estilo",
+      "source": "Origem",
+      "bulkTrash": "Mover para lixeira",
+      "bulkRestore": "Restaurar",
+      "tabs": {
+        "highlights": "Destaques",
+        "trash": "Lixeira"
+      },
+      "empty": {
+        "noMatch": "Nenhum destaque corresponde aos seus filtros.",
+        "resetFilters": "Redefinir filtros",
+        "trashEmpty": "A lixeira está vazia",
+        "noAnnotations": "Nenhuma anotação ainda. Destaques que você cria na web ou no seu e-reader aparecerão aqui."
+      },
+      "toast": {
+        "movedToTrash": "Movido para a lixeira",
+        "annotationRestored": "Anotação restaurada",
+        "annotationDeletedForever": "Anotação excluída permanentemente",
+        "failedToDelete": "Falha ao excluir",
+        "bulkTrashed": "Nenhuma anotação movida para a lixeira | {count} anotação movida para a lixeira | {count} anotações movidas para a lixeira",
+        "bulkRestored": "Nenhuma anotação restaurada | {count} anotação restaurada | {count} anotações restauradas",
+        "bulkRecolored": "Nenhuma anotação recolorida | {count} anotação recolorida | {count} anotações recoloridas",
+        "bulkRestyled": "Nenhuma anotação reestilizada | {count} anotação reestilizada | {count} anotações reestilizadas"
+      }
+    }
+  },
+  "audit": {
+    "pageTitle": "Log de Auditoria",
+    "pageSubtitle": "Um registro de ações administrativas significativas realizadas em todo o sistema.",
+    "filters": "Filtros",
+    "noActiveFilters": "Nenhum filtro ativo",
+    "clear": "Limpar",
+    "empty": "Nenhum log de auditoria encontrado",
+    "showMore": "Mostrar mais",
+    "showLess": "Mostrar menos",
+    "details": "Detalhes",
+    "hideDetails": "Ocultar detalhes",
+    "detailAction": "Ação: {value}",
+    "detailIp": "IP: {value}",
+    "showing": "Mostrando {from}-{to} de {total}",
+    "prev": "Ant",
+    "chips": {
+      "action": "Ação: {value}",
+      "user": "Usuário: {value}",
+      "from": "De: {value}",
+      "to": "Até: {value}"
+    },
+    "filterLabels": {
+      "action": "Ação",
+      "userId": "ID do Usuário",
+      "from": "De",
+      "to": "Até"
+    },
+    "filterPlaceholders": {
+      "action": "ex: auth.login",
+      "userId": "ex: 1"
+    },
+    "columns": {
+      "when": "Quando",
+      "user": "Usuário",
+      "action": "Ação",
+      "description": "Descrição",
+      "ip": "IP"
+    }
+  },
+  "auth": {
+    "backToSignIn": "Voltar para entrar",
+    "themePicker": {
+      "switchToLight": "Mudar para claro",
+      "switchToDark": "Mudar para escuro",
+      "changeRadius": "Alterar raio do canto",
+      "changeBackground": "Alterar fundo",
+      "changeAccent": "Alterar cor de destaque"
+    },
+    "fields": {
+      "username": "Nome de usuário",
+      "password": "Senha",
+      "email": "E-mail",
+      "emailAddress": "Endereço de e-mail",
+      "fullName": "Nome completo",
+      "newPassword": "Nova senha",
+      "confirmPassword": "Confirmar senha",
+      "confirmNewPassword": "Confirmar nova senha",
+      "currentPassword": "Senha atual",
+      "passwordHint": "Mín. de 8 caracteres com maiúscula, minúscula e um dígito"
+    },
+    "errors": {
+      "generic": "Algo deu errado. Por favor, tente novamente.",
+      "passwordsDoNotMatch": "As senhas não coincidem"
+    },
+    "login": {
+      "subtitle": "Entre na sua conta",
+      "signIn": "Entrar",
+      "signingIn": "Entrando...",
+      "orDivider": "ou",
+      "forgotPassword": "Esqueceu a senha?",
+      "errors": {
+        "invalidCredentials": "Nome de usuário ou senha inválidos",
+        "tooManyAttempts": "Muitas tentativas de login. Aguarde um minuto e tente novamente."
+      }
+    },
+    "oidc": {
+      "loginFailed": "O login OIDC falhou",
+      "redirecting": "Redirecionando...",
+      "signInWith": "Entrar com {provider}",
+      "completingSignIn": "Concluindo login...",
+      "tryAgain": "Tentar novamente",
+      "errors": {
+        "stateExpired": "Sua sessão de login expirou. Tente fazer login novamente.",
+        "tokenExchangeFailed": "Não foi possível concluir o login com o seu provedor. Tente novamente ou contate seu administrador.",
+        "userNotProvisioned": "Sua conta não foi configurada. Contate seu administrador para acesso.",
+        "userInactive": "Sua conta foi desativada. Contate seu administrador.",
+        "providerError": "Seu provedor de identidade retornou um erro. Tente novamente.",
+        "missingCodeOrState": "Falta parâmetro de código ou estado"
+      },
+      "providerErrors": {
+        "accessDenied": "O acesso foi negado pelo provedor de identidade.",
+        "loginRequired": "A autenticação é necessária. Por favor, faça login novamente.",
+        "interactionRequired": "Interação adicional do usuário é necessária."
+      }
+    },
+    "forgotPassword": {
+      "subtitle": "Redefinir sua senha",
+      "submitted": "Se uma conta com este e-mail existir, um link de redefinição foi enviado. Verifique sua caixa de entrada.",
+      "sending": "Enviando...",
+      "sendResetLink": "Enviar link de redefinição",
+      "errors": {
+        "emailUnavailable": "A redefinição de senha por e-mail não está disponível. Contate seu administrador."
+      }
+    },
+    "resetPassword": {
+      "subtitle": "Definir uma nova senha",
+      "saving": "Salvando...",
+      "setNewPassword": "Definir nova senha",
+      "errors": {
+        "invalidLink": "Link de redefinição inválido. Solicite um novo.",
+        "invalidOrExpired": "Link de redefinição inválido ou expirado. Solicite um novo."
+      }
+    },
+    "setup": {
+      "title": "Configuração inicial",
+      "subtitle": "Crie a primeira conta de administrador.",
+      "setupToken": "Token de configuração",
+      "setupTokenHint": "(obrigatório em produção)",
+      "creatingAccount": "Criando conta...",
+      "createAccount": "Criar conta de administrador",
+      "errors": {
+        "failed": "Falha ao concluir a configuração"
+      }
+    },
+    "changePassword": {
+      "title": "Alterar senha",
+      "saving": "Salvando…",
+      "forcedNotice": "Você deve definir uma nova senha antes de continuar.",
+      "errors": {
+        "failed": "Falha ao alterar senha"
+      }
+    },
+    "magicLink": {
+      "signingIn": "Entrando...",
+      "loginFailed": "Login falhou",
+      "goToLogin": "Ir para o login",
+      "errors": {
+        "noToken": "Nenhum token fornecido"
+      }
+    }
+  },
+  "author": {
+    "card": {
+      "portraitAlt": "Retrato de {name}",
+      "viewDetails": "Ver Detalhes do Autor",
+      "refreshMetadata": "Atualizar Metadados",
+      "deleteAuthor": "Excluir Autor"
+    },
+    "listRow": {
+      "noRecentAdditions": "Nenhuma adição recente",
+      "portraitAlt": "Retrato de {name}"
+    },
+    "filters": {
+      "title": "Filtros de Autor",
+      "clearAll": "Limpar tudo",
+      "allLibraries": "Todas as Bibliotecas",
+      "allAuthors": "Todos os autores",
+      "hasPhoto": "Tem foto",
+      "missingPhoto": "Falta foto",
+      "minBooks": "Mín. de livros",
+      "anyPlaceholder": "Qualquer"
+    },
+    "header": {
+      "never": "Nunca",
+      "portraitAlt": "Retrato de {name}",
+      "actions": "Ações",
+      "editAuthor": "Editar Autor",
+      "mergeAuthors": "Mesclar Autores",
+      "refreshing": "Atualizando...",
+      "refreshMetadata": "Atualizar Metadados",
+      "deleteAuthor": "Excluir Autor",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar mais",
+      "lookingUpMetadata": "Procurando metadados do autor...",
+      "noBiography": "Nenhuma biografia disponível. Use o menu para atualizar os metadados.",
+      "previewFrom": "Pré-visualização do {provider}. Salve os metadados para mantê-los.",
+      "booksLabel": "Livros",
+      "lastAdded": "Último Adicionado"
+    },
+    "list": {
+      "title": "Autores",
+      "searchPlaceholder": "Pesquisar autores",
+      "sortButton": "Ordenar",
+      "sortBy": "Ordenar por",
+      "ascending": "Crescente",
+      "descending": "Decrescente",
+      "asc": "Cres",
+      "desc": "Decr",
+      "filters": "Filtros",
+      "clear": "Limpar",
+      "allLoaded": "Todos os {total} autores carregados",
+      "sort": {
+        "name": "Nome",
+        "sortName": "Nome de Classificação",
+        "bookCount": "Contagem de Livros",
+        "recentAdditions": "Adições Recentes",
+        "lastEnriched": "Último Enriquecido"
+      },
+      "empty": {
+        "title": "Nenhum autor encontrado",
+        "hint": "Tente alterar o texto de pesquisa, ordenação ou filtro de biblioteca."
+      },
+      "deleteDialog": {
+        "titleOne": "Excluir autor?",
+        "titleMany": "Excluir {count} autores?",
+        "descriptionOne": "Isto remove o autor do catálogo e o desvincula dos livros associados. Esta ação não pode ser desfeita.",
+        "descriptionMany": "Isto remove os autores selecionados do catálogo e os desvincula dos livros associados. Esta ação não pode ser desfeita."
+      },
+      "selection": {
+        "selectVisible": "Selecionar visíveis",
+        "refreshMetadata": "Atualizar metadados",
+        "refreshingMetadata": "Atualizando metadados...",
+        "deleteSelected": "Excluir selecionados",
+        "deleting": "Excluindo...",
+        "exitSelection": "Sair da seleção",
+        "confirmDeleteCount": "Excluir {count} autor? | Excluir {count} autor? | Excluir {count} autores?"
+      },
+      "toast": {
+        "refreshed": "Metadados do autor atualizados",
+        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem de autor foi encontrada.",
+        "refreshFailed": "Falha ao atualizar metadados do autor",
+        "bulkRefreshPartial": "Atualizado(s) {updated} autor(es), {failed} falharam",
+        "bulkRefreshSuccess": "Metadados atualizados para {updated} autor(es)",
+        "bulkRefreshFailed": "Falha ao atualizar autores selecionados",
+        "deleteSuccess": "Excluiu {count} autor; afetou {books} livros | Excluiu {count} autor; afetou {books} livros | Excluiu {count} autores; afetou {books} livros",
+        "deleteFailed": "Falha ao excluir autor(es)"
+      }
+    },
+    "detail": {
+      "pageTitle": "Autor",
+      "pageTitleNamed": "Autor · {name}",
+      "pageTitleId": "Autor #{id}",
+      "entityName": "Autor",
+      "loadingAuthor": "Carregando autor...",
+      "previewError": "Não foi possível carregar a pré-visualização externa do autor no momento.",
+      "edit": {
+        "name": "Nome",
+        "sortName": "Nome de Classificação",
+        "description": "Descrição",
+        "image": "Imagem",
+        "uploading": "Enviando...",
+        "replaceImage": "Substituir imagem",
+        "uploadImage": "Enviar imagem",
+        "removing": "Removendo...",
+        "removeImage": "Remover imagem",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP até {size} MB",
+        "saving": "Salvando..."
+      },
+      "merge": {
+        "searchPlaceholder": "Pesquise autores para mesclar neste autor",
+        "searching": "Pesquisando...",
+        "bookCount": "nenhum livro | {count} livro | {count} livros",
+        "selectedSummary": "Selecionado(s) {count} autor(es), aprox. {books} livros afetados.",
+        "merging": "Mesclando...",
+        "mergeSelected": "Mesclar Selecionados",
+        "confirmLabel": "Mesclar"
+      },
+      "mergeDialog": {
+        "title": "Mesclar {count} autor(es) em \"{name}\"?",
+        "titleFallback": "Mesclar autores selecionados?",
+        "description": "Isso mesclará os autores selecionados no autor atual e revinculará os livros associados. Essa ação não pode ser desfeita.",
+        "descriptionEmpty": "Essa ação não pode ser desfeita."
+      },
+      "deleteDialog": {
+        "title": "Excluir autor?",
+        "description": "Isto remove o autor do catálogo e o desvincula dos livros associados. Esta ação não pode ser desfeita."
+      },
+      "books": {
+        "heading": "Livros",
+        "allLibraries": "Todas as Bibliotecas",
+        "asc": "Cres",
+        "desc": "Decr",
+        "ascending": "Crescente",
+        "descending": "Decrescente",
+        "allLoaded": "Todos os {total} livros carregados",
+        "sort": {
+          "recentlyAdded": "Adicionado Recentemente",
+          "title": "Título",
+          "publishedYear": "Ano de Publicação"
+        },
+        "empty": {
+          "title": "Nenhum livro encontrado para este autor",
+          "hint": "Tente alterar a ordenação ou selecionar outra biblioteca."
+        }
+      },
+      "toast": {
+        "refreshed": "Metadados do autor atualizados",
+        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem de autor foi encontrada.",
+        "refreshFailed": "Falha ao atualizar metadados do autor",
+        "nameRequired": "O nome do autor é obrigatório",
+        "updated": "Autor atualizado",
+        "updateFailed": "Falha ao atualizar autor",
+        "imageUpdated": "Imagem do autor atualizada",
+        "imageUploadFailed": "Falha ao enviar imagem do autor",
+        "imageRemoved": "Imagem do autor removida",
+        "imageRemoveFailed": "Falha ao remover imagem do autor",
+        "mergeSuccess": "Mesclado(s) {count} autor(es); afetou {books} livros",
+        "mergeFailed": "Falha ao mesclar autores",
+        "deleteSuccess": "Autor excluído; afetou {books} livros",
+        "deleteFailed": "Falha ao excluir autor"
+      }
+    }
+  },
+  "book": {
+    "untitled": "Sem título",
+    "unknownFormat": "desconhecido",
+    "card": {
+      "missing": "Ausente"
+    },
+    "file": {
+      "primary": "Principal",
+      "audiobook": "Audiobook"
+    },
+    "actions": {
+      "read": "Ler",
+      "listen": "Ouvir",
+      "peek": "Espiar",
+      "quickView": "Visualização Rápida",
+      "details": "Detalhes",
+      "bookDetails": "Detalhes do Livro",
+      "download": "Baixar",
+      "metadata": "Metadados",
+      "editMetadata": "Editar Metadados",
+      "refreshMetadata": "Atualizar Metadados",
+      "regenerateCover": "Regerar Capa",
+      "addToCollection": "Adicionar à Coleção",
+      "setStatus": "Definir Status",
+      "sendViaEmail": "Enviar por E-mail",
+      "rate": "Avaliar {star}",
+      "openAs": "Abrir como {format}"
+    },
+    "readStatus": {
+      "unread": "Não lido",
+      "wantToRead": "Quero Ler",
+      "reading": "Lendo",
+      "onHold": "Pausado",
+      "rereading": "Relendo",
+      "read": "Lido",
+      "skimmed": "Folheado",
+      "abandoned": "Abandonado"
+    },
+    "download": {
+      "action": "Baixar",
+      "audiobookZip": "Audiobook (ZIP)",
+      "allFormatsZip": "Todos os formatos (ZIP)",
+      "primaryOnlyZip": "Apenas principal (ZIP)"
+    },
+    "sort": {
+      "moveUp": "Mover para cima",
+      "moveDown": "Mover para baixo",
+      "ascending": "Crescente",
+      "descending": "Decrescente",
+      "remove": "Remover",
+      "emptyState": "Nenhuma ordenação configurada. Título ascendente será usado.",
+      "addLevel": "Adicionar nível de ordenação"
+    },
+    "filter": {
+      "match": "Corresponder a",
+      "all": "TODAS",
+      "any": "QUALQUER",
+      "ofFollowingRules": "das seguintes regras",
+      "anyProvider": "Qualquer provedor",
+      "communityRatingProvider": "Provedor de avaliação da comunidade",
+      "loadingLibraries": "Carregando bibliotecas...",
+      "noLibrariesAvailable": "Nenhuma biblioteca disponível",
+      "selectLibrary": "Selecione a biblioteca...",
+      "selectStatus": "Selecione o status...",
+      "withinLastPlaceholder": "ex: 7",
+      "unit": {
+        "days": "dias",
+        "weeks": "semanas",
+        "months": "meses"
+      },
+      "scorePreset": {
+        "outstanding": "Excelente",
+        "good": "Bom",
+        "fair": "Razoável",
+        "poor": "Pobre"
+      },
+      "scoreRangePlaceholder": "0-100",
+      "valuePlaceholder": "valor",
+      "maxPlaceholder": "máx",
+      "to": "até",
+      "group": "Grupo",
+      "addRule": "Adicionar regra",
+      "addGroup": "Adicionar grupo",
+      "typeToSearch": "Digite para pesquisar..."
+    },
+    "deleteDialog": {
+      "title": "Excluir livro?",
+      "description": "Isso excluirá permanentemente o livro e todos os seus metadados, arquivos, progresso de leitura e favoritos. Isso não pode ser desfeito."
+    },
+    "bulkEdit": {
+      "title": "Editar metadados - {count} livro | Editar metadados - {count} livro | Editar metadados - {count} livros",
+      "instructions": "Alterne os campos para editar e, em seguida, defina os valores. Apenas os campos alternados serão alterados.",
+      "invalidYear": "Insira um ano válido (apenas números)",
+      "clearWarning": "Isso removerá todos {field} dos livros selecionados.",
+      "searchPlaceholder": "Pesquisar {field}...",
+      "enterPlaceholder": "Inserir {field}",
+      "yearPlaceholder": "ex: 2024",
+      "leaveEmptyHint": "Deixe vazio para limpar este campo em todos os livros selecionados.",
+      "applying": "Aplicando...",
+      "apply": "Aplicar",
+      "mode": {
+        "add": "Adicionar",
+        "remove": "Remover",
+        "replace": "Substituir",
+        "clear": "Limpar"
+      }
+    },
+    "export": {
+      "title": "Exportar Metadados",
+      "scope": "Escopo",
+      "selectedRows": "Linhas selecionadas",
+      "currentlySelected": "{count} selecionados no momento",
+      "allMatchingRows": "Todas as linhas correspondentes",
+      "rowsInResult": "{count} linhas no resultado atual",
+      "format": "Formato",
+      "csvDescription": "Pronto para planilha, inclui UTF-8 BOM",
+      "jsonDescription": "Exportação estruturada com contexto de metadados",
+      "columns": "Colunas",
+      "canonicalSchema": "Esquema canônico estável",
+      "visibleColumns": "Colunas visíveis atuais",
+      "options": "Opções",
+      "includePersonalData": "Incluir dados pessoais de leitura",
+      "includeFilePaths": "Incluir caminhos de arquivo (avançado)",
+      "includeContextMeta": "Incluir metadados de contexto",
+      "preflight": "Pré-verificação",
+      "scopeLabel": "Escopo: {summary}",
+      "calculatingSize": "Calculando tamanho da exportação...",
+      "estimatedSize": "Tamanho estimado:",
+      "fileLabel": "Arquivo: {fileName}",
+      "exportAction": "Exportar",
+      "selectedRowsSummary": "{count} linha selecionada | {count} linha selecionada | {count} linhas selecionadas",
+      "matchingRowsSummary": "{count} linha correspondente | {count} linha correspondente | {count} linhas correspondentes",
+      "prepareFailed": "Falha ao preparar exportação",
+      "exportStarted": "Exportação de metadados iniciada: {fileName}",
+      "exportFailed": "A exportação de metadados falhou"
+    },
+    "columnPanel": {
+      "columnsHeading": "Colunas",
+      "reset": "Redefinir",
+      "tableDensity": "Densidade da tabela",
+      "density": {
+        "compact": "Compacta",
+        "comfortable": "Confortável",
+        "roomy": "Espaçosa"
+      },
+      "presets": "Predefinições",
+      "exportBackup": "Exportar predefinições e visualizações",
+      "importBackup": "Importar predefinições e visualizações",
+      "rename": "Renomear",
+      "renamePrompt": "Insira um novo nome",
+      "builtIn": "Integrado",
+      "saveCurrentPreset": "Salvar predefinição atual",
+      "savedViews": "Visualizações salvas",
+      "savedViewsEmpty": "Salve ordenação, layout e filtros específicos de visualização para reutilização rápida.",
+      "saveCurrentView": "Salvar visualização atual",
+      "pinnedLeft": "Fixado à esquerda",
+      "pinnedRight": "Fixado à direita",
+      "columns": {
+        "cover": "Capa",
+        "read": "Lido",
+        "actions": "Ações"
+      }
+    },
+    "shortcuts": {
+      "title": "Atalhos de Teclado",
+      "navigation": {
+        "title": "Navegação",
+        "moveFocusVertical": "Mover o foco para cima/baixo",
+        "moveFocusHorizontal": "Mover o foco para esquerda/direita",
+        "jumpFirstColumn": "Pular para a primeira coluna",
+        "jumpLastColumn": "Pular para a última coluna",
+        "jumpFirstRow": "Pular para a primeira linha",
+        "jumpLastRow": "Pular para a última linha"
+      },
+      "actions": {
+        "title": "Ações",
+        "editCell": "Editar a célula focada",
+        "cancelEditing": "Cancelar edição / Fechar sobreposição",
+        "toggleRowSelection": "Alternar seleção de linha",
+        "copyCell": "Copiar valor da célula",
+        "copyRow": "Copiar linha focada"
+      },
+      "general": {
+        "title": "Geral",
+        "toggleHelp": "Alternar esta sobreposição de ajuda"
+      }
+    },
+    "jumpRail": {
+      "jumpToSection": "Pular para a seção",
+      "jumpTo": "Pular para {label}"
+    },
+    "quickView": {
+      "title": "Visualização rápida de livro",
+      "titleFor": "Visualização rápida de {title}",
+      "description": "Visualize detalhes do livro e execute ações rápidas.",
+      "openIn": "Abrir em {provider}",
+      "pages": "{count} página | {count} página | {count} páginas",
+      "primaryFile": "Arquivo Principal",
+      "fileNumber": "Arquivo #{id}",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar mais",
+      "collections": "Coleções",
+      "noDescription": "Nenhuma descrição disponível.",
+      "openMetadataEditor": "Abrir editor de metadados",
+      "coverPreview": "Pré-visualização da capa",
+      "coverPreviewFor": "Pré-visualização da capa de {title}",
+      "coverPreviewDescription": "Caixa de diálogo de visualização da imagem da capa ampliada."
+    },
+    "tableView": {
+      "openBookDetails": "Abrir detalhes do livro",
+      "openSeries": "Abrir série",
+      "metadataRefreshFailed": "Falha ao atualizar metadados",
+      "booksSelected": "{count} livro selecionado | {count} livro selecionado | {count} livros selecionados",
+      "loadingMoreBooks": "Carregando mais livros",
+      "sort": "Ordenar",
+      "refreshingMetadata": "Atualizando metadados {processed} / {total}",
+      "failedCount": "{count} falhou",
+      "remainingCount": "{count} restantes",
+      "readOnlyNotice": "A edição da tabela está desativada em telas menores. Mude para lista ou grade para ações mais rápidas.",
+      "fetching": "Buscando...",
+      "updated": "Atualizado",
+      "failed": "Falhou",
+      "noBooks": "Nenhum livro para mostrar",
+      "scrollToTop": "Rolar para o topo",
+      "selectedStatus": "{count} selecionados",
+      "filtered": "Filtrado",
+      "loadedStatus": "{loaded} de {total} carregados",
+      "bookCount": "{count} livro | {count} livro | {count} livros",
+      "keyboardShortcutsTitle": "Atalhos de teclado (?)",
+      "showKeyboardShortcuts": "Mostrar atalhos de teclado da tabela",
+      "copyHint": "Copiar célula: Ctrl/Cmd+C · Copiar linha: Ctrl/Cmd+Shift+C"
+    },
+    "detail": {
+      "authorBooks": {
+        "alsoByAuthor": "Também deste autor",
+        "alsoByAuthors": "Também destes autores"
+      },
+      "header": {
+        "previousBook": "Livro anterior",
+        "nextBook": "Próximo livro"
+      },
+      "tabs": {
+        "details": "Detalhes",
+        "editMetadata": "Editar Metadados",
+        "files": "Arquivos",
+        "readingLog": "Registro de Leitura",
+        "highlights": "Destaques"
+      },
+      "discover": {
+        "moreInSeries": "Mais na Série",
+        "byAuthor": "Por Autor",
+        "similarBooks": "Livros Semelhantes"
+      },
+      "recommended": {
+        "moreLikeThis": "Mais Como Este"
+      },
+      "series": {
+        "moreInSeriesPrefix": "Mais na série",
+        "moreInSeriesSuffix": ""
+      },
+      "writeRename": {
+        "written": "nenhum campo gravado | Gravado (um campo) | Gravado ({count} campos)",
+        "writeFailed": "Falha na gravação",
+        "skipped": "Ignorado",
+        "renamedTo": "Renomeado para {name}",
+        "fileRenamed": "Arquivo renomeado",
+        "renameFailed": "Falha ao renomear",
+        "autoWriteAndRenameDisabled": "As gravações e renomeações automáticas estão desativadas nas configurações da biblioteca. As alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "autoWriteDisabled": "A gravação automática está desativada nas configurações da biblioteca. As alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "autoRenameDisabled": "A renomeação automática está desativada nas configurações da biblioteca. As alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "writeLabel": "Gravar:",
+        "renameLabel": "Renomear:"
+      },
+      "addFile": {
+        "uploading": "Enviando...",
+        "uploadComplete": "Envio concluído",
+        "title": "Adicionar Arquivo",
+        "dropzone": {
+          "title": "Solte os arquivos aqui ou clique para procurar",
+          "hint": "epub, pdf, mobi, cbz, m4b e mais - até {size} MB cada"
+        },
+        "addMore": "Adicionar mais arquivos",
+        "fileCount": "nenhum arquivo | um arquivo | {count} arquivos",
+        "clearAll": "Limpar tudo",
+        "done": "Concluído",
+        "retry": "Tentar novamente",
+        "filesAdded": "nenhum arquivo adicionado | um arquivo adicionado | {count} arquivos adicionados",
+        "uploadedFailed": "{done} enviados, {failed} falharam",
+        "uploadingProgress": "{done} de {total} enviando...",
+        "renameAfter": "Renomear todos os arquivos de livros após o upload",
+        "uploadCount": "Upload ({count})",
+        "upload": "Upload"
+      },
+      "addSession": {
+        "errors": {
+          "invalidDate": "Escolha uma data e hora válidas.",
+          "future": "A sessão não pode começar no futuro.",
+          "duration": "A duração deve ser entre 1 e 1440 minutos.",
+          "endProgress": "O progresso final deve ser entre 0 e 100."
+        },
+        "title": "Adicionar sessão de leitura",
+        "startedAt": "Iniciada em",
+        "duration": "Duração (minutos)",
+        "endProgress": "Progresso final %",
+        "optional": "Opcional",
+        "format": "Formato",
+        "noFormat": "Nenhum formato específico",
+        "saving": "Salvando...",
+        "submit": "Adicionar sessão"
+      },
+      "coverEditor": {
+        "unlockCover": "Desbloquear capa",
+        "lockCover": "Bloquear capa",
+        "fileTab": "Arquivo",
+        "urlTab": "URL",
+        "chooseImage": "Escolher imagem...",
+        "findCoverOnline": "Encontrar capa online",
+        "saving": "Salvando...",
+        "saveCover": "Salvar capa",
+        "revertToOriginal": "Reverter para o original",
+        "regenerateCover": "Regerar Capa"
+      },
+      "coverSearch": {
+        "title": "Pesquisa Online",
+        "subtitle": "Procurar capas de livros",
+        "titleField": "Título",
+        "authorField": "Autor",
+        "sourceField": "Origem",
+        "allSources": "Todas as Fontes",
+        "audiobookCovers": "Capas de audiobooks",
+        "squareHint": "(quadrado)",
+        "searching": "Pesquisando...",
+        "findCovers": "Encontrar capas",
+        "selectCover": "Selecionar Capa",
+        "noResultsTitle": "Nenhum resultado encontrado",
+        "noResultsHint": "Tente ajustar seus termos de pesquisa",
+        "readyTitle": "Pronto para pesquisar",
+        "readyHint": "Insira um título e autor acima",
+        "resolutionTip": "Dica: Capas de alta resolução estão marcadas em verde"
+      },
+      "details": {
+        "by": "por",
+        "narratedBy": "narrado por",
+        "ratingLocked": "A avaliação está bloqueada",
+        "rateStar": "Avaliar {star}",
+        "listen": "Ouvir",
+        "read": "Ler",
+        "chooseFormat": "Escolha o formato",
+        "audiobook": "Audiobook",
+        "primary": "Principal",
+        "peek": "Espiar",
+        "sendViaEmail": "Enviar por E-mail",
+        "editCover": "Editar capa",
+        "finished": "Concluído",
+        "resetFileProgress": "Redefinir o progresso do arquivo",
+        "resetting": "Redefinindo...",
+        "resetProgressConfirm": "Redefinir o progresso de leitura armazenado para {label}?",
+        "moreCount": "+{count} mais",
+        "untitled": "Sem título",
+        "metadataScore": "Pontuação de Metadados",
+        "primaryFormat": "Formato principal",
+        "openIn": "Abrir em {provider}",
+        "showLess": "Mostrar menos",
+        "showMore": "Mostrar mais",
+        "publisher": "Editora",
+        "published": "Publicado",
+        "language": "Idioma",
+        "pages": "Páginas",
+        "duration": "Duração",
+        "edition": "Edição",
+        "abridged": "Resumido",
+        "unabridged": "Não resumido",
+        "isbn": "ISBN",
+        "fileSize": "Tamanho do Arquivo",
+        "library": "Biblioteca",
+        "added": "Adicionado",
+        "dateStarted": "Data de Início",
+        "saving": "Salvando...",
+        "cancelDateStartedEdit": "Cancelar edição da data de início",
+        "editDateStarted": "Editar data de início",
+        "dateFinished": "Data de Conclusão",
+        "cancelDateFinishedEdit": "Cancelar edição da data de conclusão",
+        "editDateFinished": "Editar data de conclusão",
+        "customMetadata": "Metadados Personalizados",
+        "synopsis": "Sinopse",
+        "noDescription": "Nenhuma descrição disponível.",
+        "dateStartedFutureError": "A Data de Início não pode ser no futuro.",
+        "dateFinishedFutureError": "A Data de Conclusão não pode ser no futuro.",
+        "dateFinishedBeforeStartedError": "A Data de Conclusão deve ser igual ou posterior à Data de Início.",
+        "saveReadingDatesError": "Falha ao salvar as datas de leitura.",
+        "koboPendingDelete": "Exclusão pendente do dispositivo",
+        "koboPendingDeleteTooltip": "O Kobo o removerá na próxima sincronização.",
+        "koboRemovedByDevice": "Removido pelo dispositivo",
+        "koboRemovedByDeviceTooltip": "O Kobo relatou este livro como removido.",
+        "koboNotSynced": "Não sincronizado",
+        "koboNotSyncedTooltip": "Na fila para a próxima sincronização do Kobo.",
+        "filesNotFound": "Arquivos não encontrados",
+        "filesNotFoundDescription": "O(s) arquivo(s) deste livro não pode(m) mais ser encontrado(s) no disco. Os metadados ainda estão disponíveis. Execute uma verificação da biblioteca para confirmar ou remova o registro."
+      },
+      "editMetadata": {
+        "fieldCount": "nenhum campo | um campo | {count} campos",
+        "bookFilesTarget": "arquivos do livro",
+        "formatFilesTarget": "arquivos {formats}",
+        "noPrimaryFile": "Nenhum arquivo principal disponível",
+        "formatNotSupported": "Este formato de arquivo não suporta gravação",
+        "formatDisabled": "A gravação está desativada para este formato",
+        "fileExceedsSizeLimit": "Este arquivo excede o limite de tamanho para gravação",
+        "writing": "Gravando...",
+        "saveInProgress": "Salvamento em andamento",
+        "writeManualLibraryDisabled": "Gravar metadados no arquivo e renomear no disco; a gravação automática está desativada para esta biblioteca",
+        "writeManualTooltip": "Gravar {fields} em {target} e renomear no disco",
+        "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "Ignorou nenhum campo bloqueado | Ignorou um campo bloqueado | Ignorou {count} campos bloqueados",
+        "updatedFields": "atualizou nenhum campo | atualizou um campo | atualizou {count} campos",
+        "wroteFieldsToFile": "Gravou {fields} no arquivo",
+        "fileWriteFailedReason": "Falha ao gravar arquivo: {reason}",
+        "fileWriteFailed": "Falha ao gravar arquivo",
+        "fileWriteSkippedReason": "Gravação de arquivo ignorada: {reason}",
+        "fileWriteSkipped": "Gravação de arquivo ignorada",
+        "metadataSaved": "Metadados salvos",
+        "metadataWrittenToFile": "Metadados gravados no arquivo",
+        "savedButWriteFailedReason": "Metadados salvos, mas a gravação no arquivo falhou: {reason}",
+        "savedButWriteFailed": "Metadados salvos, mas a gravação no arquivo falhou",
+        "savedWriteSkippedReason": "Metadados salvos, gravação no arquivo ignorada: {reason}",
+        "savedWriteSkipped": "Metadados salvos, gravação no arquivo ignorada",
+        "loadFromFileFailed": "Falha ao carregar metadados do arquivo",
+        "loadedFieldsFromFile": "Carregou nenhum campo do arquivo | Carregou um campo do arquivo | Carregou {count} campos do arquivo",
+        "noMetadataInFile": "Nenhum metadado encontrado no arquivo",
+        "loadFromFile": "Carregar do arquivo",
+        "loadFromFileTooltip": "Carregar metadados do arquivo principal do livro",
+        "writeToFile": "Gravar no arquivo",
+        "autoFill": "Preencher automaticamente",
+        "fetchingMetadata": "Buscando metadados...",
+        "allFieldsLocked": "Todos os campos estão bloqueados",
+        "autoFillTooltip": "Preencher campos automaticamente usando suas preferências de metadados",
+        "lockAll": "Bloquear tudo",
+        "lockAllTooltip": "Bloquear todos os campos",
+        "unlockAll": "Desbloquear tudo",
+        "unlockAllTooltip": "Desbloquear todos os campos",
+        "saving": "Salvando...",
+        "fileWriteBackDetails": "Detalhes de gravação no arquivo",
+        "fileWriteBack": "Gravação de arquivo",
+        "enabled": "Ativado",
+        "saveWritesMetadata": "'Salvar' grava os metadados em {target}",
+        "formats": "Formatos",
+        "bookFiles": "Arquivos de livro",
+        "supportedFields": "Campos suportados",
+        "titleLabel": "Título",
+        "subtitleLabel": "Subtítulo",
+        "authorsLabel": "Autores",
+        "narratorsLabel": "Narradores",
+        "genresLabel": "Gêneros",
+        "tagsLabel": "Tags",
+        "ratingLabel": "Avaliação",
+        "rateStar": "Avaliar {star}",
+        "clear": "Limpar",
+        "communityRatingsLabel": "Avaliações da Comunidade",
+        "noProviderRatings": "Nenhuma avaliação de provedor",
+        "seriesLabel": "Série",
+        "publisherLabel": "Editora",
+        "languageLabel": "Idioma",
+        "yearLabel": "Ano",
+        "pageCountLabel": "Contagem de Páginas",
+        "isbn13Label": "ISBN-13",
+        "isbn10Label": "ISBN-10",
+        "durationLabel": "Duração (s)",
+        "abridgedLabel": "Resumido",
+        "providerIds": "IDs de Provedores",
+        "comicDetails": "Detalhes do Quadrinho",
+        "comicIssueNumberLabel": "Número da Edição",
+        "comicVolumeLabel": "Volume",
+        "comicStoryArcsLabel": "Arcos de História",
+        "comicPencillersLabel": "Desenhistas",
+        "comicInkersLabel": "Arte-finalistas",
+        "comicColoristsLabel": "Coloristas",
+        "comicLetterersLabel": "Letreiristas",
+        "comicCoverArtistsLabel": "Artistas da Capa",
+        "comicCharactersLabel": "Personagens",
+        "comicTeamsLabel": "Equipes",
+        "comicLocationsLabel": "Locais",
+        "customMetadata": "Metadados Personalizados",
+        "descriptionLabel": "Descrição",
+        "unlockField": "Desbloquear {field}",
+        "lockField": "Bloquear {field}",
+        "diffPanel": {
+          "untitled": "Sem título",
+          "noFieldsSelected": "Nenhum campo selecionado",
+          "fieldsSelected": "nenhum campo selecionado | um campo selecionado | {count} campos selecionados",
+          "results": "Resultados",
+          "providerMatches": "Correspondências no {provider}",
+          "selectedOf": "Selecionados {selected} de {total}",
+          "yearUnknown": "Ano desconhecido",
+          "indexOf": "{index} de {total}",
+          "switchedResult": "Resultado alterado. As seleções anteriores deste provedor foram limpas.",
+          "selectFieldsToApply": "Selecione campos para aplicar",
+          "copyMissing": "Copiar Ausentes",
+          "copyAll": "Copiar Tudo",
+          "hideUnchanged": "Ocultar inalterados",
+          "showUnchanged": "Mostrar inalterados",
+          "current": "Atual",
+          "noMetadata": "Nenhum metadado disponível desta fonte.",
+          "noChangedFields": "Nenhum campo alterado ou ausente. Use Mostrar inalterados para inspecionar tudo.",
+          "applyToForm": "Aplicar ao formulário"
+        },
+        "diff": {
+          "locked": "Bloqueado",
+          "previewAlt": "Pré-visualização",
+          "currentCoverAlt": "Capa atual",
+          "newCoverAlt": "Nova capa",
+          "pickCoverFromProvider": "Escolher capa de outro provedor",
+          "pickCoverSource": "Escolher origem da capa",
+          "pickFromProvider": "Escolher de outro provedor",
+          "pickSource": "Escolher origem",
+          "empty": "vazio",
+          "showLess": "Mostrar menos",
+          "showMore": "Mostrar mais",
+          "coverPreviewAlt": "Pré-visualização de capa"
+        },
+        "searchDrawer": {
+          "searchTitle": "Pesquisar Metadados",
+          "compareTitle": "Comparar Metadados",
+          "searchSubtitle": "Encontre a melhor correspondência de provedor para este livro.",
+          "compareSubtitle": "Revise as diferenças e aplique apenas o que desejar."
+        },
+        "searchPanel": {
+          "untitledQuery": "Consulta sem título",
+          "titlePlaceholder": "Título",
+          "authorPlaceholder": "Autor",
+          "isbnPlaceholder": "ISBN",
+          "searching": "Pesquisando...",
+          "activeQuery": "Consulta ativa",
+          "searchScope": "Escopo de pesquisa",
+          "allEnabled": "Todos os habilitados",
+          "all": "Tudo",
+          "fieldRules": "Regras de Campo",
+          "custom": "Personalizado",
+          "providerNotInFieldRules": "{provider} está habilitado, mas não nas Regras de Campo",
+          "notInFieldRulesLabel": "Não nas Regras de Campo:",
+          "notInFieldRulesText": "{providers}. Incluídos na busca manual com 'Todos os habilitados' ativo, mas não usados na busca automática de metadados.",
+          "noResults": "Nenhum resultado encontrado",
+          "noResultsHint": "Tente ajustar o título ou autor",
+          "searchPrompt": "Pesquise acima, depois clique em um resultado para começar a comparar os metadados."
+        },
+        "writeAndRename": "Gravar no Arquivo e Renomear",
+        "writeAndRenameShort": "Gravar e Renomear"
+      },
+      "files": {
+        "relative": {
+          "seconds": "{value}s atrás",
+          "minutes": "{value}m atrás",
+          "hours": "{value}h atrás",
+          "days": "{value}d atrás"
+        },
+        "renameFailed": "Falha ao renomear arquivo",
+        "deleteFailed": "Falha ao excluir arquivo",
+        "addFile": "Adicionar Arquivo",
+        "lastSynced": "Última sincronização: {time}",
+        "sort": {
+          "label": "Ordenar:",
+          "name": "Nome",
+          "format": "Formato",
+          "size": "Tamanho",
+          "date": "Data"
+        },
+        "hidePaths": "Ocultar caminhos",
+        "showPaths": "Mostrar caminhos",
+        "hideLog": "Ocultar log",
+        "viewSyncLog": "Ver log de sincronização",
+        "noWriteHistory": "Nenhum histórico de gravação ainda.",
+        "fieldsWritten": "nenhum campo | um campo | {count} campos",
+        "track": "Faixa {number}",
+        "primary": "Principal",
+        "read": "Ler",
+        "play": "Reproduzir",
+        "peek": "Espiar",
+        "download": "Baixar",
+        "moreActions": "Mais ações",
+        "rename": "Renomear",
+        "empty": {
+          "title": "Nenhum arquivo anexado",
+          "description": "Este livro não possui arquivos associados."
+        },
+        "renameModal": {
+          "title": "Renomear Arquivo",
+          "description": "Renomeie o arquivo físico no disco.",
+          "placeholder": "Novo nome de arquivo"
+        },
+        "saving": "Salvando...",
+        "deleteModal": {
+          "title": "Excluir arquivo?",
+          "description": "Tem certeza que deseja excluir \"{filename}\"? Esta ação não pode ser desfeita."
+        },
+        "deleting": "Excluindo..."
+      },
+      "highlights": {
+        "note": {
+          "placeholder": "Adicionar uma nota...",
+          "saving": "Salvando"
+        },
+        "export": {
+          "trigger": "Exportar",
+          "plainText": "Texto Simples",
+          "page": "Exportar página",
+          "selected": "Exportar selecionados"
+        },
+        "sort": {
+          "position": "Posição",
+          "newest": "Mais novos primeiro",
+          "oldest": "Mais antigos primeiro"
+        },
+        "summary": {
+          "highlights": "nenhum destaque | um destaque | {count} destaques",
+          "notes": "nenhuma nota | uma nota | {count} notas",
+          "chapters": "nenhum capítulo | um capítulo | {count} capítulos"
+        },
+        "filterByChapter": "Filtrar por capítulo",
+        "allChapters": "Todos os capítulos",
+        "untitled": "Sem título",
+        "trash": "Lixeira",
+        "empty": {
+          "noMatch": "Nenhum destaque corresponde aos seus filtros.",
+          "resetFilters": "Redefinir filtros",
+          "none": "Nenhum destaque ainda",
+          "hint": "Selecione o texto durante a leitura para criar destaques"
+        },
+        "uncategorized": "Sem categoria",
+        "paginationUnit": "destaques"
+      },
+      "readingLog": {
+        "export": {
+          "button": "Exportar"
+        },
+        "weekdays": {
+          "sun": "Dom",
+          "mon": "Seg",
+          "tue": "Ter",
+          "wed": "Qua",
+          "thu": "Qui",
+          "fri": "Sex",
+          "sat": "Sáb"
+        },
+        "months": {
+          "jan": "Jan",
+          "feb": "Fev",
+          "mar": "Mar",
+          "apr": "Abr",
+          "may": "Mai",
+          "jun": "Jun",
+          "jul": "Jul",
+          "aug": "Ago",
+          "sep": "Set",
+          "oct": "Out",
+          "nov": "Nov",
+          "dec": "Dez"
+        },
+        "heatmap": {
+          "subtitle": "{count} dia ativo · {ratio}% de consistência | {count} dia ativo · {ratio}% de consistência | {count} dias ativos · {ratio}% de consistência",
+          "minutesUnit": "min",
+          "title": "Atividade",
+          "empty": "Nenhuma atividade de leitura nesta janela."
+        },
+        "hero": {
+          "notSet": "Não definido",
+          "relative": {
+            "seconds": "{count}s atrás",
+            "minutes": "{count}m atrás",
+            "hours": "{count}h atrás",
+            "days": "{count}d atrás",
+            "months": "{count} mês atrás | {count} mês atrás | {count} meses atrás",
+            "years": "{count} ano atrás | {count} ano atrás | {count} anos atrás"
+          },
+          "noSessions": "Nenhuma sessão",
+          "dateErrors": {
+            "startFuture": "A data de início não pode ser no futuro.",
+            "finishFuture": "A data de término não pode ser no futuro.",
+            "finishBeforeStart": "A data de término deve ser posterior ou igual à data de início.",
+            "saveFailed": "Falha ao salvar as datas de leitura."
+          },
+          "eta": {
+            "max": "99h+ para terminar",
+            "minutes": "~{m}m para terminar",
+            "hours": "~{h}h para terminar",
+            "hoursMinutes": "~{h}h {m}m para terminar"
+          },
+          "momentum": {
+            "none": "Nenhuma atividade nas últimas duas semanas",
+            "new": "Nova atividade esta semana",
+            "up": "+{pct}% vs os 7 dias anteriores",
+            "down": "{pct}% vs os 7 dias anteriores",
+            "flat": "Inalterado vs os 7 dias anteriores"
+          },
+          "stats": {
+            "totalTime": "Tempo Total",
+            "sessions": "Sessões",
+            "avgSession": "Sessão Média",
+            "lastRead": "Última Leitura"
+          },
+          "firstRead": "Primeira Leitura",
+          "lastRead": "Última Leitura",
+          "dateStarted": "Data de Início",
+          "dateFinished": "Data de Conclusão",
+          "addSession": "Adicionar sessão"
+        },
+        "journey": {
+          "tooltipProgress": "Progresso",
+          "tooltipReading": "Lendo",
+          "minutesUnit": "min",
+          "title": "Jornada de progresso",
+          "empty": "Nenhum dado de progresso nesta janela."
+        },
+        "sourceSplit": {
+          "title": "Onde você leu este livro"
+        },
+        "untitled": "Sem título",
+        "addSessionFailed": "Falha ao adicionar sessão",
+        "filters": {
+          "allTime": "Todo o tempo",
+          "last30": "Últimos 30 dias",
+          "last90": "Últimos 90 dias",
+          "thisYear": "Este ano",
+          "allFormats": "Todos os formatos"
+        },
+        "table": {
+          "sourceWeb": "Web",
+          "sourceManual": "Manual",
+          "colDate": "Data",
+          "colDateMobile": "Data",
+          "colDuration": "Duração",
+          "colDurationMobile": "Duração",
+          "colProgressChange": "Mudança de Progresso",
+          "colProgressChangeMobile": "Delta",
+          "colEndProgress": "Progresso Final",
+          "colEndProgressMobile": "Fim",
+          "empty": "Nenhuma sessão de leitura registrada ainda.",
+          "colPace": "Ritmo",
+          "colSource": "Origem",
+          "colFormatMobile": "Fmt",
+          "colFormat": "Formato",
+          "cancelDelete": "Cancelar exclusão",
+          "cancelDeleteAria": "Cancelar exclusão de sessão",
+          "confirmDeleteTitle": "Clique novamente para confirmar a exclusão",
+          "confirmDeleteAria": "Confirmar exclusão da sessão",
+          "deleteAria": "Excluir sessão",
+          "loadMore": "Carregar mais",
+          "showing": "Mostrando {shown} de {total} sessões"
+        }
+      },
+      "richDescription": {
+        "linkProtocolError": "Use http, https ou mailto.",
+        "bold": "Negrito",
+        "italic": "Itálico",
+        "underline": "Sublinhado",
+        "strikethrough": "Tachado",
+        "bulletList": "Lista com marcadores",
+        "numberedList": "Lista numerada",
+        "outdentAria": "Diminuir recuo de item da lista",
+        "outdent": "Diminuir recuo",
+        "indentAria": "Aumentar recuo de item da lista",
+        "indent": "Aumentar recuo",
+        "quote": "Citação",
+        "editLink": "Editar link",
+        "link": "Link",
+        "removeLink": "Remover link",
+        "undo": "Desfazer",
+        "redo": "Refazer",
+        "clearFormatting": "Limpar formatação",
+        "previewDescription": "Pré-visualizar descrição",
+        "preview": "Pré-visualização",
+        "linkUrlLabel": "URL do link",
+        "applyLink": "Aplicar link",
+        "apply": "Aplicar",
+        "cancelLink": "Cancelar link",
+        "noDescription": "Nenhuma descrição disponível."
+      },
+      "seriesMembership": {
+        "addSeries": "Adicionar série",
+        "seriesPlaceholder": "Série",
+        "moveUp": "Mover para cima",
+        "moveDown": "Mover para baixo",
+        "removeSeries": "Remover série"
+      }
+    },
+    "table": {
+      "actions": {
+        "quickView": "Visualização Rápida",
+        "bookDetails": "Detalhes do Livro",
+        "editMetadata": "Editar Metadados",
+        "refreshMetadata": "Atualizar Metadados",
+        "addToCollection": "Adicionar à Coleção",
+        "sendToDevice": "Enviar para o Dispositivo"
+      },
+      "boolean": {
+        "ariaNotSet": "Não definido - clique para definir verdadeiro",
+        "ariaTrue": "Verdadeiro - clique para definir falso",
+        "ariaFalse": "Falso - clique para limpar"
+      },
+      "chips": {
+        "addPlaceholder": "Adicionar..."
+      },
+      "cover": {
+        "previewDescription": "Pré-visualização da capa do livro",
+        "editDescription": "Editar a capa do livro",
+        "editTitle": "Editar capa",
+        "editCover": "Editar Capa",
+        "view": "Visualizar capa"
+      },
+      "date": {
+        "justNow": "agora mesmo"
+      },
+      "format": {
+        "unknown": "desconhecido"
+      },
+      "header": {
+        "sortAscending": "Ordem Crescente",
+        "sortDescending": "Ordem Decrescente",
+        "clearSort": "Limpar Ordenação",
+        "hideColumn": "Ocultar Coluna",
+        "pinLeft": "Fixar à Esquerda",
+        "pinRight": "Fixar à Direita",
+        "unpinColumn": "Desafixar Coluna",
+        "autoFitWidth": "Ajuste Automático de Largura",
+        "autoFitAllColumns": "Ajuste Automático para Todas as Colunas",
+        "selectAllBooks": "Selecionar todos os livros",
+        "shiftClickSecondarySort": "Shift+clique para adicionar ordenação secundária",
+        "clickToSort": "Clique para ordenar"
+      },
+      "locks": {
+        "lockAll": "Bloquear todos os campos",
+        "unlockAll": "Desbloquear todos os campos",
+        "lockField": "Bloquear campo",
+        "unlockField": "Desbloquear campo",
+        "clickToLock": "Clique para bloquear",
+        "clickToUnlock": "Clique para desbloquear"
+      },
+      "progress": {
+        "complete": "{percent} concluído"
+      },
+      "rating": {
+        "label": "Avaliação",
+        "remove": "Remover avaliação",
+        "rate": "Avaliar {star} de 5"
+      },
+      "read": {
+        "play": "Reproduzir",
+        "read": "Ler",
+        "primary": "Principal",
+        "peekFormat": "Espiar {format}",
+        "chooseFormat": "Escolha o formato para ler ou reproduzir",
+        "fileFallback": "ARQUIVO"
+      },
+      "readStatus": {
+        "unread": "Não lido"
+      },
+      "series": {
+        "bookCount": "(nenhum livro) | ({count} livro) | ({count} livros)",
+        "readOfCount": "{read} de {total} lidos"
+      },
+      "text": {
+        "openDetails": "Abrir detalhes"
+      }
+    }
+  },
+  "bookMetadataFetch": {
+    "book": {
+      "title": "Busca de Metadados"
+    },
+    "author": {
+      "title": "Enriquecimento de Autor"
+    },
+    "stats": {
+      "queued": "Na fila",
+      "processing": "Processando",
+      "rateLimited": "Limite de taxa",
+      "failed": "Falhou"
+    },
+    "actions": {
+      "pause": "Pausar",
+      "resume": "Retomar",
+      "cancelQueued": "Cancelar fila"
+    },
+    "cancel": {
+      "processingWillFinish": "Os itens atualmente em processamento serão concluídos.",
+      "confirm": "Confirmar cancelamento",
+      "keepRunning": "Continuar executando"
+    },
+    "viewFailed": "Ver um que falhou | Ver {count} que falharam",
+    "card": {
+      "fetchingMetadata": "Buscando metadados",
+      "enrichingAuthors": "Enriquecendo autores"
+    },
+    "label": {
+      "paused": "Pausado",
+      "remaining": "{count} restantes",
+      "processing": "{count} processando",
+      "failed": "{count} falhou",
+      "rateLimited": "{count} limitados por taxa"
+    },
+    "report": {
+      "bookTitle": "Buscas de Metadados com Falha",
+      "authorTitle": "Enriquecimentos de Autor com Falha",
+      "noFailedItems": "Nenhum item com falha.",
+      "retryAllFailed": "Tentar novamente todos com falha",
+      "bookFallback": "Livro #{id}",
+      "authorFallback": "Autor #{id}",
+      "columns": {
+        "title": "Título",
+        "library": "Biblioteca",
+        "author": "Autor",
+        "error": "Erro",
+        "http": "HTTP"
+      }
+    },
+    "toast": {
+      "failedToPause": "Falha ao pausar",
+      "failedToResume": "Falha ao retomar",
+      "failedToCancel": "Falha ao cancelar",
+      "failedToRetry": "Falha ao tentar novamente",
+      "failedItemsRequeued": "Itens com falha re-enfileirados",
+      "bookComplete": "Busca de metadados concluída - {done} livros atualizados",
+      "bookDoneWithFailures": "Busca de metadados finalizada - {done} processados, {failed} falharam",
+      "authorComplete": "Enriquecimento de autor concluído - {done} autores atualizados",
+      "authorDoneWithFailures": "Enriquecimento de autor finalizado - {done} processados, {failed} falharam"
+    }
+  },
+  "bookDock": {
+    "apply": "Aplicar",
+    "done": "Concluído",
+    "discard": "Descartar",
+    "finalize": "Finalizar",
+    "rescan": "Reescanear",
+    "uploadAction": "Fazer upload",
+    "uploading": "Enviando...",
+    "searchPlaceholder": "Pesquisar arquivos...",
+    "setDestinationAction": "Definir Destino",
+    "bulkEditAction": "Edição em Massa",
+    "applyFetched": "Aplicar Buscados",
+    "retryErrors": "Tentar Erros Novamente",
+    "commaSeparated": "separados por vírgula",
+    "destinationLibrary": "Biblioteca de Destino",
+    "destinationFolder": "Pasta de Destino",
+    "nSelected": "nenhum arquivo selecionado | {count} selecionado | {count} selecionados",
+    "nFailed": "{count} falhou",
+    "updatedOfFiles": "Atualizou {updated} de {total} arquivos",
+    "errorStatus": "Erro {status}",
+    "applyFetchedTooltip": "Aplicar metadados do provedor buscados automaticamente a {count} arquivos | Aplicar metadados do provedor buscados automaticamente a {count} arquivo | Aplicar metadados do provedor buscados automaticamente a {count} arquivos",
+    "retryErrorsTooltip": "Tentar novamente a busca de metadados para {count} arquivos com erro | Tentar novamente a busca de metadados para {count} arquivo com erro | Tentar novamente a busca de metadados para {count} arquivos com erro",
+    "tab": {
+      "all": "Todos",
+      "pending": "Pendente",
+      "ready": "Pronto",
+      "error": "Erro"
+    },
+    "status": {
+      "pending": "Pendente",
+      "extracting": "Extraindo",
+      "fetching": "Buscando",
+      "ready": "Pronto",
+      "error": "Erro"
+    },
+    "field": {
+      "title": "Título",
+      "subtitle": "Subtítulo",
+      "authors": "Autores",
+      "authorsCommaSeparated": "Autores (separados por vírgula)",
+      "publisher": "Editora",
+      "year": "Ano",
+      "language": "Idioma",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "series": "Série",
+      "seriesIndex": "Índice da série",
+      "genres": "Gêneros",
+      "genresCommaSeparated": "Gêneros (separados por vírgula)",
+      "description": "Descrição"
+    },
+    "upload": {
+      "nDone": "{count} concluídos",
+      "nFailed": "{count} falharam",
+      "nTotal": "{count} total"
+    },
+    "fileList": {
+      "emptyTitle": "Nenhum arquivo no Book Dock",
+      "emptyMessageDefault": "Faça upload de arquivos ou solte-os na pasta do Book Dock",
+      "colCurrent": "Atual",
+      "colNew": "Novo",
+      "colFile": "Arquivo",
+      "colSize": "Tamanho",
+      "colFormat": "Formato",
+      "colMatch": "Correspondência",
+      "colApply": "Aplicar",
+      "colStatus": "Status",
+      "applyFetchedMetadata": "Aplicar metadados buscados",
+      "coverPreview": "Pré-visualização da capa",
+      "coverPreviewDescription": "Diálogo de visualização da imagem da capa ampliada.",
+      "currentCoverAlt": "Capa atual de {title}",
+      "newCoverAlt": "Nova capa de {title}",
+      "unknownLibrary": "Biblioteca desconhecida",
+      "unassigned": "Não atribuído",
+      "targetPath": "Destino: {library} · {path}",
+      "targetUnassigned": "Destino: Não atribuído",
+      "targetUnknownPath": "Destino: {library} · Caminho de destino desconhecido"
+    },
+    "sheet": {
+      "saved": "Salvo",
+      "providerMetadataFound": "Metadados de provedor encontrados",
+      "providerMetadataFoundEdited": "Metadados de provedor encontrados - aplicação em massa irá ignorar este arquivo (você possui edições)",
+      "review": "Revisar",
+      "added": "Adicionado em {date}",
+      "searchMetadata": "Pesquisar Metadados",
+      "results": "Resultados"
+    },
+    "bulkEdit": {
+      "title": "Editar em massa nenhum arquivo | Editar em massa {count} arquivo | Editar em massa {count} arquivos",
+      "resultTitle": "Resultados da Edição em Massa",
+      "instructions": "Alterne os campos que deseja atualizar. Apenas os campos ativados serão aplicados.",
+      "mergeArrays": "Mesclar arrays (adicionar aos valores existentes em vez de substituir)",
+      "failed": "A edição em massa falhou"
+    },
+    "setDestination": {
+      "title": "Definir Destino para nenhum arquivo | Definir Destino para {count} arquivo | Definir Destino para {count} arquivos",
+      "resultTitle": "Destino Atualizado",
+      "failed": "Falha ao definir o destino"
+    },
+    "finalizeDialog": {
+      "title": "Finalizar nenhum arquivo | Finalizar {count} arquivo | Finalizar {count} arquivos",
+      "resultTitle": "Resultados da Finalização",
+      "needDestination": "{without} de {count} arquivos selecionados precisam de um destino | {without} de {count} arquivo selecionado precisa de um destino | {without} de {count} arquivos selecionados precisam de um destino",
+      "allHaveDestination": "Todos os arquivos selecionados já possuem destino definido",
+      "defaultDestinationLibrary": "Biblioteca de Destino Padrão",
+      "defaultDestinationFolder": "Pasta de Destino Padrão",
+      "renamePreview": "Pré-visualização de renomeação",
+      "moreFiles": "+{count} mais arquivos",
+      "start": "Iniciar",
+      "filesFinalized": "{succeeded} de {total} arquivos finalizados",
+      "failedWithDuplicates": "{failed} falharam ({count} duplicatas) | {failed} falhou ({count} duplicata) | {failed} falharam ({count} duplicatas)",
+      "view": "Ver",
+      "viewExisting": "Ver existente",
+      "importAnyway": "Importar mesmo assim",
+      "hide": "Ocultar",
+      "details": "Detalhes",
+      "alreadyExistsSaveAs": "Já existe - salvar como:",
+      "renamePlaceholder": "ex: {name} (2)",
+      "import": "Importar"
+    }
+  },
+  "collection": {
+    "dialog": {
+      "name": "Nome",
+      "icon": "Ícone",
+      "iconPlaceholder": "Escolha um ícone...",
+      "nameRequired": "O nome é obrigatório",
+      "iconRequired": "Escolha um ícone",
+      "creating": "Criando...",
+      "createFailed": "Falha ao criar coleção"
+    },
+    "createDialog": {
+      "title": "Nova Coleção",
+      "namePlaceholder": "ex: Favoritos"
+    },
+    "editDialog": {
+      "title": "Editar Coleção",
+      "syncToKobo": "Sincronizar com Kobo",
+      "syncToKoboHint": "Os livros nesta coleção aparecerão no seu dispositivo Kobo",
+      "deleteCollection": "Excluir coleção",
+      "confirmDelete": "Confirmar?",
+      "deleting": "Excluindo...",
+      "saving": "Salvando...",
+      "deleted": "\"{name}\" excluída",
+      "updateFailed": "Falha ao atualizar coleção",
+      "deleteFailed": "Falha ao excluir coleção"
+    },
+    "addToSheet": {
+      "title": "Gerenciar Coleções",
+      "selectedCount": "nenhum livro selecionado | um livro selecionado | {count} livros selecionados",
+      "newCollection": "Nova Coleção",
+      "namePlaceholder": "Nome da coleção",
+      "create": "Criar",
+      "collections": "Coleções",
+      "empty": "Nenhuma coleção ainda. Crie uma acima.",
+      "done": "Concluído",
+      "added": "Adicionado",
+      "allAdded": "Todos os {total} adicionados",
+      "inCollection": "Nesta coleção",
+      "allInCollection": "Todos os {total} nesta coleção",
+      "partialInCollection": "{partial} de {total} nesta coleção",
+      "bookCount": "nenhum livro | um livro | {count} livros",
+      "loadFailed": "Falha ao carregar coleções",
+      "createdAndAdded": "Criada \"{name}\" e adicionado nenhum livro | Criada \"{name}\" e adicionado um livro | Criada \"{name}\" e adicionados {count} livros",
+      "createdButAddFailed": "Criada \"{name}\", mas falhou ao adicionar livros",
+      "createFailed": "Falha ao criar coleção",
+      "addedNewWithExisting": "Adicionado um livro novo a \"{name}\" ({alreadyHad} já lá) | Adicionado um livro novo a \"{name}\" ({alreadyHad} já lá) | Adicionados {count} novos livros a \"{name}\" ({alreadyHad} já lá)",
+      "addedToCollection": "Nenhum livro adicionado a \"{name}\" | Um livro adicionado a \"{name}\" | {count} livros adicionados a \"{name}\"",
+      "addFailed": "Falha ao adicionar à coleção",
+      "removedFromCollection": "Nenhum livro removido de \"{name}\" | Um livro removido de \"{name}\" | {count} livros removidos de \"{name}\"",
+      "removeFailed": "Falha ao remover da coleção"
+    }
+  },
+  "components": {
+    "appHeader": {
+      "searchAllBooks": "Pesquisar todos os livros...",
+      "searching": "Pesquisando...",
+      "noResults": "Sem resultados",
+      "loadingMore": "Carregando mais...",
+      "loadMore": "Carregar mais ({loaded}/{total})",
+      "allMatchesShown": "Todas as 1 correspondências mostradas | Toda a 1 correspondência mostrada | Todas as {count} correspondências mostradas",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+      "uploadedToast": "Enviado(s) {uploaded}",
+      "uploadFailedToast": "O envio falhou para {failed}",
+      "uploadPartialToast": "Enviado(s) {uploaded}, {failed} falharam",
+      "bookDock": "Book Dock",
+      "statistics": "Estatísticas",
+      "achievements": "Conquistas",
+      "annotations": "Anotações",
+      "uploadBooks": "Enviar livros",
+      "appearance": "Aparência",
+      "theme": "Tema",
+      "accent": "Destaque",
+      "radius": "Raio",
+      "background": "Fundo",
+      "settings": "Configurações",
+      "whatsNew": "O que há de novo",
+      "documentation": "Documentação",
+      "help": "Ajuda",
+      "starOnGithub": "Dê uma estrela no GitHub",
+      "new": "Novo",
+      "newReleaseNotes": "Novas notas de lançamento disponíveis",
+      "account": "Conta",
+      "changePassword": "Alterar Senha",
+      "signOut": "Sair",
+      "githubStar": {
+        "title": "Gostando do BookOrbit?",
+        "body": "Se o BookOrbit está ajudando com a sua biblioteca, por favor, considere dar uma estrela ao projeto no GitHub. Isso ajuda mais pessoas a descobrirem o aplicativo e apoia o desenvolvimento contínuo.",
+        "cta": "Dar estrela ao BookOrbit no GitHub"
+      }
+    },
+    "sidebar": {
+      "tagline": "Seu Espaço de Leitura",
+      "dashboard": "Painel",
+      "authors": "Autores",
+      "series": "Série",
+      "tools": "Ferramentas",
+      "libraries": "Bibliotecas",
+      "newLibrary": "Nova Biblioteca",
+      "libraryScanning": "{name} - Verificando {pct}%",
+      "scanProgress": "{processed} / {total} livros",
+      "smartScopes": "Smart Scopes",
+      "newSmartScope": "Novo Smart Scope",
+      "noSmartScopes": "Nenhum Smart Scope ainda",
+      "collections": "Coleções",
+      "newCollection": "Nova Coleção",
+      "noCollections": "Nenhuma coleção ainda",
+      "latest": "Mais recente {version}",
+      "newReleaseNotes": "Novas notas de lançamento disponíveis",
+      "sectionHeader": {
+        "add": "Adicionar",
+        "reorder": "Reordenar",
+        "doneReordering": "Reordenação concluída"
+      }
+    },
+    "selectionActionBar": {
+      "setReadingStatus": "Definir status de leitura",
+      "setRating": "Definir avaliação",
+      "openMetadataEditor": "Abrir editor de metadados",
+      "editIndividually": "Editar livros individualmente",
+      "addToCollection": "Adicionar à coleção",
+      "removeFromCollection": "Remover da coleção",
+      "sendViaEmail": "Enviar por e-mail",
+      "downloadFilesZip": "Baixar arquivos como ZIP",
+      "moreActions": "Mais ações",
+      "setField": "Definir campo",
+      "refreshMetadata": "Atualizar metadados",
+      "reExtractCover": "Reextrair capa",
+      "metadataLock": "Bloqueio de metadados",
+      "lockAll": "Bloquear tudo",
+      "unlockAll": "Desbloquear tudo",
+      "exportMetadata": "Exportar metadados",
+      "deleteSelected": "Excluir selecionados",
+      "exitSelection": "Sair da seleção",
+      "downloadFilesZipLabel": "Baixar arquivos como ZIP:",
+      "primaryOnly": "Apenas principal",
+      "allFormats": "Todos os formatos",
+      "audioOnly": "Apenas áudio",
+      "setRatingLabel": "Definir avaliação:",
+      "clear": "Limpar",
+      "setFieldLabel": "Definir campo:",
+      "apply": "Aplicar",
+      "fieldPlaceholder": "Deixe em branco para limpar",
+      "fieldPlaceholderArray": "Separado por vírgulas (deixe em branco para limpar)",
+      "deleteConfirm": "Excluir {count} livro? | Excluir {count} livro? | Excluir {count} livros?",
+      "typeDelete": "Digite DELETE"
+    },
+    "viewHeader": {
+      "select": "Selecionar",
+      "display": "Exibição",
+      "displayDescription": "Ajuste o tamanho da capa, o espaçamento da grade e as opções de exibição de visualização.",
+      "columnVisibilityHint": "Use o painel de visibilidade das colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
+      "columnVisibilityMobileHint": "A visibilidade das colunas pode ser gerenciada no cabeçalho da tabela.",
+      "searchPlaceholder": "Pesquisar título, autor, série, narrador...",
+      "mobileSearch": {
+        "description": "Pesquise itens por título, autor, série ou narrador.",
+        "done": "Concluído"
+      },
+      "mobileMenu": {
+        "grid": "Grade",
+        "list": "Lista",
+        "select": "Selecionar",
+        "exitSelect": "Sair da Seleção"
+      },
+      "displayControls": {
+        "display": "Exibição",
+        "coverSize": "Tamanho da capa",
+        "gridGap": "Espaçamento da grade",
+        "columnsHint": "Use o painel de visibilidade das colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
+        "coverShape": "Formato da capa",
+        "circle": "Círculo",
+        "square": "Quadrado"
+      }
+    },
+    "iconPicker": {
+      "searchLucide": "Pesquisar ícones Lucide...",
+      "searchCustom": "Pesquisar ícones personalizados...",
+      "chooseIcon": "Escolha um ícone...",
+      "selectIcon": "Selecionar ícone",
+      "customTab": "Personalizado",
+      "searching": "Pesquisando...",
+      "noIconsMatch": "Nenhum ícone corresponde a \"{query}\"",
+      "typeToSearch": "Digite para pesquisar todos os ícones",
+      "noCustomIcons": "Nenhum ícone personalizado enviado",
+      "noIconsAvailable": "Nenhum ícone disponível"
+    },
+    "entityNotFound": {
+      "title": "{entity} não encontrado",
+      "description": "Este {entity} não existe ou foi excluído.",
+      "goBack": "Voltar"
+    },
+    "themePicker": {
+      "light": "Claro",
+      "dark": "Escuro"
+    },
+    "userAvatar": {
+      "profilePicture": "Foto de perfil",
+      "profilePictureOf": "Foto de perfil de {name}"
+    },
+    "ui": {
+      "sidebar": {
+        "title": "Barra Lateral",
+        "mobileDescription": "Exibe a barra lateral móvel.",
+        "toggle": "Alternar Barra Lateral"
+      },
+      "chipInput": {
+        "typeAndEnter": "Digite e pressione Enter para adicionar",
+        "pressEnter": "Pressione Enter para adicionar"
+      }
+    }
+  },
+  "customIcons": {
+    "dialogTitle": "Enviar ícones personalizados",
+    "dialogDescription": "Revise os nomes antes de adicioná-los à sua biblioteca.",
+    "readingFiles": "Lendo arquivos...",
+    "dropPrompt": "Solte arquivos SVG ou clique para procurar",
+    "fileLimit": "Até {max} arquivos, 128 KB cada",
+    "namePlaceholder": "Nome",
+    "nameRequired": "O nome é obrigatório",
+    "invalidSvg": "SVG Inválido",
+    "invalidSvgFile": "Arquivo SVG inválido",
+    "identicalTo": "Idêntico a \"{name}\"",
+    "uploadAnyway": "Enviar mesmo assim",
+    "skipThisOne": "Ignorar este",
+    "readyToUpload": "{count} prontos para upload",
+    "noIconsStaged": "Nenhum ícone na fila de envio ainda",
+    "uploading": "Enviando...",
+    "upload": "Fazer upload",
+    "uploadCount": "Fazer upload de {count}",
+    "onlySvgSupported": "Apenas arquivos SVG são suportados",
+    "maxStaged": "Você pode enfileirar no máximo {max} ícones de uma vez",
+    "onlyMoreCanStage": "Nenhum ícone adicional pode ser enfileirado | Apenas {count} ícone adicional pode ser enfileirado | Apenas {count} ícones adicionais podem ser enfileirados",
+    "readFailed": "Falha ao ler os arquivos SVG",
+    "uploadedCount": "Nenhum ícone enviado | {count} ícone enviado | {count} ícones enviados",
+    "uploadedPartial": "{created} enviado(s), {failed} falharam",
+    "noIconsUploaded": "Nenhum ícone enviado",
+    "uploadFailed": "Falha ao enviar os ícones",
+    "uploadFailedEntry": "O envio falhou"
+  },
+  "dashboard": {
+    "common": {
+      "failedToLoad": "Falha ao carregar",
+      "retry": "Tentar novamente",
+      "untitled": "Sem título",
+      "cover": "Capa",
+      "bookCover": "Capa do livro"
+    },
+    "scroller": {
+      "failedToLoad": "Falha ao carregar.",
+      "empty": {
+        "continueReading": "Nenhum livro em andamento ainda. Comece a ler um para vê-lo aqui.",
+        "continueListening": "Nenhum audiobook em andamento ainda. Comece a ouvir um para vê-lo aqui.",
+        "wantToRead": "Nenhum livro marcado como 'quero ler' ainda.",
+        "upNextInSeries": "Nenhuma próxima escolha da série ainda. Termine um volume para sugerir o próximo.",
+        "recentlyAdded": "Nenhum livro na sua biblioteca ainda.",
+        "smartScope": "Nenhum livro corresponde a este smartScope.",
+        "default": "Nenhum livro encontrado."
+      }
+    },
+    "settings": {
+      "title": "Personalizar Painel",
+      "tabs": {
+        "widgets": "Widgets",
+        "shelves": "Prateleiras"
+      },
+      "reorderHintWidget": "Arraste para reordenar. Alterne para mostrar ou ocultar um widget.",
+      "reorderHintShelf": "Arraste para reordenar. Alterne para mostrar ou ocultar uma prateleira.",
+      "smartScope": "Smart Scope",
+      "noSmartScopes": "Nenhum Smart Scope ainda. Crie um na barra lateral.",
+      "addShelf": "Adicionar prateleira",
+      "resetToDefaults": "Redefinir para os padrões"
+    },
+    "welcome": {
+      "emptyTitle": "Sua biblioteca está vazia",
+      "noLibrariesTitle": "Nenhuma biblioteca ainda",
+      "emptyDescription": "Crie uma biblioteca para começar a organizar e ler seus livros. Aponte para uma pasta e ela fará o resto.",
+      "noLibrariesDescription": "Seu administrador não configurou nenhuma biblioteca ainda. Entre em contato com eles para começar.",
+      "createFirstLibrary": "Criar sua primeira biblioteca"
+    },
+    "widgets": {
+      "currentlyReading": {
+        "title": "Lendo Atualmente",
+        "empty": "Nenhum livro em andamento. Comece a ler um para vê-lo aqui.",
+        "continueReading": "Continuar a ler"
+      },
+      "diversityScore": {
+        "title": "Índice de Diversidade",
+        "notEnoughData": "Leia pelo menos 3 livros para ver seu índice de diversidade",
+        "booksAnalyzed": "nenhum livro analisado | {count} livro analisado | {count} livros analisados",
+        "subScores": {
+          "genre": "Gênero",
+          "author": "Autor",
+          "era": "Época",
+          "language": "Idioma"
+        }
+      },
+      "highlightOfTheDay": {
+        "title": "Destaque do Dia",
+        "empty": "Destaque passagens durante a leitura para vê-las aqui"
+      },
+      "libraryOverview": {
+        "title": "Visão Geral da Biblioteca",
+        "empty": "Sua biblioteca está vazia. Adicione alguns livros para começar.",
+        "addedThisYear": "+{count} adicionados este ano",
+        "stats": {
+          "books": "Livros",
+          "authors": "Autores",
+          "series": "Série",
+          "storage": "Armazenamento"
+        }
+      },
+      "longWait": {
+        "title": "A Longa Espera",
+        "empty": "Nenhum livro aguardando. Você já começou tudo!",
+        "daysWaiting": "dias de espera",
+        "pages": "nenhuma página | {count} página | {count} páginas",
+        "startReading": "Começar a Ler"
+      },
+      "monthlyChallenge": {
+        "title": "Desafio Mensal",
+        "complete": "Concluído!"
+      },
+      "neglectedGems": {
+        "title": "Joias Negligenciadas",
+        "empty": "Todos os seus livros com melhor classificação já foram lidos!",
+        "rating": "{rating}/5",
+        "daysWaiting": "{count}d esperando",
+        "queued": "Na fila",
+        "addToQueue": "Adicionar à fila",
+        "shuffle": "Embaralhar"
+      },
+      "readingDna": {
+        "title": "DNA de Leitura",
+        "notEnoughData": "Leia pelo menos 5 livros para desbloquear o seu DNA de Leitura",
+        "basedOn": "Com base em nenhum livro | Com base em {count} livro | Com base em {count} livros",
+        "traits": {
+          "length": "Tamanho",
+          "variety": "Variedade",
+          "rhythm": "Ritmo",
+          "time": "Tempo",
+          "speed": "Velocidade"
+        }
+      },
+      "readingGoal": {
+        "title": "Meta de Leitura {year}",
+        "setGoalPrompt": "Defina uma meta de leitura para acompanhar o seu progresso",
+        "setGoal": "Definir meta",
+        "booksPerYear": "Livros por ano",
+        "ofGoal": "de {goal}",
+        "percentComplete": "{percentage}% concluído",
+        "editGoal": "Editar meta"
+      },
+      "readingRhythm": {
+        "title": "Ritmo de Leitura",
+        "empty": "Comece a ler para ver o seu ritmo tomar forma",
+        "activeDays": "nenhum dia ativo | {count} dia ativo | {count} dias ativos",
+        "consistency": "{activeDays} · {percent}% de consistência",
+        "avgPerDay": "média de {time}/dia"
+      },
+      "readingStreak": {
+        "title": "Sequência de Leitura",
+        "empty": "Leia hoje para iniciar a sua sequência",
+        "streakLabel": "dia em sequência | dia em sequência | dias em sequência",
+        "best": "Melhor: {count} dia | Melhor: {count} dia | Melhor: {count} dias",
+        "lastSevenDays": "Últimos 7 dias"
+      },
+      "yearProjection": {
+        "title": "Projeção do Ano",
+        "books": "livros",
+        "trendUp": "Tendência de alta",
+        "trendDown": "Tendência de baixa",
+        "trendSteady": "Ritmo estável",
+        "pages": "páginas",
+        "hours": "horas",
+        "readCount": "{count} lido",
+        "daysLeft": "{count}d restantes"
+      }
+    }
+  },
+  "email": {
+    "title": "E-mail",
+    "subtitle": "Envie livros para o seu e-reader por e-mail.",
+    "loadFailed": "Falha ao carregar",
+    "saveFailed": "Falha ao salvar",
+    "deleteFailed": "Falha ao excluir",
+    "setDefaultFailed": "Falha ao definir padrão",
+    "setAsDefault": "Definir como padrão",
+    "saving": "Salvando...",
+    "update": "Atualizar",
+    "create": "Criar",
+    "deleteConfirm": "Excluir \"{name}\". Esta ação não pode ser desfeita.",
+    "badge": {
+      "default": "Padrão",
+      "shared": "Compartilhado",
+      "system": "Sistema"
+    },
+    "tabs": {
+      "providers": "Provedores",
+      "recipients": "Destinatários",
+      "groups": "Grupos",
+      "templates": "Modelos",
+      "preferences": "Preferências",
+      "history": "Histórico"
+    },
+    "providers": {
+      "heading": "Provedores SMTP",
+      "add": "Adicionar provedor",
+      "newTitle": "Novo Provedor",
+      "editTitle": "Editar Provedor",
+      "name": "Nome",
+      "namePlaceholder": "ex: Gmail",
+      "host": "Host",
+      "port": "Porta",
+      "username": "Nome de usuário",
+      "password": "Senha",
+      "passwordEdit": "Senha (deixe em branco para manter a atual)",
+      "fromName": "Nome do Remetente",
+      "fromNamePlaceholder": "Minha Biblioteca",
+      "fromAddress": "Endereço do Remetente",
+      "authentication": "Autenticação",
+      "verifyTls": "Verificar certificado TLS",
+      "tlsWarning": "A verificação TLS está desativada. O certificado do servidor não será validado - use apenas para servidores internos confiáveis.",
+      "noFromAddress": "sem endereço de remetente",
+      "emptyManage": "Nenhum provedor ainda. Adicione um provedor SMTP para começar a enviar e-mails.",
+      "emptyReadonly": "Nenhum provedor disponível. Peça a um administrador para adicionar um.",
+      "setSystemTooltip": "Definir como provedor de e-mail do sistema",
+      "removeSystemTooltip": "Remover como provedor de e-mail do sistema",
+      "testTooltip": "Testar conexão",
+      "toggleSharing": "Alternar compartilhamento",
+      "removeSystemBeforeDelete": "Remova a designação do sistema antes de excluir",
+      "notesHeading": "Notas do Provedor",
+      "notesBody": "O provedor do <strong>Sistema</strong> (apenas para superusuários) é usado para e-mails de redefinição de senha. O provedor <strong>Padrão</strong> é usado ao enviar livros sem nenhum provedor explícito selecionado. Os provedores marcados como <strong>Compartilhados</strong> estão disponíveis para todos os usuários.",
+      "deleteTitle": "Excluir provedor?",
+      "nameHostRequired": "Nome e host são obrigatórios",
+      "created": "Provedor criado",
+      "updated": "Provedor atualizado",
+      "deleted": "\"{name}\" excluído",
+      "setDefaultSuccess": "\"{name}\" definido como padrão",
+      "unshared": "Provedor descompartilhado",
+      "sharedWithAll": "Provedor compartilhado com todos os usuários",
+      "updateSharingFailed": "Falha ao atualizar compartilhamento",
+      "systemRemoved": "\"{name}\" removido como provedor de e-mail do sistema",
+      "systemSet": "\"{name}\" definido como provedor de e-mail do sistema",
+      "updateSystemFailed": "Falha ao atualizar o provedor do sistema",
+      "connectionSuccess": "Conexão bem-sucedida",
+      "connectionFailed": "Falha na conexão",
+      "testFailed": "Teste falhou"
+    },
+    "recipients": {
+      "heading": "Destinatários",
+      "add": "Adicionar destinatário",
+      "newTitle": "Novo Destinatário",
+      "editTitle": "Editar Destinatário",
+      "name": "Nome",
+      "namePlaceholder": "Meu Kindle",
+      "emailAddress": "Endereço de e-mail",
+      "deviceType": "Tipo de dispositivo",
+      "deviceNone": "Nenhum",
+      "deviceOther": "Outro",
+      "preferredFormat": "Formato preferido",
+      "formatAuto": "Automático",
+      "defaultTemplate": "Modelo padrão",
+      "useAccountDefault": "Usar padrão da conta",
+      "kindleNote": "Os destinatários Kindle recebem e-mails automaticamente com o assunto \"convert\" para acionar a conversão de formato.",
+      "empty": "Nenhum destinatário ainda.",
+      "prefersFormat": "prefere {format}",
+      "deleteTitle": "Excluir destinatário?",
+      "nameEmailRequired": "Nome e e-mail são obrigatórios",
+      "created": "Destinatário criado",
+      "updated": "Destinatário atualizado",
+      "deleted": "\"{name}\" excluído",
+      "setDefaultSuccess": "\"{name}\" definido como padrão"
+    },
+    "groups": {
+      "heading": "Grupos de Destinatários",
+      "create": "Criar grupo",
+      "newTitle": "Novo Grupo",
+      "name": "Nome do grupo",
+      "namePlaceholder": "ex: Clube do Livro",
+      "creating": "Criando...",
+      "empty": "Nenhum grupo ainda. Crie um grupo para enviar para vários destinatários de uma vez.",
+      "memberCount": "nenhum membro | um membro | {count} membros",
+      "deleteTooltip": "Excluir grupo",
+      "noMembers": "Nenhum membro ainda.",
+      "removeMember": "Remover",
+      "selectRecipient": "Selecione o destinatário...",
+      "add": "Adicionar",
+      "addMember": "Adicionar membro",
+      "allRecipientsInGroup": "Todos os destinatários já estão neste grupo.",
+      "deleteTitle": "Excluir grupo?",
+      "created": "Grupo criado",
+      "createFailed": "Falha ao criar o grupo",
+      "deleted": "\"{name}\" excluído",
+      "memberAdded": "Membro adicionado",
+      "addMemberFailed": "Falha ao adicionar membro",
+      "memberRemoved": "Membro removido",
+      "removeMemberFailed": "Falha ao remover membro"
+    },
+    "templates": {
+      "heading": "Modelos de E-mail",
+      "new": "Novo modelo",
+      "newTitle": "Novo Modelo",
+      "editTitle": "Editar Modelo",
+      "name": "Nome",
+      "namePlaceholder": "Padrão",
+      "subject": "Assunto",
+      "body": "Corpo da Mensagem",
+      "availableVariables": "Variáveis disponíveis",
+      "editTemplate": "Editar modelo",
+      "empty": "Nenhum modelo ainda.",
+      "notesHeading": "Notas do Modelo",
+      "notesBody": "Os modelos do sistema não podem ser excluídos. Os administradores podem editá-los. Use variáveis como <code class=\"font-mono text-foreground/80\">&#123;&#123;title&#125;&#125;</code> nos assuntos e no corpo da mensagem - elas são substituídas pelos detalhes do livro no momento do envio.",
+      "deleteTitle": "Excluir modelo?",
+      "nameSubjectRequired": "Nome e assunto são obrigatórios",
+      "created": "Modelo criado",
+      "updated": "Modelo atualizado",
+      "deleted": "\"{name}\" excluído",
+      "setDefaultSuccess": "\"{name}\" definido como padrão"
+    },
+    "preferences": {
+      "heading": "Preferências de E-mail",
+      "defaultProvider": "Provedor padrão",
+      "defaultProviderHint": "Usado quando nenhum provedor for especificado. Se vazio, o padrão da conta será usado.",
+      "noneAccountDefault": "Nenhum (usar padrão da conta)",
+      "defaultRecipient": "Destinatário padrão",
+      "defaultRecipientHint": "Usado para envio rápido. Deve ser configurado para usar a ação de envio rápido nos cartões de livro.",
+      "none": "Nenhum",
+      "defaultTemplate": "Modelo padrão",
+      "defaultTemplateHint": "Usado quando nenhum modelo for especificado. Retorna ao padrão do sistema se estiver vazio.",
+      "noneSystemDefault": "Nenhum (usar padrão do sistema)",
+      "save": "Salvar preferências",
+      "saved": "Preferências salvas"
+    },
+    "history": {
+      "heading": "Histórico de Envio",
+      "empty": "Nenhum e-mail enviado ainda.",
+      "noSubject": "(sem assunto)",
+      "loadMore": "Carregar mais",
+      "resend": "Reenviar",
+      "deleteTitle": "Excluir entrada do histórico?",
+      "entryDeleted": "Entrada excluída",
+      "queuedForResend": "Na fila para reenvio",
+      "resendFailed": "Falha ao reenviar",
+      "statusSent": "Enviado",
+      "statusFailed": "Falhou",
+      "statusQueued": "Na fila",
+      "statusPending": "Pendente"
+    },
+    "send": {
+      "title": "Enviar por E-mail",
+      "bookCount": "nenhum livro | um livro | {count} livros",
+      "recipients": "Destinatários",
+      "noRecipients": "Nenhum destinatário configurado. Adicione um nas configurações de E-mail.",
+      "groups": "Grupos",
+      "options": "Opções",
+      "fileFormat": "Formato de arquivo",
+      "autoRecipientPreference": "Automático (usar a preferência do destinatário)",
+      "unknownFormat": "Desconhecido",
+      "primarySuffix": "(principal)",
+      "provider": "Provedor",
+      "template": "Modelo",
+      "default": "Padrão",
+      "send": "Enviar",
+      "sending": "Enviando...",
+      "queued": "nenhum e-mail enfileirado | um e-mail enfileirado | {count} e-mails enfileirados",
+      "failed": "Falha no envio"
+    }
+  },
+  "hardcover": {
+    "settings": {
+      "subtitle": "Sincronize seu progresso de leitura, status e avaliações com o Hardcover."
+    },
+    "bookSync": {
+      "label": "Sincronização com o Hardcover",
+      "toggleAriaLabel": "Sincronizar este livro com o Hardcover",
+      "syncNow": "Sincronizar agora"
+    },
+    "connection": {
+      "title": "Conexão",
+      "description": "Conecte sua conta do Hardcover para sincronizar os dados de leitura.",
+      "connected": "Conectado",
+      "apiToken": "Token da API",
+      "tokenPlaceholder": "Cole o token da API do Hardcover",
+      "show": "Mostrar",
+      "hide": "Ocultar",
+      "findTokenAt": "Encontre o seu token em",
+      "validateToken": "Validar token",
+      "valid": "Válido ({username})",
+      "invalidToken": "Token inválido",
+      "syncOptions": "Opções de sincronização",
+      "syncInfo": "A sincronização só é executada para livros que não estão não lidos. Isso se aplica aos acionadores de status, progresso e avaliação. Esses interruptores controlam quando a sincronização é executada.",
+      "syncScope": {
+        "title": "Escopo de sincronização de livros",
+        "allEligible": {
+          "label": "Todos os livros elegíveis",
+          "description": "Sincroniza tudo, a menos que você exclua um livro."
+        },
+        "selectedOnly": {
+          "label": "Apenas livros selecionados",
+          "description": "Sincroniza apenas os livros que você inclui explicitamente."
+        }
+      },
+      "enableSync": {
+        "title": "Habilitar sincronização",
+        "description": "Pause toda a sincronização com o Hardcover sem desconectar."
+      },
+      "syncOnStatus": {
+        "title": "Sincronizar na mudança de status",
+        "description": "Envia as atualizações quando você marca um livro como lendo, lido, etc."
+      },
+      "syncOnProgress": {
+        "title": "Sincronizar na atualização de progresso",
+        "description": "Envia o progresso de leitura e as datas quando o progresso no BookOrbit ou KOReader muda."
+      },
+      "syncOnRating": {
+        "title": "Sincronizar na mudança de avaliação",
+        "description": "Envia a sua avaliação de estrelas para o Hardcover."
+      },
+      "privacy": {
+        "title": "Privacidade",
+        "description": "Visibilidade padrão para livros sincronizados no Hardcover.",
+        "public": "Público",
+        "followersOnly": "Apenas seguidores",
+        "private": "Privado"
+      },
+      "disconnect": "Desconectar",
+      "toast": {
+        "enterToken": "Insira o token da sua API do Hardcover primeiro",
+        "saved": "Configurações do Hardcover salvas",
+        "saveFailed": "Falha ao salvar as configurações",
+        "disconnected": "Hardcover desconectado"
+      }
+    },
+    "sync": {
+      "title": "Sincronização manual",
+      "description": "Envie seus {scope} para o Hardcover agora.",
+      "scope": {
+        "selected": "livros selecionados",
+        "eligible": "livros elegíveis"
+      },
+      "checkingPending": "Verificando itens pendentes...",
+      "pendingOf": "{pending} pendentes de {total} livros.",
+      "noBooksInScope": "Nenhum livro no escopo de sincronização.",
+      "allSynced": "Todos os livros já estão sincronizados.",
+      "lastSyncedLabel": "Última sincronização",
+      "lastSuccessfulSync": "Última sincronização bem-sucedida",
+      "syncing": "Sincronizando...",
+      "progressCount": "{synced} / {total} livros",
+      "unavailable": {
+        "permissionDenied": "Você não tem permissão para usar a sincronização com o Hardcover.",
+        "userDisabled": "A sincronização está pausada nas suas configurações do Hardcover."
+      },
+      "button": {
+        "unavailable": "Sincronização indisponível",
+        "syncNow": "Sincronizar agora",
+        "syncNowCount": "Sincronizar agora ({count})"
+      },
+      "lastSynced": {
+        "justNow": "Agora mesmo",
+        "minutesAgo": "{count} min atrás",
+        "hoursAgo": "{count} hora atrás | {count} hora atrás | {count} horas atrás",
+        "daysAgo": "{count} dia atrás | {count} dia atrás | {count} dias atrás"
+      }
+    },
+    "import": {
+      "title": "Importar status de leitura",
+      "description": "Revise as correspondências do Hardcover antes de preencher os status vazios do BookOrbit.",
+      "clear": "Limpar",
+      "preview": "Pré-visualizar",
+      "importProgress": "Progresso de importação",
+      "reviewMatches": "Revisar correspondências",
+      "importReady": "Pronto para importar",
+      "exactMatches": "nenhuma correspondência exata pode ser importada sem revisão | {count} correspondência exata pode ser importada sem revisão | {count} correspondências exatas podem ser importadas sem revisão",
+      "progressAvailable": "nenhuma atualização de progresso disponível | {count} atualização de progresso disponível | {count} atualizações de progresso disponíveis",
+      "progressConflicts": "nenhum conflito | {count} conflito | {count} conflitos",
+      "unavailable": {
+        "permissionDenied": "Você não tem permissão para usar a sincronização com o Hardcover.",
+        "missingToken": "Conecte o Hardcover antes de importar.",
+        "userDisabled": "A sincronização está pausada nas suas configurações do Hardcover."
+      },
+      "summary": {
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflicts": "Conflitos",
+        "unmatched": "Não Correspondido",
+        "skipped": "Ignorado"
+      },
+      "result": {
+        "summary": "{applied} importados{progress}, {failed} falharam",
+        "progressUpdated": "{count} progresso atualizado"
+      },
+      "toast": {
+        "importFailed": "Falha ao importar o status de leitura do Hardcover",
+        "imported": "nenhum status de leitura importado{progress} | {count} status de leitura importado{progress} | {count} status de leitura importados{progress}",
+        "progressUpdates": "nenhuma atualização de progresso | {count} atualização de progresso | {count} atualizações de progresso"
+      }
+    },
+    "review": {
+      "title": "Revisão de importação do Hardcover",
+      "subtitle": "{total} livros no Hardcover, {matched} correspondidos.",
+      "closeAriaLabel": "Fechar revisão de importação",
+      "searchPlaceholder": "Pesquisar título ou autor",
+      "importProgress": "Progresso de importação",
+      "untitled": "Sem título",
+      "blank": "em branco",
+      "noRows": "Nenhuma linha corresponde aos filtros atuais.",
+      "selectRowAriaLabel": "Selecionar {title}",
+      "selectionSummary": "{count} selecionados: {ready} prontos, {reviewed} revisados.",
+      "selectedProgress": "nenhuma atualização de progresso | {count} atualização de progresso | {count} atualizações de progresso",
+      "selectReady": "Selecionar prontos",
+      "selectPage": "Selecionar página",
+      "clearPage": "Limpar página",
+      "clearSelection": "Limpar seleção",
+      "importSelected": "Importar selecionados",
+      "previousPage": "Página anterior",
+      "nextPage": "Próxima página",
+      "pageRange": "{start}-{end} de {total}",
+      "tabs": {
+        "all": "Tudo",
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflicts": "Conflitos",
+        "unmatched": "Não Correspondido",
+        "skipped": "Ignorado"
+      },
+      "summary": {
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflicts": "Conflitos",
+        "unmatched": "Não Correspondido",
+        "skipped": "Ignorado"
+      },
+      "matchOptions": {
+        "all": "Todos os tipos de correspondência"
+      },
+      "matchMethod": {
+        "hardcoverId": "ID do Hardcover",
+        "isbn": "ISBN",
+        "titleAuthor": "Título + autor"
+      },
+      "outcome": {
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflict": "Conflito",
+        "unmatched": "Não Correspondido",
+        "skipped": "Ignorado"
+      },
+      "column": {
+        "progress": "Progresso"
+      }
+    }
+  },
+  "library": {
+    "creator": {
+      "createTitle": "Criar Biblioteca",
+      "editTitle": "Editar: {name}",
+      "stepOf": "Passo {current} de {total}",
+      "sections": {
+        "details": "Detalhes",
+        "folders": "Pastas",
+        "scanner": "Scanner",
+        "metadata": "Metadados",
+        "fileWrite": "Gravação de Arquivo",
+        "reading": "Leitura",
+        "schedule": "Agendamento",
+        "access": "Acesso"
+      },
+      "actions": {
+        "saving": "Salvando...",
+        "saveChanges": "Salvar alterações",
+        "creating": "Criando...",
+        "createLibrary": "Criar biblioteca"
+      },
+      "details": {
+        "libraryName": "Nome da biblioteca",
+        "namePlaceholder": "Minha Biblioteca",
+        "coverStyle": {
+          "title": "Estilo de capa",
+          "portrait": "Retrato",
+          "square": "Quadrado",
+          "hint": "Retrato para e-books ou bibliotecas mistas. Quadrado para bibliotecas apenas de audiobooks."
+        },
+        "icon": {
+          "label": "Ícone",
+          "placeholder": "Escolha um ícone...",
+          "selected": "Selecionado"
+        }
+      },
+      "folders": {
+        "title": "Pastas de verificação",
+        "description": "Adicione um ou mais diretórios para procurar livros.",
+        "browseAdd": "Procurar e adicionar uma pasta",
+        "manualEntry": "Ou digite um caminho manualmente:",
+        "pathPlaceholder": "/caminho/para/livros",
+        "test": "Testar",
+        "add": "Adicionar",
+        "pathNotAccessible": "O caminho não está acessível no servidor.",
+        "pathAccessible": "O caminho está acessível.",
+        "pathNotAccessibleShort": "Caminho não acessível",
+        "bookFilesFound": "nenhum arquivo de livro encontrado | {count} arquivo de livro encontrado | {count} arquivos de livro encontrados",
+        "overlapsWith": "Sobrepõe-se a \"{library}\"",
+        "noneAdded": "Nenhuma pasta adicionada ainda",
+        "totalFilesFound": "nenhum arquivo de livro encontrado | {count} arquivo de livro encontrado - o número real de livros pode ser menor se houver vários formatos do mesmo livro | {count} arquivos de livro encontrados - o número real de livros pode ser menor se houver vários formatos do mesmo livro",
+        "runPrescanHint": "Execute uma pré-verificação para validar os caminhos antes de salvar.",
+        "scanning": "Verificando...",
+        "prescan": "Pré-verificação"
+      },
+      "scanner": {
+        "scanMode": {
+          "title": "Modo de verificação",
+          "lockedAria": "O modo de organização está bloqueado",
+          "lockTooltip": "O modo de organização é fixado após a criação da biblioteca porque alterá-lo pode criar entradas de livro duplicadas ou ausentes. Para usar um modo diferente, crie uma nova biblioteca e faça uma nova verificação.",
+          "recommended": "Recomendado",
+          "folderAsBook": {
+            "title": "Pasta como Livro",
+            "hint": "Todos os arquivos em uma pasta são agrupados em um livro. Funciona bem quando você mantém vários formatos, como EPUB e MOBI, juntos."
+          },
+          "fileAsBook": {
+            "title": "Arquivo como Livro",
+            "hint": "Trata cada arquivo como um livro individual. Mais adequado para bibliotecas com um formato por título. Evite se os seus audiobooks abrangerem vários arquivos."
+          }
+        },
+        "allowedFormats": {
+          "title": "Formatos permitidos",
+          "allowAll": "Permitir todos",
+          "allAllowed": "Todos os formatos são permitidos.",
+          "onlySelected": "Apenas os formatos selecionados serão importados.",
+          "warning": "Livros em outros formatos que já estão na biblioteca serão marcados como ausentes na próxima verificação."
+        },
+        "excludePatterns": {
+          "title": "Padrões de exclusão",
+          "hintBefore": "Padrões glob para ignorar durante a verificação (ex: ",
+          "hintAfter": ").",
+          "add": "Adicionar",
+          "empty": "Nenhum padrão adicionado."
+        }
+      },
+      "metadata": {
+        "sourcePrecedence": {
+          "title": "Precedência da fonte",
+          "hint": "A fonte mais alta na lista é preferida quando várias estão disponíveis."
+        },
+        "formatPriority": {
+          "title": "Prioridade do formato",
+          "hint": "Quando um livro tem vários formatos, o formato mais alto na lista é o preferido."
+        }
+      },
+      "fileWrite": {
+        "maxFileSizeMb": "Tamanho máx. do arquivo (MB)",
+        "rename": {
+          "title": "Renomear arquivos na atualização de metadados",
+          "hint": "Quando ativado, atualizar título, autor, série ou ano renomeará o arquivo físico usando o padrão de nomenclatura da biblioteca."
+        },
+        "write": {
+          "title": "Gravar metadados nos arquivos",
+          "hint": "Quando ativado, salvar os metadados também gravará as alterações de volta no arquivo físico no disco."
+        },
+        "cover": {
+          "title": "Incluir imagem da capa",
+          "hint": "Grava a capa armazenada de volta em formatos de arquivo suportados."
+        },
+        "epub": {
+          "title": "EPUB",
+          "hint": "Grava os metadados no arquivo OPF dentro do arquivo EPUB."
+        },
+        "pdf": {
+          "title": "PDF",
+          "hint": "Incorpora metadados no dicionário Info do PDF e no fluxo XMP."
+        },
+        "cbx": {
+          "title": "Arquivos de quadrinhos (CBX)",
+          "hint": "Grava ComicInfo.xml dentro de arquivos CBZ e CB7."
+        },
+        "audio": {
+          "title": "Áudio",
+          "hint": "Incorpora a capa armazenada em arquivos M4B, M4A, MP3 e FLAC."
+        }
+      },
+      "reading": {
+        "readingStart": {
+          "title": "Início da leitura",
+          "hint": "Um livro é marcado como \"lendo\" assim que atinge esta porcentagem de progresso."
+        },
+        "markAsFinished": {
+          "title": "Marcar como finalizado",
+          "hint": "Um livro é marcado automaticamente como \"lido\" quando atinge esta porcentagem de progresso."
+        }
+      },
+      "schedule": {
+        "fileWatching": "Monitoramento de arquivos",
+        "autoScanSchedule": "Cronograma de verificação automática",
+        "cronExpression": "Expressão Cron",
+        "cronInvalid": "Expressão cron inválida.",
+        "cronFormat": "Formato: minuto hora dia mês dia_da_semana",
+        "watchFolders": {
+          "title": "Monitorar pastas",
+          "hint": "Detectar automaticamente novos arquivos adicionados às pastas da biblioteca."
+        },
+        "presets": {
+          "never": "Nunca",
+          "hourly": "A cada hora",
+          "every6Hours": "A cada 6 horas",
+          "every12Hours": "A cada 12 horas",
+          "daily": "Diariamente",
+          "weekly": "Semanalmente",
+          "custom": "Personalizado"
+        },
+        "human": {
+          "disabled": "Verificação automática desativada",
+          "hourly": "A cada hora",
+          "every6Hours": "A cada 6 horas",
+          "every12Hours": "A cada 12 horas",
+          "dailyMidnight": "Diariamente à meia-noite",
+          "weeklyMonday": "Semanalmente na segunda-feira à meia-noite",
+          "cron": "Cron: {cron}"
+        }
+      },
+      "access": {
+        "title": "Controle de acesso",
+        "description": "Superusuários sempre têm acesso total. Conceda acesso a outros usuários abaixo.",
+        "notYetCreated": "O acesso pode ser configurado depois que a biblioteca for criada.",
+        "selectUser": "Selecione um usuário...",
+        "grant": "Conceder",
+        "empty": "Nenhum acesso concedido a usuários ainda.",
+        "levels": {
+          "viewer": "Visualizador",
+          "editor": "Editor",
+          "owner": "Proprietário"
+        },
+        "columns": {
+          "user": "Usuário",
+          "accessLevel": "Nível de acesso"
+        },
+        "errors": {
+          "grant": "Falha ao conceder acesso",
+          "updateLevel": "Falha ao atualizar o nível de acesso",
+          "revoke": "Falha ao revogar acesso"
+        }
+      }
+    },
+    "folderPicker": {
+      "title": "Procurar pastas",
+      "newFolder": "Nova pasta",
+      "goUp": "Subir um nível",
+      "filterPlaceholder": "Filtrar pastas...",
+      "newFolderNamePlaceholder": "Nome da nova pasta",
+      "create": "Criar",
+      "noFolders": "Nenhuma pasta encontrada",
+      "selectFolder": "Selecionar esta pasta",
+      "errors": {
+        "readDirectory": "Não foi possível ler o diretório",
+        "connect": "Não foi possível conectar",
+        "invalidName": "Insira um único nome de pasta, sem barras ou pontos à esquerda",
+        "createFolder": "Não foi possível criar a pasta"
+      }
+    },
+    "upload": {
+      "library": "Biblioteca",
+      "selectLibrary": "Selecione uma biblioteca...",
+      "targetFolder": "Pasta de destino",
+      "addMoreFiles": "Adicionar mais arquivos",
+      "clearAll": "Limpar tudo",
+      "done": "Concluído",
+      "retry": "Tentar novamente",
+      "upload": "Upload",
+      "uploadWithCount": "Fazer Upload ({count})",
+      "viewInLibrary": "Ver na Biblioteca",
+      "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+      "booksAdded": "nenhum livro adicionado | {count} livro adicionado | {count} livros adicionados",
+      "uploadedFailed": "{done} enviados, {failed} falharam",
+      "progress": "{done} de {total} enviando...",
+      "header": {
+        "uploading": "Enviando...",
+        "complete": "Envio concluído",
+        "uploadTo": "Fazer upload para {library}",
+        "uploadBooks": "Fazer Upload de Livros"
+      },
+      "dropzone": {
+        "title": "Solte os arquivos aqui ou clique para procurar",
+        "hint": "{formats} - até {size} MB cada"
+      }
+    }
+  },
+  "metadataScore": {
+    "missingFields": "nenhum campo ausente - editar metadados | {count} campo ausente - editar metadados | {count} campos ausentes - editar metadados"
+  },
+  "migration": {
+    "sidebarTitle": "Importação do Booklore",
+    "status": {
+      "done": "Concluído",
+      "saved": "Salvo",
+      "running": "Executando",
+      "failed": "Falhou"
+    },
+    "badge": {
+      "validated": "Validado",
+      "upToDate": "Atualizado",
+      "completed": "Concluído"
+    },
+    "steps": {
+      "source": {
+        "short": "Conexão de Origem",
+        "title": "Conexão de Origem",
+        "subtitle": "Configure a conexão do banco de dados com a sua instância Booklore de origem."
+      },
+      "mappings": {
+        "short": "Mapeamento de Usuário e Caminho",
+        "title": "Mapeamento de Usuário e Caminho",
+        "subtitle": "Mapeie usuários de origem para usuários de destino e traduza os caminhos dos arquivos."
+      },
+      "dryRun": {
+        "short": "Teste",
+        "title": "Teste (Dry Run)",
+        "subtitle": "Pré-visualize o que será importado antes de executar a migração definitiva."
+      },
+      "migration": {
+        "short": "Executar Migração",
+        "title": "Executar Migração",
+        "subtitle": "Inicie a importação definitiva e monitore seu progresso."
+      },
+      "report": {
+        "short": "Relatório",
+        "title": "Relatório de Migração",
+        "subtitle": "Revise o que foi importado e exporte um relatório detalhado."
+      }
+    },
+    "footer": {
+      "continueToMappings": "Continuar para Mapeamentos",
+      "continueToDryRun": "Continuar para o Teste",
+      "continueToMigration": "Continuar para Migração",
+      "viewReport": "Ver Relatório",
+      "resetSetup": "Redefinir Configuração",
+      "stepOf": "Passo {current} de {total}",
+      "backToSetup": "Voltar à Configuração"
+    },
+    "stages": {
+      "init": "Inicializando",
+      "sharedOverlays": "Importando metadados",
+      "bookCovers": "Importando capas",
+      "userState": "Importando dados do usuário"
+    },
+    "source": {
+      "testConnection": "Testar Conexão",
+      "saveAndValidate": "Salvar e Validar",
+      "validatedWithWarnings": "Origem validada com avisos",
+      "fields": {
+        "type": "Tipo de Origem",
+        "name": "Nome de Origem",
+        "host": "Host",
+        "port": "Porta",
+        "user": "Usuário",
+        "password": "Senha",
+        "passwordSaved": "Salva - deixe inalterada",
+        "passwordNotSet": "Nenhuma senha definida",
+        "database": "Banco de Dados",
+        "mediaRootPath": "Caminho Raiz de Mídia",
+        "ssl": "Usar TLS/SSL"
+      },
+      "mediaPath": {
+        "hintRequired": "Obrigatório para migração de capas de livros.",
+        "hintAbsolute": "Use um caminho absoluto (exemplo: /books). Caminhos relativos não são suportados.",
+        "hintConfigured": "Caminho de importação de capa configurado. Use Testar Conexão para verificar o acesso e a estrutura de pastas de imagens do Booklore.",
+        "buttonOk": "Caminho OK",
+        "buttonIssue": "Problema no Caminho",
+        "buttonTest": "Testar Caminho"
+      },
+      "compatibility": {
+        "title": "Compatibilidade testada",
+        "verifiedAgainst": "Verificado contra:",
+        "note": "Versões posteriores são provavelmente compatíveis, mas não foram verificadas. Execute um teste primeiro para confirmar antes de confirmar os dados."
+      },
+      "snapshot": {
+        "title": "Último instantâneo de validação",
+        "sourceVersion": "Versão de origem: {version}",
+        "unknown": "Desconhecido",
+        "missingTables": "Tabelas obrigatórias ausentes: {tables}"
+      }
+    },
+    "mappings": {
+      "suggestionsAutoLoad": "As sugestões de usuário são carregadas automaticamente após a validação da origem.",
+      "refresh": "Atualizar",
+      "sourceUser": "Usuário de Origem",
+      "targetUser": "Usuário de Destino",
+      "noSourceUsersLoaded": "Nenhum usuário de origem carregado ainda.",
+      "noActiveTargetUsers": "Nenhum usuário de destino ativo encontrado. Crie ou reative um usuário BookOrbit antes de mapear.",
+      "pathPrefixMappings": "Mapeamentos de Prefixo de Caminho",
+      "addMapping": "Adicionar Mapeamento",
+      "pathMappingsExplanation": "Os mapeamentos de caminho traduzem os caminhos dos arquivos de origem para os caminhos de destino, para que os livros possam ser correspondidos pelo local do arquivo. Os livros também são correspondidos por ISBN, hash de arquivo e título/autor independentemente dos mapeamentos de caminho.",
+      "noPrefixesFound": "Nenhum prefixo encontrado - valide a origem primeiro",
+      "selectSourcePrefix": "Selecione o prefixo de origem...",
+      "selectTargetFolder": "Selecione a pasta de destino...",
+      "remove": "Remover",
+      "saveMappings": "Salvar Mapeamentos",
+      "pathValidation": {
+        "title": "Validação de caminho",
+        "mappedSummary": "{mapped} de {total} livros de origem têm um caminho mapeado",
+        "unmatched": "{count} caminhos mapeados não encontrados no disco",
+        "allMatched": "Todos os {count} caminhos mapeados encontrados no disco"
+      }
+    },
+    "dryRun": {
+      "run": "Executar Teste",
+      "matched": "Correspondidos:",
+      "unresolved": "Não resolvidos:",
+      "duplicates": "Duplicatas:",
+      "unresolvedSummary": "Resumo de não resolvidos"
+    },
+    "duplicates": {
+      "title": "Resolver correspondências de destino duplicadas",
+      "explanation": "Para cada livro de destino, escolha um livro de origem para manter. Opções recomendadas são pré-selecionadas quando há uma única correspondência mais forte.",
+      "remainingGroups": "Grupos restantes:",
+      "ofCount": "de {total}",
+      "targetBookId": "Livro de destino #{id}",
+      "recommended": "Recomendado",
+      "resolveButton": "Resolver {count} duplicata | Resolver {count} duplicata | Resolver {count} duplicatas",
+      "sourceRecordId": "ID do registro de origem #{id}",
+      "byAuthor": "por {author} (ID: {id})",
+      "byFilePath": "{filePath} (ID: {id})",
+      "bookloreSourceId": "ID de origem Booklore: {id}",
+      "libraryBookId": "Livro da biblioteca #{id}"
+    },
+    "preflight": {
+      "title": "Verificações de pré-voo",
+      "allPassed": "Todas as verificações aprovadas - pronto para migrar",
+      "sourceValidated": "Origem validada",
+      "saveAndValidateSource": "Salvar e validar conexão de origem",
+      "validateSourceConnection": "Validar conexão de origem",
+      "mappingsSaved": "Mapeamentos salvos",
+      "saveUserAndPathMappings": "Salvar mapeamentos de usuário e caminho",
+      "pathMappingsValidated": "Mapeamentos de caminho validados",
+      "savePathMappingsToValidate": "Salvar mapeamentos de caminho para validá-los",
+      "dryRunUpToDate": "O teste está atualizado",
+      "runFreshDryRun": "Executar um novo teste",
+      "issues": {
+        "saveSource": "Salvar configurações de conexão de origem",
+        "validateSource": "Validar conexão de origem",
+        "saveMappings": "Salvar mapeamentos de usuário e caminho",
+        "savePathMappings": "Salvar mapeamentos de caminho para validá-los",
+        "freshDryRun": "Executar um novo teste",
+        "resolveDuplicates": "Resolver correspondências duplicadas de livros de destino no teste",
+        "waitForRun": "Aguardar a execução ativa terminar"
+      }
+    },
+    "run": {
+      "confirmPrompt": "Isso iniciará a migração definitiva. Tem certeza?",
+      "confirmStart": "Confirmar Início",
+      "startMigration": "Iniciar Migração",
+      "cancelRun": "Cancelar Execução",
+      "refreshStatus": "Atualizar Status",
+      "pollingStopped": "A sondagem de status parou devido a um erro.",
+      "retry": "Tentar novamente",
+      "stage": "Estágio: {stage}",
+      "initializing": "inicializando",
+      "ended": "Terminou em {time}"
+    },
+    "report": {
+      "noRunYet": "Nenhuma execução de migração ainda. Conclua as etapas acima para iniciar.",
+      "runNumber": "Execução #{id}",
+      "notStarted": "Não iniciada",
+      "reloadReport": "Recarregar Relatório",
+      "loadFullReport": "Carregar Relatório Completo",
+      "exportJson": "Exportar JSON",
+      "exportCsv": "Exportar CSV",
+      "migrationFailed": "Falha na migração",
+      "retryFromLastStage": "Tentar novamente a partir do último estágio concluído",
+      "booksSection": "Livros",
+      "metadataOverlays": "Sobreposições de metadados aplicadas",
+      "authorMappings": "Mapeamentos de autor substituídos",
+      "narratorMappings": "Mapeamentos de narrador substituídos",
+      "genreMappings": "Mapeamentos de gênero substituídos",
+      "tagMappings": "Mapeamentos de tag substituídos",
+      "coversImported": "Capas importadas",
+      "coverImportSkipped": "Importação de capa ignorada - caminho raiz de mídia não configurado",
+      "couldNotMatch": "Não foi possível corresponder",
+      "userDataSection": "Dados do Usuário",
+      "readingStatuses": "Status de leitura",
+      "readingProgressEntries": "Entradas de progresso de leitura",
+      "audiobookProgressEntries": "Entradas de progresso de audiobook",
+      "readingSessions": "Sessões de leitura",
+      "bookmarks": "Favoritos",
+      "annotations": "Anotações",
+      "collectionEntries": "Entradas de coleção",
+      "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência do teste no relatório exportado.",
+      "completedNoIssues": "Migração concluída sem livros não resolvidos ou falhas.",
+      "matchedBooks": "Livros correspondidos ({count})",
+      "matchedBooksExplanation": "Estas correspondências do teste foram usadas para decidir quais livros da biblioteca receberam dados importados.",
+      "sourceBook": "Livro de origem {id}",
+      "libraryBook": "Livro da biblioteca {id}",
+      "unresolvedBooks": "Livros não resolvidos ({count})",
+      "unresolvedBooksExplanation": "Estes livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
+      "mappedUsers": "Usuários mapeados ({count})",
+      "mappedUsersExplanation": "Os totais por usuário vêm da pré-visualização do teste armazenada em cache com o plano de migração.",
+      "coverFailures": "{count} importação(ões) de capa falhou(aram). As linhas de falha detalhadas não são armazenadas.",
+      "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {sessions} sessões de leitura, {bookmarks} favoritos, {annotations} anotações, {collections} entradas de coleção"
+    },
+    "unresolvedReason": {
+      "noTitleAuthorMatch": "Nenhum livro correspondente encontrado por título ou autor",
+      "noFilePathMatch": "O caminho do arquivo não corresponde a nenhum livro nesta biblioteca",
+      "noFileHashMatch": "O hash do arquivo não corresponde a nenhum livro nesta biblioteca",
+      "noIsbnMatch": "O ISBN não corresponde a nenhum livro nesta biblioteca",
+      "insufficientSourceData": "Metadados insuficientes para tentar a correspondência",
+      "ambiguousIsbnMatch": "Múltiplos livros correspondem ao mesmo ISBN",
+      "ambiguousFileHashMatch": "Múltiplos livros correspondem ao mesmo hash de arquivo",
+      "ambiguousFilePathMatch": "Múltiplos livros correspondem ao mesmo caminho de arquivo",
+      "ambiguousTitleAuthorMatch": "Múltiplos livros correspondem ao mesmo título e autor",
+      "unknown": "Não foi possível determinar o motivo"
+    },
+    "matchStrategy": {
+      "isbn": "Correspondido por ISBN",
+      "fileHash": "Correspondido por hash de arquivo",
+      "pathMapping": "Correspondido por caminho de arquivo mapeado",
+      "titleAuthor": "Correspondido por título e autor",
+      "unavailable": "Estratégia de correspondência indisponível"
+    },
+    "connectionError": {
+      "unreachable": "Não foi possível acessar o servidor de banco de dados. Verifique o host e a porta.",
+      "authFailed": "Falha na autenticação. Verifique o nome de usuário e a senha.",
+      "databaseNotFound": "Banco de dados não encontrado. Verifique o nome do banco de dados.",
+      "timeout": "A conexão expirou. Verifique as configurações de host e firewall.",
+      "generic": "O teste de conexão falhou"
+    },
+    "userSelect": {
+      "placeholder": "Selecionar usuário",
+      "noUsersFound": "Nenhum usuário encontrado"
+    },
+    "toast": {
+      "initFailed": "Falha ao inicializar configurações de migração",
+      "loadSupportedTypesFailed": "Falha ao carregar tipos de origem de migração suportados",
+      "loadTargetUsersFailed": "Falha ao carregar usuários de destino",
+      "loadTargetFoldersFailed": "Falha ao carregar pastas da biblioteca de destino",
+      "noSourceUsers": "Nenhum usuário de origem foi retornado",
+      "suggestionsLoaded": "Sugestões de mapeamento de usuário carregadas",
+      "loadSuggestionsFailed": "Falha ao carregar sugestões de mapeamento de usuário",
+      "sourceFieldsRequired": "Host, usuário, banco de dados e nome de origem são obrigatórios",
+      "connectionPassedWithWarnings": "Teste de conexão concluído com avisos",
+      "connectionPassedWithWarningCount": "Teste de conexão concluído com {count} aviso(s). Primeiro: {warning}",
+      "connectionPassed": "Teste de conexão aprovado",
+      "connectionMissingTables": "Conexão ok, mas {count} tabela(s) obrigatória(s) estão ausentes",
+      "cannotTestMediaWhileRunning": "Não é possível testar o caminho de mídia enquanto uma execução estiver ativa",
+      "mediaPathRequired": "Caminho Raiz de Mídia é obrigatório para importação de capa.",
+      "mediaPathAbsolute": "Use um caminho absoluto (por exemplo: /books).",
+      "mediaPathVerified": "Caminho de mídia verificado.",
+      "mediaPathValid": "O caminho de mídia é válido e legível",
+      "mediaPathValidationFailed": "A validação do caminho de mídia falhou.",
+      "connectionFailedBeforeMedia": "O teste de conexão falhou antes que a validação do caminho de mídia pudesse ser concluída.",
+      "cannotModifySourceWhileRunning": "Não é possível modificar a origem enquanto uma execução estiver ativa",
+      "sourceSavedWithWarnings": "Origem salva e validada com {count} aviso(s)",
+      "sourceSaved": "Origem salva e validada",
+      "saveSourceFailed": "Falha ao salvar ou validar origem",
+      "cannotSaveMappingsWhileRunning": "Não é possível salvar mapeamentos enquanto uma execução estiver ativa",
+      "saveSourceFirst": "Salvar origem primeiro",
+      "mapAtLeastOneUser": "Mapeie pelo menos um usuário de origem para um usuário de destino",
+      "mapEveryUser": "Mapeie todos os usuários de origem antes de salvar",
+      "pathValidationFailedButSaved": "A validação do caminho falhou, mas o perfil ainda será salvo",
+      "mappingsSaved": "Mapeamentos salvos",
+      "saveMappingsFailed": "Falha ao salvar mapeamentos",
+      "cannotDryRunWhileRunning": "Não é possível executar o teste enquanto uma execução estiver ativa",
+      "saveMappingsFirst": "Salvar mapeamentos primeiro",
+      "dryRunCompleted": "Teste concluído: {matched} correspondências, {unresolved} não resolvidos",
+      "dryRunFailed": "Falha no teste",
+      "selectSourceForDuplicates": "Selecione um livro de origem para todos os {count} grupos duplicados",
+      "duplicatesResolved": "Correspondências duplicadas resolvidas",
+      "resolveDuplicatesFailed": "Falha ao resolver duplicatas",
+      "preflightNotReady": "Pré-verificação de migração não pronta",
+      "runDryRunFirst": "Execute o teste primeiro",
+      "runStarted": "Execução de migração iniciada",
+      "startFailed": "Falha ao iniciar migração",
+      "runCancelled": "Execução de migração cancelada",
+      "cancelFailed": "Falha ao cancelar migração",
+      "runRetried": "Execução de migração repetida - retomando do último estágio concluído",
+      "retryFailed": "Falha ao repetir migração",
+      "loadProgressFailed": "Falha ao carregar progresso da execução",
+      "startMigrationFirst": "Inicie a migração primeiro",
+      "reportRefreshed": "Relatório de execução atualizado",
+      "loadReportFailed": "Falha ao carregar relatório de execução",
+      "reportExported": "Relatório exportado como {format}",
+      "exportFailed": "Falha ao exportar relatório de migração"
+    }
+  },
+  "notifications": {
+    "title": "Notificações",
+    "markAllRead": "Marcar tudo como lido",
+    "clear": "Limpar",
+    "empty": "Nenhuma notificação ainda",
+    "loadMore": "Carregar mais notificações",
+    "preferences": {
+      "title": "Notificações",
+      "subtitle": "Escolha quais categorias de notificação você deseja receber.",
+      "saving": "Salvando...",
+      "unsavedChanges": "Alterações não salvas",
+      "saved": "Preferências de notificação salvas",
+      "saveFailed": "Falha ao salvar preferências",
+      "savePreferenceFailed": "Falha ao salvar preferência",
+      "whatsNewToggle": "Mostrar \"O que há de novo\" após atualizações",
+      "whatsNewToggleHint": "Um pop-up destacando novos recursos após a atualização do aplicativo. O arquivo continua disponível de qualquer maneira."
+    }
+  },
+  "reader": {
+    "retry": "Tentar novamente",
+    "loadingBook": "Carregando livro...",
+    "failedToLoadBook": "Falha ao carregar livro",
+    "chapterNumber": "Capítulo {number}",
+    "peek": {

--- a/packages/types/src/locale.ts
+++ b/packages/types/src/locale.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_LOCALES = ["en", "de", "nl", "sl"] as const;
+export const SUPPORTED_LOCALES = ["en", "de", "nl", "pt", "sl"] as const;
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 
 export const DEFAULT_LOCALE: Locale = "en";
@@ -8,6 +8,7 @@ export const LOCALE_LABELS: Record<Locale, string> = {
   en: "English",
   de: "Deutsch",
   nl: "Nederlands",
+  pt: "Português",
   sl: "Slovenščina",
 };
 
@@ -15,6 +16,7 @@ export const LOCALE_DIRECTIONS: Record<Locale, "ltr" | "rtl"> = {
   en: "ltr",
   de: "ltr",
   nl: "ltr",
+  pt: "ltr",
   sl: "ltr",
 };
 


### PR DESCRIPTION
What does this PR do?
Adds Portuguese (PT-BR) language localization files and integrates them into the project.
Closes #673 

How did you test this?
Changes were made via the GitHub Web UI. Verified the JSON syntax of the new translation files and ensured the keys perfectly match the existing English localization structure.

Screenshots
N/A - Translation files and basic UI selector update.

Anything non-obvious in the diff?
No. Standard localization mapping.

Checklist
[x] I've read through my own diff
[x] This PR was discussed in an issue and has maintainer approval (for new features)
[x] Lint and tests pass locally
[x] No unintended files included (build artifacts, .env, personal configs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Portuguese language support across the application.
  * Translated interface labels, settings, authentication, reading, library, synchronization, notifications, and other major areas.
  * Added Portuguese to the available language options with correct display and text direction settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->