### PR TITLE
i18n(client): sync translations from Crowdin

### DIFF
--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -5938,7 +5938,10 @@
       "similarityHelp": "Only for Similar title and author matches. At least one author and the book type must also match. Lower finds more possible duplicates; higher requires closer titles. Identical files, ISBN, and exact metadata are checked separately.",
       "runScan": "Run scan",
       "rescan": "Rescan",
-      "status": { "queued": "Scan queued", "running": "Scanning books" },
+      "status": {
+        "queued": "Scan queued",
+        "running": "Scanning books"
+      },
       "groupsFound": "No duplicate groups | One duplicate group | {count} duplicate groups",
       "filter": "Match type",
       "allReasons": "All match types",
@@ -5982,7 +5985,10 @@
         "title": "Find duplicate books",
         "description": "Choose a library scope and similarity level, then run a scan. No books are changed until you explicitly confirm a deletion."
       },
-      "empty": { "title": "No duplicate groups found", "description": "No books matched the current scope, similarity level, and match filter." },
+      "empty": {
+        "title": "No duplicate groups found",
+        "description": "No books matched the current scope, similarity level, and match filter."
+      },
       "deleteDialog": {
         "title": "Permanently delete duplicate books?",
         "description": "This will permanently delete {count} selected book and its files. | This will permanently delete {count} selected book and its files. | This will permanently delete {count} selected books and their files.",
@@ -5997,7 +6003,10 @@
         "results": "Could not load duplicate groups.",
         "delete": "Could not delete the selected duplicate books."
       },
-      "pagination": { "label": "Duplicate groups pages", "page": "Page {page} of {total}" }
+      "pagination": {
+        "label": "Duplicate groups pages",
+        "page": "Page {page} of {total}"
+      }
     },
     "entityManager": {
       "unknown": "Unbekannt",

--- a/client/src/locales/nl.json
+++ b/client/src/locales/nl.json
@@ -5938,7 +5938,10 @@
       "similarityHelp": "Only for Similar title and author matches. At least one author and the book type must also match. Lower finds more possible duplicates; higher requires closer titles. Identical files, ISBN, and exact metadata are checked separately.",
       "runScan": "Run scan",
       "rescan": "Rescan",
-      "status": { "queued": "Scan queued", "running": "Scanning books" },
+      "status": {
+        "queued": "Scan queued",
+        "running": "Scanning books"
+      },
       "groupsFound": "No duplicate groups | One duplicate group | {count} duplicate groups",
       "filter": "Match type",
       "allReasons": "All match types",
@@ -5982,7 +5985,10 @@
         "title": "Find duplicate books",
         "description": "Choose a library scope and similarity level, then run a scan. No books are changed until you explicitly confirm a deletion."
       },
-      "empty": { "title": "No duplicate groups found", "description": "No books matched the current scope, similarity level, and match filter." },
+      "empty": {
+        "title": "No duplicate groups found",
+        "description": "No books matched the current scope, similarity level, and match filter."
+      },
       "deleteDialog": {
         "title": "Permanently delete duplicate books?",
         "description": "This will permanently delete {count} selected book and its files. | This will permanently delete {count} selected book and its files. | This will permanently delete {count} selected books and their files.",
@@ -5997,7 +6003,10 @@
         "results": "Could not load duplicate groups.",
         "delete": "Could not delete the selected duplicate books."
       },
-      "pagination": { "label": "Duplicate groups pages", "page": "Page {page} of {total}" }
+      "pagination": {
+        "label": "Duplicate groups pages",
+        "page": "Page {page} of {total}"
+      }
     },
     "entityManager": {
       "unknown": "Onbekend",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -5938,7 +5938,10 @@
       "similarityHelp": "Only for Similar title and author matches. At least one author and the book type must also match. Lower finds more possible duplicates; higher requires closer titles. Identical files, ISBN, and exact metadata are checked separately.",
       "runScan": "Run scan",
       "rescan": "Rescan",
-      "status": { "queued": "Scan queued", "running": "Scanning books" },
+      "status": {
+        "queued": "Scan queued",
+        "running": "Scanning books"
+      },
       "groupsFound": "No duplicate groups | One duplicate group | {count} duplicate groups",
       "filter": "Match type",
       "allReasons": "All match types",
@@ -5982,7 +5985,10 @@
         "title": "Find duplicate books",
         "description": "Choose a library scope and similarity level, then run a scan. No books are changed until you explicitly confirm a deletion."
       },
-      "empty": { "title": "No duplicate groups found", "description": "No books matched the current scope, similarity level, and match filter." },
+      "empty": {
+        "title": "No duplicate groups found",
+        "description": "No books matched the current scope, similarity level, and match filter."
+      },
       "deleteDialog": {
         "title": "Permanently delete duplicate books?",
         "description": "This will permanently delete {count} selected book and its files. | This will permanently delete {count} selected book and its files. | This will permanently delete {count} selected books and their files.",
@@ -5997,7 +6003,10 @@
         "results": "Could not load duplicate groups.",
         "delete": "Could not delete the selected duplicate books."
       },
-      "pagination": { "label": "Duplicate groups pages", "page": "Page {page} of {total}" }
+      "pagination": {
+        "label": "Duplicate groups pages",
+        "page": "Page {page} of {total}"
+      }
     },
     "entityManager": {
       "unknown": "Desconhecido",

--- a/client/src/locales/sl.json
+++ b/client/src/locales/sl.json
@@ -5938,7 +5938,10 @@
       "similarityHelp": "Only for Similar title and author matches. At least one author and the book type must also match. Lower finds more possible duplicates; higher requires closer titles. Identical files, ISBN, and exact metadata are checked separately.",
       "runScan": "Run scan",
       "rescan": "Rescan",
-      "status": { "queued": "Scan queued", "running": "Scanning books" },
+      "status": {
+        "queued": "Scan queued",
+        "running": "Scanning books"
+      },
       "groupsFound": "No duplicate groups | One duplicate group | {count} duplicate groups",
       "filter": "Match type",
       "allReasons": "All match types",
@@ -5982,7 +5985,10 @@
         "title": "Find duplicate books",
         "description": "Choose a library scope and similarity level, then run a scan. No books are changed until you explicitly confirm a deletion."
       },
-      "empty": { "title": "No duplicate groups found", "description": "No books matched the current scope, similarity level, and match filter." },
+      "empty": {
+        "title": "No duplicate groups found",
+        "description": "No books matched the current scope, similarity level, and match filter."
+      },
       "deleteDialog": {
         "title": "Permanently delete duplicate books?",
         "description": "This will permanently delete {count} selected book and its files. | This will permanently delete {count} selected book and its files. | This will permanently delete {count} selected books and their files.",
@@ -5997,7 +6003,10 @@
         "results": "Could not load duplicate groups.",
         "delete": "Could not delete the selected duplicate books."
       },
-      "pagination": { "label": "Duplicate groups pages", "page": "Page {page} of {total}" }
+      "pagination": {
+        "label": "Duplicate groups pages",
+        "page": "Page {page} of {total}"
+      }
     },
     "entityManager": {
       "unknown": "Neznano",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted duplicate-book localization entries across German, Dutch, Portuguese, and Slovenian translations for improved readability.
  * No user-facing translation text or localization keys were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->