### PR TITLE
feat(client): add Portuguese language localization

### DIFF
--- a/client/src/features/book/components/detail/SeriesBooksRow.vue
+++ b/client/src/features/book/components/detail/SeriesBooksRow.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { watch, computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import { useSeriesBooks } from '@/features/book/composables/useSeriesBooks'
 import BookCarousel from '@/features/book/components/detail/BookCarousel.vue'
@@ -10,7 +9,6 @@ const props = defineProps<{
   seriesName: string
 }>()
 
-const { t } = useI18n()
 const { seriesBooks, loading, fetch } = useSeriesBooks()
 
 watch(
@@ -29,8 +27,11 @@ defineExpose({ bookIds })
     <BookCarousel :books="seriesBooks" :loading="loading" :current-book-id="bookId" :show-series-index="true">
       <template #header>
         <p class="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
-          {{ t('book.detail.series.moreInSeriesPrefix') }} <span class="italic">{{ seriesName }}</span>
-          {{ t('book.detail.series.moreInSeriesSuffix') }}
+          <i18n-t keypath="book.detail.series.moreInSeries" scope="global">
+            <template #series>
+              <span class="italic">{{ seriesName }}</span>
+            </template>
+          </i18n-t>
         </p>
       </template>
     </BookCarousel>

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -3095,8 +3095,7 @@
         "moreLikeThis": "Mehr davon"
       },
       "series": {
-        "moreInSeriesPrefix": "Mehr aus der",
-        "moreInSeriesSuffix": "Reihe"
+        "moreInSeries": "Mehr aus der Reihe {series}"
       },
       "writeRename": {
         "written": "keine Felder geschrieben | Geschrieben (ein Feld) | Geschrieben ({count} Felder)",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -3089,8 +3089,7 @@
         "moreLikeThis": "More Like This"
       },
       "series": {
-        "moreInSeriesPrefix": "More in the",
-        "moreInSeriesSuffix": "series"
+        "moreInSeries": "More in the {series} series"
       },
       "writeRename": {
         "written": "no fields written | Written (one field) | Written ({count} fields)",

--- a/client/src/locales/nl.json
+++ b/client/src/locales/nl.json
@@ -3100,8 +3100,7 @@
         "moreLikeThis": "Meer zoals dit"
       },
       "series": {
-        "moreInSeriesPrefix": "Meer in de",
-        "moreInSeriesSuffix": "reeks"
+        "moreInSeries": "Meer in de reeks {series}"
       },
       "writeRename": {
         "written": "geen velden geschreven | Geschreven (één veld) | Geschreven ({count} velden)",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1,0 +1,6251 @@
+{
+  "common": {
+    "resetSortAria": "Restaurar ordenação padrão",
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "close": "Fechar",
+    "confirm": "Confirmar",
+    "loading": "Carregando...",
+    "search": "Buscar",
+    "back": "Voltar",
+    "next": "Próximo",
+    "previous": "Anterior",
+    "retry": "Tentar novamente",
+    "yes": "Sim",
+    "no": "Não"
+  },
+  "settings": {
+    "privacySharing": {
+      "title": "Privacidade e Compartilhamento",
+      "subtitle": "Controle se os administradores podem ver um resumo identificável da sua atividade de leitura.",
+      "levelLegend": "Nível de compartilhamento de insights de leitura",
+      "current": "Configuração atual",
+      "levels": {
+        "private": { "title": "Privado", "description": "Apenas você pode ver suas estatísticas de leitura." },
+        "summary": {
+          "title": "Compartilhar resumo",
+          "description": "Compartilhar hábitos agregados sem títulos de livros, autores, séries ou narradores."
+        },
+        "detailed": {
+          "title": "Compartilhar insights detalhados",
+          "description": "Compartilhar também livros, autores, séries, gêneros e narradores recentes e mais lidos."
+        }
+      },
+      "fields": {
+        "frequency": "Frequência de leitura e dias ativos",
+        "completion": "Total de livros iniciados e concluídos",
+        "formats": "Distribuição de formatos",
+        "genres": "Distribuição geral de gêneros",
+        "trend": "Tendência geral de leitura",
+        "books": "Títulos de livros atuais, recentes e mais lidos",
+        "authors": "Principais autores",
+        "series": "Principais séries",
+        "narrators": "Principais narradores"
+      },
+      "confirm": {
+        "shareTitle": "Ativar {level}?",
+        "shareDescription": "Administradores com permissão poderão ver as seguintes informações.",
+        "stopTitle": "Parar de compartilhar insights de leitura?",
+        "stopDescription": "O acesso do administrador será bloqueado imediatamente. Os registros de acesso existentes permanecem no seu histórico.",
+        "recordedNotice": "Cada visualização do perfil por um administrador é registrada e aparece no seu histórico de acesso."
+      },
+      "preview": {
+        "title": "Pré-visualizar seu perfil compartilhado",
+        "description": "Veja as informações atualmente disponíveis para administradores autorizados.",
+        "action": "Carregar pré-visualização",
+        "readingTime": "Tempo de leitura",
+        "activeDays": "Dias ativos",
+        "started": "Livros iniciados",
+        "completed": "Livros concluídos",
+        "topBooks": "Livros mais lidos"
+      },
+      "history": {
+        "title": "Histórico de acesso ao perfil",
+        "description": "Visualizações recentes do seu perfil de leitura compartilhado por administradores.",
+        "empty": "Nenhum administrador visualizou seu perfil de leitura compartilhado.",
+        "paginationLabel": "Páginas do histórico de acesso ao perfil"
+      },
+      "durationMinutes": "{count} minuto | {count} minutos",
+      "durationHours": "{count} horas",
+      "unknownTitle": "Livro sem título",
+      "errors": {
+        "load": "Falha ao carregar configurações de compartilhamento.",
+        "save": "Falha ao atualizar configurações de compartilhamento.",
+        "preview": "Falha ao carregar a pré-visualização do perfil compartilhado."
+      }
+    },
+    "appearance": {
+      "language": {
+        "title": "Idioma",
+        "description": "Escolha o idioma usado em toda a interface.",
+        "label": "Idioma da interface",
+        "loadError": "Falha ao carregar o idioma selecionado",
+        "saveError": "Falha ao salvar preferência de idioma"
+      },
+      "pageTitle": "Exibição",
+      "pageSubtitle": "Controle temas, capas, layout e como sua biblioteca é apresentada.",
+      "mobileSummary": "Tema: {theme} • Destaque: {accent} • Fundo: {background}",
+      "themeMode": {
+        "light": "Claro",
+        "dark": "Escuro"
+      },
+      "theme": {
+        "title": "Tema",
+        "colorScheme": {
+          "label": "Esquema de cores",
+          "hint": "Interface clara ou escura"
+        },
+        "accentColor": {
+          "label": "Cor de destaque",
+          "hint": "Controla realces e elementos interativos"
+        },
+        "cornerRadius": {
+          "label": "Arredondamento das bordas",
+          "hint": "Arredondamento de cartões e elementos da interface"
+        },
+        "surfaceBrightness": {
+          "label": "Brilho da superfície",
+          "hint": "Clarear superfícies no modo escuro",
+          "reset": "Restaurar"
+        },
+        "libraryBackground": {
+          "title": "Fundo da Biblioteca",
+          "pattern": {
+            "label": "Padrão de fundo",
+            "hint": "Padrão exibido atrás da grade de livros"
+          }
+        },
+        "backgroundGroups": {
+          "fundamental": "Fundamental",
+          "structural": "Estrutural",
+          "ambient": "Ambiente",
+          "refractive": "Refrativo"
+        }
+      },
+      "storage": {
+        "title": "Onde salvar as preferências de aparência",
+        "active": "Ativo",
+        "notAvailable": "Não disponível",
+        "device": {
+          "title": "Apenas neste dispositivo",
+          "description": "As preferências ficam no seu navegador. Ideal se você quiser uma aparência diferente em dispositivos diferentes."
+        },
+        "account": {
+          "title": "Minha conta",
+          "description": "As preferências são salvas na sua conta. Ideal se você quiser a mesma aparência em todos os dispositivos."
+        },
+        "toasts": {
+          "synced": "As preferências agora serão sincronizadas",
+          "local": "As preferências permanecerão neste dispositivo"
+        },
+        "errors": {
+          "demoRestricted": "A conta restrita de demonstração não pode alterar o modo de armazenamento do tema",
+          "update": "Falha ao atualizar o modo de armazenamento",
+          "generic": "Ocorreu um erro ao atualizar o modo de armazenamento"
+        }
+      },
+      "bookCovers": {
+        "title": "Capas dos Livros",
+        "displayMode": {
+          "title": "Modo de exibição da capa",
+          "hint": "Controle como as capas reais se encaixam nos espaços dos livros quando as proporções são diferentes",
+          "blurredFit": {
+            "label": "Ajuste com desfoque",
+            "hint": "Exibir a capa inteira com um preenchimento desfocado ao fundo"
+          },
+          "fillCrop": {
+            "label": "Preencher cartão",
+            "hint": "Preencher todo o espaço cortando as bordas quando as proporções forem diferentes"
+          },
+          "naturalBottom": {
+            "label": "Base natural",
+            "hint": "Manter a proporção original da capa e fixá-la na parte inferior"
+          }
+        },
+        "spine": {
+          "title": "Sobreposição de lombada do livro",
+          "hint": "Adiciona uma lombada estilizada e efeito de brilho aos cartões de capa",
+          "off": {
+            "label": "Desativado",
+            "hint": "Sem efeito de lombada/brilho nas capas"
+          },
+          "subtle": {
+            "label": "Sutil",
+            "hint": "Lombada e brilho leves, mais próximos do visual padrão"
+          },
+          "strong": {
+            "label": "Forte",
+            "hint": "Tratamento de lombada e brilho mais pronunciado"
+          }
+        },
+        "showSpineOnComics": {
+          "label": "Exibir lombada em quadrinhos",
+          "hint": "Aplicar o efeito de lombada e brilho em capas de quadrinhos (cbz, cbr, cb7)"
+        },
+        "shadow": {
+          "title": "Intensidade da sombra da capa",
+          "hint": "Controle a profundidade sob as capas na grade, lista, tabela e miniaturas do painel",
+          "default": {
+            "label": "Padrão",
+            "hint": "Elevação e profundidade atuais"
+          },
+          "strong": {
+            "label": "Forte",
+            "hint": "Sombra projetada mais pesada, estilo prateleira, sob as capas"
+          }
+        },
+        "overlays": {
+          "title": "Sobreposições nos cartões",
+          "hint": "Escolha os metadados exibidos diretamente nos cartões de capa dos livros",
+          "progressBar": {
+            "label": "Barra de progresso",
+            "hint": "Linha colorida fina ao longo da borda inferior"
+          },
+          "format": {
+            "label": "Formato do arquivo",
+            "hint": "Emblema codificado por cores (EPUB, PDF, CBZ) no canto inferior direito"
+          },
+          "rating": {
+            "label": "Avaliação",
+            "hint": "Indicador de avaliação por estrelas no canto inferior esquerdo"
+          },
+          "readStatus": {
+            "label": "Status de leitura",
+            "hint": "Ícone colorido mostrando o status de leitura atual no canto superior esquerdo"
+          },
+          "seriesPosition": {
+            "label": "Número na série",
+            "hint": "Emblema mostrando a posição do livro na série no canto superior direito (ex: #3, #1.5)"
+          },
+          "lockStatus": {
+            "label": "Status de bloqueio",
+            "hint": "Ícone de bloqueio de metadados no canto superior direito - laranja quando bloqueado, verde quando desbloqueado"
+          }
+        }
+      },
+      "layout": {
+        "coverSize": "Tamanho da capa",
+        "gridSpacing": "Espaçamento da grade",
+        "gridLayout": {
+          "title": "Layout da Grade da Biblioteca"
+        },
+        "coverSizeBehavior": {
+          "label": "Comportamento do tamanho da capa",
+          "hint": "Controle se os tamanhos retrato/quadrado e o espaçamento da grade são compartilhados entre todas as visualizações ou mantidos por visualização",
+          "perViewHint": "Modo por visualização: ajuste o tamanho da capa e o espaçamento em cada painel de Exibição da visualização.",
+          "syncAll": "Sincronizar todas as visualizações",
+          "perView": "Tamanhos por visualização"
+        },
+        "portraitCoverSize": {
+          "label": "Tamanho da capa retrato",
+          "hint": "Usado para bibliotecas e visualizações em modo retrato"
+        },
+        "squareCoverSize": {
+          "label": "Tamanho da capa quadrada",
+          "hint": "Usado para bibliotecas e visualizações em modo quadrado"
+        },
+        "portraitGridSpacing": {
+          "label": "Espaçamento da grade retrato",
+          "hint": "Espaço entre capas retrato"
+        },
+        "squareGridSpacing": {
+          "label": "Espaçamento da grade quadrada",
+          "hint": "Espaço entre capas quadradas"
+        },
+        "cardInfoMode": {
+          "label": "Modo de informação do cartão",
+          "hint": "Onde exibir o título e o autor do livro nos cartões da grade",
+          "onHover": "Ao passar o mouse",
+          "belowCover": "Abaixo da capa",
+          "off": "Desativado"
+        },
+        "primaryCardLabel": {
+          "label": "Rótulo primário do cartão",
+          "hint": "Texto exibido abaixo de cada capa de livro (primeira linha)"
+        },
+        "secondaryCardLabel": {
+          "label": "Rótulo secundário do cartão",
+          "hint": "Texto adicional abaixo do rótulo primário (segunda linha)"
+        },
+        "labelField": {
+          "hidden": "Oculto",
+          "bookTitle": "Título do livro",
+          "seriesTitle": "Título da série",
+          "seriesTitlePosition": "Título da série + posição",
+          "author": "Autor"
+        },
+        "seriesDisplay": {
+          "title": "Exibição de Séries",
+          "collapsedCover": {
+            "label": "Capa da série recolhida",
+            "hint": "Escolha qual capa exibir quando as séries estiverem recolhidas na grade de livros"
+          },
+          "stack": "Pilha",
+          "mosaic": "Mosaico",
+          "first": "Primeiro",
+          "latest": "Mais recente",
+          "firstUnread": "Primeiro não lido"
+        },
+        "authorGrid": {
+          "title": "Grade de Autores",
+          "coverSize": {
+            "label": "Tamanho da capa",
+            "hint": "Largura das capas dos autores na grade"
+          },
+          "coverShape": {
+            "label": "Formato da capa",
+            "hint": "Formato das capas dos autores na grade"
+          },
+          "circle": "Círculo",
+          "square": "Quadrado"
+        },
+        "listTableViews": {
+          "title": "Visualizações em Lista e Tabela"
+        },
+        "zebraStriping": {
+          "label": "Linhas zebradas",
+          "hint": "Alternar cores de fundo das linhas para facilitar a leitura"
+        }
+      },
+      "behavior": {
+        "title": "Comportamento da Biblioteca",
+        "thumbnailClicks": {
+          "label": "Cliques na miniatura",
+          "hint": "Escolha o que acontece ao abrir um livro a partir das visualizações em grade e lista",
+          "readFirst": "Ler primeiro",
+          "readFirstHint": "Abrir o leitor quando existir um arquivo legível",
+          "openDetails": "Abrir detalhes",
+          "openDetailsHint": "Ir para a página de detalhes do livro a partir das miniaturas de grade e lista"
+        },
+        "filterPreview": {
+          "label": "Exibir pré-visualização do filtro por padrão",
+          "hint": "Expandir o resumo do filtro e ordenação ativos ao abrir um escopo inteligente (smartScope)"
+        },
+        "collapseSeries": {
+          "label": "Recolher séries por padrão",
+          "hint": "Agrupar livros da mesma série em um único cartão nas visualizações de biblioteca e coleção"
+        }
+      },
+      "icons": {
+        "title": "Ícones Personalizados",
+        "uploadIcons": "Enviar ícones",
+        "uploadedCount": "nenhum ícone enviado | {count} ícone enviado | {count} ícones enviados",
+        "searchPlaceholder": "Buscar ícones",
+        "sort": {
+          "newest": "Mais recentes",
+          "name": "Nome"
+        },
+        "selectedCount": "{count} selecionado(s)",
+        "clear": "Limpar",
+        "deleteSelected": "Excluir selecionados",
+        "loading": "Carregando ícones...",
+        "emptySearch": "Nenhum ícone corresponde à sua busca.",
+        "emptyNoIcons": "Nenhum ícone personalizado enviado ainda.",
+        "namePlaceholder": "Nome",
+        "checkingUsage": "Verificando uso...",
+        "usedBy": "Usado por {count}",
+        "notUsedYet": "Não usado ainda",
+        "rename": "Renomear",
+        "replace": "Substituir",
+        "usage": {
+          "libraries": "nenhuma biblioteca | {count} biblioteca | {count} bibliotecas",
+          "collections": "nenhuma coleção | {count} coleção | {count} coleções",
+          "smartScopes": "nenhum escopo inteligente | {count} escopo inteligente | {count} escopos inteligentes"
+        },
+        "confirm": {
+          "deleteOne": "Excluir \"{name}\"? Os usos existentes reverterão para o ícone padrão.",
+          "deleteMany": "Excluir nenhum ícone? | Excluir {count} ícone? Os usos existentes reverterão para o ícone padrão. | Excluir {count} ícones? Os usos existentes reverterão para o ícone padrão."
+        },
+        "toasts": {
+          "saved": "Ícone salvo",
+          "updated": "Ícone atualizado",
+          "deleted": "Ícone excluído",
+          "bulkDeleted": "Nenhum ícone excluído | Excluído {count} ícone | Excluídos {count} ícones",
+          "bulkDeletePartial": "Excluído(s) {deleted}, {failed} falhou(aram)"
+        },
+        "errors": {
+          "load": "Falha ao carregar ícones",
+          "save": "Falha ao salvar ícone",
+          "replace": "Falha ao substituir ícone",
+          "delete": "Falha ao excluir ícone",
+          "bulkDelete": "Falha ao excluir ícones"
+        }
+      },
+      "tabs": {
+        "theme": "Tema",
+        "book-covers": "Capas dos Livros",
+        "icons": "Ícones",
+        "layout": "Layout",
+        "behavior": "Comportamento"
+      }
+    },
+    "account": {
+      "title": "Conta",
+      "subtitle": "Gerencie as configurações do seu perfil pessoal.",
+      "subtitleAll": "Gerencie seu perfil e preferências de notificação.",
+      "tabs": {
+        "profile": "Perfil",
+        "privacy": "Privacidade e Compartilhamento",
+        "notifications": "Notificações",
+        "restrictions": "Restrições"
+      },
+      "demoRestricted": {
+        "cannotEdit": "A conta restrita de demonstração não pode editar as configurações da conta",
+        "notice": "Conta restrita de demonstração: a edição de perfil, senha, avatar e identidades vinculadas está desativada."
+      },
+      "feedback": {
+        "unsavedChanges": "Alterações não salvas",
+        "allSaved": "Todas as alterações foram salvas"
+      },
+      "profile": {
+        "securityHeading": "Perfil e Segurança",
+        "username": "Nome de usuário",
+        "fullName": "Nome completo",
+        "email": "E-mail",
+        "emailHint": "Entre em contato com um administrador para alterar seu endereço de e-mail.",
+        "save": "Salvar perfil",
+        "saving": "Salvando...",
+        "changePassword": "Alterar senha",
+        "accountType": "Tipo de conta:",
+        "accountTypeOidc": "OIDC / SSO",
+        "accountTypeShared": "Compartilhada",
+        "accountTypeLocal": "Local",
+        "nameRequired": "O nome é obrigatório",
+        "updateFailed": "Falha ao atualizar o perfil",
+        "updated": "Perfil atualizado"
+      },
+      "readingPreferences": {
+        "title": "Preferências de Leitura",
+        "timezoneHint": "O fuso horário é usado para conquistas sensíveis ao tempo, como Madrugador e Corujão.",
+        "timezone": "Fuso horário",
+        "save": "Salvar preferências",
+        "enableAchievements": "Ativar conquistas",
+        "enableAchievementsHint": "Acompanhe o progresso das conquistas e exiba a interface relacionada a elas. Gerencie as notificações de conquistas separadamente em Notificações."
+      },
+      "preferences": {
+        "saveFailed": "Falha ao salvar preferências",
+        "saved": "Preferências salvas"
+      },
+      "avatar": {
+        "title": "Foto do Perfil",
+        "unknownUser": "Usuário desconhecido",
+        "formatHint": "PNG/JPEG/WEBP de até {size} MB",
+        "upload": "Enviar foto",
+        "replace": "Substituir foto",
+        "uploading": "Enviando...",
+        "remove": "Remover foto",
+        "removing": "Removendo...",
+        "updated": "Foto do perfil atualizada",
+        "uploadFailed": "Falha ao enviar a foto do perfil",
+        "removed": "Foto do perfil removida",
+        "removeFailed": "Falha ao remover a foto do perfil",
+        "removeConfirm": {
+          "title": "Remover foto do perfil?",
+          "description": "Seu avatar será removido e substituído por iniciais.",
+          "confirm": "Remover"
+        }
+      },
+      "connectedAccounts": {
+        "title": "Contas Conectadas",
+        "unlink": "Desvincular",
+        "unlinking": "Desvinculando...",
+        "linkAdditional": "Vincular provedores adicionais:",
+        "linkProvider": "Vincular {provider}",
+        "redirecting": "Redirecionando...",
+        "noneConfigured": "Nenhum provedor OIDC está configurado. Peça a um administrador para configurar o SSO.",
+        "linkStateFailed": "Falha ao gerar o estado de vinculação",
+        "startLinkFailed": "Falha ao iniciar a vinculação OIDC",
+        "unlinkFailed": "Falha ao desvincular",
+        "unlinked": "Identidade desvinculada",
+        "unlinkIdentityFailed": "Falha ao desvincular identidade",
+        "unlinkDialog": {
+          "title": "Desvincular identidade {provider}?",
+          "description": "Digite sua senha para confirmar. Você não poderá mais fazer login com este provedor.",
+          "currentPassword": "Senha atual"
+        }
+      },
+      "tour": {
+        "title": "Tour Guiado",
+        "description": "Repita a apresentação que destaca os principais recursos do aplicativo.",
+        "action": "Fazer o tour novamente"
+      },
+      "restrictions": {
+        "none": {
+          "title": "Sem restrições de conteúdo",
+          "description": "Sua conta tem acesso total a todo o conteúdo dentro das bibliotecas atribuídas."
+        },
+        "banner": "Sua conta possui restrições de conteúdo aplicadas por um administrador. Alguns livros podem não ficar visíveis para você.",
+        "allowedTags": {
+          "title": "Tags permitidas",
+          "description": "Apenas livros que possuem pelo menos uma dessas tags são exibidos para você."
+        },
+        "blockedTags": {
+          "title": "Tags bloqueadas",
+          "description": "Livros com qualquer uma dessas tags ficam ocultos para você."
+        },
+        "allowedGenres": {
+          "title": "Gêneros permitidos",
+          "description": "Apenas livros que possuem pelo menos um desses gêneros são exibidos para você."
+        },
+        "blockedGenres": {
+          "title": "Gêneros bloqueados",
+          "description": "Livros com qualquer um desses gêneros ficam ocultos para você."
+        }
+      }
+    },
+    "magicLinks": {
+      "title": "Links Mágicos",
+      "subtitle": "Crie links de login compartilháveis para contas compartilhadas.",
+      "createLink": "Criar link",
+      "noSharedAccounts": "Nenhuma conta compartilhada encontrada",
+      "noSharedAccountsHint": "Primeiro, crie uma conta compartilhada em {usersPage} para gerar links mágicos.",
+      "activeLinks": "Links ativos",
+      "inactiveLinks": "Links inativos",
+      "paused": "Pausado",
+      "deletedUser": "Usuário excluído",
+      "expiredPrefix": "Expirado ",
+      "never": "Nenhuma atividade registrada",
+      "noExpiry": "Sem expiração",
+      "expired": "Expirado",
+      "expiresOn": "Expira em {date}",
+      "revokedOn": "Revogado em {date}",
+      "expiredOn": "Expirou em {date}",
+      "usesCount": "nenhum uso | um uso | {count} usos",
+      "copied": "Copiado!",
+      "copyLink": "Copiar link",
+      "pause": "Pausar",
+      "resume": "Retomar",
+      "revoke": "Revogar",
+      "revoking": "Revogando...",
+      "emptyState": "Nenhum link mágico criado ainda. Clique em \"{action}\" para gerar uma URL de login compartilhável.",
+      "columns": {
+        "label": "Rótulo",
+        "account": "Conta",
+        "createdBy": "Criado por",
+        "expires": "Expira",
+        "uses": "Usos",
+        "lastUsed": "Último uso",
+        "created": "Criado",
+        "status": "Status",
+        "totalUses": "Ocorrências totais"
+      },
+      "createDialog": {
+        "title": "Criar link mágico",
+        "description": "Gere uma URL de login compartilhável para uma conta compartilhada.",
+        "sharedAccount": "Conta compartilhada",
+        "selectAccount": "Selecione uma conta compartilhada",
+        "label": "Rótulo",
+        "labelPlaceholder": "ex: Link de demonstração para conferência",
+        "expiresAt": "Expira em",
+        "optional": "(opcional)",
+        "create": "Criar",
+        "creating": "Criando..."
+      },
+      "revokeDialog": {
+        "title": "Revogar link mágico?",
+        "description": "Isso invalidará imediatamente o link e encerrará todas as sessões ativas para a conta vinculada."
+      },
+      "errors": {
+        "create": "Falha ao criar",
+        "copy": "Falha ao copiar o link mágico",
+        "update": "Falha ao atualizar o link mágico",
+        "revoke": "Falha ao revogar"
+      },
+      "usersPage": "Página de usuários",
+      "emptyTitle": "Nenhum link mágico criado ainda",
+      "emptyHint": "Clique em \"{action}\" para gerar uma URL de login compartilhável.",
+      "noActiveTitle": "Nenhum link mágico ativo",
+      "noActiveHint": "Todos os links mágicos gerados para esta página expiraram ou foram revogados."
+    },
+    "oidc": {
+      "title": "OIDC / SSO",
+      "subtitle": "Gerencie provedores OpenID Connect para logon único (SSO).",
+      "providers": "Provedores",
+      "addProvider": "Adicionar Provedor",
+      "editProvider": "Editar Provedor",
+      "configureNew": "Configure um novo provedor OIDC.",
+      "editing": "Editando {slug}",
+      "enabled": "Ativado",
+      "disabled": "Desativado",
+      "empty": {
+        "title": "Nenhum provedor ainda",
+        "description": "Adicione um provedor OIDC para permitir o logon único para seus usuários."
+      },
+      "form": {
+        "status": "Status",
+        "enableProvider": "Ativar provedor",
+        "enableProviderHint": "Exibir este provedor na página de login.",
+        "identity": "Identidade do Provedor",
+        "slug": "Slug",
+        "slugHint": "Identificador único (minúsculas, hífens). Não pode ser alterado posteriormente.",
+        "displayName": "Nome de Exibição",
+        "displayNameHint": "Exibido no botão de login.",
+        "iconUrl": "URL do Ícone",
+        "iconUrlHint": "Logo opcional exibido ao lado do botão de login.",
+        "iconPreviewAlt": "pré-visualização do ícone",
+        "connection": "Conexão",
+        "issuerUri": "URI do Emissor (Issuer)",
+        "issuerUriHint": "A URL base do provedor.",
+        "test": "Testar",
+        "testing": "Testando...",
+        "clientId": "ID do Cliente (Client ID)",
+        "clientSecret": "Segredo do Cliente (Client Secret)",
+        "clientSecretPlaceholder": "Deixe em branco para manter o existente",
+        "scopes": "Escopos (Scopes)",
+        "claimMapping": "Mapeamento de Claims",
+        "previewClaims": "Pré-visualizar claims",
+        "redirecting": "Redirecionando...",
+        "mappedClaims": "Claims mapeadas",
+        "rawClaims": "Claims brutas",
+        "usernameClaim": "Claim de nome de usuário",
+        "nameClaim": "Claim de nome",
+        "emailClaim": "Claim de e-mail",
+        "groupsClaim": "Claim de grupos",
+        "autoProvisioning": "Provisionamento Automático",
+        "autoProvisionUsers": "Provisionar usuários automaticamente",
+        "autoProvisionUsersHint": "Criar contas no primeiro login OIDC se o usuário não existir.",
+        "allowLocalLinking": "Permitir vinculação de conta local",
+        "allowLocalLinkingHint": "Vincular identidade OIDC a uma conta local existente por correspondência de nome de usuário.",
+        "defaultPermissions": "Permissões padrão",
+        "defaultPermissionsHint": "Permissões concedidas a novos usuários no primeiro login OIDC.",
+        "createProvider": "Criar Provedor",
+        "saveChanges": "Salvar Alterações",
+        "saving": "Salvando...",
+        "deleteProvider": "Excluir Provedor",
+        "deleting": "Excluindo..."
+      },
+      "test": {
+        "connected": "Conectado - {issuer}",
+        "connectionFailed": "Falha na conexão",
+        "hide": "Ocultar",
+        "details": "Detalhes",
+        "supported": "suportado",
+        "notSupported": "não suportado"
+      },
+      "groupMappings": {
+        "title": "Mapeamento de Grupos",
+        "description": "Mapeie claims de grupo OIDC para permissões do BookOrbit. Sincronizado a cada login.",
+        "noPermission": "Nenhuma permissão",
+        "empty": "Nenhum mapeamento de grupo configurado.",
+        "addMapping": "Adicionar mapeamento",
+        "claimPlaceholder": "Claim de grupo OIDC (ex: admins)",
+        "add": "Adicionar",
+        "adding": "Adicionando..."
+      },
+      "toasts": {
+        "providerCreated": "Provedor criado",
+        "providerSaved": "Provedor salvo",
+        "providerDeleted": "Provedor excluído",
+        "mappingAdded": "Mapeamento de grupo adicionado",
+        "mappingRemoved": "Mapeamento de grupo removido"
+      },
+      "errors": {
+        "loadProvider": "Falha ao carregar o provedor",
+        "createProvider": "Falha ao criar o provedor",
+        "save": "Falha ao salvar",
+        "delete": "Falha ao excluir",
+        "deleteProvider": "Falha ao excluir o provedor",
+        "requestFailed": "A requisição falhou",
+        "previewState": "Falha ao gerar estado de pré-visualização",
+        "startPreview": "Falha ao iniciar pré-visualização",
+        "addMapping": "Falha ao adicionar mapeamento",
+        "removeMapping": "Falha ao remover mapeamento de grupo"
+      }
+    },
+    "admin": {
+      "title": "Admin",
+      "subtitle": "Gerencie usuários e configurações de autenticação.",
+      "system": {
+        "title": "Sistema",
+        "subtitle": "Organização de arquivos, importação e configurações de manutenção."
+      },
+      "maintenance": {
+        "title": "Manutenção",
+        "subtitle": "Gerencie tarefas em segundo plano, índices do sistema e operações de manutenção.",
+        "importGroup": "Importar",
+        "recommendationsGroup": "Recomendações",
+        "achievementsGroup": "Conquistas",
+        "updatesGroup": "Atualizações",
+        "importFromBooklore": "Importar do Booklore",
+        "bookloreImportConfigured": "Importação do Booklore configurada",
+        "migrationRunning": "Migração em execução",
+        "migrationCompleted": "Migração concluída",
+        "migrationFailed": "Falha na migração",
+        "importDescription": "Importação única de livros, metadados e progresso de leitura de uma instalação anterior do Booklore.",
+        "configuredDescription": "Origem: {name}. Nenhuma migração executada ainda - continue a configuração para executar a importação.",
+        "runningDescription": "Etapa: {stage} - iniciada em {started}",
+        "completedDescription": "De {name} - concluída em {date}",
+        "migrationErrorGeneric": "Ocorreu um erro durante a migração.",
+        "stageInitializing": "inicializando",
+        "recently": "recentemente",
+        "getStarted": "Começar",
+        "continueSetup": "Continuar Configuração",
+        "viewDetails": "Ver Detalhes",
+        "refreshRecommendationIndex": "Atualizar índice de recomendações",
+        "refreshRecommendationHint": "Atualize o mecanismo de recomendações com as alterações mais recentes da sua biblioteca. Este processo roda em segundo plano.",
+        "booksQueuedForProcessing": "nenhum livro na fila de processamento | {count} livro na fila de processamento | {count} livros na fila de processamento",
+        "run": "Executar",
+        "running": "Executando...",
+        "backfillAchievements": "Preenchimento retroativo de conquistas",
+        "backfillAchievementsHint": "Reavaliar conquistas para todos os usuários.",
+        "backfillResult": "{users} usuários processados; {awards} prêmios concedidos.",
+        "runBackfill": "Executar Preenchimento Retroativo",
+        "checkForUpdates": "Verificar atualizações",
+        "checkForUpdatesHint": "Verificar automaticamente no GitHub se há uma nova versão ao iniciar e exibir um indicador na barra lateral quando houver uma disponível.",
+        "updateChecksEnabled": "Verificação de atualizações ativada",
+        "updateChecksDisabled": "Verificação de atualizações desativada",
+        "updateSettingFailed": "Falha ao atualizar configuração",
+        "booksQueuedForEmbedding": "nenhum livro na fila de incorporação | {count} livro na fila de incorporação | {count} livros na fila de incorporação",
+        "failed": "Falhou",
+        "unknownError": "Erro desconhecido",
+        "rebuildEmbeddingsFailed": "Falha ao reconstruir incorporações (embeddings): {error}",
+        "achievementBackfillConfirm": "Executar o preenchimento retroativo de todas as conquistas para todos os usuários? Isso pode demorar um pouco.",
+        "achievementBackfillComplete": "Preenchimento retroativo de conquistas concluído: {count} prêmios concedidos",
+        "backfillRunFailed": "Falha ao executar o preenchimento retroativo",
+        "achievementBackfillFailed": "Falha ao executar o preenchimento retroativo de conquistas: {error}",
+        "uploadsGroup": "Uploads",
+        "maxUploadSize": "Limite máximo de tamanho de arquivo para upload",
+        "maxUploadSizeHint": "Configure o limite máximo de tamanho para envio de arquivos em todo o sistema.",
+        "save": "Salvar",
+        "uploadSizeInvalid": "O limite de tamanho de upload deve ser maior que 0",
+        "uploadSizeUpdated": "Limite de tamanho de upload atualizado"
+      },
+      "migration": {
+        "title": "Migração",
+        "subtitle": "Importação única do Booklore: conecte a origem, mapeie usuários, faça a simulação (dry-run), inicie a migração e exporte um relatório.",
+        "progress": "Progresso",
+        "stepSourceConnection": "Conexão de Origem",
+        "stepUserPathMapping": "Mapeamento de Usuários e Caminhos",
+        "stepDryRun": "Simulação (Dry-Run)",
+        "stepDryRunTitle": "Simulação",
+        "stepRunMigration": "Executar Migração",
+        "stepReport": "Relatório",
+        "stepReportTitle": "Relatório de Migração",
+        "subtitleSource": "Configure a conexão de banco de dados com sua instância de origem do Booklore.",
+        "subtitleMappings": "Mapeie usuários de origem para usuários de destino e traduza caminhos de arquivo.",
+        "subtitleDryRun": "Pré-visualize o que será importado antes de executar a migração real.",
+        "subtitleRun": "Inicie a importação real e acompanhe seu progresso.",
+        "subtitleReport": "Revise o que foi importado e exporte um relatório detalhado.",
+        "continueToMappings": "Continuar para Mapeamentos",
+        "continueToDryRun": "Continuar para Simulação",
+        "continueToMigration": "Continuar para Migração",
+        "viewReport": "Ver Relatório",
+        "badgeValidated": "Validado",
+        "badgeSaved": "Salvo",
+        "badgeUpToDate": "Atualizado",
+        "badgeCompleted": "Concluído",
+        "badgeRunning": "Executando",
+        "badgeFailed": "Falhou",
+        "mediaPathRequired": "Obrigatório para migrar capas de livros.",
+        "mediaPathAbsolute": "Use um caminho absoluto (por exemplo: /books). Caminhos relativos não são suportados.",
+        "mediaPathConfigured": "Caminho de importação de capas configurado. Use Testar Conexão para verificar o acesso e a estrutura da pasta de imagens do Booklore.",
+        "issueSaveSource": "Salvar configurações de conexão de origem",
+        "issueValidateSource": "Validar conexão de origem",
+        "issueSaveMappings": "Salvar mapeamento de usuários e caminhos",
+        "issueSavePathMappings": "Salvar mapeamentos de caminho para validá-los",
+        "issueFreshDryRun": "Executar uma nova simulação",
+        "issueResolveDuplicates": "Resolver correspondências duplicatas de livros de destino na simulação",
+        "issueWaitActiveRun": "Aguardar a execução ativa terminar",
+        "sourceRecordId": "ID do registro de origem #{id}",
+        "byAuthorWithId": "por {author} (ID: {id})",
+        "filePathWithId": "{path} (ID: {id})",
+        "bookloreSourceId": "ID de origem do Booklore: {id}",
+        "libraryBookNum": "Livro da biblioteca #{id}",
+        "errorInitialize": "Falha ao inicializar configurações de migração",
+        "errorLoadSourceTypes": "Falha ao carregar tipos de origem de migração suportados",
+        "errorLoadTargetUsers": "Falha ao carregar usuários de destino",
+        "errorLoadLibraryFolders": "Falha ao carregar pastas da biblioteca de destino",
+        "noSourceUsersReturned": "Nenhum usuário de origem foi retornado",
+        "userMappingSuggestionsLoaded": "Sugestões de mapeamento de usuários carregadas",
+        "errorLoadSuggestions": "Falha ao carregar sugestões de mapeamento de usuários",
+        "requiredFields": "Host, usuário, banco de dados e nome da origem são obrigatórios",
+        "connectionTestPassedWithWarnings": "O teste de conexão passou com avisos",
+        "connectionTestPassedWithCount": "O teste de conexão passou com {count} aviso(s). Primeiro: {first}",
+        "connectionTestPassed": "O teste de conexão passou",
+        "connectionOkMissingTables": "Conexão ok, mas {count} tabela(s) obrigatória(s) está(ão) ausente(s)",
+        "cannotTestMediaPathActiveRun": "Não é possível testar o caminho de mídia enquanto uma execução está ativa",
+        "mediaRootPathRequiredCover": "O Caminho Raiz de Mídia é obrigatório para importação de capas.",
+        "useAbsolutePath": "Use um caminho absoluto (por exemplo: /books).",
+        "mediaPathVerified": "Caminho de mídia verificado.",
+        "mediaPathValidReadable": "O caminho de mídia é válido e legível",
+        "mediaPathValidationFailed": "Falha na validação do caminho de mídia.",
+        "connectionFailedBeforeMediaPath": "O teste de conexão falhou antes que a validação do caminho de mídia pudesse ser concluída.",
+        "cannotModifySourceActiveRun": "Não é possível modificar a origem enquanto uma execução está ativa",
+        "sourceSavedValidatedWarnings": "Origem salva e validada com {count} aviso(s)",
+        "sourceSavedValidated": "Origem salva e validada",
+        "errorSaveValidateSource": "Falha ao salvar ou validar a origem",
+        "cannotSaveMappingsActiveRun": "Não é possível salvar mapeamentos enquanto uma execução está ativa",
+        "saveSourceFirst": "Salvar origem primeiro",
+        "mapAtLeastOneUser": "Mapeie pelo menos um usuário de origem para um usuário de destino",
+        "mapEveryUser": "Mapeie todos os usuários de origem antes de salvar",
+        "pathValidationFailedProfileSaved": "Falha na validação do caminho, mas o perfil ainda será salvo",
+        "mappingsSaved": "Mapeamentos salvos",
+        "errorSaveMappings": "Falha ao salvar mapeamentos",
+        "cannotRunDryRunActiveRun": "Não é possível executar uma simulação enquanto uma execução está ativa",
+        "saveMappingsFirst": "Salvar mapeamentos primeiro",
+        "dryRunCompleted": "Simulação concluída: {matched} correspondidos, {unresolved} não resolvidos",
+        "dryRunFailed": "Falha na simulação",
+        "selectSourceForAllGroups": "Selecione um livro de origem para todos os {count} grupos duplicados",
+        "duplicatesResolved": "Correspondências duplicadas resolvidas",
+        "errorResolveDuplicates": "Falha ao resolver duplicatas",
+        "preflightNotReady": "As verificações pré-migração não estão prontas",
+        "runDryRunFirst": "Execute a simulação primeiro",
+        "runStarted": "Execução da migração iniciada",
+        "errorStartMigration": "Falha ao iniciar migração",
+        "runCancelled": "Execução da migração cancelada",
+        "errorCancelMigration": "Falha ao cancelar migração",
+        "runRetried": "Execução da migração reiniciada - continuando da última etapa concluída",
+        "errorRetryMigration": "Falha ao tentar a migração novamente",
+        "errorLoadRunProgress": "Falha ao carregar progresso da execução",
+        "startMigrationFirst": "Inicie a migração primeiro",
+        "reportRefreshed": "Relatório de execução atualizado",
+        "errorLoadReport": "Falha ao carregar relatório da execução",
+        "reportExported": "Relatório exportado como {format}",
+        "errorExportReport": "Falha ao exportar relatório de migração",
+        "reasonNoTitleAuthorMatch": "Nenhum livro correspondente encontrado por título ou autor",
+        "reasonNoFilePathMatch": "O caminho do arquivo não correspondeu a nenhum livro nesta biblioteca",
+        "reasonNoFileHashMatch": "O hash do arquivo não correspondeu a nenhum livro nesta biblioteca",
+        "reasonNoIsbnMatch": "O ISBN não correspondeu a nenhum livro nesta biblioteca",
+        "reasonInsufficientSourceData": "Metadados insuficientes para tentar a correspondência",
+        "reasonAmbiguousIsbnMatch": "Múltiplos livros corresponderam ao mesmo ISBN",
+        "reasonAmbiguousFileHashMatch": "Múltiplos livros corresponderam ao mesmo hash de arquivo",
+        "reasonAmbiguousFilePathMatch": "Múltiplos livros corresponderam ao mesmo caminho de arquivo",
+        "reasonAmbiguousTitleAuthorMatch": "Múltiplos livros corresponderam ao mesmo título e autor",
+        "reasonUnknown": "Não foi possível determinar o motivo",
+        "strategyIsbn": "Correspondido por ISBN",
+        "strategyFileHash": "Correspondido por hash de arquivo",
+        "strategyPathMapping": "Correspondido por caminho de arquivo mapeado",
+        "strategyTitleAuthor": "Correspondido por título e autor",
+        "strategyUnavailable": "Estratégia de correspondência indisponível",
+        "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {bookmarks} marcadores, {annotations} anotações, {collections} entradas de coleção",
+        "connErrorUnreachable": "Não foi possível conectar ao servidor de banco de dados. Verifique o host e a porta.",
+        "connErrorAuth": "Falha na autenticação. Verifique o nome de usuário e a senha.",
+        "connErrorUnknownDatabase": "Banco de dados não encontrado. Verifique o nome do banco de dados.",
+        "connErrorTimeout": "A conexão expirou. Verifique as configurações de host e firewall.",
+        "connErrorGeneric": "Falha no teste de conexão",
+        "sourceType": "Tipo de Origem",
+        "sourceName": "Nome da Origem",
+        "host": "Host",
+        "port": "Porta",
+        "user": "Usuário",
+        "password": "Senha",
+        "passwordSavedPlaceholder": "Salvo - deixe inalterado",
+        "passwordEmptyPlaceholder": "Nenhuma senha definida",
+        "database": "Banco de Dados",
+        "mediaRootPath": "Caminho Raiz de Mídia",
+        "pathOk": "Caminho OK",
+        "pathIssue": "Problema no Caminho",
+        "testPath": "Testar Caminho",
+        "useTls": "Usar TLS/SSL",
+        "testConnection": "Testar Conexão",
+        "saveAndValidate": "Salvar e Validar",
+        "sourceValidatedWithWarnings": "Origem validada com avisos",
+        "lastValidationSnapshot": "Último instantâneo de validação",
+        "sourceVersion": "Versão da origem: {version}",
+        "unknown": "Desconhecido",
+        "missingRequiredTables": "Tabelas obrigatórias ausentes: {tables}",
+        "suggestionsAutoLoad": "Sugestões de usuários carregam automaticamente após a validação da origem.",
+        "refresh": "Atualizar",
+        "sourceUser": "Usuário de Origem",
+        "targetUser": "Usuário de Destino",
+        "noSourceUsersLoaded": "Nenhum usuário de origem carregado ainda.",
+        "noActiveTargetUsers": "Nenhum usuário de destino ativo encontrado. Crie ou reative um usuário no BookOrbit antes de mapear.",
+        "pathPrefixMappings": "Mapeamentos de Prefixo de Caminho",
+        "addMapping": "Adicionar Mapeamento",
+        "pathMappingsHelp1": "Os mapeamentos de caminho traduzem caminhos de arquivos da origem para caminhos de destino para que os livros possam ser correspondidos pelo local do arquivo. Por exemplo, se a sua biblioteca Booklore armazenou arquivos em",
+        "pathMappingsHelp2": "e os mesmos arquivos agora estão em",
+        "pathMappingsHelp3": ", adicione esse mapeamento aqui. Os livros também são correspondidos por ISBN, hash de arquivo e título/autor independentemente dos mapeamentos de caminho - o mapeamento de caminho é apenas uma das quatro estratégias e não limita quais livros de origem são incluídos na migração.",
+        "noPrefixesFound": "Nenhum prefixo encontrado - valide a origem primeiro",
+        "selectSourcePrefix": "Selecione o prefixo de origem...",
+        "selectTargetFolder": "Selecione a pasta de destino...",
+        "remove": "Remover",
+        "pathValidation": "Validação de caminho",
+        "pathValidationMapped": "{mapped} de {total} livros de origem têm um caminho mapeado",
+        "pathValidationUnmatched": "{count} caminhos mapeados não foram encontrados no disco - esses livros reverterão para correspondência por ISBN / título",
+        "pathValidationAllMatched": "Todos os {count} caminhos mapeados foram encontrados no disco",
+        "saveMappings": "Salvar Mapeamentos",
+        "runDryRun": "Executar Simulação",
+        "matched": "Correspondidos:",
+        "unresolved": "Não resolvidos:",
+        "duplicateMatches": "Correspondências duplicadas:",
+        "unresolvedSummary": "Resumo de não resolvidos",
+        "resolveDuplicateMatches": "Resolver correspondências duplicadas de destino",
+        "resolveDuplicateHint": "Para cada livro de destino, escolha um livro de origem para manter. Opções recomendadas são pré-selecionadas quando há uma única correspondência mais forte.",
+        "remainingGroups": "Grupos restantes:",
+        "ofCount": "de {count}",
+        "targetBookNum": "Livro de destino #{id}",
+        "recommended": "Recomendado",
+        "resolveDuplicatesButton": "Resolver {count} duplicata | Resolver {count} duplicata | Resolver {count} duplicatas",
+        "preflightChecks": "Verificações pré-migração",
+        "allChecksPassed": "Todas as verificações passaram - pronto para migrar",
+        "checkSourceValidated": "Origem validada",
+        "checkSaveValidateSource": "Salvar e validar conexão de origem",
+        "checkValidateSource": "Validar conexão de origem",
+        "checkMappingsSaved": "Mapeamentos salvos",
+        "checkSaveMappings": "Salvar mapeamento de usuários e caminhos",
+        "checkPathMappingsValidated": "Mapeamentos de caminho validados",
+        "checkSavePathMappings": "Salvar mapeamentos de caminho para validá-los",
+        "checkDryRunUpToDate": "A simulação está atualizada",
+        "checkFreshDryRun": "Executar uma nova simulação",
+        "startConfirmPrompt": "Isso iniciará a migração real. Tem certeza?",
+        "confirmStart": "Confirmar Início",
+        "startMigration": "Iniciar Migração",
+        "cancelRun": "Cancelar Execução",
+        "refreshStatus": "Atualizar Status",
+        "statusPollingStopped": "A verificação contínua de status foi interrompida devido a um erro.",
+        "retry": "Tentar novamente",
+        "stageLabel": "Etapa: {stage}",
+        "stageInitializing": "inicializando",
+        "endedLabel": "Terminou em {date}",
+        "stageCompleted": "Concluído",
+        "stageInit": "Inicializando",
+        "stageSharedOverlays": "Importando metadados",
+        "stageBookCovers": "Importando capas",
+        "stageUserState": "Importando dados de usuário",
+        "noRunYet": "Nenhuma migração executada ainda. Conclua as etapas acima para iniciar.",
+        "runNum": "Execução #{id}",
+        "notStarted": "Não iniciado",
+        "reloadReport": "Recarregar Relatório",
+        "loadFullReport": "Carregar Relatório Completo",
+        "exportJson": "Exportar JSON",
+        "exportCsv": "Exportar CSV",
+        "migrationFailed": "Falha na migração",
+        "retryFromLastStage": "Tentar novamente a partir da última etapa concluída",
+        "booksCard": "Livros",
+        "metadataOverlaysApplied": "Sobreposições de metadados aplicadas",
+        "authorMappingsReplaced": "Mapeamentos de autor substituídos",
+        "narratorMappingsReplaced": "Mapeamentos de narrador substituídos",
+        "genreMappingsReplaced": "Mapeamentos de gênero substituídos",
+        "tagMappingsReplaced": "Mapeamentos de tag substituídos",
+        "coversImported": "Capas importadas",
+        "coverImportSkipped": "A importação de capas foi ignorada - o caminho raiz de mídia não está configurado na origem",
+        "couldNotMatch": "Não foi possível corresponder",
+        "userDataCard": "Dados do Usuário",
+        "readingStatuses": "Status de leitura",
+        "readingProgressEntries": "Entradas de progresso de leitura",
+        "audiobookProgressEntries": "Entradas de progresso de audiolivro",
+        "bookmarksLabel": "Marcadores",
+        "annotationsLabel": "Anotações",
+        "collectionEntries": "Entradas de coleção",
+        "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência da simulação no relatório exportado.",
+        "completedNoIssues": "Migração concluída sem livros não resolvidos ou falhas.",
+        "matchedBooksHeading": "Livros correspondidos ({count})",
+        "matchedBooksHint": "Essas correspondências da simulação foram usadas para decidir quais livros da biblioteca receberam dados importados.",
+        "sourceBookFallback": "Livro de origem {id}",
+        "libraryBookFallback": "Livro da biblioteca {id}",
+        "unresolvedBooksHeading": "Livros não resolvidos ({count})",
+        "unresolvedBooksHint": "Esses livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
+        "mappedUsersHeading": "Usuários mapeados ({count})",
+        "mappedUsersHint": "Os totais por usuário vêm da pré-visualização da simulação em cache com o plano de migração.",
+        "coverImportsFailed": "{count} importação(ões) de capa falhou(aram). As linhas detalhadas de falha não são armazenadas.",
+        "backToSetup": "Voltar para a Configuração"
+      },
+      "libraries": {
+        "title": "Bibliotecas",
+        "subtitle": "Gerencie suas bibliotecas de mídia e inicie verificações de conteúdo.",
+        "scanAll": "Escanear Todas",
+        "scanning": "Escaneando...",
+        "addLibrary": "Adicionar Biblioteca",
+        "scan": "Escanear",
+        "editLibrary": "Editar biblioteca",
+        "refreshCovers": "Atualizar capas",
+        "syncMetadataToFiles": "Sincronizar metadados para os arquivos",
+        "deleteLibrary": "Excluir biblioteca",
+        "bookCount": "nenhum livro | {count} livro | {count} livros",
+        "addedDate": "Adicionado em {date}",
+        "fileMode": "Modo por arquivo",
+        "folderMode": "Modo por pasta",
+        "folderCount": "nenhuma pasta | {count} pasta | {count} pastas",
+        "watching": "Monitorando",
+        "fileWrite": "Gravação de arquivo",
+        "fileRename": "Renomeação de arquivo",
+        "emptyTitle": "Nenhuma biblioteca ainda",
+        "emptyHint": "Adicione uma biblioteca para começar a organizar seus livros.",
+        "addFirstLibrary": "Adicione sua primeira biblioteca",
+        "deleteConfirmTitle": "Excluir \"{name}\"?",
+        "deleteConfirmBody": "Isso removerá permanentemente todos os livros, metadados, progresso de leitura, marcadores e anotações nesta biblioteca. Isso não pode ser desfeito.",
+        "deleteConfirmTypeName": "Digite o nome da biblioteca para confirmar:",
+        "deleting": "Excluindo...",
+        "deleteLibraryButton": "Excluir Biblioteca",
+        "syncConfirmTitle": "Sincronizar metadados para os arquivos?",
+        "syncConfirmBodyPrefix": "Isso sobrescreverá os metadados dentro de cada arquivo suportado em",
+        "syncConfirmBodySuffix": "diretamente no disco. Isso não pode ser desfeito.",
+        "syncFiles": "Sincronizar arquivos",
+        "metadataSynced": "Metadados sincronizados com os arquivos em \"{name}\"",
+        "fileWriteNotEnabled": "A gravação de arquivos de metadados não está ativada para esta biblioteca. Ative-a nas configurações da biblioteca.",
+        "fileSyncFailed": "Falha na sincronização de arquivos para \"{name}\"",
+        "scanStarted": "Escaneamento iniciado para \"{name}\"",
+        "scanStartFailed": "Falha ao iniciar escaneamento para \"{name}\"",
+        "refreshCoversFailed": "Falha ao atualizar capas para \"{name}\"",
+        "scanStartedAll": "Escaneamento iniciado para todas as bibliotecas",
+        "librariesFailedToStart": "nenhuma biblioteca falhou ao iniciar | {count} biblioteca falhou ao iniciar | {count} bibliotecas falharam ao iniciar",
+        "scansStartFailed": "Falha ao iniciar escaneamentos",
+        "libraryCreated": "Biblioteca \"{name}\" criada",
+        "libraryUpdated": "Biblioteca \"{name}\" atualizada",
+        "libraryDeleted": "\"{name}\" excluída",
+        "deleteFailed": "Falha ao excluir biblioteca",
+        "scanningProgress": "Escaneando {pct}% ({processed}/{total})",
+        "scanDone": "Concluído - {added} adicionado(s), {updated} atualizado(s)",
+        "scanFailedWithError": "Falhou: {error}",
+        "scanFailed": "Falha no escaneamento",
+        "refreshingCovers": "Atualizando capas {pct}% ({processed}/{total})",
+        "coversRefreshed": "Capas atualizadas ({count} processada(s))"
+      },
+      "authorEnrichment": {
+        "configuration": "Configuração",
+        "saving": "Salvando...",
+        "running": "Executando...",
+        "runEligibleShort": "Executar elegíveis",
+        "runAllShort": "Executar todos",
+        "enableTitle": "Ativar enriquecimento automático de autor",
+        "enableHint": "Buscar automaticamente biografias e fotos de perfil de autores quando livros forem adicionados ou atualizados.",
+        "updateStrategyTitle": "Estratégia de atualização",
+        "updateStrategyHint": "O que fazer quando um autor já possui uma biografia ou foto.",
+        "writeModeMissingOnly": "Preencher apenas dados ausentes (recomendado)",
+        "writeModeAlwaysRefetch": "Sempre atualizar os dados existentes",
+        "triggerOnImportTitle": "Disparar na importação",
+        "triggerOnImportHint": "Colocar autores na fila para enriquecimento quando os livros forem adicionados pela primeira vez a uma biblioteca.",
+        "eligibilityTitle": "Condições de elegibilidade",
+        "eligibilityHint": "Um autor é elegível se corresponder a qualquer condição ativada.",
+        "neverEnrichedTitle": "Nunca enriquecido",
+        "neverEnrichedHint": "Enriquecer autores que nunca tiveram um enriquecimento bem-sucedido.",
+        "missingBioTitle": "Sem biografia",
+        "missingBioHint": "Enriquecer se o autor não tiver biografia.",
+        "missingPhotoTitle": "Sem foto",
+        "missingPhotoHint": "Enriquecer se o autor não tiver foto de perfil.",
+        "runForEligibleAuthors": "Executar para autores elegíveis",
+        "eligibleCount": "~{count} elegíveis",
+        "runForAllAuthors": "Executar para todos os autores",
+        "saved": "Configurações de enriquecimento de autor salvas",
+        "saveFailed": "Falha ao salvar configurações de enriquecimento de autor",
+        "noEligibleAuthors": "Nenhum autor elegível encontrado",
+        "noAuthorsToEnrich": "Nenhum autor para enriquecer",
+        "queueFailed": "Falha ao colocar o enriquecimento de autor na fila"
+      },
+      "scoreWeights": {
+        "groupLabel": "Pesos das Pontuações",
+        "assignHintPrefix": "Atribua um peso a cada campo. Peso total:",
+        "areYouSure": "Tem certeza?",
+        "resetToDefaultsButton": "Restaurar padrões",
+        "recalculateAll": "Recalcular todos",
+        "confirmReset": "Confirmar redefinição",
+        "reset": "Restaurar",
+        "recalculate": "Recalcular",
+        "subtotal": "subtotal: {count}",
+        "savedRecalculating": "Pesos das pontuações salvos. Recalculando pontuações da biblioteca...",
+        "saveFailed": "Falha ao salvar pesos das pontuações",
+        "recalcStarted": "Recálculo de pontuação iniciado em segundo plano",
+        "recalcFailed": "Falha no recálculo",
+        "resetToDefaults": "Pesos restaurados para os padrões. Salve para aplicar."
+      },
+      "tabs": {
+        "users": "Usuários",
+        "account-activity": "Atividade da Conta",
+        "magic-links": "Links Mágicos",
+        "oidc": "OIDC / SSO"
+      }
+    },
+    "common": {
+      "nav": {
+        "libraries": "Bibliotecas",
+        "display": "Exibição",
+        "reader": "Leitor",
+        "metadata": "Metadados",
+        "email": "E-mail",
+        "opds": "OPDS",
+        "kobo": "Kobo",
+        "koreader": "KOReader",
+        "hardcover": "Hardcover",
+        "admin": "Admin",
+        "system": "Sistema",
+        "account": "Conta"
+      }
+    },
+    "metadata": {
+      "title": "Metadados",
+      "noPermission": "Você não tem permissão para gerenciar as configurações de metadados.",
+      "fields": {
+        "title": "Título",
+        "subtitle": "Subtítulo",
+        "description": "Descrição",
+        "cover": "Capa",
+        "authors": "Autores",
+        "publisher": "Editora",
+        "publishedYear": "Ano de publicação",
+        "language": "Idioma",
+        "pageCount": "Número de páginas",
+        "communityRating": "Avaliação da comunidade",
+        "seriesName": "Nome da série",
+        "seriesIndex": "Índice da série",
+        "genres": "Gêneros",
+        "narrators": "Narradores",
+        "duration": "Duração",
+        "abridged": "Abreviado / Resumido"
+      },
+      "mergeStrategy": {
+        "fillMissing": {
+          "label": "Preencher ausentes",
+          "description": "Gravar apenas se o campo estiver vazio"
+        },
+        "overwriteIfProvided": {
+          "label": "Sobrescrever se fornecido",
+          "description": "Gravar se o provedor retornou um valor"
+        },
+        "overwrite": {
+          "label": "Sempre sobrescrever",
+          "description": "Sempre substituir o valor existente"
+        }
+      },
+      "autoFetch": {
+        "globalSettings": "Configurações Globais",
+        "perLibraryOverrides": "Substituições por Biblioteca",
+        "saving": "Salvando...",
+        "running": "Executando...",
+        "runNow": "Executar agora",
+        "runForEligible": "Executar para livros elegíveis",
+        "enable": {
+          "label": "Ativar busca automática",
+          "hint": "Buscar metadados automaticamente para livros elegíveis."
+        },
+        "triggerOnImport": {
+          "label": "Disparar na importação",
+          "hint": "Colocar livros elegíveis na fila quando forem adicionados pela primeira vez a uma biblioteca."
+        },
+        "status": {
+          "inQueuePaused": "{count} na fila - pausado",
+          "remaining": "{count} restante(s)",
+          "eligible": "~{count} elegíveis"
+        },
+        "trigger": {
+          "queued": "{count} livro na fila | {count} livros na fila",
+          "noneFound": "Nenhum livro elegível encontrado"
+        },
+        "lastRun": {
+          "justNow": "agora mesmo",
+          "minutesAgo": "há {count}m",
+          "hoursAgo": "há {count}h",
+          "yesterday": "ontem",
+          "daysAgo": "há {count} dias",
+          "label": "Última execução: {when}",
+          "labelQueued": "Última execução: {when} - {count} livro(s) na fila",
+          "labelNoneEligible": "Última execução: {when} - nenhum livro elegível"
+        },
+        "conditions": {
+          "title": "Condições de elegibilidade",
+          "hint": "Um livro é elegível se corresponder a qualquer condição ativada.",
+          "noneEnabled": "Nenhuma condição ativada",
+          "neverFetched": {
+            "label": "Nunca buscado",
+            "hint": "Buscar livros que nunca tiveram uma tentativa de busca de metadados.",
+            "summary": "Nunca buscado"
+          },
+          "scoreThreshold": {
+            "label": "Pontuação baixa de metadados",
+            "hint": "Buscar se a pontuação de metadados estiver abaixo de um limite.",
+            "scoreBelow": "Pontuação abaixo de",
+            "summary": "Pontuação < {threshold}"
+          },
+          "missingFields": {
+            "label": "Campos ausentes",
+            "hint": "Buscar se qualquer um dos campos selecionados estiver vazio.",
+            "summary": "Ausente em {count} campo | Ausente em {count} campos"
+          }
+        },
+        "library": {
+          "inheritingGlobal": "Herdando padrões globais",
+          "inheritFromGlobal": "Herdar do global",
+          "usingGlobalDefaults": "Usando padrões globais.",
+          "saveOverride": "Salvar substituição"
+        }
+      },
+      "providers": {
+        "availableSources": "Fontes Disponíveis",
+        "saveChanges": "Salvar Alterações",
+        "test": "Testar",
+        "testing": "Testando...",
+        "enabled": "Ativado",
+        "retryIn": "Tentar novamente em {duration}",
+        "runTestBeforeEnabling": "Execute o Teste antes de ativar",
+        "hardcoverEnableHint": "Execute o Teste com o token atual para desbloquear a chave de ativação.",
+        "badge": {
+          "setupRequired": "Configuração Necessária",
+          "throttled": "Limitado (Throttled)",
+          "ready": "Pronto"
+        },
+        "fields": {
+          "apiKey": "Chave de API",
+          "region": "Região",
+          "cookie": "Cookie",
+          "coverResolution": "Resolução da Capa",
+          "country": "País",
+          "language": "Idioma",
+          "ttbKey": "Chave TTB"
+        },
+        "helpers": {
+          "googleApiKey": "Chave de API do Google Books do Google Cloud."
+        },
+        "hints": {
+          "google": "Ampla cobertura do índice de livros do Google. O Google Books agora exige uma chave de API antes que este provedor possa ser ativado.",
+          "amazon": "O cookie de sessão é recomendado. Cole apenas o valor do cookie (sem \"Cookie:\").",
+          "goodreads": "A maior comunidade de leitura na web. Nenhuma configuração é necessária.",
+          "hardcover": "Uma alternativa moderna ao Goodreads. Token obtido em hardcover.app/account/api. O prefixo \"Bearer \" é opcional.",
+          "openLibrary": "O catálogo gratuito de livros do Internet Archive. Nenhuma configuração é necessária.",
+          "itunes": "O catálogo digital de livros da Apple. Escolha se deseja buscar capas de alta resolução ou padrão.",
+          "kobo": "Coleta páginas públicas de livros da Kobo. O país e o idioma devem corresponder aos caminhos da URL da Kobo; proteções antibot podem bloquear requisições.",
+          "audible": "Extrai metadados de audiolivros do Audible. Nenhuma configuração adicional é necessária.",
+          "audnexus": "Metadados de audiolivros focados na comunidade. Nenhuma configuração é necessária.",
+          "comicvine": "Metadados de quadrinhos do ComicVine. Uma chave de API gratuita é necessária em comicvine.gamespot.com.",
+          "ranobedb": "Metadados de light novels japonesas do RanobeDB. Nenhuma configuração é necessária.",
+          "lubimyczytac": "Catálogo de livros polonês (lubimyczytac.pl). Coleta páginas públicas de livros. Nenhuma configuração é necessária.",
+          "aladin": "Metadados de livros coreanos do Aladin (알라딘). Uma Chave TTB de aladin.co.kr é necessária."
+        },
+        "blocked": {
+          "google": "O Google Books requer uma chave de API antes de poder ser ativado",
+          "hardcover": "O Hardcover requer uma chave de API antes de poder ser ativado",
+          "hardcoverTest": "O token do Hardcover deve passar no Teste antes de poder ser ativado",
+          "comicvine": "O ComicVine requer uma chave de API antes de poder ser ativado",
+          "aladin": "O Aladin requer uma Chave TTB antes de poder ser ativado"
+        }
+      },
+      "fieldRules": {
+        "clearAllProviders": "Limpar Todos os Provedores",
+        "clearAll": "Limpar Tudo",
+        "resetToDefault": "Restaurar Padrão",
+        "reset": "Restaurar",
+        "dragProvidersHint": "Arraste os provedores daqui para qualquer campo para adicioná-los",
+        "dragProviderHere": "arraste um provedor para cá",
+        "howItWorks": {
+          "title": "Como Funcionam as Regras de Campo",
+          "priorityOrder": {
+            "title": "Ordem de Prioridade",
+            "body": "Arraste os provedores na lista para reordená-los. O provedor mais ao topo que retornar um resultado será a fonte principal para esse campo."
+          },
+          "mergeStrategy": {
+            "title": "Estratégia de Mesclagem",
+            "fillMissingTerm": "Preencher ausentes:",
+            "fillMissingBody": "Gravar apenas se o valor atual estiver vazio.",
+            "overwriteTerm": "Sobrescrever:",
+            "overwriteBody": "Substituir sempre que um provedor tiver dados."
+          }
+        },
+        "libraryOverrides": {
+          "title": "Substituições da Biblioteca",
+          "hint": "Expanda uma biblioteca para personalizar campos individuais. Os campos não substituídos herdam os padrões globais."
+        },
+        "global": {
+          "title": "Padrões Globais",
+          "hint": "Regras padrão aplicadas a todas as bibliotecas. Substitua por biblioteca abaixo.",
+          "saveDefaults": "Salvar Padrões",
+          "clearAllConfirm": "Remover todos os provedores ativos de todos os campos? Isso será salvo imediatamente e não poderá ser desfeito.",
+          "resetConfirm": "Restaurar todas as regras globais de campo para os padrões do sistema? Isso sobrescreverá sua configuração atual."
+        },
+        "advanced": {
+          "title": "Comportamento Avançado de Busca",
+          "combineGenres": {
+            "label": "Combinar gêneros de todos os provedores selecionados",
+            "hint": "Coletar e remover duplicatas de gêneros de cada provedor atribuído ao campo Gêneros, em vez de parar no primeiro resultado."
+          },
+          "storeProviderIds": {
+            "label": "Armazenar IDs de provedores nos livros",
+            "hint": "Ao buscar metadados, salvar os IDs de provedores retornados (ISBN, ASIN, ID do Goodreads, etc.) no registro do livro para futuras consultas mais precisas."
+          }
+        },
+        "library": {
+          "primary": "Primário:",
+          "overrideCount": "{count} Substituição | {count} Substituições",
+          "unsavedSuffix": "(não salvo)",
+          "unsavedChanges": "Alterações não salvas",
+          "globalDefaults": "Padrões Globais",
+          "overriding": "Substituindo: {fields}",
+          "inheritingAll": "Herdando todas as regras globais de metadados",
+          "subHint": "Campos não substituídos herdam os padrões globais.",
+          "resetTooltip": "Remover todas as substituições e herdar padrões globais",
+          "clearAllConfirm": "Remover todos os provedores ativos de todos os campos em \"{library}\"?",
+          "resetConfirm": "Restaurar \"{library}\" para os padrões globais? Todas as substituições da biblioteca serão removidas."
+        },
+        "groups": {
+          "core": "Principal",
+          "contributors": "Colaboradores",
+          "publication": "Publicação",
+          "series": "Séries",
+          "classification": "Classificação",
+          "audiobook": "Audiolivro"
+        },
+        "groupSummary": {
+          "base": "{fields} campos · {enabled} ativados",
+          "withOverrides": "{base} · {overrides} substituições"
+        },
+        "table": {
+          "field": "Campo",
+          "activeProviders": "Provedores Ativos (ordenados por prioridade)",
+          "mergeStrategy": "Estratégia de Mesclagem",
+          "status": "Status"
+        },
+        "field": {
+          "noProviders": "Ativado, mas não possui provedores",
+          "empty": "Vazio",
+          "config": "Configuração",
+          "custom": "Personalizado",
+          "default": "Padrão",
+          "resetToDefault": "Restaurar para o padrão"
+        },
+        "reservoir": {
+          "disabled": "{provider} - desativado",
+          "notConfigured": "{provider} - não configurado",
+          "dragToAssign": "Arraste para atribuir {provider} a um campo"
+        },
+        "sheet": {
+          "subtitle": "Toque nos provedores para atribuir, use as setas para reordenar",
+          "enableField": "Ativar este campo durante a atualização",
+          "providers": "Provedores",
+          "statusDisabled": "desativado",
+          "statusNotConfigured": "não configurado",
+          "done": "Concluído"
+        }
+      },
+      "genreBlocklist": {
+        "heading": "Exclusões Globais de Gênero",
+        "hint": "Valores exatos de gênero nesta lista são removidos dos resultados do provedor antes da gravação dos metadados.",
+        "saving": "Salvando",
+        "genreValueLabel": "Valor do gênero",
+        "addPlaceholder": "Adicione um valor de gênero, por exemplo: Audiolivro",
+        "duplicate": "Este gênero já está bloqueado.",
+        "add": "Adicionar",
+        "filterPlaceholder": "Filtrar lista de bloqueio",
+        "entryCount": "{count} entrada | {count} entradas",
+        "filteredCount": "{shown} de {total}",
+        "noFilterMatch": "Nenhum gênero bloqueado corresponde ao filtro atual.",
+        "emptyTitle": "Nenhum gênero bloqueado",
+        "emptyHint": "Adicione valores exatos como Audiolivro ou Adulto para mantê-los fora dos metadados buscados.",
+        "removeLabel": "Remover {genre}"
+      },
+      "customFields": {
+        "label": "Rótulo",
+        "labelPlaceholder": "ex: Título Original",
+        "labelTooLong": "O rótulo deve ter 255 caracteres ou menos",
+        "labelDuplicate": "Um campo com este rótulo já existe",
+        "type": "Tipo",
+        "usage": "Usado por {count} livro | Usado por {count} livros",
+        "newField": {
+          "title": "Novo Campo",
+          "hint": "Defina um campo de metadado personalizado e escolha quais bibliotecas o utilizam."
+        },
+        "previewToggle": "Pré-visualizar como este campo aparece ao editar um livro",
+        "untitledField": "Campo sem título",
+        "addField": "Adicionar campo",
+        "fields": "Campos",
+        "fieldsHint": "Arraste para reordenar, edite rótulos, alterne bibliotecas ou arquive campos que não precisa mais.",
+        "searchPlaceholder": "Buscar campos",
+        "searchAriaLabel": "Buscar campos personalizados",
+        "emptyTitle": "Nenhum campo personalizado ainda",
+        "emptyHint": "Use o formulário acima para definir seu primeiro campo de metadado personalizado.",
+        "noMatchTitle": "Nenhum campo corresponde a \"{query}\"",
+        "noMatchHint": "Tente um rótulo, chave ou tipo diferente.",
+        "clearSearchToReorder": "Limpe a busca para reordenar",
+        "dragToReorder": "Arraste para reordenar",
+        "dragToReorderField": "Arraste para reordenar o campo",
+        "unsaved": "Não salvo",
+        "archive": "Arquivar",
+        "archivedFields": "Campos Arquivados",
+        "archivedSummary": "{count} campo arquivado - restaure ou exclua permanentemente. | {count} campos arquivados - restaure ou exclua permanentemente.",
+        "archivedAt": "Arquivado em {when}",
+        "restore": "Restaurar",
+        "deleteForever": "Excluir permanentemente",
+        "deleteDialog": {
+          "title": "Excluir campo permanentemente",
+          "bodyBefore": "Isso excluirá permanentemente",
+          "bodyMiddle": "e removerá seus valores armazenados de",
+          "bodyAfter": ". Isso não pode ser desfeito.",
+          "confirmBefore": "Digite",
+          "confirmAfter": "para confirmar",
+          "confirmPlaceholder": "Digite o rótulo do campo para confirmar"
+        },
+        "preview": "Pré-visualizar",
+        "sampleValue": "Valor de exemplo",
+        "enabledLibraries": "Bibliotecas Ativadas",
+        "countOf": "{selected} de {total}",
+        "selectAll": "Selecionar todos",
+        "clear": "Limpar",
+        "noLibraries": "Nenhuma biblioteca disponível ainda.",
+        "allLibraries": "Todas as bibliotecas"
+      },
+      "tabs": {
+        "providers": "Provedores",
+        "field-rules": "Regras de Campo",
+        "custom-fields": "Campos Personalizados",
+        "genre-blocklist": "Lista de Bloqueio de Gêneros",
+        "score": "Pontuação",
+        "auto-fetch": "Livros",
+        "authors": "Autores"
+      },
+      "tabTitles": {
+        "providers": "Provedores",
+        "field-rules": "Regras por Campo",
+        "custom-fields": "Metadados Personalizados",
+        "genre-blocklist": "Lista de Bloqueio de Gêneros",
+        "score": "Pontuação de Confiança",
+        "auto-fetch": "Busca Automática de Livros",
+        "authors": "Busca Automática de Autores"
+      },
+      "tabSubtitles": {
+        "providers": "Ative fontes externas de metadados e configure suas credenciais.",
+        "field-rules": "Controle qual provedor fornece cada campo de metadados e como os valores são mesclados em suas bibliotecas.",
+        "custom-fields": "Defina campos de metadados personalizados e escolha quais bibliotecas os utilizam.",
+        "genre-blocklist": "Evite que valores indesejados de gêneros dos provedores sejam gravados nos livros.",
+        "score": "Atribua pesos aos campos de metadados para calcular o quanto confiar nos resultados buscados.",
+        "auto-fetch": "Busque automaticamente capas, descrições e outros detalhes quando novos livros forem adicionados à sua biblioteca.",
+        "authors": "Busque automaticamente biografias e fotos de perfil quando novos autores aparecerem em sua biblioteca."
+      }
+    },
+    "reader": {
+      "resetToDefaults": "Restaurar padrões",
+      "all": {
+        "title": "Leitor",
+        "subtitle": "Configure padrões para todos os modos de leitura em um só lugar."
+      },
+      "general": {
+        "title": "Leitura",
+        "subtitle": "Comportamento geral que se aplica a todos os tipos de leitores.",
+        "storageLabel": "Onde salvar as preferências do leitor",
+        "deviceOnly": "Apenas neste dispositivo",
+        "deviceOnlyHint": "As preferências ficam no seu navegador. Ideal se você lê sempre neste dispositivo ou quer configurações diferentes por dispositivo.",
+        "myAccount": "Minha conta",
+        "myAccountHint": "As preferências são salvas na sua conta. Ideal se você faz login de vários dispositivos e quer uma experiência consistente em todos os lugares.",
+        "active": "Ativo",
+        "notAvailable": "Não disponível",
+        "demoCannotChangeStorage": "A conta restrita de demonstração não pode alterar o modo de armazenamento do leitor",
+        "preferencesSynced": "As preferências agora serão sincronizadas",
+        "preferencesLocal": "As preferências permanecerão neste dispositivo",
+        "storageUpdateFailed": "Falha ao atualizar o modo de armazenamento",
+        "storageUpdateError": "Ocorreu um erro ao atualizar o modo de armazenamento"
+      },
+      "ebook": {
+        "title": "Leitor de eBook",
+        "subtitle": "Configurações padrão aplicadas ao abrir arquivos EPUB, MOBI, FB2 e TXT.",
+        "newBooks": "Novos Livros",
+        "applySettings": "Aplicar minhas configurações a novos livros",
+        "applySettingsHint": "Quando desativado, novos livros abrem com as fontes e layout da editora. Suas configurações só são aplicadas assim que você altera algo dentro do leitor.",
+        "layout": "Layout",
+        "readingFlow": "Fluxo de leitura",
+        "readingFlowHint": "Paginado vira páginas; rolado flui continuamente",
+        "paginated": "Paginado",
+        "scrolled": "Rolado",
+        "fixedLayoutSpread": "Páginas duplas em layout fixo",
+        "fixedLayoutSpreadHint": "Padrão para mangás, quadrinhos e EPUBs baseados em imagens",
+        "bookDefault": "Padrão do livro",
+        "singlePage": "Página única",
+        "columns": "Colunas",
+        "columnsHint": "Número de colunas de texto por página",
+        "theme": "Tema",
+        "darkMode": "Modo escuro",
+        "darkModeHint": "Usar a variante escura do tema selecionado",
+        "typography": "Tipografia",
+        "font": "Fonte",
+        "fontHint": "Tipo de letra usado no corpo do texto",
+        "builtInFonts": "Fontes embutidas",
+        "yourFonts": "Suas Fontes",
+        "fontSize": "Tamanho da fonte",
+        "fontSizeHint": "Tamanho base do texto em pixels",
+        "lineHeight": "Altura da linha",
+        "lineHeightHint": "Espaçamento vertical entre as linhas",
+        "justify": "Justificar texto",
+        "justifyHint": "Alinhar texto a ambas as margens",
+        "hyphenation": "Hifenização",
+        "hyphenationHint": "Quebrar automaticamente palavras longas com hifens",
+        "advanced": "Avançado",
+        "maxContentWidth": "Largura máxima do conteúdo",
+        "maxContentWidthHint": "Largura máxima da área de texto em pixels",
+        "columnGap": "Espaço entre colunas",
+        "columnGapHint": "Preenchimento horizontal em cada lado da área de texto"
+      },
+      "pdf": {
+        "title": "Leitor de PDF",
+        "subtitle": "Configurações padrão aplicadas ao abrir arquivos PDF.",
+        "layout": "Layout",
+        "scrollMode": "Modo de rolagem",
+        "scrollModeHint": "Página vira uma de cada vez; contínuo rola por todas as páginas",
+        "page": "Página",
+        "scrolled": "Rolado",
+        "pageSpread": "Exibição de página dupla",
+        "pageSpreadHint": "Qual número de página começa à direita na visualização de duas páginas",
+        "spreadNone": "Nenhum",
+        "spreadOdd": "Ímpar",
+        "spreadEven": "Par",
+        "zoom": "Zoom",
+        "defaultFit": "Ajuste padrão",
+        "defaultFitHint": "Como as páginas são dimensionadas quando um PDF é aberto",
+        "fitPage": "Ajustar à Página",
+        "fitWidth": "Ajustar à Largura",
+        "custom": "Personalizado",
+        "zoomLevel": "Nível de zoom",
+        "zoomLevelHint": "Fator de escala para o modo de zoom personalizado"
+      },
+      "comics": {
+        "title": "Leitor de Quadrinhos",
+        "subtitle": "Configurações padrão aplicadas ao abrir arquivos CBZ, CBR e CB7.",
+        "view": "Visualização",
+        "readingMode": "Modo de leitura",
+        "readingModeHint": "Como as páginas são navegadas - use \"Infinito (sem espaços)\" para webtoons",
+        "paginated": "Paginado",
+        "infiniteSpaced": "Infinito (com espaços)",
+        "infiniteNoGaps": "Infinito (sem espaços)",
+        "pageView": "Visualização de página",
+        "pageViewHint": "Exibir uma ou duas páginas lado a lado",
+        "single": "Única",
+        "twoPage": "Página dupla",
+        "fitMode": "Modo de ajuste",
+        "fitModeHint": "Como as páginas são dimensionadas para caber na tela",
+        "fitPage": "Página",
+        "fitWidth": "Largura",
+        "fitHeight": "Altura",
+        "fitActual": "Real",
+        "readingDirection": "Direção de leitura",
+        "readingDirectionHint": "Esquerda para a direita para quadrinhos ocidentais; direita para a esquerda para mangás",
+        "ltr": "E para D",
+        "rtl": "D para E",
+        "spreadAlignment": "Alinhamento de página dupla",
+        "spreadAlignmentHint": "Deslocar o pareamento em uma página após a capa para digitalizações com descompasso de página",
+        "alignmentNormal": "Normal",
+        "alignmentShifted": "Deslocado",
+        "widePageHandling": "Tratamento de páginas largas",
+        "widePageHandlingHint": "Exibe automaticamente páginas largas sozinhas no modo paginado de duas páginas",
+        "widePageAuto": "Automático",
+        "widePageDisable": "Desativar",
+        "forceTwoPage": "Forçar página dupla em telas pequenas",
+        "forceTwoPageHint": "Ignorar a reversão automática para mobile quando o modo paginado de duas páginas estiver selecionado",
+        "off": "Desativado",
+        "on": "Ativado",
+        "display": "Exibição",
+        "backgroundColor": "Cor de fundo",
+        "backgroundColorHint": "Cor do plano de fundo atrás das páginas",
+        "bgBlack": "Preto",
+        "bgGray": "Cinza",
+        "bgWhite": "Branco"
+      },
+      "audio": {
+        "title": "Reprodutor de Audiolivros",
+        "subtitle": "Configurações padrão aplicadas ao reproduzir arquivos M4B, MP3 e outros formatos de áudio.",
+        "playback": "Reprodução",
+        "playbackSpeed": "Velocidade de reprodução padrão",
+        "playbackSpeedHint": "Multiplicador de velocidade aplicado ao abrir um novo audiolivro",
+        "volume": "Volume padrão",
+        "volumeHint": "Nível de volume inicial (0 a 100%)",
+        "skipControls": "Controles de salto",
+        "skipBack": "Duração do salto para trás",
+        "skipBackHint": "Segundos retrocedidos ao pressionar o botão de salto para trás",
+        "skipForward": "Duração do salto para frente",
+        "skipForwardHint": "Segundos avançados ao pressionar o botão de salto para frente"
+      },
+      "fonts": {
+        "title": "Fontes",
+        "subtitle": "Envie fontes personalizadas para uso no leitor de eBook.",
+        "uploadFonts": "Enviar Fontes",
+        "notAvailableDemo": "Não disponível para contas de demonstração",
+        "uploading": "Enviando...",
+        "dropFilesHere": "Solte os arquivos aqui",
+        "dragFontsPrefix": "Arraste os arquivos de fonte para cá ou",
+        "browse": "procure",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - máx. 10 MB cada",
+        "yourFonts": "Suas Fontes",
+        "fontsUsed": "{count} / {max} usado",
+        "noFontsYet": "Nenhuma fonte enviada ainda",
+        "noFontsHint": "Arraste um arquivo de fonte acima para começar.",
+        "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+        "pangram": "A rápida raposa marrom salta sobre o cão preguiçoso",
+        "renameFamily": "Renomear família",
+        "deleteFamily": "Excluir família",
+        "editVariant": "Editar peso/estilo",
+        "deleteVariant": "Excluir variante",
+        "styleNormal": "Normal",
+        "styleItalic": "Itálico",
+        "weightThin": "Fino (Thin)",
+        "weightExtraLight": "Extra Leve",
+        "weightLight": "Leve",
+        "weightRegular": "Regular",
+        "weightMedium": "Médio",
+        "weightSemiBold": "Semi Negrito",
+        "weightBold": "Negrito",
+        "weightExtraBold": "Extra Negrito",
+        "weightBlack": "Preto (Black)",
+        "renameFamilyFailed": "Falha ao renomear família de fontes",
+        "renamedTo": "Renomeada para \"{name}\"",
+        "updateVariantFailed": "Falha ao atualizar variante da fonte",
+        "deleteFontFailed": "Falha ao excluir fonte",
+        "deleteFamilyFailed": "Falha ao excluir família de fontes",
+        "demoCannotManage": "A conta restrita de demonstração não pode gerenciar fontes",
+        "fileAdded": "\"{name}\" adicionada",
+        "uploadFailed": "Falha no envio"
+      },
+      "bookDock": {
+        "title": "Doca de Livros (Book Dock)",
+        "subtitle": "Configure como os arquivos são processados quando entram na Doca de Livros.",
+        "dropFolder": "Pasta de depósito",
+        "containerPath": "Caminho do contêiner",
+        "containerPathHint": "Copie ou mova arquivos de livros para esta pasta e eles serão automaticamente coletados e processados pela Doca de Livros. Subdiretórios são suportados.",
+        "changePathPrefix": "Para alterar este caminho, defina",
+        "changePathMiddle": "no seu arquivo",
+        "changePathSuffix": ".",
+        "metadata": "Metadados",
+        "autoFetch": "Buscar metadados de provedores automaticamente",
+        "autoFetchHint": "Buscar automaticamente metadados de provedores configurados (Google Books, iTunes, Open Library, etc.) após a adição de um arquivo à Doca de Livros.",
+        "autoFinalize": "Finalização automática",
+        "enableAutoFinalize": "Ativar finalização automática",
+        "enableAutoFinalizeHint": "Arquivos com uma pontuação de confiança de metadados igual ou superior ao limite serão finalizados automaticamente.",
+        "confidenceThreshold": "Limite de confiança: {value}%",
+        "thresholdIgnored": "(ignorado no modo Apenas embutido)",
+        "destinationLibrary": "Biblioteca de destino",
+        "selectLibrary": "Selecione uma biblioteca...",
+        "metadataMode": "Modo de metadados",
+        "metadataModeSafeMerge": "Mesclagem segura (recomendado)",
+        "metadataModeFetchedOnly": "Apenas buscados",
+        "metadataModeEmbeddedOnly": "Apenas embutidos",
+        "destinationFolder": "Pasta de destino",
+        "selectFolder": "Selecione uma pasta...",
+        "saveSettingFailed": "Falha ao salvar configuração",
+        "updateSettingFailed": "Falha ao atualizar configuração",
+        "autoFetchEnabled": "Busca automática ativada",
+        "autoFetchDisabled": "Busca automática desativada",
+        "autoFinalizeEnabled": "Finalização automática ativada",
+        "autoFinalizeDisabled": "Finalização automática desativada",
+        "destinationLibraryUpdated": "Biblioteca de destino atualizada",
+        "destinationFolderUpdated": "Pasta de destino atualizada",
+        "confidenceThresholdUpdated": "Limite de confiança atualizado",
+        "metadataModeUpdated": "Modo de metadados atualizado"
+      },
+      "fileNaming": {
+        "title": "Nomeação de Arquivos",
+        "subtitle": "Controle como os arquivos são organizados no disco ao serem enviados e como são nomeados ao serem baixados usando tokens de preenchimento.",
+        "copy": "Copiar",
+        "previewLabel": "Pré-visualização:",
+        "fileAsBookPreview": "Pré-visualização Arquivo como Livro",
+        "folderAsBookPreview": "Pré-visualização Pasta como Livro",
+        "downloadPreview": "Pré-visualização de download",
+        "globalDefaults": "Padrões Globais",
+        "crossPlatform": "Higienização de caminhos multiplataforma",
+        "crossPlatformHint": "Torne os nomes de arquivos e pastas gerados seguros para o Windows, substituindo caracteres inválidos e nomes reservados, e removendo pontos e espaços finais. Desative apenas para configurações exclusivas de Linux que mantêm intencionalmente esses caracteres.",
+        "fileAsBookDefault": "Padrão de Arquivo como Livro",
+        "fileAsBookDefaultHint": "Padrão de envio para bibliotecas que usam o modo Arquivo como Livro. Cada arquivo é um livro.",
+        "folderAsBookDefault": "Padrão de Pasta como Livro",
+        "folderAsBookDefaultHint": "Padrão de envio para bibliotecas que usam o modo Pasta como Livro. Cada livro deve estar em sua própria pasta.",
+        "downloadPattern": "Padrão de Download",
+        "downloadPatternHint": "Nomes de arquivos sugeridos para downloads de um único arquivo e arquivos dentro de arquivos ZIP exportados.",
+        "libraryOverrides": "Substituições por Biblioteca",
+        "noLibraries": "Nenhuma biblioteca configurada. Crie uma nas configurações da Biblioteca para definir padrões de nomeação personalizados.",
+        "badgeCustom": "Personalizado",
+        "badgeDefault": "Padrão",
+        "orgFolderAsBook": "Pasta como Livro",
+        "orgFileAsBook": "Arquivo como Livro",
+        "resetToDefault": "Restaurar padrão",
+        "patternReference": "Referência de Padrões",
+        "placeholderReference": "Referência de Variáveis (Placeholders)",
+        "placeholderReferenceHint": "- guia para criar padrões de nomeação personalizados",
+        "tokens": "Tokens",
+        "tokensHint": "Copie variáveis rapidamente",
+        "clickTokenHint": "Clique em qualquer token para copiá-lo para a área de transferência.",
+        "copyValue": "Copiar {value}",
+        "modifiers": "Modificadores",
+        "modifiersHint": "Transforme os valores dos tokens",
+        "modifiersExplain": "Adicione um modificador dentro de um token para transformar seu valor:",
+        "modFirst": "Apenas o primeiro valor",
+        "modSort": "Formato Sobrenome, Nome",
+        "modInitial": "Apenas a primeira letra",
+        "modFixed2": "Duas casas decimais",
+        "folderOnlyPrefix": "Termine um padrão com",
+        "folderOnlySuffix": "para especificar apenas uma pasta. O nome original do arquivo será preservado dentro dela.",
+        "conditionalLogic": "Lógica Condicional",
+        "conditionalLogicHint": "Segmentos opcionais e alternativas",
+        "conditionalPart1": "Envolva em",
+        "conditionalPart2": "para pular um segmento quando seu token estiver vazio. Use",
+        "conditionalPart3": "para um valor padrão.",
+        "examples": "Exemplos",
+        "patternExamples": "Exemplos de Padrões",
+        "patternExamplesHint": "Padrões prontos para estilos comuns de biblioteca",
+        "copyPatternTooltip": "Copiar padrão para a área de transferência",
+        "exCalibre": "Padrão estilo Calibre",
+        "exSeriesReader": "Leitor por série",
+        "exCleanDownload": "Nome de arquivo limpo para download",
+        "exAlphabetical": "Agrupamento alfabético com séries",
+        "exSeriesFallback": "Alternativa entre série e livro avulso",
+        "exOptionalSubtitle": "Download com subtítulo opcional",
+        "exMultilingual": "Biblioteca multilíngue",
+        "exPublisher": "Organizado por editora",
+        "exStacked": "Pastas opcionais empilhadas",
+        "exFolderDrop": "Depósito em pasta com nome de ordenação",
+        "caseWithYear": "com ano",
+        "caseNoYear": "sem ano",
+        "caseInSeries": "na série",
+        "caseStandalone": "livro avulso",
+        "caseNoSeries": "sem série",
+        "caseFull": "completo",
+        "caseMinimal": "mínimo",
+        "caseWithLanguage": "com idioma",
+        "caseNoLanguage": "sem idioma",
+        "caseWithPublisher": "com editora",
+        "caseNoPublisher": "sem editora",
+        "caseAllSet": "tudo configurado",
+        "copiedToClipboard": "{value} copiado para a área de transferência",
+        "copyTokenFailed": "Falha ao copiar token",
+        "patternCopied": "Padrão copiado para a área de transferência",
+        "copyPatternFailed": "Falha ao copiar padrão",
+        "labelCopied": "{label} copiado para a área de transferência",
+        "copyLabelFailed": "Falha ao copiar {label}"
+      },
+      "kobo": {
+        "title": "Sincronização Kobo",
+        "subtitle": "Emparelhe seu dispositivo Kobo para sincronizar sua biblioteca.",
+        "copy": "Copiar",
+        "never": "Nunca",
+        "justNow": "Agora mesmo",
+        "minutesAgo": "há {count}m",
+        "hoursAgo": "há {count}h",
+        "daysAgo": "há {count}d",
+        "loadFailed": "Falha ao carregar",
+        "devicePaired": "Dispositivo emparelhado com sucesso",
+        "devicePairedHint": "Você está pronto para configurar o seu Kobo. Siga as instruções abaixo.",
+        "syncUrl": "URL de Sincronização",
+        "urlNotShownAgain": "Esta URL não será mostrada novamente. Mantenha-a em sigilo.",
+        "registeredDevices": "Dispositivos Registrados",
+        "addDevice": "Adicionar dispositivo",
+        "deviceName": "Nome do dispositivo",
+        "deviceNamePlaceholder": "ex: Meu Kobo Libra",
+        "creating": "Criando...",
+        "createDevice": "Criar dispositivo",
+        "createDeviceFailed": "Falha ao criar dispositivo",
+        "deviceRegistered": "Dispositivo \"{name}\" registrado",
+        "noDevicesYet": "Nenhum dispositivo ainda",
+        "noDevicesHint": "Adicione um dispositivo para começar a sincronizar seus livros com o seu Kobo.",
+        "lastSync": "Última sincronização: {time}",
+        "renameDevice": "Renomear dispositivo",
+        "revokeAccess": "Revogar acesso",
+        "deviceRenamed": "Dispositivo renomeado",
+        "renameDeviceFailed": "Falha ao renomear dispositivo",
+        "revokeConfirm": "Revogar acesso para \"{name}\"? O dispositivo não poderá sincronizar até ser emparelhado novamente.",
+        "accessRevoked": "Acesso revogado para \"{name}\"",
+        "revokeFailed": "Falha ao revogar acesso",
+        "syncUrlCopied": "URL de sincronização copiada para a área de transferência",
+        "syncUrlCopyFailed": "Falha ao copiar URL de sincronização",
+        "syncPreferences": "Preferências de Sincronização",
+        "twoWaySync": "Sincronização de progresso bilateral",
+        "twoWaySyncHint": "Sincronizar posição de leitura entre o BookOrbit e o Kobo. Requer envio no formato KEPUB para localizações precisas e restauração de página confiável.",
+        "syncHighlights": "Sincronizar destaques do BookOrbit com o Kobo",
+        "syncHighlightsHint": "Envie os destaques feitos no BookOrbit ou no KOReader para o seu Kobo. Os destaques do Kobo são importados para o BookOrbit mesmo com esta opção desativada. Anotações vinculadas sincronizam edições e exclusões nos dois sentidos. Requer envio de KEPUB; o livro no Kobo deve ser o KEPUB baixado do BookOrbit.",
+        "convertKepub": "Converter para KEPUB",
+        "convertKepubHint": "Enviar EPUBs elegíveis como KEPUB. Esta opção permanece ativa quando a sincronização de progresso ou os destaques do BookOrbit para o Kobo estão ativados. Na próxima sincronização do Kobo, os livros afetados serão oferecidos novamente como downloads KEPUB; remova qualquer cópia EPUB antiga se o Kobo continuar abrindo ela.",
+        "forceHyphenation": "Forçar hifenização",
+        "forceHyphenationHint": "Garante um alinhamento justificado consistente de texto. Isso gerará novamente os KEPUBs em cache.",
+        "progressThresholds": "Limites de Progresso",
+        "progressThresholdsHint": "Defina quando o progresso de leitura do Kobo atualiza o status na sua biblioteca.",
+        "markAsReading": "Marcar como Lendo",
+        "markAsReadingHint": "Porcentagem mínima para mover um livro para \"Lendo\".",
+        "markAsFinished": "Marcar como Concluído",
+        "markAsFinishedHint": "Limite de porcentagem para marcar um livro como \"Concluído\".",
+        "kepubLimit": "Limite de conversão KEPUB",
+        "kepubLimitHint": "Livros acima desse limite são enviados como EPUBs normais, logo, o BookOrbit não sincronizará a posição de leitura deles de volta com o Kobo.",
+        "changesMustBeSaved": "As alterações devem ser salvas para entrarem em vigor.",
+        "saving": "Salvando...",
+        "saveSyncSettings": "Salvar Configurações de Sincronização",
+        "thresholdOrderError": "O limite de leitura deve ser menor que o limite de conclusão",
+        "saveSettingsFailed": "Falha ao salvar configurações",
+        "settingsSaved": "Configurações de sincronização do Kobo salvas",
+        "saveFailed": "Falha ao salvar",
+        "activity": {
+          "waitingForActivity": "Aguardando atividade",
+          "needsAttention": "Precisa de atenção",
+          "syncHealthy": "Sincronização normal",
+          "never": "Nunca",
+          "none": "Nenhuma",
+          "unknown": "Desconhecido",
+          "failureCount": "{count} falha | {count} falhas",
+          "noActivityRecorded": "Nenhuma atividade de sincronização do Kobo foi registrada.",
+          "lastSuccess": "Último sucesso em {time}",
+          "lastFailure": "Última falha em {time}",
+          "noFailedActivity": "Nenhuma atividade do Kobo com falha no histórico recente.",
+          "noActivityYet": "Nenhuma atividade do Kobo ainda.",
+          "event": {
+            "librarySync": "Biblioteca verificada quanto a atualizações",
+            "bookDownload": "Livro baixado",
+            "progressUpdate": "Posição de leitura atualizada",
+            "annotationsPull": "Destaques enviados para o Kobo",
+            "annotationsPush": "Destaques recebidos do Kobo"
+          },
+          "outcome": {
+            "failed": "Falhou",
+            "noUpdates": "Sem atualizações",
+            "noChanges": "Sem alterações",
+            "pending": "Pendente",
+            "completed": "Concluído",
+            "downloaded": "Baixado",
+            "updated": "Atualizado",
+            "sent": "Enviado",
+            "imported": "Importado"
+          },
+          "failure": {
+            "librarySync": "A verificação da biblioteca não foi concluída",
+            "bookDownload": "O download não foi concluído",
+            "progressUpdate": "A posição de leitura não foi atualizada",
+            "annotationsPull": "Os destaques não foram enviados",
+            "annotationsPush": "Os destaques não foram importados"
+          },
+          "chip": {
+            "morePending": "Mais pendentes",
+            "noUpdatesPending": "Nenhuma atualização pendente",
+            "bookCount": "{count} livro | {count} livros",
+            "deletedAnnotations": "{count} anotações excluídas",
+            "deviceAlreadyCurrent": "Dispositivo já atualizado",
+            "freshHighlightData": "Dados de destaque recentes",
+            "created": "{count} criado(s)",
+            "updated": "{count} atualizado(s)",
+            "deleted": "{count} excluído(s)",
+            "unchanged": "{count} inalterado(s)"
+          },
+          "readingPositionSyncedTitle": "Posição de leitura sincronizada: {title}",
+          "readingPositionSynced": "Posição de leitura sincronizada",
+          "labelWithTitle": "{label}: {title}",
+          "updateCount": "{count} atualização | {count} atualizações",
+          "directionToKobo": "BookOrbit -> Kobo",
+          "directionToBookOrbit": "Kobo -> BookOrbit",
+          "twoWaySyncEnabled": "Sincronização bilateral ativada",
+          "deviceProgressSaved": "Progresso do dispositivo salvo",
+          "summary": {
+            "noLibraryUpdatesPending": "Nenhuma atualização de biblioteca pendente para este dispositivo",
+            "libraryUpdatesPrepared": "{count} atualização de biblioteca preparada para o dispositivo | {count} atualizações de biblioteca preparadas para o dispositivo",
+            "bookDownloadedBy": "{title} foi baixado por {device}",
+            "booksDownloaded": "{count} livro baixado | {count} livros baixados",
+            "progressUpdatesSyncedFor": "{count} atualização de progresso sincronizada para {title} | {count} atualizações de progresso sincronizadas para {title}",
+            "progressUpdatesSynced": "{count} atualização de progresso sincronizada | {count} atualizações de progresso sincronizadas",
+            "newReadingPositionFor": "O Kobo informou uma nova posição de leitura para {title}",
+            "newReadingPosition": "O Kobo informou uma nova posição de leitura",
+            "noHighlightChangesNeededFor": "Nenhuma alteração de destaque necessária para {title}",
+            "noHighlightChangesNeeded": "Nenhuma alteração de destaque necessária",
+            "highlightsSentToKoboFor": "{count} destaque enviado ao Kobo para {title} | {count} destaques enviados ao Kobo para {title}",
+            "highlightsSentToKobo": "{count} destaque enviado ao Kobo | {count} destaques enviados ao Kobo",
+            "noKoboHighlightChangesFor": "Nenhuma alteração de destaque do Kobo para {title}",
+            "noKoboHighlightChanges": "Nenhuma alteração de destaque do Kobo",
+            "highlightsImportedFromKoboFor": "{count} destaque importado do Kobo para {title} | {count} destaques importados do Kobo para {title}",
+            "highlightsImportedFromKobo": "{count} destaque importado do Kobo | {count} destaques importados do Kobo"
+          },
+          "timeRange": "{from} até {to}",
+          "eventsGrouped": "{count} evento agrupado | {count} eventos agrupados",
+          "removedDevice": "Dispositivo removido",
+          "loadMoreFailed": "Falha ao carregar mais histórico",
+          "historyRefreshed": "Histórico de sincronização do Kobo atualizado",
+          "refreshFailed": "Falha ao atualizar o histórico",
+          "recentActivity": "Atividade Recente do Kobo",
+          "filterAll": "Tudo",
+          "filterFailures": "Falhas",
+          "refresh": "Atualizar",
+          "loadingActivity": "Carregando atividade do Kobo...",
+          "noActivityHint": "As atividades de sincronização recentes aparecerão depois que um Kobo emparelhado entrar em contato com o BookOrbit.",
+          "error": "Erro",
+          "loading": "Carregando...",
+          "loadMore": "Carregar mais atividades"
+        },
+        "howBooksSynced": {
+          "title": "Como os livros são sincronizados",
+          "body": "Para enviar livros ao seu dispositivo Kobo, você deve ativar {syncToKobo} nas coleções que contêm esses livros. Abra uma coleção na barra lateral, clique no ícone Editar e ative {syncToKobo}. Livros que não fazem parte de uma coleção ativada não serão sincronizados."
+        },
+        "nextSteps": {
+          "title": "Próximos Passos",
+          "step1": "1. Configure seu dispositivo Kobo para sincronizar com a URL de Sincronização acima.",
+          "step2": "2. No BookOrbit, abra uma coleção na barra lateral, clique no ícone Editar e ative {syncToKobo}. Apenas livros em coleções com sincronização ativada serão baixados para o seu dispositivo."
+        },
+        "syncToKobo": "Sincronizar com o Kobo",
+        "tabs": {
+          "syncSettings": "Configurações de Sincronização",
+          "activityLog": "Registro de Atividades"
+        }
+      },
+      "koreader": {
+        "title": "Sincronização KOReader",
+        "subtitle": "Navegue pelo seu catálogo BookOrbit no KOReader e sincronize progresso, atividade de leitura, destaques e alterações nas anotações.",
+        "tabs": {
+          "sync": "Configurações de Sincronização",
+          "fileNaming": "Nomeação de Arquivos"
+        },
+        "fileNaming": {
+          "accountTitle": "Padrão KOReader da conta",
+          "accountDescription": "Define a pasta relativa e o nome de arquivo padrão usados pelos downloads do plugin BookOrbit para sua conta KOReader. Regras específicas do dispositivo podem substituí-lo abaixo.",
+          "defaultPattern": "Padrão do caminho do livro",
+          "accountHelp": "O padrão da sua conta para downloads do plugin KOReader, a menos que um dispositivo tenha uma regra personalizada.",
+          "accountHint": "Usado pelos seus dispositivos KOReader que não têm uma substituição personalizada.",
+          "preview": "Pré-visualização",
+          "saveAccount": "Salvar padrão da conta",
+          "deviceTitle": "Substituições por dispositivo KOReader",
+          "deviceDescription": "Personalize qualquer combinação de caminhos padrão, de séries e de livros avulsos. Linhas específicas do dispositivo que estiverem vazias herdam o padrão do dispositivo, que pode herdar o padrão KOReader da conta.",
+          "noDevices": "Os dispositivos aparecerão aqui após sincronizarem com o BookOrbit.",
+          "customOrganization": "Organização personalizada",
+          "usingAccountDefault": "Usando o padrão da conta",
+          "deviceDefaultHelp": "Alternativa para este dispositivo. Mantenha-o igual ao padrão da conta para herdar automaticamente alterações futuras.",
+          "seriesBooks": "Livros de uma série",
+          "seriesHelp": "Caminho opcional usado apenas para livros com metadados de série. Deixe vazio para usar o padrão de caminho deste dispositivo.",
+          "standaloneBooks": "Livros avulsos",
+          "standaloneHelp": "Caminho opcional usado apenas para livros sem metadados de série. Deixe vazio para usar o padrão de caminho deste dispositivo.",
+          "inheritPlaceholder": "Deixe vazio para usar o padrão deste dispositivo",
+          "useAccount": "Usar padrão da conta",
+          "saveOverride": "Salvar substituição",
+          "loadFailed": "Falha ao carregar configurações de organização de arquivos",
+          "accountRequired": "Insira um padrão de caminho do livro antes de salvar.",
+          "accountSaved": "Padrão KOReader da conta salvo",
+          "accountSaveFailed": "Falha ao salvar configurações de organização de arquivos",
+          "deviceUsesAccount": "O dispositivo agora usa o padrão KOReader da conta",
+          "deviceSaved": "Substituição de organização do dispositivo salva",
+          "deviceSaveFailed": "Falha ao salvar a substituição do dispositivo",
+          "deviceResetFailed": "Falha ao redefinir a substituição do dispositivo"
+        },
+        "loadingSettings": "Carregando configurações do KOReader...",
+        "loadFailed": "Falha ao carregar configurações do KOReader",
+        "never": "Nunca",
+        "justNow": "Agora mesmo",
+        "minutesAgo": "há {count}m",
+        "hoursAgo": "há {count}h",
+        "daysAgo": "há {count}d",
+        "unknown": "Desconhecido",
+        "updateAvailable": "Atualização disponível",
+        "upToDate": "Atualizado",
+        "versionUnknown": "Versão desconhecida",
+        "latestPlugin": "Plugin mais recente: v{version}",
+        "latestPluginUnavailable": "Plugin mais recente indisponível",
+        "notConfigured": "A sincronização do KOReader não está configurada",
+        "notConfiguredHint": "Crie um conjunto de credenciais de sincronização e use-as com o plugin BookOrbit para KOReader para navegação, downloads, progresso, eventos de leitura, destaques e exclusões.",
+        "createCredentials": "Criar credenciais",
+        "createFormTitle": "Criar Credenciais de Sincronização KOReader",
+        "createFormHint": "Estas credenciais autenticam seus dispositivos KOReader com o BookOrbit.",
+        "username": "Nome de usuário",
+        "usernamePlaceholder": "ex: meuleitor",
+        "password": "Senha",
+        "passwordPlaceholder": "Mín. 6 caracteres",
+        "creating": "Criando...",
+        "create": "Criar",
+        "credentialsCreated": "Credenciais de sincronização KOReader criadas",
+        "createCredentialsFailed": "Falha ao criar credenciais",
+        "status": "Status do KOReader",
+        "refresh": "Atualizar",
+        "progressSync": "Sincronização de progresso",
+        "progressSyncHint": "Permitir que dispositivos KOReader sincronizem progresso, atividade de leitura, destaques e exclusão de anotações com o BookOrbit.",
+        "lastSync": "Última sincronização",
+        "syncedBooks": "Livros sincronizados",
+        "bookCount": "nenhum livro | {count} livro | {count} livros",
+        "devices": "Dispositivos",
+        "deviceCount": "nenhum dispositivo | {count} dispositivo | {count} dispositivos",
+        "credentialsCreatedLabel": "Credenciais criadas",
+        "setup": "Configuração",
+        "pluginServerUrl": "URL do servidor do plugin",
+        "copied": "Copiada",
+        "copyUrl": "Copiar URL",
+        "preconfiguredPlugin": "Plugin do BookOrbit pré-configurado",
+        "preconfiguredPluginHintPrefix": "Baixe um arquivo zip com a URL do servidor e seu login de sincronização já configurados. O plugin inclui navegação no catálogo e sincronização. Copie a pasta para",
+        "preconfiguredPluginHintSuffix": "e reinicie o KOReader.",
+        "latestPluginNote": "{label}. Atualizações no dispositivo podem ser feitas a partir do menu BookOrbit no KOReader.",
+        "preparing": "Preparando...",
+        "downloadPlugin": "Baixar Plugin",
+        "noDevicesSynced": "Nenhum dispositivo foi sincronizado ainda",
+        "noDevicesSyncedHint": "Instale o plugin BookOrbit para sincronização completa, ou configure a sincronização nativa de progresso do KOReader para atualizações apenas de progresso.",
+        "lastSyncLabel": "Última sincronização:",
+        "lastBookLabel": "Último livro:",
+        "noneYet": "Nenhum ainda",
+        "pluginActivity": "Atividade do Plugin",
+        "noPluginActivity": "Nenhuma atividade do plugin foi relatada ainda.",
+        "lastFullSync": "Última sincronização completa: {time}",
+        "latestPluginSuffix": "- plugin mais recente v{version}",
+        "matchedBooks": "Livros correspondidos",
+        "readingEvents": "Eventos de leitura",
+        "highlights": "Destaques",
+        "syncedTotals": "Totais sincronizados",
+        "trashedHighlights": "Destaques na lixeira",
+        "pendingDeletes": "nenhum destaque excluído aguardando confirmação do plugin KOReader. | {count} destaque excluído aguardando confirmação do plugin KOReader. | {count} destaques excluídos aguardando confirmação do plugin KOReader.",
+        "failedPositions": "nenhuma posição de destaque precisa de atenção. | {count} posição de destaque precisa de atenção. | {count} posições de destaque precisam de atenção.",
+        "setupGuide": "Guia de Configuração",
+        "setupSteps": "Passos para configuração do KOReader",
+        "setupStepsHint": "Use o plugin do BookOrbit para navegação no catálogo, downloads, progresso, eventos de leitura e destaques. Use o plugin nativo apenas para progresso.",
+        "pluginGuideTitle": "Plugin BookOrbit",
+        "pluginStep1": "Baixe o plugin pré-configurado acima.",
+        "pluginStep2Prefix": "Descompacte-o e copie",
+        "pluginStep2Middle": "para",
+        "pluginStep2Suffix": "no seu dispositivo.",
+        "pluginStep3": "Reinicie o KOReader. O servidor e o login já estarão configurados automaticamente.",
+        "pluginStep4Prefix": "Abra",
+        "pluginStep4Suffix": "para buscar, baixar e vincular livros para sincronizar.",
+        "stockGuideTitle": "Plugin nativo de sincronização de progresso",
+        "stockStep1Prefix": "No seu dispositivo KOReader, vá até",
+        "stockStep1Suffix": ".",
+        "stockStep2": "Defina o servidor de sincronização personalizado como a URL exibida acima.",
+        "stockStep3": "Insira o nome de usuário e a senha que você criou, e depois toque em Entrar (Login).",
+        "locationNote": "O BookOrbit salva localizações de EPUB compatíveis com o KOReader a partir do leitor web. A restauração deve cair bem perto da mesma posição, embora a colocação exata da linha possa variar conforme o leitor e o layout do EPUB.",
+        "dangerZone": "Zona de Perigo",
+        "deleteCredentials": "Excluir credenciais do KOReader",
+        "deleteCredentialsHint": "Remover credenciais de sincronização e desconectar todos os dispositivos. Os dados de progresso serão mantidos.",
+        "credentialsDeleted": "Credenciais do KOReader excluídas",
+        "deleteCredentialsFailed": "Falha ao excluir credenciais",
+        "deleteConfirmTitle": "Excluir credenciais do KOReader?",
+        "deleteConfirmBody": "Isso removerá suas credenciais de sincronização e desconectará todos os dispositivos KOReader. Os dados de progresso existentes serão mantidos.",
+        "syncEnabled": "Sincronização KOReader ativada",
+        "syncDisabled": "Sincronização KOReader desativada",
+        "toggleSyncFailed": "Falha ao alternar a sincronização",
+        "syncUrlCopied": "URL de sincronização copiada para a área de transferência",
+        "syncUrlCopyFailed": "Falha ao copiar a URL de sincronização",
+        "statusRefreshed": "Status de sincronização atualizado",
+        "refreshFailed": "Falha ao atualizar",
+        "pluginDownloaded": "Plugin baixado. Copie a pasta bookorbit.koplugin do arquivo zip para koreader/plugins/ no seu dispositivo.",
+        "pluginDownloadFailed": "Falha ao baixar o plugin",
+        "hashLinks": {
+          "unmatchedTitle": "Livros do KOReader Não Correspondidos",
+          "unmatchedBooks": "Livros não correspondidos",
+          "manualTitle": "Vínculos Manuais do KOReader",
+          "refresh": "Atualizar",
+          "link": "Vincular",
+          "change": "Alterar",
+          "unlink": "Desvincular",
+          "hash": "Hash:",
+          "lastOpened": "Última abertura:",
+          "firstSeen": "Visto pela primeira vez:",
+          "lastSeen": "Visto pela última vez:",
+          "linked": "Vinculado:",
+          "updated": "Atualizado:",
+          "linkedTo": "Vinculado a {title}",
+          "loadingUnmatched": "Carregando livros não correspondidos...",
+          "loadingManual": "Carregando vínculos manuais de hash...",
+          "noUnmatched": "Nenhum livro do KOReader sem correspondência.",
+          "noManual": "Nenhum vínculo manual do KOReader.",
+          "pageOf": "Página {page} de {total}",
+          "showingRange": "Exibindo {start}-{end} de {total}",
+          "unknownFile": "Arquivo desconhecido do KOReader {hash}",
+          "unknownAuthor": "Autor desconhecido",
+          "noTitleOrAuthor": "Nenhum título ou autor informado",
+          "bookNumber": "Livro BookOrbit #{id}",
+          "toast": {
+            "unmatchedRefreshed": "Livros não correspondidos atualizados",
+            "unmatchedRefreshFailed": "Falha ao atualizar livros não correspondidos",
+            "manualRefreshed": "Vínculos manuais de hash atualizados",
+            "manualRefreshFailed": "Falha ao atualizar vínculos manuais de hash",
+            "bookLinked": "Livro vinculado",
+            "linkUpdated": "Vínculo atualizado",
+            "linkFailed": "Falha ao vincular o livro",
+            "linkRemoved": "Vínculo removido",
+            "unlinkFailed": "Falha ao desvincular o livro",
+            "unmatchedDismissed": "Livro não correspondido dispensado",
+            "dismissFailed": "Falha ao dispensar o livro não correspondido",
+            "allDismissed": "Nenhum livro dispensado | Dispensado {count} livro não correspondido | Dispensados {count} livros não correspondidos",
+            "dismissAllFailed": "Falha ao dispensar todos os livros não correspondidos"
+          },
+          "modal": {
+            "linkTitle": "Vincular livro do KOReader",
+            "changeTitle": "Alterar vínculo do KOReader",
+            "bookOrbitBook": "Livro do BookOrbit",
+            "searchPlaceholder": "Busque na sua biblioteca do BookOrbit",
+            "minChars": "Digite pelo menos 2 caracteres.",
+            "searching": "Buscando...",
+            "noBooksFound": "Nenhum livro encontrado.",
+            "untitledBook": "Livro sem título",
+            "selected": "Selecionado",
+            "select": "Selecionar",
+            "loadMore": "Carregar mais",
+            "confirmTitle": "Confirmar vínculo do KOReader",
+            "koreader": "KOReader",
+            "bookOrbit": "BookOrbit",
+            "bookId": "ID do Livro: {id}",
+            "syncedStatsNote": "Estatísticas já sincronizadas permanecerão em seu livro atual do BookOrbit.",
+            "chooseDifferent": "Escolher outro",
+            "saving": "Salvando...",
+            "confirmLink": "Confirmar vínculo",
+            "unlinkTitle": "Desvincular livro do KOReader?",
+            "unlinkBody": "Sincronizações futuras para este hash deixarão de apontar para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no seu livro atual no BookOrbit.",
+            "unlinking": "Desvinculando..."
+          },
+          "dismiss": "Dispensar",
+          "dismissAll": "Dispensar todos",
+          "dismissing": "Dispensando...",
+          "unlinking": "Desvinculando...",
+          "unlinkConfirmTitle": "Desvincular livro do KOReader?",
+          "unlinkConfirmBody": "Sincronizações futuras para este hash deixarão de apontar para {title} até que seja vinculado novamente. As estatísticas já sincronizadas permanecerão no seu livro atual no BookOrbit.",
+          "dismissConfirmTitle": "Dispensar {title}?",
+          "dismissConfirmBody": "Isso o remove da sua lista de livros não correspondidos. Se qualquer dispositivo informar este hash novamente no futuro, ele reaparecerá como uma nova entrada.",
+          "dismissAllConfirmTitle": "Nenhum livro | Dispensar todos os {count} livros não correspondidos? | Dispensar todos os {count} livros não correspondidos?",
+          "dismissAllConfirmBody": "Isso limpa toda a sua lista de livros não correspondidos, não apenas a página atual. Se algum dispositivo informar um desses hashes novamente, ele reaparecerá como uma nova entrada.",
+          "changeLinkTitle": "Alterar vínculo do KOReader",
+          "linkBookTitle": "Vincular livro do KOReader",
+          "bookOrbitBook": "Livro do BookOrbit",
+          "searchLibraryPlaceholder": "Busque na sua biblioteca do BookOrbit",
+          "enterMinChars": "Digite pelo menos 2 caracteres.",
+          "searching": "Buscando...",
+          "noBooksFound": "Nenhum livro encontrado.",
+          "untitledBook": "Livro sem título",
+          "selected": "Selecionado",
+          "select": "Selecionar",
+          "loadMore": "Carregar mais",
+          "loadingMore": "Carregando...",
+          "confirmLinkTitle": "Confirmar vínculo do KOReader",
+          "bookId": "ID do Livro: {id}",
+          "syncedStatsNote": "Estatísticas já sincronizadas permanecerão em seu livro atual do BookOrbit.",
+          "chooseDifferent": "Escolher outro",
+          "saving": "Salvando...",
+          "confirmLink": "Confirmar vínculo"
+        },
+        "remove": "Remover",
+        "removing": "Removendo...",
+        "unmatchedBooks": "Livros não correspondidos",
+        "deviceRemoved": "Dispositivo removido",
+        "removeDeviceFailed": "Falha ao remover o dispositivo",
+        "removeDeviceConfirmTitle": "Remover {device}?",
+        "removeDeviceConfirmBody": "Isso exclui permanentemente o progresso sincronizado deste dispositivo, a atividade de leitura e quaisquer entradas de livros não correspondidos que não sejam relatados por outro dispositivo. Se o dispositivo sincronizar novamente mais tarde, ele reaparecerá como uma nova entrada."
+      },
+      "opds": {
+        "title": "OPDS",
+        "subtitle": "Conecte aplicativos de leitura compatíveis com OPDS, como o KOReader ou Thorium Reader, à sua biblioteca.",
+        "copy": "Copiar",
+        "loadFailed": "Falha ao carregar",
+        "server": "Servidor",
+        "catalogServer": "Servidor de Catálogo OPDS",
+        "catalogServerHint": "Permitir que clientes OPDS naveguem e baixem livros",
+        "endpoint": "Endereço (Endpoint)",
+        "accounts": "Contas OPDS",
+        "add": "Adicionar",
+        "addAccount": "Adicionar conta",
+        "username": "Nome de usuário",
+        "usernameLabel": "Nome de usuário",
+        "usernamePlaceholder": "ex: koreader",
+        "password": "Senha",
+        "passwordPlaceholder": "Mín. 8 caracteres",
+        "defaultSort": "Ordenação Padrão",
+        "sortLabel": "Ordenação",
+        "creating": "Criando...",
+        "create": "Criar",
+        "noAccounts": "Nenhuma conta OPDS ainda. Crie uma para começar a usar clientes OPDS.",
+        "hideDetails": "Ocultar detalhes",
+        "showDetails": "Exibir detalhes",
+        "copyUsername": "Copiar nome de usuário",
+        "notes": "Notas sobre o OPDS",
+        "notesBody": "Use contas OPDS em aplicativos de leitura. Mantenha as credenciais em sigilo e altere as senhas caso sejam compartilhadas por engano.",
+        "deleteConfirmTitle": "Excluir conta OPDS?",
+        "deleteConfirmBody": "Excluir \"{username}\". Esta ação não pode ser desfeita.",
+        "sortRecent": "Adicionados Recentes",
+        "sortTitleAsc": "Título (A-Z)",
+        "sortTitleDesc": "Título (Z-A)",
+        "sortAuthorAsc": "Autor (A-Z)",
+        "sortAuthorDesc": "Autor (Z-A)",
+        "sortSeriesAsc": "Série (A-Z)",
+        "sortSeriesDesc": "Série (Z-A)",
+        "serverEnabled": "Servidor OPDS ativado",
+        "serverDisabled": "Servidor OPDS desativado",
+        "updateSettingsFailed": "Falha ao atualizar configurações OPDS",
+        "urlCopied": "URL do OPDS copiada para a área de transferência",
+        "urlCopyFailed": "Falha ao copiar a URL do OPDS",
+        "createUserFailed": "Falha ao criar o usuário OPDS",
+        "userCreated": "Usuário OPDS \"{username}\" criado",
+        "sortOrderUpdated": "Ordem de classificação atualizada para \"{username}\"",
+        "updateSortFailed": "Falha ao atualizar a ordem de classificação",
+        "userDeleted": "Usuário OPDS \"{username}\" excluído",
+        "deleteUserFailed": "Falha ao excluir usuário OPDS",
+        "labelCopied": "{label} copiado(a)",
+        "copyLabelFailed": "Falha ao copiar {label}"
+      },
+      "tabs": {
+        "general": "Geral",
+        "ebook": "eBook",
+        "pdf": "PDF",
+        "comics": "Quadrinhos",
+        "audio": "Audiolivro",
+        "fonts": "Fontes"
+      }
+    },
+    "system": {
+      "tabs": {
+        "file-naming": "Nomeação de Arquivos",
+        "book-dock": "Doca de Livros",
+        "maintenance": "Manutenção",
+        "audit-log": "Registro de Auditoria"
+      }
+    }
+  },
+  "achievements": {
+    "title": "Conquistas",
+    "tiersCount": "{earned} / {total} níveis",
+    "loadFailed": "Falha ao carregar conquistas",
+    "tryAgain": "Tentar novamente",
+    "noMatchFilter": "Nenhuma conquista corresponde a este filtro",
+    "secretAchievement": "Conquista Secreta",
+    "earnedOn": "Conquistado em {date}",
+    "whileReading": "Ao ler “{title}”",
+    "tierProgress": "Nível {earned} de {total}",
+    "progressToNext": "{current} / {threshold} para {name}",
+    "rarity": {
+      "common": "Comum",
+      "rare": "Rara",
+      "epic": "Épica",
+      "legendary": "Lendária"
+    },
+    "filter": {
+      "all": "Todas",
+      "earned": "Conquistadas ({count})",
+      "inProgress": "Em Progresso ({count})",
+      "locked": "Bloqueadas ({count})"
+    }
+  },
+  "adminFeature": {
+    "accountActivity": {
+      "title": "Atividade da Conta",
+      "subtitle": "Revise a atividade de autenticação da conta sem expor o histórico de leitura.",
+      "privacyNotice": "Esta página relata apenas logins e atualizações de autenticação. Ela não usa o histórico de leitura, progresso de livros ou atividades na biblioteca.",
+      "privacyLabel": "Sobre a privacidade das atividades da conta",
+      "never": "Nunca",
+      "openInsightsFor": "Abrir insights de leitura compartilhados para {name}",
+      "permissionLabel": "Ver atividade do usuário",
+      "states": {
+        "recent": "Ativo recentemente",
+        "dormant": "Inativo / Dormente",
+        "never": "Nenhuma atividade registrada",
+        "disabled": "Desativado"
+      },
+      "filters": {
+        "search": "Buscar contas",
+        "searchPlaceholder": "Buscar por nome ou nome de usuário",
+        "state": "Estado de atividade",
+        "allStates": "Todos os estados de atividade",
+        "provisioning": "Método de autenticação",
+        "allMethods": "Todos os métodos de autenticação",
+        "sort": "Ordenar contas",
+        "mostRecent": "Atividade mais recente",
+        "leastRecent": "Atividade menos recente",
+        "lastLogin": "Login mais recente",
+        "newest": "Contas mais recentes",
+        "oldest": "Contas mais antigas",
+        "name": "Nome",
+        "apply": "Aplicar",
+        "clear": "Limpar"
+      },
+      "methods": { "local": "Local", "manual": "Criado pelo administrador", "oidc": "OIDC / SSO", "shared": "Link mágico compartilhado" },
+      "columns": {
+        "user": "Usuário",
+        "state": "Estado da conta",
+        "lastLogin": "Último login",
+        "lastAuthenticated": "Última autenticação",
+        "created": "Criada",
+        "readingInsights": "Insights de leitura"
+      },
+      "sharing": { "private": "Não compartilhado", "summary": "Resumo compartilhado", "detailed": "Detalhes compartilhados" },
+      "empty": { "title": "Nenhuma conta encontrada", "description": "Tente alterar ou limpar os filtros atuais." },
+      "pagination": { "label": "Páginas da atividade da conta", "page": "Página {page} de {totalPages}" },
+      "errors": { "load": "Falha ao carregar a atividade da conta." }
+    },
+    "sharedInsights": {
+      "title": "Insights de leitura compartilhados",
+      "subtitle": "Informações de leitura que este usuário escolheu voluntariamente compartilhar.",
+      "auditNotice": "O acesso a este perfil é registrado e fica visível para o usuário.",
+      "period": "Período do relatório",
+      "periodDays": "Últimos {count} dias",
+      "durationMinutes": "{count} minuto | {count} minutos",
+      "durationHours": "{count} horas",
+      "metrics": {
+        "sessions": "Sessões",
+        "readingTime": "Tempo de leitura",
+        "activeDays": "Dias ativos",
+        "started": "Livros iniciados",
+        "completed": "Livros concluídos"
+      },
+      "trend": "Tendência de leitura diária",
+      "emptyTitle": "Nenhuma atividade de leitura neste período",
+      "noData": "Nenhum dado de leitura registrado para este período.",
+      "sessionCount": "{count} sessão | {count} sessões",
+      "sourceNames": { "web": "Leitor web", "koreader": "KOReader", "manual": "Manual", "kobo": "Kobo", "unknown": "Desconhecido" },
+      "formats": "Formatos",
+      "genres": "Gêneros",
+      "broadGenres": {
+        "science_fiction": "Ficção científica",
+        "fantasy": "Fantasia",
+        "mystery_thriller": "Mistério e Suspense",
+        "romance": "Romance",
+        "horror": "Terror",
+        "history_biography": "História e Biografia",
+        "science_technology": "Ciência e Tecnologia",
+        "business_economics": "Negócios e Economia",
+        "self_development": "Desenvolvimento pessoal",
+        "society_culture": "Sociedade e Cultura",
+        "children_young_adult": "Infantil e Jovem Adulto",
+        "comics_graphic_novels": "Quadrinhos e Graphic Novels",
+        "poetry": "Poesia",
+        "other": "Outro"
+      },
+      "sources": "Fontes de dados",
+      "topBooks": "Livros mais lidos",
+      "recentBooks": "Lidos recentemente",
+      "unknownTitle": "Livro sem título",
+      "top": { "authors": "Principais autores", "genres": "Principais gêneros", "series": "Principais séries", "narrators": "Principais narradores" },
+      "errors": {
+        "READING_INSIGHTS_PRIVATE": "Este usuário não está compartilhando insights de leitura.",
+        "READING_INSIGHTS_SUMMARY_ONLY": "Este usuário compartilha apenas insights resumidos.",
+        "READING_INSIGHTS_VIEW_SESSION_REQUIRED": "Uma sessão de visualização do perfil é necessária.",
+        "READING_INSIGHTS_VIEW_SESSION_INVALID": "Esta visualização do perfil expirou ou não é mais válida.",
+        "LOAD_FAILED": "Não foi possível carregar os insights de leitura compartilhados.",
+        "cleared": "Nenhuma informação do perfil carregada anteriormente está sendo exibida."
+      }
+    },
+    "resetLink": {
+      "title": "Link para Redefinição de Senha",
+      "description": "Compartilhe este link com o usuário. Ele expira em 15 minutos.",
+      "copy": "Copiar",
+      "copied": "Copiado!",
+      "copyFailed": "Falha ao copiar",
+      "notShownAgain": "Este link não será exibido novamente."
+    },
+    "userForm": {
+      "editUser": "Editar Usuário",
+      "createUser": "Criar Usuário",
+      "createSharedAccount": "Criar Conta Compartilhada",
+      "sharedBadge": "Compartilhada",
+      "active": "Ativo",
+      "suspended": "Suspenso",
+      "tabs": {
+        "general": "geral",
+        "access": "acesso",
+        "restrictions": "restrições"
+      },
+      "sharedAccount": "Conta compartilhada",
+      "sharedAccountHint": "Sem senha. O acesso é concedido apenas por meio de links mágicos.",
+      "sharedAccountManageHint": "Gerencie links de login em Configurações - Links Mágicos.",
+      "username": "Nome de usuário",
+      "fullName": "Nome completo",
+      "email": "E-mail",
+      "optional": "(opcional)",
+      "libraryAccess": "Acesso a Bibliotecas",
+      "noLibrariesSelected": "Nenhuma biblioteca selecionada. O usuário não poderá ver nenhum livro.",
+      "permissions": "Permissões",
+      "presetStandard": "Padrão",
+      "presetAdmin": "Admin",
+      "presetClearAll": "Limpar Tudo",
+      "permissionGroups": {
+        "content": "Conteúdo",
+        "devicesAccess": "Dispositivos e Acesso",
+        "email": "E-mail",
+        "administration": "Administração",
+        "notifications": "Notificações",
+        "restrictions": "Restrições"
+      },
+      "superuserTarget": "Alvo Superusuário",
+      "superuserTargetHint": "Restrições de conteúdo não podem ser aplicadas a superusuários.",
+      "noRestrictions": "Sem restrições de conteúdo",
+      "noRestrictionsHint": "Este usuário tem acesso total a todos os livros em suas bibliotecas atribuídas.",
+      "addRestrictions": "+ Adicionar Restrições de Conteúdo",
+      "contentRestrictions": "Restrições de Conteúdo",
+      "remove": "Remover",
+      "includeTags": "Incluir tags",
+      "includeTagsHint": "(exibir apenas livros com estas tags)",
+      "excludeTags": "Excluir tags",
+      "excludeTagsHint": "(ocultar livros com estas tags)",
+      "includeGenres": "Incluir gêneros",
+      "includeGenresHint": "(exibir apenas livros com estes gêneros)",
+      "excludeGenres": "Excluir gêneros",
+      "excludeGenresHint": "(ocultar livros com estes gêneros)",
+      "searchTagsPlaceholder": "Buscar tags...",
+      "searchGenresPlaceholder": "Buscar gêneros...",
+      "saving": "Salvando...",
+      "errors": {
+        "updateUser": "Falha ao atualizar o usuário",
+        "updatePermissions": "Falha ao atualizar as permissões",
+        "updateLibraryAccess": "Falha ao atualizar o acesso à biblioteca",
+        "updateContentFilters": "Falha ao atualizar os filtros de conteúdo",
+        "emailRequired": "O e-mail é obrigatório",
+        "createSharedAccount": "Falha ao criar conta compartilhada",
+        "createUser": "Falha ao criar o usuário"
+      }
+    },
+    "usersPage": {
+      "usersTitle": "Usuários",
+      "magicLinksTitle": "Links Mágicos",
+      "usersSubtitle": "Gerencie contas de usuário e atribuições de permissão.",
+      "magicLinksSubtitle": "Crie links de login compartilháveis para contas compartilhadas.",
+      "createUser": "Criar usuário",
+      "createLink": "Criar link",
+      "usersTab": "Usuários",
+      "magicLinksTab": "Links Mágicos",
+      "columns": {
+        "name": "Nome",
+        "username": "Nome de usuário",
+        "email": "E-mail",
+        "access": "Acesso",
+        "status": "Status"
+      },
+      "adminBadge": "Admin",
+      "permissionCount": "nenhuma permissão | uma permissão | {count} permissões",
+      "filteredBadge": "Filtrado",
+      "contentRestrictionsActive": "Restrições de conteúdo ativas",
+      "statusActive": "Ativo",
+      "statusInactive": "Inativo",
+      "resetPassword": "Redefinir senha",
+      "resetPasswordOidcHint": "Usuários OIDC redefinem suas senhas em seu provedor de identidade",
+      "resetPasswordSharedHint": "Contas compartilhadas não possuem senha",
+      "resetPasswordOidcHintFull": "Usuários OIDC redefinem suas senhas em seu provedor de identidade.",
+      "resetPasswordSharedHintFull": "Contas compartilhadas não possuem senha.",
+      "deleteUserAction": "Excluir usuário",
+      "deleteDialogTitle": "Excluir usuário?",
+      "deleteDialogBody": "Excluir o usuário \"{username}\". Esta ação não pode ser desfeita.",
+      "deleting": "Excluindo...",
+      "errors": {
+        "loadData": "Falha ao carregar os dados",
+        "load": "Falha ao carregar",
+        "deleteUser": "Falha ao excluir o usuário"
+      },
+      "currentUsers": "Usuários Atuais",
+      "defaultLibraryAccess": {
+        "title": "Acesso Padrão às Bibliotecas",
+        "subtitle": "Acesso de visualizador concedido a usuários autorregistrados e provisionados via OIDC.",
+        "description": "Selecione as bibliotecas atribuídas automaticamente a novos usuários.",
+        "noLibraries": "Nenhuma biblioteca disponível.",
+        "save": "Salvar padrões",
+        "saving": "Salvando...",
+        "saved": "Acesso padrão às bibliotecas salvo.",
+        "saveError": "Falha ao salvar o acesso padrão às bibliotecas"
+      }
+    }
+  },
+  "annotations": {
+    "unknownBook": "Livro desconhecido",
+    "styles": {
+      "highlight": "Destaque",
+      "underline": "Sublinhado",
+      "strike": "Tachado",
+      "squiggle": "Linha ondulada",
+      "invert": "Inverter"
+    },
+    "combobox": {
+      "filterByBook": "Filtrar por livro",
+      "allBooks": "Todos os livros",
+      "clearBookFilter": "Limpar filtro de livro",
+      "searching": "Buscando...",
+      "noBooksFound": "Nenhum livro encontrado"
+    },
+    "bulk": {
+      "countSelected": "{count} selecionado(s)",
+      "pageSelected": "Página selecionada",
+      "selectPage": "Selecionar página",
+      "clear": "Limpar",
+      "recolorTo": "Recolorir para {color}",
+      "restyleTo": "Alterar estilo para {style}"
+    },
+    "chips": {
+      "active": "Ativo:",
+      "removeFilter": "Remover filtro {label}",
+      "clearAll": "Limpar tudo"
+    },
+    "filters": {
+      "colors": "Cores",
+      "dateRange": "Período",
+      "fromDate": "A partir de",
+      "toDate": "Até a data",
+      "to": "até",
+      "clearDateRange": "Limpar período",
+      "clearAll": "Limpar tudo"
+    },
+    "pagination": {
+      "showing": "Exibindo {start}-{end} de {total}",
+      "pageOf": "Página {page} de {totalPages}",
+      "firstPage": "Primeira página",
+      "previousPage": "Página anterior",
+      "nextPage": "Próxima página",
+      "lastPage": "Última página"
+    },
+    "sync": {
+      "loading": "Carregando detalhes da sincronização",
+      "positions": "Posições",
+      "devices": "Dispositivos",
+      "retryConversion": "Tentar conversão novamente",
+      "noStoredPositions": "Nenhuma posição armazenada.",
+      "notSynced": "Não sincronizado com nenhum dispositivo ainda.",
+      "upToDate": "Atualizado",
+      "pendingVersion": "Pendente v{version}",
+      "syncedAt": "sincronizado em {date}",
+      "format": {
+        "webReader": "Leitor web",
+        "koreader": "KOReader",
+        "pdf": "PDF",
+        "kobo": "Kobo"
+      },
+      "status": {
+        "exact": "Exato",
+        "repaired": "Corrigido",
+        "failed": "Falhou",
+        "pending": "Pendente"
+      }
+    },
+    "toolbar": {
+      "searchPlaceholder": "Buscar no texto e notas",
+      "filters": "Filtros",
+      "sortOrder": "Ordem de classificação",
+      "switchToCompact": "Mudar para visualização compacta",
+      "switchToComfortable": "Mudar para visualização confortável",
+      "compactView": "Visualização compacta",
+      "comfortableView": "Visualização confortável"
+    },
+    "listItem": {
+      "pageNumber": "p. {page}",
+      "chapterNumber": "capítulo {chapter}",
+      "selectAnnotation": "Selecionar anotação",
+      "collapse": "Recolher",
+      "expand": "Expandir",
+      "hideSyncDetail": "Ocultar detalhes da sincronização",
+      "showSyncDetail": "Exibir detalhes da sincronização",
+      "exactPositionUnavailable": "Posição exata do leitor indisponível",
+      "saving": "Salvando",
+      "bookDetails": "Detalhes do livro",
+      "openInReader": "Abrir no leitor",
+      "restore": "Restaurar",
+      "deleteForever": "Excluir permanentemente",
+      "editNote": "Editar nota",
+      "addNote": "Adicionar nota",
+      "colorAndStyle": "Cor e estilo",
+      "copied": "Copiado",
+      "copyText": "Copiar texto",
+      "trash": "Lixeira",
+      "moveToTrash": "Mover para a lixeira"
+    },
+    "hub": {
+      "title": "Anotações",
+      "totalCount": "{count} no total",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "noteCount": "nenhuma nota | {count} nota | {count} notas",
+      "export": "Exportar",
+      "exportMarkdown": "Markdown",
+      "exportCsv": "CSV",
+      "exportJson": "JSON",
+      "notesOnly": "Apenas notas",
+      "style": "Estilo",
+      "source": "Fonte",
+      "bulkTrash": "Excluir para lixeira",
+      "bulkRestore": "Restaurar",
+      "tabs": {
+        "highlights": "Destaques",
+        "trash": "Lixeira"
+      },
+      "empty": {
+        "noMatch": "Nenhum destaque corresponde aos seus filtros.",
+        "resetFilters": "Restaurar filtros",
+        "trashEmpty": "A lixeira está vazia",
+        "noAnnotations": "Nenhuma anotação ainda. Os destaques criados na web ou em seu e-reader aparecerão aqui."
+      },
+      "toast": {
+        "movedToTrash": "Movido para a lixeira",
+        "annotationRestored": "Anotação restaurada",
+        "annotationDeletedForever": "Anotação excluída permanentemente",
+        "failedToDelete": "Falha ao excluir",
+        "bulkTrashed": "Nenhuma anotação movida para a lixeira | Movida {count} anotação para a lixeira | Movidas {count} anotações para a lixeira",
+        "bulkRestored": "Nenhuma anotação restaurada | Restaurada {count} anotação | Restauradas {count} anotações",
+        "bulkRecolored": "Nenhuma anotação recolorida | Recolorida {count} anotação | Recoloridas {count} anotações",
+        "bulkRestyled": "Estilo não alterado | Alterado o estilo de {count} anotação | Alterado o estilo de {count} anotações"
+      }
+    }
+  },
+  "audit": {
+    "pageTitle": "Registro de Auditoria",
+    "pageSubtitle": "Um histórico das ações administrativas relevantes realizadas em todo o sistema.",
+    "filters": "Filtros",
+    "noActiveFilters": "Nenhum filtro ativo",
+    "clear": "Limpar",
+    "empty": "Nenhum registro de auditoria encontrado",
+    "showMore": "Exibir mais",
+    "showLess": "Exibir menos",
+    "details": "Detalhes",
+    "hideDetails": "Ocultar detalhes",
+    "detailAction": "Ação: {value}",
+    "detailIp": "IP: {value}",
+    "showing": "Exibindo {from}-{to} de {total}",
+    "prev": "Anterior",
+    "chips": {
+      "action": "Ação: {value}",
+      "user": "Usuário: {value}",
+      "from": "De: {value}",
+      "to": "Até: {value}"
+    },
+    "filterLabels": {
+      "action": "Ação",
+      "userId": "ID do Usuário",
+      "from": "De",
+      "to": "Até"
+    },
+    "filterPlaceholders": {
+      "action": "ex: auth.login",
+      "userId": "ex: 1"
+    },
+    "columns": {
+      "when": "Data/Hora",
+      "user": "Usuário",
+      "action": "Ação",
+      "description": "Descrição",
+      "ip": "IP"
+    }
+  },
+  "auth": {
+    "backToSignIn": "Voltar para o login",
+    "themePicker": {
+      "switchToLight": "Mudar para modo claro",
+      "switchToDark": "Mudar para modo escuro",
+      "changeRadius": "Alterar arredondamento das bordas",
+      "changeBackground": "Alterar fundo",
+      "changeAccent": "Alterar cor de destaque"
+    },
+    "fields": {
+      "username": "Nome de usuário",
+      "password": "Senha",
+      "email": "E-mail",
+      "emailAddress": "Endereço de e-mail",
+      "fullName": "Nome completo",
+      "newPassword": "Nova senha",
+      "confirmPassword": "Confirmar senha",
+      "confirmNewPassword": "Confirmar nova senha",
+      "currentPassword": "Senha atual",
+      "passwordHint": "Mín. de 8 caracteres com maiúscula, minúscula e um número"
+    },
+    "errors": {
+      "generic": "Ocorreu um erro. Por favor, tente novamente.",
+      "passwordsDoNotMatch": "As senhas não coincidem"
+    },
+    "login": {
+      "subtitle": "Entre na sua conta",
+      "signIn": "Entrar",
+      "signingIn": "Entrando...",
+      "orDivider": "ou",
+      "forgotPassword": "Esqueceu a senha?",
+      "errors": {
+        "invalidCredentials": "Nome de usuário ou senha inválidos",
+        "tooManyAttempts": "Muitas tentativas de login. Por favor, aguarde um minuto e tente novamente."
+      }
+    },
+    "oidc": {
+      "loginFailed": "Falha no login OIDC",
+      "redirecting": "Redirecionando...",
+      "signInWith": "Entrar com {provider}",
+      "completingSignIn": "Concluindo o login...",
+      "tryAgain": "Tentar novamente",
+      "errors": {
+        "stateExpired": "Sua sessão de login expirou. Por favor, tente entrar novamente.",
+        "tokenExchangeFailed": "Não foi possível concluir o login com seu provedor. Tente novamente ou entre em contato com um administrador.",
+        "userNotProvisioned": "Sua conta não foi configurada. Entre em contato com um administrador para obter acesso.",
+        "userInactive": "Sua conta foi desativada. Entre em contato com o seu administrador.",
+        "providerError": "Seu provedor de identidade retornou um erro. Por favor, tente novamente.",
+        "missingCodeOrState": "Código ou parâmetro de estado ausente"
+      },
+      "providerErrors": {
+        "accessDenied": "O acesso foi negado pelo provedor de identidade.",
+        "loginRequired": "Autenticação é necessária. Por favor, faça login novamente.",
+        "interactionRequired": "Interação adicional do usuário é necessária."
+      }
+    },
+    "forgotPassword": {
+      "subtitle": "Redefina sua senha",
+      "submitted": "Se uma conta com este e-mail existir, um link de redefinição foi enviado. Verifique sua caixa de entrada.",
+      "sending": "Enviando...",
+      "sendResetLink": "Enviar link de redefinição",
+      "errors": {
+        "emailUnavailable": "A redefinição de senha por e-mail não está disponível. Entre em contato com seu administrador."
+      }
+    },
+    "resetPassword": {
+      "subtitle": "Crie uma nova senha",
+      "saving": "Salvando...",
+      "setNewPassword": "Definir nova senha",
+      "errors": {
+        "invalidLink": "Link de redefinição inválido. Por favor, solicite um novo.",
+        "invalidOrExpired": "Link de redefinição inválido ou expirado. Por favor, solicite um novo."
+      }
+    },
+    "setup": {
+      "title": "Configuração inicial",
+      "subtitle": "Crie a primeira conta de administrador.",
+      "setupToken": "Token de configuração",
+      "setupTokenHint": "(obrigatório em produção)",
+      "creatingAccount": "Criando conta...",
+      "createAccount": "Criar conta de administrador",
+      "errors": {
+        "failed": "Falha ao concluir a configuração"
+      }
+    },
+    "changePassword": {
+      "title": "Alterar senha",
+      "saving": "Salvando…",
+      "forcedNotice": "Você precisa definir uma nova senha antes de continuar.",
+      "errors": {
+        "failed": "Falha ao alterar a senha"
+      }
+    },
+    "magicLink": {
+      "signingIn": "Conectando você...",
+      "loginFailed": "Falha no login",
+      "goToLogin": "Ir para o login",
+      "errors": {
+        "noToken": "Nenhum token fornecido"
+      }
+    }
+  },
+  "author": {
+    "card": {
+      "portraitAlt": "Retrato de {name}",
+      "viewDetails": "Ver Detalhes do Autor",
+      "refreshMetadata": "Atualizar Metadados",
+      "deleteAuthor": "Excluir Autor"
+    },
+    "listRow": {
+      "noRecentAdditions": "Nenhuma adição recente",
+      "portraitAlt": "Retrato de {name}"
+    },
+    "filters": {
+      "title": "Filtros de Autores",
+      "clearAll": "Limpar tudo",
+      "allLibraries": "Todas as Bibliotecas",
+      "allAuthors": "Todos os autores",
+      "hasPhoto": "Com foto",
+      "missingPhoto": "Sem foto",
+      "minBooks": "Mínimo de livros",
+      "anyPlaceholder": "Qualquer"
+    },
+    "header": {
+      "never": "Nunca",
+      "portraitAlt": "Retrato de {name}",
+      "actions": "Ações",
+      "editAuthor": "Editar Autor",
+      "mergeAuthors": "Mesclar Autores",
+      "refreshing": "Atualizando...",
+      "refreshMetadata": "Atualizar Metadados",
+      "deleteAuthor": "Excluir Autor",
+      "showLess": "Exibir menos",
+      "showMore": "Exibir mais",
+      "lookingUpMetadata": "Buscando metadados do autor...",
+      "noBiography": "Nenhuma biografia disponível. Use o menu para atualizar os metadados.",
+      "previewFrom": "Pré-visualização do {provider}. Salve os metadados para mantê-los.",
+      "booksLabel": "Livros",
+      "lastAdded": "Adicionado por Último"
+    },
+    "list": {
+      "title": "Autores",
+      "showControlsAria": "Exibir controles de autor",
+      "searchPlaceholder": "Buscar autores",
+      "sortButton": "Ordenar",
+      "sortBy": "Ordenar por",
+      "ascending": "Crescente",
+      "descending": "Decrescente",
+      "asc": "Cresc",
+      "desc": "Decresc",
+      "filters": "Filtros",
+      "clear": "Limpar",
+      "allLoaded": "Todos os {total} autores carregados",
+      "sort": {
+        "name": "Nome",
+        "sortName": "Nome de Ordenação",
+        "bookCount": "Quantidade de Livros",
+        "recentAdditions": "Adicionados Recentemente",
+        "lastEnriched": "Último Enriquecimento"
+      },
+      "empty": {
+        "title": "Nenhum autor encontrado",
+        "hint": "Tente alterar o texto de busca, ordenação ou filtro de biblioteca."
+      },
+      "deleteDialog": {
+        "titleOne": "Excluir autor?",
+        "titleMany": "Excluir {count} autores?",
+        "descriptionOne": "Isso remove o autor do catálogo e desvincula os livros associados a ele. Esta ação não pode ser desfeita.",
+        "descriptionMany": "Isso remove os autores selecionados do catálogo e desvincula os livros associados a eles. Esta ação não pode ser desfeita."
+      },
+      "selection": {
+        "selectVisible": "Selecionar visíveis",
+        "refreshMetadata": "Atualizar metadados",
+        "refreshingMetadata": "Atualizando metadados...",
+        "deleteSelected": "Excluir selecionados",
+        "deleting": "Excluindo...",
+        "exitSelection": "Sair da seleção",
+        "confirmDeleteCount": "Excluir {count} autor? | Excluir {count} autor? | Excluir {count} autores?"
+      },
+      "toast": {
+        "refreshed": "Metadados do autor atualizados",
+        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem do autor foi encontrada.",
+        "refreshFailed": "Falha ao atualizar metadados do autor",
+        "bulkRefreshPartial": "Atualizado(s) {updated} autor(es), {failed} falhou(aram)",
+        "bulkRefreshSuccess": "Metadados atualizados para {updated} autor(es)",
+        "bulkRefreshFailed": "Falha ao atualizar os autores selecionados",
+        "deleteSuccess": "Excluído {count} autor; {books} livros afetados | Excluído {count} autor; {books} livros afetados | Excluídos {count} autores; {books} livros afetados",
+        "deleteFailed": "Falha ao excluir autor(es)"
+      }
+    },
+    "detail": {
+      "pageTitle": "Autor",
+      "pageTitleNamed": "Autor · {name}",
+      "pageTitleId": "Autor #{id}",
+      "entityName": "Autor",
+      "loadingAuthor": "Carregando autor...",
+      "previewError": "Não foi possível carregar a pré-visualização dos metadados externos do autor no momento.",
+      "edit": {
+        "name": "Nome",
+        "sortName": "Nome de Ordenação",
+        "description": "Descrição",
+        "image": "Imagem",
+        "uploading": "Enviando...",
+        "replaceImage": "Substituir imagem",
+        "uploadImage": "Enviar imagem",
+        "removing": "Removendo...",
+        "removeImage": "Remover imagem",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP de até {size} MB",
+        "saving": "Salvando..."
+      },
+      "merge": {
+        "searchPlaceholder": "Busque autores para mesclar a este autor",
+        "searching": "Buscando...",
+        "bookCount": "nenhum livro | {count} livro | {count} livros",
+        "selectedSummary": "Selecionado(s) {count} autor(es), aprox. {books} livros afetados.",
+        "merging": "Mesclando...",
+        "mergeSelected": "Mesclar Selecionados",
+        "confirmLabel": "Mesclar"
+      },
+      "mergeDialog": {
+        "title": "Mesclar {count} autor(es) com \"{name}\"?",
+        "titleFallback": "Mesclar autores selecionados?",
+        "description": "Isso mesclará os autores selecionados com o autor atual e revinculará os livros associados. Esta ação não pode ser desfeita.",
+        "descriptionEmpty": "Esta ação não pode ser desfeita."
+      },
+      "deleteDialog": {
+        "title": "Excluir autor?",
+        "description": "Isso remove o autor do catálogo e desvincula os livros associados a ele. Esta ação não pode ser desfeita."
+      },
+      "books": {
+        "heading": "Livros",
+        "allLibraries": "Todas as Bibliotecas",
+        "asc": "Cresc",
+        "desc": "Decresc",
+        "ascending": "Crescente",
+        "descending": "Decrescente",
+        "allLoaded": "Todos os {total} livros carregados",
+        "sort": {
+          "recentlyAdded": "Adicionados Recentemente",
+          "title": "Título",
+          "publishedYear": "Ano de Publicação"
+        },
+        "empty": {
+          "title": "Nenhum livro encontrado para este autor",
+          "hint": "Tente alterar a ordenação/ordem ou selecionar outra biblioteca."
+        }
+      },
+      "toast": {
+        "refreshed": "Metadados do autor atualizados",
+        "refreshedNoImage": "Metadados atualizados, mas nenhuma imagem do autor foi encontrada.",
+        "refreshFailed": "Falha ao atualizar metadados do autor",
+        "nameRequired": "O nome do autor é obrigatório",
+        "updated": "Autor atualizado",
+        "updateFailed": "Falha ao atualizar autor",
+        "imageUpdated": "Imagem do autor atualizada",
+        "imageUploadFailed": "Falha ao enviar a imagem do autor",
+        "imageRemoved": "Imagem do autor removida",
+        "imageRemoveFailed": "Falha ao remover a imagem do autor",
+        "mergeSuccess": "Mesclado(s) {count} autor(es); {books} livros afetados",
+        "mergeFailed": "Falha ao mesclar autores",
+        "deleteSuccess": "Autor excluído; {books} livros afetados",
+        "deleteFailed": "Falha ao excluir o autor"
+      }
+    }
+  },
+  "book": {
+    "untitled": "Sem título",
+    "unknownFormat": "desconhecido",
+    "collapsedSeries": {
+      "label": "Série",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "readCount": "{count} lido(s)"
+    },
+    "card": {
+      "missing": "Ausente"
+    },
+    "file": {
+      "primary": "Primário",
+      "audiobook": "Audiolivro"
+    },
+    "actions": {
+      "read": "Ler",
+      "listen": "Ouvir",
+      "peek": "Espiar",
+      "quickView": "Visualização Rápida",
+      "details": "Detalhes",
+      "bookDetails": "Detalhes do Livro",
+      "download": "Baixar",
+      "metadata": "Metadados",
+      "editMetadata": "Editar Metadados",
+      "refreshMetadata": "Atualizar Metadados",
+      "regenerateCover": "Gerar Capa Novamente",
+      "addToCollection": "Adicionar à Coleção",
+      "setStatus": "Definir Status",
+      "sendViaEmail": "Enviar por E-mail",
+      "rate": "Avaliar {star}",
+      "openAs": "Abrir como {format}"
+    },
+    "readStatus": {
+      "unread": "Não Lido",
+      "wantToRead": "Quero Ler",
+      "reading": "Lendo",
+      "onHold": "Pausado",
+      "rereading": "Relendo",
+      "read": "Lido",
+      "skimmed": "Folheado",
+      "abandoned": "Abandonado"
+    },
+    "download": {
+      "action": "Baixar",
+      "audiobookZip": "Audiolivro (ZIP)",
+      "allFormatsZip": "Todos os formatos (ZIP)",
+      "primaryOnlyZip": "Apenas primário (ZIP)"
+    },
+    "sort": {
+      "moveUp": "Mover para cima",
+      "moveDown": "Mover para baixo",
+      "ascending": "Crescente",
+      "descending": "Decrescente",
+      "remove": "Remover",
+      "emptyState": "Nenhuma ordenação configurada. Ordem alfabética por título (crescente) será utilizada.",
+      "addLevel": "Adicionar nível de ordenação"
+    },
+    "filter": {
+      "match": "Corresponder",
+      "all": "TODAS",
+      "any": "QUALQUER",
+      "ofFollowingRules": "das seguintes regras",
+      "anyProvider": "Qualquer provedor",
+      "communityRatingProvider": "Provedor de avaliação da comunidade",
+      "loadingLibraries": "Carregando bibliotecas...",
+      "noLibrariesAvailable": "Nenhuma biblioteca disponível",
+      "selectLibrary": "Selecione a biblioteca...",
+      "selectStatus": "Selecione o status...",
+      "withinLastPlaceholder": "ex: 7",
+      "unit": {
+        "days": "dias",
+        "weeks": "semanas",
+        "months": "meses"
+      },
+      "scorePreset": {
+        "outstanding": "Excepcional",
+        "good": "Bom",
+        "fair": "Razoável",
+        "poor": "Ruim"
+      },
+      "scoreRangePlaceholder": "0-100",
+      "valuePlaceholder": "valor",
+      "maxPlaceholder": "máx",
+      "to": "até",
+      "group": "Grupo",
+      "addRule": "Adicionar regra",
+      "addGroup": "Adicionar grupo",
+      "typeToSearch": "Digite para buscar..."
+    },
+    "deleteDialog": {
+      "title": "Excluir livro?",
+      "description": "Isso excluirá permanentemente o livro e todos os seus metadados, arquivos, progresso de leitura e marcadores. Isso não pode ser desfeito."
+    },
+    "bulkEdit": {
+      "title": "Editar metadados - {count} livro | Editar metadados - {count} livro | Editar metadados - {count} livros",
+      "instructions": "Alterne os campos para editar e, em seguida, configure os valores. Apenas os campos ativados serão alterados.",
+      "invalidYear": "Digite um ano válido (apenas números)",
+      "clearWarning": "Isso removerá todo o campo {field} dos livros selecionados.",
+      "searchPlaceholder": "Buscar {field}...",
+      "enterPlaceholder": "Digite {field}",
+      "yearPlaceholder": "ex: 2024",
+      "leaveEmptyHint": "Deixe vazio para limpar este campo em todos os livros selecionados.",
+      "applying": "Aplicando...",
+      "apply": "Aplicar",
+      "mode": {
+        "add": "Adicionar",
+        "remove": "Remover",
+        "replace": "Substituir",
+        "clear": "Limpar"
+      }
+    },
+    "export": {
+      "title": "Exportar Metadados",
+      "scope": "Escopo",
+      "selectedRows": "Linhas selecionadas",
+      "currentlySelected": "{count} atualmente selecionada(s)",
+      "allMatchingRows": "Todas as linhas correspondentes",
+      "rowsInResult": "{count} linhas no resultado atual",
+      "format": "Formato",
+      "csvDescription": "Ideal para planilhas, inclui BOM UTF-8",
+      "jsonDescription": "Exportação estruturada com contexto de metadados",
+      "columns": "Colunas",
+      "canonicalSchema": "Esquema canônico estável",
+      "visibleColumns": "Colunas visíveis atuais",
+      "options": "Opções",
+      "includePersonalData": "Incluir dados pessoais de leitura",
+      "includeFilePaths": "Incluir caminhos de arquivo (avançado)",
+      "includeContextMeta": "Incluir metadados de contexto",
+      "preflight": "Verificações Prévias",
+      "scopeLabel": "Escopo: {summary}",
+      "calculatingSize": "Calculando tamanho da exportação...",
+      "estimatedSize": "Tamanho estimado:",
+      "fileLabel": "Arquivo: {fileName}",
+      "exportAction": "Exportar",
+      "selectedRowsSummary": "{count} linha selecionada | {count} linha selecionada | {count} linhas selecionadas",
+      "matchingRowsSummary": "{count} linha correspondente | {count} linha correspondente | {count} linhas correspondentes",
+      "prepareFailed": "Falha ao preparar exportação",
+      "exportStarted": "Exportação de metadados iniciada: {fileName}",
+      "exportFailed": "Falha na exportação de metadados"
+    },
+    "columnPanel": {
+      "columnsHeading": "Colunas",
+      "reset": "Redefinir",
+      "tableDensity": "Densidade da tabela",
+      "density": {
+        "compact": "Compacta",
+        "comfortable": "Confortável",
+        "roomy": "Espaçosa"
+      },
+      "presets": "Predefinições",
+      "exportBackup": "Exportar predefinições e visualizações salvas",
+      "importBackup": "Importar predefinições e visualizações salvas",
+      "rename": "Renomear",
+      "renamePrompt": "Insira um novo nome",
+      "builtIn": "Embutido",
+      "saveCurrentPreset": "Salvar predefinição atual",
+      "savedViews": "Visualizações salvas",
+      "savedViewsEmpty": "Salve ordenação, layout e filtros específicos da visualização para reutilização rápida.",
+      "saveCurrentView": "Salvar visualização atual",
+      "pinnedLeft": "Fixado à esquerda",
+      "pinnedRight": "Fixado à direita",
+      "columns": {
+        "cover": "Capa",
+        "read": "Lido",
+        "actions": "Ações"
+      }
+    },
+    "shortcuts": {
+      "title": "Atalhos de Teclado",
+      "navigation": {
+        "title": "Navegação",
+        "moveFocusVertical": "Mover foco para cima/baixo",
+        "moveFocusHorizontal": "Mover foco para esquerda/direita",
+        "jumpFirstColumn": "Pular para a primeira coluna",
+        "jumpLastColumn": "Pular para a última coluna",
+        "jumpFirstRow": "Pular para a primeira linha",
+        "jumpLastRow": "Pular para a última linha"
+      },
+      "actions": {
+        "title": "Ações",
+        "editCell": "Editar célula em foco",
+        "cancelEditing": "Cancelar edição / Fechar sobreposição",
+        "toggleRowSelection": "Alternar seleção de linha",
+        "copyCell": "Copiar valor da célula",
+        "copyRow": "Copiar linha em foco"
+      },
+      "general": {
+        "title": "Geral",
+        "toggleHelp": "Alternar esta sobreposição de ajuda"
+      }
+    },
+    "jumpRail": {
+      "jumpToSection": "Pular para a seção",
+      "jumpTo": "Pular para {label}"
+    },
+    "quickView": {
+      "title": "Visualização rápida do livro",
+      "titleFor": "Visualização rápida de {title}",
+      "description": "Pré-visualize detalhes do livro e execute ações rápidas.",
+      "openIn": "Abrir em {provider}",
+      "pages": "{count} página | {count} página | {count} páginas",
+      "primaryFile": "Arquivo Primário",
+      "fileNumber": "Arquivo #{id}",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar mais",
+      "collections": "Coleções",
+      "noDescription": "Nenhuma descrição disponível.",
+      "openMetadataEditor": "Abrir editor de metadados",
+      "coverPreview": "Pré-visualização da capa do livro",
+      "coverPreviewFor": "Pré-visualização da capa de {title}",
+      "coverPreviewDescription": "Caixa de diálogo com pré-visualização ampliada da imagem da capa."
+    },
+    "tableView": {
+      "openBookDetails": "Abrir detalhes do livro",
+      "openSeries": "Abrir série",
+      "metadataRefreshFailed": "Falha na atualização de metadados",
+      "booksSelected": "{count} livro selecionado | {count} livro selecionado | {count} livros selecionados",
+      "loadingMoreBooks": "Carregando mais livros",
+      "sort": "Ordenar",
+      "refreshingMetadata": "Atualizando metadados {processed} / {total}",
+      "failedCount": "{count} falhou",
+      "remainingCount": "{count} restante(s)",
+      "readOnlyNotice": "A edição da tabela está desativada em telas menores. Mude para lista ou grade para ações mais rápidas.",
+      "fetching": "Buscando...",
+      "updated": "Atualizado",
+      "failed": "Falhou",
+      "noBooks": "Nenhum livro para exibir",
+      "scrollToTop": "Rolar para o topo",
+      "selectedStatus": "{count} selecionado(s)",
+      "filtered": "Filtrado",
+      "loadedStatus": "{loaded} de {total} carregados",
+      "bookCount": "{count} livro | {count} livro | {count} livros",
+      "keyboardShortcutsTitle": "Atalhos de teclado (?)",
+      "showKeyboardShortcuts": "Mostrar atalhos de teclado da tabela",
+      "copyHint": "Copiar célula: Ctrl/Cmd+C · Copiar linha: Ctrl/Cmd+Shift+C"
+    },
+    "detail": {
+      "authorBooks": {
+        "alsoByAuthor": "Também deste autor",
+        "alsoByAuthors": "Também destes autores"
+      },
+      "header": {
+        "previousBook": "Livro anterior",
+        "nextBook": "Próximo livro"
+      },
+      "tabs": {
+        "details": "Detalhes",
+        "editMetadata": "Editar Metadados",
+        "files": "Arquivos",
+        "readingLog": "Registro de Leitura",
+        "highlights": "Destaques"
+      },
+      "discover": {
+        "moreInSeries": "Mais na Série",
+        "byAuthor": "Pelo Autor",
+        "similarBooks": "Livros Semelhantes"
+      },
+      "recommended": {
+        "moreLikeThis": "Mais Como Este"
+      },
+      "series": {
+        "moreInSeries": "Mais na série {series}"
+      },
+      "writeRename": {
+        "written": "nenhum campo gravado | Gravado (um campo) | Gravados ({count} campos)",
+        "writeFailed": "Falha na gravação",
+        "skipped": "Ignorado",
+        "renamedTo": "Renomeado para {name}",
+        "fileRenamed": "Arquivo renomeado",
+        "renameFailed": "Falha ao renomear",
+        "autoWriteAndRenameDisabled": "Gravação e renomeação automáticas estão desativadas nas configurações da biblioteca. Alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "autoWriteDisabled": "A gravação automática está desativada nas configurações da biblioteca. Alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "autoRenameDisabled": "A renomeação automática está desativada nas configurações da biblioteca. Alterações não serão sincronizadas automaticamente em salvamentos futuros.",
+        "writeLabel": "Gravar:",
+        "renameLabel": "Renomear:"
+      },
+      "addFile": {
+        "uploading": "Enviando...",
+        "uploadComplete": "Upload concluído",
+        "title": "Adicionar Arquivo",
+        "dropzone": {
+          "title": "Arraste arquivos aqui ou clique para procurar",
+          "hint": "epub, pdf, mobi, cbz, m4b e mais - até {size} MB cada"
+        },
+        "addMore": "Adicionar mais arquivos",
+        "fileCount": "nenhum arquivo | um arquivo | {count} arquivos",
+        "clearAll": "Limpar tudo",
+        "done": "Concluído",
+        "retry": "Tentar novamente",
+        "filesAdded": "nenhum arquivo adicionado | um arquivo adicionado | {count} arquivos adicionados",
+        "uploadedFailed": "{done} enviados, {failed} falharam",
+        "uploadingProgress": "{done} de {total} enviando...",
+        "renameAfter": "Renomear todos os arquivos do livro após o upload",
+        "uploadCount": "Enviar ({count})",
+        "upload": "Enviar"
+      },
+      "addSession": {
+        "errors": {
+          "invalidDate": "Escolha uma data e hora válidas.",
+          "future": "A sessão não pode começar no futuro.",
+          "duration": "A duração deve ser entre 1 e 1440 minutos.",
+          "endProgress": "O progresso final deve ser entre 0 e 100."
+        },
+        "title": "Adicionar sessão de leitura",
+        "startedAt": "Iniciado em",
+        "duration": "Duração (minutos)",
+        "endProgress": "Progresso final %",
+        "optional": "Opcional",
+        "format": "Formato",
+        "noFormat": "Sem formato específico",
+        "saving": "Salvando...",
+        "submit": "Adicionar sessão"
+      },
+      "coverEditor": {
+        "unlockCover": "Desbloquear capa",
+        "lockCover": "Bloquear capa",
+        "fileTab": "Arquivo",
+        "urlTab": "URL",
+        "chooseImage": "Escolher imagem...",
+        "findCoverOnline": "Encontrar capa online",
+        "saving": "Salvando...",
+        "saveCover": "Salvar capa",
+        "revertToOriginal": "Reverter para o original",
+        "regenerateCover": "Gerar Capa Novamente"
+      },
+      "coverSearch": {
+        "title": "Busca Online",
+        "subtitle": "Buscar capas de livros",
+        "titleField": "Título",
+        "authorField": "Autor",
+        "sourceField": "Fonte",
+        "allSources": "Todas as Fontes",
+        "audiobookCovers": "Capas de audiolivros",
+        "squareHint": "(quadrada)",
+        "searching": "Buscando...",
+        "findCovers": "Encontrar capas",
+        "selectCover": "Selecionar Capa",
+        "noResultsTitle": "Nenhum resultado encontrado",
+        "noResultsHint": "Tente ajustar seus termos de busca",
+        "readyTitle": "Pronto para buscar",
+        "readyHint": "Insira um título e autor acima",
+        "resolutionTip": "Dica: Capas de alta resolução estão marcadas em verde"
+      },
+      "details": {
+        "by": "por",
+        "narratedBy": "narrado por",
+        "ratingLocked": "A avaliação está bloqueada",
+        "rateStar": "Avaliar {star}",
+        "listen": "Ouvir",
+        "read": "Ler",
+        "chooseFormat": "Escolher formato",
+        "audiobook": "Audiolivro",
+        "primary": "Primário",
+        "peek": "Espiar",
+        "sendViaEmail": "Enviar por E-mail",
+        "personalReview": {
+          "title": "Revisão Pessoal",
+          "toggleAria": "Alternar revisão pessoal",
+          "editAria": "Editar revisão pessoal",
+          "placeholder": "Revisão privada",
+          "clearAria": "Limpar revisão pessoal",
+          "cancelEditAria": "Cancelar edição da revisão pessoal"
+        },
+        "editCover": "Editar capa",
+        "finished": "Concluído",
+        "resetFileProgress": "Redefinir progresso do arquivo",
+        "resetting": "Redefinindo...",
+        "resetProgressConfirm": "Redefinir progresso de leitura armazenado para {label}?",
+        "moreCount": "+{count} mais",
+        "untitled": "Sem título",
+        "metadataScore": "Pontuação de Metadados",
+        "primaryFormat": "Formato primário",
+        "openIn": "Abrir em {provider}",
+        "showLess": "Mostrar menos",
+        "showMore": "Mostrar mais",
+        "publisher": "Editora",
+        "published": "Publicado",
+        "language": "Idioma",
+        "pages": "Páginas",
+        "duration": "Duração",
+        "edition": "Edição",
+        "abridged": "Resumido",
+        "unabridged": "Integral",
+        "isbn": "ISBN",
+        "fileSize": "Tamanho do Arquivo",
+        "library": "Biblioteca",
+        "added": "Adicionado",
+        "dateStarted": "Data de Início",
+        "saving": "Salvando...",
+        "cancelDateStartedEdit": "Cancelar edição da data de início",
+        "editDateStarted": "Editar data de início",
+        "dateFinished": "Data de Término",
+        "cancelDateFinishedEdit": "Cancelar edição da data de término",
+        "editDateFinished": "Editar data de término",
+        "customMetadata": "Metadados Personalizados",
+        "synopsis": "Sinopse",
+        "noDescription": "Nenhuma descrição disponível.",
+        "dateStartedFutureError": "A Data de Início não pode ser no futuro.",
+        "dateFinishedFutureError": "A Data de Término não pode ser no futuro.",
+        "dateFinishedBeforeStartedError": "A Data de Término deve ser igual ou posterior à Data de Início.",
+        "saveReadingDatesError": "Falha ao salvar datas de leitura.",
+        "koboPendingDelete": "Exclusão pendente no dispositivo",
+        "koboPendingDeleteTooltip": "O Kobo o removerá na próxima sincronização.",
+        "koboRemovedByDevice": "Removido pelo dispositivo",
+        "koboRemovedByDeviceTooltip": "O Kobo informou que este livro foi removido.",
+        "koboNotSynced": "Não sincronizado",
+        "koboNotSyncedTooltip": "Na fila para a próxima sincronização do Kobo.",
+        "filesNotFound": "Arquivos não encontrados",
+        "filesNotFoundDescription": "O(s) arquivo(s) deste livro não podem mais ser encontrados no disco. Os metadados ainda estão disponíveis. Execute um escaneamento da biblioteca para confirmar, ou remova o registro."
+      },
+      "editMetadata": {
+        "fieldCount": "nenhum campo | um campo | {count} campos",
+        "bookFilesTarget": "arquivos do livro",
+        "formatFilesTarget": "arquivos {formats}",
+        "noPrimaryFile": "Nenhum arquivo primário disponível",
+        "formatNotSupported": "Este formato de arquivo não suporta regravação",
+        "formatDisabled": "A regravação está desativada para este formato",
+        "fileExceedsSizeLimit": "Este arquivo excede o limite de tamanho de regravação",
+        "writing": "Gravando...",
+        "saveInProgress": "Salvamento em andamento",
+        "writeManualLibraryDisabled": "Gravar metadados no arquivo e renomear no disco; a regravação automática está desativada para esta biblioteca",
+        "writeManualTooltip": "Gravar {fields} em {target} e renomear no disco",
+        "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "Nenhum campo bloqueado ignorado | Ignorado um campo bloqueado | Ignorados {count} campos bloqueados",
+        "updatedFields": "nenhum campo atualizado | um campo atualizado | {count} campos atualizados",
+        "wroteFieldsToFile": "Gravados {fields} no arquivo",
+        "fileWriteFailedReason": "Falha na gravação do arquivo: {reason}",
+        "fileWriteFailed": "Falha na gravação do arquivo",
+        "fileWriteSkippedReason": "Gravação do arquivo ignorada: {reason}",
+        "fileWriteSkipped": "Gravação do arquivo ignorada",
+        "metadataSaved": "Metadados salvos",
+        "metadataWrittenToFile": "Metadados gravados no arquivo",
+        "savedButWriteFailedReason": "Metadados salvos, mas a gravação do arquivo falhou: {reason}",
+        "savedButWriteFailed": "Metadados salvos, mas a gravação do arquivo falhou",
+        "savedWriteSkippedReason": "Metadados salvos, gravação do arquivo ignorada: {reason}",
+        "savedWriteSkipped": "Metadados salvos, gravação do arquivo ignorada",
+        "loadFromFileFailed": "Falha ao carregar metadados do arquivo",
+        "loadedFieldsFromFile": "Nenhum campo carregado do arquivo | Um campo carregado do arquivo | {count} campos carregados do arquivo",
+        "noMetadataInFile": "Nenhum metadado encontrado no arquivo",
+        "loadFromFile": "Carregar do arquivo",
+        "loadFromFileTooltip": "Carregar metadados do arquivo primário do livro",
+        "writeToFile": "Gravar no arquivo",
+        "autoFill": "Preenchimento automático",
+        "fetchingMetadata": "Buscando metadados...",
+        "allFieldsLocked": "Todos os campos estão bloqueados",
+        "autoFillTooltip": "Preencher campos automaticamente usando suas preferências de metadados",
+        "lockAll": "Bloquear tudo",
+        "lockAllTooltip": "Bloquear todos os campos",
+        "unlockAll": "Desbloquear tudo",
+        "unlockAllTooltip": "Desbloquear todos os campos",
+        "saving": "Salvando...",
+        "fileWriteBackDetails": "Detalhes de regravação do arquivo",
+        "fileWriteBack": "Regravação de arquivo",
+        "enabled": "Ativado",
+        "saveWritesMetadata": "'Salvar' grava metadados em {target}",
+        "formats": "Formatos",
+        "bookFiles": "Arquivos do livro",
+        "supportedFields": "Campos suportados",
+        "titleLabel": "Título",
+        "subtitleLabel": "Subtítulo",
+        "authorsLabel": "Autores",
+        "narratorsLabel": "Narradores",
+        "genresLabel": "Gêneros",
+        "tagsLabel": "Tags",
+        "ratingLabel": "Avaliação",
+        "rateStar": "Avaliar {star}",
+        "clear": "Limpar",
+        "communityRatingsLabel": "Avaliações da Comunidade",
+        "noProviderRatings": "Sem avaliações de provedores",
+        "seriesLabel": "Série",
+        "publisherLabel": "Editora",
+        "languageLabel": "Idioma",
+        "yearLabel": "Ano",
+        "pageCountLabel": "Contagem de Páginas",
+        "isbn13Label": "ISBN-13",
+        "isbn10Label": "ISBN-10",
+        "durationLabel": "Duração (s)",
+        "abridgedLabel": "Resumido",
+        "providerIds": "IDs do Provedor",
+        "comicDetails": "Detalhes do Quadrinho",
+        "comicIssueNumberLabel": "Número da Edição",
+        "comicVolumeLabel": "Volume",
+        "comicStoryArcsLabel": "Arcos de História",
+        "comicPencillersLabel": "Desenhistas",
+        "comicInkersLabel": "Arte-finalistas",
+        "comicColoristsLabel": "Coloristas",
+        "comicLetterersLabel": "Letristas",
+        "comicCoverArtistsLabel": "Artistas de Capa",
+        "comicCharactersLabel": "Personagens",
+        "comicTeamsLabel": "Equipes",
+        "comicLocationsLabel": "Locais",
+        "customMetadata": "Metadados Personalizados",
+        "descriptionLabel": "Descrição",
+        "unlockField": "Desbloquear {field}",
+        "lockField": "Bloquear {field}",
+        "diffPanel": {
+          "untitled": "Sem título",
+          "noFieldsSelected": "Nenhum campo selecionado",
+          "fieldsSelected": "nenhum campo selecionado | um campo selecionado | {count} campos selecionados",
+          "results": "Resultados",
+          "providerMatches": "Correspondências no {provider}",
+          "selectedOf": "Selecionados {selected} de {total}",
+          "yearUnknown": "Ano desconhecido",
+          "indexOf": "{index} de {total}",
+          "switchedResult": "Resultado alterado. As seleções anteriores deste provedor foram limpas.",
+          "selectFieldsToApply": "Selecione campos para aplicar",
+          "copyMissing": "Copiar Ausentes",
+          "copyAll": "Copiar Tudo",
+          "hideUnchanged": "Ocultar inalterados",
+          "showUnchanged": "Mostrar inalterados",
+          "current": "Atual",
+          "noMetadata": "Nenhum metadado disponível desta fonte.",
+          "noChangedFields": "Nenhum campo alterado ou ausente. Use Mostrar inalterados para inspecionar tudo.",
+          "applyToForm": "Aplicar ao formulário"
+        },
+        "diff": {
+          "locked": "Bloqueado",
+          "previewAlt": "Pré-visualização",
+          "currentCoverAlt": "Capa atual",
+          "newCoverAlt": "Nova capa",
+          "pickCoverFromProvider": "Escolher capa de outro provedor",
+          "pickCoverSource": "Escolher fonte da capa",
+          "pickFromProvider": "Escolher de outro provedor",
+          "pickSource": "Escolher fonte",
+          "empty": "vazio",
+          "showLess": "Mostrar menos",
+          "showMore": "Mostrar mais",
+          "coverPreviewAlt": "Pré-visualização da capa"
+        },
+        "searchDrawer": {
+          "searchTitle": "Buscar Metadados",
+          "compareTitle": "Comparar Metadados",
+          "searchSubtitle": "Encontre a melhor correspondência de provedor para este livro.",
+          "compareSubtitle": "Revise as diferenças e aplique apenas o que desejar."
+        },
+        "searchPanel": {
+          "untitledQuery": "Consulta sem título",
+          "titlePlaceholder": "Título",
+          "authorPlaceholder": "Autor",
+          "isbnPlaceholder": "ISBN",
+          "searching": "Buscando...",
+          "activeQuery": "Consulta ativa",
+          "searchScope": "Escopo de busca",
+          "allEnabled": "Todos ativados",
+          "all": "Todos",
+          "fieldRules": "Regras de Campo",
+          "custom": "Personalizado",
+          "providerNotInFieldRules": "{provider} está ativado mas não nas Regras de Campo",
+          "notInFieldRulesLabel": "Não está nas Regras de Campo:",
+          "notInFieldRulesText": "{providers}. Incluídos na busca manual com Todos ativados, mas não utilizados na busca automática de metadados.",
+          "noResults": "Nenhum resultado encontrado",
+          "noResultsHint": "Tente ajustar o título ou autor",
+          "searchPrompt": "Busque acima, então clique em um resultado para começar a comparar os metadados."
+        },
+        "writeAndRename": "Gravar no Arquivo & Renomear",
+        "writeAndRenameShort": "Gravar & Renomear"
+      },
+      "files": {
+        "title": "Arquivos do livro",
+        "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+        "synced": "Sincronizado {time}",
+        "sortAria": "Ordenar arquivos",
+        "syncHistory": "Histórico de sincronização",
+        "metadataWriteBack": "Regravação de metadados",
+        "relative": {
+          "seconds": "há {value}s",
+          "minutes": "há {value}m",
+          "hours": "há {value}h",
+          "days": "há {value}d"
+        },
+        "renameFailed": "Falha ao renomear arquivo",
+        "deleteFailed": "Falha ao excluir arquivo",
+        "addFile": "Adicionar Arquivo",
+        "lastSynced": "Última sincronização: {time}",
+        "sort": {
+          "label": "Ordenar:",
+          "name": "Nome",
+          "format": "Formato",
+          "size": "Tamanho",
+          "date": "Data"
+        },
+        "hidePaths": "Esconder caminhos",
+        "showPaths": "Mostrar caminhos",
+        "hideLog": "Esconder log",
+        "viewSyncLog": "Ver log de sincronização",
+        "noWriteHistory": "Nenhum histórico de gravação ainda.",
+        "fieldsWritten": "nenhum campo | um campo | {count} campos",
+        "track": "Faixa {number}",
+        "primary": "Primário",
+        "read": "Ler",
+        "play": "Ouvir",
+        "peek": "Espiar",
+        "download": "Baixar",
+        "moreActions": "Mais ações",
+        "rename": "Renomear",
+        "empty": {
+          "title": "Nenhum arquivo anexado",
+          "description": "Este livro não possui arquivos associados."
+        },
+        "renameModal": {
+          "title": "Renomear Arquivo",
+          "description": "Renomear o arquivo físico no disco.",
+          "placeholder": "Novo nome do arquivo"
+        },
+        "saving": "Salvando...",
+        "deleteModal": {
+          "title": "Excluir arquivo?",
+          "description": "Tem certeza que deseja excluir \"{filename}\"? Esta ação não pode ser desfeita."
+        },
+        "deleting": "Excluindo..."
+      },
+      "highlights": {
+        "note": {
+          "placeholder": "Adicionar uma nota...",
+          "saving": "Salvando"
+        },
+        "export": {
+          "trigger": "Exportar",
+          "plainText": "Texto Simples",
+          "page": "Exportar página",
+          "selected": "Exportar selecionados"
+        },
+        "sort": {
+          "position": "Posição",
+          "newest": "Mais novos primeiro",
+          "oldest": "Mais antigos primeiro"
+        },
+        "summary": {
+          "highlights": "nenhum destaque | um destaque | {count} destaques",
+          "notes": "nenhuma nota | uma nota | {count} notas",
+          "chapters": "nenhum capítulo | um capítulo | {count} capítulos"
+        },
+        "filterByChapter": "Filtrar por capítulo",
+        "allChapters": "Todos os capítulos",
+        "untitled": "Sem título",
+        "trash": "Lixeira",
+        "empty": {
+          "noMatch": "Nenhum destaque corresponde aos seus filtros.",
+          "resetFilters": "Redefinir filtros",
+          "none": "Nenhum destaque ainda",
+          "hint": "Selecione o texto durante a leitura para criar destaques"
+        },
+        "uncategorized": "Sem categoria",
+        "paginationUnit": "destaques"
+      },
+      "readingLog": {
+        "moreActionsAria": "Mais ações do registro de leitura",
+        "export": {
+          "button": "Exportar"
+        },
+        "weekdays": {
+          "sun": "Dom",
+          "mon": "Seg",
+          "tue": "Ter",
+          "wed": "Qua",
+          "thu": "Qui",
+          "fri": "Sex",
+          "sat": "Sáb"
+        },
+        "months": {
+          "jan": "Jan",
+          "feb": "Fev",
+          "mar": "Mar",
+          "apr": "Abr",
+          "may": "Mai",
+          "jun": "Jun",
+          "jul": "Jul",
+          "aug": "Ago",
+          "sep": "Set",
+          "oct": "Out",
+          "nov": "Nov",
+          "dec": "Dez"
+        },
+        "heatmap": {
+          "subtitle": "{count} dia ativo · {ratio}% consistência | {count} dia ativo · {ratio}% consistência | {count} dias ativos · {ratio}% consistência",
+          "minutesUnit": "min",
+          "title": "Atividade",
+          "empty": "Nenhuma atividade de leitura nesta janela.",
+          "emptyHint": "Sessões registradas aqui construirão sua visão de consistência."
+        },
+        "hero": {
+          "summaryAria": "Resumo de leitura",
+          "notSet": "Não definido",
+          "relative": {
+            "seconds": "há {count}s",
+            "minutes": "há {count}m",
+            "hours": "há {count}h",
+            "days": "há {count}d",
+            "months": "há {count} mês | há {count} mês | há {count} meses",
+            "years": "há {count} ano | há {count} ano | há {count} anos"
+          },
+          "noSessions": "Sem sessões",
+          "dateErrors": {
+            "startFuture": "A data de início não pode ser no futuro.",
+            "finishFuture": "A data de término não pode ser no futuro.",
+            "finishBeforeStart": "A data de término deve ser igual ou posterior à data de início.",
+            "saveFailed": "Falha ao salvar datas de leitura."
+          },
+          "eta": {
+            "max": "99h+ para terminar",
+            "minutes": "~{m}m para terminar",
+            "hours": "~{h}h para terminar",
+            "hoursMinutes": "~{h}h {m}m para terminar"
+          },
+          "momentum": {
+            "none": "Nenhuma atividade nas últimas duas semanas",
+            "new": "Nova atividade esta semana",
+            "up": "+{pct}% em relação aos 7 dias anteriores",
+            "down": "{pct}% em relação aos 7 dias anteriores",
+            "flat": "Inalterado em relação aos 7 dias anteriores"
+          },
+          "stats": {
+            "totalTime": "Tempo Total",
+            "sessions": "Sessões",
+            "avgSession": "Sessão Média",
+            "lastRead": "Última Leitura"
+          },
+          "firstRead": "Primeira Leitura",
+          "lastRead": "Última Leitura",
+          "dateStarted": "Data de Início",
+          "dateFinished": "Data de Término",
+          "addSession": "Adicionar sessão"
+        },
+        "journey": {
+          "tooltipProgress": "Progresso",
+          "tooltipReading": "Lendo",
+          "minutesUnit": "min",
+          "title": "Jornada de progresso",
+          "empty": "Nenhum dado de progresso nesta janela.",
+          "emptyHint": "O progresso aparecerá depois que uma sessão registrar uma posição de leitura."
+        },
+        "sourceSplit": {
+          "title": "Fontes de leitura",
+          "shortTitle": "Fontes"
+        },
+        "untitled": "Sem título",
+        "addSessionFailed": "Falha ao adicionar sessão",
+        "filters": {
+          "show": "Mostrar",
+          "dateRangeAria": "Período da sessão de leitura",
+          "allTime": "Todo o período",
+          "last30": "Últimos 30 dias",
+          "last90": "Últimos 90 dias",
+          "thisYear": "Este ano",
+          "allFormats": "Todos os formatos"
+        },
+        "table": {
+          "title": "Sessões",
+          "sourceWeb": "Web",
+          "sourceManual": "Manual",
+          "colDate": "Data",
+          "colDateMobile": "Data",
+          "colDuration": "Duração",
+          "colDurationMobile": "Duração",
+          "colProgressChange": "Mudança de Progresso",
+          "colProgressChangeMobile": "Delta",
+          "colEndProgress": "Progresso Final",
+          "colEndProgressMobile": "Fim",
+          "empty": "Nenhuma sessão de leitura registrada ainda.",
+          "emptyHint": "Adicione uma sessão para começar a construir o histórico de leitura deste livro.",
+          "colPace": "Ritmo",
+          "colSource": "Fonte",
+          "colFormatMobile": "Fmt",
+          "colFormat": "Formato",
+          "cancelDelete": "Cancelar exclusão",
+          "cancelDeleteAria": "Cancelar exclusão de sessão",
+          "confirmDeleteTitle": "Clique novamente para confirmar exclusão",
+          "confirmDeleteAria": "Confirmar exclusão de sessão",
+          "deleteAria": "Excluir sessão",
+          "loadMore": "Carregar mais",
+          "showing": "Exibindo {shown} de {total} sessões"
+        }
+      },
+      "richDescription": {
+        "linkProtocolError": "Use http, https, ou mailto.",
+        "bold": "Negrito",
+        "italic": "Itálico",
+        "underline": "Sublinhado",
+        "strikethrough": "Tachado",
+        "bulletList": "Lista de marcadores",
+        "numberedList": "Lista numerada",
+        "outdentAria": "Diminuir recuo do item da lista",
+        "outdent": "Diminuir recuo",
+        "indentAria": "Aumentar recuo do item da lista",
+        "indent": "Aumentar recuo",
+        "quote": "Citação",
+        "editLink": "Editar link",
+        "link": "Link",
+        "removeLink": "Remover link",
+        "undo": "Desfazer",
+        "redo": "Refazer",
+        "clearFormatting": "Limpar formatação",
+        "previewDescription": "Pré-visualizar descrição",
+        "preview": "Pré-visualizar",
+        "linkUrlLabel": "URL do Link",
+        "applyLink": "Aplicar link",
+        "apply": "Aplicar",
+        "cancelLink": "Cancelar link",
+        "noDescription": "Nenhuma descrição disponível."
+      },
+      "seriesMembership": {
+        "addSeries": "Adicionar série",
+        "seriesPlaceholder": "Série",
+        "moveUp": "Mover para cima",
+        "moveDown": "Mover para baixo",
+        "removeSeries": "Remover série"
+      }
+    },
+    "table": {
+      "actions": {
+        "quickView": "Visualização Rápida",
+        "bookDetails": "Detalhes do Livro",
+        "editMetadata": "Editar Metadados",
+        "refreshMetadata": "Atualizar Metadados",
+        "addToCollection": "Adicionar à Coleção",
+        "sendToDevice": "Enviar para o Dispositivo"
+      },
+      "boolean": {
+        "ariaNotSet": "Não definido - clique para definir como verdadeiro",
+        "ariaTrue": "Verdadeiro - clique para definir como falso",
+        "ariaFalse": "Falso - clique para limpar"
+      },
+      "chips": {
+        "addPlaceholder": "Adicionar..."
+      },
+      "cover": {
+        "previewDescription": "Pré-visualização da capa do livro",
+        "editDescription": "Editar capa do livro",
+        "editTitle": "Editar capa",
+        "editCover": "Editar Capa",
+        "view": "Visualizar capa"
+      },
+      "date": {
+        "justNow": "agora mesmo"
+      },
+      "format": {
+        "unknown": "desconhecido"
+      },
+      "header": {
+        "sortAscending": "Ordem Crescente",
+        "sortDescending": "Ordem Decrescente",
+        "clearSort": "Limpar Ordenação",
+        "hideColumn": "Ocultar Coluna",
+        "pinLeft": "Fixar à Esquerda",
+        "pinRight": "Fixar à Direita",
+        "unpinColumn": "Desafixar Coluna",
+        "autoFitWidth": "Ajustar Largura Automaticamente",
+        "autoFitAllColumns": "Ajustar Todas as Colunas",
+        "selectAllBooks": "Selecionar todos os livros",
+        "shiftClickSecondarySort": "Shift+clique para adicionar ordenação secundária",
+        "clickToSort": "Clique para ordenar"
+      },
+      "locks": {
+        "lockAll": "Bloquear todos os campos",
+        "unlockAll": "Desbloquear todos os campos",
+        "lockField": "Bloquear campo",
+        "unlockField": "Desbloquear campo",
+        "clickToLock": "Clique para bloquear",
+        "clickToUnlock": "Clique para desbloquear"
+      },
+      "progress": {
+        "complete": "{percent} concluído"
+      },
+      "rating": {
+        "label": "Avaliação",
+        "remove": "Remover avaliação",
+        "rate": "Avaliar com {star} de 5"
+      },
+      "read": {
+        "play": "Ouvir",
+        "read": "Ler",
+        "primary": "Primário",
+        "peekFormat": "Espiar {format}",
+        "chooseFormat": "Escolha o formato para ler ou ouvir",
+        "fileFallback": "ARQUIVO"
+      },
+      "readStatus": {
+        "unread": "Não Lido"
+      },
+      "series": {
+        "bookCount": "(nenhum livro) | ({count} livro) | ({count} livros)",
+        "readOfCount": "{read} de {total} lidos"
+      },
+      "text": {
+        "openDetails": "Abrir detalhes"
+      }
+    }
+  },
+  "bookMetadataFetch": {
+    "book": {
+      "title": "Busca de Metadados"
+    },
+    "author": {
+      "title": "Enriquecimento de Autor"
+    },
+    "stats": {
+      "queued": "Na fila",
+      "processing": "Processando",
+      "rateLimited": "Limite de taxa",
+      "failed": "Falhou"
+    },
+    "actions": {
+      "pause": "Pausar",
+      "resume": "Retomar",
+      "cancelQueued": "Cancelar na fila",
+      "dismissBookStatus": "Dispensar status da busca de metadados",
+      "dismissAuthorStatus": "Dispensar status do enriquecimento de autor"
+    },
+    "cancel": {
+      "processingWillFinish": "Os itens atualmente em processamento serão concluídos.",
+      "confirm": "Confirmar cancelamento",
+      "keepRunning": "Continuar executando"
+    },
+    "viewFailed": "Ver um falhado | Ver {count} falhados",
+    "card": {
+      "fetchingMetadata": "Buscando metadados",
+      "enrichingAuthors": "Enriquecendo autores",
+      "metadataFetchFinished": "Busca de metadados concluída",
+      "authorEnrichmentFinished": "Enriquecimento de autor concluído"
+    },
+    "label": {
+      "paused": "Pausado",
+      "remaining": "{count} restante(s)",
+      "processing": "{count} processando",
+      "failed": "{count} falhou",
+      "rateLimited": "{count} no limite de taxa"
+    },
+    "report": {
+      "bookTitle": "Buscas de Metadados Falhas",
+      "authorTitle": "Enriquecimentos de Autor Falhos",
+      "noFailedItems": "Nenhum item falhou.",
+      "retryAllFailed": "Tentar novamente todos os falhados",
+      "bookFallback": "Livro #{id}",
+      "authorFallback": "Autor #{id}",
+      "columns": {
+        "title": "Título",
+        "library": "Biblioteca",
+        "author": "Autor",
+        "error": "Erro",
+        "http": "HTTP"
+      }
+    },
+    "toast": {
+      "failedToPause": "Falha ao pausar",
+      "failedToResume": "Falha ao retomar",
+      "failedToCancel": "Falha ao cancelar",
+      "failedToRetry": "Falha ao tentar novamente",
+      "failedItemsRequeued": "Itens falhados recolocados na fila",
+      "bookComplete": "Busca de metadados concluída - {done} livros atualizados",
+      "bookDoneWithFailures": "Busca de metadados finalizada - {done} processados, {failed} falharam",
+      "authorComplete": "Enriquecimento de autor concluído - {done} autores atualizados",
+      "authorDoneWithFailures": "Enriquecimento de autor finalizado - {done} processados, {failed} falharam"
+    }
+  },
+  "bookDock": {
+    "apply": "Aplicar",
+    "done": "Concluído",
+    "discard": "Descartar",
+    "finalize": "Finalizar",
+    "rescan": "Reescanear",
+    "uploadAction": "Fazer Upload",
+    "uploading": "Enviando...",
+    "searchPlaceholder": "Buscar arquivos...",
+    "setDestinationAction": "Definir Destino",
+    "bulkEditAction": "Edição em Massa",
+    "applyFetched": "Aplicar Buscados",
+    "retryErrors": "Tentar Erros Novamente",
+    "commaSeparated": "separado por vírgulas",
+    "destinationLibrary": "Biblioteca de Destino",
+    "destinationFolder": "Pasta de Destino",
+    "nSelected": "nenhum arquivo selecionado | {count} selecionado | {count} selecionados",
+    "nFailed": "{count} falharam",
+    "updatedOfFiles": "Atualizados {updated} de {total} arquivos",
+    "errorStatus": "Erro {status}",
+    "applyFetchedTooltip": "Aplicar metadados buscados automaticamente a {count} arquivos | Aplicar metadados buscados automaticamente a {count} arquivo | Aplicar metadados buscados automaticamente a {count} arquivos",
+    "retryErrorsTooltip": "Tentar buscar metadados novamente para {count} arquivos com erro | Tentar buscar metadados novamente para {count} arquivo com erro | Tentar buscar metadados novamente para {count} arquivos com erro",
+    "tab": {
+      "all": "Todos",
+      "pending": "Pendentes",
+      "ready": "Prontos",
+      "error": "Erro"
+    },
+    "status": {
+      "pending": "Pendente",
+      "extracting": "Extraindo",
+      "fetching": "Buscando",
+      "ready": "Pronto",
+      "error": "Erro"
+    },
+    "field": {
+      "title": "Título",
+      "subtitle": "Subtítulo",
+      "authors": "Autores",
+      "authorsCommaSeparated": "Autores (separados por vírgulas)",
+      "publisher": "Editora",
+      "publishedDate": "Data de Publicação",
+      "year": "Ano",
+      "language": "Idioma",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "series": "Série",
+      "seriesIndex": "Nº da Série",
+      "genres": "Gêneros",
+      "genresCommaSeparated": "Gêneros (separados por vírgulas)",
+      "description": "Descrição"
+    },
+    "upload": {
+      "nDone": "{count} concluídos",
+      "nFailed": "{count} falharam",
+      "nTotal": "{count} total"
+    },
+    "fileList": {
+      "emptyTitle": "Nenhum arquivo na Doca de Livros",
+      "emptyMessageDefault": "Faça o upload de arquivos ou solte-os na pasta Doca de Livros",
+      "colCurrent": "Atual",
+      "colNew": "Novo",
+      "colFile": "Arquivo",
+      "colSize": "Tamanho",
+      "colFormat": "Formato",
+      "colMatch": "Correspondência",
+      "colApply": "Aplicar",
+      "colStatus": "Status",
+      "applyFetchedMetadata": "Aplicar metadados buscados",
+      "coverPreview": "Pré-visualização da capa",
+      "coverPreviewDescription": "Caixa de diálogo com pré-visualização ampliada da imagem da capa.",
+      "currentCoverAlt": "Capa atual de {title}",
+      "newCoverAlt": "Nova capa de {title}",
+      "unknownLibrary": "Biblioteca desconhecida",
+      "unassigned": "Não atribuído",
+      "targetPath": "Destino: {library} · {path}",
+      "targetUnassigned": "Destino: Não atribuído",
+      "targetUnknownPath": "Destino: {library} · Caminho de destino desconhecido"
+    },
+    "sheet": {
+      "saved": "Salvo",
+      "providerMetadataFound": "Metadados do provedor encontrados",
+      "providerMetadataFoundEdited": "Metadados do provedor encontrados - a aplicação em massa irá ignorar este arquivo (você possui edições manuais)",
+      "review": "Revisar",
+      "added": "Adicionado {date}",
+      "searchMetadata": "Buscar Metadados",
+      "results": "Resultados"
+    },
+    "bulkEdit": {
+      "title": "Edição em Massa de nenhum arquivo | Edição em Massa de {count} arquivo | Edição em Massa de {count} arquivos",
+      "resultTitle": "Resultados da Edição em Massa",
+      "instructions": "Alterne os campos que você deseja atualizar. Apenas os campos ativados serão aplicados.",
+      "mergeArrays": "Mesclar listas (adicionar aos valores existentes em vez de substituir)",
+      "failed": "Falha na edição em massa"
+    },
+    "setDestination": {
+      "title": "Definir Destino para nenhum arquivo | Definir Destino para {count} arquivo | Definir Destino para {count} arquivos",
+      "resultTitle": "Destino Atualizado",
+      "failed": "Falha ao definir destino"
+    },
+    "finalizeDialog": {
+      "title": "Finalizar nenhum arquivo | Finalizar {count} arquivo | Finalizar {count} arquivos",
+      "resultTitle": "Resultados da Finalização",
+      "needDestination": "{without} de {count} arquivos selecionados precisam de um destino | {without} de {count} arquivo selecionado precisa de um destino | {without} de {count} arquivos selecionados precisam de um destino",
+      "allHaveDestination": "Todos os arquivos selecionados já possuem destino definido",
+      "defaultDestinationLibrary": "Biblioteca de Destino Padrão",
+      "defaultDestinationFolder": "Pasta de Destino Padrão",
+      "renamePreview": "Pré-visualização da renomeação",
+      "moreFiles": "+{count} mais arquivos",
+      "start": "Iniciar",
+      "filesFinalized": "{succeeded} de {total} arquivos finalizados",
+      "checking": "Verificando arquivos selecionados...",
+      "readyCount": "nenhum arquivo pronto | {count} arquivo pronto | {count} arquivos prontos",
+      "duplicateCount": "nenhum já existe na biblioteca | {count} já existe na biblioteca | {count} já existem na biblioteca",
+      "conflictCount": "nenhum conflito de nome de arquivo | {count} conflito de nome de arquivo | {count} conflitos de nome de arquivo",
+      "missingDestinationCount": "nenhum destino ausente | {count} destino ausente | {count} destinos ausentes",
+      "blockedCount": "nenhum arquivo bloqueado | {count} arquivo bloqueado | {count} arquivos bloqueados",
+      "moreDuplicates": "+{count} mais já existentes na biblioteca",
+      "discardDuplicates": "Descartar duplicatas",
+      "failedCount": "nenhum arquivo falhou | {count} arquivo falhou | {count} arquivos falharam",
+      "failedWithDuplicates": "{failed} falhou ({count} duplicatas) | {failed} falhou ({count} duplicata) | {failed} falharam ({count} duplicatas)",
+      "view": "Ver",
+      "viewExisting": "Ver existente",
+      "importAnyway": "Importar de qualquer forma",
+      "hide": "Esconder",
+      "details": "Detalhes",
+      "alreadyExistsSaveAs": "Já existe - salvar como:",
+      "renamePlaceholder": "ex: {name} (2)",
+      "import": "Importar"
+    }
+  },
+  "collection": {
+    "dialog": {
+      "name": "Nome",
+      "icon": "Ícone",
+      "iconPlaceholder": "Escolha um ícone...",
+      "nameRequired": "O nome é obrigatório",
+      "iconRequired": "Escolha um ícone",
+      "creating": "Criando...",
+      "createFailed": "Falha ao criar coleção"
+    },
+    "createDialog": {
+      "title": "Nova Coleção",
+      "namePlaceholder": "ex: Favoritos"
+    },
+    "editDialog": {
+      "title": "Editar Coleção",
+      "syncToKobo": "Sincronizar com Kobo",
+      "syncToKoboHint": "Livros nesta coleção aparecerão no seu dispositivo Kobo",
+      "deleteCollection": "Excluir coleção",
+      "confirmDelete": "Confirmar?",
+      "deleting": "Excluindo...",
+      "saving": "Salvando...",
+      "deleted": "\"{name}\" excluída",
+      "updateFailed": "Falha ao atualizar coleção",
+      "deleteFailed": "Falha ao excluir coleção"
+    },
+    "addToSheet": {
+      "title": "Gerenciar Coleções",
+      "selectedCount": "nenhum livro selecionado | um livro selecionado | {count} livros selecionados",
+      "newCollection": "Nova Coleção",
+      "namePlaceholder": "Nome da coleção",
+      "create": "Criar",
+      "collections": "Coleções",
+      "empty": "Nenhuma coleção ainda. Crie uma acima.",
+      "done": "Concluído",
+      "added": "Adicionado",
+      "allAdded": "Todos os {total} adicionados",
+      "inCollection": "Nesta coleção",
+      "allInCollection": "Todos os {total} nesta coleção",
+      "partialInCollection": "{partial} de {total} nesta coleção",
+      "bookCount": "nenhum livro | um livro | {count} livros",
+      "loadFailed": "Falha ao carregar coleções",
+      "createdAndAdded": "Criada \"{name}\" e adicionado nenhum livro | Criada \"{name}\" e adicionado um livro | Criada \"{name}\" e adicionados {count} livros",
+      "createdButAddFailed": "Criada \"{name}\", mas falhou ao adicionar livros",
+      "createFailed": "Falha ao criar coleção",
+      "addedNewWithExisting": "Adicionado um livro novo a \"{name}\" ({alreadyHad} já estavam lá) | Adicionado um livro novo a \"{name}\" ({alreadyHad} já estavam lá) | Adicionados {count} novos livros a \"{name}\" ({alreadyHad} já estavam lá)",
+      "addedToCollection": "Nenhum livro adicionado a \"{name}\" | Um livro adicionado a \"{name}\" | {count} livros adicionados a \"{name}\"",
+      "addFailed": "Falha ao adicionar à coleção",
+      "removedFromCollection": "Nenhum livro removido de \"{name}\" | Um livro removido de \"{name}\" | {count} livros removidos de \"{name}\"",
+      "removeFailed": "Falha ao remover da coleção"
+    }
+  },
+  "components": {
+    "appHeader": {
+      "searchAllBooks": "Buscar em todos os livros...",
+      "searching": "Buscando...",
+      "noResults": "Nenhum resultado",
+      "loadingMore": "Carregando mais...",
+      "loadMore": "Carregar mais ({loaded}/{total})",
+      "allMatchesShown": "Nenhum resultado exibido | {count} resultado exibido | {count} resultados exibidos",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+      "uploadedToast": "Enviado(s) {uploaded}",
+      "uploadFailedToast": "Upload falhou para {failed}",
+      "uploadPartialToast": "Enviado(s) {uploaded}, {failed} falharam",
+      "bookDock": "Doca de Livros",
+      "statistics": "Estatísticas",
+      "achievements": "Conquistas",
+      "annotations": "Anotações",
+      "uploadBooks": "Upload de livros",
+      "appearance": "Aparência",
+      "theme": "Tema",
+      "accent": "Destaque",
+      "radius": "Arredondamento",
+      "background": "Fundo",
+      "settings": "Configurações",
+      "whatsNew": "O que há de novo",
+      "documentation": "Documentação",
+      "help": "Ajuda",
+      "starOnGithub": "Dar estrela no GitHub",
+      "new": "Novo",
+      "newReleaseNotes": "Novas notas de lançamento disponíveis",
+      "account": "Conta",
+      "changePassword": "Alterar Senha",
+      "signOut": "Sair",
+      "githubStar": {
+        "title": "Gostando do BookOrbit?",
+        "body": "Se o BookOrbit está ajudando com sua biblioteca, por favor, considere dar uma estrela ao projeto no GitHub. Isso ajuda mais pessoas a descobrirem o aplicativo e apoia o desenvolvimento contínuo.",
+        "cta": "Dar estrela ao BookOrbit no GitHub"
+      }
+    },
+    "sidebar": {
+      "tagline": "Seu Espaço de Leitura",
+      "dashboard": "Painel",
+      "authors": "Autores",
+      "series": "Séries",
+      "tools": "Ferramentas",
+      "libraries": "Bibliotecas",
+      "newLibrary": "Nova Biblioteca",
+      "libraryScanning": "{name} - Escaneando {pct}%",
+      "scanProgress": "{processed} / {total} livros",
+      "smartScopes": "SmartScopes",
+      "newSmartScope": "Novo SmartScope",
+      "noSmartScopes": "Nenhum SmartScope ainda",
+      "collections": "Coleções",
+      "newCollection": "Nova Coleção",
+      "noCollections": "Nenhuma coleção ainda",
+      "latest": "Última versão {version}",
+      "newReleaseNotes": "Novas notas de lançamento disponíveis",
+      "support": "Apoie o BookOrbit",
+      "supportShort": "Apoiar",
+      "supportAria": "Apoie o BookOrbit no Ko-fi",
+      "sectionHeader": {
+        "add": "Adicionar",
+        "reorder": "Reordenar",
+        "doneReordering": "Concluída a reordenação"
+      }
+    },
+    "selectionActionBar": {
+      "setReadingStatus": "Definir status de leitura",
+      "setRating": "Definir avaliação",
+      "openMetadataEditor": "Abrir editor de metadados",
+      "editIndividually": "Editar livros individualmente",
+      "addToCollection": "Adicionar à coleção",
+      "removeFromCollection": "Remover da coleção",
+      "sendViaEmail": "Enviar por e-mail",
+      "downloadFilesZip": "Baixar arquivos como ZIP",
+      "moreActions": "Mais ações",
+      "setField": "Definir campo",
+      "refreshMetadata": "Atualizar metadados",
+      "reExtractCover": "Extrair capa novamente",
+      "metadataLock": "Bloqueio de metadados",
+      "lockAll": "Bloquear tudo",
+      "unlockAll": "Desbloquear tudo",
+      "exportMetadata": "Exportar metadados",
+      "deleteSelected": "Excluir selecionados",
+      "exitSelection": "Sair da seleção",
+      "downloadFilesZipLabel": "Baixar arquivos como ZIP:",
+      "primaryOnly": "Apenas primário",
+      "allFormats": "Todos os formatos",
+      "audioOnly": "Apenas áudio",
+      "setRatingLabel": "Definir avaliação:",
+      "clear": "Limpar",
+      "setFieldLabel": "Definir campo:",
+      "apply": "Aplicar",
+      "fieldPlaceholder": "Deixe em branco para limpar",
+      "fieldPlaceholderArray": "Separado por vírgulas (deixe em branco para limpar)",
+      "deleteConfirm": "Excluir {count} livro? | Excluir {count} livro? | Excluir {count} livros?",
+      "typeDelete": "Digite DELETE"
+    },
+    "viewHeader": {
+      "select": "Selecionar",
+      "display": "Exibição",
+      "displayDescription": "Ajustar tamanho da capa, espaçamento da grade e opções de exibição da visualização.",
+      "columnVisibilityHint": "Use o painel de visibilidade de colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
+      "columnVisibilityMobileHint": "A visibilidade das colunas pode ser gerenciada no cabeçalho da tabela.",
+      "searchPlaceholder": "Buscar título, autor, série, narrador...",
+      "mobileSearch": {
+        "description": "Buscar itens por título, autor, série ou narrador.",
+        "done": "Concluído"
+      },
+      "mobileMenu": {
+        "grid": "Grade",
+        "list": "Lista",
+        "select": "Selecionar",
+        "exitSelect": "Sair da Seleção"
+      },
+      "displayControls": {
+        "display": "Exibição",
+        "coverSize": "Tamanho da capa",
+        "gridGap": "Espaçamento da grade",
+        "columnsHint": "Use o painel de visibilidade de colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
+        "coverShape": "Formato da capa",
+        "circle": "Círculo",
+        "square": "Quadrado"
+      }
+    },
+    "iconPicker": {
+      "clearSelectionAria": "Limpar ícone selecionado",
+      "searchLucide": "Buscar ícones Lucide...",
+      "searchCustom": "Buscar ícones personalizados...",
+      "chooseIcon": "Escolha um ícone...",
+      "selectIcon": "Selecionar ícone",
+      "customTab": "Personalizado",
+      "searching": "Buscando...",
+      "noIconsMatch": "Nenhum ícone corresponde a \"{query}\"",
+      "typeToSearch": "Digite para buscar em todos os ícones",
+      "noCustomIcons": "Nenhum ícone personalizado enviado",
+      "noIconsAvailable": "Nenhum ícone disponível"
+    },
+    "entityNotFound": {
+      "title": "{entity} não encontrado(a)",
+      "description": "Este(a) {entity} não existe ou foi excluído(a).",
+      "goBack": "Voltar"
+    },
+    "themePicker": {
+      "light": "Claro",
+      "dark": "Escuro"
+    },
+    "userAvatar": {
+      "profilePicture": "Foto de perfil",
+      "profilePictureOf": "Foto de perfil de {name}"
+    },
+    "ui": {
+      "sidebar": {
+        "title": "Barra lateral",
+        "mobileDescription": "Exibe a barra lateral em dispositivos móveis.",
+        "toggle": "Alternar Barra Lateral"
+      },
+      "chipInput": {
+        "typeAndEnter": "Digite e pressione Enter para adicionar",
+        "pressEnter": "Pressione Enter para adicionar"
+      }
+    }
+  },
+  "customIcons": {
+    "dialogTitle": "Enviar ícones personalizados",
+    "dialogDescription": "Revise os nomes antes de adicioná-los à sua biblioteca.",
+    "readingFiles": "Lendo arquivos...",
+    "dropPrompt": "Arraste arquivos SVG ou clique para procurar",
+    "fileLimit": "Até {max} arquivos, 128 KB cada",
+    "namePlaceholder": "Nome",
+    "nameRequired": "O nome é obrigatório",
+    "invalidSvg": "SVG inválido",
+    "invalidSvgFile": "Arquivo SVG inválido",
+    "identicalTo": "Idêntico a \"{name}\"",
+    "uploadAnyway": "Enviar mesmo assim",
+    "skipThisOne": "Pular este",
+    "readyToUpload": "{count} pronto(s) para enviar",
+    "noIconsStaged": "Nenhum ícone preparado ainda",
+    "uploading": "Enviando...",
+    "upload": "Enviar",
+    "uploadCount": "Enviar {count}",
+    "onlySvgSupported": "Apenas arquivos SVG são suportados",
+    "maxStaged": "Você pode preparar no máximo {max} ícones por vez",
+    "onlyMoreCanStage": "Nenhum outro ícone pode ser preparado | Apenas mais {count} ícone pode ser preparado | Apenas mais {count} ícones podem ser preparados",
+    "readFailed": "Falha ao ler arquivos SVG",
+    "uploadedCount": "Nenhum ícone enviado | {count} ícone enviado | {count} ícones enviados",
+    "uploadedPartial": "Enviado(s) {created}, {failed} falharam",
+    "noIconsUploaded": "Nenhum ícone enviado",
+    "uploadFailed": "Falha ao enviar os ícones",
+    "uploadFailedEntry": "Falha no envio"
+  },
+  "dashboard": {
+    "common": {
+      "failedToLoad": "Falha ao carregar",
+      "retry": "Tentar novamente",
+      "untitled": "Sem título",
+      "cover": "Capa",
+      "bookCover": "Capa do livro"
+    },
+    "scroller": {
+      "failedToLoad": "Falha ao carregar.",
+      "empty": {
+        "continueReading": "Nenhum livro em andamento ainda. Comece a ler um para vê-lo aqui.",
+        "continueListening": "Nenhum audiolivro em andamento ainda. Comece a ouvir um para vê-lo aqui.",
+        "wantToRead": "Nenhum livro marcado como quero ler ainda.",
+        "upNextInSeries": "Nenhuma escolha para a próxima série ainda. Termine um volume para sugerir o próximo.",
+        "recentlyAdded": "Nenhum livro em sua biblioteca ainda.",
+        "smartScope": "Nenhum livro corresponde a este SmartScope.",
+        "default": "Nenhum livro encontrado."
+      }
+    },
+    "settings": {
+      "title": "Personalizar Painel",
+      "tabs": {
+        "widgets": "Widgets",
+        "shelves": "Prateleiras"
+      },
+      "reorderHintWidget": "Arraste para reordenar. Alterne para mostrar ou ocultar um widget.",
+      "reorderHintShelf": "Arraste para reordenar. Alterne para mostrar ou ocultar uma prateleira.",
+      "smartScope": "SmartScope",
+      "noSmartScopes": "Nenhum SmartScope ainda. Crie um pela barra lateral.",
+      "addShelf": "Adicionar prateleira",
+      "resetToDefaults": "Restaurar padrões"
+    },
+    "welcome": {
+      "emptyTitle": "Sua biblioteca está vazia",
+      "noLibrariesTitle": "Nenhuma biblioteca ainda",
+      "emptyDescription": "Crie uma biblioteca para começar a organizar e ler seus livros. Aponte-a para uma pasta e ela fará o resto.",
+      "noLibrariesDescription": "Seu administrador ainda não configurou nenhuma biblioteca. Entre em contato com ele para começar.",
+      "createFirstLibrary": "Criar sua primeira biblioteca"
+    },
+    "widgets": {
+      "currentlyReading": {
+        "title": "Lendo Atualmente",
+        "empty": "Nenhum livro em andamento. Comece a ler um para vê-lo aqui.",
+        "continueReading": "Continuar lendo"
+      },
+      "diversityScore": {
+        "title": "Score de Diversidade",
+        "notEnoughData": "Leia pelo menos 3 livros para ver seu score de diversidade",
+        "booksAnalyzed": "nenhum livro analisado | {count} livro analisado | {count} livros analisados",
+        "subScores": {
+          "genre": "Gênero",
+          "author": "Autor",
+          "era": "Época",
+          "language": "Idioma"
+        }
+      },
+      "highlightOfTheDay": {
+        "title": "Destaque do Dia",
+        "empty": "Destaque passagens durante a leitura para vê-las aqui"
+      },
+      "libraryOverview": {
+        "title": "Visão Geral da Biblioteca",
+        "empty": "Sua biblioteca está vazia. Adicione alguns livros para começar.",
+        "addedThisYear": "+{count} adicionados este ano",
+        "stats": {
+          "books": "Livros",
+          "authors": "Autores",
+          "series": "Séries",
+          "storage": "Armazenamento"
+        }
+      },
+      "longWait": {
+        "title": "O Longo Esperar",
+        "empty": "Nenhum livro na fila de espera. Você começou tudo!",
+        "daysWaiting": "dias em espera",
+        "pages": "nenhuma página | {count} página | {count} páginas",
+        "startReading": "Começar a Ler"
+      },
+      "monthlyChallenge": {
+        "title": "Desafio Mensal",
+        "complete": "Concluído!"
+      },
+      "neglectedGems": {
+        "title": "Joias Negligenciadas",
+        "empty": "Todos os seus livros com melhor avaliação foram lidos!",
+        "rating": "{rating}/5",
+        "daysWaiting": "{count}d esperando",
+        "queued": "Na fila",
+        "addToQueue": "Adicionar à fila",
+        "shuffle": "Misturar"
+      },
+      "readingDna": {
+        "title": "DNA de Leitura",
+        "notEnoughData": "Leia pelo menos 5 livros para desbloquear seu DNA de Leitura",
+        "basedOn": "Baseado em nenhum livro | Baseado em {count} livro | Baseado em {count} livros",
+        "traits": {
+          "length": "Extensão",
+          "variety": "Variedade",
+          "rhythm": "Ritmo",
+          "time": "Tempo",
+          "speed": "Velocidade"
+        }
+      },
+      "readingGoal": {
+        "title": "Meta de Leitura {year}",
+        "setGoalPrompt": "Defina uma meta de leitura para acompanhar o seu progresso",
+        "setGoal": "Definir meta",
+        "booksPerYear": "Livros por ano",
+        "ofGoal": "de {goal}",
+        "percentComplete": "{percentage}% concluída",
+        "editGoal": "Editar meta"
+      },
+      "readingRhythm": {
+        "title": "Ritmo de Leitura",
+        "empty": "Comece a ler para ver seu ritmo tomar forma",
+        "activeDays": "nenhum dia ativo | {count} dia ativo | {count} dias ativos",
+        "consistency": "{activeDays} · {percent}% de consistência",
+        "avgPerDay": "média de {time}/dia"
+      },
+      "readingStreak": {
+        "title": "Sequência de Leitura",
+        "empty": "Leia hoje para iniciar sua sequência",
+        "streakLabel": "dia de sequência | dia de sequência | dias de sequência",
+        "best": "Melhor: {count} dia | Melhor: {count} dia | Melhor: {count} dias",
+        "lastSevenDays": "Últimos 7 dias"
+      },
+      "yearProjection": {
+        "title": "Projeção Anual",
+        "books": "livros",
+        "trendUp": "Tendência de alta",
+        "trendDown": "Tendência de baixa",
+        "trendSteady": "Ritmo constante",
+        "pages": "páginas",
+        "hours": "horas",
+        "readCount": "{count} lido(s)",
+        "daysLeft": "{count}d restantes"
+      }
+    }
+  },
+  "email": {
+    "title": "E-mail",
+    "subtitle": "Envie livros para o seu e-reader via e-mail.",
+    "loadFailed": "Falha ao carregar",
+    "saveFailed": "Falha ao salvar",
+    "deleteFailed": "Falha ao excluir",
+    "setDefaultFailed": "Falha ao definir como padrão",
+    "setAsDefault": "Definir como padrão",
+    "saving": "Salvando...",
+    "update": "Atualizar",
+    "create": "Criar",
+    "deleteConfirm": "Excluir \"{name}\". Esta ação não pode ser desfeita.",
+    "badge": {
+      "default": "Padrão",
+      "shared": "Compartilhado",
+      "system": "Sistema"
+    },
+    "tabs": {
+      "providers": "Provedores SMTP",
+      "recipients": "Destinatários",
+      "groups": "Grupos",
+      "templates": "Modelos",
+      "preferences": "Preferências",
+      "history": "Histórico"
+    },
+    "providers": {
+      "heading": "Provedores SMTP",
+      "add": "Adicionar provedor",
+      "newTitle": "Novo Provedor",
+      "editTitle": "Editar Provedor",
+      "name": "Nome",
+      "namePlaceholder": "ex: Gmail",
+      "host": "Host",
+      "port": "Porta",
+      "username": "Nome de usuário",
+      "password": "Senha",
+      "passwordEdit": "Senha (deixe em branco para manter a atual)",
+      "fromName": "Nome do Remetente",
+      "fromNamePlaceholder": "Minha Biblioteca",
+      "fromAddress": "Endereço do Remetente",
+      "authentication": "Autenticação",
+      "verifyTls": "Verificar certificado TLS",
+      "tlsWarning": "A verificação TLS está desativada. O certificado do servidor não será validado - use apenas para servidores internos confiáveis.",
+      "noFromAddress": "sem endereço de remetente",
+      "emptyManage": "Nenhum provedor ainda. Adicione um provedor SMTP para começar a enviar e-mails.",
+      "emptyReadonly": "Nenhum provedor disponível. Peça a um administrador para adicionar um.",
+      "setSystemTooltip": "Definir como provedor de e-mail do sistema",
+      "removeSystemTooltip": "Remover como provedor de e-mail do sistema",
+      "testTooltip": "Testar conexão",
+      "toggleSharing": "Alternar compartilhamento",
+      "removeSystemBeforeDelete": "Remova a designação do sistema antes de excluir",
+      "notesHeading": "Notas sobre o Provedor",
+      "notesBody": "O provedor {system} (apenas para superusuário) é usado para e-mails de redefinição de senha. O provedor {defaultProvider} é usado ao enviar livros sem nenhum provedor explicitamente selecionado. Provedores marcados como {shared} estão disponíveis para todos os usuários.",
+      "deleteTitle": "Excluir provedor?",
+      "nameHostRequired": "Nome e host são obrigatórios",
+      "created": "Provedor criado",
+      "updated": "Provedor atualizado",
+      "deleted": "\"{name}\" excluído",
+      "setDefaultSuccess": "\"{name}\" definido como padrão",
+      "unshared": "Compartilhamento do provedor removido",
+      "sharedWithAll": "Provedor compartilhado com todos os usuários",
+      "updateSharingFailed": "Falha ao atualizar compartilhamento",
+      "systemRemoved": "\"{name}\" removido como provedor de e-mail do sistema",
+      "systemSet": "\"{name}\" definido como provedor de e-mail do sistema",
+      "updateSystemFailed": "Falha ao atualizar provedor do sistema",
+      "connectionSuccess": "Conexão bem-sucedida",
+      "connectionFailed": "Falha na conexão",
+      "testFailed": "O teste falhou"
+    },
+    "recipients": {
+      "heading": "Destinatários",
+      "add": "Adicionar destinatário",
+      "newTitle": "Novo Destinatário",
+      "editTitle": "Editar Destinatário",
+      "name": "Nome",
+      "namePlaceholder": "Meu Kindle",
+      "emailAddress": "Endereço de e-mail",
+      "deviceType": "Tipo de dispositivo",
+      "deviceNone": "Nenhum",
+      "deviceOther": "Outro",
+      "preferredFormat": "Formato preferido",
+      "formatAuto": "Automático",
+      "defaultTemplate": "Modelo padrão",
+      "useAccountDefault": "Usar padrão da conta",
+      "kindleNote": "Destinatários Kindle recebem automaticamente e-mails com o assunto \"convert\" para disparar a conversão de formato.",
+      "empty": "Nenhum destinatário ainda.",
+      "prefersFormat": "prefere {format}",
+      "deleteTitle": "Excluir destinatário?",
+      "nameEmailRequired": "Nome e e-mail são obrigatórios",
+      "created": "Destinatário criado",
+      "updated": "Destinatário atualizado",
+      "deleted": "\"{name}\" excluído",
+      "setDefaultSuccess": "\"{name}\" definido como padrão"
+    },
+    "groups": {
+      "heading": "Grupos de Destinatários",
+      "create": "Criar grupo",
+      "newTitle": "Novo Grupo",
+      "name": "Nome do grupo",
+      "namePlaceholder": "ex: Clube do Livro",
+      "creating": "Criando...",
+      "empty": "Nenhum grupo ainda. Crie um grupo para enviar a vários destinatários de uma vez.",
+      "memberCount": "nenhum membro | um membro | {count} membros",
+      "deleteTooltip": "Excluir grupo",
+      "noMembers": "Nenhum membro ainda.",
+      "removeMember": "Remover",
+      "selectRecipient": "Selecionar destinatário...",
+      "add": "Adicionar",
+      "addMember": "Adicionar membro",
+      "allRecipientsInGroup": "Todos os destinatários já estão neste grupo.",
+      "deleteTitle": "Excluir grupo?",
+      "created": "Grupo criado",
+      "createFailed": "Falha ao criar grupo",
+      "deleted": "\"{name}\" excluído",
+      "memberAdded": "Membro adicionado",
+      "addMemberFailed": "Falha ao adicionar membro",
+      "memberRemoved": "Membro removido",
+      "removeMemberFailed": "Falha ao remover membro"
+    },
+    "templates": {
+      "heading": "Modelos de E-mail",
+      "new": "Novo modelo",
+      "newTitle": "Novo Modelo",
+      "editTitle": "Editar Modelo",
+      "name": "Nome",
+      "namePlaceholder": "Padrão",
+      "subject": "Assunto",
+      "body": "Corpo",
+      "availableVariables": "Variáveis disponíveis",
+      "editTemplate": "Editar modelo",
+      "empty": "Nenhum modelo ainda.",
+      "notesHeading": "Notas do Modelo",
+      "notesBody": "Modelos do sistema não podem ser excluídos. Administradores podem editá-los. Use variáveis como {variable} nos assuntos e corpos - elas são substituídas por detalhes do livro no momento do envio.",
+      "deleteTitle": "Excluir modelo?",
+      "nameSubjectRequired": "Nome e assunto são obrigatórios",
+      "created": "Modelo criado",
+      "updated": "Modelo atualizado",
+      "deleted": "\"{name}\" excluído",
+      "setDefaultSuccess": "\"{name}\" definido como padrão"
+    },
+    "preferences": {
+      "heading": "Preferências de E-mail",
+      "defaultProvider": "Provedor padrão",
+      "defaultProviderHint": "Usado quando nenhum provedor é especificado. Se vazio, o padrão da conta será usado.",
+      "noneAccountDefault": "Nenhum (usar padrão da conta)",
+      "defaultRecipient": "Destinatário padrão",
+      "defaultRecipientHint": "Usado para envio rápido. Deve ser configurado para usar a ação de envio rápido nos cartões dos livros.",
+      "none": "Nenhum",
+      "defaultTemplate": "Modelo padrão",
+      "defaultTemplateHint": "Usado quando nenhum modelo é especificado. Reverte para o padrão do sistema se estiver vazio.",
+      "noneSystemDefault": "Nenhum (usar padrão do sistema)",
+      "save": "Salvar preferências",
+      "saved": "Preferências salvas"
+    },
+    "history": {
+      "heading": "Histórico de Envios",
+      "empty": "Nenhum e-mail enviado ainda.",
+      "noSubject": "(sem assunto)",
+      "loadMore": "Carregar mais",
+      "resend": "Reenviar",
+      "deleteTitle": "Excluir entrada do histórico?",
+      "entryDeleted": "Entrada excluída",
+      "queuedForResend": "Na fila para reenvio",
+      "resendFailed": "Falha ao reenviar",
+      "statusSent": "Enviado",
+      "statusFailed": "Falhou",
+      "statusQueued": "Na fila",
+      "statusPending": "Pendente"
+    },
+    "send": {
+      "title": "Enviar por E-mail",
+      "bookCount": "nenhum livro | um livro | {count} livros",
+      "recipients": "Destinatários",
+      "noRecipients": "Nenhum destinatário configurado. Adicione um nas configurações de E-mail.",
+      "groups": "Grupos",
+      "options": "Opções",
+      "fileFormat": "Formato de arquivo",
+      "autoRecipientPreference": "Automático (usar preferência do destinatário)",
+      "unknownFormat": "Desconhecido",
+      "primarySuffix": "(primário)",
+      "provider": "Provedor",
+      "template": "Modelo",
+      "default": "Padrão",
+      "send": "Enviar",
+      "sending": "Enviando...",
+      "queued": "nenhum e-mail na fila | um e-mail na fila | {count} e-mails na fila",
+      "failed": "Falha ao enviar"
+    }
+  },
+  "hardcover": {
+    "settings": {
+      "subtitle": "Sincronize seu progresso de leitura, status e avaliações com o Hardcover."
+    },
+    "bookSync": {
+      "label": "Sincronização Hardcover",
+      "toggleAriaLabel": "Sincronizar este livro com o Hardcover",
+      "syncNow": "Sincronizar agora"
+    },
+    "connection": {
+      "title": "Conexão",
+      "description": "Conecte sua conta do Hardcover para sincronizar os dados de leitura.",
+      "connected": "Conectado",
+      "apiToken": "Token de API",
+      "tokenPlaceholder": "Cole seu token de API do Hardcover",
+      "show": "Mostrar",
+      "hide": "Esconder",
+      "findTokenAt": "Encontre seu token em",
+      "validateToken": "Validar token",
+      "valid": "Válido ({username})",
+      "invalidToken": "Token inválido",
+      "syncOptions": "Opções de sincronização",
+      "syncInfo": "A sincronização ocorre apenas para livros que não estão como 'não lido'. Isso se aplica a gatilhos de status, progresso e avaliação. Esses interruptores controlam quando uma sincronização é executada.",
+      "syncScope": {
+        "title": "Escopo de sincronização de livros",
+        "allEligible": {
+          "label": "Todos os livros elegíveis",
+          "description": "Sincronizar tudo, a menos que você exclua um livro."
+        },
+        "selectedOnly": {
+          "label": "Apenas livros selecionados",
+          "description": "Sincronizar apenas livros que você incluir explicitamente."
+        }
+      },
+      "enableSync": {
+        "title": "Ativar sincronização",
+        "description": "Pausar toda a sincronização com o Hardcover sem desconectar."
+      },
+      "syncOnStatus": {
+        "title": "Sincronizar na alteração de status",
+        "description": "Enviar atualizações quando você marcar um livro como lendo, lido, etc."
+      },
+      "syncOnProgress": {
+        "title": "Sincronizar na atualização de progresso",
+        "description": "Enviar progresso de leitura e datas quando o progresso no BookOrbit ou KOReader for alterado."
+      },
+      "syncOnRating": {
+        "title": "Sincronizar na alteração de avaliação",
+        "description": "Enviar suas avaliações de estrelas para o Hardcover."
+      },
+      "privacy": {
+        "title": "Privacidade",
+        "description": "Visibilidade padrão para livros sincronizados no Hardcover.",
+        "public": "Público",
+        "followersOnly": "Apenas seguidores",
+        "private": "Privado"
+      },
+      "disconnect": "Desconectar",
+      "toast": {
+        "enterToken": "Insira seu token de API do Hardcover primeiro",
+        "saved": "Configurações do Hardcover salvas",
+        "saveFailed": "Falha ao salvar configurações",
+        "disconnected": "Hardcover desconectado"
+      }
+    },
+    "sync": {
+      "title": "Sincronização manual",
+      "description": "Envie seu {scope} para o Hardcover agora.",
+      "scope": {
+        "selected": "livros selecionados",
+        "eligible": "livros elegíveis"
+      },
+      "checkingPending": "Verificando itens pendentes...",
+      "pendingOf": "{pending} pendente(s) de {total} livros.",
+      "noBooksInScope": "Nenhum livro no escopo de sincronização.",
+      "allSynced": "Todos os livros já estão sincronizados.",
+      "lastSyncedLabel": "Última sincronização",
+      "lastSuccessfulSync": "Última sincronização bem-sucedida",
+      "syncing": "Sincronizando...",
+      "progressCount": "{synced} / {total} livros",
+      "unavailable": {
+        "permissionDenied": "Você não tem permissão para usar a sincronização do Hardcover.",
+        "userDisabled": "A sincronização está pausada nas suas configurações do Hardcover."
+      },
+      "button": {
+        "unavailable": "Sincronização indisponível",
+        "syncNow": "Sincronizar agora",
+        "syncNowCount": "Sincronizar agora ({count})"
+      },
+      "lastSynced": {
+        "justNow": "Agora mesmo",
+        "minutesAgo": "há {count} min",
+        "hoursAgo": "há {count} hora | há {count} hora | há {count} horas",
+        "daysAgo": "há {count} dia | há {count} dia | há {count} dias"
+      }
+    },
+    "import": {
+      "title": "Puxar status de leitura",
+      "description": "Pré-visualize correspondências do Hardcover antes de preencher os status vazios do BookOrbit.",
+      "clear": "Limpar",
+      "preview": "Pré-visualizar",
+      "importProgress": "Importar progresso",
+      "reviewMatches": "Revisar correspondências",
+      "importReady": "Pronto para importar",
+      "exactMatches": "nenhuma correspondência exata pode ser importada sem revisão | {count} correspondência exata pode ser importada sem revisão | {count} correspondências exatas podem ser importadas sem revisão",
+      "progressAvailable": "nenhuma atualização de progresso disponível | {count} atualização de progresso disponível | {count} atualizações de progresso disponíveis",
+      "progressConflicts": "nenhum conflito | {count} conflito | {count} conflitos",
+      "unavailable": {
+        "permissionDenied": "Você não tem permissão para usar a sincronização do Hardcover.",
+        "missingToken": "Conecte-se ao Hardcover antes de importar.",
+        "userDisabled": "A sincronização está pausada nas suas configurações do Hardcover."
+      },
+      "summary": {
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflicts": "Conflitos",
+        "unmatched": "Não correspondidos",
+        "skipped": "Ignorados"
+      },
+      "result": {
+        "summary": "{applied} importados{progress}, {failed} falharam",
+        "progressUpdated": "{count} progresso(s) atualizado(s)"
+      },
+      "toast": {
+        "importFailed": "Falha ao importar status de leitura do Hardcover",
+        "imported": "nenhum status de leitura importado{progress} | {count} status de leitura importado{progress} | {count} status de leitura importados{progress}",
+        "progressUpdates": "nenhuma atualização de progresso | {count} atualização de progresso | {count} atualizações de progresso"
+      }
+    },
+    "review": {
+      "title": "Revisão da importação do Hardcover",
+      "subtitle": "{total} livros do Hardcover, {matched} correspondidos.",
+      "closeAriaLabel": "Fechar revisão da importação",
+      "searchPlaceholder": "Buscar título ou autor",
+      "importProgress": "Importar progresso",
+      "untitled": "Sem título",
+      "blank": "vazio",
+      "noRows": "Nenhuma linha corresponde aos filtros atuais.",
+      "selectRowAriaLabel": "Selecionar {title}",
+      "selectionSummary": "{count} selecionados: {ready} prontos, {reviewed} revisados.",
+      "selectedProgress": "nenhuma atualização de progresso | {count} atualização de progresso | {count} atualizações de progresso",
+      "selectReady": "Selecionar prontos",
+      "selectPage": "Selecionar página",
+      "clearPage": "Limpar página",
+      "clearSelection": "Limpar seleção",
+      "importSelected": "Importar selecionados",
+      "previousPage": "Página anterior",
+      "nextPage": "Próxima página",
+      "pageRange": "{start}-{end} de {total}",
+      "tabs": {
+        "all": "Todos",
+        "ready": "Prontos",
+        "review": "Revisar",
+        "conflicts": "Conflitos",
+        "unmatched": "Não correspondidos",
+        "skipped": "Ignorados"
+      },
+      "summary": {
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflicts": "Conflitos",
+        "unmatched": "Não correspondidos",
+        "skipped": "Ignorado"
+      },
+      "matchOptions": {
+        "all": "Todos os tipos de correspondência"
+      },
+      "matchMethod": {
+        "hardcoverId": "ID do Hardcover",
+        "isbn": "ISBN",
+        "titleAuthor": "Título + autor"
+      },
+      "outcome": {
+        "ready": "Pronto",
+        "review": "Revisar",
+        "conflict": "Conflito",
+        "unmatched": "Não correspondido",
+        "skipped": "Ignorado"
+      },
+      "column": {
+        "progress": "Progresso"
+      }
+    }
+  },
+  "library": {
+    "creator": {
+      "createTitle": "Criar Biblioteca",
+      "editTitle": "Editar: {name}",
+      "stepOf": "Passo {current} de {total}",
+      "unsaved": "Não salvo",
+      "required": "Obrigatório",
+      "closeAria": "Fechar criador de biblioteca",
+      "progressAria": "Progresso da configuração da biblioteca",
+      "sectionsAria": "Seções de configurações da biblioteca",
+      "loadingAria": "Carregando configurações da biblioteca",
+      "sections": {
+        "details": "Detalhes",
+        "folders": "Pastas",
+        "scanner": "Escâner",
+        "metadata": "Metadados",
+        "fileWrite": "Gravação de Arquivo",
+        "reading": "Leitura",
+        "schedule": "Agendamento",
+        "access": "Acesso"
+      },
+      "actions": {
+        "saving": "Salvando…",
+        "saveChanges": "Salvar alterações",
+        "creating": "Criando…",
+        "createLibrary": "Criar biblioteca"
+      },
+      "details": {
+        "libraryName": "Nome da biblioteca",
+        "namePlaceholder": "Minha Biblioteca",
+        "coverStyle": {
+          "title": "Estilo da capa",
+          "portrait": "Retrato",
+          "square": "Quadrado",
+          "hint": "Retrato para e-books ou bibliotecas mistas. Quadrado para bibliotecas exclusivas de audiolivros."
+        },
+        "icon": {
+          "label": "Ícone",
+          "placeholder": "Escolha um ícone...",
+          "selected": "Selecionado"
+        }
+      },
+      "folders": {
+        "title": "Pastas a escanear",
+        "description": "Adicione um ou mais diretórios para escanear por livros.",
+        "browseAdd": "Procurar e adicionar uma pasta",
+        "browseTitle": "Procurar pastas no servidor",
+        "browseDescription": "Selecione uma ou mais pastas sem sair do navegador.",
+        "selectedTitle": "Pastas selecionadas",
+        "addFolders": "Adicionar pastas",
+        "manualEntry": "Inserir um caminho manualmente",
+        "absolutePath": "Caminho absoluto no servidor",
+        "addFolder": "Adicionar pasta",
+        "removeFolder": "Remover {folder}",
+        "manualCheckHint": "Caminhos manuais são verificados em conjunto com o restante das pastas selecionadas.",
+        "pathPlaceholder": "/caminho/para/os/livros",
+        "test": "Testar",
+        "add": "Adicionar",
+        "pathNotAccessible": "O caminho não está acessível no servidor.",
+        "pathAccessible": "O caminho está acessível.",
+        "pathNotAccessibleShort": "Caminho não acessível",
+        "bookFilesFound": "nenhum arquivo de livro encontrado | {count} arquivo de livro encontrado | {count} arquivos de livro encontrados",
+        "overlapsWith": "Sobrepõe-se a \"{library}\"",
+        "noneAdded": "Nenhuma pasta adicionada ainda",
+        "totalFilesFound": "nenhum arquivo de livro encontrado | {count} arquivo de livro encontrado - o número real de livros pode ser menor se houver vários formatos do mesmo livro | {count} arquivos de livro encontrados - o número real de livros pode ser menor se houver vários formatos do mesmo livro",
+        "runPrescanHint": "Execute uma verificação prévia (prescan) para validar os caminhos antes de salvar.",
+        "scanning": "Escaneando…",
+        "prescan": "Verificação prévia"
+      },
+      "scanner": {
+        "scanMode": {
+          "title": "Modo de escaneamento",
+          "lockedAria": "O modo de organização está bloqueado",
+          "lockTooltip": "O modo de organização é fixado após a criação da biblioteca porque alterá-lo pode criar entradas de livro duplicadas ou ausentes. Para usar um modo diferente, crie uma nova biblioteca e reescaneie.",
+          "recommended": "Recomendado",
+          "folderAsBook": {
+            "title": "Pasta como Livro",
+            "hint": "Todos os arquivos em uma pasta são agrupados em um único livro. Funciona bem quando você mantém vários formatos, como EPUB e MOBI, juntos."
+          },
+          "fileAsBook": {
+            "title": "Arquivo como Livro",
+            "hint": "Trata cada arquivo como um livro individual. Mais adequado para bibliotecas com um formato por título. Evite se seus audiolivros abrangerem vários arquivos."
+          }
+        },
+        "allowedFormats": {
+          "title": "Formatos permitidos",
+          "allowAll": "Permitir todos",
+          "allAllowed": "Todos os formatos são permitidos.",
+          "onlySelected": "Apenas os formatos selecionados serão importados.",
+          "warning": "Livros em outros formatos já presentes na biblioteca serão marcados como ausentes no próximo escaneamento."
+        },
+        "excludePatterns": {
+          "title": "Padrões de exclusão",
+          "hintBefore": "Padrões Glob para pular durante a verificação (ex: ",
+          "hintAfter": ").",
+          "add": "Adicionar",
+          "empty": "Nenhum padrão adicionado."
+        }
+      },
+      "metadata": {
+        "sourcePrecedence": {
+          "title": "Precedência de origem",
+          "hint": "A origem mais alta na lista é a preferida quando várias estiverem disponíveis."
+        },
+        "formatPriority": {
+          "title": "Prioridade de formato",
+          "hint": "Quando um livro possui vários formatos, o formato mais alto na lista é o preferido."
+        }
+      },
+      "fileWrite": {
+        "maxFileSizeMb": "Tamanho máx. do arquivo (MB)",
+        "formatLimits": "Limites por formato",
+        "rename": {
+          "title": "Renomear arquivos após alterações de metadados",
+          "hint": "Renomeia arquivos físicos quando o título, autor, série ou ano muda, utilizando o padrão de nomenclatura da biblioteca."
+        },
+        "write": {
+          "title": "Gravar metadados nos arquivos",
+          "hint": "Quando ativado, salvar os metadados também gravará as alterações de volta no arquivo físico no disco."
+        },
+        "cover": {
+          "title": "Incluir imagem da capa",
+          "hint": "Grava a capa armazenada de volta nos formatos de arquivo compatíveis."
+        },
+        "epub": {
+          "title": "EPUB",
+          "hint": "Grava os metadados no arquivo OPF dentro do arquivo EPUB.",
+          "toggleAria": "Gravar metadados no EPUB"
+        },
+        "pdf": {
+          "title": "PDF",
+          "hint": "Embutir metadados no dicionário Info do PDF e no fluxo XMP.",
+          "toggleAria": "Gravar metadados no PDF"
+        },
+        "cbx": {
+          "title": "Arquivos de quadrinhos (CBX)",
+          "hint": "Grava ComicInfo.xml dentro de arquivos CBZ e CB7.",
+          "toggleAria": "Gravar metadados em arquivos de quadrinhos"
+        },
+        "audio": {
+          "title": "Áudio",
+          "hint": "Embutir a capa armazenada nos arquivos M4B, M4A, MP3 e FLAC.",
+          "toggleAria": "Gravar capas de áudio"
+        }
+      },
+      "reading": {
+        "readingStart": {
+          "title": "Início da leitura",
+          "hint": "Um livro é marcado como \"lendo\" assim que atingir esta porcentagem de progresso."
+        },
+        "markAsFinished": {
+          "title": "Marcar como concluído",
+          "hint": "Um livro é automaticamente marcado como \"lido\" quando atingir esta porcentagem de progresso."
+        }
+      },
+      "schedule": {
+        "fileWatching": "Monitoramento de arquivos",
+        "autoScanSchedule": "Agendamento de auto-escaneamento",
+        "cronExpression": "Expressão Cron",
+        "cronInvalid": "Expressão cron inválida.",
+        "cronFormat": "Formato: minuto hora dia mês dia_da_semana",
+        "watchFolders": {
+          "title": "Pastas monitoradas",
+          "hint": "Detecta automaticamente novos arquivos adicionados às pastas da biblioteca."
+        },
+        "presets": {
+          "never": "Nunca",
+          "hourly": "A cada hora",
+          "every6Hours": "A cada 6 horas",
+          "every12Hours": "A cada 12 horas",
+          "daily": "Diariamente",
+          "weekly": "Semanalmente",
+          "custom": "Personalizado"
+        },
+        "human": {
+          "disabled": "Auto-escaneamento desativado",
+          "hourly": "A cada hora",
+          "every6Hours": "A cada 6 horas",
+          "every12Hours": "A cada 12 horas",
+          "dailyMidnight": "Diariamente à meia-noite",
+          "weeklyMonday": "Semanalmente às segundas-feiras à meia-noite",
+          "cron": "Cron: {cron}"
+        }
+      },
+      "access": {
+        "title": "Controle de acesso",
+        "description": "Superusuários sempre têm acesso total. Conceda acesso a outros usuários abaixo.",
+        "notYetCreated": "O acesso pode ser configurado após a criação da biblioteca.",
+        "selectUser": "Selecione um usuário…",
+        "grant": "Conceder",
+        "empty": "Nenhum acesso concedido a usuários ainda.",
+        "loading": "Carregando configurações de acesso...",
+        "userSelectAria": "Usuário a receber acesso",
+        "levelSelectAria": "Nível de acesso a ser concedido",
+        "levels": {
+          "viewer": "Visualizador",
+          "editor": "Editor",
+          "owner": "Proprietário"
+        },
+        "columns": {
+          "user": "Usuário",
+          "accessLevel": "Nível de acesso"
+        },
+        "errors": {
+          "grant": "Falha ao conceder acesso",
+          "updateLevel": "Falha ao atualizar nível de acesso",
+          "revoke": "Falha ao revogar acesso"
+        }
+      }
+    },
+    "folderPicker": {
+      "title": "Procurar pastas no servidor",
+      "description": "Selecione uma ou mais pastas para esta biblioteca.",
+      "closeAria": "Fechar navegador de pastas",
+      "currentFolderAria": "Pasta atual",
+      "parentFolder": "Ir para a pasta pai",
+      "newFolder": "Nova pasta",
+      "goUp": "Subir",
+      "filterPlaceholder": "Filtrar pastas…",
+      "clearFilterAria": "Limpar filtro de pasta",
+      "newFolderNamePlaceholder": "Nome da nova pasta",
+      "create": "Criar",
+      "loading": "Carregando pastas...",
+      "selectCurrent": "Selecionar pasta atual",
+      "noMatches": "Nenhuma pasta correspondente",
+      "noMatchesHint": "Tente um filtro diferente.",
+      "empty": "Esta pasta está vazia",
+      "emptyHint": "Você pode selecionar a pasta atual ou criar uma nova.",
+      "openFolderAria": "Abrir {name}",
+      "selectedCount": "nenhuma pasta selecionada | {count} pasta selecionada | {count} pastas selecionadas",
+      "noFolders": "Nenhuma pasta encontrada",
+      "selectFolder": "Selecionar esta pasta",
+      "errors": {
+        "readDirectory": "Não foi possível ler o diretório",
+        "connect": "Não foi possível conectar",
+        "invalidName": "Insira o nome de uma única pasta, sem barras ou pontos iniciais",
+        "createFolder": "Não foi possível criar a pasta"
+      }
+    },
+    "upload": {
+      "library": "Biblioteca",
+      "selectLibrary": "Selecione uma biblioteca...",
+      "targetFolder": "Pasta de destino",
+      "addMoreFiles": "Adicionar mais arquivos",
+      "clearAll": "Limpar tudo",
+      "done": "Concluído",
+      "retry": "Tentar novamente",
+      "upload": "Fazer Upload",
+      "uploadWithCount": "Fazer Upload ({count})",
+      "viewInLibrary": "Ver na Biblioteca",
+      "fileCount": "nenhum arquivo | {count} arquivo | {count} arquivos",
+      "booksAdded": "nenhum livro adicionado | {count} livro adicionado | {count} livros adicionados",
+      "uploadedFailed": "{done} enviados, {failed} falharam",
+      "progress": "{done} de {total} enviando...",
+      "header": {
+        "uploading": "Enviando...",
+        "complete": "Upload concluído",
+        "uploadTo": "Fazer upload para {library}",
+        "uploadBooks": "Fazer Upload de Livros"
+      },
+      "dropzone": {
+        "title": "Arraste os arquivos aqui ou clique para procurar",
+        "hint": "{formats} - até {size} MB cada"
+      }
+    }
+  },
+  "metadataScore": {
+    "missingFields": "nenhum campo faltando - editar metadados | {count} campo faltando - editar metadados | {count} campos faltando - editar metadados"
+  },
+  "migration": {
+    "sidebarTitle": "Importação do Booklore",
+    "status": {
+      "done": "Concluído",
+      "saved": "Salvo",
+      "running": "Executando",
+      "failed": "Falhou"
+    },
+    "badge": {
+      "validated": "Validado",
+      "upToDate": "Atualizado",
+      "completed": "Concluído"
+    },
+    "steps": {
+      "source": {
+        "short": "Conexão de Origem",
+        "title": "Conexão de Origem",
+        "subtitle": "Configure a conexão com o banco de dados da sua instância Booklore de origem."
+      },
+      "mappings": {
+        "short": "Mapeamento de Usuário e Caminho",
+        "title": "Mapeamento de Usuário e Caminho",
+        "subtitle": "Mapeie usuários de origem para usuários de destino e traduza os caminhos dos arquivos."
+      },
+      "dryRun": {
+        "short": "Simulação",
+        "title": "Simulação (Dry Run)",
+        "subtitle": "Pré-visualize o que será importado antes de executar a migração real."
+      },
+      "migration": {
+        "short": "Executar Migração",
+        "title": "Executar Migração",
+        "subtitle": "Inicie a importação real e monitore seu progresso."
+      },
+      "report": {
+        "short": "Relatório",
+        "title": "Relatório de Migração",
+        "subtitle": "Revise o que foi importado e exporte um relatório detalhado."
+      }
+    },
+    "footer": {
+      "continueToMappings": "Continuar para Mapeamentos",
+      "continueToDryRun": "Continuar para a Simulação",
+      "continueToMigration": "Continuar para a Migração",
+      "viewReport": "Ver Relatório",
+      "resetSetup": "Redefinir Configuração",
+      "stepOf": "Passo {current} de {total}",
+      "backToSetup": "Voltar para a Configuração"
+    },
+    "stages": {
+      "init": "Inicializando",
+      "sharedOverlays": "Importando metadados",
+      "bookCovers": "Importando capas",
+      "userState": "Importando dados do usuário"
+    },
+    "source": {
+      "testConnection": "Testar Conexão",
+      "saveAndValidate": "Salvar & Validar",
+      "validatedWithWarnings": "Origem validada com avisos",
+      "fields": {
+        "type": "Tipo de Origem",
+        "name": "Nome da Origem",
+        "host": "Host",
+        "port": "Porta",
+        "user": "Usuário",
+        "password": "Senha",
+        "passwordSaved": "Salva - deixe inalterado",
+        "passwordNotSet": "Sem senha definida",
+        "database": "Banco de Dados",
+        "mediaRootPath": "Caminho Raiz de Mídia",
+        "ssl": "Usar TLS/SSL"
+      },
+      "mediaPath": {
+        "hintRequired": "Obrigatório para migrar capas de livros.",
+        "hintAbsolute": "Use um caminho absoluto (exemplo: /livros). Caminhos relativos não são suportados.",
+        "hintConfigured": "Caminho de importação de capas configurado. Use 'Testar Conexão' para verificar o acesso e a estrutura da pasta de imagens do Booklore.",
+        "buttonOk": "Caminho OK",
+        "buttonIssue": "Problema no Caminho",
+        "buttonTest": "Testar Caminho"
+      },
+      "compatibility": {
+        "title": "Compatibilidade testada",
+        "verifiedAgainst": "Verificado em:",
+        "note": "As versões mais recentes provavelmente são compatíveis, mas não foram verificadas. Execute uma simulação (dry-run) primeiro para confirmar antes de confirmar os dados."
+      },
+      "snapshot": {
+        "title": "Último instantâneo de validação",
+        "sourceVersion": "Versão de origem: {version}",
+        "unknown": "Desconhecido",
+        "missingTables": "Tabelas obrigatórias ausentes: {tables}"
+      }
+    },
+    "mappings": {
+      "suggestionsAutoLoad": "As sugestões de usuário são carregadas automaticamente após a validação da origem.",
+      "refresh": "Atualizar",
+      "sourceUser": "Usuário de Origem",
+      "targetUser": "Usuário de Destino",
+      "noSourceUsersLoaded": "Nenhum usuário de origem carregado ainda.",
+      "noActiveTargetUsers": "Nenhum usuário de destino ativo foi encontrado. Crie ou reative um usuário do BookOrbit antes de mapear.",
+      "pathPrefixMappings": "Mapeamentos de Prefixo de Caminho",
+      "addMapping": "Adicionar Mapeamento",
+      "pathMappingsExplanation": "Os mapeamentos de caminho traduzem os caminhos de arquivo da origem para os caminhos de destino para que os livros possam ser correspondidos pelo local do arquivo. Os livros também são correspondidos por ISBN, hash de arquivo e título/autor, independentemente dos mapeamentos de caminho.",
+      "noPrefixesFound": "Nenhum prefixo encontrado - valide a origem primeiro",
+      "selectSourcePrefix": "Selecione o prefixo de origem...",
+      "selectTargetFolder": "Selecione a pasta de destino...",
+      "remove": "Remover",
+      "saveMappings": "Salvar Mapeamentos",
+      "pathValidation": {
+        "title": "Validação de caminho",
+        "mappedSummary": "{mapped} de {total} livros de origem possuem um caminho mapeado",
+        "unmatched": "{count} caminhos mapeados não foram encontrados no disco",
+        "allMatched": "Todos os {count} caminhos mapeados foram encontrados no disco"
+      }
+    },
+    "dryRun": {
+      "run": "Executar Simulação",
+      "matched": "Correspondidos:",
+      "unresolved": "Não resolvidos:",
+      "duplicates": "Duplicatas:",
+      "unresolvedSummary": "Resumo de não resolvidos"
+    },
+    "duplicates": {
+      "title": "Resolver correspondências duplicadas no destino",
+      "explanation": "Para cada livro de destino, escolha um livro de origem para manter. Opções recomendadas são pré-selecionadas quando há uma correspondência única e forte.",
+      "remainingGroups": "Grupos restantes:",
+      "ofCount": "de {total}",
+      "targetBookId": "Livro de destino #{id}",
+      "recommended": "Recomendado",
+      "resolveButton": "Resolver {count} duplicata | Resolver {count} duplicata | Resolver {count} duplicatas",
+      "sourceRecordId": "ID de registro de origem #{id}",
+      "byAuthor": "por {author} (ID: {id})",
+      "byFilePath": "{filePath} (ID: {id})",
+      "bookloreSourceId": "ID de origem do Booklore: {id}",
+      "libraryBookId": "Livro da biblioteca #{id}"
+    },
+    "preflight": {
+      "title": "Verificações prévias",
+      "allPassed": "Todas as verificações passaram - pronto para migrar",
+      "sourceValidated": "Origem validada",
+      "saveAndValidateSource": "Salvar e validar conexão de origem",
+      "validateSourceConnection": "Validar conexão de origem",
+      "mappingsSaved": "Mapeamentos salvos",
+      "saveUserAndPathMappings": "Salvar mapeamentos de usuário e caminho",
+      "pathMappingsValidated": "Mapeamentos de caminho validados",
+      "savePathMappingsToValidate": "Salvar mapeamentos de caminho para validá-los",
+      "dryRunUpToDate": "A simulação está atualizada",
+      "runFreshDryRun": "Executar uma nova simulação",
+      "issues": {
+        "saveSource": "Salvar as configurações de conexão da origem",
+        "validateSource": "Validar a conexão de origem",
+        "saveMappings": "Salvar os mapeamentos de usuário e caminho",
+        "savePathMappings": "Salvar os mapeamentos de caminho para validá-los",
+        "freshDryRun": "Executar uma nova simulação",
+        "resolveDuplicates": "Resolver as correspondências duplicadas de livros de destino na simulação",
+        "waitForRun": "Aguardar a execução ativa terminar"
+      }
+    },
+    "run": {
+      "confirmPrompt": "Isso iniciará a migração real. Tem certeza?",
+      "confirmStart": "Confirmar Início",
+      "startMigration": "Iniciar Migração",
+      "cancelRun": "Cancelar Execução",
+      "refreshStatus": "Atualizar Status",
+      "pollingStopped": "A verificação de status foi interrompida devido a um erro.",
+      "retry": "Tentar novamente",
+      "stage": "Etapa: {stage}",
+      "initializing": "inicializando",
+      "ended": "Terminou {time}"
+    },
+    "report": {
+      "noRunYet": "Nenhuma migração foi executada ainda. Conclua as etapas acima para iniciar.",
+      "runNumber": "Execução #{id}",
+      "notStarted": "Não iniciado",
+      "reloadReport": "Recarregar Relatório",
+      "loadFullReport": "Carregar Relatório Completo",
+      "exportJson": "Exportar JSON",
+      "exportCsv": "Exportar CSV",
+      "migrationFailed": "Falha na migração",
+      "retryFromLastStage": "Tentar novamente a partir da última etapa concluída",
+      "booksSection": "Livros",
+      "metadataOverlays": "Sobreposições de metadados aplicadas",
+      "authorMappings": "Mapeamentos de autor substituídos",
+      "narratorMappings": "Mapeamentos de narrador substituídos",
+      "genreMappings": "Mapeamentos de gênero substituídos",
+      "tagMappings": "Mapeamentos de tag substituídos",
+      "coversImported": "Capas importadas",
+      "coverImportSkipped": "A importação de capas foi ignorada - o caminho raiz de mídia não está configurado",
+      "couldNotMatch": "Não foi possível corresponder",
+      "userDataSection": "Dados do Usuário",
+      "readingStatuses": "Status de leitura",
+      "readingProgressEntries": "Entradas de progresso de leitura",
+      "audiobookProgressEntries": "Entradas de progresso de audiolivro",
+      "readingSessions": "Sessões de leitura",
+      "bookmarks": "Marcadores",
+      "annotations": "Anotações",
+      "collectionEntries": "Entradas de coleção",
+      "loadFullReportHint": "Clique em \"Carregar Relatório Completo\" para incluir o resumo de correspondência da simulação no relatório exportado.",
+      "completedNoIssues": "A migração foi concluída sem falhas ou livros não resolvidos.",
+      "matchedBooks": "Livros correspondidos ({count})",
+      "matchedBooksExplanation": "Essas correspondências da simulação foram usadas para decidir quais livros da biblioteca receberam os dados importados.",
+      "sourceBook": "Livro de origem {id}",
+      "libraryBook": "Livro da biblioteca {id}",
+      "unresolvedBooks": "Livros não resolvidos ({count})",
+      "unresolvedBooksExplanation": "Esses livros existem na origem, mas não puderam ser correspondidos a nenhum livro na sua biblioteca.",
+      "mappedUsers": "Usuários mapeados ({count})",
+      "mappedUsersExplanation": "Os totais por usuário são provenientes da pré-visualização da simulação armazenada em cache com o plano de migração.",
+      "coverFailures": "{count} importação(ões) de capa falhou(aram). Linhas com detalhes de falhas não são armazenadas.",
+      "userPreviewCounts": "{statuses} status, {progress} entradas de progresso, {sessions} sessões de leitura, {bookmarks} marcadores, {annotations} anotações, {collections} entradas de coleção"
+    },
+    "unresolvedReason": {
+      "noTitleAuthorMatch": "Nenhum livro correspondente encontrado por título ou autor",
+      "noFilePathMatch": "O caminho do arquivo não correspondeu a nenhum livro nesta biblioteca",
+      "noFileHashMatch": "O hash do arquivo não correspondeu a nenhum livro nesta biblioteca",
+      "noIsbnMatch": "O ISBN não corresponde a nenhum livro nesta biblioteca",
+      "insufficientSourceData": "Metadados insuficientes para tentar correspondência",
+      "ambiguousIsbnMatch": "Vários livros corresponderam ao mesmo ISBN",
+      "ambiguousFileHashMatch": "Vários livros corresponderam ao mesmo hash de arquivo",
+      "ambiguousFilePathMatch": "Vários livros corresponderam ao mesmo caminho de arquivo",
+      "ambiguousTitleAuthorMatch": "Vários livros corresponderam ao mesmo título e autor",
+      "unknown": "Não foi possível determinar o motivo"
+    },
+    "matchStrategy": {
+      "isbn": "Correspondido por ISBN",
+      "fileHash": "Correspondido por hash de arquivo",
+      "pathMapping": "Correspondido pelo caminho do arquivo mapeado",
+      "titleAuthor": "Correspondido por título e autor",
+      "unavailable": "Estratégia de correspondência indisponível"
+    },
+    "connectionError": {
+      "unreachable": "Não foi possível contatar o servidor do banco de dados. Verifique o host e a porta.",
+      "authFailed": "Falha na autenticação. Verifique o usuário e a senha.",
+      "databaseNotFound": "Banco de dados não encontrado. Verifique o nome do banco de dados.",
+      "timeout": "Tempo limite de conexão excedido. Verifique o host e as configurações do firewall.",
+      "generic": "O teste de conexão falhou"
+    },
+    "userSelect": {
+      "placeholder": "Selecione o usuário",
+      "noUsersFound": "Nenhum usuário encontrado"
+    },
+    "toast": {
+      "initFailed": "Falha ao inicializar as configurações de migração",
+      "loadSupportedTypesFailed": "Falha ao carregar tipos de fontes de migração suportados",
+      "loadTargetUsersFailed": "Falha ao carregar usuários de destino",
+      "loadTargetFoldersFailed": "Falha ao carregar as pastas da biblioteca de destino",
+      "noSourceUsers": "Nenhum usuário de origem retornado",
+      "suggestionsLoaded": "Sugestões de mapeamento de usuários carregadas",
+      "loadSuggestionsFailed": "Falha ao carregar sugestões de mapeamento de usuário",
+      "sourceFieldsRequired": "Host, usuário, banco de dados e nome de origem são obrigatórios",
+      "connectionPassedWithWarnings": "Teste de conexão concluído com avisos",
+      "connectionPassedWithWarningCount": "O teste de conexão passou com {count} aviso(s). O primeiro foi: {warning}",
+      "connectionPassed": "O teste de conexão passou",
+      "connectionMissingTables": "Conexão ok, mas faltam {count} tabela(s) necessária(s)",
+      "cannotTestMediaWhileRunning": "Não é possível testar o caminho de mídia enquanto uma migração estiver em andamento",
+      "mediaPathRequired": "O Caminho Raiz da Mídia é obrigatório para a importação de capas.",
+      "mediaPathAbsolute": "Use um caminho absoluto (por exemplo: /livros).",
+      "mediaPathVerified": "Caminho da mídia verificado.",
+      "mediaPathValid": "O caminho da mídia é válido e está acessível",
+      "mediaPathValidationFailed": "Falha na validação do caminho da mídia.",
+      "connectionFailedBeforeMedia": "O teste de conexão falhou antes que a validação do caminho de mídia pudesse ser concluída.",
+      "cannotModifySourceWhileRunning": "Não é possível modificar a origem enquanto houver uma migração em andamento",
+      "sourceSavedWithWarnings": "Origem salva e validada com {count} aviso(s)",
+      "sourceSaved": "A origem foi salva e validada",
+      "saveSourceFailed": "Falha ao salvar ou validar a origem",
+      "cannotSaveMappingsWhileRunning": "Não é possível salvar os mapeamentos enquanto uma execução estiver ativa",
+      "saveSourceFirst": "Salve a origem primeiro",
+      "mapAtLeastOneUser": "Mapeie pelo menos um usuário de origem para um usuário de destino",
+      "mapEveryUser": "Mapeie todos os usuários de origem antes de salvar",
+      "pathValidationFailedButSaved": "A validação do caminho falhou, mas o perfil ainda será salvo",
+      "mappingsSaved": "Mapeamentos salvos",
+      "saveMappingsFailed": "Falha ao salvar os mapeamentos",
+      "cannotDryRunWhileRunning": "Não é possível executar a simulação enquanto houver uma migração em andamento",
+      "saveMappingsFirst": "Salve os mapeamentos primeiro",
+      "dryRunCompleted": "Simulação concluída: {matched} correspondências, {unresolved} não resolvidas",
+      "dryRunFailed": "Falha na simulação",
+      "selectSourceForDuplicates": "Selecione um livro de origem para todos os {count} grupos de duplicatas",
+      "duplicatesResolved": "As correspondências duplicadas foram resolvidas",
+      "resolveDuplicatesFailed": "Falha ao resolver as duplicatas",
+      "preflightNotReady": "As verificações prévias de migração não estão prontas",
+      "runDryRunFirst": "Execute a simulação (dry-run) primeiro",
+      "runStarted": "Migração iniciada",
+      "startFailed": "Falha ao iniciar a migração",
+      "runCancelled": "A execução da migração foi cancelada",
+      "cancelFailed": "Falha ao cancelar a migração",
+      "runRetried": "Migração reiniciada - retomando a partir da última etapa concluída",
+      "retryFailed": "Falha ao tentar a migração novamente",
+      "loadProgressFailed": "Falha ao carregar o progresso da execução",
+      "startMigrationFirst": "Inicie a migração primeiro",
+      "reportRefreshed": "Relatório da execução atualizado",
+      "loadReportFailed": "Falha ao carregar o relatório da execução",
+      "reportExported": "Relatório exportado no formato {format}",
+      "exportFailed": "Falha ao exportar o relatório da migração"
+    }
+  },
+  "notifications": {
+    "title": "Notificações",
+    "markAllRead": "Marcar todas como lidas",
+    "clear": "Limpar",
+    "empty": "Nenhuma notificação ainda",
+    "loadMore": "Carregar mais notificações",
+    "preferences": {
+      "title": "Notificações",
+      "subtitle": "Escolha quais categorias de notificação você quer receber.",
+      "saving": "Salvando...",
+      "unsavedChanges": "Alterações não salvas",
+      "saved": "Preferências de notificação salvas",
+      "saveFailed": "Falha ao salvar as preferências",
+      "savePreferenceFailed": "Falha ao salvar a preferência",
+      "whatsNewToggle": "Mostrar \"O que há de novo\" depois das atualizações",
+      "whatsNewToggleHint": "Um pop-up destacando as novidades sempre que o aplicativo for atualizado. O arquivo continua disponível de qualquer maneira."
+    }
+  },
+  "reader": {
+    "retry": "Tentar novamente",
+    "pdf": {
+      "openError": "Não foi possível abrir este PDF",
+      "preparing": "Preparando o leitor de PDF",
+      "opening": "Abrindo PDF"
+    },
+    "loadingBook": "Carregando o livro…",
+    "failedToLoadBook": "Falha ao carregar o livro",
+    "chapterNumber": "Capítulo {number}",
+    "peek": {
+      "badge": "Espiando",
+      "startReading": "Começar a ler"
+    },
+    "toast": {
+      "linkedHighlightError": "Não foi possível abrir a posição vinculada ao destaque",
+      "resumed": "Retomado em {pct}% - {label}"
+    },
+    "header": {
+      "goBack": "Voltar",
+      "tableOfContents": "Índice",
+      "toggleBookmark": "Alternar marcador",
+      "cycleFooterMode": "Alternar modo de informação do rodapé",
+      "keyboardShortcutsHint": "Atalhos de teclado (?)",
+      "enterFullscreen": "Entrar em tela cheia",
+      "exitFullscreen": "Sair da tela cheia",
+      "footerMode": {
+        "pageProgress": "Informação do rodapé: página + progresso",
+        "sessionTimeLeft": "Informação do rodapé: sessão de leitura + tempo restante",
+        "chapterTimeLeft": "Informação do rodapé: capítulo + tempo restante no capítulo"
+      }
+    },
+    "footer": {
+      "previousSection": "Seção anterior",
+      "nextSection": "Próxima seção",
+      "goToPlaceholder": "45 ou p123",
+      "jumpToLocation": "Pular para o local",
+      "jumpTooltip": "Pular para % ou página (ex. 45 ou p123)",
+      "go": "Ir"
+    },
+    "settings": {
+      "title": "Configurações",
+      "ariaLabel": "Configurações do Leitor",
+      "tabs": {
+        "appearance": "Aparência",
+        "text": "Texto",
+        "layout": "Layout"
+      },
+      "appearance": {
+        "mode": "Modo",
+        "light": "Claro",
+        "dark": "Escuro",
+        "colorTheme": "Tema de cor"
+      },
+      "text": {
+        "fontSize": "Tamanho da fonte",
+        "fontSizeRange": "Intervalo: 10-32px",
+        "lineHeight": "Altura da linha",
+        "lineHeightRange": "Intervalo: 0.8-3.0",
+        "fontFamily": "Família de fontes",
+        "fontFamilyDescription": "Escolha as fontes internas ou importadas para o corpo do texto.",
+        "builtIn": "Internas",
+        "yourFonts": "Suas fontes"
+      },
+      "layout": {
+        "pageSpreads": "Disposição das páginas",
+        "pageSpreadsDescription": "Escolha como esse EPUB baseado em imagem emparelha as páginas.",
+        "bookDefault": "Padrão do livro",
+        "singlePage": "Página única",
+        "readingFlow": "Fluxo de leitura",
+        "readingFlowDescription": "Alterne entre rolagem contínua e páginas separadas.",
+        "paginated": "Paginado",
+        "scrolled": "Rolar",
+        "textColumns": "Colunas de texto",
+        "textColumnsRange": "Intervalo: 1-10",
+        "columnGap": "Espaçamento das colunas",
+        "columnGapRange": "Intervalo: 0-50%",
+        "maxWidth": "Largura máxima",
+        "maxWidthRange": "Intervalo: 400-1600",
+        "justifyText": "Justificar texto",
+        "justifyTextDescription": "Habilitar alinhamento de parágrafos para a largura completa.",
+        "hyphenation": "Hifenização",
+        "hyphenationDescription": "Habilitar hifenização automática na quebra de linha."
+      }
+    },
+    "search": {
+      "placeholder": "Buscar no livro (mín. de {min} letras)...",
+      "searching": "Buscando…",
+      "tooShort": "Digite no mínimo {min} caracteres",
+      "noResults": "Nenhum resultado encontrado",
+      "prompt": "Digite para pesquisar",
+      "resultCount": "nenhum resultado | {count} resultado | {count} resultados"
+    },
+    "sidebar": {
+      "tabs": {
+        "chapters": "Capítulos",
+        "bookmarks": "Marcadores",
+        "highlights": "Destaques",
+        "toc": "Índice",
+        "tocShort": "Índice",
+        "marksShort": "Marcadores",
+        "notesShort": "Anotações"
+      },
+      "pin": "Fixar barra lateral",
+      "unpin": "Desafixar barra lateral",
+      "close": "Fechar barra lateral",
+      "noChapters": "Nenhum capítulo encontrado",
+      "noBookmarks": "Nenhum marcador ainda",
+      "noBookmarksMatch": "Nenhum marcador corresponde aos seus filtros",
+      "noHighlights": "Nenhum destaque ainda",
+      "noHighlightsMatch": "Nenhum destaque corresponde aos seus filtros",
+      "searchBookmarks": "Buscar marcadores...",
+      "searchHighlights": "Buscar destaques...",
+      "bookmarkFallback": "Marcador",
+      "locationUnavailable": "Local não disponível",
+      "customColor": "Personalizada ({color})",
+      "allColors": "Todas as cores",
+      "allChapters": "Todos os capítulos",
+      "notesOnly": "Apenas anotações",
+      "deleteBookmark": "Excluir marcador",
+      "deleteHighlight": "Excluir destaque",
+      "approximatePosition": "Sincronizado a partir do dispositivo; a posição exata não está disponível, pula para o capítulo",
+      "sort": {
+        "readingOrder": "Ordem de leitura",
+        "newest": "Mais novos primeiro",
+        "oldest": "Mais antigos primeiro"
+      }
+    },
+    "selection": {
+      "copy": "Copiar",
+      "copied": "Copiado!",
+      "highlight": "Destacar",
+      "translate": "Traduzir",
+      "define": "Definir",
+      "deleteAnnotation": "Excluir anotação",
+      "apply": "Aplicar"
+    },
+    "note": {
+      "title": "Adicionar nota",
+      "placeholder": "Escreva a sua nota…"
+    },
+    "dictionary": {
+      "noDefinition": "Nenhuma definição encontrada",
+      "loadError": "Não foi possível carregar a definição"
+    },
+    "translation": {
+      "original": "Original",
+      "translation": "Tradução",
+      "translating": "Traduzindo...",
+      "noTranslation": "Sem tradução ainda",
+      "viaProvider": "via {provider}",
+      "copyTranslation": "Copiar tradução"
+    },
+    "shortcuts": {
+      "title": "Atalhos de teclado",
+      "groups": {
+        "panels": "Painéis",
+        "reading": "Leitura",
+        "actions": "Ações"
+      },
+      "toggleToc": "Exibir/ocultar índice",
+      "toggleSearch": "Exibir/ocultar barra de busca",
+      "toggleHelp": "Exibir/ocultar esta ajuda",
+      "closePanel": "Fechar painel",
+      "prevNextPage": "Página anterior/próxima",
+      "goToStart": "Ir para o começo do livro",
+      "goToEnd": "Ir para o fim do livro",
+      "toggleBookmark": "Alternar o marcador",
+      "toggleFullscreen": "Alternar tela cheia",
+      "cycleFooterMode": "Alternar modo de rodapé"
+    },
+    "cbz": {
+      "tabs": {
+        "view": "Ver",
+        "reading": "Leitura",
+        "layout": "Layout"
+      },
+      "fitMode": "Modo de preenchimento",
+      "background": "Fundo",
+      "scrollMode": "Modo de rolagem",
+      "scrollModeHint": "Use \"Sem lacunas\" para webtoons e tiras verticais.",
+      "readingDirection": "Direção de leitura",
+      "pageView": "Visualização da página",
+      "autoFallback": "Preenchimento automático (fallback)",
+      "spreadAlignmentLabel": "Alinhamento das páginas",
+      "spreadAlignmentHint": "O alinhamento das páginas não está disponível no modo de fallback automático.",
+      "focusTwoPageToggle": "Alternar para focar em duas páginas",
+      "forceTwoPage": "Forçar duas páginas",
+      "off": "Desligado",
+      "on": "Ligado",
+      "widePages": "Páginas largas",
+      "resetBookViewSettings": "Redefinir configurações de exibição do livro",
+      "resetConfirm": "Redefinir as configurações de visualização deste livro para os seus padrões globais?",
+      "firstPage": "Primeira página",
+      "lastPage": "Última página",
+      "fit": {
+        "page": "Ajustar à página",
+        "width": "Ajustar à largura",
+        "height": "Ajustar à altura",
+        "actual": "Tamanho real"
+      },
+      "view": {
+        "single": "Única",
+        "twoPage": "Duas páginas"
+      },
+      "scroll": {
+        "paged": "Paginado",
+        "infinite": "Infinito",
+        "noGaps": "Sem lacunas"
+      },
+      "direction": {
+        "ltr": "E para D",
+        "rtl": "D para E"
+      },
+      "spreadAlignment": {
+        "normal": "Normal",
+        "shifted": "Deslocado"
+      },
+      "widePage": {
+        "auto": "Automático",
+        "inSpreads": "Em páginas duplas"
+      },
+      "bg": {
+        "black": "Preto",
+        "gray": "Cinza",
+        "white": "Branco"
+      }
+    },
+    "audiobook": {
+      "untitled": "Sem título",
+      "loading": "Carregando audiolivro...",
+      "loadError": "Falha ao carregar audiolivro",
+      "noAudioFiles": "Nenhum arquivo de áudio encontrado para este livro.",
+      "speed": "Velocidade",
+      "chapters": "Capítulos",
+      "bookmarks": "Marcadores",
+      "volume": "Volume",
+      "muted": "Mutado",
+      "sleep": "Pausa",
+      "chapterAbbrev": "Cap.",
+      "sleepTimer": "Temporizador de pausa",
+      "minutes": "{count} minutos",
+      "endOfChapter": "Fim do capítulo",
+      "noChaptersAvailable": "Nenhum capítulo disponível",
+      "extend15": "+ 15 minutos",
+      "timeLeft": "({time} restante)",
+      "playbackSpeed": "Velocidade de reprodução",
+      "noChapters": "Nenhum capítulo disponível.",
+      "noBookmarks": "Nenhum marcador ainda.",
+      "noBookmarksHint": "Toque no ícone de marcador na parte superior para salvar sua posição atual.",
+      "playerSettings": "Configurações do player",
+      "skipBack": "Pular para trás",
+      "skipForward": "Pular para frente"
+    }
+  },
+  "scanner": {
+    "filesProgress": "{processed}/{total} arquivos",
+    "booksFound": "nenhum livro encontrado | {count} livro encontrado | {count} livros encontrados"
+  },
+  "series": {
+    "completion": {
+      "readOfTotal": "{read} de {total} lido(s) ({percentage}%)"
+    },
+    "gaps": {
+      "label": "Possíveis lacunas:"
+    },
+    "filters": {
+      "title": "Filtros de Séries",
+      "clearAll": "Limpar todos",
+      "allLibraries": "Todas as Bibliotecas",
+      "allCompletion": "Toda a conclusão",
+      "notStarted": "Não iniciada",
+      "inProgress": "Em progresso",
+      "complete": "Concluída"
+    },
+    "list": {
+      "title": "Séries",
+      "showControlsAria": "Exibir os controles de série",
+      "searchPlaceholder": "Buscar série ou autor",
+      "sortButton": "Ordenar",
+      "sortBy": "Ordenar por",
+      "ascending": "Crescente",
+      "descending": "Decrescente",
+      "ascShort": "Cresc",
+      "descShort": "Decresc",
+      "filters": "Filtros",
+      "clear": "Limpar",
+      "noMatch": "Nenhuma série corresponde aos seus filtros.",
+      "empty": "Nenhuma série foi encontrada em suas bibliotecas.",
+      "sort": {
+        "name": "Nome",
+        "bookCount": "Contagem de Livros",
+        "recentAdditions": "Adições Recentes",
+        "readingProgress": "Progresso de Leitura"
+      }
+    },
+    "detail": {
+      "pageTitle": "Série",
+      "pageTitleNamed": "Série · {name}",
+      "pageTitleWithId": "Série #{id}",
+      "entityName": "Série",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "byAuthors": "por {authors}",
+      "moreAuthors": "+{count} mais",
+      "preparingEditor": "Preparando editor...",
+      "editMetadata": "Editar Metadados",
+      "firstInSeries": "Primeiro da Série",
+      "untitled": "Sem título",
+      "loadingFirstBook": "Carregando a pré-visualização do primeiro livro...",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar mais",
+      "moreGenres": "+{count} mais",
+      "synopsis": "Sinopse",
+      "noDescription": "Nenhuma descrição disponível.",
+      "updatingPreview": "Atualizando a pré-visualização...",
+      "noBooksToPreview": "Não há livros disponíveis para pré-visualização.",
+      "loadingSeries": "Carregando série...",
+      "booksHeading": "Livros",
+      "allLibraries": "Todas as Bibliotecas",
+      "groupByMedia": "Agrupar por mídia",
+      "noBooksFound": "Nenhum livro foi encontrado nesta série",
+      "trySelectingLibrary": "Tente selecionar outra biblioteca.",
+      "allBooksLoaded": "Todos os {count} livros carregados",
+      "leadBookLoadError": "Falha ao carregar detalhes do livro principal",
+      "noBooksToEdit": "Esta série não tem livros para edição.",
+      "loadFullSeriesError": "Falha ao carregar a série completa para a edição.",
+      "sort": {
+        "seriesOrder": "Ordem da Série",
+        "title": "Título",
+        "recentlyAdded": "Adicionados Recentemente"
+      },
+      "order": {
+        "ascending": "Crescente",
+        "descending": "Decrescente"
+      }
+    }
+  },
+  "smartScope": {
+    "syncToKobo": "Sincronizar com o Kobo",
+    "syncToKoboHint": "Os livros que correspondem a este escopo aparecerão no seu dispositivo Kobo",
+    "dialog": {
+      "name": "Nome",
+      "namePlaceholder": "ex. Ficção Científica Não Lida",
+      "icon": "Ícone",
+      "iconPlaceholder": "Escolha um ícone...",
+      "nameRequired": "O nome é obrigatório",
+      "iconRequired": "Escolha um ícone",
+      "create": "Criar",
+      "creating": "Criando...",
+      "saving": "Salvando..."
+    },
+    "createDialog": {
+      "title": "Novo SmartScope",
+      "visibleToAll": "Visível a todos os usuários",
+      "createFailed": "Falha ao criar o SmartScope"
+    },
+    "saveAsDialog": {
+      "title": "Salvar como SmartScope",
+      "save": "Salvar SmartScope",
+      "saveFailed": "Falha ao salvar o SmartScope"
+    },
+    "editorPanel": {
+      "untitled": "SmartScope Sem Título",
+      "subtitle": "Configure as definições do SmartScope",
+      "counting": "contando...",
+      "bookCount": "nenhum livro | um livro | {count} livros",
+      "identity": "Identidade",
+      "filters": "Filtros",
+      "noFilters": "Nenhum filtro definido. Todos os livros acessíveis serão incluídos neste SmartScope.",
+      "buildFromScratch": "Construir do zero",
+      "replaceWithTemplate": "Substituir por modelo:",
+      "defaultSort": "Ordenação Padrão",
+      "saveChanges": "Salvar alterações",
+      "saveFailed": "Falha ao salvar",
+      "templates": {
+        "hasSeries": "Possui Série",
+        "addedRecently": "Adicionado Recentemente",
+        "pdfOnly": "Apenas PDF",
+        "noGenres": "Sem Gêneros",
+        "epubOnly": "Apenas EPUB"
+      }
+    }
+  },
+  "statistics": {
+    "tabs": {
+      "library": "Estatísticas da Biblioteca",
+      "user": "Minha Leitura"
+    },
+    "filter": {
+      "allLibraries": "Todas as Bibliotecas",
+      "librarySelection": "{count} de {total} Bibliotecas"
+    },
+    "config": {
+      "button": "Configurar",
+      "title": "Configurar Gráficos",
+      "description": "Arraste para reordenar, clique para mostrar ou esconder.",
+      "reset": "Redefinir padrões"
+    },
+    "summary": {
+      "books": "Livros",
+      "authors": "Autores",
+      "series": "Séries",
+      "publishers": "Editoras",
+      "storage": "Armazenamento",
+      "genres": "Gêneros",
+      "languages": "Idiomas",
+      "published": "Publicados",
+      "thisYear": "Neste Ano",
+      "started": "Iniciados",
+      "inProgress": "Em Progresso",
+      "completed": "Concluídos",
+      "avgProgress": "Progresso Médio"
+    },
+    "card": {
+      "loadError": "Falha ao carregar os dados",
+      "emptyTitle": "Ainda não há dados",
+      "emptyDescription": "Nenhum dado disponível para este gráfico",
+      "unknownField": "nenhum dado para este campo | {count} livro sem dados para este campo | {count} livros sem dados para este campo"
+    },
+    "breakdown": {
+      "ariaLabel": "Detalhamento por fonte ou formato"
+    },
+    "empty": {
+      "notEnoughData": "Dados insuficientes ainda"
+    },
+    "charts": {
+      "acquisitionLag": {
+        "title": "Atraso de Aquisição"
+      },
+      "booksAddedOverTime": {
+        "title": "Livros Adicionados ao Longo do Tempo",
+        "monthly": "Mensalmente",
+        "yearly": "Anualmente",
+        "allTime": "Todo o Período",
+        "last5Years": "Últimos 5 Anos",
+        "lastYear": "Último Ano"
+      },
+      "formatDistribution": {
+        "title": "Distribuição de Formatos"
+      },
+      "formatShareOverTime": {
+        "title": "Fatia de Formato ao Longo do Tempo"
+      },
+      "genreCooccurrence": {
+        "title": "Coocorrência de Gêneros"
+      },
+      "genreDistribution": {
+        "title": "Distribuição de Gêneros"
+      },
+      "languageDistribution": {
+        "title": "Distribuição de Idiomas"
+      },
+      "largestBooks": {
+        "title": "Top 50 Maiores Livros"
+      },
+      "libraryIntegrity": {
+        "title": "Integridade da Biblioteca"
+      },
+      "libraryMetadataCompleteness": {
+        "title": "Completude de Metadados da Biblioteca"
+      },
+      "metadataCompleteness": {
+        "title": "Completude de Metadados"
+      },
+      "metadataFreshness": {
+        "title": "Atualização dos Metadados"
+      },
+      "metadataScoreDistribution": {
+        "title": "Distribuição de Pontuação de Metadados"
+      },
+      "pageCountDistribution": {
+        "title": "Distribuição de Número de Páginas"
+      },
+      "publicationDecade": {
+        "title": "Década de Publicação"
+      },
+      "publicationYearTimeline": {
+        "title": "Linha do Tempo do Ano de Publicação"
+      },
+      "storageByFormat": {
+        "title": "Armazenamento por Formato"
+      },
+      "topAuthors": {
+        "title": "Top 25 Autores"
+      },
+      "topSeries": {
+        "title": "Top 50 Séries"
+      },
+      "booksCompleted": {
+        "title": "Livros Concluídos",
+        "notEnoughData": "Precisa de pelo menos {count} livros concluídos para este gráfico."
+      },
+      "completionLatency": {
+        "title": "Tempo até a Conclusão",
+        "notEnoughData": "Precisa de pelo menos {count} livros concluídos para este gráfico."
+      },
+      "completionTimeline": {
+        "title": "Linha do Tempo de Conclusão",
+        "notEnoughData": "Precisa de pelo menos {count} livros concluídos para este gráfico."
+      },
+      "favoriteReadingDays": {
+        "title": "Dias Favoritos de Leitura",
+        "notEnoughData": "Precisa de pelo menos {count} eventos de leitura para este gráfico."
+      },
+      "genreReadingTime": {
+        "title": "Tempo de Leitura por Gênero",
+        "notEnoughData": "Precisa de pelo menos {count} gêneros com tempo de leitura para este gráfico."
+      },
+      "goalTrajectory": {
+        "title": "Ritmo vs Meta",
+        "noCompletedTitle": "Ainda não há livros concluídos",
+        "noCompletedDescription": "Conclua um livro neste período para comparar o seu ritmo com a meta anual.",
+        "notEnoughData": "Precisa de pelo menos {count} livros concluídos para este gráfico."
+      },
+      "peakReadingHours": {
+        "title": "Horários de Pico de Leitura",
+        "notEnoughData": "Precisa de pelo menos {count} eventos de leitura para este gráfico."
+      },
+      "progressFunnel": {
+        "title": "Funil de Progresso",
+        "modePercent": "Porcentagem",
+        "modeCounts": "Contagens",
+        "modeDropoff": "Desistência",
+        "started": "Iniciados {count}",
+        "notEnoughData": "Precisa de pelo menos {count} livros iniciados para este gráfico.",
+        "noDropOffTitle": "Nenhuma desistência observada",
+        "noDropOffDescription": "Todos os livros iniciados progrediram em todos os estágios do funil neste período."
+      },
+      "readingClock": {
+        "title": "Relógio de Leitura",
+        "notEnoughData": "Precisa de pelo menos {count} sessões de leitura para este gráfico."
+      },
+      "readingHeatmap": {
+        "title": "Mapa de Calor de Leitura",
+        "notEnoughData": "Precisa de atividade em pelo menos {count} dias para este gráfico."
+      },
+      "readingPace": {
+        "title": "Ritmo de Leitura",
+        "notEnoughData": "Precisa de pelo menos {count} sessões com dados de progresso para este gráfico."
+      },
+      "readingSessionTimeline": {
+        "title": "Linha do Tempo da Sessão de Leitura",
+        "dragOn": "Arrastar: Ligado",
+        "dragOff": "Arrastar: Desligado",
+        "prev": "Anterior",
+        "next": "Próximo",
+        "week": "Semana {week}",
+        "dragHint": "Arraste as barras para mover as sessões. A duração é bloqueada e sessões sobrepostas são rejeitadas.",
+        "noSessionsTitle": "Nenhuma sessão nesta semana",
+        "noSessionsDescription": "Utilize Anterior/Próximo ou o seletor de semana para visualizar uma semana diferente.",
+        "overlapError": "A sessão se sobrepõe a outra sessão nesta janela",
+        "moveError": "Falha ao mover a sessão"
+      },
+      "sessionArchetypes": {
+        "title": "Arquétipos de Sessões"
+      },
+      "sourceDistribution": {
+        "title": "Onde Você Lê",
+        "emptyTitle": "Nenhuma atividade de leitura ainda",
+        "emptyDescription": "Leia na web, KOReader ou Kobo para ver sua distribuição de fontes."
+      }
+    }
+  },
+  "tools": {
+    "header": {
+      "entityManager": "Gerenciador de Entidades",
+      "bulkRename": "Renomeação em Massa"
+    },
+    "entityTypes": {
+      "authors": "Autores",
+      "genres": "Gêneros",
+      "tags": "Tags",
+      "narrators": "Narradores",
+      "publishers": "Editoras",
+      "languages": "Idiomas",
+      "series": "Séries"
+    },
+    "bulkRename": {
+      "library": "Biblioteca",
+      "selectLibraryPlaceholder": "Selecione uma biblioteca...",
+      "noEligibleLibraries": "Nenhuma biblioteca possui a renomeação de arquivos ativada. Ative isso em Configurações da Biblioteca.",
+      "refresh": "Atualizar",
+      "applyRename": "Aplicar Renomeação",
+      "showFullPaths": "Mostrar caminhos completos",
+      "columnsMenu": "Colunas",
+      "renamingInProgress": "Renomeando arquivos - você pode cancelar a qualquer momento.",
+      "executionFailed": "A renomeação em massa falhou",
+      "previewFailed": "Falha ao carregar a pré-visualização",
+      "noBooksMatch": "Nenhum livro corresponde ao filtro atual.",
+      "openBookDetails": "Abrir detalhes do livro",
+      "columns": {
+        "title": "Título",
+        "currentPath": "Caminho Atual",
+        "newPath": "Novo Caminho",
+        "status": "Status"
+      },
+      "status": {
+        "willRename": "Será Renomeado",
+        "unchanged": "Inalterado",
+        "collision": "Colisão",
+        "noPattern": "Sem Padrão",
+        "error": "Erro"
+      },
+      "filter": {
+        "all": "Todos"
+      },
+      "summary": {
+        "label": "Resumo",
+        "toRename": "{count} para renomear",
+        "unchanged": "{count} inalterado",
+        "collisions": "{count} colisão | {count} colisão | {count} colisões",
+        "errors": "{count} erro | {count} erro | {count} erros"
+      },
+      "empty": {
+        "title": "Escolha uma Biblioteca para Iniciar",
+        "description": "Selecione uma biblioteca acima para pré-visualizar alterações de nome, filtrar por status e aplicar a execução da renomeação em massa.",
+        "chooseLibrary": "Escolher Biblioteca"
+      },
+      "completed": {
+        "title": "Renomeação em massa concluída",
+        "stats": "{succeeded} renomeados, {failed} falharam, {skipped} ignorados ({processed} totais)"
+      },
+      "pagination": {
+        "showing": "Exibindo {from}-{to} de {total}"
+      },
+      "confirmDialog": {
+        "title": "Confirmar Renomeação em Massa",
+        "body": "Isto renomeará {count} livro no disco. Arquivos com colisões ou erros serão ignorados. Esta ação não pode ser desfeita. | Isto renomeará {count} livro no disco. Arquivos com colisões ou erros serão ignorados. Esta ação não pode ser desfeita. | Isto renomeará {count} livros no disco. Arquivos com colisões ou erros serão ignorados. Esta ação não pode ser desfeita.",
+        "renameButton": "Renomear {count} livro | Renomear {count} livro | Renomear {count} livros"
+      }
+    },
+    "entityManager": {
+      "unknown": "Desconhecido",
+      "bookCount": "nenhum livro | {count} livro | {count} livros",
+      "sortPrefix": "· ordenação: {sortName}",
+      "selectTargetToKeep": "Selecione o destino que deseja manter",
+      "writeToFiles": "Gravar nos arquivos",
+      "writeChangesToFiles": "Gravar alterações nos arquivos",
+      "mergeIntoTarget": "Mesclar {count} no destino",
+      "modes": {
+        "browse": "Navegar & Gerenciar",
+        "duplicates": "Localizar Duplicatas"
+      },
+      "actions": {
+        "rename": "Renomear",
+        "split": "Dividir"
+      },
+      "duplicates": {
+        "similarity": "Similaridade:",
+        "scan": "Analisar",
+        "scanning": "Analisando...",
+        "computing": "Computando candidatos...",
+        "computedAt": "Candidatos computados {date}",
+        "recompute": "Recomputar",
+        "noneComputed": "Nenhum candidato computado ainda.",
+        "computeNow": "Computar agora",
+        "emptyTitle": "Encontrar entidades duplicadas",
+        "emptyDescription": "Ajuste o limite de similaridade e clique em Analisar para detectar possíveis duplicatas.",
+        "noneFoundTitle": "Nenhuma duplicata encontrada",
+        "noneFoundDescription": "Não foram detectadas possíveis duplicatas com as configurações atuais.",
+        "clustersFound": "nenhum cluster encontrado | {count} cluster encontrado | {count} clusters encontrados",
+        "plusOthers": "+ {count} outro | + {count} outro | + {count} outros",
+        "percentSimilar": "{percent}% semelhante",
+        "pairDetails": "Detalhes do par",
+        "dismissEntityTitle": "Ignorar todos os pares desta entidade",
+        "dismissPairTitle": "Ignorar este par"
+      },
+      "dismissed": {
+        "loading": "Carregando pares ignorados...",
+        "empty": "Nenhum par ignorado",
+        "restore": "Restaurar",
+        "restoreTitle": "Restaurar este par",
+        "hidePairs": "Ocultar pares ignorados",
+        "showPairs": "Mostrar pares ignorados"
+      },
+      "browse": {
+        "searchPlaceholder": "Pesquisar...",
+        "emptyOnly": "Somente vazias",
+        "clear": "Limpar",
+        "noEntities": "Nenhuma entidade encontrada",
+        "mergeCount": "Mesclar ({count})",
+        "deleteCount": "Excluir ({count})",
+        "totalCount": "{count} no total",
+        "sortLabel": "ordenação: {sortName}",
+        "sort": {
+          "nameAsc": "Nome A-Z",
+          "nameDesc": "Nome Z-A",
+          "fewestBooks": "Menos livros",
+          "mostBooks": "Mais livros"
+        }
+      },
+      "deleteMode": {
+        "label": "Modo de exclusão",
+        "softTitle": "Exclusão suave",
+        "softDescription": "Desvincular de todos os livros, mas manter o registro da entidade",
+        "softDescriptionPlural": "Desvincular de todos os livros, mas manter os registros das entidades",
+        "hardTitle": "Exclusão permanente",
+        "hardDescription": "Remover a entidade e todas as associações permanentemente",
+        "hardDescriptionPlural": "Remover as entidades e todas as associações permanentemente"
+      },
+      "renameModal": {
+        "title": "Renomear Entidade",
+        "currentName": "Nome atual",
+        "newName": "Novo nome"
+      },
+      "deleteModal": {
+        "title": "Excluir Entidade",
+        "confirm": "Tem certeza que quer excluir {name}?"
+      },
+      "splitModal": {
+        "title": "Dividir Entidade",
+        "splitting": "Dividindo",
+        "newNames": "Novos nomes (mín 2)",
+        "namePlaceholder": "Insira o nome...",
+        "addAnother": "Adicionar outro"
+      },
+      "bulkDeleteModal": {
+        "title": "Exclusão em Massa",
+        "confirm": "Tem certeza que quer excluir {count} entidade selecionada? | Tem certeza que quer excluir {count} entidade selecionada? | Tem certeza que quer excluir {count} entidades selecionadas?",
+        "deleteButton": "Excluir {count}"
+      },
+      "mergeModal": {
+        "title": "Mesclar Entidades",
+        "description": "Selecione qual entidade você deseja manter. As demais serão mescladas nela e em seguida removidas."
+      }
+    }
+  },
+  "views": {
+    "entity": {
+      "book": "Livro",
+      "collection": "Coleção",
+      "library": "Biblioteca",
+      "smartScope": "SmartScope"
+    },
+    "common": {
+      "retry": "Tentar novamente"
+    },
+    "bookView": {
+      "sort": "Ordenar",
+      "sortOn": "Em",
+      "resetSort": "Restaurar ordenação padrão",
+      "filters": "Filtros",
+      "clear": "Limpar",
+      "clearAllFilters": "Limpar todos os filtros",
+      "expandSeries": "Expandir séries",
+      "collapseSeries": "Recolher séries",
+      "expanded": "Expandida(s)",
+      "exportMetadata": "Exportar metadados",
+      "showControlsAria": "Exibir controles de biblioteca",
+      "export": "Exportar",
+      "searchPlaceholder": "Buscar título, autor, série, narrador...",
+      "allBooksLoaded": "Todos os {count} livros carregados"
+    },
+    "notFound": {
+      "title": "Página não encontrada",
+      "description": "A página que você está procurando não existe.",
+      "goHome": "Ir para o Início"
+    },
+    "dashboard": {
+      "customize": "Personalizar painel",
+      "allShelvesHidden": "Todas as prateleiras estão ocultas.",
+      "greeting": {
+        "night": "Boa noite,",
+        "morning": "Bom dia,",
+        "afternoon": "Boa tarde,",
+        "evening": "Boa noite,",
+        "fallbackName": "olá"
+      }
+    },
+    "bookDetail": {
+      "title": "Livro",
+      "titleWithId": "Livro #{id}",
+      "pageTitle": {
+        "book": "Livro · {base}",
+        "editMetadata": "Editar Metadados · {base}",
+        "edit": "Editar · {base}",
+        "files": "Arquivos · {base}",
+        "readingLog": "Registro de Leitura · {base}",
+        "highlights": "Destaques · {base}"
+      }
+    },
+    "bookDock": {
+      "title": "Doca de Livros",
+      "newFilesDetected": "Novos arquivos detectados",
+      "reconnecting": "Reconectando",
+      "rescanFailed": "O reescaneamento falhou",
+      "totalInDock": "{size} na Doca de Livros",
+      "dropFiles": "Arraste os arquivos para a Doca de Livros",
+      "supportedFormats": "Suportado: {formats}",
+      "empty": {
+        "noSearchMatch": "Nenhum arquivo corresponde a \"{query}\"",
+        "noStatusFiles": "Nenhum arquivo em {status}",
+        "uploadPrompt": "Faça o upload de arquivos ou arraste para a pasta Doca de Livros"
+      },
+      "retry": {
+        "noneToRetry": "Nenhum erro de arquivo para tentar novamente",
+        "retrying": "Tentando um arquivo novamente | Tentando um arquivo novamente | Tentando {count} arquivos novamente"
+      },
+      "applyFetched": {
+        "applied": "Aplicado a nenhum arquivo | Aplicado a um arquivo | Aplicado a {count} arquivos",
+        "skippedEdited": "ignorado um arquivo por ter edições manuais | ignorado um arquivo por ter edições manuais | ignorados {count} arquivos por terem edições manuais",
+        "skippedNoMetadata": "ignorado um arquivo por não ter metadados buscados | ignorado um arquivo por não ter metadados buscados | ignorados {count} arquivos por não terem metadados buscados",
+        "noneApplied": "Nenhum arquivo aplicado; {reasons}",
+        "noneSelected": "Nenhum arquivo selecionado"
+      }
+    },
+    "collection": {
+      "title": "Coleção",
+      "pageTitle": "Coleção · {name}",
+      "pageTitleWithId": "Coleção #{id}",
+      "editCollection": "Editar coleção",
+      "showControlsAria": "Exibir controles de coleção",
+      "loadError": "Não foi possível carregar esta coleção",
+      "toast": {
+        "removed": "Nenhum livro removido da coleção | Um livro removido da coleção | {count} livros removidos da coleção",
+        "removeFailed": "Falha ao remover livros da coleção"
+      },
+      "empty": {
+        "noSearchMatch": "Nenhum livro corresponde a esta pesquisa",
+        "noSearchMatchHint": "Tente um termo de pesquisa diferente ou limpe a pesquisa.",
+        "noBooks": "Nenhum livro nesta coleção",
+        "noBooksHint": "Selecione livros da sua biblioteca e adicione-os aqui."
+      }
+    },
+    "library": {
+      "title": "Biblioteca",
+      "pageTitle": "Biblioteca · {name}",
+      "pageTitleWithId": "Biblioteca #{id}",
+      "filterRules": "Regras de filtro",
+      "saveAsSmartScope": "Salvar como SmartScope",
+      "saveScope": "Salvar Escopo",
+      "saveAsSmartScopeTooltip": "Salvar este filtro como um SmartScope nomeado",
+      "saved": "Salvo",
+      "saveFilter": "Salvar filtro",
+      "filterSaved": "Filtro salvo",
+      "saveFilterTooltip": "Salvar filtro para esta biblioteca",
+      "removeSavedFilter": "Remover filtro salvo",
+      "empty": {
+        "noFilterMatch": "Nenhum livro corresponde aos seus filtros",
+        "noFilterMatchHint": "Tente ajustar ou limpar seus filtros para ver mais livros.",
+        "clearFilters": "Limpar filtros",
+        "scanning": "Escaneando sua biblioteca...",
+        "scanningHint": "Livros aparecerão aqui à medida que forem encontrados.",
+        "emptyLibrary": "A sua biblioteca está vazia",
+        "emptyLibraryHint": "Assim que adicionar livros à biblioteca, eles aparecerão aqui."
+      },
+      "querySelection": {
+        "loadedSelected": "{selected} de {total} livros carregados selecionados.",
+        "selectAllMatching": "Selecionar todos os {total} livros correspondentes"
+      }
+    },
+    "smartScope": {
+      "title": "SmartScope",
+      "pageTitle": "SmartScope · {name}",
+      "pageTitleWithId": "SmartScope #{id}",
+      "defaultName": "Escopo inteligente",
+      "filter": "Filtro",
+      "edit": "Editar SmartScope",
+      "showControlsAria": "Exibir controles do SmartScope",
+      "hideFilter": "Ocultar filtro",
+      "showFilter": "Mostrar filtro",
+      "confirmDelete": "Confirma?",
+      "loadError": "Não foi possível carregar este SmartScope",
+      "toast": {
+        "deleted": "\"{name}\" excluído(a)",
+        "deleteFailed": "Falha ao excluir \"{name}\""
+      },
+      "empty": {
+        "noRules": "Nenhuma regra configurada",
+        "noRulesHint": "Abra o editor para definir quais livros aparecerão neste SmartScope usando filtros e regras de classificação.",
+        "configure": "Configurar SmartScope",
+        "noMatch": "Nenhum livro corresponde a este SmartScope",
+        "noMatchHint": "Tente ajustar as regras de filtro.",
+        "edit": "Editar SmartScope"
+      }
+    }
+  },
+  "whatsNew": {
+    "title": "O que há de novo",
+    "subtitle": "Tudo o que foi lançado, do mais recente ao mais antigo.",
+    "versionPrefix": "Versão {version}",
+    "newUpdates": "nenhuma nova atualização | uma nova atualização | {count} novas atualizações",
+    "remindLater": "Lembrar mais tarde",
+    "gotIt": "Entendi",
+    "latest": "Última versão",
+    "fullChangelog": "Log de alterações completo",
+    "seeAllReleases": "Ver todos os lançamentos",
+    "versions": "Versões",
+    "currentVersion": "Versão atual",
+    "youreHere": "Você está aqui",
+    "searchPlaceholder": "Pesquisar lançamentos…",
+    "noReleasesFound": "Nenhum lançamento encontrado.",
+    "noHighlights": "Sem destaques para este lançamento.",
+    "showChangelog": "Exibir log de alterações completo",
+    "hideChangelog": "Ocultar log de alterações completo",
+    "openOnGitHub": "Abrir no GitHub",
+    "loadMore": "Carregar mais",
+    "loadingMore": "Carregando…",
+    "loadFailed": "Falha ao carregar lançamentos",
+    "loadMoreFailed": "Não foi possível carregar mais lançamentos. Por favor, tente novamente.",
+    "loadErrorHint": "Não conseguimos carregar os lançamentos. Verifique sua conexão e tente novamente.",
+    "retry": "Tentar novamente",
+    "imageViewer": "Visualizador de imagem",
+    "closeImage": "Fechar imagem",
+    "previousImage": "Imagem anterior",
+    "nextImage": "Próxima imagem"
+  },
+  "titles": {
+    "dashboard": "Painel",
+    "libraries": "Bibliotecas",
+    "opds": "OPDS",
+    "koboSync": "Sincronização Kobo",
+    "koreaderSync": "Sincronização KOReader",
+    "bookDock": "Doca de Livros",
+    "whatsNew": "O que há de novo",
+    "annotations": "Anotações",
+    "achievements": "Conquistas",
+    "statistics": "Estatísticas",
+    "authors": "Autores",
+    "series": "Séries",
+    "entityManager": "Gerenciador de Entidades",
+    "bulkRename": "Renomeação em Massa",
+    "notFound": "Não Encontrado",
+    "signIn": "Entrar",
+    "initialSetup": "Configuração Inicial",
+    "forgotPassword": "Esqueci a Senha",
+    "resetPassword": "Redefinir Senha",
+    "completingSignIn": "Concluindo o Login",
+    "magicLinkLogin": "Login via Link Mágico",
+    "readPrefix": "Ler",
+    "emailSuffix": "E-mail",
+    "library": "Biblioteca",
+    "smartScope": "SmartScope",
+    "collection": "Coleção",
+    "author": "Autor",
+    "book": "Livro",
+    "seriesItem": "Série",
+    "appearance": {
+      "theme": "Exibição",
+      "book-covers": "Capas de Livros",
+      "icons": "Ícones",
+      "layout": "Layout da Exibição",
+      "behavior": "Comportamento da Biblioteca"
+    },
+    "reader": {
+      "general": "Configurações do Leitor",
+      "ebook": "Leitor de eBook",
+      "pdf": "Leitor de PDF",
+      "comics": "Leitor de Quadrinhos",
+      "audio": "Reprodutor de Audiolivros",
+      "fonts": "Fontes do Leitor"
+    },
+    "email": {
+      "providers": "Provedores",
+      "recipients": "Destinatários",
+      "groups": "Grupos",
+      "templates": "Modelos",
+      "preferences": "Preferências",
+      "history": "Histórico"
+    },
+    "metadata": {
+      "providers": "Provedores",
+      "field-rules": "Regras por Campo",
+      "custom-fields": "Metadados Personalizados",
+      "genre-blocklist": "Lista de Bloqueio de Gêneros",
+      "score": "Pontuação de Confiança",
+      "auto-fetch": "Busca Automática de Livro",
+      "authors": "Busca Automática de Autor"
+    },
+    "admin": {
+      "users": "Usuários",
+      "account-activity": "Atividade da Conta",
+      "magic-links": "Links Mágicos",
+      "oidc": "OIDC / SSO"
+    },
+    "system": {
+      "file-naming": "Nomeação de Arquivos",
+      "book-dock": "Doca de Livros",
+      "maintenance": "Manutenção",
+      "audit-log": "Registro de Auditoria"
+    },
+    "account": {
+      "profile": "Conta",
+      "privacy": "Privacidade e Compartilhamento",
+      "notifications": "Notificações",
+      "restrictions": "Restrições de Conteúdo"
+    }
+  }
+}

--- a/client/src/locales/sl.json
+++ b/client/src/locales/sl.json
@@ -3092,8 +3092,7 @@
         "moreLikeThis": "Več podobnega"
       },
       "series": {
-        "moreInSeriesPrefix": "Več v",
-        "moreInSeriesSuffix": "zbirki"
+        "moreInSeries": "Več v zbirki {series}"
       },
       "writeRename": {
         "written": "ni zapisanih polj | Zapisano (eno polje) | Zapisano ({count} polj)",

--- a/client/src/stores/__tests__/locale.spec.ts
+++ b/client/src/stores/__tests__/locale.spec.ts
@@ -32,7 +32,7 @@ describe('locale store', () => {
     expect(matchSupportedLocale(['nl-NL', 'en-US'])).toBe('nl')
     expect(matchSupportedLocale(['de-DE', 'en-GB'])).toBe('de')
     expect(matchSupportedLocale(['nl-BE', 'en'])).toBe('nl')
-    expect(matchSupportedLocale(['pt-BR'])).toBeNull()
+    expect(matchSupportedLocale(['pt-BR'])).toBe('pt')
   })
 
   it('prefers the stored locale over browser detection', async () => {

--- a/packages/types/src/locale.ts
+++ b/packages/types/src/locale.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_LOCALES = ["en", "de", "nl", "sl"] as const;
+export const SUPPORTED_LOCALES = ["en", "de", "nl", "pt", "sl"] as const;
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 
 export const DEFAULT_LOCALE: Locale = "en";
@@ -8,6 +8,7 @@ export const LOCALE_LABELS: Record<Locale, string> = {
   en: "English",
   de: "Deutsch",
   nl: "Nederlands",
+  pt: "Português",
   sl: "Slovenščina",
 };
 
@@ -15,6 +16,7 @@ export const LOCALE_DIRECTIONS: Record<Locale, "ltr" | "rtl"> = {
   en: "ltr",
   de: "ltr",
   nl: "ltr",
+  pt: "ltr",
   sl: "ltr",
 };
 


### PR DESCRIPTION
What does this PR do?
Adds Portuguese (PT-BR) language localization files and integrates them into the project.
Closes #673 

How did you test this?
Changes were made via the GitHub Web UI. Verified the JSON syntax of the new translation files and ensured the keys perfectly match the existing English localization structure.

Screenshots
N/A - Translation files and basic UI selector update.

Anything non-obvious in the diff?
No. Standard localization mapping.

Checklist
[x] I've read through my own diff
[x] This PR was discussed in an issue and has maintainer approval (for new features)
[x] Lint and tests pass locally
[x] No unintended files included (build artifacts, .env, personal configs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full Portuguese (Brazil) localization across the application.
  * Portuguese is now selectable, and `pt-BR` now maps to the supported Portuguese interface.

* **Localization Updates**
  * Updated the “More in series” book label to use a single parameterized translation including the series name (updated in English, German, Dutch, and Slovenian).

* **Tests**
  * Adjusted locale-matching expectations to confirm `pt-BR` resolves to `pt`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->