### PR TITLE
Implement Audiobookshelf API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,11 @@ NODE_MAX_OLD_SPACE_SIZE=2048
 # Default false. Enable only in trusted self-hosted networks.
 # OIDC_ALLOW_LOCAL_ISSUERS=false
 
+# Extra mobile redirect URIs allowed for the Audiobookshelf-compatible OIDC login,
+# beyond the built-in `audiobookshelf://oauth`. Comma-separated, exact-match (no wildcards).
+# Add the redirect URI of each third-party ABS client you want to support.
+# ABS_OIDC_MOBILE_REDIRECT_URIS=stillapp://oauth,prologue://oauth
+
 # Optional: allow Cloudflare Web Analytics beacon when using automatic setup.
 # Keep unset/false to preserve strict CSP (`script-src 'self'`).
 # CSP_ALLOW_CLOUDFLARE_INSIGHTS=false

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ server/src/metadata.ts
 # Test results (generated artifacts - uploaded to CI, not committed)
 test-results/
 
+# abs-capture-proxy DUMP=1 output (tools/abs-capture-proxy)
+abs-capture/
+
 # IDE
 .idea/
 

--- a/docs/abs-api/COVERAGE.md
+++ b/docs/abs-api/COVERAGE.md
@@ -1,0 +1,103 @@
+# API Documentation Coverage Matrix
+
+Tracks every route group against two documentation sources:
+
+- **Markdown** = documented in [`ENDPOINTS.md`](./ENDPOINTS.md) + [`REIMPLEMENTATION_GUIDE.md`](./REIMPLEMENTATION_GUIDE.md) (this set).
+- **OpenAPI** = present in the maintained spec under `docs/` (`root.yaml` → `controllers/*.yaml`).
+
+## How this was verified
+
+The authoritative route list comes from the routers, not the OpenAPI spec:
+
+```bash
+# 197 /api routes:
+grep -nE "this\.router\.(get|post|patch|delete|put)\('" server/routers/ApiRouter.js
+# HLS + public:
+grep -nE "this\.router\.(get|post|patch|delete|put)\('" server/routers/HlsRouter.js server/routers/PublicRouter.js
+# auth/discovery routes:  server/Auth.js (initAuthRoutes) + server/Server.js (/init,/status,/ping,/healthcheck)
+```
+
+Counts: **197** `/api/*` routes + **1** HLS + **6** public + **11** auth/discovery ≈ **215 total**
+(4 discovery: `/ping` `/healthcheck` `/status` `/init`; 7 auth: `/login` `/auth/refresh` `/logout`
+`/auth/openid` `/auth/openid/callback` `/auth/openid/mobile-redirect` `/auth/openid/config`).
+All are listed in `ENDPOINTS.md`.
+
+## Controller-level coverage
+
+| Domain / Controller                       |              Routes | Markdown | OpenAPI (existing) |  Client-critical  |
+| ----------------------------------------- | ------------------: | :------: | :----------------: | :---------------: |
+| Discovery + Auth (`Auth`,`Server`)        |                  11 |    ✅    |         ❌         |         ★         |
+| Libraries (`LibraryController`)           |                  28 |    ✅    |     ⚠️ partial     |         ★         |
+| Library items (`LibraryItemController`)   |                  26 |    ✅    |         ❌         |         ★         |
+| Current user (`MeController`)             |                  18 |    ✅    |         ❌         |         ★         |
+| Sessions (`SessionController`)            | 9 (+1 public track) |    ✅    |         ❌         |         ★         |
+| HLS (`HlsRouter`)                         |                   1 |    ✅    |         ❌         |         ★         |
+| Public (`PublicRouter`/`ShareController`) |                   6 |    ✅    |         ❌         | ★ (session track) |
+| Collections (`CollectionController`)      |                   9 |    ✅    |         ❌         |                   |
+| Playlists (`PlaylistController`)          |                  10 |    ✅    |         ❌         |     ★ (list)      |
+| Authors (`AuthorController`)              |                   7 |    ✅    |         ✅         |                   |
+| Series (`SeriesController`)               |                   2 |    ✅    |         ✅         |                   |
+| Podcasts (`PodcastController`)            |                  13 |    ✅    |         ✅         |                   |
+| Users (`UserController`)                  |                   9 |    ✅    |         ❌         |                   |
+| Notifications (`NotificationController`)  |                   8 |    ✅    |         ✅         |                   |
+| Emails (`EmailController`)                |                   5 |    ✅    |         ✅         |                   |
+| Search (`SearchController`)               |                   6 |    ✅    |         ❌         |                   |
+| RSS feeds (`RSSFeedController`)           |                   5 |    ✅    |         ❌         |                   |
+| Shares (`ShareController`)                |       2 (+4 public) |    ✅    |         ❌         |                   |
+| Tools (`ToolsController`)                 |                   4 |    ✅    |         ❌         |                   |
+| Backups (`BackupController`)              |                   7 |    ✅    |         ❌         |                   |
+| API keys (`ApiKeyController`)             |                   4 |    ✅    |         ❌         |                   |
+| Custom metadata providers                 |                   3 |    ✅    |         ❌         |                   |
+| Filesystem (`FileSystemController`)       |                   2 |    ✅    |         ❌         |                   |
+| Cache (`CacheController`)                 |                   2 |    ✅    |         ❌         |                   |
+| Stats (`StatsController`)                 |                   2 |    ✅    |         ❌         |                   |
+| Misc/settings (`MiscController`)          |                  17 |    ✅    |         ❌         |                   |
+
+**Legend:** ✅ documented · ⚠️ partial · ❌ not present · ★ client-critical.
+
+### OpenAPI spec status
+
+The repo's existing OpenAPI project (`docs/root.yaml`, bundled to `docs/openapi.json`) ships
+per-controller YAML for **6** controllers only: `AuthorController`, `EmailController`,
+`LibraryController` (partial), `NotificationController`, `PodcastController`, `SeriesController`.
+The **client-critical** controllers (`LibraryItemController`, `MeController`, `SessionController`),
+the auth/token routes, HLS, and the Socket.IO contract are **absent** from the spec. This markdown
+set fills those gaps; extending the OpenAPI YAML for machine consumption is a separate, mechanical
+follow-up (see below).
+
+## Re-implementation completeness (client-critical) — all ✅
+
+Every endpoint and event needed for a working client is documented in the markdown set:
+
+- ✅ Discovery `/status` `/ping` `/init`
+- ✅ Auth `/login` `/auth/refresh` `/logout` (+ token lifecycle, grace-window rotation)
+- ✅ `/api/me`, `/api/libraries`, `/api/libraries/:id`
+- ✅ Browse `/libraries/:id/items` `/personalized` `/filterdata` `/search` `/series` `/collections` `/recent-episodes`
+- ✅ Item detail `/items/:id`, cover `/items/:id/cover`
+- ✅ Playback `/items/:id/play(/:episodeId)` (direct vs transcode)
+- ✅ Streaming `/hls/:stream/:file` (+ `stream_reset`), `/public/session/:id/track/:index`
+- ✅ Sync `/session/:id/sync` `/close`, `/me/progress/...`, `/session/local-all` (merge rule)
+- ✅ Socket: `auth`→`init`, `user_item_progress_updated`, `user_session_closed`, `stream_reset`, `item_*`
+
+## Follow-up: extending the OpenAPI YAML (optional, for tooling)
+
+If machine-readable specs are wanted (codegen, mock servers, contract tests), extend the existing
+exploded redocly project in priority order:
+
+1. `LibraryItemController.yaml`, `MeController.yaml`, `SessionController.yaml` (client-critical)
+2. Object schemas not yet in `docs/objects/`: **PlaybackSession**, **MediaProgress**, **DeviceInfo**
+3. `CollectionController`, `PlaylistController`, `SearchController`, `ShareController`
+4. Admin-only controllers last
+
+Method: add `controllers/<Name>.yaml`, reference shared schemas from `docs/objects/*` and
+`docs/schemas.yaml`, register each path in `docs/root.yaml`, then rebuild per `docs/README.md`:
+
+```bash
+cd docs
+npx @redocly/cli bundle root.yaml > bundled.yaml
+npx yq -p yaml -o json bundled.yaml > openapi.json
+npx @redocly/cli lint root.yaml
+```
+
+Validate request/response shapes at runtime with the `wiretap` tool (noted in `docs/README.md`)
+against a live server while driving the official client.

--- a/docs/abs-api/ENDPOINTS.md
+++ b/docs/abs-api/ENDPOINTS.md
@@ -1,0 +1,385 @@
+# Audiobookshelf API — Endpoint Reference
+
+Per-domain reference for every route in `server/routers/ApiRouter.js`, `HlsRouter.js`,
+`PublicRouter.js`, and the auth/discovery routes. Read alongside
+[`REIMPLEMENTATION_GUIDE.md`](./REIMPLEMENTATION_GUIDE.md) (contracts) and
+[`COVERAGE.md`](./COVERAGE.md) (completeness matrix).
+
+**Legend** — **Auth column:** `none` = unauthenticated · `jwt` = any valid user token · `admin` =
+admin/root · `owner` = owner-of-resource or admin · `key` = covered by API key too. **★** = client-
+critical (needed for a working mobile/web client). All `/api/*` routes require `jwt` unless noted.
+
+> **Permission middleware note.** Many controllers gate writes on user permissions
+> (`canUpdate`, `canDelete`, `canDownload`, `canUpload`, `canAccessExplicitContent`) and gate
+> admin-only reads/writes via a per-controller `middleware`/`adminMiddleware`. Non-admins typically
+> get `403`, but some admin reads return `404` to avoid leaking existence (noted inline).
+
+---
+
+## 0. Discovery & auth (router root — NOT under `/api`)
+
+| ★   | Method | Path                           | Auth                         | Purpose                                                                   |
+| --- | ------ | ------------------------------ | ---------------------------- | ------------------------------------------------------------------------- |
+|     | GET    | `/ping`                        | none                         | `{ success:true }` liveness                                               |
+|     | GET    | `/healthcheck`                 | none                         | `200` empty                                                               |
+| ★   | GET    | `/status`                      | none                         | server identity + `isInit` + auth methods                                 |
+| ★   | POST   | `/init`                        | none                         | create first root user (only when `!isInit`, else 500)                    |
+| ★   | POST   | `/login`                       | none (rate-limited)          | local login; `x-return-tokens:true` ⇒ tokens in body, else refresh cookie |
+| ★   | POST   | `/auth/refresh`                | refresh token (rate-limited) | rotate tokens; cookie or `x-refresh-token` header                         |
+| ★   | POST   | `/logout`                      | jwt                          | destroy session, clear cookie, returns `{ redirect_url }`                 |
+|     | GET    | `/auth/openid`                 | none (rate-limited)          | begin OIDC, redirect to provider                                          |
+|     | GET    | `/auth/openid/callback`        | none                         | OIDC code exchange                                                        |
+|     | GET    | `/auth/openid/mobile-redirect` | none                         | bounce to `audiobookshelf://oauth`                                        |
+|     | GET    | `/auth/openid/config`          | admin                        | read provider `.well-known` config                                        |
+
+See guide §2 for the token lifecycle and §1.3 for discovery payloads.
+
+---
+
+## 1. Libraries — `LibraryController` (`/api/libraries`)
+
+| ★   | Method | Path                                   | Auth            | Purpose                                                                            |
+| --- | ------ | -------------------------------------- | --------------- | ---------------------------------------------------------------------------------- |
+|     | POST   | `/libraries`                           | admin           | create library                                                                     |
+| ★   | GET    | `/libraries`                           | jwt             | list libraries                                                                     |
+| ★   | GET    | `/libraries/:id`                       | jwt             | get one (`?include=filterdata`)                                                    |
+|     | PATCH  | `/libraries/:id`                       | admin           | update                                                                             |
+|     | DELETE | `/libraries/:id`                       | admin           | delete                                                                             |
+| ★   | GET    | `/libraries/:id/items`                 | jwt             | **primary browse** — `limit/page/sort/desc/filter/minified/collapseseries/include` |
+|     | DELETE | `/libraries/:id/issues`                | admin           | remove missing/invalid items                                                       |
+|     | GET    | `/libraries/:id/episode-downloads`     | jwt             | podcast download queue                                                             |
+| ★   | GET    | `/libraries/:id/series`                | jwt             | series in library (paginated)                                                      |
+|     | GET    | `/libraries/:id/series/:seriesId`      | jwt             | one series                                                                         |
+| ★   | GET    | `/libraries/:id/collections`           | jwt             | collections                                                                        |
+| ★   | GET    | `/libraries/:id/playlists`             | jwt             | user playlists                                                                     |
+| ★   | GET    | `/libraries/:id/personalized`          | jwt             | **home-screen shelves**                                                            |
+| ★   | GET    | `/libraries/:id/filterdata`            | jwt             | valid filter values/ids (genres, tags, authors, narrators…)                        |
+| ★   | GET    | `/libraries/:id/search`                | jwt             | search within library (`?q=`)                                                      |
+|     | GET    | `/libraries/:id/stats`                 | jwt             | library stats                                                                      |
+|     | GET    | `/libraries/:id/authors`               | jwt             | authors list                                                                       |
+|     | GET    | `/libraries/:id/narrators`             | jwt             | narrators list                                                                     |
+|     | PATCH  | `/libraries/:id/narrators/:narratorId` | admin           | rename narrator                                                                    |
+|     | DELETE | `/libraries/:id/narrators/:narratorId` | admin           | remove narrator                                                                    |
+|     | GET    | `/libraries/:id/matchall`              | admin           | match all items to metadata providers                                              |
+|     | POST   | `/libraries/:id/scan`                  | admin           | trigger scan                                                                       |
+| ★   | GET    | `/libraries/:id/recent-episodes`       | jwt             | podcast "latest" shelf                                                             |
+|     | GET    | `/libraries/:id/opml`                  | jwt             | export podcasts as OPML                                                            |
+|     | POST   | `/libraries/order`                     | admin           | reorder libraries                                                                  |
+|     | POST   | `/libraries/:id/remove-metadata`       | admin           | delete metadata files                                                              |
+|     | GET    | `/libraries/:id/podcast-titles`        | jwt             | podcast title list                                                                 |
+|     | GET    | `/libraries/:id/download`              | jwt+canDownload | zip-download multiple items                                                        |
+
+Browse response envelope & filter encoding: guide §4.1–4.2.
+
+---
+
+## 2. Library items — `LibraryItemController` (/api/items) ★ core
+
+| ★   | Method | Path                               | Auth                          | Purpose                                 |
+| --- | ------ | ---------------------------------- | ----------------------------- | --------------------------------------- |
+|     | POST   | `/items/batch/delete`              | admin+canDelete               | delete many                             |
+|     | POST   | `/items/batch/update`              | jwt+canUpdate                 | update many                             |
+| ★   | POST   | `/items/batch/get`                 | jwt                           | fetch many by id                        |
+|     | POST   | `/items/batch/quickmatch`          | admin                         | quick-match many                        |
+|     | POST   | `/items/batch/scan`                | admin                         | scan many                               |
+| ★   | GET    | `/items/:id`                       | jwt                           | item detail (`?expanded=1&include=...`) |
+|     | DELETE | `/items/:id`                       | admin+canDelete               | delete item                             |
+|     | GET    | `/items/:id/download`              | jwt+canDownload               | download item (zip)                     |
+|     | PATCH  | `/items/:id/media`                 | jwt+canUpdate                 | update media metadata                   |
+| ★   | GET    | `/items/:id/cover`                 | **none** (GET in ignore list) | cover image; `?token=&raw=1&ts=`        |
+|     | POST   | `/items/:id/cover`                 | jwt+canUpload                 | upload cover                            |
+|     | PATCH  | `/items/:id/cover`                 | jwt+canUpdate                 | set cover by url/path                   |
+|     | DELETE | `/items/:id/cover`                 | jwt+canUpdate                 | remove cover                            |
+|     | POST   | `/items/:id/match`                 | jwt+canUpdate                 | match to metadata provider              |
+| ★   | POST   | `/items/:id/play`                  | jwt                           | **start playback session** (book)       |
+| ★   | POST   | `/items/:id/play/:episodeId`       | jwt                           | start playback (podcast episode)        |
+|     | PATCH  | `/items/:id/tracks`                | jwt+canUpdate                 | reorder/update tracks                   |
+|     | POST   | `/items/:id/scan`                  | admin                         | rescan item                             |
+|     | GET    | `/items/:id/metadata-object`       | jwt                           | computed metadata object                |
+|     | POST   | `/items/:id/chapters`              | jwt+canUpdate                 | update chapters                         |
+|     | GET    | `/items/:id/ffprobe/:fileid`       | admin                         | raw ffprobe data                        |
+| ★   | GET    | `/items/:id/file/:fileid`          | jwt                           | stream a file (inline)                  |
+|     | DELETE | `/items/:id/file/:fileid`          | admin+canDelete               | delete a file                           |
+| ★   | GET    | `/items/:id/file/:fileid/download` | jwt+canDownload               | download a file                         |
+|     | GET    | `/items/:id/ebook/:fileid?`        | jwt                           | ebook file                              |
+|     | PATCH  | `/items/:id/ebook/:fileid/status`  | jwt+canUpdate                 | set ebook as primary/etc.               |
+
+Play request/response (direct vs transcode): guide §5.
+
+---
+
+## 3. Current user — `MeController` (/api/me) ★ core
+
+| ★   | Method | Path                                                     | Auth               | Purpose                                                           |
+| --- | ------ | -------------------------------------------------------- | ------------------ | ----------------------------------------------------------------- |
+| ★   | GET    | `/me`                                                    | jwt                | current user object (incl. mediaProgress, bookmarks, permissions) |
+|     | GET    | `/me/listening-sessions`                                 | jwt                | paginated history (`itemsPerPage/page`)                           |
+|     | GET    | `/me/item/listening-sessions/:libraryItemId/:episodeId?` | jwt                | sessions for one item                                             |
+|     | GET    | `/me/listening-stats`                                    | jwt                | aggregate stats                                                   |
+|     | GET    | `/me/progress/:id/remove-from-continue-listening`        | jwt                | hide from Continue                                                |
+| ★   | GET    | `/me/progress/:id/:episodeId?`                           | jwt                | get one MediaProgress                                             |
+| ★   | PATCH  | `/me/progress/batch/update`                              | jwt                | upsert many progresses                                            |
+| ★   | PATCH  | `/me/progress/:libraryItemId/:episodeId?`                | jwt                | **upsert one MediaProgress**                                      |
+|     | DELETE | `/me/progress/:id`                                       | jwt                | delete progress                                                   |
+|     | POST   | `/me/item/:id/bookmark`                                  | jwt                | create bookmark                                                   |
+|     | PATCH  | `/me/item/:id/bookmark`                                  | jwt                | update bookmark                                                   |
+|     | DELETE | `/me/item/:id/bookmark/:time`                            | jwt                | remove bookmark                                                   |
+|     | PATCH  | `/me/password`                                           | jwt (rate-limited) | change own password                                               |
+| ★   | GET    | `/me/items-in-progress`                                  | jwt                | Continue-listening shelf                                          |
+|     | GET    | `/me/series/:id/remove-from-continue-listening`          | jwt                | hide series                                                       |
+|     | GET    | `/me/series/:id/readd-to-continue-listening`             | jwt                | unhide series                                                     |
+|     | GET    | `/me/stats/year/:year`                                   | jwt                | year-in-review stats                                              |
+|     | POST   | `/me/ereader-devices`                                    | jwt                | update user's e-reader devices                                    |
+
+Progress semantics: guide §7.
+
+---
+
+## 4. Sessions — `SessionController` (/api/sessions, /api/session) ★ core
+
+| ★   | Method | Path                     | Auth                     | Purpose                                                                   |
+| --- | ------ | ------------------------ | ------------------------ | ------------------------------------------------------------------------- |
+|     | GET    | `/sessions`              | admin (404 to non-admin) | all sessions w/ user data, paginated (`itemsPerPage/page/sort/desc/user`) |
+|     | DELETE | `/sessions/:id`          | jwt+canDelete            | delete a session                                                          |
+|     | GET    | `/sessions/open`         | admin (404)              | open in-memory sessions + share sessions                                  |
+|     | POST   | `/sessions/batch/delete` | admin                    | delete many (`{ sessions:[id] }`)                                         |
+| ★   | POST   | `/session/local`         | jwt                      | sync **one** offline session                                              |
+| ★   | POST   | `/session/local-all`     | jwt                      | sync many offline sessions ⇒ `{ results:[...] }`                          |
+| ★   | GET    | `/session/:id`           | owner/admin              | get open session                                                          |
+| ★   | POST   | `/session/:id/sync`      | owner/admin              | sync `{ currentTime, timeListened, duration? }` ⇒ 200/500                 |
+| ★   | POST   | `/session/:id/close`     | owner/admin              | close (optional final sync body)                                          |
+
+Open-session middleware (owner-or-admin) + offline merge rule: guide §7.2–7.3.
+
+---
+
+## 5. Playback streaming — HLS & public
+
+| ★   | Method | Path                               | Auth                   | Purpose                                         |
+| --- | ------ | ---------------------------------- | ---------------------- | ----------------------------------------------- |
+| ★   | GET    | `/hls/:stream/:file`               | stream id must be open | HLS `.m3u8`/`.ts`; emits `stream_reset` on seek |
+| ★   | GET    | `/public/session/:id/track/:index` | open session           | stream a direct audio track                     |
+|     | GET    | `/public/share/:slug`              | none                   | media-item share landing                        |
+|     | GET    | `/public/share/:slug/track/:index` | none                   | share audio track                               |
+|     | GET    | `/public/share/:slug/cover`        | none                   | share cover                                     |
+|     | GET    | `/public/share/:slug/download`     | none                   | download shared item                            |
+|     | PATCH  | `/public/share/:slug/progress`     | none (share session)   | update share playback progress                  |
+
+HLS seek/reset behavior: guide §5.3.
+
+---
+
+## 6. Collections — `CollectionController` (/api/collections)
+
+| Method | Path                            | Auth          | Purpose               |
+| ------ | ------------------------------- | ------------- | --------------------- |
+| POST   | `/collections`                  | jwt+canUpdate | create                |
+| GET    | `/collections`                  | jwt           | all (access-filtered) |
+| GET    | `/collections/:id`              | jwt           | one                   |
+| PATCH  | `/collections/:id`              | jwt+canUpdate | update                |
+| DELETE | `/collections/:id`              | jwt+canUpdate | delete                |
+| POST   | `/collections/:id/book`         | jwt+canUpdate | add book              |
+| DELETE | `/collections/:id/book/:bookId` | jwt+canUpdate | remove book           |
+| POST   | `/collections/:id/batch/add`    | jwt+canUpdate | add many              |
+| POST   | `/collections/:id/batch/remove` | jwt+canUpdate | remove many           |
+
+## 7. Playlists — `PlaylistController` (/api/playlists)
+
+| ★   | Method | Path                                             | Auth  | Purpose                |
+| --- | ------ | ------------------------------------------------ | ----- | ---------------------- |
+| ★   | POST   | `/playlists`                                     | jwt   | create                 |
+| ★   | GET    | `/playlists`                                     | jwt   | all for user           |
+|     | GET    | `/playlists/:id`                                 | owner | one                    |
+|     | PATCH  | `/playlists/:id`                                 | owner | update                 |
+|     | DELETE | `/playlists/:id`                                 | owner | delete                 |
+|     | POST   | `/playlists/:id/item`                            | owner | add item               |
+|     | DELETE | `/playlists/:id/item/:libraryItemId/:episodeId?` | owner | remove item            |
+|     | POST   | `/playlists/:id/batch/add`                       | owner | add many               |
+|     | POST   | `/playlists/:id/batch/remove`                    | owner | remove many            |
+|     | POST   | `/playlists/collection/:collectionId`            | jwt   | create from collection |
+
+## 8. Authors — `AuthorController` (/api/authors)
+
+| Method | Path                 | Auth                          | Purpose                           |
+| ------ | -------------------- | ----------------------------- | --------------------------------- |
+| GET    | `/authors/:id`       | jwt                           | one (`?include=items,series`)     |
+| PATCH  | `/authors/:id`       | jwt+canUpdate                 | update                            |
+| DELETE | `/authors/:id`       | admin                         | delete                            |
+| POST   | `/authors/:id/match` | jwt+canUpdate                 | match metadata                    |
+| GET    | `/authors/:id/image` | **none** (GET in ignore list) | author image; `?token=&raw=1&ts=` |
+| POST   | `/authors/:id/image` | jwt+canUpdate                 | upload image                      |
+| DELETE | `/authors/:id/image` | jwt+canUpdate                 | remove image                      |
+
+## 9. Series — `SeriesController` (/api/series)
+
+| Method | Path          | Auth          | Purpose                           |
+| ------ | ------------- | ------------- | --------------------------------- |
+| GET    | `/series/:id` | jwt           | one (`?include=progress,rssfeed`) |
+| PATCH  | `/series/:id` | jwt+canUpdate | update                            |
+
+## 10. Podcasts — `PodcastController` (/api/podcasts)
+
+| Method | Path                               | Auth            | Purpose                         |
+| ------ | ---------------------------------- | --------------- | ------------------------------- |
+| POST   | `/podcasts`                        | admin           | create podcast from feed        |
+| POST   | `/podcasts/feed`                   | jwt             | parse a feed URL                |
+| POST   | `/podcasts/opml/parse`             | jwt             | parse OPML text                 |
+| POST   | `/podcasts/opml/create`            | admin           | bulk-create from OPML feed urls |
+| GET    | `/podcasts/:id/checknew`           | admin           | check for new episodes          |
+| GET    | `/podcasts/:id/downloads`          | jwt             | episode download queue          |
+| GET    | `/podcasts/:id/clear-queue`        | admin           | clear download queue            |
+| GET    | `/podcasts/:id/search-episode`     | admin           | find an episode                 |
+| POST   | `/podcasts/:id/download-episodes`  | admin           | queue episode downloads         |
+| POST   | `/podcasts/:id/match-episodes`     | admin           | quick-match episodes            |
+| GET    | `/podcasts/:id/episode/:episodeId` | jwt             | one episode                     |
+| PATCH  | `/podcasts/:id/episode/:episodeId` | jwt+canUpdate   | update episode                  |
+| DELETE | `/podcasts/:id/episode/:episodeId` | admin+canDelete | remove episode                  |
+
+## 11. Users — `UserController` (/api/users) — admin
+
+| Method | Path                            | Auth  | Purpose                             |
+| ------ | ------------------------------- | ----- | ----------------------------------- |
+| POST   | `/users`                        | admin | create user                         |
+| GET    | `/users`                        | admin | list users                          |
+| GET    | `/users/online`                 | jwt   | online users (from socket presence) |
+| GET    | `/users/:id`                    | admin | one user                            |
+| PATCH  | `/users/:id`                    | admin | update                              |
+| DELETE | `/users/:id`                    | admin | delete                              |
+| PATCH  | `/users/:id/openid-unlink`      | admin | unlink OIDC                         |
+| GET    | `/users/:id/listening-sessions` | admin | user's history                      |
+| GET    | `/users/:id/listening-stats`    | admin | user's stats                        |
+
+## 12. Notifications — `NotificationController` (/api/notifications) — admin
+
+| Method | Path                      | Auth  | Purpose                             |
+| ------ | ------------------------- | ----- | ----------------------------------- |
+| GET    | `/notifications`          | admin | settings + configured notifications |
+| PATCH  | `/notifications`          | admin | update settings                     |
+| GET    | `/notificationdata`       | admin | available events/variables          |
+| GET    | `/notifications/test`     | admin | fire a test event                   |
+| POST   | `/notifications`          | admin | create a notification               |
+| DELETE | `/notifications/:id`      | admin | delete                              |
+| PATCH  | `/notifications/:id`      | admin | update one                          |
+| GET    | `/notifications/:id/test` | admin | send test for one                   |
+
+## 13. Emails / e-reader — `EmailController` (/api/emails) — admin
+
+| Method | Path                           | Auth  | Purpose                   |
+| ------ | ------------------------------ | ----- | ------------------------- |
+| GET    | `/emails/settings`             | admin | SMTP settings             |
+| PATCH  | `/emails/settings`             | admin | update settings           |
+| POST   | `/emails/test`                 | admin | send test email           |
+| POST   | `/emails/ereader-devices`      | admin | manage e-reader devices   |
+| POST   | `/emails/send-ebook-to-device` | jwt   | send an ebook to a device |
+
+## 14. Search (providers) — `SearchController` (/api/search)
+
+| Method | Path                | Auth | Purpose                 |
+| ------ | ------------------- | ---- | ----------------------- |
+| GET    | `/search/covers`    | jwt  | search cover images     |
+| GET    | `/search/books`     | jwt  | search book metadata    |
+| GET    | `/search/podcast`   | jwt  | search podcasts         |
+| GET    | `/search/authors`   | jwt  | search authors          |
+| GET    | `/search/chapters`  | jwt  | search chapters         |
+| GET    | `/search/providers` | jwt  | list metadata providers |
+
+## 15. RSS feeds — `RSSFeedController` (/api/feeds)
+
+| Method | Path                                   | Auth            | Purpose                  |
+| ------ | -------------------------------------- | --------------- | ------------------------ |
+| GET    | `/feeds`                               | admin           | open feeds               |
+| POST   | `/feeds/item/:itemId/open`             | jwt+canDownload | open feed for item       |
+| POST   | `/feeds/collection/:collectionId/open` | jwt+canDownload | open feed for collection |
+| POST   | `/feeds/series/:seriesId/open`         | jwt+canDownload | open feed for series     |
+| POST   | `/feeds/:id/close`                     | admin           | close feed               |
+
+## 16. Shares — `ShareController` (/api/share + /public/share)
+
+| Method                              | Path                   | Auth | Purpose               |
+| ----------------------------------- | ---------------------- | ---- | --------------------- |
+| POST                                | `/share/mediaitem`     | jwt  | create a public share |
+| DELETE                              | `/share/mediaitem/:id` | jwt  | delete a share        |
+| (public `/public/share/*` — see §5) |                        |      |                       |
+
+## 17. Tools — `ToolsController` (/api/tools) — admin
+
+| Method | Path                             | Auth              | Purpose                   |
+| ------ | -------------------------------- | ----------------- | ------------------------- |
+| POST   | `/tools/item/:id/encode-m4b`     | admin+canDownload | encode item to M4B        |
+| DELETE | `/tools/item/:id/encode-m4b`     | admin+canDownload | cancel encode             |
+| POST   | `/tools/item/:id/embed-metadata` | admin+canUpdate   | embed metadata into audio |
+| POST   | `/tools/batch/embed-metadata`    | admin+canUpdate   | batch embed               |
+
+## 18. Backups — `BackupController` (/api/backups) — admin
+
+| Method | Path                    | Auth  | Purpose           |
+| ------ | ----------------------- | ----- | ----------------- |
+| GET    | `/backups`              | admin | list              |
+| POST   | `/backups`              | admin | create            |
+| DELETE | `/backups/:id`          | admin | delete            |
+| GET    | `/backups/:id/download` | admin | download          |
+| GET    | `/backups/:id/apply`    | admin | restore           |
+| POST   | `/backups/upload`       | admin | upload backup     |
+| PATCH  | `/backups/path`         | admin | change backup dir |
+
+## 19. API keys — `ApiKeyController` (/api/api-keys) — admin
+
+| Method | Path            | Auth  | Purpose                           |
+| ------ | --------------- | ----- | --------------------------------- |
+| GET    | `/api-keys`     | admin | list keys                         |
+| POST   | `/api-keys`     | admin | create key (returns the JWT once) |
+| PATCH  | `/api-keys/:id` | admin | update                            |
+| DELETE | `/api-keys/:id` | admin | delete                            |
+
+## 20. Custom metadata providers — (/api/custom-metadata-providers) — admin
+
+| Method | Path                             | Auth  | Purpose |
+| ------ | -------------------------------- | ----- | ------- |
+| GET    | `/custom-metadata-providers`     | admin | list    |
+| POST   | `/custom-metadata-providers`     | admin | create  |
+| DELETE | `/custom-metadata-providers/:id` | admin | delete  |
+
+## 21. Filesystem — `FileSystemController` (/api/filesystem) — admin
+
+| Method | Path                     | Auth  | Purpose             |
+| ------ | ------------------------ | ----- | ------------------- |
+| GET    | `/filesystem`            | admin | list server paths   |
+| POST   | `/filesystem/pathexists` | admin | check a path exists |
+
+## 22. Cache — `CacheController` (/api/cache) — admin
+
+| Method | Path                 | Auth  | Purpose          |
+| ------ | -------------------- | ----- | ---------------- |
+| POST   | `/cache/purge`       | admin | purge all cache  |
+| POST   | `/cache/items/purge` | admin | purge item cache |
+
+## 23. Stats — `StatsController` (/api/stats) — admin
+
+| Method | Path                | Auth  | Purpose           |
+| ------ | ------------------- | ----- | ----------------- |
+| GET    | `/stats/year/:year` | admin | server year stats |
+| GET    | `/stats/server`     | admin | server stats      |
+
+## 24. Misc / settings — `MiscController` (/api)
+
+| Method | Path                | Auth               | Purpose                             |
+| ------ | ------------------- | ------------------ | ----------------------------------- |
+| POST   | `/upload`           | jwt+canUpload      | upload media files                  |
+| GET    | `/tasks`            | jwt                | running/finished tasks              |
+| PATCH  | `/settings`         | admin              | update server settings              |
+| PATCH  | `/sorting-prefixes` | admin              | update sort-ignore prefixes         |
+| POST   | `/authorize`        | jwt (rate-limited) | re-fetch login payload from a token |
+| GET    | `/tags`             | jwt                | all tags                            |
+| POST   | `/tags/rename`      | admin              | rename tag                          |
+| DELETE | `/tags/:tag`        | admin              | delete tag                          |
+| GET    | `/genres`           | jwt                | all genres                          |
+| POST   | `/genres/rename`    | admin              | rename genre                        |
+| DELETE | `/genres/:genre`    | admin              | delete genre                        |
+| POST   | `/validate-cron`    | admin              | validate a cron expr                |
+| GET    | `/auth-settings`    | admin              | auth config                         |
+| PATCH  | `/auth-settings`    | admin              | update auth config                  |
+| POST   | `/watcher/update`   | admin              | force watcher rescan path           |
+| GET    | `/logger-data`      | admin              | recent logs                         |
+
+> `POST /api/authorize` is how a client with only a token re-derives the full login payload
+> (user + serverSettings + libraries) without re-authenticating — useful after a token refresh.

--- a/docs/abs-api/MediaProgress.yaml
+++ b/docs/abs-api/MediaProgress.yaml
@@ -1,0 +1,118 @@
+components:
+  schemas:
+    mediaProgressId:
+      type: string
+      description: The ID of the media progress. For book items this equals the libraryItemId; for podcast episodes it is `{libraryItemId}-{episodeId}`.
+      example: e4bb1afb-4a4f-4dd6-8be0-e615d233185b
+    MediaProgress:
+      type: object
+      description: >-
+        A user's listening/reading progress for a single media item (book) or podcast episode.
+        Upserted via PATCH /api/me/progress and during session sync, and emitted to a user's other
+        sockets as `user_item_progress_updated`. The auto-finish thresholds
+        (markAsFinishedPercentComplete / markAsFinishedTimeRemaining) come from the item's library
+        settings, not a global default.
+      properties:
+        id:
+          $ref: "#/components/schemas/mediaProgressId"
+        libraryItemId:
+          $ref: "./LibraryItem.yaml#/components/schemas/libraryItemId"
+        episodeId:
+          type: string
+          format: uuid
+          nullable: true
+          description: The podcast episode ID, or null for books.
+        mediaItemId:
+          type: string
+          description: The ID of the underlying media item (book or episode).
+        duration:
+          type: number
+          format: float
+          description: The total duration (in seconds) of the media item.
+        progress:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          description: The fraction of the item completed, clamp(currentTime / duration, 0..1).
+          example: 0.25
+        currentTime:
+          type: number
+          format: float
+          description: The current playback position (in seconds).
+        isFinished:
+          type: boolean
+          description: Whether the item has been marked finished.
+        hideFromContinueListening:
+          type: boolean
+          description: Whether to suppress this item from the Continue-listening shelf.
+        ebookLocation:
+          type: string
+          nullable: true
+          description: For ebooks, the EPUB CFI or PDF page location.
+        ebookProgress:
+          type: number
+          format: float
+          nullable: true
+          minimum: 0
+          maximum: 1
+          description: For ebooks, the reading progress fraction.
+        lastUpdate:
+          type: integer
+          format: int64
+          description: The time (ms since POSIX epoch) of the last update.
+        startedAt:
+          $ref: "../schemas.yaml#/components/schemas/createdAt"
+        finishedAt:
+          type: integer
+          format: int64
+          nullable: true
+          description: The time (ms since POSIX epoch) the item was finished, or null.
+        createdAt:
+          $ref: "../schemas.yaml#/components/schemas/createdAt"
+        updatedAt:
+          $ref: "../schemas.yaml#/components/schemas/updatedAt"
+    MediaProgressUpdate:
+      type: object
+      description: >-
+        Request body for PATCH /api/me/progress/{libraryItemId}/{episodeId?}. All fields optional;
+        send only those being changed.
+      properties:
+        duration:
+          type: number
+          format: float
+        currentTime:
+          type: number
+          format: float
+        progress:
+          type: number
+          format: float
+        isFinished:
+          type: boolean
+        hideFromContinueListening:
+          type: boolean
+        ebookLocation:
+          type: string
+        ebookProgress:
+          type: number
+          format: float
+        finishedAt:
+          type: integer
+          format: int64
+          nullable: true
+    SessionSyncRequest:
+      type: object
+      description: Request body for POST /api/session/{id}/sync (and the optional body of /close).
+      properties:
+        currentTime:
+          type: number
+          format: float
+          description: The current media position in seconds.
+        timeListened:
+          type: number
+          format: float
+          description: Seconds listened since the last sync (added to the session's timeListening).
+        duration:
+          type: number
+          format: float
+          description: Total media duration in seconds (optional since v2.15.1).

--- a/docs/abs-api/PlaybackSession.yaml
+++ b/docs/abs-api/PlaybackSession.yaml
@@ -1,0 +1,171 @@
+components:
+  schemas:
+    playbackSessionId:
+      type: string
+      description: The ID of the playback session.
+      format: uuid
+      example: c1a2b3c4-d5e6-4f70-8a9b-0c1d2e3f4a5b
+    playMethod:
+      type: integer
+      description: >-
+        How the media is being played.
+        0 = direct play, 1 = direct stream, 2 = transcode, 3 = local.
+      enum: [0, 1, 2, 3]
+      example: 0
+    PlaybackSession:
+      type: object
+      description: >-
+        A playback session as returned to clients by POST /api/items/{id}/play and
+        GET /api/session/{id} (PlaybackSession.toJSONForClient). The `audioTracks` array differs by
+        play method: for direct play it lists the item's real tracks; for transcode it contains a
+        single synthetic track whose contentUrl points at the HLS playlist under /hls.
+      properties:
+        id:
+          $ref: "#/components/schemas/playbackSessionId"
+        userId:
+          type: string
+          format: uuid
+          description: The ID of the user the session belongs to.
+        libraryId:
+          type: string
+          format: uuid
+          nullable: true
+          description: The ID of the library the item belongs to.
+        libraryItemId:
+          $ref: "./LibraryItem.yaml#/components/schemas/libraryItemId"
+        bookId:
+          type: string
+          format: uuid
+          nullable: true
+          description: The ID of the book media. Null for podcast episode sessions.
+        episodeId:
+          type: string
+          format: uuid
+          nullable: true
+          description: The ID of the podcast episode. Null for book sessions.
+        mediaType:
+          type: string
+          enum: [book, podcast]
+          description: The media type of the library item.
+        mediaMetadata:
+          type: object
+          description: Snapshot of the media metadata at session start.
+        chapters:
+          type: array
+          description: Chapters for the media item.
+          items:
+            type: object
+        displayTitle:
+          type: string
+          description: Title to display for the playing media.
+        displayAuthor:
+          type: string
+          description: Author to display for the playing media.
+        coverPath:
+          type: string
+          nullable: true
+          description: The absolute path on the server of the cover image.
+        duration:
+          type: number
+          format: float
+          description: The total duration (in seconds) of the playing media.
+        playMethod:
+          $ref: "#/components/schemas/playMethod"
+        mediaPlayer:
+          type: string
+          description: The media player the client reported using.
+        deviceInfo:
+          $ref: "#/components/schemas/DeviceInfo"
+        serverVersion:
+          type: string
+          description: The server version the session was created on.
+        date:
+          type: string
+          description: The day the session was started, formatted YYYY-MM-DD.
+          example: "2026-01-01"
+        dayOfWeek:
+          type: string
+          description: The day of the week the session was started.
+          example: Monday
+        timeListening:
+          type: number
+          format: float
+          description: The amount of time (in seconds) the user has listened during this session.
+        startTime:
+          type: number
+          format: float
+          description: The media position (in seconds) at the start of the session (resume point).
+        currentTime:
+          type: number
+          format: float
+          description: The last reported media position (in seconds).
+        startedAt:
+          $ref: "../schemas.yaml#/components/schemas/createdAt"
+        updatedAt:
+          $ref: "../schemas.yaml#/components/schemas/updatedAt"
+        audioTracks:
+          type: array
+          description: The audio tracks the client should play.
+          items:
+            $ref: "./files/AudioTrack.yaml#/components/schemas/AudioTrack"
+        libraryItem:
+          description: >-
+            The expanded library item (toOldJSONExpanded) — the base fields below plus a fully
+            populated `media` object. A dedicated expanded schema is not yet defined in this spec.
+          allOf:
+            - $ref: "./LibraryItem.yaml#/components/schemas/libraryItemBase"
+        coverAspectRatio:
+          type: number
+          nullable: true
+          description: Present only for share sessions.
+    DeviceInfo:
+      type: object
+      description: >-
+        Information about the device a playback session is running on. Built server-side from the
+        request IP and user-agent merged with the client-supplied deviceInfo. When the client sends
+        deviceInfo.deviceId, the server upserts a Device row keyed by it.
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The server-side device record ID.
+        deviceId:
+          type: string
+          nullable: true
+          description: The client-supplied stable device identifier.
+        userId:
+          type: string
+          format: uuid
+          nullable: true
+        ipAddress:
+          type: string
+          nullable: true
+        browserName:
+          type: string
+          nullable: true
+        browserVersion:
+          type: string
+          nullable: true
+        osName:
+          type: string
+          nullable: true
+        osVersion:
+          type: string
+          nullable: true
+        clientName:
+          type: string
+          nullable: true
+          description: The name of the client app (e.g. "Abs Android").
+        clientVersion:
+          type: string
+          nullable: true
+        manufacturer:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        sdkVersion:
+          type: integer
+          nullable: true
+          description: Android SDK version, when applicable.

--- a/docs/abs-api/README.md
+++ b/docs/abs-api/README.md
@@ -1,0 +1,35 @@
+# Audiobookshelf API — Re-implementation Documentation
+
+A standalone, re-implementation-grade description of the Audiobookshelf (ABS) server API. The intent
+is to let a **separate service implement an ABS-compatible API** so that existing ABS clients (the
+official mobile apps and web client) can connect to it unmodified.
+
+## Read in this order
+
+1. **[REIMPLEMENTATION_GUIDE.md](./REIMPLEMENTATION_GUIDE.md)** — the contract narrative: route
+   mounting, auth & token lifecycle, data models, query/error conventions, **streaming & HLS**, the
+   **Socket.IO event contract**, and **progress/offline-sync semantics**. The §8 checklist is the
+   minimum for client compatibility.
+2. **[ENDPOINTS.md](./ENDPOINTS.md)** — every route grouped by domain (method, path, auth, purpose),
+   with client-critical routes marked ★.
+3. **[COVERAGE.md](./COVERAGE.md)** — route-inventory verification + what the existing OpenAPI spec
+   does and doesn't cover + how to extend it.
+
+## Scope & sourcing
+
+- Documented against the v2.35.x server line (`package.json` `version`).
+- Source of truth is server code — primarily `server/routers/ApiRouter.js`,
+  `server/routers/HlsRouter.js`, `server/routers/PublicRouter.js`, `server/Auth.js`,
+  `server/auth/TokenManager.js`, `server/managers/PlaybackSessionManager.js`, and
+  `server/SocketAuthority.js`. The companion OpenAPI spec lives one level up in `docs/`.
+- This set intentionally documents the parts OpenAPI can't model (token rotation, the playback
+  state machine, HLS seek/reset, socket events, sync conflict rules).
+
+## Build a client/server against this
+
+Trace the §8 checklist end-to-end: `GET /status` → `POST /login` → `GET /api/libraries` →
+`GET /api/libraries/:id/items` → `GET /api/items/:id` → `POST /api/items/:id/play` →
+stream (`/hls/...` or `/public/session/:id/track/:index`) → `POST /api/session/:id/sync` → `/close`,
+with a `/socket.io` connection emitting `auth` and handling `stream_reset` /
+`user_item_progress_updated`. If all of that works against your server with an unmodified ABS client,
+you're compatible.

--- a/docs/abs-api/REIMPLEMENTATION_GUIDE.md
+++ b/docs/abs-api/REIMPLEMENTATION_GUIDE.md
@@ -1,0 +1,586 @@
+# Audiobookshelf API — Re-implementation Guide
+
+> **Purpose.** This document describes the Audiobookshelf (ABS) server API as a _contract_ — enough
+> to re-implement a server that the existing ABS clients (official mobile apps and the web client)
+> can connect to unmodified. It covers the parts the machine-readable OpenAPI spec (`docs/openapi.json`)
+> cannot express: the auth/token lifecycle, the playback-session state machine, HLS streaming, the
+> Socket.IO event contract, progress/offline-sync semantics, and the query/error conventions.
+>
+> **Source of truth.** Every claim here is traced to server code. Routes live in
+> `server/routers/ApiRouter.js` (the canonical list), `server/routers/HlsRouter.js`,
+> `server/routers/PublicRouter.js`, and `server/Auth.js`. When in doubt, the code wins.
+>
+> **Companion files:** [`ENDPOINTS.md`](./ENDPOINTS.md) (per-domain endpoint reference) and
+> [`COVERAGE.md`](./COVERAGE.md) (route → handler → documented matrix). Server version documented
+> against: see `package.json` `version` (v2.35.x line).
+
+---
+
+## 1. Overview & conventions
+
+### 1.1 Route mounting
+
+The Express app mounts three routers plus auth/discovery routes at the **router base path** (default
+empty; configurable via `RouterBasePath` for reverse-proxy sub-path hosting). See `server/Server.js:286-369`.
+
+| Prefix                                      | Router                | Auth                                     | Notes                                        |
+| ------------------------------------------- | --------------------- | ---------------------------------------- | -------------------------------------------- |
+| `/api/*`                                    | `ApiRouter`           | JWT required (except 2 image GETs)       | The bulk of the API, ~197 routes             |
+| `/hls/*`                                    | `HlsRouter`           | token in stream path                     | HLS transcode segments/playlists             |
+| `/public/*`                                 | `PublicRouter`        | per-resource (share slug / open session) | Shares + open-session track streaming        |
+| `/login`, `/logout`, `/auth/*`              | `Auth.initAuthRoutes` | n/a                                      | **Mounted at router root, NOT under `/api`** |
+| `/init`, `/status`, `/ping`, `/healthcheck` | `Server.js`           | none                                     | Discovery / first-run                        |
+| `/feed/:slug*`                              | `Server.js`           | none                                     | RSS feed serving                             |
+
+> ⚠️ **Critical for compatibility:** auth and discovery routes are **not** under `/api`. A client
+> POSTs to `/login`, not `/api/login`.
+
+**Reverse-proxy base path.** If `RouterBasePath` is set, every request URL is rewritten to include
+the prefix (`Server.js:289-299`), and `req.originalHostPrefix` (`{protocol}://{host}{prefix}`) is used
+when building absolute URLs (e.g. RSS feeds). A re-implementation hosting under a sub-path must
+replicate this so client-built URLs resolve.
+
+### 1.2 Body parsing limits
+
+- `express.urlencoded({ extended: true, limit: '5mb' })`
+- `express.json({ limit: '10mb' })` (skipped for `/internal-api`)
+- File uploads via `express-fileupload` with temp files (`Server.js:305-316`).
+
+### 1.3 Discovery handshake
+
+A client bootstraps by calling these **before** authenticating:
+
+- `GET /ping` → `{ "success": true }`. Liveness only.
+- `GET /healthcheck` → `200` empty. For load balancers.
+- `GET /status` → server identity + init state. The client uses this to decide whether to show the
+  first-run "create root user" screen and which auth methods to offer:
+
+```jsonc
+{
+  "app": "audiobookshelf",
+  "serverVersion": "2.35.1",
+  "isInit": true, // false => no root user yet
+  "language": "en-us",
+  "authMethods": ["local"], // subset of: local, openid
+  "authFormData": {/* openid button text etc. */},
+  // only when !isInit:
+  "ConfigPath": "/config",
+  "MetadataPath": "/metadata",
+}
+```
+
+- `POST /init` → only valid when `isInit === false` (no root user). Creates the first admin user.
+  Returns `500` if a root user already exists. (`Server.js:341-364`.)
+
+---
+
+## 2. Authentication & token lifecycle
+
+ABS uses **JWT access tokens + opaque-rotating refresh tokens**, with two transport modes (web
+cookies vs mobile headers), plus **API keys** and **OIDC**. Implementation: `server/Auth.js`,
+`server/auth/TokenManager.js`, `server/auth/LocalAuthStrategy.js`, `server/auth/OidcAuthStrategy.js`.
+
+### 2.1 Tokens at a glance
+
+| Token       | Lifetime                           | Signed payload (JWT)                              | Where stored                                                                                                    |
+| ----------- | ---------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **Access**  | 1h (`ACCESS_TOKEN_EXPIRY`, secs)   | `{ userId, username, jti, type: "access", exp }`  | client memory; sent as `Authorization: Bearer`                                                                  |
+| **Refresh** | 30d (`REFRESH_TOKEN_EXPIRY`, secs) | `{ userId, username, jti, type: "refresh", exp }` | web: httpOnly `refresh_token` cookie; mobile: client storage; **server also persists it in a `Session` DB row** |
+| **API key** | configurable / none                | `{ userId?, keyId, type: "api", exp? }`           | created via `/api/api-keys`; sent as Bearer                                                                     |
+
+- Secret: `JWT_SECRET_KEY` env var, else auto-generated 256-byte base64 stored in server settings
+  (`TokenManager.initTokenSecret`). HS256.
+- JWT is accepted from the `Authorization: Bearer` header **or** a `?token=` query param
+  (`Auth.js:126`, `ExtractJwt.fromUrlQueryParameter('token')`). The query-param form is how
+  `<img>`/`<audio>` tags authenticate (covers, tracks).
+- Expiration is checked **manually** in `jwtAuthCheck` (`ignoreExpiration: true` on the strategy),
+  so that expired API keys can be deactivated as a side effect (`TokenManager.js:255-313`).
+
+> 🔎 **Legacy tokens.** Old clients may present a JWT with **no `exp`** (the deprecated
+> `generateAccessToken`). The server still accepts these and flags `user.isOldToken`. A
+> re-implementation should accept non-expiring legacy access tokens if it must serve old app builds,
+> otherwise it can reject tokens without `type`/`exp`.
+
+### 2.2 Local login — `POST /login`
+
+Rate-limited (`authRateLimiter`). Passport `local` strategy validates `{ username, password }`.
+On success the server calls `handleLoginSuccess(req, res, returnTokens)`:
+
+- **Mobile flow:** client sends header `x-return-tokens: true`. Response **body** includes both
+  `user.accessToken` and `user.refreshToken`. No cookie is relied upon.
+- **Web flow:** no header. `user.refreshToken` in the body is `null`; instead the server sets an
+  httpOnly `refresh_token` cookie (`sameSite=lax`, `secure` when behind https) via
+  `setRefreshTokenCookie`.
+
+Each login creates a **server-side `Session` row** (`createTokensAndSession`) keyed by the refresh
+token, storing IP + user-agent + `expiresAt`.
+
+**Login/refresh response payload** (`Auth.getUserLoginResponsePayload`, `Auth.js:96-105`):
+
+```jsonc
+{
+  "user": { /* user.toOldJSONForBrowser() */
+    "id": "...", "username": "...", "type": "root|admin|user|guest",
+    "token": "...",          // legacy non-expiring token (still emitted for old clients)
+    "accessToken": "...",    // 1h JWT  (added in handleLoginSuccess)
+    "refreshToken": "..."|null, // present only for mobile/api flow
+    "mediaProgress": [ /* MediaProgress[] */ ],
+    "bookmarks": [...], "permissions": {...}, "librariesAccessible": [...], ...
+  },
+  "userDefaultLibraryId": "lib_...",
+  "serverSettings": { /* ServerSettings.toJSONForBrowser() */ },
+  "ereaderDevices": [ /* e-reader device configs visible to user */ ],
+  "Source": "docker|..."     // global.Source
+}
+```
+
+### 2.3 Refresh — `POST /auth/refresh`
+
+Rate-limited. The refresh token is taken from the `refresh_token` **cookie** (web) **or** the
+`x-refresh-token` **header** (mobile). If the header is used, the rotated refresh token is returned
+in the response body; otherwise it's only set as a cookie. (`Auth.js:329-357`.)
+
+**Rotation with grace period** (`TokenManager.handleRefreshToken` / `rotateTokensForSession`):
+
+1. Verify JWT signature + `type === "refresh"`.
+2. Find the `Session` row where `refreshToken == token` **OR** `lastRefreshToken == token`.
+3. If it matched `refreshToken`: check DB `expiresAt`; if expired, destroy session → `401`.
+   Otherwise rotate: generate new access + refresh tokens, store the **old** refresh token as
+   `lastRefreshToken` with a **1-minute grace window** (`lastRefreshTokenExpiresAt`), and `UPDATE`
+   the row **only if** `refreshToken` still equals the value we read (optimistic concurrency).
+4. If it matched `lastRefreshToken` and we're still inside the grace window: don't rotate again —
+   issue a fresh access token and return the _current_ refresh token. (Handles races where a client
+   fires two refreshes near-simultaneously.)
+5. Concurrency: if the conditional `UPDATE` affects 0 rows, re-read the row and use its current
+   tokens.
+
+> 🧠 **Why this matters for re-impl:** mobile clients refresh aggressively and sometimes
+> concurrently. Without the `lastRefreshToken` grace window you will spuriously log users out. You
+> must persist sessions server-side; pure stateless JWT refresh will not be wire-compatible.
+
+### 2.4 Logout — `POST /logout`
+
+Reads refresh token from cookie or `x-refresh-token` header, clears the `refresh_token` cookie,
+**destroys the matching `Session` row** (`invalidateRefreshToken`), runs `req.logout()`, and returns
+`{ "redirect_url": <oidc end-session url|null> }`. For OIDC sessions it also clears `openid_id_token`.
+
+### 2.5 API keys
+
+JWTs with `type: "api"` and a `keyId`. On each request `jwtAuthCheck` loads the `ApiKey` row, checks
+`isActive`, and if `exp` has passed it **deactivates the key** (`isActive=false`) and denies. The key
+resolves to its owning `userId`. Managed via `GET/POST/PATCH/DELETE /api/api-keys` (admin).
+
+> Note: API-key auth is **not** currently supported over the socket connection (see §6.1).
+
+### 2.6 OIDC (OpenID Connect)
+
+Optional, enabled when `authActiveAuthMethods` includes `openid`. Routes (`Auth.js:359-472`):
+
+- `GET /auth/openid` — builds the provider authorize URL, stashes callback/state in short-lived
+  cookies (`paramsToCookies`, 2-min TTL). Web callbacks must be **same-origin** (validated).
+- `GET /auth/openid/callback` — exchanges the code; supports PKCE `code_verifier` forwarded by the
+  client (crucial for mobile). On success behaves per the stored `auth_method` cookie (§2.7).
+- `GET /auth/openid/mobile-redirect` — bounces to an app link `audiobookshelf://oauth` for native apps.
+- `GET /auth/openid/config?issuer=...` — admin helper to read `.well-known/openid-configuration`.
+
+**`auth_method` cookie** drives callback behavior: `local`, `api` (mobile native login), `openid`
+(web), `openid-mobile`. API-based methods (`api`, `openid-mobile`) get tokens in the JSON body;
+web methods redirect to the stored callback URL with `?setToken=<legacy>&accessToken=<jwt>&state=...`.
+
+### 2.7 Socket auth handshake
+
+The Socket.IO connection authenticates **separately** from HTTP — see §6.1.
+
+---
+
+## 3. Core data models
+
+These are the shapes clients read. The OpenAPI `docs/objects/*` schemas define the entity bodies
+(LibraryItem, Book, Podcast, Author, Series, AudioFile, AudioTrack, metadata, etc.); below are the
+client-contract models that are **not** in the spec yet.
+
+### 3.1 PlaybackSession (`server/objects/PlaybackSession.js`)
+
+Returned by `POST /api/items/:id/play`, `GET /api/session/:id`. `toJSONForClient`:
+
+```jsonc
+{
+  "id": "uuid",
+  "userId": "uuid",
+  "libraryId": "uuid",
+  "libraryItemId": "uuid",
+  "bookId": "uuid|null",        // null for podcast episode sessions
+  "episodeId": "uuid|null",     // set for podcast episodes
+  "mediaType": "book|podcast",
+  "mediaMetadata": { /* book/podcast metadata snapshot */ },
+  "chapters": [ { "id", "start", "end", "title" } ],
+  "displayTitle": "string",
+  "displayAuthor": "string",
+  "coverPath": "string|null",
+  "duration": 0,                // seconds (float)
+  "playMethod": 0,              // 0=direct, 1=directStream, 2=transcode, 3=local (see PlayMethod)
+  "mediaPlayer": "string",
+  "deviceInfo": { "id", "deviceId", "ipAddress", "clientName", "deviceName", ... },
+  "serverVersion": "2.35.1",
+  "date": "YYYY-MM-DD",
+  "dayOfWeek": "Monday",
+  "timeListening": 0,           // accumulated seconds listened this session
+  "startTime": 0,               // media position (s) at session start = resume point
+  "currentTime": 0,             // last reported position (s)
+  "startedAt": 1680000000000,   // epoch ms
+  "updatedAt": 1680000000000,
+  "audioTracks": [ AudioTrack ],   // see §5.2 — direct vs transcode differ here
+  "libraryItem": { /* expanded library item */ },
+  "coverAspectRatio": 1            // present only for share sessions
+}
+```
+
+`PlayMethod` constants (`server/utils/constants.js`): `DIRECTPLAY=0`, `DIRECTSTREAM=1`,
+`TRANSCODE=2`, `LOCAL=3`.
+
+### 3.2 MediaProgress (the `mediaProgressObject` shape)
+
+The unit of progress sync. The server upserts these via `User.createUpdateMediaProgressFromPayload`.
+The session's contribution (`PlaybackSession.mediaProgressObject`) is:
+
+```jsonc
+{
+  "duration": 0,
+  "currentTime": 0,
+  "progress": 0.0,
+  "lastUpdate": 1680000000000,
+}
+```
+
+`progress` is `clamp(currentTime / duration, 0..1)`. A stored MediaProgress (as seen in
+`user.mediaProgress[]` and emitted on `user_item_progress_updated`) additionally carries:
+`id`, `libraryItemId`, `episodeId|null`, `mediaItemId`, `isFinished`, `hideFromContinueListening`,
+`startedAt`, `finishedAt`, `createdAt`, `updatedAt`.
+
+**Auto-finish rules** (passed into every upsert from the item's library settings):
+`markAsFinishedPercentComplete` and `markAsFinishedTimeRemaining` — when the reported position
+crosses either threshold the item is marked finished. A re-implementation must apply the _library's_
+settings, not a global default.
+
+### 3.3 DeviceInfo
+
+Built server-side from request IP + user-agent merged with the client-supplied `deviceInfo`
+(`PlaybackSessionManager.getDeviceInfo`). If the client sends `deviceInfo.deviceId`, the server
+upserts a `Device` row keyed by it, so sessions from the same device coalesce. Client-supplied fields
+typically include: `deviceId`, `clientName`, `clientVersion`, `manufacturer`, `model`, `sdkVersion`.
+
+---
+
+## 4. Query & response conventions
+
+### 4.1 Pagination & sort
+
+Two conventions coexist (be careful):
+
+- **Library items** (`GET /api/libraries/:id/items`): `limit` (0 = no limit), `page` (0-based);
+  `offset = page * limit`. Sort: `sort=<field>`, `desc=1`. (`LibraryController.getLibraryItems:604`.)
+  Response: `{ results, total, limit, page, sortBy, sortDesc, filterBy, mediaType, minified,
+collapseseries, include, offset }`.
+- **Sessions / listening history** (`GET /api/sessions`, `/api/me/listening-sessions`):
+  `itemsPerPage` (default 10), `page` (0-based), `sort`, `desc=1`. Response:
+  `{ total, numPages, page, itemsPerPage, sessions }`. (`SessionController.getAllWithUserData:29`.)
+
+> ⚠️ Don't unify these. The item endpoint uses `limit`; the session endpoints use `itemsPerPage`,
+> with a whitelist of sortable columns and a different response envelope (`numPages`).
+
+### 4.2 Filtering — the base64 encoding
+
+Library item / series / collection list endpoints accept `filter=<group>.<base64url(value)>`.
+The server splits on the **first** `.`, takes the group, and base64-decodes the remainder
+(`libraryFilters.decode`, used at `LibraryController.js:627-631`). Groups include `genres`,
+`tags`, `series`, `authors`, `narrators`, `languages`, `progress`, `missing`, `ebooks`, etc.
+
+Example: filter by narrator "Stephen Fry" →
+`filter=narrators.` + `base64url("Stephen Fry")`. For ID-based groups the decoded value is the entity
+id; for narrators it's the base64 of the _name_. Get the valid values/ids per library from
+`GET /api/libraries/:id/filterdata`.
+
+### 4.3 Common query flags
+
+| Flag               | Endpoints                  | Meaning                                                           |
+| ------------------ | -------------------------- | ----------------------------------------------------------------- |
+| `minified=1`       | item lists                 | return reduced item objects                                       |
+| `collapseseries=1` | item lists                 | collapse books of a series into one entry                         |
+| `include=<csv>`    | items, libraries           | eager-load extras: e.g. `include=rssfeed,authors,downloads,share` |
+| `expanded=1`       | `GET /api/items/:id`       | full nested media object                                          |
+| `desc=1`           | sortable lists             | descending                                                        |
+| `token=<jwt>`      | cover/image/track GETs     | auth via query param instead of header                            |
+| `raw=1`            | `GET /api/items/:id/cover` | return original cover, bypass resize                              |
+| `ts=<epoch>`       | cover GETs                 | cache-buster                                                      |
+
+### 4.4 Error conventions ⚠️ NOT uniform
+
+There is **no single error-body schema**. Handlers variously use:
+
+- `res.sendStatus(4xx/5xx)` — empty body (very common; e.g. all of `HlsRouter`, much of
+  `SessionController`, every `middleware` permission check returns bare `403/404`).
+- `res.status(4xx).send("plain text message")` — e.g. validation failures.
+- `res.status(4xx).json({ error: "..." })` — auth routes (`/auth/refresh` → `{ error }`).
+- `200` with a domain payload that itself carries `{ error }` / `{ success:false }` (e.g.
+  `syncLocalSessions` returns `{ results: [{ id, success, error? }] }`).
+
+A re-implementation must match **per-endpoint** behavior, not impose a global error envelope, or
+clients that branch on status-only (most of them) vs. body will misbehave. The endpoint reference
+notes the status codes per route where they're non-obvious.
+
+> Notable status quirks: admin-only endpoints often return **`404`** (not `403`) to non-admins to
+> avoid leaking existence (e.g. `SessionController.getAllWithUserData` → `404`). Others return `403`.
+> Follow the code per endpoint.
+
+---
+
+## 5. Streaming & HLS
+
+This is the highest-risk area for compatibility. Entry point:
+`POST /api/items/:id/play` (and `/play/:episodeId`) → `PlaybackSessionManager.startSession`.
+
+### 5.1 Direct-play vs transcode decision
+
+Request body (`startSessionRequest` → `startSession`, `PlaybackSessionManager.js:80-364`):
+
+```jsonc
+{
+  "deviceInfo": { "deviceId": "...", "clientName": "...", "clientVersion": "..." },
+  "mediaPlayer": "AVPlayer|ExoPlayer|...",
+  "forceDirectPlay": false,
+  "forceTranscode": false,
+  "supportedMimeTypes": ["audio/mpeg", "audio/mp4", "audio/flac", ...]
+}
+```
+
+Decision: `shouldDirectPlay = forceDirectPlay || (!forceTranscode && media.checkCanDirectPlay(supportedMimeTypes, episodeId))`.
+
+- **Resume point:** the server seeds `startTime`/`currentTime` from the user's saved MediaProgress
+  (`userProgress.currentTime`), unless the item is **finished**, in which case it starts at 0 (the
+  client restarts the title). The returned session tells the client where to seek.
+- Starting a new session for a (user, device) pair **closes any already-open session** for that pair
+  first (so a device has at most one open session).
+
+### 5.2 The two response shapes
+
+**Direct play** (`playMethod = 0`):
+
+- `audioTracks` = the item's real track list (`libraryItem.getTrackList(episodeId)`), one entry per
+  audio file. Each `AudioTrack` has `index`, `startOffset`, `duration`, `title`, `contentUrl`,
+  `mimeType`, and `metadata.path`. The `contentUrl` points at the file-serving endpoint; the client
+  fetches the actual bytes (with `?token=`), or for an open session via
+  `GET /public/session/:id/track/:index`.
+
+**Transcode** (`playMethod = 2`):
+
+- The server creates a `Stream`, generates an HLS playlist, and **starts ffmpeg**
+  (`stream.generatePlaylist()` + `stream.start()`).
+- `audioTracks` = a **single** synthetic track (`stream.getAudioTrack()`) whose `contentUrl` is the
+  HLS `.m3u8` under `/hls/:streamId/...`. The client plays the playlist.
+
+> 🧩 **Negotiation must be exact.** If `supportedMimeTypes` is wrong/empty the server transcodes
+> unnecessarily (or fails to). Mirror `checkCanDirectPlay`: it compares each audio file's codec/mime
+> against the client's `supportedMimeTypes` and the container's direct-play eligibility.
+
+### 5.3 HLS segment serving — `GET /hls/:stream/:file`
+
+`HlsRouter.streamFileRequest` (`HlsRouter.js:51-98`):
+
+1. The `:stream` segment is the **session/stream id**; the stream must be open in memory
+   (`playbackSessionManager.getStream`) → else `404`.
+2. Path traversal is blocked: the resolved file must stay inside the stream dir, and extension must
+   be `.ts` or `.m3u8` (else `400`).
+3. If the requested `.ts` segment **doesn't exist yet**:
+   - parse its segment number from the filename (`output-<n>.ts`);
+   - if the stream `isResetting`, just `404` (client retries);
+   - else call `stream.checkSegmentNumberRequest(segNum)`. If that returns a `startTimeForReset`
+     (the requested segment is **outside the currently-transcoded window** — i.e. the user seeked),
+     the server **kicks the transcoder to that time** and emits a socket event:
+     ```js
+     SocketAuthority.emitter("stream_reset", { startTime, streamId });
+     ```
+     then `404`s the segment. HLS.js restarts playback at the new `startTime`.
+
+> 🚨 **You must implement `stream_reset`.** Seeking forward/backward beyond the buffered window does
+> **not** work via range requests — the server re-bases the transcode and notifies the client over
+> the socket. A client that ignores `stream_reset` appears to "stick" on seek.
+
+### 5.4 Serving direct track bytes — `GET /public/session/:id/track/:index`
+
+`SessionController.getTrack` (public router, `:279-330`). While a session is open, the client streams
+each audio track here by index. Notable behaviors to replicate:
+
+- Podcast index quirk: index `0` falls back to the first track (old episodes had `null` index).
+- If the session is **transcode** and the track has a `contentUrl`, it **302-redirects** to the HLS
+  URL (compat shim for an old Android build).
+- `X-Accel-Redirect` support when `global.XAccel` is set (nginx internal redirect).
+- Correct audio mime types are forced for `.m4b` etc. (Express guesses wrong) — see
+  `getAudioMimeTypeFromExtname`.
+
+Also relevant: `GET /api/items/:id/file/:fileid[/download]`, `GET /api/items/:id/download` (zip of
+whole item), `GET /api/items/:id/ebook/:fileid?` for ebooks.
+
+---
+
+## 6. Socket.IO event contract
+
+Real-time state is delivered over Socket.IO (`server/SocketAuthority.js`). Clients depend on it for
+live progress sync across devices, library updates, download progress, and the seek `stream_reset`.
+
+### 6.1 Connection & auth
+
+- Path: `/socket.io` (and additionally `<RouterBasePath>/socket.io` when a base path is set — a
+  **second** Socket.IO server is created, `SocketAuthority.js:168-174`).
+- CORS: `origin: '*'`, methods `GET, POST`.
+- After connecting, the client **must emit `auth`** with its **access-token JWT** (not an API key):
+  ```js
+  socket.emit("auth", accessTokenJwt);
+  ```
+  The server validates the JWT directly (`TokenManager.validateAccessToken`), loads the active user,
+  associates the socket with the user, and replies with **`init`**:
+  ```jsonc
+  // to the authing socket
+  {
+    "userId": "...",
+    "username": "...",
+    "usersOnline": [/* admins only */],
+  }
+  ```
+  On failure it emits **`auth_failed`** `{ "message": "Invalid token" | "Invalid user" }`.
+- API keys over the socket are **not** supported yet (`TokenManager.validateAccessToken` only).
+
+### 6.2 Client → server events
+
+| Event                 | Payload                                           | Auth  | Purpose                            |
+| --------------------- | ------------------------------------------------- | ----- | ---------------------------------- |
+| `auth`                | `token` (JWT string)                              | —     | associate socket with user (above) |
+| `ping`                | —                                                 | any   | server replies `pong`              |
+| `cancel_scan`         | `libraryId`                                       | admin | cancel a running library scan      |
+| `search_covers`       | `{ requestId, title, author, provider, podcast }` | user  | stream cover-search results        |
+| `cancel_cover_search` | `requestId`                                       | user  | cancel a cover search              |
+| `set_log_listener`    | `level` (int LogLevel)                            | admin | stream server logs to this socket  |
+| `remove_log_listener` | —                                                 | admin | stop log streaming                 |
+| `message_all_users`   | `{ message }`                                     | admin | broadcast `admin_message` toast    |
+
+### 6.3 Server → client events (the ones clients act on)
+
+Emitted via three fan-out helpers — **match the targeting**, it's part of the contract:
+`emitter` (all authed clients), `clientEmitter(userId, …)` (one user's sockets),
+`adminEmitter` (admins only), plus `libraryItemEmitter`/`libraryItemsEmitter` (access-filtered).
+
+| Event                                                                                                      | Target            | Payload                                                     | Meaning                                                                        |
+| ---------------------------------------------------------------------------------------------------------- | ----------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `init`                                                                                                     | socket            | `{ userId, username, usersOnline? }`                        | post-auth bootstrap                                                            |
+| `auth_failed`                                                                                              | socket            | `{ message }`                                               | socket auth rejected                                                           |
+| `pong`                                                                                                     | socket            | —                                                           | reply to `ping`                                                                |
+| `user_item_progress_updated`                                                                               | user              | `{ id, sessionId, deviceDescription, data: MediaProgress }` | **another device updated progress** — clients re-sync the now-playing position |
+| `user_session_closed`                                                                                      | user              | `sessionId` (string)                                        | a playback session was closed                                                  |
+| `user_stream_update`                                                                                       | admin             | `user.toJSONForPublic(sessions)`                            | a user's open streams changed                                                  |
+| `user_online` / `user_offline`                                                                             | admin             | `user.toJSONForPublic(sessions)`                            | presence                                                                       |
+| `stream_reset`                                                                                             | all               | `{ startTime, streamId }`                                   | **seek re-base** (see §5.3)                                                    |
+| `item_updated` / `item_added` / `item_removed`                                                             | access-filtered   | expanded LibraryItem                                        | library item changes                                                           |
+| `items_added` / `items_updated`                                                                            | access-filtered   | LibraryItem[]                                               | batch item changes                                                             |
+| `library_added`/`_updated`/`_removed`                                                                      | all               | Library                                                     | library CRUD                                                                   |
+| `series_added`/`_updated`/`_removed`                                                                       | all               | Series                                                      | series changes                                                                 |
+| `author_added`/`_updated`/`_removed`                                                                       | all               | Author                                                      | author changes                                                                 |
+| `collection_added`/`_updated`/`_removed`                                                                   | all               | Collection                                                  | collection changes                                                             |
+| `playlist_added`/`_updated`/`_removed`                                                                     | user              | Playlist                                                    | playlist changes                                                               |
+| `episode_download_queued`/`_started`/`_finished`/`_queue_cleared`                                          | admin             | download item                                               | podcast episode downloads                                                      |
+| `task_started`/`task_finished`/`task_progress`                                                             | varies            | Task                                                        | long-running jobs (scan, m4b encode, embed)                                    |
+| `admin_message`                                                                                            | all               | string                                                      | toast from an admin                                                            |
+| `cover_search_result`/`_complete`/`_provider_error`/`_error`/`_cancelled`                                  | requesting socket | `{ requestId, ... }`                                        | streamed cover search                                                          |
+| `rss_feed_open`/`rss_feed_closed`                                                                          | varies            | feed                                                        | RSS feed lifecycle                                                             |
+| `metadata_embed_queue_update`, `backup_applied`, `notifications_updated`, `ereader-devices-updated`, `log` | varies            | —                                                           | misc admin/UI updates                                                          |
+
+> For a minimal compatible client you must handle at least: `init`, `auth_failed`,
+> `user_item_progress_updated`, `user_session_closed`, `stream_reset`, and the `item_*` updates.
+
+---
+
+## 7. Progress & session sync semantics
+
+There are **two overlapping mechanisms**. A re-implementation must support both because different
+clients/states use different ones.
+
+### 7.1 Stateless progress upsert — `PATCH /api/me/progress/:libraryItemId/:episodeId?`
+
+Direct upsert of a MediaProgress for the current user (`MeController.createUpdateMediaProgress`).
+Body carries some/all of `{ duration, currentTime, progress, isFinished, hideFromContinueListening,
+ebookLocation, ebookProgress, finishedAt, markAsFinished... }`. Used for quick "set finished",
+ebook progress, and lightweight position saves. Batch variant: `PATCH /api/me/progress/batch/update`
+(array of such payloads). Remove: `DELETE /api/me/progress/:id`. Read:
+`GET /api/me/progress/:id/:episodeId?`.
+
+### 7.2 Stateful open session — `/api/session/:id/sync` & `/close`
+
+Used during active playback. Lifecycle:
+
+1. `POST /api/items/:id/play` opens a session (held **in memory** in `playbackSessionManager.sessions`).
+2. Periodically the client `POST /api/session/:id/sync` with
+   `{ currentTime, timeListened, duration? }` (`SessionController.sync`).
+   - `syncSession` (`PlaybackSessionManager.js:373-412`): sets `currentTime`, **adds** `timeListened`
+     to the session's `timeListening`, then upserts MediaProgress (applying the library's
+     auto-finish thresholds) and emits `user_item_progress_updated` to the user's other sockets.
+   - Responds **`200`** on success, **`500`** on failure (no body).
+3. `POST /api/session/:id/close` with optional final sync body (same shape). If a body is present it
+   syncs first; then saves, emits `user_stream_update` + `user_session_closed`, and removes the
+   in-memory session. Closing requires the open-session middleware (owner or admin, else `403/404`).
+4. `GET /api/session/:id` returns the open session (`toJSONForClient`).
+
+**Accounting details to replicate:**
+
+- `timeListening` accumulates _reported listened seconds_, not wall-clock or position delta.
+- `date` / `dayOfWeek` are stamped (`YYYY-MM-DD`, e.g. `Monday`) and drive listening stats.
+- A session is **only persisted to the DB once it has non-zero `timeListening`** (`saveSession`).
+- Stale open sessions (no update in 36h) are dropped; orphan stream dirs are GC'd.
+
+### 7.3 Offline reconciliation — `POST /api/session/local` & `/local-all`
+
+How the mobile app uploads playback recorded while offline
+(`PlaybackSessionManager.syncLocalSession`, `:127-274`):
+
+- `/session/local` syncs **one** local session; `/session/local-all` takes `{ sessions: [...] }` and
+  returns `{ results: [{ id, success, progressSynced, error? }] }`.
+- Local sessions arrive with client-generated ids (legacy `play_local_*` ids get remapped to UUIDs
+  and remembered in `oldPlaybackSessionMap`). Legacy `li_`/`ep_`/`lib_`/`local_` ids are stripped.
+- The server backfills missing `mediaMetadata`/`displayTitle`/`displayAuthor`/`duration` from the
+  current library item, inserts or updates the persisted session, then **conditionally** updates
+  MediaProgress: it **skips** updating if the stored progress is _newer_ than the incoming session
+  (`userProgress.updatedAt > session.updatedAt`) — a last-write-by-timestamp merge. On success emits
+  `user_item_progress_updated`.
+
+> 🧠 **Conflict rule to copy exactly:** newest `updatedAt` wins per media item. Getting this wrong
+> causes offline listening to silently overwrite newer cross-device progress (or vice-versa).
+
+### 7.4 Continue-listening
+
+- `GET /api/me/items-in-progress` — the "Continue" shelf.
+- `GET /api/me/progress/:id/remove-from-continue-listening` — hide one item.
+- `GET /api/me/series/:id/remove-from-continue-listening` / `.../readd-to-continue-listening`.
+- Items auto-marked finished (via thresholds) drop off; `hideFromContinueListening` suppresses
+  manually.
+
+---
+
+## 8. Re-implementation checklist (minimum viable client compatibility)
+
+1. **Discovery:** `GET /status`, `/ping`; `POST /init` first-run.
+2. **Auth:** `POST /login` (both `x-return-tokens` and cookie modes), `POST /auth/refresh`
+   (header + cookie, with `lastRefreshToken` grace window + server-side `Session` rows),
+   `POST /logout`. JWT HS256 with `{ userId, username, jti, type, exp }`; accept Bearer and `?token=`.
+3. **User/libraries:** `GET /api/me`, `GET /api/libraries`, `GET /api/libraries/:id`.
+4. **Browse:** `GET /api/libraries/:id/items` (limit/page/sort/`filter=group.base64`),
+   `/personalized`, `/filterdata`, `/search`, `/series`, `/collections`, `/recent-episodes`.
+5. **Item + cover:** `GET /api/items/:id` (`?expanded=1`), `GET /api/items/:id/cover` (token in query,
+   unauthenticated path).
+6. **Playback:** `POST /api/items/:id/play(/:episodeId)` with correct `supportedMimeTypes`; handle
+   both direct-play `audioTracks` and transcode `.m3u8`; serve `/hls/:stream/:file` and emit
+   `stream_reset` on out-of-window seeks; serve `/public/session/:id/track/:index`.
+7. **Sync:** `POST /api/session/:id/sync` + `/close`; `PATCH /api/me/progress/...`;
+   `POST /api/session/local-all` with newest-`updatedAt`-wins merge.
+8. **Socket:** `/socket.io`, emit `auth`, handle `init`/`auth_failed`/`user_item_progress_updated`/
+   `user_session_closed`/`stream_reset`/`item_*`.
+9. **Conventions:** dual pagination envelopes, base64 filters, per-endpoint error/status behavior.
+
+See [`ENDPOINTS.md`](./ENDPOINTS.md) for the full per-route reference and [`COVERAGE.md`](./COVERAGE.md)
+for the completeness matrix.

--- a/docs/abs-api/TODO.md
+++ b/docs/abs-api/TODO.md
@@ -1,0 +1,200 @@
+# ABS API — Implementation TODO
+
+Gap list between the documented upstream surface ([`ENDPOINTS.md`](./ENDPOINTS.md), ~215 routes)
+and the routes actually wired up in `server/src/modules/abs/`. Generated 2026-06-19; refreshed
+2026-07-13 against the controllers.
+
+**★** = client-critical per `ENDPOINTS.md` (needed for a working mobile/web client). These should be
+prioritised. Unmarked rows are admin/server-management routes that may be deferred by design — confirm
+against `REIMPLEMENTATION_GUIDE.md` before treating as required.
+
+> Status snapshot (2026-07-12): ~53/215 routes implemented (the client-critical vertical slice —
+> verified end-to-end with Prologue). Controllers present: `abs-libraries`,
+> `abs-items` (incl. `batch/get`, file stream/download, cover), `abs-me`, `abs-sessions`,
+> `abs-playlists` (list only), `abs-authors` (`GET :id` only), `abs-public`, `abs-hls`,
+> `abs-authorize`, `auth/abs-auth`, `auth/abs-discovery`, `auth/abs-openid`.
+
+---
+
+## Priority 1 — client-critical (★) gaps in existing controllers
+
+These belong to controllers that already exist; the slice is incomplete.
+
+### Streaming / playback
+
+- [x] **★ `GET /hls/:stream/:file`** — HLS playlist/segment streaming. Implemented: transcode
+      negotiation (`playMethod=2`) in `abs-playback.service.ts`, ffmpeg-backed stream manager in
+      `abs-transcode.service.ts`, route in `abs-hls.controller.ts`, and `stream_reset` socket emit on
+      out-of-window seeks (REIMPLEMENTATION_GUIDE §5.1–5.3).
+- [x] **★ `GET /items/:id/file/:fileid`** — inline file stream. Implemented: `streamFileInline` in
+      `abs-items.controller.ts` + `getItemFile` in `abs-catalog.service.ts` (jwt + library access only,
+      no `canDownload`), range-aware via `abs-stream.service.ts`.
+- [ ] **★ public share track** — `GET /public/share/:slug/track/:index` (+ landing/cover/download/progress, see Priority 2 §Shares)
+
+### Playlists (only `GET /playlists` list is implemented)
+
+- [ ] **★ `POST /playlists`** — create
+- [ ] `GET /playlists/:id`
+- [ ] `PATCH /playlists/:id`
+- [ ] `DELETE /playlists/:id`
+- [ ] `POST /playlists/:id/item` / `DELETE /playlists/:id/item/:libraryItemId/:episodeId?` (episode param N/A — BookOrbit items have no episodes)
+- [ ] `POST /playlists/:id/batch/add` / `POST /playlists/:id/batch/remove`
+- [ ] `POST /playlists/collection/:collectionId` — create from collection
+
+---
+
+## Priority 2 — remaining gaps in existing controllers
+
+### Auth / discovery (OIDC)
+
+Thin adapter (`abs-openid.controller.ts`) over BookOrbit's existing OIDC stack (`OidcService`); mirrors ABS
+`OidcAuthStrategy`/`Auth.js`. Same provider record, claim mapping, and auto-provisioning, so an ABS OIDC login
+resolves to the same BookOrbit user as the web flow. `/status` advertises `openid` + button text when a provider
+is enabled. Flow is detected as ABS does (`response_type=code` | `redirect_uri` | `code_challenge` ⇒ mobile).
+**Operator note:** register `<server>/auth/openid/callback` (web) and `<server>/auth/openid/mobile-redirect`
+(mobile — IdPs can't redirect to the `audiobookshelf://` app scheme) as allowed redirect URIs on the IdP client;
+same client/provider as BookOrbit's web login (which uses `<appUrl>/oauth2-callback`). ABS has no provider
+selection, so the first enabled provider is used.
+
+- [x] `GET /auth/openid` — authorize redirect. Web: server-owned PKCE, IdP→`/callback`. Mobile: native client owns PKCE (`code_challenge` relayed), client `state` preserved, IdP→`/mobile-redirect`
+- [x] `GET /auth/openid/callback` — code exchange (verifier server-stashed or client-forwarded); tokens as JSON for mobile/native, same-origin redirect for web
+- [x] `GET /auth/openid/mobile-redirect` — IdP hop: bounces the auth `code` (no token) to `audiobookshelf://oauth`; app then calls `/callback` with the verifier
+- [x] `GET /auth/openid/config` — admin-only `.well-known` read (403 to non-admin)
+
+### Library items (writes & extras)
+
+- [ ] `POST /items/batch/delete`, `batch/update`, `batch/quickmatch`, `batch/scan`
+- [ ] `DELETE /items/:id`
+- [ ] `PATCH /items/:id/media`
+- [ ] `POST /items/:id/cover` (upload), `PATCH /items/:id/cover` (set), `DELETE /items/:id/cover`
+- [ ] `POST /items/:id/match`
+- [ ] `PATCH /items/:id/tracks`
+- [ ] `POST /items/:id/scan`
+- [ ] `GET /items/:id/metadata-object`
+- [ ] `POST /items/:id/chapters`
+- [ ] `GET /items/:id/ffprobe/:fileid`
+- [ ] `DELETE /items/:id/file/:fileid`
+- [ ] `GET /items/:id/ebook/:fileid?`, `PATCH /items/:id/ebook/:fileid/status` — note: until ebook
+      support lands (`ebookFile` is always `null`), books without a playable audio content file are
+      intentionally invisible to ABS clients: `AbsReadRepository` gates every book query on an
+      audio-content-file `EXISTS` (they would otherwise render as track-less, unplayable items)
+
+### Current user (`/me`)
+
+- [x] `GET /me/listening-sessions` — real paginated history from the persisted `abs_playback_sessions` log, ABS envelope math (`itemsPerPage` default 10 / `page` default 0)
+- [x] `GET /me/item/listening-sessions/:libraryItemId/:episodeId?` — per-item history filtered by book id; 404s on garbage/unknown items (episode param N/A — BookOrbit items have no episodes)
+- [x] `GET /me/listening-stats` — real aggregates from persisted sessions, mirrors `ApiRouter.getUserListeningStatsHelpers` bug-for-bug (`items[]` entries carry NO `lastUpdate` key, like ABS 2.35.1)
+- [x] `GET /me/progress/:id/remove-from-continue-listening` — persisted `hide_from_continue_listening` flag on `audiobook_progress`; clears when the position moves, ABS-asymmetric shelf filtering (`/personalized` filters hidden, `items-in-progress` does not)
+- [x] `DELETE /me/progress/:id` — deletes the `audiobook_progress` row via `AbsProgressService#deleteProgress`; accepts the composite `usr_<u>-li_<b>` id (or bare `li_<b>`), verifies the user segment, 404 when absent
+- [x] `PATCH /me/password` — delegates to `AuthService.changePassword` (single source of truth: hashing, audit event, web-session revocation, OIDC/shared blocking); maps to ABS wire shapes (demo → 403, bad input/wrong current password → 400 text, success → 200). Enforces BookOrbit's password policy so the ABS route isn't a weak-password side door
+- [ ] `GET /me/series/:id/remove-from-continue-listening` / `readd-to-continue-listening` — blocked
+      on storage: ABS keeps this in user `extraData.seriesHideFromContinueListening`, which has no
+      BookOrbit home yet; implement when a client is seen calling it (Still hit the item-level route)
+- [x] `GET /me/stats/year/:year` — real year-in-review from persisted sessions (mirrors `userStats.js getStatsForYear`: top-3 authors/genres with substring junk-genre filter, months, narrator; finished side approximated from MediaProgress `finishedAt`)
+- [ ] `POST /me/ereader-devices`
+
+### Sessions (admin side)
+
+Unblocked by the persisted `abs_playback_sessions` log (2026-07-13) but deliberately deferred to a
+follow-up: superuser-gated, new `abs-admin-sessions.controller.ts`, repo gains
+`listAllPaginated`/`deleteById(s)`.
+
+- [ ] `GET /sessions` (admin, 404 to non-admin)
+- [ ] `DELETE /sessions/:id`
+- [ ] `GET /sessions/open`
+- [ ] `POST /sessions/batch/delete`
+
+### Libraries (admin / podcast)
+
+- [ ] `POST /libraries` (create), `PATCH /libraries/:id`, `DELETE /libraries/:id`
+- [ ] `DELETE /libraries/:id/issues`
+- [ ] `GET /libraries/:id/series/:seriesId`
+- [ ] `GET /libraries/:id/stats`
+- [x] `GET /libraries/:id/authors` — authors with in-library book counts (primary browse axis for author-centric clients, e.g. Prologue)
+- [ ] `GET /libraries/:id/narrators`, `PATCH`/`DELETE /libraries/:id/narrators/:narratorId`
+- [ ] `GET /libraries/:id/matchall`, `POST /libraries/:id/scan`
+- [ ] `POST /libraries/order`, `POST /libraries/:id/remove-metadata`
+- [ ] `GET /libraries/:id/download`
+
+### Public shares (rest of §5)
+
+- [ ] `GET /public/share/:slug` (landing)
+- [ ] `GET /public/share/:slug/cover`
+- [ ] `GET /public/share/:slug/download`
+- [ ] `PATCH /public/share/:slug/progress`
+
+---
+
+## Priority 3 — controllers not started
+
+Each is a whole domain with zero routes today.
+
+- [ ] **Collections** (`/api/collections`) — 9 routes (CRUD + book add/remove + batch)
+- [~] **Authors** (`/api/authors`) — `GET /authors/:id` (with `?include=items,series`) implemented; remaining: update/delete, match, image get/upload/delete
+- [ ] **Series** standalone (`/api/series`) — 2 routes (get one, update)
+- [ ] **Users** (`/api/users`, admin) — 9 routes
+- [ ] **Notifications** (`/api/notifications`, admin) — 8 routes (reduced relevance: ABS events are mostly `onPodcastEpisodeDownloaded`; without podcasts only backup/test events remain)
+- [ ] **Emails / e-reader** (`/api/emails`) — 5 routes
+- [ ] **Search providers** (`/api/search`) — 6 routes (covers/books/~~podcast~~/authors/chapters/providers; `GET /search/podcast` N/A — no podcast support)
+- [ ] **RSS feeds** (`/api/feeds`) — 5 routes
+- [ ] **Shares** (`/api/share`) — `POST /share/mediaitem`, `DELETE /share/mediaitem/:id` (public side in Priority 2)
+- [ ] **Tools** (`/api/tools`, admin) — 4 routes (encode-m4b, embed-metadata)
+- [ ] **Backups** (`/api/backups`, admin) — 7 routes
+- [ ] **API keys** (`/api/api-keys`, admin) — 4 routes
+- [ ] **Custom metadata providers** (`/api/custom-metadata-providers`, admin) — 3 routes
+- [ ] **Filesystem** (`/api/filesystem`, admin) — 2 routes
+- [ ] **Cache** (`/api/cache`, admin) — 2 routes
+- [ ] **Stats** (`/api/stats`, admin) — 2 routes
+- [ ] **Misc / settings** (`/api`, admin) — 16 routes (`/upload`, `/tasks`, `/settings`, tags, genres,
+      `/validate-cron`, `/auth-settings`, `/watcher/update`, `/logger-data`, …). `POST /authorize` already done.
+
+---
+
+## Priority 4 — podcasts (not planned)
+
+BookOrbit does not currently support podcasts, so this part of the ABS API is **out of scope**. These
+routes are tracked only for completeness against the upstream surface; do not implement them unless
+podcast support is added to BookOrbit. Even the ★ client-critical markings below are deprioritised here.
+
+- [ ] **★ `POST /items/:id/play/:episodeId`** — podcast-episode playback (book `play` exists, episode variant missing)
+- [ ] **★ `GET /libraries/:id/recent-episodes`** — podcast "latest" shelf
+- [ ] `GET /libraries/:id/episode-downloads`
+- [ ] `GET /libraries/:id/opml`, `GET /libraries/:id/podcast-titles`
+- [ ] **Podcasts** (`/api/podcasts`) — 13 routes (feed parse, OPML, episodes, downloads, match)
+
+---
+
+## Behavioral gaps — routes that exist but don't match ABS semantics/values
+
+The route checklist above misses these: the endpoint responds with a valid ABS shape, but the
+_content_ diverges from what real ABS 2.35.1 would return (strict-Codable clients care about values
+as much as shapes).
+
+- ~~**No listening-session history.**~~ **Resolved 2026-07-13**: sessions persist to
+  `abs_playback_sessions` with ABS semantics (row appears only once
+  `timeListening > 0`; sync/close/device-takeover save, stale-prune doesn't; `session/local[-all]`
+  upsert by client id). The four `/me` history/stats endpoints serve real data; admin session routes
+  are now unblocked (still deferred, see above). Remaining approximation: `finishedAt` in year stats
+  is the progress row's `updatedAt` once past the library finish threshold (BookOrbit has no
+  persisted finish timestamp).
+- **Playlists are a hardcoded empty list.** `GET /api/playlists` returns `{results: [], total: 0}`;
+  no playlist model exists. Any client playlist UI is inert.
+- **Ebook-only books are invisible by design.** `AbsReadRepository` gates every query on an
+  audio-content-file `EXISTS`; `ebookFile` is always `null` and the `/items/:id/ebook` routes are
+  absent. ABS ereader clients see an audiobook-only subset of the library.
+- **`titleIgnorePrefix` / `nameIgnorePrefix` don't move articles** ("The …" sorts under T).
+- **Socket surface is the client-critical subset only.** Implemented: `auth`/`init`/`auth_failed`,
+  `ping`/`pong`, `user_item_progress_updated`, `user_session_closed`, `stream_reset`, item/library
+  added/updated/removed. Missing vs `SocketAuthority`: `user_online`/`user_offline` presence
+  (`init.usersOnline` is always `[]`), `user_updated`, scan/task/backup progress events,
+  `admin_message`, cover-search events.
+- **No user `extraData`** (`seriesHideFromContinueListening` etc.) — blocks the series-level
+  continue-listening routes above.
+- Pre-existing `architecture-boundaries.test.ts` failure (abs-session/abs-bookmark/abs-progress
+  inject DB directly) needs its own cleanup.
+
+## Notes
+
+- Counts are documented-route counts from `ENDPOINTS.md`, not a commitment to ship all of them.
+- Reconcile this list with `COVERAGE.md` (doc coverage) to split
+  "deferred by design" (much of the admin/server-management surface) from "genuinely pending."

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "db:seed": "bash ./scripts/db/seed-baseline.sh",
     "e2e:db:prepare": "bash ./scripts/e2e/prepare-db.sh",
     "e2e:db:migrate": "pnpm --filter server e2e:db:migrate",
+    "abs:capture": "node ./tools/abs-capture-proxy/abs-capture-proxy.mjs",
     "prepare": "husky"
   },
   "engines": {

--- a/server/.env.example
+++ b/server/.env.example
@@ -50,6 +50,9 @@ APP_DATA_PATH=../local/data
 # Allow OIDC issuer/discovery URLs that resolve to private/local addresses in production.
 # Default false. Keep false unless you intentionally trust your private network.
 # OIDC_ALLOW_LOCAL_ISSUERS=false
+# Extra mobile redirect URIs allowed for the Audiobookshelf-compatible OIDC login,
+# beyond the built-in `audiobookshelf://oauth`. Comma-separated, exact-match (no wildcards).
+# ABS_OIDC_MOBILE_REDIRECT_URIS=stillapp://oauth,prologue://oauth
 
 # App URL (used for building password reset links in emails)
 APP_URL=http://localhost:5173

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -72,6 +72,7 @@ import { CustomIconModule } from './modules/custom-icon/custom-icon.module';
 import { AccountActivityModule } from './modules/account-activity/account-activity.module';
 import { SharedReadingInsightsModule } from './modules/shared-reading-insights/shared-reading-insights.module';
 import { BookDuplicatesModule } from './modules/book-duplicates/book-duplicates.module';
+import { AbsModule } from './modules/abs/abs.module';
 
 @Module({
   imports: [
@@ -151,6 +152,7 @@ import { BookDuplicatesModule } from './modules/book-duplicates/book-duplicates.
     AccountActivityModule,
     SharedReadingInsightsModule,
     BookDuplicatesModule,
+    AbsModule,
   ],
   providers: [
     { provide: APP_INTERCEPTOR, useClass: AuditInterceptor },

--- a/server/src/common/filters/http-exception.filter.test.ts
+++ b/server/src/common/filters/http-exception.filter.test.ts
@@ -3,11 +3,11 @@ import { BadRequestException, HttpException, HttpStatus, Logger } from '@nestjs/
 
 import { GlobalExceptionFilter } from './http-exception.filter';
 
-function makeHost(options: { sent?: boolean } = {}) {
+function makeHost(options: { sent?: boolean; url?: string } = {}) {
   const send = vi.fn();
   const status = vi.fn().mockReturnValue({ send });
   const reply = { status, sent: options.sent ?? false };
-  const request = { url: '/api/books/1', id: 'req-123' };
+  const request = { url: options.url ?? '/api/books/1', id: 'req-123' };
 
   const host = {
     switchToHttp: () => ({
@@ -111,5 +111,24 @@ describe('GlobalExceptionFilter', () => {
     filter.catch(new BadRequestException('too late'), host);
 
     expect(status).not.toHaveBeenCalled();
+  });
+
+  it('sends a bare status (no envelope) when the suppress predicate matches the request url', () => {
+    const filter = new GlobalExceptionFilter((url) => url.startsWith('/api/me'));
+    const { host, status, send } = makeHost({ url: '/api/me/listening-sessions' });
+
+    filter.catch(new HttpException('Not Found', HttpStatus.NOT_FOUND), host);
+
+    expect(status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    expect(send).toHaveBeenCalledWith();
+  });
+
+  it('still emits the envelope for urls the suppress predicate rejects', () => {
+    const filter = new GlobalExceptionFilter((url) => url.startsWith('/api/me'));
+    const { host, send } = makeHost({ url: '/api/books/1' });
+
+    filter.catch(new BadRequestException('invalid query'), host);
+
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ statusCode: HttpStatus.BAD_REQUEST }));
   });
 });

--- a/server/src/common/filters/http-exception.filter.ts
+++ b/server/src/common/filters/http-exception.filter.ts
@@ -5,6 +5,13 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 export class GlobalExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(GlobalExceptionFilter.name);
 
+  /**
+   * `suppressEnvelopeFor` lets a foreign-protocol adapter (the ABS API) opt its routes out of
+   * BookOrbit's JSON error envelope. When it matches the request URL, the filter replies with a bare
+   * status and empty body — the shape unmatched ABS routes need (see abs-route-rewrite.util.ts).
+   */
+  constructor(private readonly suppressEnvelopeFor?: (url: string) => boolean) {}
+
   catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const reply = ctx.getResponse<FastifyReply>();
@@ -33,6 +40,11 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     }
 
     if (reply.sent) {
+      return;
+    }
+
+    if (this.suppressEnvelopeFor?.(request.url)) {
+      reply.status(status).send();
       return;
     }
 

--- a/server/src/common/utils/bootstrap.utils.test.ts
+++ b/server/src/common/utils/bootstrap.utils.test.ts
@@ -264,12 +264,33 @@ describe('empty request body bootstrap handling', () => {
     const chunks: Buffer[] = [];
 
     for await (const chunk of stream) {
+      // Fastify Buffer.concat()s the raw chunks without coercion; a string chunk crashes the process.
       expect(Buffer.isBuffer(chunk)).toBe(true);
       chunks.push(Buffer.from(chunk));
     }
 
     expect(headers['content-length']).toBe('2');
     expect(Buffer.concat(chunks).toString('utf8')).toBe('{}');
+  });
+
+  it('parses an empty application/json request through the real JSON parser without crashing', async () => {
+    // Regression: Plappa sends POST /api/authorize with content-type application/json and
+    // content-length 0. The injected replacement stream must yield Buffer chunks — Fastify's
+    // default JSON parser Buffer.concat()s them, and a string chunk threw an uncatchable
+    // ERR_INVALID_ARG_TYPE inside a stream callback, killing the server process.
+    await withEmptyJsonHookApp(async (app) => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/body',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': '0',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ body: {} });
+    });
   });
 
   it('accepts empty unsupported content types as an empty object', async () => {
@@ -374,6 +395,26 @@ describe('empty request body bootstrap handling', () => {
 async function withParserApp(run: (app: FastifyInstance) => Promise<void>): Promise<void> {
   const app = Fastify({ logger: false });
   registerEmptyBodyContentTypeParser(app);
+  app.post('/body', (request) => ({ body: request.body ?? null }));
+
+  try {
+    await app.ready();
+    await run(app);
+  } finally {
+    await app.close();
+  }
+}
+
+/** A Fastify app wired with the same empty-JSON-body preParsing hook as `main.ts`. */
+async function withEmptyJsonHookApp(run: (app: FastifyInstance) => Promise<void>): Promise<void> {
+  const app = Fastify({ logger: false });
+  app.addHook('preParsing', (request, _reply, payload, done) => {
+    if (shouldInjectEmptyJsonBody(request.method, request.headers)) {
+      done(null, buildEmptyJsonBodyStream(request.headers));
+      return;
+    }
+    done(null, payload);
+  });
   app.post('/body', (request) => ({ body: request.body ?? null }));
 
   try {

--- a/server/src/common/utils/bootstrap.utils.ts
+++ b/server/src/common/utils/bootstrap.utils.ts
@@ -80,6 +80,8 @@ export function shouldInjectEmptyJsonBody(method: string, headers: IncomingHttpH
 
 export function buildEmptyJsonBodyStream(headers: IncomingHttpHeaders): Readable {
   headers['content-length'] = String(Buffer.byteLength(EMPTY_JSON_BODY));
+  // Must be a Buffer chunk: Fastify's content-type parser Buffer.concat()s the raw chunks and
+  // throws (crashing the process) on string chunks.
   return Readable.from([Buffer.from(EMPTY_JSON_BODY)]);
 }
 

--- a/server/src/config/config.test.ts
+++ b/server/src/config/config.test.ts
@@ -11,6 +11,7 @@ function resetEnv(): void {
   delete process.env.APP_VERSION;
   delete process.env.OIDC_ALLOW_LOCAL_ISSUERS;
   delete process.env.SWAGGER_ENABLED;
+  delete process.env.ABS_OIDC_MOBILE_REDIRECT_URIS;
   delete process.env.KOBO_CLOUDSCRAPER_PYTHON;
   delete process.env.KOREADER_PLUGIN_PATH;
   delete process.env.DATABASE_URL;
@@ -50,6 +51,7 @@ describe('config', () => {
       githubReleasesToken: undefined,
       oidcAllowLocalIssuers: false,
       swaggerEnabled: false,
+      absAllowedAppRedirects: [],
       koboCloudscraperPython: undefined,
       koreaderPluginSourcePath: undefined,
     });
@@ -61,6 +63,7 @@ describe('config', () => {
     process.env.APP_VERSION = 'v2.3.4';
     process.env.OIDC_ALLOW_LOCAL_ISSUERS = 'true';
     process.env.SWAGGER_ENABLED = 'true';
+    process.env.ABS_OIDC_MOBILE_REDIRECT_URIS = 'stillapp://oauth, prologue://oauth';
     process.env.KOBO_CLOUDSCRAPER_PYTHON = '/opt/bookorbit-python/bin/python';
     process.env.KOREADER_PLUGIN_PATH = '/opt/koreader/bookorbit.koplugin';
     process.env.GITHUB_RELEASES_REPO = 'acme/app';
@@ -74,9 +77,15 @@ describe('config', () => {
       githubReleasesToken: 'ghp_example',
       oidcAllowLocalIssuers: true,
       swaggerEnabled: true,
+      absAllowedAppRedirects: ['stillapp://oauth', 'prologue://oauth'],
       koboCloudscraperPython: '/opt/bookorbit-python/bin/python',
       koreaderPluginSourcePath: '/opt/koreader/bookorbit.koplugin',
     });
+  });
+
+  it('parses ABS_OIDC_MOBILE_REDIRECT_URIS into a trimmed list, dropping blanks', () => {
+    process.env.ABS_OIDC_MOBILE_REDIRECT_URIS = ' stillapp://oauth ,, prologue://oauth ,';
+    expect(appConfig().absAllowedAppRedirects).toEqual(['stillapp://oauth', 'prologue://oauth']);
   });
 
   it('falls back to false when OIDC_ALLOW_LOCAL_ISSUERS is invalid', () => {

--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -9,6 +9,9 @@ export const appConfig = registerAs('app', () => ({
   githubReleasesToken: process.env.GITHUB_RELEASES_TOKEN?.trim() || undefined,
   oidcAllowLocalIssuers: parseBooleanFlag(process.env.OIDC_ALLOW_LOCAL_ISSUERS, false),
   swaggerEnabled: parseBooleanFlag(process.env.SWAGGER_ENABLED, false),
+  // Extra exact-match mobile redirect URIs allowed for the ABS OIDC flow, beyond the built-in
+  // `audiobookshelf://oauth`. Operators add third-party ABS clients (e.g. stillapp://oauth) here.
+  absAllowedAppRedirects: parseCommaList(process.env.ABS_OIDC_MOBILE_REDIRECT_URIS),
   koboCloudscraperPython: process.env.KOBO_CLOUDSCRAPER_PYTHON?.trim() || undefined,
   koreaderPluginSourcePath: process.env.KOREADER_PLUGIN_PATH?.trim() || undefined,
 }));
@@ -64,6 +67,14 @@ function parsePositiveInteger(value: string | undefined, fallback: number): numb
     return fallback;
   }
   return Math.floor(parsed);
+}
+
+function parseCommaList(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 }
 
 function parseBooleanFlag(value: string | undefined, fallback: boolean): boolean {

--- a/server/src/config/env.validation.ts
+++ b/server/src/config/env.validation.ts
@@ -79,6 +79,26 @@ const envSchema = z.object({
     .string()
     .transform((val) => val.trim())
     .optional(),
+  ABS_OIDC_MOBILE_REDIRECT_URIS: z
+    .string()
+    .optional()
+    .refine(
+      (val) =>
+        !val ||
+        val
+          .split(',')
+          .map((uri) => uri.trim())
+          .filter(Boolean)
+          .every((uri) => {
+            try {
+              new URL(uri);
+              return true;
+            } catch {
+              return false;
+            }
+          }),
+      'ABS_OIDC_MOBILE_REDIRECT_URIS must be a comma-separated list of valid URIs (e.g. stillapp://oauth,prologue://oauth)',
+    ),
 });
 
 export function validateEnv(config: Record<string, unknown>) {

--- a/server/src/db/migrations/0055_add_abs_api.sql
+++ b/server/src/db/migrations/0055_add_abs_api.sql
@@ -1,0 +1,47 @@
+CREATE TABLE "abs_playback_sessions" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"user_id" integer NOT NULL,
+	"library_id" integer,
+	"book_id" integer NOT NULL,
+	"display_title" text DEFAULT '' NOT NULL,
+	"display_author" text DEFAULT '' NOT NULL,
+	"cover_path" text,
+	"media_metadata" jsonb NOT NULL,
+	"chapters" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"duration" double precision DEFAULT 0 NOT NULL,
+	"play_method" integer NOT NULL,
+	"media_player" varchar(64) DEFAULT 'unknown' NOT NULL,
+	"device_info" jsonb,
+	"server_version" varchar(32) NOT NULL,
+	"date" varchar(10) NOT NULL,
+	"day_of_week" varchar(16) NOT NULL,
+	"time_listening" double precision DEFAULT 0 NOT NULL,
+	"start_time_seconds" double precision DEFAULT 0 NOT NULL,
+	"current_time_seconds" double precision DEFAULT 0 NOT NULL,
+	"started_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "abs_sessions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" integer NOT NULL,
+	"refresh_token" text NOT NULL,
+	"last_refresh_token" text,
+	"last_refresh_token_expires_at" timestamp with time zone,
+	"expires_at" timestamp with time zone NOT NULL,
+	"ip_address" varchar(64),
+	"user_agent" varchar(512),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "audiobook_progress" ADD COLUMN "hide_from_continue_listening" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "abs_playback_sessions" ADD CONSTRAINT "abs_playback_sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "abs_sessions" ADD CONSTRAINT "abs_sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "abs_playback_sessions_user_updated_idx" ON "abs_playback_sessions" USING btree ("user_id","updated_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "abs_playback_sessions_user_book_idx" ON "abs_playback_sessions" USING btree ("user_id","book_id");--> statement-breakpoint
+CREATE INDEX "abs_playback_sessions_user_created_idx" ON "abs_playback_sessions" USING btree ("user_id","created_at");--> statement-breakpoint
+CREATE INDEX "abs_sessions_user_id_idx" ON "abs_sessions" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "abs_sessions_refresh_token_idx" ON "abs_sessions" USING btree ("refresh_token");--> statement-breakpoint
+CREATE INDEX "abs_sessions_last_refresh_token_idx" ON "abs_sessions" USING btree ("last_refresh_token");

--- a/server/src/db/migrations/meta/0055_snapshot.json
+++ b/server/src/db/migrations/meta/0055_snapshot.json
@@ -1,0 +1,15593 @@
+{
+  "id": "16f371ad-1a26-4a10-8a66-838a14f77be8",
+  "prevId": "32d3ce71-fe36-46aa-a09c-7ae01276bb08",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_username": {
+          "name": "actor_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_user_id": {
+          "name": "idx_audit_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource": {
+          "name": "idx_audit_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_action": {
+          "name": "idx_audit_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_ip": {
+          "name": "idx_audit_ip",
+          "columns": [
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_created_at": {
+          "name": "idx_audit_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_reading_insights_access": {
+          "name": "idx_audit_reading_insights_access",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.magic_access_tokens": {
+      "name": "magic_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_token": {
+          "name": "raw_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "magic_access_tokens_user_id_idx": {
+          "name": "magic_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "magic_access_tokens_user_id_users_id_fk": {
+          "name": "magic_access_tokens_user_id_users_id_fk",
+          "tableFrom": "magic_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "magic_access_tokens_created_by_users_id_fk": {
+          "name": "magic_access_tokens_created_by_users_id_fk",
+          "tableFrom": "magic_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "magic_access_tokens_token_hash_unique": {
+          "name": "magic_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "magic_access_tokens_use_count_nonneg_chk": {
+          "name": "magic_access_tokens_use_count_nonneg_chk",
+          "value": "\"magic_access_tokens\".\"use_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "password_reset_tokens_user_id_idx": {
+          "name": "password_reset_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_tokens_expires_at_idx": {
+          "name": "password_reset_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_hash_unique": {
+          "name": "password_reset_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "password_reset_tokens_expires_after_created_chk": {
+          "name": "password_reset_tokens_expires_after_created_chk",
+          "value": "\"password_reset_tokens\".\"expires_at\" > \"password_reset_tokens\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by_token_hash": {
+          "name": "replaced_by_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "refresh_tokens_expires_after_created_chk": {
+          "name": "refresh_tokens_expires_after_created_chk",
+          "value": "\"refresh_tokens\".\"expires_at\" > \"refresh_tokens\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_content_filter_genres": {
+      "name": "user_content_filter_genres",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "content_filter_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_content_filter_genres_genre_id_idx": {
+          "name": "user_content_filter_genres_genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_content_filter_genres_user_id_users_id_fk": {
+          "name": "user_content_filter_genres_user_id_users_id_fk",
+          "tableFrom": "user_content_filter_genres",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_content_filter_genres_genre_id_genres_id_fk": {
+          "name": "user_content_filter_genres_genre_id_genres_id_fk",
+          "tableFrom": "user_content_filter_genres",
+          "tableTo": "genres",
+          "columnsFrom": ["genre_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_content_filter_genres_user_id_filter_type_genre_id_pk": {
+          "name": "user_content_filter_genres_user_id_filter_type_genre_id_pk",
+          "columns": ["user_id", "filter_type", "genre_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_content_filter_tags": {
+      "name": "user_content_filter_tags",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "content_filter_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_content_filter_tags_tag_id_idx": {
+          "name": "user_content_filter_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_content_filter_tags_user_id_users_id_fk": {
+          "name": "user_content_filter_tags_user_id_users_id_fk",
+          "tableFrom": "user_content_filter_tags",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_content_filter_tags_tag_id_tags_id_fk": {
+          "name": "user_content_filter_tags_tag_id_tags_id_fk",
+          "tableFrom": "user_content_filter_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_content_filter_tags_user_id_filter_type_tag_id_pk": {
+          "name": "user_content_filter_tags_user_id_filter_type_tag_id_pk",
+          "columns": ["user_id", "filter_type", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_library_access": {
+      "name": "user_library_access",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_level": {
+          "name": "access_level",
+          "type": "library_access_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        }
+      },
+      "indexes": {
+        "user_library_access_library_user_idx": {
+          "name": "user_library_access_library_user_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_library_access_user_id_users_id_fk": {
+          "name": "user_library_access_user_id_users_id_fk",
+          "tableFrom": "user_library_access",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_library_access_library_id_libraries_id_fk": {
+          "name": "user_library_access_library_id_libraries_id_fk",
+          "tableFrom": "user_library_access",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_library_access_user_id_library_id_pk": {
+          "name": "user_library_access_user_id_library_id_pk",
+          "columns": ["user_id", "library_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_permissions": {
+      "name": "user_permissions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_name": {
+          "name": "permission_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_permissions_user_id_users_id_fk": {
+          "name": "user_permissions_user_id_users_id_fk",
+          "tableFrom": "user_permissions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_permissions_user_id_permission_name_pk": {
+          "name": "user_permissions_user_id_permission_name_pk",
+          "columns": ["user_id", "permission_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_superuser": {
+          "name": "is_superuser",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default_password": {
+          "name": "is_default_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_source": {
+          "name": "avatar_source",
+          "type": "user_avatar_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "avatar_version": {
+          "name": "avatar_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "provisioning_method": {
+          "name": "provisioning_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_authenticated_at": {
+          "name": "last_authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reading_insights_sharing_level": {
+          "name": "reading_insights_sharing_level",
+          "type": "reading_insights_sharing_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "reading_insights_consented_at": {
+          "name": "reading_insights_consented_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_username_lower_uidx": {
+          "name": "users_username_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_lower_uidx": {
+          "name": "users_email_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"email\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_oidc_subject_issuer_uidx": {
+          "name": "users_oidc_subject_issuer_uidx",
+          "columns": [
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"users\".\"oidc_subject\" is not null and \"users\".\"oidc_issuer\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_last_authenticated_at_idx": {
+          "name": "users_last_authenticated_at_idx",
+          "columns": [
+            {
+              "expression": "last_authenticated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_provisioning_method_chk": {
+          "name": "users_provisioning_method_chk",
+          "value": "\"users\".\"provisioning_method\" in ('local', 'manual', 'oidc', 'shared')"
+        },
+        "users_token_version_nonnegative_chk": {
+          "name": "users_token_version_nonnegative_chk",
+          "value": "\"users\".\"token_version\" >= 0"
+        },
+        "users_failed_login_attempts_nonnegative_chk": {
+          "name": "users_failed_login_attempts_nonnegative_chk",
+          "value": "\"users\".\"failed_login_attempts\" >= 0"
+        },
+        "users_avatar_version_nonnegative_chk": {
+          "name": "users_avatar_version_nonnegative_chk",
+          "value": "\"users\".\"avatar_version\" >= 0"
+        },
+        "users_reading_insights_consent_chk": {
+          "name": "users_reading_insights_consent_chk",
+          "value": "(\"users\".\"reading_insights_sharing_level\" = 'private' and \"users\".\"reading_insights_consented_at\" is null) or (\"users\".\"reading_insights_sharing_level\" <> 'private' and \"users\".\"reading_insights_consented_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comic_metadata": {
+      "name": "comic_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_name": {
+          "name": "volume_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pencillers": {
+          "name": "pencillers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inkers": {
+          "name": "inkers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "colorists": {
+          "name": "colorists",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "letterers": {
+          "name": "letterers",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_artists": {
+          "name": "cover_artists",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "characters": {
+          "name": "characters",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teams": {
+          "name": "teams",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locations": {
+          "name": "locations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "story_arcs": {
+          "name": "story_arcs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comic_metadata_book_id_books_id_fk": {
+          "name": "comic_metadata_book_id_books_id_fk",
+          "tableFrom": "comic_metadata",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "comic_metadata_book_id_unique": {
+          "name": "comic_metadata_book_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["book_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_custom_metadata_values": {
+      "name": "book_custom_metadata_values",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_text": {
+          "name": "value_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_number": {
+          "name": "value_number",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_boolean": {
+          "name": "value_boolean",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_custom_metadata_values_field_idx": {
+          "name": "book_custom_metadata_values_field_idx",
+          "columns": [
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_custom_metadata_values_book_id_books_id_fk": {
+          "name": "book_custom_metadata_values_book_id_books_id_fk",
+          "tableFrom": "book_custom_metadata_values",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_custom_metadata_values_field_id_custom_metadata_fields_id_fk": {
+          "name": "book_custom_metadata_values_field_id_custom_metadata_fields_id_fk",
+          "tableFrom": "book_custom_metadata_values",
+          "tableTo": "custom_metadata_fields",
+          "columnsFrom": ["field_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_custom_metadata_values_book_id_field_id_pk": {
+          "name": "book_custom_metadata_values_book_id_field_id_pk",
+          "columns": ["book_id", "field_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_custom_metadata_values_single_value_chk": {
+          "name": "book_custom_metadata_values_single_value_chk",
+          "value": "(\n        (\"book_custom_metadata_values\".\"value_text\" is not null)::int +\n        (\"book_custom_metadata_values\".\"value_number\" is not null)::int +\n        (\"book_custom_metadata_values\".\"value_date\" is not null)::int +\n        (\"book_custom_metadata_values\".\"value_boolean\" is not null)::int\n      ) <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_metadata_fields": {
+      "name": "custom_metadata_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_metadata_fields_key_uidx": {
+          "name": "custom_metadata_fields_key_uidx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_metadata_fields_active_order_idx": {
+          "name": "custom_metadata_fields_active_order_idx",
+          "columns": [
+            {
+              "expression": "archived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_metadata_fields_type_chk": {
+          "name": "custom_metadata_fields_type_chk",
+          "value": "\"custom_metadata_fields\".\"type\" in ('text', 'url', 'number', 'date', 'boolean')"
+        },
+        "custom_metadata_fields_key_format_chk": {
+          "name": "custom_metadata_fields_key_format_chk",
+          "value": "\"custom_metadata_fields\".\"key\" ~ '^[a-z0-9][a-z0-9_]{0,99}$'"
+        },
+        "custom_metadata_fields_label_not_blank_chk": {
+          "name": "custom_metadata_fields_label_not_blank_chk",
+          "value": "length(btrim(\"custom_metadata_fields\".\"label\")) > 0"
+        },
+        "custom_metadata_fields_display_order_nonnegative_chk": {
+          "name": "custom_metadata_fields_display_order_nonnegative_chk",
+          "value": "\"custom_metadata_fields\".\"display_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_metadata_library_fields": {
+      "name": "custom_metadata_library_fields",
+      "schema": "",
+      "columns": {
+        "field_id": {
+          "name": "field_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_metadata_library_fields_field_idx": {
+          "name": "custom_metadata_library_fields_field_idx",
+          "columns": [
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_metadata_library_fields_library_order_idx": {
+          "name": "custom_metadata_library_fields_library_order_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_metadata_library_fields_field_id_custom_metadata_fields_id_fk": {
+          "name": "custom_metadata_library_fields_field_id_custom_metadata_fields_id_fk",
+          "tableFrom": "custom_metadata_library_fields",
+          "tableTo": "custom_metadata_fields",
+          "columnsFrom": ["field_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_metadata_library_fields_library_id_libraries_id_fk": {
+          "name": "custom_metadata_library_fields_library_id_libraries_id_fk",
+          "tableFrom": "custom_metadata_library_fields",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "custom_metadata_library_fields_library_id_field_id_pk": {
+          "name": "custom_metadata_library_fields_library_id_field_id_pk",
+          "columns": ["library_id", "field_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_metadata_library_fields_display_order_nonnegative_chk": {
+          "name": "custom_metadata_library_fields_display_order_nonnegative_chk",
+          "value": "\"custom_metadata_library_fields\".\"display_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.custom_icons": {
+      "name": "custom_icons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_name": {
+          "name": "stored_file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_icons_slug_uidx": {
+          "name": "custom_icons_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "custom_icons_slug_chk": {
+          "name": "custom_icons_slug_chk",
+          "value": "\"custom_icons\".\"slug\" ~ '^[a-z0-9][a-z0-9-]*[a-z0-9]$' or \"custom_icons\".\"slug\" ~ '^[a-z0-9]$'"
+        },
+        "custom_icons_file_size_positive_chk": {
+          "name": "custom_icons_file_size_positive_chk",
+          "value": "\"custom_icons\".\"file_size\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_plan_artifacts": {
+      "name": "migration_plan_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot_hash": {
+          "name": "source_snapshot_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_hash": {
+          "name": "profile_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_hash": {
+          "name": "plan_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_data": {
+          "name": "source_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_plan_artifacts_plan_hash_uidx": {
+          "name": "migration_plan_artifacts_plan_hash_uidx",
+          "columns": [
+            {
+              "expression": "plan_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_plan_artifacts_source_id_idx": {
+          "name": "migration_plan_artifacts_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_plan_artifacts_profile_id_idx": {
+          "name": "migration_plan_artifacts_profile_id_idx",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_plan_artifacts_source_id_migration_sources_id_fk": {
+          "name": "migration_plan_artifacts_source_id_migration_sources_id_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "migration_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_plan_artifacts_profile_id_migration_profiles_id_fk": {
+          "name": "migration_plan_artifacts_profile_id_migration_profiles_id_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "migration_profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_plan_artifacts_created_by_user_id_users_id_fk": {
+          "name": "migration_plan_artifacts_created_by_user_id_users_id_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "migration_plan_artifacts_profile_source_fk": {
+          "name": "migration_plan_artifacts_profile_source_fk",
+          "tableFrom": "migration_plan_artifacts",
+          "tableTo": "migration_profiles",
+          "columnsFrom": ["profile_id", "source_id"],
+          "columnsTo": ["id", "source_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "migration_plan_artifacts_id_source_profile_unique": {
+          "name": "migration_plan_artifacts_id_source_profile_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "source_id", "profile_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_profiles": {
+      "name": "migration_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "user_mappings": {
+          "name": "user_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_mappings": {
+          "name": "path_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_profiles_source_name_version_uidx": {
+          "name": "migration_profiles_source_name_version_uidx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_profiles_source_id_idx": {
+          "name": "migration_profiles_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_profiles_source_id_migration_sources_id_fk": {
+          "name": "migration_profiles_source_id_migration_sources_id_fk",
+          "tableFrom": "migration_profiles",
+          "tableTo": "migration_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_profiles_created_by_user_id_users_id_fk": {
+          "name": "migration_profiles_created_by_user_id_users_id_fk",
+          "tableFrom": "migration_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "migration_profiles_id_source_id_unique": {
+          "name": "migration_profiles_id_source_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "source_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "migration_profiles_version_positive_chk": {
+          "name": "migration_profiles_version_positive_chk",
+          "value": "\"migration_profiles\".\"version\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_run_metrics": {
+      "name": "migration_run_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported": {
+          "name": "imported",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unresolved": {
+          "name": "unresolved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_run_metrics_run_stage_entity_uidx": {
+          "name": "migration_run_metrics_run_stage_entity_uidx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_run_metrics_run_id_idx": {
+          "name": "migration_run_metrics_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_run_metrics_run_id_migration_runs_id_fk": {
+          "name": "migration_run_metrics_run_id_migration_runs_id_fk",
+          "tableFrom": "migration_run_metrics",
+          "tableTo": "migration_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_run_metrics_processed_nonnegative_chk": {
+          "name": "migration_run_metrics_processed_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"processed\" >= 0"
+        },
+        "migration_run_metrics_imported_nonnegative_chk": {
+          "name": "migration_run_metrics_imported_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"imported\" >= 0"
+        },
+        "migration_run_metrics_skipped_nonnegative_chk": {
+          "name": "migration_run_metrics_skipped_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"skipped\" >= 0"
+        },
+        "migration_run_metrics_unresolved_nonnegative_chk": {
+          "name": "migration_run_metrics_unresolved_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"unresolved\" >= 0"
+        },
+        "migration_run_metrics_failed_nonnegative_chk": {
+          "name": "migration_run_metrics_failed_nonnegative_chk",
+          "value": "\"migration_run_metrics\".\"failed\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_artifact_id": {
+          "name": "plan_artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bookorbit'"
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_runs_source_target_state_idx": {
+          "name": "migration_runs_source_target_state_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_state_idx": {
+          "name": "migration_runs_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_source_id_migration_sources_id_fk": {
+          "name": "migration_runs_source_id_migration_sources_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_profile_id_migration_profiles_id_fk": {
+          "name": "migration_runs_profile_id_migration_profiles_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "migration_runs_plan_artifact_id_migration_plan_artifacts_id_fk": {
+          "name": "migration_runs_plan_artifact_id_migration_plan_artifacts_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_plan_artifacts",
+          "columnsFrom": ["plan_artifact_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "migration_runs_triggered_by_user_id_users_id_fk": {
+          "name": "migration_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": ["triggered_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "migration_runs_profile_source_fk": {
+          "name": "migration_runs_profile_source_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_profiles",
+          "columnsFrom": ["profile_id", "source_id"],
+          "columnsTo": ["id", "source_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_plan_artifact_source_profile_fk": {
+          "name": "migration_runs_plan_artifact_source_profile_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "migration_plan_artifacts",
+          "columnsFrom": ["plan_artifact_id", "source_id", "profile_id"],
+          "columnsTo": ["id", "source_id", "profile_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_state_chk": {
+          "name": "migration_runs_state_chk",
+          "value": "\"state\" IN ('draft', 'preflight_failed', 'dry_run_ready', 'running', 'failed', 'completed')"
+        },
+        "migration_runs_started_before_ended_chk": {
+          "name": "migration_runs_started_before_ended_chk",
+          "value": "\"migration_runs\".\"ended_at\" is null or \"migration_runs\".\"started_at\" is null or \"migration_runs\".\"ended_at\" >= \"migration_runs\".\"started_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_sources": {
+      "name": "migration_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_config": {
+          "name": "connection_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_validated_at": {
+          "name": "last_validated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "migration_sources_type_name_uidx": {
+          "name": "migration_sources_type_name_uidx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_sources_created_by_user_id_idx": {
+          "name": "migration_sources_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_sources_created_by_user_id_users_id_fk": {
+          "name": "migration_sources_created_by_user_id_users_id_fk",
+          "tableFrom": "migration_sources",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.libraries": {
+      "name": "libraries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cover_aspect_ratio": {
+          "name": "cover_aspect_ratio",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2/3'"
+        },
+        "watch": {
+          "name": "watch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_scan_cron_expression": {
+          "name": "auto_scan_cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_precedence": {
+          "name": "metadata_precedence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"folderStructure\",\"embedded\",\"nfoFile\",\"opfFile\",\"sidecar\"]'::jsonb"
+        },
+        "format_priority": {
+          "name": "format_priority",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"epub\",\"pdf\",\"cbz\",\"cbr\",\"cb7\",\"mobi\",\"azw3\",\"azw\",\"fb2\",\"m4b\",\"mp3\",\"m4a\",\"opus\",\"ogg\",\"flac\"]'::jsonb"
+        },
+        "allowed_formats": {
+          "name": "allowed_formats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "organization_mode": {
+          "name": "organization_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'book_per_folder'"
+        },
+        "exclude_patterns": {
+          "name": "exclude_patterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reading_threshold": {
+          "name": "reading_threshold",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.25
+        },
+        "mark_as_finished_percent_complete": {
+          "name": "mark_as_finished_percent_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 98
+        },
+        "file_write_enabled": {
+          "name": "file_write_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_write_write_cover": {
+          "name": "file_write_write_cover",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "file_write_epub_enabled": {
+          "name": "file_write_epub_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "file_write_epub_max_file_size_mb": {
+          "name": "file_write_epub_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "file_write_pdf_enabled": {
+          "name": "file_write_pdf_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "file_write_pdf_max_file_size_mb": {
+          "name": "file_write_pdf_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "file_write_cbx_enabled": {
+          "name": "file_write_cbx_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_write_cbx_max_file_size_mb": {
+          "name": "file_write_cbx_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "file_write_audio_enabled": {
+          "name": "file_write_audio_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_write_audio_max_file_size_mb": {
+          "name": "file_write_audio_max_file_size_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 500
+        },
+        "file_rename_enabled": {
+          "name": "file_rename_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_naming_pattern": {
+          "name": "file_naming_pattern",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_fetch_preferences": {
+          "name": "metadata_fetch_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_metadata_fetch_config": {
+          "name": "book_metadata_fetch_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_metadata_fetch_last_run_at": {
+          "name": "book_metadata_fetch_last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_metadata_fetch_last_queued_count": {
+          "name": "book_metadata_fetch_last_queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scan_mode": {
+          "name": "scan_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "poll_interval_seconds": {
+          "name": "poll_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 300
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "libraries_name_lower_uidx": {
+          "name": "libraries_name_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "libraries_display_order_nonnegative_chk": {
+          "name": "libraries_display_order_nonnegative_chk",
+          "value": "\"libraries\".\"display_order\" >= 0"
+        },
+        "libraries_organization_mode_chk": {
+          "name": "libraries_organization_mode_chk",
+          "value": "\"libraries\".\"organization_mode\" in ('book_per_folder', 'book_per_file')"
+        },
+        "libraries_reading_threshold_range_chk": {
+          "name": "libraries_reading_threshold_range_chk",
+          "value": "\"libraries\".\"reading_threshold\" >= 0 and \"libraries\".\"reading_threshold\" <= 100"
+        },
+        "libraries_mark_finished_percent_range_chk": {
+          "name": "libraries_mark_finished_percent_range_chk",
+          "value": "\"libraries\".\"mark_as_finished_percent_complete\" >= 0 and \"libraries\".\"mark_as_finished_percent_complete\" <= 100"
+        },
+        "libraries_scan_mode_chk": {
+          "name": "libraries_scan_mode_chk",
+          "value": "\"libraries\".\"scan_mode\" in ('auto', 'manual')"
+        },
+        "libraries_poll_interval_nonnegative_chk": {
+          "name": "libraries_poll_interval_nonnegative_chk",
+          "value": "\"libraries\".\"poll_interval_seconds\" is null or \"libraries\".\"poll_interval_seconds\" >= 0"
+        },
+        "libraries_file_write_epub_max_size_chk": {
+          "name": "libraries_file_write_epub_max_size_chk",
+          "value": "\"libraries\".\"file_write_epub_max_file_size_mb\" >= 1"
+        },
+        "libraries_file_write_pdf_max_size_chk": {
+          "name": "libraries_file_write_pdf_max_size_chk",
+          "value": "\"libraries\".\"file_write_pdf_max_file_size_mb\" >= 1"
+        },
+        "libraries_file_write_cbx_max_size_chk": {
+          "name": "libraries_file_write_cbx_max_size_chk",
+          "value": "\"libraries\".\"file_write_cbx_max_file_size_mb\" >= 1"
+        },
+        "libraries_file_write_audio_max_size_chk": {
+          "name": "libraries_file_write_audio_max_size_chk",
+          "value": "\"libraries\".\"file_write_audio_max_file_size_mb\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.library_folders": {
+      "name": "library_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_folders_library_id_idx": {
+          "name": "library_folders_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_folders_library_path_uidx": {
+          "name": "library_folders_library_path_uidx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_folders_library_id_libraries_id_fk": {
+          "name": "library_folders_library_id_libraries_id_fk",
+          "tableFrom": "library_folders",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "library_folders_id_library_id_unique": {
+          "name": "library_folders_id_library_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "library_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_files": {
+      "name": "book_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_folder_id": {
+          "name": "library_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_path": {
+          "name": "absolute_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rel_path": {
+          "name": "rel_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ino": {
+          "name": "ino",
+          "type": "numeric(20, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'content'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_files_absolute_path_uidx": {
+          "name": "book_files_absolute_path_uidx",
+          "columns": [
+            {
+              "expression": "absolute_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_book_id_idx": {
+          "name": "book_files_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_library_folder_id_idx": {
+          "name": "book_files_library_folder_id_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_file_hash_idx": {
+          "name": "book_files_file_hash_idx",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_ino_idx": {
+          "name": "book_files_ino_idx",
+          "columns": [
+            {
+              "expression": "ino",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_format_idx": {
+          "name": "book_files_format_idx",
+          "columns": [
+            {
+              "expression": "format",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_library_folder_file_hash_idx": {
+          "name": "book_files_library_folder_file_hash_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_files_library_folder_ino_idx": {
+          "name": "book_files_library_folder_ino_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ino",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_files_book_id_books_id_fk": {
+          "name": "book_files_book_id_books_id_fk",
+          "tableFrom": "book_files",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_files_library_folder_id_library_folders_id_fk": {
+          "name": "book_files_library_folder_id_library_folders_id_fk",
+          "tableFrom": "book_files",
+          "tableTo": "library_folders",
+          "columnsFrom": ["library_folder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_files_book_folder_consistency_fk": {
+          "name": "book_files_book_folder_consistency_fk",
+          "tableFrom": "book_files",
+          "tableTo": "books",
+          "columnsFrom": ["book_id", "library_folder_id"],
+          "columnsTo": ["id", "library_folder_id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_files_role_chk": {
+          "name": "book_files_role_chk",
+          "value": "\"book_files\".\"role\" in ('content', 'cover', 'metadata', 'supplement')"
+        },
+        "book_files_size_bytes_nonnegative_chk": {
+          "name": "book_files_size_bytes_nonnegative_chk",
+          "value": "\"book_files\".\"size_bytes\" is null or \"book_files\".\"size_bytes\" >= 0"
+        },
+        "book_files_duration_seconds_nonnegative_chk": {
+          "name": "book_files_duration_seconds_nonnegative_chk",
+          "value": "\"book_files\".\"duration_seconds\" is null or \"book_files\".\"duration_seconds\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.books": {
+      "name": "books",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_folder_id": {
+          "name": "library_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_file_id": {
+          "name": "primary_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_author_sort_name": {
+          "name": "primary_author_sort_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_path": {
+          "name": "folder_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'present'"
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "books_library_id_folder_path_idx": {
+          "name": "books_library_id_folder_path_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folder_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_primary_file_id_idx": {
+          "name": "books_primary_file_id_idx",
+          "columns": [
+            {
+              "expression": "primary_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_status_idx": {
+          "name": "books_library_status_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_added_at_idx": {
+          "name": "books_library_added_at_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"added_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_visible_added_id_idx": {
+          "name": "books_library_visible_added_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"added_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"books\".\"status\" <> 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_author_sort_id_idx": {
+          "name": "books_library_author_sort_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"primary_author_sort_name\" asc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"books\".\"status\" <> 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "books_library_author_sort_desc_id_idx": {
+          "name": "books_library_author_sort_desc_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"primary_author_sort_name\" desc nulls last",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"books\".\"status\" <> 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "books_library_id_libraries_id_fk": {
+          "name": "books_library_id_libraries_id_fk",
+          "tableFrom": "books",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "books_library_folder_id_library_folders_id_fk": {
+          "name": "books_library_folder_id_library_folders_id_fk",
+          "tableFrom": "books",
+          "tableTo": "library_folders",
+          "columnsFrom": ["library_folder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "books_primary_file_id_book_files_id_fk": {
+          "name": "books_primary_file_id_book_files_id_fk",
+          "tableFrom": "books",
+          "tableTo": "book_files",
+          "columnsFrom": ["primary_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "books_library_folder_library_fk": {
+          "name": "books_library_folder_library_fk",
+          "tableFrom": "books",
+          "tableTo": "library_folders",
+          "columnsFrom": ["library_folder_id", "library_id"],
+          "columnsTo": ["id", "library_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "books_id_library_folder_id_unique": {
+          "name": "books_id_library_folder_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "library_folder_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "books_status_chk": {
+          "name": "books_status_chk",
+          "value": "\"books\".\"status\" in ('present', 'missing', 'processing')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_duplicate_group_members": {
+      "name": "book_duplicate_group_members",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_duplicate_group_members_group_idx": {
+          "name": "book_duplicate_group_members_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_duplicate_group_members_group_id_book_duplicate_groups_id_fk": {
+          "name": "book_duplicate_group_members_group_id_book_duplicate_groups_id_fk",
+          "tableFrom": "book_duplicate_group_members",
+          "tableTo": "book_duplicate_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_duplicate_group_members_scan_id_book_duplicate_scans_id_fk": {
+          "name": "book_duplicate_group_members_scan_id_book_duplicate_scans_id_fk",
+          "tableFrom": "book_duplicate_group_members",
+          "tableTo": "book_duplicate_scans",
+          "columnsFrom": ["scan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_duplicate_group_members_book_id_books_id_fk": {
+          "name": "book_duplicate_group_members_book_id_books_id_fk",
+          "tableFrom": "book_duplicate_group_members",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_duplicate_group_members_scan_id_book_id_pk": {
+          "name": "book_duplicate_group_members_scan_id_book_id_pk",
+          "columns": ["scan_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_duplicate_groups": {
+      "name": "book_duplicate_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_book_id": {
+          "name": "root_book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_title_similarity": {
+          "name": "max_title_similarity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_duplicate_groups_scan_root_uidx": {
+          "name": "book_duplicate_groups_scan_root_uidx",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_duplicate_groups_scan_id_idx": {
+          "name": "book_duplicate_groups_scan_id_idx",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_duplicate_groups_scan_member_count_idx": {
+          "name": "book_duplicate_groups_scan_member_count_idx",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "member_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_duplicate_groups_scan_id_book_duplicate_scans_id_fk": {
+          "name": "book_duplicate_groups_scan_id_book_duplicate_scans_id_fk",
+          "tableFrom": "book_duplicate_groups",
+          "tableTo": "book_duplicate_scans",
+          "columnsFrom": ["scan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_duplicate_groups_root_book_id_books_id_fk": {
+          "name": "book_duplicate_groups_root_book_id_books_id_fk",
+          "tableFrom": "book_duplicate_groups",
+          "tableTo": "books",
+          "columnsFrom": ["root_book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_duplicate_pairs": {
+      "name": "book_duplicate_pairs",
+      "schema": "",
+      "columns": {
+        "scan_id": {
+          "name": "scan_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_id_a": {
+          "name": "book_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id_b": {
+          "name": "book_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasons": {
+          "name": "reasons",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title_similarity": {
+          "name": "title_similarity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "book_duplicate_pairs_group_idx": {
+          "name": "book_duplicate_pairs_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_duplicate_pairs_scan_a_idx": {
+          "name": "book_duplicate_pairs_scan_a_idx",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_duplicate_pairs_scan_b_idx": {
+          "name": "book_duplicate_pairs_scan_b_idx",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_duplicate_pairs_scan_id_book_duplicate_scans_id_fk": {
+          "name": "book_duplicate_pairs_scan_id_book_duplicate_scans_id_fk",
+          "tableFrom": "book_duplicate_pairs",
+          "tableTo": "book_duplicate_scans",
+          "columnsFrom": ["scan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_duplicate_pairs_group_id_book_duplicate_groups_id_fk": {
+          "name": "book_duplicate_pairs_group_id_book_duplicate_groups_id_fk",
+          "tableFrom": "book_duplicate_pairs",
+          "tableTo": "book_duplicate_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_duplicate_pairs_book_id_a_books_id_fk": {
+          "name": "book_duplicate_pairs_book_id_a_books_id_fk",
+          "tableFrom": "book_duplicate_pairs",
+          "tableTo": "books",
+          "columnsFrom": ["book_id_a"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_duplicate_pairs_book_id_b_books_id_fk": {
+          "name": "book_duplicate_pairs_book_id_b_books_id_fk",
+          "tableFrom": "book_duplicate_pairs",
+          "tableTo": "books",
+          "columnsFrom": ["book_id_b"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_duplicate_pairs_scan_id_book_id_a_book_id_b_pk": {
+          "name": "book_duplicate_pairs_scan_id_book_id_a_book_id_b_pk",
+          "columns": ["scan_id", "book_id_a", "book_id_b"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_duplicate_pairs_order_chk": {
+          "name": "book_duplicate_pairs_order_chk",
+          "value": "\"book_duplicate_pairs\".\"book_id_a\" < \"book_duplicate_pairs\".\"book_id_b\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_duplicate_scan_keys": {
+      "name": "book_duplicate_scan_keys",
+      "schema": "",
+      "columns": {
+        "scan_id": {
+          "name": "scan_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_duplicate_scan_keys_lookup_idx": {
+          "name": "book_duplicate_scan_keys_lookup_idx",
+          "columns": [
+            {
+              "expression": "scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_duplicate_scan_keys_scan_id_book_duplicate_scans_id_fk": {
+          "name": "book_duplicate_scan_keys_scan_id_book_duplicate_scans_id_fk",
+          "tableFrom": "book_duplicate_scan_keys",
+          "tableTo": "book_duplicate_scans",
+          "columnsFrom": ["scan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_duplicate_scan_keys_book_id_books_id_fk": {
+          "name": "book_duplicate_scan_keys_book_id_books_id_fk",
+          "tableFrom": "book_duplicate_scan_keys",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_duplicate_scan_keys_scan_id_book_id_kind_value_pk": {
+          "name": "book_duplicate_scan_keys_scan_id_book_id_kind_value_pk",
+          "columns": ["scan_id", "book_id", "kind", "value"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_duplicate_scan_keys_kind_chk": {
+          "name": "book_duplicate_scan_keys_kind_chk",
+          "value": "\"book_duplicate_scan_keys\".\"kind\" in ('file_hash', 'isbn', 'exact_metadata')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_duplicate_scans": {
+      "name": "book_duplicate_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_ids": {
+          "name": "library_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_library_id": {
+          "name": "requested_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "similarity_percent": {
+          "name": "similarity_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "processed_books": {
+          "name": "processed_books",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_books": {
+          "name": "total_books",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_groups": {
+          "name": "total_groups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "book_duplicate_scans_user_created_idx": {
+          "name": "book_duplicate_scans_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_duplicate_scans_status_idx": {
+          "name": "book_duplicate_scans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_duplicate_scans_user_id_users_id_fk": {
+          "name": "book_duplicate_scans_user_id_users_id_fk",
+          "tableFrom": "book_duplicate_scans",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_duplicate_scans_similarity_chk": {
+          "name": "book_duplicate_scans_similarity_chk",
+          "value": "\"book_duplicate_scans\".\"similarity_percent\" between 70 and 100"
+        },
+        "book_duplicate_scans_status_chk": {
+          "name": "book_duplicate_scans_status_chk",
+          "value": "\"book_duplicate_scans\".\"status\" in ('queued', 'running', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collection_books": {
+      "name": "collection_books",
+      "schema": "",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_books_book_id_idx": {
+          "name": "collection_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_books_collection_id_collections_id_fk": {
+          "name": "collection_books_collection_id_collections_id_fk",
+          "tableFrom": "collection_books",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_books_book_id_books_id_fk": {
+          "name": "collection_books_book_id_books_id_fk",
+          "tableFrom": "collection_books",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_books_collection_id_book_id_pk": {
+          "name": "collection_books_collection_id_book_id_pk",
+          "columns": ["collection_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_to_kobo": {
+          "name": "sync_to_kobo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collections_user_name_uidx": {
+          "name": "collections_user_name_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_user_display_name_idx": {
+          "name": "collections_user_display_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_user_id_users_id_fk": {
+          "name": "collections_user_id_users_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.smart_scopes": {
+      "name": "smart_scopes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_sort": {
+          "name": "default_sort",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_to_kobo": {
+          "name": "sync_to_kobo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "smart_scopes_user_id_users_id_fk": {
+          "name": "smart_scopes_user_id_users_id_fk",
+          "tableFrom": "smart_scopes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "smart_scopes_user_id_name_unique": {
+          "name": "smart_scopes_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_series": {
+      "name": "book_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_series_normalized_name_uidx": {
+          "name": "book_series_normalized_name_uidx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_series_name_trgm_idx": {
+          "name": "book_series_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "book_series_name_unaccent_trgm_idx": {
+          "name": "book_series_name_unaccent_trgm_idx",
+          "columns": [
+            {
+              "expression": "public.bookorbit_unaccent(\"name\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "book_series_name_lower_idx": {
+          "name": "book_series_name_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_series_memberships": {
+      "name": "book_series_memberships",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_index": {
+          "name": "series_index",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_series_memberships_book_display_uidx": {
+          "name": "book_series_memberships_book_display_uidx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_series_memberships_series_index_book_idx": {
+          "name": "book_series_memberships_series_index_book_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "series_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_series_memberships_book_display_idx": {
+          "name": "book_series_memberships_book_display_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_series_memberships_book_id_books_id_fk": {
+          "name": "book_series_memberships_book_id_books_id_fk",
+          "tableFrom": "book_series_memberships",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_series_memberships_series_id_book_series_id_fk": {
+          "name": "book_series_memberships_series_id_book_series_id_fk",
+          "tableFrom": "book_series_memberships",
+          "tableTo": "book_series",
+          "columnsFrom": ["series_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_series_memberships_book_id_series_id_pk": {
+          "name": "book_series_memberships_book_id_series_id_pk",
+          "columns": ["book_id", "series_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_series_memberships_display_order_nonnegative_chk": {
+          "name": "book_series_memberships_display_order_nonnegative_chk",
+          "value": "\"book_series_memberships\".\"display_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.author_enrichment_queue": {
+      "name": "author_enrichment_queue",
+      "schema": "",
+      "columns": {
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "author_enrichment_queue_status_next_attempt_idx": {
+          "name": "author_enrichment_queue_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "author_enrichment_queue_next_attempt_idx": {
+          "name": "author_enrichment_queue_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "author_enrichment_queue_single_processing_idx": {
+          "name": "author_enrichment_queue_single_processing_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"author_enrichment_queue\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "author_enrichment_queue_author_id_authors_id_fk": {
+          "name": "author_enrichment_queue_author_id_authors_id_fk",
+          "tableFrom": "author_enrichment_queue",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "author_enrichment_queue_status_chk": {
+          "name": "author_enrichment_queue_status_chk",
+          "value": "\"author_enrichment_queue\".\"status\" in ('queued', 'processing', 'rate_limited', 'failed', 'done')"
+        },
+        "author_enrichment_queue_reason_chk": {
+          "name": "author_enrichment_queue_reason_chk",
+          "value": "\"author_enrichment_queue\".\"reason\" in ('unknown', 'metadata_replace', 'manual_backfill', 'manual_backfill_all', 'author_rename', 'author_merge_target')"
+        },
+        "author_enrichment_queue_attempt_count_nonnegative_chk": {
+          "name": "author_enrichment_queue_attempt_count_nonnegative_chk",
+          "value": "\"author_enrichment_queue\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_photo": {
+          "name": "has_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_enriched_at": {
+          "name": "last_enriched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "authors_name_trgm_idx": {
+          "name": "authors_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "authors_name_unaccent_trgm_idx": {
+          "name": "authors_name_unaccent_trgm_idx",
+          "columns": [
+            {
+              "expression": "public.bookorbit_unaccent(\"name\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authors_name_unique": {
+          "name": "authors_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_authors": {
+      "name": "book_authors",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "book_authors_author_id_idx": {
+          "name": "book_authors_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_authors_book_display_idx": {
+          "name": "book_authors_book_display_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_authors_book_display_author_idx": {
+          "name": "book_authors_book_display_author_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_authors_book_id_books_id_fk": {
+          "name": "book_authors_book_id_books_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_authors_author_id_authors_id_fk": {
+          "name": "book_authors_author_id_authors_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "authors",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_authors_book_id_author_id_pk": {
+          "name": "book_authors_book_id_author_id_pk",
+          "columns": ["book_id", "author_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_community_ratings": {
+      "name": "book_community_ratings",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_count": {
+          "name": "rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_community_ratings_provider_idx": {
+          "name": "book_community_ratings_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_community_ratings_rating_book_idx": {
+          "name": "book_community_ratings_rating_book_idx",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_community_ratings_provider_rating_book_idx": {
+          "name": "book_community_ratings_provider_rating_book_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_community_ratings_book_id_books_id_fk": {
+          "name": "book_community_ratings_book_id_books_id_fk",
+          "tableFrom": "book_community_ratings",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_community_ratings_book_id_provider_pk": {
+          "name": "book_community_ratings_book_id_provider_pk",
+          "columns": ["book_id", "provider"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_community_ratings_rating_range_chk": {
+          "name": "book_community_ratings_rating_range_chk",
+          "value": "\"book_community_ratings\".\"rating\" >= 0 and \"book_community_ratings\".\"rating\" <= 5"
+        },
+        "book_community_ratings_count_nonnegative_chk": {
+          "name": "book_community_ratings_count_nonnegative_chk",
+          "value": "\"book_community_ratings\".\"rating_count\" is null or \"book_community_ratings\".\"rating_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_genres": {
+      "name": "book_genres",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_id": {
+          "name": "genre_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_genres_genre_id_idx": {
+          "name": "book_genres_genre_id_idx",
+          "columns": [
+            {
+              "expression": "genre_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_genres_book_id_books_id_fk": {
+          "name": "book_genres_book_id_books_id_fk",
+          "tableFrom": "book_genres",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_genres_genre_id_genres_id_fk": {
+          "name": "book_genres_genre_id_genres_id_fk",
+          "tableFrom": "book_genres",
+          "tableTo": "genres",
+          "columnsFrom": ["genre_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_genres_book_id_genre_id_pk": {
+          "name": "book_genres_book_id_genre_id_pk",
+          "columns": ["book_id", "genre_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_metadata": {
+      "name": "book_metadata",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn10": {
+          "name": "isbn10",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn13": {
+          "name": "isbn13",
+          "type": "varchar(13)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_year": {
+          "name": "published_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_name": {
+          "name": "series_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_index": {
+          "name": "series_index",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_source": {
+          "name": "cover_source",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_books_id": {
+          "name": "google_books_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goodreads_id": {
+          "name": "goodreads_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amazon_id": {
+          "name": "amazon_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_id": {
+          "name": "hardcover_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_edition_id": {
+          "name": "hardcover_edition_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_library_id": {
+          "name": "open_library_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itunes_id": {
+          "name": "itunes_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_id": {
+          "name": "kobo_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_score": {
+          "name": "metadata_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_metadata_fetch_at": {
+          "name": "last_metadata_fetch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_written_at": {
+          "name": "last_written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abridged": {
+          "name": "abridged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audible_id": {
+          "name": "audible_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "librofm_id": {
+          "name": "librofm_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comicvine_id": {
+          "name": "comicvine_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranobedb_id": {
+          "name": "ranobedb_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lubimyczytac_id": {
+          "name": "lubimyczytac_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aladin_id": {
+          "name": "aladin_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_fields": {
+          "name": "locked_fields",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bm_title_trgm_idx": {
+          "name": "bm_title_trgm_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_title_unaccent_trgm_idx": {
+          "name": "bm_title_unaccent_trgm_idx",
+          "columns": [
+            {
+              "expression": "public.bookorbit_unaccent(\"title\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_title_lower_idx": {
+          "name": "bm_title_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"title\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_title_book_id_idx": {
+          "name": "bm_title_book_id_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_trgm_idx": {
+          "name": "bm_series_trgm_idx",
+          "columns": [
+            {
+              "expression": "series_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_series_unaccent_trgm_idx": {
+          "name": "bm_series_unaccent_trgm_idx",
+          "columns": [
+            {
+              "expression": "public.bookorbit_unaccent(\"series_name\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_series_id_idx": {
+          "name": "bm_series_id_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_id_index_book_id_idx": {
+          "name": "bm_series_id_index_book_id_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "series_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_name_lower_btrim_idx": {
+          "name": "bm_series_name_lower_btrim_idx",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"series_name\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_publisher_trgm_idx": {
+          "name": "bm_publisher_trgm_idx",
+          "columns": [
+            {
+              "expression": "publisher",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_publisher_unaccent_trgm_idx": {
+          "name": "bm_publisher_unaccent_trgm_idx",
+          "columns": [
+            {
+              "expression": "public.bookorbit_unaccent(\"publisher\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_language_idx": {
+          "name": "bm_language_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_language_trgm_idx": {
+          "name": "bm_language_trgm_idx",
+          "columns": [
+            {
+              "expression": "language",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_language_unaccent_trgm_idx": {
+          "name": "bm_language_unaccent_trgm_idx",
+          "columns": [
+            {
+              "expression": "public.bookorbit_unaccent(\"language\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bm_published_date_idx": {
+          "name": "bm_published_date_idx",
+          "columns": [
+            {
+              "expression": "published_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_published_year_idx": {
+          "name": "bm_published_year_idx",
+          "columns": [
+            {
+              "expression": "published_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_published_date_sort_idx": {
+          "name": "bm_published_date_sort_idx",
+          "columns": [
+            {
+              "expression": "coalesce(\"published_date\", make_date(\"published_year\", 1, 1))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_series_name_index_idx": {
+          "name": "bm_series_name_index_idx",
+          "columns": [
+            {
+              "expression": "series_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "series_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_isbn10_idx": {
+          "name": "bm_isbn10_idx",
+          "columns": [
+            {
+              "expression": "isbn10",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_isbn13_idx": {
+          "name": "bm_isbn13_idx",
+          "columns": [
+            {
+              "expression": "isbn13",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bm_embedding_hnsw_cosine_idx": {
+          "name": "bm_embedding_hnsw_cosine_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_metadata_book_id_books_id_fk": {
+          "name": "book_metadata_book_id_books_id_fk",
+          "tableFrom": "book_metadata",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_metadata_series_id_book_series_id_fk": {
+          "name": "book_metadata_series_id_book_series_id_fk",
+          "tableFrom": "book_metadata",
+          "tableTo": "book_series",
+          "columnsFrom": ["series_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_metadata_rating_range_chk": {
+          "name": "book_metadata_rating_range_chk",
+          "value": "\"book_metadata\".\"rating\" is null or (\"book_metadata\".\"rating\" >= 1 and \"book_metadata\".\"rating\" <= 10)"
+        },
+        "book_metadata_published_date_range_chk": {
+          "name": "book_metadata_published_date_range_chk",
+          "value": "\"book_metadata\".\"published_date\" is null or (extract(year from \"book_metadata\".\"published_date\") >= 1000 and extract(year from \"book_metadata\".\"published_date\") <= 2200)"
+        },
+        "book_metadata_published_year_range_chk": {
+          "name": "book_metadata_published_year_range_chk",
+          "value": "\"book_metadata\".\"published_year\" is null or (\"book_metadata\".\"published_year\" >= 1000 and \"book_metadata\".\"published_year\" <= 2200)"
+        },
+        "book_metadata_page_count_nonnegative_chk": {
+          "name": "book_metadata_page_count_nonnegative_chk",
+          "value": "\"book_metadata\".\"page_count\" is null or \"book_metadata\".\"page_count\" >= 0"
+        },
+        "book_metadata_duration_seconds_nonnegative_chk": {
+          "name": "book_metadata_duration_seconds_nonnegative_chk",
+          "value": "\"book_metadata\".\"duration_seconds\" is null or \"book_metadata\".\"duration_seconds\" >= 0"
+        },
+        "book_metadata_cover_source_chk": {
+          "name": "book_metadata_cover_source_chk",
+          "value": "\"book_metadata\".\"cover_source\" is null or \"book_metadata\".\"cover_source\" in ('extracted', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_metadata_fetch_queue": {
+      "name": "book_metadata_fetch_queue",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual_trigger'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_http_status": {
+          "name": "last_http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bmfq_status_idx": {
+          "name": "bmfq_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bmfq_created_at_idx": {
+          "name": "bmfq_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bmfq_status_created_book_idx": {
+          "name": "bmfq_status_created_book_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_metadata_fetch_queue_book_id_books_id_fk": {
+          "name": "book_metadata_fetch_queue_book_id_books_id_fk",
+          "tableFrom": "book_metadata_fetch_queue",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_metadata_fetch_queue_status_chk": {
+          "name": "book_metadata_fetch_queue_status_chk",
+          "value": "\"book_metadata_fetch_queue\".\"status\" in ('queued', 'processing', 'failed')"
+        },
+        "book_metadata_fetch_queue_reason_chk": {
+          "name": "book_metadata_fetch_queue_reason_chk",
+          "value": "\"book_metadata_fetch_queue\".\"reason\" in ('event_import', 'manual_trigger', 'manual_retry')"
+        },
+        "book_metadata_fetch_queue_attempt_count_nonnegative_chk": {
+          "name": "book_metadata_fetch_queue_attempt_count_nonnegative_chk",
+          "value": "\"book_metadata_fetch_queue\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_tags": {
+      "name": "book_tags",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "book_tags_tag_id_idx": {
+          "name": "book_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_tags_book_id_books_id_fk": {
+          "name": "book_tags_book_id_books_id_fk",
+          "tableFrom": "book_tags",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_tags_tag_id_tags_id_fk": {
+          "name": "book_tags_tag_id_tags_id_fk",
+          "tableFrom": "book_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_tags_book_id_tag_id_pk": {
+          "name": "book_tags_book_id_tag_id_pk",
+          "columns": ["book_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "genres_name_trgm_idx": {
+          "name": "genres_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "genres_name_unaccent_trgm_idx": {
+          "name": "genres_name_unaccent_trgm_idx",
+          "columns": [
+            {
+              "expression": "public.bookorbit_unaccent(\"name\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_name_unique": {
+          "name": "genres_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_trgm_idx": {
+          "name": "tags_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "tags_name_unaccent_trgm_idx": {
+          "name": "tags_name_unaccent_trgm_idx",
+          "columns": [
+            {
+              "expression": "public.bookorbit_unaccent(\"name\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_narrators": {
+      "name": "book_narrators",
+      "schema": "",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrator_id": {
+          "name": "narrator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "book_narrators_narrator_id_idx": {
+          "name": "book_narrators_narrator_id_idx",
+          "columns": [
+            {
+              "expression": "narrator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_narrators_book_id_books_id_fk": {
+          "name": "book_narrators_book_id_books_id_fk",
+          "tableFrom": "book_narrators",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_narrators_narrator_id_narrators_id_fk": {
+          "name": "book_narrators_narrator_id_narrators_id_fk",
+          "tableFrom": "book_narrators",
+          "tableTo": "narrators",
+          "columnsFrom": ["narrator_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_narrators_book_id_narrator_id_pk": {
+          "name": "book_narrators_book_id_narrator_id_pk",
+          "columns": ["book_id", "narrator_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.narrators": {
+      "name": "narrators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_name": {
+          "name": "sort_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "narrators_name_trgm_idx": {
+          "name": "narrators_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "narrators_name_unaccent_trgm_idx": {
+          "name": "narrators_name_unaccent_trgm_idx",
+          "columns": [
+            {
+              "expression": "public.bookorbit_unaccent(\"name\") gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "narrators_name_unique": {
+          "name": "narrators_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_dir_scan_state": {
+      "name": "library_dir_scan_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_folder_id": {
+          "name": "library_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dir_path": {
+          "name": "dir_path",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_mtime_ms": {
+          "name": "last_seen_mtime_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_dir_scan_state_folder_dir_uidx": {
+          "name": "library_dir_scan_state_folder_dir_uidx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dir_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_dir_scan_state_folder_idx": {
+          "name": "library_dir_scan_state_folder_idx",
+          "columns": [
+            {
+              "expression": "library_folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_dir_scan_state_library_folder_id_library_folders_id_fk": {
+          "name": "library_dir_scan_state_library_folder_id_library_folders_id_fk",
+          "tableFrom": "library_dir_scan_state",
+          "tableTo": "library_folders",
+          "columnsFrom": ["library_folder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scan_jobs": {
+      "name": "scan_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_count": {
+          "name": "added_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "missing_count": {
+          "name": "missing_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "scan_jobs_library_status_idx": {
+          "name": "scan_jobs_library_status_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scan_jobs_library_id_libraries_id_fk": {
+          "name": "scan_jobs_library_id_libraries_id_fk",
+          "tableFrom": "scan_jobs",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scan_jobs_status_chk": {
+          "name": "scan_jobs_status_chk",
+          "value": "\"scan_jobs\".\"status\" in ('running', 'completed', 'failed')"
+        },
+        "scan_jobs_triggered_by_chk": {
+          "name": "scan_jobs_triggered_by_chk",
+          "value": "\"scan_jobs\".\"triggered_by\" in ('manual', 'watcher', 'schedule')"
+        },
+        "scan_jobs_added_count_nonnegative_chk": {
+          "name": "scan_jobs_added_count_nonnegative_chk",
+          "value": "\"scan_jobs\".\"added_count\" >= 0"
+        },
+        "scan_jobs_updated_count_nonnegative_chk": {
+          "name": "scan_jobs_updated_count_nonnegative_chk",
+          "value": "\"scan_jobs\".\"updated_count\" >= 0"
+        },
+        "scan_jobs_missing_count_nonnegative_chk": {
+          "name": "scan_jobs_missing_count_nonnegative_chk",
+          "value": "\"scan_jobs\".\"missing_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.annotation_positions": {
+      "name": "annotation_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "annotation_id": {
+          "name": "annotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pos0": {
+          "name": "pos0",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pos1": {
+          "name": "pos1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exact'"
+        },
+        "converter_version": {
+          "name": "converter_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extras": {
+          "name": "extras",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annotation_positions_annotation_format_uidx": {
+          "name": "annotation_positions_annotation_format_uidx",
+          "columns": [
+            {
+              "expression": "annotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "format",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_positions_user_idx": {
+          "name": "annotation_positions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_positions_book_file_id_idx": {
+          "name": "annotation_positions_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_positions_format_status_idx": {
+          "name": "annotation_positions_format_status_idx",
+          "columns": [
+            {
+              "expression": "format",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "annotation_positions_annotation_id_annotations_id_fk": {
+          "name": "annotation_positions_annotation_id_annotations_id_fk",
+          "tableFrom": "annotation_positions",
+          "tableTo": "annotations",
+          "columnsFrom": ["annotation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "annotation_positions_user_id_users_id_fk": {
+          "name": "annotation_positions_user_id_users_id_fk",
+          "tableFrom": "annotation_positions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "annotation_positions_book_file_id_book_files_id_fk": {
+          "name": "annotation_positions_book_file_id_book_files_id_fk",
+          "tableFrom": "annotation_positions",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "annotation_positions_format_chk": {
+          "name": "annotation_positions_format_chk",
+          "value": "\"annotation_positions\".\"format\" in ('cfi', 'xpointer', 'pdf', 'kobo_span')"
+        },
+        "annotation_positions_status_chk": {
+          "name": "annotation_positions_status_chk",
+          "value": "\"annotation_positions\".\"status\" in ('exact', 'repaired', 'failed', 'pending')"
+        },
+        "annotation_positions_pos0_chk": {
+          "name": "annotation_positions_pos0_chk",
+          "value": "\"annotation_positions\".\"status\" in ('failed', 'pending') or \"annotation_positions\".\"pos0\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.annotation_sync_state": {
+      "name": "annotation_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "annotation_id": {
+          "name": "annotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_key": {
+          "name": "external_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_created_at": {
+          "name": "external_created_at",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_applied_version": {
+          "name": "last_applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "delete_acked_at": {
+          "name": "delete_acked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_synced_at": {
+          "name": "first_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annotation_sync_state_annotation_source_device_uidx": {
+          "name": "annotation_sync_state_annotation_source_device_uidx",
+          "columns": [
+            {
+              "expression": "annotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_sync_state_user_source_device_key_idx": {
+          "name": "annotation_sync_state_user_source_device_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_sync_state_user_key_idx": {
+          "name": "annotation_sync_state_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotation_sync_state_annotation_id_idx": {
+          "name": "annotation_sync_state_annotation_id_idx",
+          "columns": [
+            {
+              "expression": "annotation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "annotation_sync_state_annotation_id_annotations_id_fk": {
+          "name": "annotation_sync_state_annotation_id_annotations_id_fk",
+          "tableFrom": "annotation_sync_state",
+          "tableTo": "annotations",
+          "columnsFrom": ["annotation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "annotation_sync_state_user_id_users_id_fk": {
+          "name": "annotation_sync_state_user_id_users_id_fk",
+          "tableFrom": "annotation_sync_state",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "annotation_sync_state_source_chk": {
+          "name": "annotation_sync_state_source_chk",
+          "value": "\"annotation_sync_state\".\"source\" in ('koreader', 'kobo')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.annotations": {
+      "name": "annotations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yellow'"
+        },
+        "style": {
+          "name": "style",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'highlight'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_title": {
+          "name": "chapter_title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_created_at": {
+          "name": "device_created_at",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_updated_at": {
+          "name": "device_updated_at",
+          "type": "varchar(19)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annotations_user_id_idx": {
+          "name": "annotations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotations_user_id_id_idx": {
+          "name": "annotations_user_id_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotations_user_book_idx": {
+          "name": "annotations_user_book_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotations_book_id_idx": {
+          "name": "annotations_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "annotations_user_book_active_idx": {
+          "name": "annotations_user_book_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"annotations\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "annotations_user_id_users_id_fk": {
+          "name": "annotations_user_id_users_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "annotations_book_id_books_id_fk": {
+          "name": "annotations_book_id_books_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "annotations_style_chk": {
+          "name": "annotations_style_chk",
+          "value": "\"annotations\".\"style\" in ('highlight', 'underline', 'strikethrough', 'squiggly', 'invert')"
+        },
+        "annotations_origin_chk": {
+          "name": "annotations_origin_chk",
+          "value": "\"annotations\".\"origin\" in ('web', 'koreader', 'kobo')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audiobook_progress": {
+      "name": "audiobook_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_file_id": {
+          "name": "current_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hide_from_continue_listening": {
+          "name": "hide_from_continue_listening",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "abp_user_id_idx": {
+          "name": "abp_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audiobook_progress_book_id_idx": {
+          "name": "audiobook_progress_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audiobook_progress_current_file_id_idx": {
+          "name": "audiobook_progress_current_file_id_idx",
+          "columns": [
+            {
+              "expression": "current_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audiobook_progress_user_id_users_id_fk": {
+          "name": "audiobook_progress_user_id_users_id_fk",
+          "tableFrom": "audiobook_progress",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audiobook_progress_book_id_books_id_fk": {
+          "name": "audiobook_progress_book_id_books_id_fk",
+          "tableFrom": "audiobook_progress",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audiobook_progress_current_file_id_book_files_id_fk": {
+          "name": "audiobook_progress_current_file_id_book_files_id_fk",
+          "tableFrom": "audiobook_progress",
+          "tableTo": "book_files",
+          "columnsFrom": ["current_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audiobook_progress_user_id_book_id_pk": {
+          "name": "audiobook_progress_user_id_book_id_pk",
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audiobook_progress_percentage_range_chk": {
+          "name": "audiobook_progress_percentage_range_chk",
+          "value": "\"audiobook_progress\".\"percentage\" >= 0 and \"audiobook_progress\".\"percentage\" <= 100"
+        },
+        "audiobook_progress_position_seconds_nonnegative_chk": {
+          "name": "audiobook_progress_position_seconds_nonnegative_chk",
+          "value": "\"audiobook_progress\".\"position_seconds\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cfi": {
+          "name": "cfi",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_book_idx": {
+          "name": "bookmarks_user_book_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_book_id_idx": {
+          "name": "bookmarks_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_user_book_cfi_uidx": {
+          "name": "bookmarks_user_book_cfi_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cfi",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bookmarks\".\"cfi\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bookmarks_user_book_pos_uidx": {
+          "name": "bookmarks_user_book_pos_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position_seconds",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bookmarks\".\"position_seconds\" is not null and \"bookmarks\".\"cfi\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_book_id_books_id_fk": {
+          "name": "bookmarks_book_id_books_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reader_default_preferences": {
+      "name": "reader_default_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format_group": {
+          "name": "format_group",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rdp_user_format_idx": {
+          "name": "rdp_user_format_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "format_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reader_default_preferences_user_id_users_id_fk": {
+          "name": "reader_default_preferences_user_id_users_id_fk",
+          "tableFrom": "reader_default_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reader_default_preferences_format_group_chk": {
+          "name": "reader_default_preferences_format_group_chk",
+          "value": "\"reader_default_preferences\".\"format_group\" in ('epub', 'pdf', 'cbx', 'audio')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reader_preferences": {
+      "name": "reader_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rp_user_file_idx": {
+          "name": "rp_user_file_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reader_preferences_book_file_id_idx": {
+          "name": "reader_preferences_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reader_preferences_user_id_users_id_fk": {
+          "name": "reader_preferences_user_id_users_id_fk",
+          "tableFrom": "reader_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reader_preferences_book_file_id_book_files_id_fk": {
+          "name": "reader_preferences_book_file_id_book_files_id_fk",
+          "tableFrom": "reader_preferences",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_attempts": {
+      "name": "reading_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_on": {
+          "name": "started_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_on": {
+          "name": "ended_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_provider": {
+          "name": "external_provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_attempts_user_book_idx": {
+          "name": "reading_attempts_user_book_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reading_attempts_book_id_idx": {
+          "name": "reading_attempts_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reading_attempts_user_outcome_ended_idx": {
+          "name": "reading_attempts_user_outcome_ended_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ended_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reading_attempts_one_active_uidx": {
+          "name": "reading_attempts_one_active_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"reading_attempts\".\"outcome\" is null and \"reading_attempts\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reading_attempts_external_uidx": {
+          "name": "reading_attempts_external_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"reading_attempts\".\"external_provider\" is not null and \"reading_attempts\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reading_attempts_user_id_users_id_fk": {
+          "name": "reading_attempts_user_id_users_id_fk",
+          "tableFrom": "reading_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_attempts_book_id_books_id_fk": {
+          "name": "reading_attempts_book_id_books_id_fk",
+          "tableFrom": "reading_attempts",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reading_attempts_outcome_chk": {
+          "name": "reading_attempts_outcome_chk",
+          "value": "\"reading_attempts\".\"outcome\" is null or \"reading_attempts\".\"outcome\" in ('completed', 'skimmed', 'abandoned')"
+        },
+        "reading_attempts_origin_chk": {
+          "name": "reading_attempts_origin_chk",
+          "value": "\"reading_attempts\".\"origin\" in ('manual', 'bookorbit', 'kobo', 'koreader', 'hardcover', 'migration')"
+        },
+        "reading_attempts_end_after_start_chk": {
+          "name": "reading_attempts_end_after_start_chk",
+          "value": "\"reading_attempts\".\"ended_on\" is null or \"reading_attempts\".\"started_on\" is null or \"reading_attempts\".\"ended_on\" >= \"reading_attempts\".\"started_on\""
+        },
+        "reading_attempts_closed_has_outcome_chk": {
+          "name": "reading_attempts_closed_has_outcome_chk",
+          "value": "\"reading_attempts\".\"ended_on\" is null or \"reading_attempts\".\"outcome\" is not null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reading_progress": {
+      "name": "reading_progress",
+      "schema": "",
+      "columns": {
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cfi": {
+          "name": "cfi",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_number": {
+          "name": "page_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_seconds": {
+          "name": "position_seconds",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_location_source": {
+          "name": "kobo_location_source",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_location_type": {
+          "name": "kobo_location_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_location_value": {
+          "name": "kobo_location_value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kobo_content_source_progress_percent": {
+          "name": "kobo_content_source_progress_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koreader_progress": {
+          "name": "koreader_progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reading_progress_user_id_idx": {
+          "name": "reading_progress_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reading_progress_user_updated_at_idx": {
+          "name": "reading_progress_user_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reading_progress_book_file_id_book_files_id_fk": {
+          "name": "reading_progress_book_file_id_book_files_id_fk",
+          "tableFrom": "reading_progress",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_progress_user_id_users_id_fk": {
+          "name": "reading_progress_user_id_users_id_fk",
+          "tableFrom": "reading_progress",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reading_progress_book_file_id_user_id_pk": {
+          "name": "reading_progress_book_file_id_user_id_pk",
+          "columns": ["book_file_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reading_progress_percentage_range_chk": {
+          "name": "reading_progress_percentage_range_chk",
+          "value": "\"reading_progress\".\"percentage\" >= 0 and \"reading_progress\".\"percentage\" <= 100"
+        },
+        "reading_progress_page_number_nonnegative_chk": {
+          "name": "reading_progress_page_number_nonnegative_chk",
+          "value": "\"reading_progress\".\"page_number\" is null or \"reading_progress\".\"page_number\" >= 0"
+        },
+        "reading_progress_position_seconds_nonnegative_chk": {
+          "name": "reading_progress_position_seconds_nonnegative_chk",
+          "value": "\"reading_progress\".\"position_seconds\" is null or \"reading_progress\".\"position_seconds\" >= 0"
+        },
+        "reading_progress_kobo_content_source_progress_range_chk": {
+          "name": "reading_progress_kobo_content_source_progress_range_chk",
+          "value": "\"reading_progress\".\"kobo_content_source_progress_percent\" is null or (\"reading_progress\".\"kobo_content_source_progress_percent\" >= 0 and \"reading_progress\".\"kobo_content_source_progress_percent\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reading_sessions": {
+      "name": "reading_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress_delta": {
+          "name": "progress_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_progress": {
+          "name": "end_progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rs_user_session_id_uidx": {
+          "name": "rs_user_session_id_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_user_started_at_idx": {
+          "name": "rs_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_book_file_started_at_idx": {
+          "name": "rs_book_file_started_at_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_user_book_file_idx": {
+          "name": "rs_user_book_file_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_user_book_started_at_idx": {
+          "name": "rs_user_book_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reading_sessions_book_id_idx": {
+          "name": "reading_sessions_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rs_attempt_started_at_idx": {
+          "name": "rs_attempt_started_at_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reading_sessions_user_id_users_id_fk": {
+          "name": "reading_sessions_user_id_users_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_sessions_book_file_id_book_files_id_fk": {
+          "name": "reading_sessions_book_file_id_book_files_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_sessions_book_id_books_id_fk": {
+          "name": "reading_sessions_book_id_books_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_sessions_attempt_id_reading_attempts_id_fk": {
+          "name": "reading_sessions_attempt_id_reading_attempts_id_fk",
+          "tableFrom": "reading_sessions",
+          "tableTo": "reading_attempts",
+          "columnsFrom": ["attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reading_sessions_source_chk": {
+          "name": "reading_sessions_source_chk",
+          "value": "\"reading_sessions\".\"source\" in ('web', 'koreader', 'manual', 'kobo')"
+        },
+        "reading_sessions_duration_seconds_nonnegative_chk": {
+          "name": "reading_sessions_duration_seconds_nonnegative_chk",
+          "value": "\"reading_sessions\".\"duration_seconds\" >= 0"
+        },
+        "reading_sessions_end_progress_range_chk": {
+          "name": "reading_sessions_end_progress_range_chk",
+          "value": "\"reading_sessions\".\"end_progress\" is null or (\"reading_sessions\".\"end_progress\" >= 0 and \"reading_sessions\".\"end_progress\" <= 100)"
+        },
+        "reading_sessions_ended_after_started_chk": {
+          "name": "reading_sessions_ended_after_started_chk",
+          "value": "\"reading_sessions\".\"ended_at\" >= \"reading_sessions\".\"started_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_book_notes": {
+      "name": "user_book_notes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ubn_user_id_idx": {
+          "name": "ubn_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubn_book_id_idx": {
+          "name": "ubn_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubn_book_user_idx": {
+          "name": "ubn_book_user_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_book_notes_user_id_users_id_fk": {
+          "name": "user_book_notes_user_id_users_id_fk",
+          "tableFrom": "user_book_notes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_book_notes_book_id_books_id_fk": {
+          "name": "user_book_notes_book_id_books_id_fk",
+          "tableFrom": "user_book_notes",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_book_notes_user_id_book_id_pk": {
+          "name": "user_book_notes_user_id_book_id_pk",
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_book_notes_note_length_chk": {
+          "name": "user_book_notes_note_length_chk",
+          "value": "\"user_book_notes\".\"note\" is null or char_length(\"user_book_notes\".\"note\") <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_book_ratings": {
+      "name": "user_book_ratings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ubr_user_id_idx": {
+          "name": "ubr_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubr_book_id_idx": {
+          "name": "ubr_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubr_book_user_rating_idx": {
+          "name": "ubr_book_user_rating_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_book_ratings_user_id_users_id_fk": {
+          "name": "user_book_ratings_user_id_users_id_fk",
+          "tableFrom": "user_book_ratings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_book_ratings_book_id_books_id_fk": {
+          "name": "user_book_ratings_book_id_books_id_fk",
+          "tableFrom": "user_book_ratings",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_book_ratings_user_id_book_id_pk": {
+          "name": "user_book_ratings_user_id_book_id_pk",
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_book_ratings_rating_range_chk": {
+          "name": "user_book_ratings_rating_range_chk",
+          "value": "\"user_book_ratings\".\"rating\" is null or (\"user_book_ratings\".\"rating\" >= 1 and \"user_book_ratings\".\"rating\" <= 5)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_book_status": {
+      "name": "user_book_status",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unread'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ubs_user_id_idx": {
+          "name": "ubs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubs_user_status_idx": {
+          "name": "ubs_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ubs_book_user_idx": {
+          "name": "ubs_book_user_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_book_status_user_id_users_id_fk": {
+          "name": "user_book_status_user_id_users_id_fk",
+          "tableFrom": "user_book_status",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_book_status_book_id_books_id_fk": {
+          "name": "user_book_status_book_id_books_id_fk",
+          "tableFrom": "user_book_status",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_book_status_user_id_book_id_pk": {
+          "name": "user_book_status_user_id_book_id_pk",
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_book_status_status_chk": {
+          "name": "user_book_status_status_chk",
+          "value": "\"user_book_status\".\"status\" in ('unread', 'want_to_read', 'reading', 'on_hold', 'rereading', 'read', 'skimmed', 'abandoned')"
+        },
+        "user_book_status_source_chk": {
+          "name": "user_book_status_source_chk",
+          "value": "\"user_book_status\".\"source\" in ('auto', 'manual')"
+        },
+        "user_book_status_finished_after_started_chk": {
+          "name": "user_book_status_finished_after_started_chk",
+          "value": "\"user_book_status\".\"finished_at\" is null or \"user_book_status\".\"started_at\" is null or \"user_book_status\".\"finished_at\" >= \"user_book_status\".\"started_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_reading_daily_stats": {
+      "name": "user_reading_daily_stats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reading_seconds": {
+          "name": "reading_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_delta": {
+          "name": "progress_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sessions_count": {
+          "name": "sessions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "urds_user_day_idx": {
+          "name": "urds_user_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_reading_daily_stats_library_id_idx": {
+          "name": "user_reading_daily_stats_library_id_idx",
+          "columns": [
+            {
+              "expression": "library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_reading_daily_stats_user_id_users_id_fk": {
+          "name": "user_reading_daily_stats_user_id_users_id_fk",
+          "tableFrom": "user_reading_daily_stats",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_reading_daily_stats_library_id_libraries_id_fk": {
+          "name": "user_reading_daily_stats_library_id_libraries_id_fk",
+          "tableFrom": "user_reading_daily_stats",
+          "tableTo": "libraries",
+          "columnsFrom": ["library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_reading_daily_stats_user_id_library_id_day_pk": {
+          "name": "user_reading_daily_stats_user_id_library_id_day_pk",
+          "columns": ["user_id", "library_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_reading_daily_stats_reading_seconds_nonnegative_chk": {
+          "name": "user_reading_daily_stats_reading_seconds_nonnegative_chk",
+          "value": "\"user_reading_daily_stats\".\"reading_seconds\" >= 0"
+        },
+        "user_reading_daily_stats_sessions_count_nonnegative_chk": {
+          "name": "user_reading_daily_stats_sessions_count_nonnegative_chk",
+          "value": "\"user_reading_daily_stats\".\"sessions_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oidc_group_mappings": {
+      "name": "oidc_group_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_group_claim": {
+          "name": "oidc_group_claim",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_name": {
+          "name": "permission_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_group_mappings_provider_claim_uidx": {
+          "name": "oidc_group_mappings_provider_claim_uidx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_group_claim",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_group_mappings_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_group_mappings_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_group_mappings",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_identities": {
+      "name": "oidc_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_identities_provider_subject_uidx": {
+          "name": "oidc_identities_provider_subject_uidx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_identities_user_provider_uidx": {
+          "name": "oidc_identities_user_provider_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_identities_issuer_subject_uidx": {
+          "name": "oidc_identities_issuer_subject_uidx",
+          "columns": [
+            {
+              "expression": "oidc_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_identities_user_id_idx": {
+          "name": "oidc_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_identities_user_id_users_id_fk": {
+          "name": "oidc_identities_user_id_users_id_fk",
+          "tableFrom": "oidc_identities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_identities_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_identities_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_identities",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_permission_grants": {
+      "name": "oidc_permission_grants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_name": {
+          "name": "permission_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oidc_permission_grants_user_id_users_id_fk": {
+          "name": "oidc_permission_grants_user_id_users_id_fk",
+          "tableFrom": "oidc_permission_grants",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_permission_grants_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_permission_grants_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_permission_grants",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "oidc_permission_grants_user_id_provider_id_permission_name_pk": {
+          "name": "oidc_permission_grants_user_id_provider_id_permission_name_pk",
+          "columns": ["user_id", "provider_id", "permission_name"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_providers": {
+      "name": "oidc_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "issuer_uri": {
+          "name": "issuer_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openid profile email'"
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_mapping": {
+          "name": "claim_mapping",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"username\":\"preferred_username\",\"name\":\"name\",\"email\":\"email\",\"groups\":\"groups\"}'::jsonb"
+        },
+        "auto_provision": {
+          "name": "auto_provision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"enabled\":false,\"allowLocalLinking\":false,\"defaultPermissionNames\":[]}'::jsonb"
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oidc_providers_enabled_order_idx": {
+          "name": "oidc_providers_enabled_order_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oidc_providers_slug_unique": {
+          "name": "oidc_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "oidc_providers_issuer_uri_unique": {
+          "name": "oidc_providers_issuer_uri_unique",
+          "nullsNotDistinct": false,
+          "columns": ["issuer_uri"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_sessions": {
+      "name": "oidc_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oidc_subject": {
+          "name": "oidc_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_issuer": {
+          "name": "oidc_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_session_id": {
+          "name": "oidc_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token_hint": {
+          "name": "id_token_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idp_refresh_token": {
+          "name": "idp_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oidc_sessions_user_active_idx": {
+          "name": "oidc_sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"oidc_sessions\".\"revoked\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_subject_issuer_idx": {
+          "name": "oidc_sessions_subject_issuer_idx",
+          "columns": [
+            {
+              "expression": "oidc_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oidc_issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_sid_idx": {
+          "name": "oidc_sessions_sid_idx",
+          "columns": [
+            {
+              "expression": "oidc_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_expires_at_idx": {
+          "name": "oidc_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oidc_sessions_provider_id_idx": {
+          "name": "oidc_sessions_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_sessions_user_id_users_id_fk": {
+          "name": "oidc_sessions_user_id_users_id_fk",
+          "tableFrom": "oidc_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_sessions_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_sessions_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_sessions",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_states": {
+      "name": "oidc_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meta": {
+          "name": "meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oidc_states_expires_at_idx": {
+          "name": "oidc_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_states_provider_id_oidc_providers_id_fk": {
+          "name": "oidc_states_provider_id_oidc_providers_id_fk",
+          "tableFrom": "oidc_states",
+          "tableTo": "oidc_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_used_jtis": {
+      "name": "oidc_used_jtis",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oidc_used_jtis_expires_at_idx": {
+          "name": "oidc_used_jtis_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opds_users": {
+      "name": "opds_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "opds_sort_order",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recent'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opds_users_username_lower_uidx": {
+          "name": "opds_users_username_lower_uidx",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opds_users_user_id_users_id_fk": {
+          "name": "opds_users_user_id_users_id_fk",
+          "tableFrom": "opds_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opds_users_username_unique": {
+          "name": "opds_users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_book_entitlements": {
+      "name": "kobo_book_entitlements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "needs_legacy_numeric_removal": {
+          "name": "needs_legacy_numeric_removal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kobo_book_entitlements_user_id_idx": {
+          "name": "kobo_book_entitlements_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kobo_book_entitlements_book_id_idx": {
+          "name": "kobo_book_entitlements_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_book_entitlements_user_id_users_id_fk": {
+          "name": "kobo_book_entitlements_user_id_users_id_fk",
+          "tableFrom": "kobo_book_entitlements",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_book_entitlements_book_id_books_id_fk": {
+          "name": "kobo_book_entitlements_book_id_books_id_fk",
+          "tableFrom": "kobo_book_entitlements",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_book_entitlements_user_book_unique": {
+          "name": "kobo_book_entitlements_user_book_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "book_id"]
+        },
+        "kobo_book_entitlements_user_entitlement_unique": {
+          "name": "kobo_book_entitlements_user_entitlement_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "entitlement_id"]
+        },
+        "kobo_book_entitlements_user_cover_unique": {
+          "name": "kobo_book_entitlements_user_cover_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "cover_image_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_devices": {
+      "name": "kobo_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_device_id": {
+          "name": "client_device_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kobo_devices_user_id_idx": {
+          "name": "kobo_devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_devices_user_id_users_id_fk": {
+          "name": "kobo_devices_user_id_users_id_fk",
+          "tableFrom": "kobo_devices",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_devices_token_unique": {
+          "name": "kobo_devices_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        },
+        "kobo_devices_client_device_id_unique": {
+          "name": "kobo_devices_client_device_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_device_id"]
+        },
+        "kobo_devices_id_user_id_unique": {
+          "name": "kobo_devices_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_library_snapshots": {
+      "name": "kobo_library_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_device_cutoff_at": {
+          "name": "legacy_device_cutoff_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kobo_library_snapshots_user_id_users_id_fk": {
+          "name": "kobo_library_snapshots_user_id_users_id_fk",
+          "tableFrom": "kobo_library_snapshots",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_library_snapshots_user_id_unique": {
+          "name": "kobo_library_snapshots_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_snapshot_books": {
+      "name": "kobo_snapshot_books",
+      "schema": "",
+      "columns": {
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_delete": {
+          "name": "pending_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_by_device": {
+          "name": "removed_by_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_hash": {
+          "name": "delivery_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_hash": {
+          "name": "metadata_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kobo_snapshot_books_book_id_idx": {
+          "name": "kobo_snapshot_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kobo_snapshot_books_snapshot_synced_book_idx": {
+          "name": "kobo_snapshot_books_snapshot_synced_book_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "synced",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_snapshot_books_snapshot_id_kobo_library_snapshots_id_fk": {
+          "name": "kobo_snapshot_books_snapshot_id_kobo_library_snapshots_id_fk",
+          "tableFrom": "kobo_snapshot_books",
+          "tableTo": "kobo_library_snapshots",
+          "columnsFrom": ["snapshot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_snapshot_books_book_id_books_id_fk": {
+          "name": "kobo_snapshot_books_book_id_books_id_fk",
+          "tableFrom": "kobo_snapshot_books",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kobo_snapshot_books_snapshot_id_book_id_pk": {
+          "name": "kobo_snapshot_books_snapshot_id_book_id_pk",
+          "columns": ["snapshot_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_device_library_snapshots": {
+      "name": "kobo_device_library_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kobo_device_library_snapshots_user_id_idx": {
+          "name": "kobo_device_library_snapshots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_device_library_snapshots_user_id_users_id_fk": {
+          "name": "kobo_device_library_snapshots_user_id_users_id_fk",
+          "tableFrom": "kobo_device_library_snapshots",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_device_library_snapshots_device_owner_fk": {
+          "name": "kobo_device_library_snapshots_device_owner_fk",
+          "tableFrom": "kobo_device_library_snapshots",
+          "tableTo": "kobo_devices",
+          "columnsFrom": ["device_id", "user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_device_library_snapshots_device_id_unique": {
+          "name": "kobo_device_library_snapshots_device_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["device_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_reading_states": {
+      "name": "kobo_reading_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entitlement_id": {
+          "name": "entitlement_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at_kobo": {
+          "name": "created_at_kobo",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_kobo": {
+          "name": "last_modified_kobo",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority_timestamp": {
+          "name": "priority_timestamp",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bookmark": {
+          "name": "current_bookmark",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statistics": {
+          "name": "statistics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_info": {
+          "name": "status_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kobo_reading_states_book_id_idx": {
+          "name": "kobo_reading_states_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_reading_states_user_id_users_id_fk": {
+          "name": "kobo_reading_states_user_id_users_id_fk",
+          "tableFrom": "kobo_reading_states",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_reading_states_book_id_books_id_fk": {
+          "name": "kobo_reading_states_book_id_books_id_fk",
+          "tableFrom": "kobo_reading_states",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_reading_states_user_id_book_id_unique": {
+          "name": "kobo_reading_states_user_id_book_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_device_snapshot_books": {
+      "name": "kobo_device_snapshot_books",
+      "schema": "",
+      "columns": {
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced": {
+          "name": "synced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pending_delete": {
+          "name": "pending_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_new": {
+          "name": "is_new",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "removed_by_device": {
+          "name": "removed_by_device",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "needs_legacy_numeric_removal": {
+          "name": "needs_legacy_numeric_removal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_hash": {
+          "name": "delivery_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_hash": {
+          "name": "metadata_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "kobo_device_snapshot_books_book_id_idx": {
+          "name": "kobo_device_snapshot_books_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kobo_device_snapshot_books_snapshot_synced_book_idx": {
+          "name": "kobo_device_snapshot_books_snapshot_synced_book_idx",
+          "columns": [
+            {
+              "expression": "snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "synced",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_device_snapshot_books_snapshot_id_kobo_device_library_snapshots_id_fk": {
+          "name": "kobo_device_snapshot_books_snapshot_id_kobo_device_library_snapshots_id_fk",
+          "tableFrom": "kobo_device_snapshot_books",
+          "tableTo": "kobo_device_library_snapshots",
+          "columnsFrom": ["snapshot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_device_snapshot_books_book_id_books_id_fk": {
+          "name": "kobo_device_snapshot_books_book_id_books_id_fk",
+          "tableFrom": "kobo_device_snapshot_books",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kobo_device_snapshot_books_snapshot_id_book_id_pk": {
+          "name": "kobo_device_snapshot_books_snapshot_id_book_id_pk",
+          "columns": ["snapshot_id", "book_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kobo_sync_history": {
+      "name": "kobo_sync_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counts": {
+          "name": "counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kobo_sync_history_user_created_idx": {
+          "name": "kobo_sync_history_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kobo_sync_history_device_created_idx": {
+          "name": "kobo_sync_history_device_created_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kobo_sync_history_user_id_users_id_fk": {
+          "name": "kobo_sync_history_user_id_users_id_fk",
+          "tableFrom": "kobo_sync_history",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kobo_sync_history_device_id_kobo_devices_id_fk": {
+          "name": "kobo_sync_history_device_id_kobo_devices_id_fk",
+          "tableFrom": "kobo_sync_history",
+          "tableTo": "kobo_devices",
+          "columnsFrom": ["device_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "kobo_sync_history_event_chk": {
+          "name": "kobo_sync_history_event_chk",
+          "value": "\"kobo_sync_history\".\"event\" in ('library_sync', 'book_download', 'progress_update', 'annotations_pull', 'annotations_push')"
+        },
+        "kobo_sync_history_status_chk": {
+          "name": "kobo_sync_history_status_chk",
+          "value": "\"kobo_sync_history\".\"status\" in ('success', 'failed')"
+        },
+        "kobo_sync_history_duration_nonnegative_chk": {
+          "name": "kobo_sync_history_duration_nonnegative_chk",
+          "value": "\"kobo_sync_history\".\"duration_ms\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.kobo_sync_settings": {
+      "name": "kobo_sync_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reading_threshold": {
+          "name": "reading_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finished_threshold": {
+          "name": "finished_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 99
+        },
+        "convert_to_kepub": {
+          "name": "convert_to_kepub",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "force_enable_hyphenation": {
+          "name": "force_enable_hyphenation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "kepub_conversion_limit_mb": {
+          "name": "kepub_conversion_limit_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "two_way_progress_sync": {
+          "name": "two_way_progress_sync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sync_bookorbit_annotations_to_kobo": {
+          "name": "sync_bookorbit_annotations_to_kobo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kobo_sync_settings_user_id_users_id_fk": {
+          "name": "kobo_sync_settings_user_id_users_id_fk",
+          "tableFrom": "kobo_sync_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "kobo_sync_settings_user_id_unique": {
+          "name": "kobo_sync_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "kobo_sync_settings_reading_threshold_range_chk": {
+          "name": "kobo_sync_settings_reading_threshold_range_chk",
+          "value": "\"kobo_sync_settings\".\"reading_threshold\" >= 0 and \"kobo_sync_settings\".\"reading_threshold\" <= 100"
+        },
+        "kobo_sync_settings_finished_threshold_range_chk": {
+          "name": "kobo_sync_settings_finished_threshold_range_chk",
+          "value": "\"kobo_sync_settings\".\"finished_threshold\" >= 0 and \"kobo_sync_settings\".\"finished_threshold\" <= 100"
+        },
+        "kobo_sync_settings_conversion_limit_nonnegative_chk": {
+          "name": "kobo_sync_settings_conversion_limit_nonnegative_chk",
+          "value": "\"kobo_sync_settings\".\"kepub_conversion_limit_mb\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_dock_files": {
+      "name": "book_dock_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_path": {
+          "name": "absolute_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "embedded_metadata": {
+          "name": "embedded_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_metadata": {
+          "name": "selected_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_metadata": {
+          "name": "fetched_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_path": {
+          "name": "cover_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_library_id": {
+          "name": "target_library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_folder_id": {
+          "name": "target_folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_metadata_sources": {
+          "name": "fetched_metadata_sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_edited_at": {
+          "name": "metadata_edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_dock_files_status_idx": {
+          "name": "book_dock_files_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_dock_files_target_library_id_idx": {
+          "name": "book_dock_files_target_library_id_idx",
+          "columns": [
+            {
+              "expression": "target_library_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_dock_files_uploaded_by_idx": {
+          "name": "book_dock_files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_dock_files_target_library_id_libraries_id_fk": {
+          "name": "book_dock_files_target_library_id_libraries_id_fk",
+          "tableFrom": "book_dock_files",
+          "tableTo": "libraries",
+          "columnsFrom": ["target_library_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_dock_files_target_folder_id_library_folders_id_fk": {
+          "name": "book_dock_files_target_folder_id_library_folders_id_fk",
+          "tableFrom": "book_dock_files",
+          "tableTo": "library_folders",
+          "columnsFrom": ["target_folder_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_dock_files_uploaded_by_users_id_fk": {
+          "name": "book_dock_files_uploaded_by_users_id_fk",
+          "tableFrom": "book_dock_files",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "book_dock_files_absolute_path_unique": {
+          "name": "book_dock_files_absolute_path_unique",
+          "nullsNotDistinct": false,
+          "columns": ["absolute_path"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "book_dock_files_status_chk": {
+          "name": "book_dock_files_status_chk",
+          "value": "\"book_dock_files\".\"status\" in ('pending', 'extracting', 'fetching', 'ready', 'error')"
+        },
+        "book_dock_files_confidence_range_chk": {
+          "name": "book_dock_files_confidence_range_chk",
+          "value": "\"book_dock_files\".\"confidence\" is null or (\"book_dock_files\".\"confidence\" >= 0 and \"book_dock_files\".\"confidence\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.file_write_log": {
+      "name": "file_write_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fields_written": {
+          "name": "fields_written",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "written_at": {
+          "name": "written_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fwl_book_id_written_at_idx": {
+          "name": "fwl_book_id_written_at_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "written_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_write_log_book_file_id_idx": {
+          "name": "file_write_log_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_write_log_book_id_books_id_fk": {
+          "name": "file_write_log_book_id_books_id_fk",
+          "tableFrom": "file_write_log",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_write_log_book_file_id_book_files_id_fk": {
+          "name": "file_write_log_book_file_id_book_files_id_fk",
+          "tableFrom": "file_write_log",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "file_write_log_user_id_users_id_fk": {
+          "name": "file_write_log_user_id_users_id_fk",
+          "tableFrom": "file_write_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_write_log_status_chk": {
+          "name": "file_write_log_status_chk",
+          "value": "\"file_write_log\".\"status\" in ('success', 'skipped', 'failed')"
+        },
+        "file_write_log_triggered_by_chk": {
+          "name": "file_write_log_triggered_by_chk",
+          "value": "\"file_write_log\".\"triggered_by\" in ('auto', 'sync')"
+        },
+        "file_write_log_duration_ms_nonnegative_chk": {
+          "name": "file_write_log_duration_ms_nonnegative_chk",
+          "value": "\"file_write_log\".\"duration_ms\" is null or \"file_write_log\".\"duration_ms\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_templates_one_default_per_user_uidx": {
+          "name": "email_templates_one_default_per_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"is_default\" = true and \"email_templates\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_templates_system_name_unique": {
+          "name": "email_templates_system_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_templates\".\"user_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_user_id_users_id_fk": {
+          "name": "email_templates_user_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_templates_user_id_name_unique": {
+          "name": "email_templates_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_providers": {
+      "name": "email_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_enc": {
+          "name": "password_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ssl": {
+          "name": "ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "start_tls": {
+          "name": "start_tls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_system_provider": {
+          "name": "is_system_provider",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls_reject_unauthorized": {
+          "name": "tls_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_providers_one_default_per_user_uidx": {
+          "name": "email_providers_one_default_per_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_providers\".\"is_default\" = true and \"email_providers\".\"user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_providers_one_system_provider_uidx": {
+          "name": "email_providers_one_system_provider_uidx",
+          "columns": [
+            {
+              "expression": "is_system_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_providers\".\"is_system_provider\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_providers_user_id_users_id_fk": {
+          "name": "email_providers_user_id_users_id_fk",
+          "tableFrom": "email_providers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_providers_user_id_name_unique": {
+          "name": "email_providers_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name"]
+        },
+        "email_providers_id_user_id_unique": {
+          "name": "email_providers_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_providers_port_range_chk": {
+          "name": "email_providers_port_range_chk",
+          "value": "\"email_providers\".\"port\" >= 1 and \"email_providers\".\"port\" <= 65535"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_recipient_group_members": {
+      "name": "email_recipient_group_members",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_recipient_group_members_user_id_users_id_fk": {
+          "name": "email_recipient_group_members_user_id_users_id_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_group_id_email_recipient_groups_id_fk": {
+          "name": "email_recipient_group_members_group_id_email_recipient_groups_id_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipient_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_recipient_id_email_recipients_id_fk": {
+          "name": "email_recipient_group_members_recipient_id_email_recipients_id_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipients",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_group_user_fk": {
+          "name": "email_recipient_group_members_group_user_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipient_groups",
+          "columnsFrom": ["group_id", "user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "email_recipient_group_members_recipient_user_fk": {
+          "name": "email_recipient_group_members_recipient_user_fk",
+          "tableFrom": "email_recipient_group_members",
+          "tableTo": "email_recipients",
+          "columnsFrom": ["recipient_id", "user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_recipient_group_members_group_id_recipient_id_pk": {
+          "name": "email_recipient_group_members_group_id_recipient_id_pk",
+          "columns": ["group_id", "recipient_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_recipient_groups": {
+      "name": "email_recipient_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_template_id": {
+          "name": "default_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_recipient_groups_user_id_users_id_fk": {
+          "name": "email_recipient_groups_user_id_users_id_fk",
+          "tableFrom": "email_recipient_groups",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipient_groups_default_template_id_email_templates_id_fk": {
+          "name": "email_recipient_groups_default_template_id_email_templates_id_fk",
+          "tableFrom": "email_recipient_groups",
+          "tableTo": "email_templates",
+          "columnsFrom": ["default_template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_recipient_groups_user_id_name_unique": {
+          "name": "email_recipient_groups_user_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name"]
+        },
+        "email_recipient_groups_id_user_id_unique": {
+          "name": "email_recipient_groups_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_recipients": {
+      "name": "email_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_format": {
+          "name": "preferred_format",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_template_id": {
+          "name": "default_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_recipients_user_email_lower_uidx": {
+          "name": "email_recipients_user_email_lower_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_recipients_one_default_per_user_uidx": {
+          "name": "email_recipients_one_default_per_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_recipients\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_recipients_user_id_users_id_fk": {
+          "name": "email_recipients_user_id_users_id_fk",
+          "tableFrom": "email_recipients",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_recipients_default_template_id_email_templates_id_fk": {
+          "name": "email_recipients_default_template_id_email_templates_id_fk",
+          "tableFrom": "email_recipients",
+          "tableTo": "email_templates",
+          "columnsFrom": ["default_template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_recipients_user_id_email_unique": {
+          "name": "email_recipients_user_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "email"]
+        },
+        "email_recipients_id_user_id_unique": {
+          "name": "email_recipients_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_recipients_device_type_chk": {
+          "name": "email_recipients_device_type_chk",
+          "value": "\"email_recipients\".\"device_type\" is null or \"email_recipients\".\"device_type\" in ('kindle', 'kobo', 'other')"
+        },
+        "email_recipients_preferred_format_chk": {
+          "name": "email_recipients_preferred_format_chk",
+          "value": "\"email_recipients\".\"preferred_format\" is null or \"email_recipients\".\"preferred_format\" in ('epub', 'pdf', 'mobi', 'azw3', 'cbz', 'cbr')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_preferences": {
+      "name": "email_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_provider_id": {
+          "name": "default_provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_recipient_id": {
+          "name": "default_recipient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_template_id": {
+          "name": "default_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_preferences_user_id_users_id_fk": {
+          "name": "email_preferences_user_id_users_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_provider_id_email_providers_id_fk": {
+          "name": "email_preferences_default_provider_id_email_providers_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_providers",
+          "columnsFrom": ["default_provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_recipient_id_email_recipients_id_fk": {
+          "name": "email_preferences_default_recipient_id_email_recipients_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_recipients",
+          "columnsFrom": ["default_recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_template_id_email_templates_id_fk": {
+          "name": "email_preferences_default_template_id_email_templates_id_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_templates",
+          "columnsFrom": ["default_template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_preferences_default_recipient_owner_fk": {
+          "name": "email_preferences_default_recipient_owner_fk",
+          "tableFrom": "email_preferences",
+          "tableTo": "email_recipients",
+          "columnsFrom": ["default_recipient_id", "user_id"],
+          "columnsTo": ["id", "user_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_preferences_user_id_unique": {
+          "name": "email_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_send_log": {
+      "name": "email_send_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_email": {
+          "name": "to_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_name": {
+          "name": "to_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_send_log_user_created_at_idx": {
+          "name": "email_send_log_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_send_log_book_id_idx": {
+          "name": "email_send_log_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_send_log_book_file_id_idx": {
+          "name": "email_send_log_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_send_log_created_at_idx": {
+          "name": "email_send_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_send_log_status_next_retry_idx": {
+          "name": "email_send_log_status_next_retry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_send_log_user_id_users_id_fk": {
+          "name": "email_send_log_user_id_users_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_send_log_book_id_books_id_fk": {
+          "name": "email_send_log_book_id_books_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_send_log_book_file_id_book_files_id_fk": {
+          "name": "email_send_log_book_file_id_book_files_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_send_log_provider_id_email_providers_id_fk": {
+          "name": "email_send_log_provider_id_email_providers_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "email_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_send_log_template_id_email_templates_id_fk": {
+          "name": "email_send_log_template_id_email_templates_id_fk",
+          "tableFrom": "email_send_log",
+          "tableTo": "email_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_send_log_status_chk": {
+          "name": "email_send_log_status_chk",
+          "value": "\"email_send_log\".\"status\" in ('pending', 'sent', 'failed')"
+        },
+        "email_send_log_attempt_count_nonnegative_chk": {
+          "name": "email_send_log_attempt_count_nonnegative_chk",
+          "value": "\"email_send_log\".\"attempt_count\" >= 0"
+        },
+        "email_send_log_sent_after_created_chk": {
+          "name": "email_send_log_sent_after_created_chk",
+          "value": "\"email_send_log\".\"sent_at\" is null or \"email_send_log\".\"sent_at\" >= \"email_send_log\".\"created_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dismissed_duplicate_pairs": {
+      "name": "dismissed_duplicate_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_a": {
+          "name": "entity_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_b": {
+          "name": "entity_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by": {
+          "name": "dismissed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dismissed_duplicate_pairs_entity_a_idx": {
+          "name": "dismissed_duplicate_pairs_entity_a_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dismissed_duplicate_pairs_entity_b_idx": {
+          "name": "dismissed_duplicate_pairs_entity_b_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dismissed_duplicate_pairs_dismissed_by_users_id_fk": {
+          "name": "dismissed_duplicate_pairs_dismissed_by_users_id_fk",
+          "tableFrom": "dismissed_duplicate_pairs",
+          "tableTo": "users",
+          "columnsFrom": ["dismissed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dismissed_duplicate_pairs_unique": {
+          "name": "dismissed_duplicate_pairs_unique",
+          "nullsNotDistinct": false,
+          "columns": ["entity_type", "entity_id_a", "entity_id_b"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dismissed_inline_duplicate_pairs": {
+      "name": "dismissed_inline_duplicate_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_a": {
+          "name": "value_a",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_b": {
+          "name": "value_b",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_by": {
+          "name": "dismissed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dismissed_inline_pairs_entity_a_idx": {
+          "name": "dismissed_inline_pairs_entity_a_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dismissed_inline_pairs_entity_b_idx": {
+          "name": "dismissed_inline_pairs_entity_b_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dismissed_inline_duplicate_pairs_dismissed_by_users_id_fk": {
+          "name": "dismissed_inline_duplicate_pairs_dismissed_by_users_id_fk",
+          "tableFrom": "dismissed_inline_duplicate_pairs",
+          "tableTo": "users",
+          "columnsFrom": ["dismissed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dismissed_inline_duplicate_pairs_unique": {
+          "name": "dismissed_inline_duplicate_pairs_unique",
+          "nullsNotDistinct": false,
+          "columns": ["entity_type", "value_a", "value_b"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_duplicate_candidates": {
+      "name": "entity_duplicate_candidates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_a": {
+          "name": "entity_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id_b": {
+          "name": "entity_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sim_score": {
+          "name": "sim_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_dup_candidates_type_sim_idx": {
+          "name": "entity_dup_candidates_type_sim_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sim_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_dup_candidates_entity_a_idx": {
+          "name": "entity_dup_candidates_entity_a_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_dup_candidates_entity_b_idx": {
+          "name": "entity_dup_candidates_entity_b_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entity_duplicate_candidates_unique": {
+          "name": "entity_duplicate_candidates_unique",
+          "nullsNotDistinct": false,
+          "columns": ["entity_type", "entity_id_a", "entity_id_b"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_duplicate_scan_status": {
+      "name": "entity_duplicate_scan_status",
+      "schema": "",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_computing": {
+          "name": "is_computing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pairs": {
+          "name": "total_pairs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_count": {
+          "name": "processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_fonts": {
+      "name": "user_fonts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_name": {
+          "name": "family_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_file_name": {
+          "name": "original_file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_file_name": {
+          "name": "stored_file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 400
+        },
+        "style": {
+          "name": "style",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uf_user_hash_uidx": {
+          "name": "uf_user_hash_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uf_user_family_weight_style_uidx": {
+          "name": "uf_user_family_weight_style_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "family_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "style",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_fonts_user_id_users_id_fk": {
+          "name": "user_fonts_user_id_users_id_fk",
+          "tableFrom": "user_fonts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_fonts_format_chk": {
+          "name": "user_fonts_format_chk",
+          "value": "\"user_fonts\".\"format\" in ('ttf', 'otf', 'woff', 'woff2')"
+        },
+        "user_fonts_weight_chk": {
+          "name": "user_fonts_weight_chk",
+          "value": "\"user_fonts\".\"weight\" >= 100 and \"user_fonts\".\"weight\" <= 900 and \"user_fonts\".\"weight\" % 100 = 0"
+        },
+        "user_fonts_style_chk": {
+          "name": "user_fonts_style_chk",
+          "value": "\"user_fonts\".\"style\" in ('normal', 'italic')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.book_file_chapters": {
+      "name": "book_file_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_index": {
+          "name": "chapter_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "href": {
+          "name": "href",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spine_index": {
+          "name": "spine_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "book_file_chapters_book_file_id_chapter_index_uidx": {
+          "name": "book_file_chapters_book_file_id_chapter_index_uidx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chapter_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_file_chapters_book_file_id_idx": {
+          "name": "book_file_chapters_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_file_chapters_book_file_id_book_files_id_fk": {
+          "name": "book_file_chapters_book_file_id_book_files_id_fk",
+          "tableFrom": "book_file_chapters",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.book_file_hash_history": {
+      "name": "book_file_hash_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "book_file_hash_history_book_file_id_file_hash_idx": {
+          "name": "book_file_hash_history_book_file_id_file_hash_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "book_file_hash_history_file_hash_idx": {
+          "name": "book_file_hash_history_file_hash_idx",
+          "columns": [
+            {
+              "expression": "file_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "book_file_hash_history_book_file_id_book_files_id_fk": {
+          "name": "book_file_hash_history_book_file_id_book_files_id_fk",
+          "tableFrom": "book_file_hash_history",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "book_file_hash_history_reason_chk": {
+          "name": "book_file_hash_history_reason_chk",
+          "value": "\"book_file_hash_history\".\"reason\" in ('file_write', 'external_change', 'rescan')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_book_hash_links": {
+      "name": "koreader_book_hash_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "koreader_title": {
+          "name": "koreader_title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koreader_authors": {
+          "name": "koreader_authors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "koreader_last_open": {
+          "name": "koreader_last_open",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_book_hash_links_user_hash_uidx": {
+          "name": "koreader_book_hash_links_user_hash_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_book_hash_links_user_updated_idx": {
+          "name": "koreader_book_hash_links_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_book_hash_links_book_file_id_idx": {
+          "name": "koreader_book_hash_links_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_book_hash_links_user_id_users_id_fk": {
+          "name": "koreader_book_hash_links_user_id_users_id_fk",
+          "tableFrom": "koreader_book_hash_links",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "koreader_book_hash_links_book_file_id_book_files_id_fk": {
+          "name": "koreader_book_hash_links_book_file_id_book_files_id_fk",
+          "tableFrom": "koreader_book_hash_links",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_book_hash_links_hash_chk": {
+          "name": "koreader_book_hash_links_hash_chk",
+          "value": "\"koreader_book_hash_links\".\"hash\" ~ '^[0-9a-f]{32}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_device_progress": {
+      "name": "koreader_device_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device": {
+          "name": "device",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'KOReader'"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chapter_index": {
+          "name": "chapter_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_timestamp": {
+          "name": "sync_timestamp",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned": {
+          "name": "orphaned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "orphaned_hash": {
+          "name": "orphaned_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_device_progress_book_user_device_uidx": {
+          "name": "koreader_device_progress_book_user_device_uidx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"koreader_device_progress\".\"orphaned\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_device_progress_orphaned_hash_idx": {
+          "name": "koreader_device_progress_orphaned_hash_idx",
+          "columns": [
+            {
+              "expression": "orphaned_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"koreader_device_progress\".\"orphaned\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_device_progress_user_updated_at_idx": {
+          "name": "koreader_device_progress_user_updated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_device_progress_book_file_id_idx": {
+          "name": "koreader_device_progress_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"koreader_device_progress\".\"book_file_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_device_progress_book_file_id_book_files_id_fk": {
+          "name": "koreader_device_progress_book_file_id_book_files_id_fk",
+          "tableFrom": "koreader_device_progress",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "koreader_device_progress_user_id_users_id_fk": {
+          "name": "koreader_device_progress_user_id_users_id_fk",
+          "tableFrom": "koreader_device_progress",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_device_progress_percentage_range_chk": {
+          "name": "koreader_device_progress_percentage_range_chk",
+          "value": "\"koreader_device_progress\".\"percentage\" is null or (\"koreader_device_progress\".\"percentage\" >= 0 and \"koreader_device_progress\".\"percentage\" <= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_device_settings": {
+      "name": "koreader_device_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_naming_pattern": {
+          "name": "file_naming_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "series_file_naming_pattern": {
+          "name": "series_file_naming_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standalone_file_naming_pattern": {
+          "name": "standalone_file_naming_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_device_settings_user_id_idx": {
+          "name": "koreader_device_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_device_settings_user_id_users_id_fk": {
+          "name": "koreader_device_settings_user_id_users_id_fk",
+          "tableFrom": "koreader_device_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "koreader_device_settings_user_id_device_id_pk": {
+          "name": "koreader_device_settings_user_id_device_id_pk",
+          "columns": ["user_id", "device_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.koreader_device_sweeps": {
+      "name": "koreader_device_sweeps",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_model": {
+          "name": "device_model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'KOReader'"
+        },
+        "plugin_version": {
+          "name": "plugin_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sweep_at": {
+          "name": "last_sweep_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sweep_books_matched": {
+          "name": "last_sweep_books_matched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sweep_page_stats": {
+          "name": "last_sweep_page_stats",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sweep_annotations": {
+          "name": "last_sweep_annotations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kds_user_id_idx": {
+          "name": "kds_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_device_sweeps_user_id_users_id_fk": {
+          "name": "koreader_device_sweeps_user_id_users_id_fk",
+          "tableFrom": "koreader_device_sweeps",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "koreader_device_sweeps_user_id_device_id_pk": {
+          "name": "koreader_device_sweeps_user_id_device_id_pk",
+          "columns": ["user_id", "device_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.koreader_page_stats": {
+      "name": "koreader_page_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_file_id": {
+          "name": "book_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_pages": {
+          "name": "total_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "kps_user_file_device_page_start_uidx": {
+          "name": "kps_user_file_device_page_start_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kps_user_file_device_start_idx": {
+          "name": "kps_user_file_device_start_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "kps_user_id_idx": {
+          "name": "kps_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_page_stats_book_file_id_idx": {
+          "name": "koreader_page_stats_book_file_id_idx",
+          "columns": [
+            {
+              "expression": "book_file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_page_stats_user_id_users_id_fk": {
+          "name": "koreader_page_stats_user_id_users_id_fk",
+          "tableFrom": "koreader_page_stats",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "koreader_page_stats_book_file_id_book_files_id_fk": {
+          "name": "koreader_page_stats_book_file_id_book_files_id_fk",
+          "tableFrom": "koreader_page_stats",
+          "tableTo": "book_files",
+          "columnsFrom": ["book_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_page_stats_duration_nonnegative_chk": {
+          "name": "koreader_page_stats_duration_nonnegative_chk",
+          "value": "\"koreader_page_stats\".\"duration_seconds\" >= 0"
+        },
+        "koreader_page_stats_page_nonnegative_chk": {
+          "name": "koreader_page_stats_page_nonnegative_chk",
+          "value": "\"koreader_page_stats\".\"page\" >= 0"
+        },
+        "koreader_page_stats_total_pages_positive_chk": {
+          "name": "koreader_page_stats_total_pages_positive_chk",
+          "value": "\"koreader_page_stats\".\"total_pages\" > 0"
+        },
+        "koreader_page_stats_start_time_positive_chk": {
+          "name": "koreader_page_stats_start_time_positive_chk",
+          "value": "\"koreader_page_stats\".\"start_time\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_unmatched_book_devices": {
+      "name": "koreader_unmatched_book_devices",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_unmatched_book_devices_user_device_idx": {
+          "name": "koreader_unmatched_book_devices_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_unmatched_book_devices_user_id_users_id_fk": {
+          "name": "koreader_unmatched_book_devices_user_id_users_id_fk",
+          "tableFrom": "koreader_unmatched_book_devices",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "koreader_unmatched_book_devices_user_hash_fk": {
+          "name": "koreader_unmatched_book_devices_user_hash_fk",
+          "tableFrom": "koreader_unmatched_book_devices",
+          "tableTo": "koreader_unmatched_books",
+          "columnsFrom": ["user_id", "hash"],
+          "columnsTo": ["user_id", "hash"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "koreader_unmatched_book_devices_user_id_hash_device_id_pk": {
+          "name": "koreader_unmatched_book_devices_user_id_hash_device_id_pk",
+          "columns": ["user_id", "hash", "device_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_unmatched_book_devices_hash_chk": {
+          "name": "koreader_unmatched_book_devices_hash_chk",
+          "value": "\"koreader_unmatched_book_devices\".\"hash\" ~ '^[0-9a-f]{32}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_unmatched_books": {
+      "name": "koreader_unmatched_books",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors": {
+          "name": "authors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_open": {
+          "name": "last_open",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'statistics'"
+        },
+        "metadata_ambiguous": {
+          "name": "metadata_ambiguous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_unmatched_books_user_seen_idx": {
+          "name": "koreader_unmatched_books_user_seen_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"last_seen_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_unmatched_books_user_id_users_id_fk": {
+          "name": "koreader_unmatched_books_user_id_users_id_fk",
+          "tableFrom": "koreader_unmatched_books",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "koreader_unmatched_books_user_id_hash_pk": {
+          "name": "koreader_unmatched_books_user_id_hash_pk",
+          "columns": ["user_id", "hash"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "koreader_unmatched_books_hash_chk": {
+          "name": "koreader_unmatched_books_hash_chk",
+          "value": "\"koreader_unmatched_books\".\"hash\" ~ '^[0-9a-f]{32}$'"
+        },
+        "koreader_unmatched_books_source_chk": {
+          "name": "koreader_unmatched_books_source_chk",
+          "value": "\"koreader_unmatched_books\".\"source\" in ('current_file', 'file', 'statistics')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.koreader_user_settings": {
+      "name": "koreader_user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "default_file_naming_pattern": {
+          "name": "default_file_naming_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "koreader_user_settings_user_id_users_id_fk": {
+          "name": "koreader_user_settings_user_id_users_id_fk",
+          "tableFrom": "koreader_user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.koreader_users": {
+      "name": "koreader_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_md5": {
+          "name": "password_md5",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_enabled": {
+          "name": "sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "koreader_users_user_id_uidx": {
+          "name": "koreader_users_user_id_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "koreader_users_username_uidx": {
+          "name": "koreader_users_username_uidx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "koreader_users_user_id_users_id_fk": {
+          "name": "koreader_users_user_id_users_id_fk",
+          "tableFrom": "koreader_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "achievements_category_sort_idx": {
+          "name": "achievements_category_sort_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "achievements_group_key_idx": {
+          "name": "achievements_group_key_idx",
+          "columns": [
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "achievements_category_chk": {
+          "name": "achievements_category_chk",
+          "value": "\"achievements\".\"category\" in ('reading', 'library', 'exploration', 'dedication', 'devices')"
+        },
+        "achievements_rarity_chk": {
+          "name": "achievements_rarity_chk",
+          "value": "\"achievements\".\"rarity\" in ('common', 'rare', 'epic', 'legendary')"
+        },
+        "achievements_tier_chk": {
+          "name": "achievements_tier_chk",
+          "value": "\"achievements\".\"tier\" is null or (\"achievements\".\"tier\" >= 1 and \"achievements\".\"tier\" <= 4)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_key": {
+          "name": "achievement_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded_at": {
+          "name": "awarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "context_json": {
+          "name": "context_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_achievements_user_key_uidx": {
+          "name": "user_achievements_user_key_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "achievement_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_user_id_idx": {
+          "name": "user_achievements_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_achievements_user_awarded_at_idx": {
+          "name": "user_achievements_user_awarded_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "awarded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_key_achievements_key_fk": {
+          "name": "user_achievements_achievement_key_achievements_key_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": ["achievement_key"],
+          "columnsTo": ["key"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hardcover_book_state": {
+      "name": "hardcover_book_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hardcover_book_id": {
+          "name": "hardcover_book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_edition_id": {
+          "name": "hardcover_edition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_user_book_id": {
+          "name": "hardcover_user_book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hardcover_read_id": {
+          "name": "hardcover_read_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_error": {
+          "name": "match_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_status": {
+          "name": "last_synced_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_progress": {
+          "name": "last_synced_progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_rating": {
+          "name": "last_synced_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_started_at": {
+          "name": "last_synced_started_at",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_finished_at": {
+          "name": "last_synced_finished_at",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_override": {
+          "name": "sync_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_excluded": {
+          "name": "sync_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hardcover_book_state_book_id_idx": {
+          "name": "hardcover_book_state_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hardcover_book_state_user_id_users_id_fk": {
+          "name": "hardcover_book_state_user_id_users_id_fk",
+          "tableFrom": "hardcover_book_state",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hardcover_book_state_book_id_books_id_fk": {
+          "name": "hardcover_book_state_book_id_books_id_fk",
+          "tableFrom": "hardcover_book_state",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hardcover_book_state_user_book_uidx": {
+          "name": "hardcover_book_state_user_book_uidx",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hardcover_user_settings": {
+      "name": "hardcover_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_sync_mode": {
+          "name": "book_sync_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_eligible'"
+        },
+        "auto_sync_on_status_change": {
+          "name": "auto_sync_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_sync_on_progress_update": {
+          "name": "auto_sync_on_progress_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_sync_on_rating_change": {
+          "name": "auto_sync_on_rating_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_setting_id": {
+          "name": "privacy_setting_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hardcover_user_settings_user_id_users_id_fk": {
+          "name": "hardcover_user_settings_user_id_users_id_fk",
+          "tableFrom": "hardcover_user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hardcover_user_settings_user_id_unique": {
+          "name": "hardcover_user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.readwise_user_settings": {
+      "name": "readwise_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_token": {
+          "name": "api_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_synced_annotation_id": {
+          "name": "last_synced_annotation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "readwise_user_settings_user_id_users_id_fk": {
+          "name": "readwise_user_settings_user_id_users_id_fk",
+          "tableFrom": "readwise_user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "readwise_user_settings_user_id_unique": {
+          "name": "readwise_user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storygraph_book_state": {
+      "name": "storygraph_book_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storygraph_book_id": {
+          "name": "storygraph_book_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_method": {
+          "name": "match_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_error": {
+          "name": "match_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_status": {
+          "name": "last_synced_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_progress": {
+          "name": "last_synced_progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_override": {
+          "name": "sync_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storygraph_book_state_book_id_idx": {
+          "name": "storygraph_book_state_book_id_idx",
+          "columns": [
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storygraph_book_state_user_sync_override_idx": {
+          "name": "storygraph_book_state_user_sync_override_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sync_override",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storygraph_book_state_user_sync_error_idx": {
+          "name": "storygraph_book_state_user_sync_error_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"storygraph_book_state\".\"sync_error\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storygraph_book_state_user_id_users_id_fk": {
+          "name": "storygraph_book_state_user_id_users_id_fk",
+          "tableFrom": "storygraph_book_state",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storygraph_book_state_book_id_books_id_fk": {
+          "name": "storygraph_book_state_book_id_books_id_fk",
+          "tableFrom": "storygraph_book_state",
+          "tableTo": "books",
+          "columnsFrom": ["book_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storygraph_book_state_user_book_uidx": {
+          "name": "storygraph_book_state_user_book_uidx",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "book_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storygraph_user_settings": {
+      "name": "storygraph_user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_cookie": {
+          "name": "session_cookie",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remember_token": {
+          "name": "remember_token",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "book_sync_mode": {
+          "name": "book_sync_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_eligible'"
+        },
+        "auto_sync_on_status_change": {
+          "name": "auto_sync_on_status_change",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_sync_on_progress_update": {
+          "name": "auto_sync_on_progress_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storygraph_user_settings_user_id_users_id_fk": {
+          "name": "storygraph_user_settings_user_id_users_id_fk",
+          "tableFrom": "storygraph_user_settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "storygraph_user_settings_user_id_unique": {
+          "name": "storygraph_user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shared_reading_insight_view_sessions": {
+      "name": "shared_reading_insight_view_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "viewer_user_id": {
+          "name": "viewer_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharing_level": {
+          "name": "sharing_level",
+          "type": "reading_insights_sharing_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shared_insight_view_subject_created_idx": {
+          "name": "shared_insight_view_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shared_insight_view_expires_idx": {
+          "name": "shared_insight_view_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shared_reading_insight_view_sessions_viewer_user_id_users_id_fk": {
+          "name": "shared_reading_insight_view_sessions_viewer_user_id_users_id_fk",
+          "tableFrom": "shared_reading_insight_view_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["viewer_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shared_reading_insight_view_sessions_subject_user_id_users_id_fk": {
+          "name": "shared_reading_insight_view_sessions_subject_user_id_users_id_fk",
+          "tableFrom": "shared_reading_insight_view_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["subject_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "up_user_category_idx": {
+          "name": "up_user_category_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.abs_playback_sessions": {
+      "name": "abs_playback_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "library_id": {
+          "name": "library_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_title": {
+          "name": "display_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "display_author": {
+          "name": "display_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cover_path": {
+          "name": "cover_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_metadata": {
+          "name": "media_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapters": {
+          "name": "chapters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "play_method": {
+          "name": "play_method",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_player": {
+          "name": "media_player",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_version": {
+          "name": "server_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_listening": {
+          "name": "time_listening",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "start_time_seconds": {
+          "name": "start_time_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_time_seconds": {
+          "name": "current_time_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "abs_playback_sessions_user_updated_idx": {
+          "name": "abs_playback_sessions_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "abs_playback_sessions_user_book_idx": {
+          "name": "abs_playback_sessions_user_book_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "book_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "abs_playback_sessions_user_created_idx": {
+          "name": "abs_playback_sessions_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "abs_playback_sessions_user_id_users_id_fk": {
+          "name": "abs_playback_sessions_user_id_users_id_fk",
+          "tableFrom": "abs_playback_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.abs_sessions": {
+      "name": "abs_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh_token": {
+          "name": "last_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_token_expires_at": {
+          "name": "last_refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "abs_sessions_user_id_idx": {
+          "name": "abs_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "abs_sessions_refresh_token_idx": {
+          "name": "abs_sessions_refresh_token_idx",
+          "columns": [
+            {
+              "expression": "refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "abs_sessions_last_refresh_token_idx": {
+          "name": "abs_sessions_last_refresh_token_idx",
+          "columns": [
+            {
+              "expression": "last_refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "abs_sessions_user_id_users_id_fk": {
+          "name": "abs_sessions_user_id_users_id_fk",
+          "tableFrom": "abs_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.content_filter_type": {
+      "name": "content_filter_type",
+      "schema": "public",
+      "values": ["include", "exclude"]
+    },
+    "public.library_access_level": {
+      "name": "library_access_level",
+      "schema": "public",
+      "values": ["viewer", "editor", "owner"]
+    },
+    "public.reading_insights_sharing_level": {
+      "name": "reading_insights_sharing_level",
+      "schema": "public",
+      "values": ["private", "summary", "detailed"]
+    },
+    "public.user_avatar_source": {
+      "name": "user_avatar_source",
+      "schema": "public",
+      "values": ["none", "external", "uploaded"]
+    },
+    "public.opds_sort_order": {
+      "name": "opds_sort_order",
+      "schema": "public",
+      "values": ["recent", "title_asc", "title_desc", "author_asc", "author_desc", "series_asc", "series_desc"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/src/db/migrations/meta/_journal.json
+++ b/server/src/db/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1784079674841,
       "tag": "0054_add_book_duplicate_scans",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1784410626447,
+      "tag": "0055_add_abs_api",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/db/schema/abs.ts
+++ b/server/src/db/schema/abs.ts
@@ -1,0 +1,100 @@
+import { doublePrecision, index, integer, jsonb, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+
+import { users } from './auth';
+
+/**
+ * Server-side session rows backing the Audiobookshelf-compatible refresh-token flow.
+ *
+ * ABS clients refresh aggressively and sometimes concurrently, so a session keeps the
+ * current `refreshToken` plus the previous one (`lastRefreshToken`) inside a short grace
+ * window. A refresh that presents either token within the window succeeds without forcing
+ * a re-rotation, which is what prevents spurious logouts (see REIMPLEMENTATION_GUIDE §2.3).
+ *
+ * Intentionally separate from `refresh_tokens` (BookOrbit's native auth), whose rotation
+ * revokes immediately and treats reuse as theft — incompatible with the ABS wire contract.
+ */
+export const absSessions = pgTable(
+  'abs_sessions',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    userId: integer('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    // The signed refresh JWT currently active for this session.
+    refreshToken: text('refresh_token').notNull(),
+    // The immediately-previous refresh JWT, honored only until lastRefreshTokenExpiresAt.
+    lastRefreshToken: text('last_refresh_token'),
+    lastRefreshTokenExpiresAt: timestamp('last_refresh_token_expires_at', { withTimezone: true }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    ipAddress: varchar('ip_address', { length: 64 }),
+    userAgent: varchar('user_agent', { length: 512 }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdateFn(() => new Date()),
+  },
+  (t) => [
+    index('abs_sessions_user_id_idx').on(t.userId),
+    index('abs_sessions_refresh_token_idx').on(t.refreshToken),
+    index('abs_sessions_last_refresh_token_idx').on(t.lastRefreshToken),
+  ],
+);
+
+export type AbsSession = typeof absSessions.$inferSelect;
+export type NewAbsSession = typeof absSessions.$inferInsert;
+
+/**
+ * Persisted listening-session history backing the ABS `playbackSessions` table
+ * (REIMPLEMENTATION_GUIDE §7): one row per playback session with `timeListening > 0`,
+ * feeding `/api/me/listening-sessions`, `/me/listening-stats`, and `/me/stats/year/:year`.
+ *
+ * Rows are an immutable log: `book_id`/`library_id` are plain snapshots (no FK) so history
+ * survives book/library deletion, exactly like ABS. Display fields and `media_metadata`
+ * (ABS `oldMetadataToJSON` shape) are snapshotted at session start for the same reason.
+ */
+export const absPlaybackSessions = pgTable(
+  'abs_playback_sessions',
+  {
+    // Server-generated for online sessions; client-supplied for offline (local) uploads.
+    id: uuid('id').primaryKey(),
+    userId: integer('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    libraryId: integer('library_id'),
+    bookId: integer('book_id').notNull(),
+    displayTitle: text('display_title').notNull().default(''),
+    displayAuthor: text('display_author').notNull().default(''),
+    coverPath: text('cover_path'),
+    mediaMetadata: jsonb('media_metadata').notNull().$type<Record<string, unknown>>(),
+    chapters: jsonb('chapters').notNull().default([]).$type<Record<string, unknown>[]>(),
+    duration: doublePrecision('duration').notNull().default(0),
+    playMethod: integer('play_method').notNull(),
+    mediaPlayer: varchar('media_player', { length: 64 }).notNull().default('unknown'),
+    deviceInfo: jsonb('device_info').$type<Record<string, unknown>>(),
+    serverVersion: varchar('server_version', { length: 32 }).notNull(),
+    // Listening-stats bucket keys, stamped at write time like ABS (server-local calendar).
+    date: varchar('date', { length: 10 }).notNull(),
+    dayOfWeek: varchar('day_of_week', { length: 16 }).notNull(),
+    timeListening: doublePrecision('time_listening').notNull().default(0),
+    // `current_time` is reserved in Postgres; wire names stay startTime/currentTime.
+    startTimeSeconds: doublePrecision('start_time_seconds').notNull().default(0),
+    currentTimeSeconds: doublePrecision('current_time_seconds').notNull().default(0),
+    startedAt: timestamp('started_at', { withTimezone: true }).notNull(),
+    // Year-in-review buckets by createdAt (ABS `userStats.js`), NOT startedAt.
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    // Local uploads set this explicitly from the client's value; $onUpdateFn covers server syncs.
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdateFn(() => new Date()),
+  },
+  (t) => [
+    index('abs_playback_sessions_user_updated_idx').on(t.userId, t.updatedAt.desc()),
+    index('abs_playback_sessions_user_book_idx').on(t.userId, t.bookId),
+    index('abs_playback_sessions_user_created_idx').on(t.userId, t.createdAt),
+  ],
+);
+
+export type AbsPlaybackSessionRow = typeof absPlaybackSessions.$inferSelect;
+export type NewAbsPlaybackSessionRow = typeof absPlaybackSessions.$inferInsert;

--- a/server/src/db/schema/index.ts
+++ b/server/src/db/schema/index.ts
@@ -34,3 +34,4 @@ export * from './readwise';
 export * from './storygraph';
 export * from './shared-reading-insights';
 export * from './user-preferences';
+export * from './abs';

--- a/server/src/db/schema/reader.ts
+++ b/server/src/db/schema/reader.ts
@@ -1,5 +1,20 @@
 import { sql } from 'drizzle-orm';
-import { check, date, index, integer, jsonb, pgTable, primaryKey, real, serial, text, timestamp, uniqueIndex, varchar } from 'drizzle-orm/pg-core';
+import {
+  boolean,
+  check,
+  date,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  real,
+  serial,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from 'drizzle-orm/pg-core';
 import type { ReadStatus, ReadStatusSource, ReadingAttemptOrigin, ReadingAttemptOutcome, ReadingSessionSource } from '@bookorbit/types';
 
 import { bookFiles, books } from './books';
@@ -274,6 +289,8 @@ export const audiobookProgress = pgTable(
       .notNull()
       .references(() => bookFiles.id, { onDelete: 'cascade' }),
     positionSeconds: real('position_seconds').notNull().default(0),
+    // ABS MediaProgress "remove from Continue Listening" flag; reset when playback position moves.
+    hideFromContinueListening: boolean('hide_from_continue_listening').notNull().default(false),
     updatedAt: timestamp('updated_at', { withTimezone: true })
       .notNull()
       .defaultNow()

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -22,13 +22,21 @@ import {
   registerEmptyBodyContentTypeParser,
   shouldInjectEmptyJsonBody,
 } from './common/utils/bootstrap.utils';
+import { ABS_EXCLUDED_ROUTES, isAbsRoute, rewriteAbsUrl } from './modules/abs/abs-route-rewrite.util';
 
 const MAX_COVER_BYTES = 20 * 1024 * 1024;
 
 async function bootstrap() {
   const allowCloudflareInsights = parseBooleanEnv(process.env.CSP_ALLOW_CLOUDFLARE_INSIGHTS, false);
 
-  const adapter = new FastifyAdapter({ logger: false, trustProxy: parseTrustProxy(process.env.TRUST_PROXY), maxParamLength: 1000 });
+  const adapter = new FastifyAdapter({
+    logger: false,
+    trustProxy: parseTrustProxy(process.env.TRUST_PROXY),
+    maxParamLength: 1000,
+    // Remap the ABS `/auth/refresh` route to a private path before routing so it does not collide
+    // with BookOrbit's own `auth/refresh` controller (see abs-route-rewrite.util.ts).
+    rewriteUrl: (req) => rewriteAbsUrl(req.url ?? '/'),
+  });
   const app = await NestFactory.create<NestFastifyApplication>(AppModule, adapter, { bufferLogs: true });
   app.useLogger(app.get(Logger));
 
@@ -57,7 +65,7 @@ async function bootstrap() {
   app.useWebSocketAdapter(new IoAdapter(app));
 
   app.setGlobalPrefix('api/v1', {
-    exclude: ['api/kobo/:deviceToken/(.*)', 'api/v3/(.*)', 'api/UserStorage/(.*)'],
+    exclude: ['api/kobo/:deviceToken/(.*)', 'api/v3/(.*)', 'api/UserStorage/(.*)', ...ABS_EXCLUDED_ROUTES],
   });
 
   app.useGlobalPipes(
@@ -68,7 +76,9 @@ async function bootstrap() {
     }),
   );
 
-  app.useGlobalFilters(new GlobalExceptionFilter());
+  // ABS routes that never reach a controller (e.g. unimplemented endpoints 404ing) bypass the
+  // controller-scoped AbsExceptionFilter, so suppress BookOrbit's envelope for them here.
+  app.useGlobalFilters(new GlobalExceptionFilter(isAbsRoute));
 
   const appConfiguration = app.get<ConfigType<typeof appConfig>>(appConfig.KEY);
   if (appConfiguration.swaggerEnabled) {

--- a/server/src/modules/abs/__testing__/abs-test-helpers.ts
+++ b/server/src/modules/abs/__testing__/abs-test-helpers.ts
@@ -1,0 +1,80 @@
+import { Permission } from '@bookorbit/types';
+
+import type { RequestUser } from '../../../common/types/request-user';
+
+/** A RequestUser with the fields the ABS adapter reads; superuser by default. */
+export function makeAbsUser(overrides: Partial<RequestUser> = {}): RequestUser {
+  return {
+    id: 1,
+    username: 'admin',
+    name: 'admin',
+    email: null,
+    active: true,
+    isSuperuser: true,
+    isDefaultPassword: false,
+    tokenVersion: 0,
+    settings: {},
+    avatarUrl: null,
+    provisioningMethod: 'local',
+    permissions: [],
+    contentFilters: { rules: [] } as unknown as RequestUser['contentFilters'],
+    ...overrides,
+  };
+}
+
+export const ALL_LIBRARY_PERMISSIONS: Permission[] = [
+  Permission.LibraryDownload,
+  Permission.LibraryUpload,
+  Permission.LibraryEditMetadata,
+  Permission.LibraryDeleteBooks,
+];
+
+/**
+ * Resolve the status thrown by an ABS handler (AbsHttpException). Returns the numeric HTTP status,
+ * or the literal `'no-throw'` when the function unexpectedly returns. Works for sync and async fns.
+ */
+export async function thrownStatus(fn: () => unknown | Promise<unknown>): Promise<number | 'no-throw'> {
+  try {
+    await fn();
+    return 'no-throw';
+  } catch (err) {
+    const e = err as { getStatus?: () => number };
+    return typeof e.getStatus === 'function' ? e.getStatus() : -1;
+  }
+}
+
+interface CapturedReply {
+  statusCode: number;
+  headers: Record<string, unknown>;
+  body: unknown;
+  contentType?: string;
+}
+
+/** Minimal chainable Fastify reply mock that records status/headers/body for assertions. */
+export function makeReply(): { reply: any; captured: CapturedReply } {
+  const captured: CapturedReply = { statusCode: 200, headers: {}, body: undefined };
+  const reply: any = {
+    status(code: number) {
+      captured.statusCode = code;
+      return reply;
+    },
+    header(key: string, value: unknown) {
+      captured.headers[key] = value;
+      return reply;
+    },
+    type(value: string) {
+      captured.contentType = value;
+      return reply;
+    },
+    send(body: unknown) {
+      captured.body = body;
+      return reply;
+    },
+  };
+  return { reply, captured };
+}
+
+/** Minimal Fastify request mock carrying headers + query. */
+export function makeRequest(opts: { headers?: Record<string, unknown>; query?: Record<string, unknown> } = {}): any {
+  return { headers: opts.headers ?? {}, query: opts.query ?? {} };
+}

--- a/server/src/modules/abs/abs-compatibility-gaps.test.ts
+++ b/server/src/modules/abs/abs-compatibility-gaps.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Documented-but-unimplemented ABS contract (docs/abs-api README §8 checklist).
+ *
+ * Every test in this file encodes a behavior the re-implementation guide requires for full client
+ * compatibility but which the current vertical slice does NOT yet provide. They are therefore
+ * EXPECTED TO FAIL until the corresponding feature lands — the suite doubles as an executable gap
+ * list. As each capability is implemented, its test here should flip to green (and can move into the
+ * relevant feature spec).
+ *
+ * Run just this file to see the outstanding work:
+ *   pnpm vitest run src/modules/abs/abs-compatibility-gaps.test.ts
+ */
+import { ConfigService } from '@nestjs/config';
+import { tmpdir } from 'os';
+
+import type { LibraryService } from '../library/library.service';
+import type { AbsPlaybackSessionRepository } from './abs-playback-session.repository';
+import type { AbsAudioFileRow, AbsItemRow, AbsReadRepository } from './abs-read.repository';
+import { AbsSocketGateway } from './abs-socket.gateway';
+import { AbsItemsController } from './controllers/abs-items.controller';
+import { AbsLibrariesController } from './controllers/abs-libraries.controller';
+import { AbsMeController } from './controllers/abs-me.controller';
+import { AbsPlaybackService } from './services/abs-playback.service';
+import type { AbsTranscodeService } from './services/abs-transcode.service';
+import type { AbsCatalogService } from './services/abs-catalog.service';
+import type { AbsProgressService } from './services/abs-progress.service';
+import { makeAbsUser } from './__testing__/abs-test-helpers';
+
+/** Asserts a route handler / method exists on a class instance (the documented contract surface). */
+function expectHandler(instance: object, method: string): void {
+  expect(typeof (instance as Record<string, unknown>)[method]).toBe('function');
+}
+
+// ---------------------------------------------------------------------------------------------
+// §5 Streaming — transcode / HLS
+// ---------------------------------------------------------------------------------------------
+
+// Implemented — transcode negotiation, HLS serving (/hls/:stream/:file), and stream_reset are wired
+// up (see abs-transcode.service.ts, abs-hls.controller.ts).
+describe('GAP §5.1–5.3 — transcode playback (playMethod=2 / HLS)', () => {
+  function item(): AbsItemRow {
+    return {
+      id: 3,
+      libraryId: 5,
+      status: 'ready',
+      addedAt: new Date(),
+      updatedAt: new Date(),
+      title: 'T',
+      subtitle: null,
+      description: null,
+      publishedYear: null,
+      publisher: null,
+      language: 'en',
+      isbn13: null,
+      isbn10: null,
+      seriesName: null,
+      seriesIndex: null,
+      durationSeconds: null,
+      chapters: [],
+    };
+  }
+  function file(id: number): AbsAudioFileRow {
+    return { id, bookId: 3, format: 'flac', sortOrder: id, durationSeconds: 100, sizeBytes: 1000, absolutePath: `/b/${id}.flac` };
+  }
+
+  function buildPlayback() {
+    const readRepo = {
+      findItem: vi.fn().mockResolvedValue(item()),
+      audioFilesByBookId: vi.fn().mockResolvedValue([file(10), file(11)]),
+      authorsByBookIds: vi.fn().mockResolvedValue([]),
+      narratorsByBookIds: vi.fn().mockResolvedValue([]),
+      seriesByBookIds: vi.fn().mockResolvedValue([]),
+      genresByBookIds: vi.fn().mockResolvedValue([]),
+    } as unknown as AbsReadRepository;
+    const progressService = { getMediaProgress: vi.fn().mockResolvedValue(null), upsertFromCurrentTime: vi.fn() } as unknown as AbsProgressService;
+    const socketGateway = { emitUserItemProgressUpdated: vi.fn(), emitUserSessionClosed: vi.fn() } as unknown as AbsSocketGateway;
+    const libraryService = { findAccessibleLibraryIds: vi.fn().mockResolvedValue([5]) } as unknown as LibraryService;
+    const transcodeService = {
+      createStream: vi.fn().mockResolvedValue('/hls/s/output.m3u8'),
+      closeStream: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AbsTranscodeService;
+    const sessionRepo = {
+      insert: vi.fn(),
+      updateSync: vi.fn(),
+      updateFromLocal: vi.fn(),
+      findById: vi.fn().mockResolvedValue(null),
+    } as unknown as AbsPlaybackSessionRepository;
+    return new AbsPlaybackService(readRepo, progressService, socketGateway, libraryService, transcodeService, sessionRepo);
+  }
+
+  it('honors forceTranscode by returning a transcode session (playMethod=2) with a single .m3u8 track', async () => {
+    const session = await buildPlayback().startSession(makeAbsUser(), 3, { forceTranscode: true, supportedMimeTypes: [] });
+    expect(session.playMethod).toBe(2);
+    const tracks = session.audioTracks as Record<string, unknown>[];
+    expect(tracks).toHaveLength(1);
+    expect(String(tracks[0]?.contentUrl)).toContain('.m3u8');
+  });
+
+  it('exposes the HLS stream_reset socket emit used on out-of-window seeks', () => {
+    const gateway = new AbsSocketGateway({} as never, {} as never);
+    expectHandler(gateway, 'emitStreamReset');
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// §4.2 Filtering — base64 filter encoding on browse
+// ---------------------------------------------------------------------------------------------
+
+describe('GAP §4.2 — base64 filter on GET /api/libraries/:id/items', () => {
+  it('plumbs the `filter=group.base64` query param through to the catalog service', async () => {
+    const listLibraryItems = vi.fn().mockResolvedValue({ results: [], total: 0 });
+    const libraryService = {} as unknown as LibraryService;
+    const controller = new AbsLibrariesController(libraryService, { listLibraryItems } as unknown as AbsCatalogService);
+
+    // narrators."Stephen Fry" -> base64url
+    await controller.items(makeAbsUser(), 'lib_5', { filter: 'narrators.U3RlcGhlbiBGcnk' });
+
+    expect(listLibraryItems).toHaveBeenCalledWith(expect.anything(), 5, expect.objectContaining({ filter: expect.anything() }));
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// §7 Progress & session sync — routes not yet wired
+// ---------------------------------------------------------------------------------------------
+
+describe('GAP §7.1 — stateless MediaProgress upsert (PATCH /api/me/progress/:libraryItemId)', () => {
+  it('AbsMeController exposes an upsert-progress handler', () => {
+    const controller = new AbsMeController({} as never, {} as never);
+    expectHandler(controller, 'updateProgress');
+  });
+});
+
+describe('GAP §7.4 — continue-listening shelf (GET /api/me/items-in-progress)', () => {
+  it('AbsMeController exposes an items-in-progress handler', () => {
+    const controller = new AbsMeController({} as never, {} as never);
+    expectHandler(controller, 'itemsInProgress');
+  });
+});
+
+describe('GAP §7.3 — offline reconciliation (POST /api/session/local-all)', () => {
+  it('AbsPlaybackService exposes a syncLocalSessions method (newest-updatedAt-wins merge)', () => {
+    const service = new AbsPlaybackService({} as never, {} as never, {} as never, {} as never, {} as never, {} as never);
+    expectHandler(service, 'syncLocalSessions');
+  });
+});
+
+// ---------------------------------------------------------------------------------------------
+// §2 / §6 Items & libraries — routes documented in ENDPOINTS.md but not yet exposed
+// ---------------------------------------------------------------------------------------------
+
+describe('GAP ENDPOINTS §2 — POST /api/items/batch/get', () => {
+  it('AbsItemsController exposes a batch-get handler (the catalog service method already exists)', () => {
+    const controller = new AbsItemsController({} as never, {} as never, {} as never, { get: () => tmpdir() } as unknown as ConfigService);
+    expectHandler(controller, 'batchGet');
+  });
+});
+
+// Deferred — BookOrbit has no podcast/episode model, so podcast episode playback is out of scope.
+describe.skip('GAP ENDPOINTS §2 — POST /api/items/:id/play/:episodeId (podcast episode playback)', () => {
+  it('AbsItemsController exposes a play-episode handler', () => {
+    const controller = new AbsItemsController({} as never, {} as never, {} as never, { get: () => tmpdir() } as unknown as ConfigService);
+    expectHandler(controller, 'playEpisode');
+  });
+});
+
+describe('GAP §4 (checklist) — home-screen shelves & filter data', () => {
+  function librariesController() {
+    return new AbsLibrariesController({} as never, {} as never);
+  }
+
+  it('exposes GET /api/libraries/:id/personalized', () => {
+    expectHandler(librariesController(), 'personalized');
+  });
+
+  it('exposes GET /api/libraries/:id/filterdata', () => {
+    expectHandler(librariesController(), 'filterdata');
+  });
+
+  it('exposes GET /api/libraries/:id/search', () => {
+    expectHandler(librariesController(), 'search');
+  });
+});

--- a/server/src/modules/abs/abs-errors.ts
+++ b/server/src/modules/abs/abs-errors.ts
@@ -1,0 +1,45 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/**
+ * ABS has no uniform error envelope (REIMPLEMENTATION_GUIDE §4.4): handlers variously reply with a
+ * bare status, a plain-text body, or `{ error }` JSON, and some admin reads deliberately return 404
+ * instead of 403. ABS controllers throw these so `AbsExceptionFilter` can emit the exact wire shape
+ * the endpoint requires, rather than BookOrbit's `{ statusCode, message, ... }` envelope.
+ */
+export type AbsErrorShape = 'bare' | 'text' | 'json';
+
+export class AbsHttpException extends HttpException {
+  readonly shape: AbsErrorShape;
+
+  private constructor(status: number, body: string | Record<string, unknown>, shape: AbsErrorShape) {
+    super(body, status);
+    this.shape = shape;
+  }
+
+  /** Empty-body status response (the most common ABS error form). */
+  static bare(status: number): AbsHttpException {
+    return new AbsHttpException(status, '', 'bare');
+  }
+
+  /** `res.status(x).send("message")` — plain text. */
+  static text(status: number, message: string): AbsHttpException {
+    return new AbsHttpException(status, message, 'text');
+  }
+
+  /** `res.status(x).json({ error })` — used by the auth routes. */
+  static json(status: number, body: Record<string, unknown>): AbsHttpException {
+    return new AbsHttpException(status, body, 'json');
+  }
+
+  static unauthorized(): AbsHttpException {
+    return AbsHttpException.bare(HttpStatus.UNAUTHORIZED);
+  }
+
+  static notFound(): AbsHttpException {
+    return AbsHttpException.bare(HttpStatus.NOT_FOUND);
+  }
+
+  static forbidden(): AbsHttpException {
+    return AbsHttpException.bare(HttpStatus.FORBIDDEN);
+  }
+}

--- a/server/src/modules/abs/abs-event-bridge.service.test.ts
+++ b/server/src/modules/abs/abs-event-bridge.service.test.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from 'events';
+
+import type { LibraryService } from '../library/library.service';
+import { ACHIEVEMENT_EVENT_LIBRARY_CATALOG_CHANGED, type AchievementEventsService } from '../achievement/achievement-events.service';
+import { AbsEventBridgeService } from './abs-event-bridge.service';
+import type { AbsSocketGateway } from './abs-socket.gateway';
+
+function build(libraryFindOne = vi.fn().mockResolvedValue({ id: 5, name: 'Audiobooks', folders: [] })) {
+  const achievementEvents = new EventEmitter() as unknown as AchievementEventsService;
+  const libraryService = { findOne: libraryFindOne } as unknown as LibraryService;
+  const socketGateway = { emitLibraryUpdated: vi.fn() } as unknown as AbsSocketGateway;
+  const bridge = new AbsEventBridgeService(achievementEvents, libraryService, socketGateway);
+  bridge.onModuleInit();
+  return { bridge, achievementEvents, libraryService, socketGateway };
+}
+
+describe('AbsEventBridgeService', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('re-emits a debounced library_updated when the catalog changes', async () => {
+    const { achievementEvents, socketGateway } = build();
+
+    (achievementEvents as unknown as EventEmitter).emit(ACHIEVEMENT_EVENT_LIBRARY_CATALOG_CHANGED, { userId: 1, libraryId: 5 });
+    expect(socketGateway.emitLibraryUpdated).not.toHaveBeenCalled(); // debounced
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(socketGateway.emitLibraryUpdated).toHaveBeenCalledTimes(1);
+    expect(socketGateway.emitLibraryUpdated).toHaveBeenCalledWith(expect.objectContaining({ id: 'lib_5', name: 'Audiobooks' }));
+  });
+
+  it('coalesces a burst of catalog-change events for the same library into one emit', async () => {
+    const { achievementEvents, socketGateway } = build();
+    const emitter = achievementEvents as unknown as EventEmitter;
+
+    for (let i = 0; i < 5; i++) emitter.emit(ACHIEVEMENT_EVENT_LIBRARY_CATALOG_CHANGED, { userId: 1, libraryId: 5 });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(socketGateway.emitLibraryUpdated).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows errors when the library was removed before the tick', async () => {
+    const { achievementEvents, socketGateway } = build(vi.fn().mockRejectedValue(new Error('Library not found')));
+
+    (achievementEvents as unknown as EventEmitter).emit(ACHIEVEMENT_EVENT_LIBRARY_CATALOG_CHANGED, { userId: 1, libraryId: 9 });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(socketGateway.emitLibraryUpdated).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/abs/abs-event-bridge.service.ts
+++ b/server/src/modules/abs/abs-event-bridge.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+
+import {
+  ACHIEVEMENT_EVENT_LIBRARY_CATALOG_CHANGED,
+  AchievementEventsService,
+  type LibraryCatalogChangedPayload,
+} from '../achievement/achievement-events.service';
+import { LibraryService } from '../library/library.service';
+import { AbsSocketGateway } from './abs-socket.gateway';
+import { toAbsLibrary } from './mappers/abs-library.mapper';
+
+/**
+ * Bridges BookOrbit's internal catalog-change signal to the ABS socket contract (§6.3). The scanner
+ * and library service already emit `LIBRARY_CATALOG_CHANGED` on the shared event bus when a scan
+ * ingests/updates books or access changes; we re-emit it as an ABS `library_updated` so connected
+ * clients refresh that library's items/personalized shelves. Purely a consumer — no core changes.
+ *
+ * Per-item `item_added`/`items_updated` events would need the changed book ids, which the current
+ * signal doesn't carry; library-level invalidation is the faithful subset we can drive today.
+ */
+@Injectable()
+export class AbsEventBridgeService implements OnModuleInit {
+  private readonly logger = new Logger(AbsEventBridgeService.name);
+  /** Coalesce bursts of catalog-change events per library (scans fire many in quick succession). */
+  private readonly pending = new Map<number, NodeJS.Timeout>();
+  private static readonly DEBOUNCE_MS = 1000;
+
+  constructor(
+    private readonly achievementEvents: AchievementEventsService,
+    private readonly libraryService: LibraryService,
+    private readonly socketGateway: AbsSocketGateway,
+  ) {}
+
+  onModuleInit(): void {
+    this.achievementEvents.on(ACHIEVEMENT_EVENT_LIBRARY_CATALOG_CHANGED, (payload: LibraryCatalogChangedPayload) => {
+      this.scheduleLibraryUpdate(payload.libraryId);
+    });
+  }
+
+  private scheduleLibraryUpdate(libraryId: number): void {
+    const existing = this.pending.get(libraryId);
+    if (existing) clearTimeout(existing);
+    this.pending.set(
+      libraryId,
+      setTimeout(() => {
+        this.pending.delete(libraryId);
+        void this.emitLibraryUpdated(libraryId);
+      }, AbsEventBridgeService.DEBOUNCE_MS).unref(),
+    );
+  }
+
+  private async emitLibraryUpdated(libraryId: number): Promise<void> {
+    try {
+      const library = await this.libraryService.findOne(libraryId);
+      this.socketGateway.emitLibraryUpdated(toAbsLibrary(library));
+    } catch (err) {
+      // Library may have been removed between the signal and this tick — nothing to broadcast.
+      this.logger.debug(`[abs.event_bridge] libraryId=${libraryId} skip - ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}

--- a/server/src/modules/abs/abs-exception.filter.ts
+++ b/server/src/modules/abs/abs-exception.filter.ts
@@ -1,0 +1,60 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException, HttpStatus, Logger } from '@nestjs/common';
+import type { FastifyReply } from 'fastify';
+
+import { AbsHttpException } from './abs-errors';
+
+/**
+ * Controller-scoped filter for the ABS adapter. Emits ABS-shaped errors and, crucially, never
+ * leaks BookOrbit's `{ statusCode, message, ... }` envelope — ABS clients branch on status (and
+ * occasionally a `{ error }` body), so a foreign envelope breaks them (REIMPLEMENTATION_GUIDE §4.4).
+ *
+ * Applied via `@UseFilters(AbsExceptionFilter)` on ABS controllers; controller-scoped filters take
+ * precedence over the global `GlobalExceptionFilter`.
+ */
+@Catch()
+export class AbsExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(AbsExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const reply = host.switchToHttp().getResponse<FastifyReply>();
+    const exc = exception as Record<string, unknown> | undefined;
+
+    if (exc?.code === 'ERR_STREAM_PREMATURE_CLOSE') return;
+    if (reply.sent) return;
+
+    if (exception instanceof AbsHttpException) {
+      this.sendAbs(reply, exception);
+      return;
+    }
+
+    // Any other HttpException (e.g. a Nest built-in thrown by a reused service) collapses to a
+    // bare status; unknown errors are logged and reported as a bare 500.
+    if (exception instanceof HttpException) {
+      reply.status(exception.getStatus()).send();
+      return;
+    }
+
+    this.logger.error(exception);
+    reply.status(HttpStatus.INTERNAL_SERVER_ERROR).send();
+  }
+
+  private sendAbs(reply: FastifyReply, exception: AbsHttpException): void {
+    const status = exception.getStatus();
+    const body = exception.getResponse();
+    switch (exception.shape) {
+      case 'text':
+        reply
+          .status(status)
+          .type('text/plain')
+          .send(typeof body === 'string' ? body : '');
+        return;
+      case 'json':
+        reply.status(status).send(body);
+        return;
+      case 'bare':
+      default:
+        reply.status(status).send();
+        return;
+    }
+  }
+}

--- a/server/src/modules/abs/abs-filter.util.ts
+++ b/server/src/modules/abs/abs-filter.util.ts
@@ -1,0 +1,26 @@
+/**
+ * ABS browse filters arrive as `filter=<group>.<base64url(value)>` (REIMPLEMENTATION_GUIDE §4.2).
+ * The server splits on the **first** `.`, takes the group, and base64url-decodes the remainder.
+ * For id-based groups (authors, series, genres, tags) the decoded value is the *encoded* ABS id;
+ * for narrators/languages it is the raw name/code.
+ */
+export interface AbsFilter {
+  group: string;
+  value: string;
+}
+
+export function decodeAbsFilter(raw: string | undefined): AbsFilter | null {
+  if (!raw) return null;
+  const dot = raw.indexOf('.');
+  if (dot === -1) return null;
+  const group = raw.slice(0, dot);
+  const encoded = raw.slice(dot + 1);
+  if (!group || !encoded) return null;
+  try {
+    const value = Buffer.from(encoded, 'base64url').toString('utf8');
+    if (!value) return null;
+    return { group, value };
+  } catch {
+    return null;
+  }
+}

--- a/server/src/modules/abs/abs-id.util.test.ts
+++ b/server/src/modules/abs/abs-id.util.test.ts
@@ -1,0 +1,26 @@
+import { decodeAbsId, encodeAbsId } from './abs-id.util';
+
+describe('abs-id.util', () => {
+  it('round-trips ids per type', () => {
+    expect(decodeAbsId('library', encodeAbsId('library', 42))).toBe(42);
+    expect(decodeAbsId('libraryItem', encodeAbsId('libraryItem', 7))).toBe(7);
+    expect(decodeAbsId('user', encodeAbsId('user', 1))).toBe(1);
+  });
+
+  it('produces namespaced, non-colliding ids for the same integer', () => {
+    expect(encodeAbsId('library', 1)).not.toBe(encodeAbsId('libraryItem', 1));
+    // Decoding with the wrong type prefix must fail rather than silently mismatch.
+    expect(decodeAbsId('libraryItem', encodeAbsId('library', 1))).toBeNull();
+  });
+
+  it('rejects malformed or hostile input', () => {
+    expect(decodeAbsId('library', undefined)).toBeNull();
+    expect(decodeAbsId('library', '')).toBeNull();
+    expect(decodeAbsId('library', 'lib_')).toBeNull();
+    expect(decodeAbsId('library', 'lib_abc')).toBeNull();
+    expect(decodeAbsId('library', 'lib_-5')).toBeNull();
+    expect(decodeAbsId('library', 'lib_0')).toBeNull();
+    expect(decodeAbsId('library', 'lib_1.5')).toBeNull();
+    expect(decodeAbsId('library', '42')).toBeNull();
+  });
+});

--- a/server/src/modules/abs/abs-id.util.ts
+++ b/server/src/modules/abs/abs-id.util.ts
@@ -1,0 +1,40 @@
+/**
+ * Audiobookshelf objects carry opaque string IDs (UUID-shaped in real ABS). BookOrbit uses
+ * serial integer primary keys, so the ABS adapter exposes a deterministic, reversible string
+ * encoding: a type prefix plus the integer. Clients treat these as opaque and only need them to
+ * round-trip exactly through item / cover / progress / play requests.
+ *
+ * Prefixes are namespaced per entity so the same integer in two tables never collides.
+ */
+export const ABS_ID_PREFIX = {
+  user: 'usr',
+  library: 'lib',
+  libraryItem: 'li',
+  book: 'bk',
+  author: 'aut',
+  series: 'ser',
+  collection: 'col',
+  playlist: 'pl',
+  bookFile: 'bf',
+} as const;
+
+export type AbsIdType = keyof typeof ABS_ID_PREFIX;
+
+export function encodeAbsId(type: AbsIdType, id: number): string {
+  return `${ABS_ID_PREFIX[type]}_${id}`;
+}
+
+/**
+ * Decode a prefixed ABS id back to its integer. Returns null when the string does not match the
+ * expected prefix or does not carry a positive integer, so callers can answer with a 404 rather
+ * than throwing on malformed client input.
+ */
+export function decodeAbsId(type: AbsIdType, value: string | undefined | null): number | null {
+  if (!value) return null;
+  const prefix = `${ABS_ID_PREFIX[type]}_`;
+  if (!value.startsWith(prefix)) return null;
+  const raw = value.slice(prefix.length);
+  if (!/^\d+$/.test(raw)) return null;
+  const id = Number.parseInt(raw, 10);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}

--- a/server/src/modules/abs/abs-media.util.test.ts
+++ b/server/src/modules/abs/abs-media.util.test.ts
@@ -1,0 +1,60 @@
+import { audioMimeType, normalizeChapters } from './abs-media.util';
+
+describe('audioMimeType', () => {
+  it('forces correct mime types per audio format', () => {
+    expect(audioMimeType('mp3')).toBe('audio/mpeg');
+    expect(audioMimeType('m4b')).toBe('audio/mp4'); // Express/Fastify guess wrong here
+    expect(audioMimeType('M4A')).toBe('audio/mp4'); // case-insensitive
+    expect(audioMimeType('flac')).toBe('audio/flac');
+    expect(audioMimeType('opus')).toBe('audio/opus');
+  });
+
+  it('falls back to audio/mpeg for unknown or missing formats', () => {
+    expect(audioMimeType('wav')).toBe('audio/mpeg');
+    expect(audioMimeType(null)).toBe('audio/mpeg');
+    expect(audioMimeType(undefined)).toBe('audio/mpeg');
+  });
+});
+
+describe('normalizeChapters', () => {
+  it('converts stored startMs offsets to seconds and derives chapter ends', () => {
+    const chapters = normalizeChapters(
+      [
+        { title: 'Intro', startMs: 0 },
+        { title: 'Chapter 1', startMs: 100_000 },
+      ],
+      250,
+    );
+    // end is derived from the next chapter's start; the last ends at the book duration
+    expect(chapters).toEqual([
+      { id: 0, start: 0, end: 100, title: 'Intro' },
+      { id: 1, start: 100, end: 250, title: 'Chapter 1' },
+    ]);
+  });
+
+  it('honors a legacy start/end (seconds) shape when present', () => {
+    const chapters = normalizeChapters(
+      [
+        { start: 0, end: 100, title: 'Intro' },
+        { start: 100, end: 250, title: 'Chapter 1' },
+      ],
+      250,
+    );
+    expect(chapters).toEqual([
+      { id: 0, start: 0, end: 100, title: 'Intro' },
+      { id: 1, start: 100, end: 250, title: 'Chapter 1' },
+    ]);
+  });
+
+  it('defaults missing fields (end -> next start / fallbackDuration, title -> "Chapter N")', () => {
+    const chapters = normalizeChapters([{ startMs: 5000 }], 999);
+    expect(chapters).toEqual([{ id: 0, start: 5, end: 999, title: 'Chapter 1' }]);
+  });
+
+  it('returns an empty array for non-array / malformed input', () => {
+    expect(normalizeChapters(null, 100)).toEqual([]);
+    expect(normalizeChapters(undefined, 100)).toEqual([]);
+    expect(normalizeChapters('nope', 100)).toEqual([]);
+    expect(normalizeChapters([null, 42, 'x'], 100)).toEqual([]);
+  });
+});

--- a/server/src/modules/abs/abs-media.util.ts
+++ b/server/src/modules/abs/abs-media.util.ts
@@ -1,0 +1,59 @@
+/** Force correct audio MIME types — Express/Fastify guess wrong for .m4b (REIMPLEMENTATION_GUIDE §5.4). */
+const MIME_BY_FORMAT: Record<string, string> = {
+  mp3: 'audio/mpeg',
+  m4b: 'audio/mp4',
+  m4a: 'audio/mp4',
+  flac: 'audio/flac',
+  ogg: 'audio/ogg',
+  opus: 'audio/opus',
+};
+
+export function audioMimeType(format: string | null | undefined): string {
+  if (!format) return 'audio/mpeg';
+  return MIME_BY_FORMAT[format.toLowerCase()] ?? 'audio/mpeg';
+}
+
+/**
+ * Direct-play eligibility check (REIMPLEMENTATION_GUIDE §5.1, mirrors `checkCanDirectPlay`). Every
+ * audio file's mime type must be in the client's `supportedMimeTypes`; otherwise the session must
+ * transcode. When the client sends no list we default to direct play (BookOrbit divergence — ABS
+ * transcodes on an empty list — to keep the no-negotiation MVP path direct and cheap).
+ */
+export function canDirectPlay(formats: (string | null)[], supportedMimeTypes: string[] | undefined): boolean {
+  if (!supportedMimeTypes || supportedMimeTypes.length === 0) return true;
+  return formats.every((format) => supportedMimeTypes.includes(audioMimeType(format)));
+}
+
+export interface AbsChapter {
+  id: number;
+  start: number;
+  end: number;
+  title: string;
+}
+
+/**
+ * Normalize whatever is stored in bookMetadata.chapters into the ABS chapter shape.
+ *
+ * Stored chapters are `AudiobookChapter` ({ title, startMs }) — only a start offset in
+ * milliseconds. ABS chapters need start/end in seconds, so we convert startMs and derive
+ * each chapter's end from the next chapter's start (the last chapter ends at the book
+ * duration). A legacy `start`/`end` (seconds) shape is still honored if present.
+ */
+export function normalizeChapters(raw: unknown, fallbackDuration: number): AbsChapter[] {
+  if (!Array.isArray(raw)) return [];
+  const parsed: { start: number; end: number | null; title: string }[] = [];
+  raw.forEach((entry, index) => {
+    if (!entry || typeof entry !== 'object') return;
+    const e = entry as Record<string, unknown>;
+    const start = typeof e.startMs === 'number' ? e.startMs / 1000 : typeof e.start === 'number' ? e.start : 0;
+    const end = typeof e.end === 'number' ? e.end : null;
+    const title = typeof e.title === 'string' ? e.title : `Chapter ${index + 1}`;
+    parsed.push({ start, end, title });
+  });
+  return parsed.map((chapter, index) => ({
+    id: index,
+    start: chapter.start,
+    end: chapter.end ?? (index + 1 < parsed.length ? parsed[index + 1].start : fallbackDuration),
+    title: chapter.title,
+  }));
+}

--- a/server/src/modules/abs/abs-playback-session.repository.test.ts
+++ b/server/src/modules/abs/abs-playback-session.repository.test.ts
@@ -1,0 +1,89 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { describe, expect, it } from 'vitest';
+
+import * as schema from '../../db/schema';
+import { AbsPlaybackSessionRepository } from './abs-playback-session.repository';
+
+/**
+ * Captures the SQL each method executes by stubbing `pool.query` (never connects). Queries resolve
+ * to empty result sets — enough to assert the rendered predicates and parameters.
+ */
+function captureQueries() {
+  const pool = new Pool();
+  const queries: { text: string; values: unknown[] }[] = [];
+  (pool as unknown as { query: (cfg: { text: string; values?: unknown[] } | string, values?: unknown[]) => Promise<unknown> }).query = (
+    cfg,
+    values,
+  ) => {
+    const text = typeof cfg === 'string' ? cfg : cfg.text;
+    queries.push({ text, values: (typeof cfg === 'string' ? values : (cfg.values ?? values)) ?? [] });
+    return Promise.resolve({ rows: [], fields: [] });
+  };
+  const repo = new AbsPlaybackSessionRepository(drizzle(pool, { schema }));
+  return { repo, queries };
+}
+
+describe('AbsPlaybackSessionRepository', () => {
+  it('listForUser orders the full history newest-updatedAt-first', async () => {
+    const { repo, queries } = captureQueries();
+    await repo.listForUser(7);
+    expect(queries).toHaveLength(1);
+    expect(queries[0].text).toContain('"abs_playback_sessions"');
+    expect(queries[0].text).toMatch(/order by .*"updated_at" desc/);
+    expect(queries[0].text).not.toContain('"book_id" =');
+    expect(queries[0].values).toEqual([7]);
+  });
+
+  it('listForUser with bookId filters to the one item', async () => {
+    const { repo, queries } = captureQueries();
+    await repo.listForUser(7, { bookId: 42 });
+    expect(queries[0].text).toContain('"user_id" =');
+    expect(queries[0].text).toContain('"book_id" =');
+    expect(queries[0].values).toEqual([7, 42]);
+  });
+
+  it('listForUserCreatedInYear brackets createdAt to the calendar year', async () => {
+    const { repo, queries } = captureQueries();
+    await repo.listForUserCreatedInYear(7, 2026);
+    expect(queries[0].text).toContain('"created_at" >=');
+    expect(queries[0].text).toContain('"created_at" <');
+    const [, start, end] = queries[0].values as [number, unknown, unknown];
+    expect(new Date(String(start)).getFullYear()).toBe(2026);
+    expect(new Date(String(end)).getFullYear()).toBe(2027);
+  });
+
+  it('updateSync touches only the sync columns of the addressed row', async () => {
+    const { repo, queries } = captureQueries();
+    await repo.updateSync('s-1', { currentTime: 10.5, timeListening: 33, updatedAt: new Date(1000) });
+    expect(queries[0].text).toContain('update "abs_playback_sessions"');
+    expect(queries[0].text).toContain('"current_time_seconds"');
+    expect(queries[0].text).toContain('"time_listening"');
+    expect(queries[0].text).toContain('"updated_at"');
+    expect(queries[0].text).not.toContain('"date"');
+    expect(queries[0].text).toContain('"id" =');
+  });
+
+  it('updateFromLocal also rewrites the client-owned date buckets', async () => {
+    const { repo, queries } = captureQueries();
+    await repo.updateFromLocal('s-1', {
+      currentTime: 10,
+      timeListening: 5,
+      updatedAt: new Date(1000),
+      date: '2026-07-12',
+      dayOfWeek: 'Sunday',
+    });
+    expect(queries[0].text).toContain('"date"');
+    expect(queries[0].text).toContain('"day_of_week"');
+    expect(queries[0].values).toContain('2026-07-12');
+    expect(queries[0].values).toContain('Sunday');
+  });
+
+  it('findById selects by primary key with limit 1', async () => {
+    const { repo, queries } = captureQueries();
+    const found = await repo.findById('s-1');
+    expect(found).toBeNull();
+    expect(queries[0].text).toContain('"id" =');
+    expect(queries[0].text).toContain('limit');
+  });
+});

--- a/server/src/modules/abs/abs-playback-session.repository.ts
+++ b/server/src/modules/abs/abs-playback-session.repository.ts
@@ -1,0 +1,85 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { and, desc, eq, gte, lt } from 'drizzle-orm';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { DB } from '../../db';
+import * as schema from '../../db/schema';
+import type { AbsPlaybackSessionRow, NewAbsPlaybackSessionRow } from '../../db/schema';
+
+/**
+ * CRUD for the persisted listening-session log (`abs_playback_sessions`), mirroring ABS's
+ * `playbackSessions` table. Reads deliberately load a user's full history and reduce in JS —
+ * exactly what ABS does (`getUserListeningSessionsHelper`) — which guarantees behavioral parity
+ * for pagination and the stats maps; per-user session counts stay small in BookOrbit deployments.
+ */
+@Injectable()
+export class AbsPlaybackSessionRepository {
+  constructor(@Inject(DB) private readonly db: NodePgDatabase<typeof schema>) {}
+
+  async insert(row: NewAbsPlaybackSessionRow): Promise<void> {
+    await this.db.insert(schema.absPlaybackSessions).values(row);
+  }
+
+  /** Periodic save of an open server session (ABS `saveSession` update path). */
+  async updateSync(id: string, values: { currentTime: number; timeListening: number; updatedAt: Date }): Promise<void> {
+    await this.db
+      .update(schema.absPlaybackSessions)
+      .set({
+        currentTimeSeconds: values.currentTime,
+        timeListening: values.timeListening,
+        updatedAt: values.updatedAt,
+      })
+      .where(eq(schema.absPlaybackSessions.id, id));
+  }
+
+  /**
+   * Upsert-update path for an offline session re-uploaded by a client: the client owns the row's
+   * clock, so `updatedAt` and the recomputed date buckets come from the payload.
+   */
+  async updateFromLocal(
+    id: string,
+    values: { currentTime: number; timeListening: number; updatedAt: Date; date: string; dayOfWeek: string },
+  ): Promise<void> {
+    await this.db
+      .update(schema.absPlaybackSessions)
+      .set({
+        currentTimeSeconds: values.currentTime,
+        timeListening: values.timeListening,
+        updatedAt: values.updatedAt,
+        date: values.date,
+        dayOfWeek: values.dayOfWeek,
+      })
+      .where(eq(schema.absPlaybackSessions.id, id));
+  }
+
+  async findById(id: string): Promise<AbsPlaybackSessionRow | null> {
+    const rows = await this.db.select().from(schema.absPlaybackSessions).where(eq(schema.absPlaybackSessions.id, id)).limit(1);
+    return rows[0] ?? null;
+  }
+
+  /** A user's full history, newest sync first (the order every ABS history endpoint assumes). */
+  async listForUser(userId: number, opts?: { bookId?: number }): Promise<AbsPlaybackSessionRow[]> {
+    const where =
+      opts?.bookId !== undefined
+        ? and(eq(schema.absPlaybackSessions.userId, userId), eq(schema.absPlaybackSessions.bookId, opts.bookId))
+        : eq(schema.absPlaybackSessions.userId, userId);
+    return this.db.select().from(schema.absPlaybackSessions).where(where).orderBy(desc(schema.absPlaybackSessions.updatedAt));
+  }
+
+  /** Sessions created within a calendar year (year-in-review buckets by `createdAt`, like ABS). */
+  async listForUserCreatedInYear(userId: number, year: number): Promise<AbsPlaybackSessionRow[]> {
+    const start = new Date(year, 0, 1);
+    const end = new Date(year + 1, 0, 1);
+    return this.db
+      .select()
+      .from(schema.absPlaybackSessions)
+      .where(
+        and(
+          eq(schema.absPlaybackSessions.userId, userId),
+          gte(schema.absPlaybackSessions.createdAt, start),
+          lt(schema.absPlaybackSessions.createdAt, end),
+        ),
+      )
+      .orderBy(desc(schema.absPlaybackSessions.updatedAt));
+  }
+}

--- a/server/src/modules/abs/abs-read.repository.test.ts
+++ b/server/src/modules/abs/abs-read.repository.test.ts
@@ -1,0 +1,126 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { describe, expect, it } from 'vitest';
+
+import * as schema from '../../db/schema';
+import { AbsReadRepository } from './abs-read.repository';
+
+// The Pool is never connected — drizzle only builds SQL here, so no DB is needed.
+function buildRepo() {
+  const db = drizzle(new Pool(), { schema });
+  return { repo: new AbsReadRepository(db), db };
+}
+
+function renderedSql(repo: AbsReadRepository, db: ReturnType<typeof drizzle>, group: string, value: string): string | undefined {
+  const where = repo.filterWhere(group, value);
+  if (!where) return undefined;
+  return db.select({ id: schema.books.id }).from(schema.books).where(where).toSQL().sql;
+}
+
+describe('AbsReadRepository.filterWhere — missing.* group (ABS libraryItemsBookFilters)', () => {
+  it('missing.authors excludes books that have any author row', () => {
+    const { repo, db } = buildRepo();
+    const sql = renderedSql(repo, db, 'missing', 'authors');
+    expect(sql).toBeDefined();
+    expect(sql).toContain('not in');
+    expect(sql).toContain('book_authors');
+  });
+
+  it('missing.series excludes books with a series membership', () => {
+    const { repo, db } = buildRepo();
+    const sql = renderedSql(repo, db, 'missing', 'series');
+    expect(sql).toBeDefined();
+    expect(sql).toContain('not in');
+    expect(sql).toContain('book_series_memberships');
+  });
+
+  it('missing scalar metadata fields match null-or-empty (or no metadata row)', () => {
+    const { repo, db } = buildRepo();
+    for (const field of ['subtitle', 'description', 'publisher', 'language', 'publishedYear', 'isbn']) {
+      const sql = renderedSql(repo, db, 'missing', field);
+      expect(sql, field).toBeDefined();
+      expect(sql, field).toContain('not in');
+      expect(sql, field).toContain('book_metadata');
+    }
+  });
+
+  it('unknown missing field yields no predicate, matching ABS (no filtering)', () => {
+    const { repo } = buildRepo();
+    expect(repo.filterWhere('missing', 'asin')).toBeUndefined();
+  });
+
+  it('authors filter (positive) still selects books IN the author junction', () => {
+    const { repo, db } = buildRepo();
+    const sql = renderedSql(repo, db, 'authors', '7');
+    expect(sql).toBeDefined();
+    expect(sql).toContain('in');
+    expect(sql).not.toContain('not in');
+    expect(sql).toContain('book_authors');
+  });
+});
+
+/**
+ * Captures the SQL each repository method executes by stubbing `pool.query` (still no DB). Queries
+ * resolve to empty result sets; methods that then throw on empty rows are caught — the SQL has
+ * already been recorded by that point.
+ */
+function captureQueries() {
+  const pool = new Pool();
+  const queries: { text: string; values: unknown[] }[] = [];
+  (pool as unknown as { query: (cfg: { text: string; values?: unknown[] } | string, values?: unknown[]) => Promise<unknown> }).query = (
+    cfg,
+    values,
+  ) => {
+    const text = typeof cfg === 'string' ? cfg : cfg.text;
+    queries.push({ text, values: (typeof cfg === 'string' ? values : (cfg.values ?? values)) ?? [] });
+    // collectionsForUser only runs its (gated) members query if the user has a collection row.
+    if (text.includes('from "collections"')) return Promise.resolve({ rows: [[1, 'c', null]], fields: [] });
+    return Promise.resolve({ rows: [], fields: [] });
+  };
+  const repo = new AbsReadRepository(drizzle(pool, { schema }));
+  return { repo, queries };
+}
+
+describe('ABS visibility gate — books without a playable audio content file are excluded', () => {
+  const hasAudioGate = (q: { text: string; values: unknown[] }) =>
+    q.text.includes('exists') && q.text.includes('"book_files"') && q.text.includes('lower(');
+
+  it('gates listItems and its count query, binding the content role and audio formats', async () => {
+    const { repo, queries } = captureQueries();
+    await repo.listItems({ libraryId: 1, limit: 10, offset: 0, sort: 'addedAt', desc: true }).catch(() => undefined);
+    expect(queries.length).toBeGreaterThan(0);
+    expect(queries.every(hasAudioGate)).toBe(true);
+    for (const value of ['content', 'm4b', 'm4a', 'mp3', 'opus', 'ogg', 'flac']) {
+      expect(queries[0].values).toContain(value);
+    }
+  });
+
+  it('gates single and batch item lookups (direct GET of an ebook-only item finds nothing)', async () => {
+    const { repo, queries } = captureQueries();
+    await repo.findItem(1);
+    await repo.findItemsByIds([1, 2]);
+    expect(queries).toHaveLength(2);
+    expect(queries.every(hasAudioGate)).toBe(true);
+  });
+
+  it('gates search, series, author, collection, and filter-data queries', async () => {
+    const { repo, queries } = captureQueries();
+    await repo.searchItems(1, 'dune', 5);
+    await repo.seriesInLibrary(1);
+    await repo.authorsInLibrary(1);
+    await repo.bookIdsForAuthor(7);
+    await repo.collectionsForUser(1, 1);
+    await repo.filterData(1);
+    // Every query except the ungated user-collections list must carry the audio-file predicate.
+    const gated = queries.filter((q) => !q.text.includes('from "collections"'));
+    expect(gated.length).toBeGreaterThanOrEqual(10);
+    expect(gated.every(hasAudioGate)).toBe(true);
+    expect(queries.some((q) => q.text.includes('from "collections"'))).toBe(true);
+  });
+
+  it('still keeps the processing-status gate alongside the audio gate', async () => {
+    const { repo, queries } = captureQueries();
+    await repo.listItems({ libraryId: 1, limit: 10, offset: 0, sort: 'addedAt', desc: true }).catch(() => undefined);
+    expect(queries[0].text).toContain("<> 'processing'");
+  });
+});

--- a/server/src/modules/abs/abs-read.repository.ts
+++ b/server/src/modules/abs/abs-read.repository.ts
@@ -1,0 +1,583 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { and, asc, desc, eq, exists, ilike, inArray, isNotNull, ne, notInArray, or, sql, type SQL } from 'drizzle-orm';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { AnyPgColumn } from 'drizzle-orm/pg-core';
+
+import { DB } from '../../db';
+import * as schema from '../../db/schema';
+
+const AUDIO_FORMATS = ['m4b', 'm4a', 'mp3', 'opus', 'ogg', 'flac'];
+
+function stripTotal(row: AbsItemRow & { _total: number }): AbsItemRow {
+  const { _total: _ignored, ...rest } = row;
+  void _ignored;
+  return rest;
+}
+
+export interface AbsItemRow {
+  id: number;
+  libraryId: number;
+  status: string;
+  addedAt: Date;
+  updatedAt: Date;
+  title: string | null;
+  subtitle: string | null;
+  description: string | null;
+  publishedYear: number | null;
+  publisher: string | null;
+  language: string | null;
+  isbn13: string | null;
+  isbn10: string | null;
+  seriesName: string | null;
+  seriesIndex: number | null;
+  durationSeconds: number | null;
+  chapters: unknown;
+}
+
+export interface AbsAudioFileRow {
+  id: number;
+  bookId: number;
+  format: string | null;
+  sortOrder: number | null;
+  durationSeconds: number | null;
+  sizeBytes: number | null;
+  absolutePath: string;
+}
+
+export type AbsItemSortField = 'addedAt' | 'title' | 'publishedYear';
+
+/**
+ * Focused read queries for the ABS adapter. Kept separate from BookOrbit's FE-tuned BookCard
+ * queries (`BookReadService.findCards`) so the ABS → wire mapping stays explicit.
+ */
+@Injectable()
+export class AbsReadRepository {
+  constructor(@Inject(DB) private readonly db: NodePgDatabase<typeof schema>) {}
+
+  private baseItemSelect() {
+    return {
+      id: schema.books.id,
+      libraryId: schema.books.libraryId,
+      status: schema.books.status,
+      addedAt: schema.books.addedAt,
+      updatedAt: schema.books.updatedAt,
+      title: schema.bookMetadata.title,
+      subtitle: schema.bookMetadata.subtitle,
+      description: schema.bookMetadata.description,
+      publishedYear: schema.bookMetadata.publishedYear,
+      publisher: schema.bookMetadata.publisher,
+      language: schema.bookMetadata.language,
+      isbn13: schema.bookMetadata.isbn13,
+      isbn10: schema.bookMetadata.isbn10,
+      seriesName: schema.bookMetadata.seriesName,
+      seriesIndex: schema.bookMetadata.seriesIndex,
+      durationSeconds: schema.bookMetadata.durationSeconds,
+      chapters: schema.bookMetadata.chapters,
+    };
+  }
+
+  /** Conditions selecting playable audio content rows in `book_files` (shared with {@link hasPlayableAudio}). */
+  private audioContentFileConditions(): SQL[] {
+    return [eq(schema.bookFiles.role, 'content'), inArray(sql`lower(${schema.bookFiles.format})`, AUDIO_FORMATS)];
+  }
+
+  /** Correlated predicate: the book has at least one playable audio content file. */
+  private hasPlayableAudio(): SQL {
+    return exists(
+      this.db
+        .select({ one: sql`1` })
+        .from(schema.bookFiles)
+        .where(and(eq(schema.bookFiles.bookId, schema.books.id), ...this.audioContentFileConditions())),
+    );
+  }
+
+  /**
+   * Base visibility gate for every book the ABS API exposes: fully scanned (not `processing`) and
+   * with playable audio. Ebook-only books are intentionally invisible to ABS clients — they would
+   * render as track-less, unplayable items — until `ebookFile` support is implemented.
+   */
+  private visibleBookConditions(): SQL[] {
+    return [sql`${schema.books.status} <> 'processing'`, this.hasPlayableAudio()];
+  }
+
+  private orderExpr(field: AbsItemSortField, descending: boolean): SQL[] {
+    const dir = descending ? desc : asc;
+    switch (field) {
+      case 'title':
+        return [dir(schema.bookMetadata.title), asc(schema.books.id)];
+      case 'publishedYear':
+        return [dir(schema.bookMetadata.publishedYear), asc(schema.books.id)];
+      case 'addedAt':
+      default:
+        return [dir(schema.books.addedAt), asc(schema.books.id)];
+    }
+  }
+
+  /** List present books in a library, paginated and sorted, with a total count. */
+  async listItems(opts: {
+    libraryId: number;
+    limit: number;
+    offset: number;
+    sort: AbsItemSortField;
+    desc: boolean;
+    extraWhere?: SQL;
+  }): Promise<{ rows: AbsItemRow[]; total: number }> {
+    const where = and(eq(schema.books.libraryId, opts.libraryId), ...this.visibleBookConditions(), ...(opts.extraWhere ? [opts.extraWhere] : []));
+
+    const rows = (await this.db
+      .select({ ...this.baseItemSelect(), _total: sql<number>`count(*) over()`.as('_total') })
+      .from(schema.books)
+      .leftJoin(schema.bookMetadata, eq(schema.bookMetadata.bookId, schema.books.id))
+      .where(where)
+      .orderBy(...this.orderExpr(opts.sort, opts.desc))
+      .limit(opts.limit > 0 ? opts.limit : Number.MAX_SAFE_INTEGER)
+      .offset(opts.offset)) as Array<AbsItemRow & { _total: number }>;
+
+    const total = rows.length > 0 ? Number(rows[0]._total) : await this.countItems(opts.libraryId, opts.extraWhere);
+    return { rows: rows.map((row) => stripTotal(row)), total };
+  }
+
+  async countItems(libraryId: number, extraWhere?: SQL): Promise<number> {
+    const [{ total }] = await this.db
+      .select({ total: sql<number>`count(*)` })
+      .from(schema.books)
+      .where(and(eq(schema.books.libraryId, libraryId), ...this.visibleBookConditions(), ...(extraWhere ? [extraWhere] : [])));
+    return Number(total);
+  }
+
+  async findItem(bookId: number): Promise<AbsItemRow | null> {
+    const [row] = await this.db
+      .select(this.baseItemSelect())
+      .from(schema.books)
+      .leftJoin(schema.bookMetadata, eq(schema.bookMetadata.bookId, schema.books.id))
+      .where(and(eq(schema.books.id, bookId), ...this.visibleBookConditions()))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async findItemsByIds(bookIds: number[]): Promise<AbsItemRow[]> {
+    if (bookIds.length === 0) return [];
+    return this.db
+      .select(this.baseItemSelect())
+      .from(schema.books)
+      .leftJoin(schema.bookMetadata, eq(schema.bookMetadata.bookId, schema.books.id))
+      .where(and(inArray(schema.books.id, bookIds), ...this.visibleBookConditions()));
+  }
+
+  /** Authors for a set of books, ordered for display. */
+  async authorsByBookIds(bookIds: number[]): Promise<{ bookId: number; id: number; name: string }[]> {
+    if (bookIds.length === 0) return [];
+    return this.db
+      .select({ bookId: schema.bookAuthors.bookId, id: schema.authors.id, name: schema.authors.name })
+      .from(schema.bookAuthors)
+      .innerJoin(schema.authors, eq(schema.authors.id, schema.bookAuthors.authorId))
+      .where(inArray(schema.bookAuthors.bookId, bookIds))
+      .orderBy(asc(schema.bookAuthors.bookId), asc(schema.bookAuthors.displayOrder));
+  }
+
+  async narratorsByBookIds(bookIds: number[]): Promise<{ bookId: number; name: string }[]> {
+    if (bookIds.length === 0) return [];
+    return this.db
+      .select({ bookId: schema.bookNarrators.bookId, name: schema.narrators.name })
+      .from(schema.bookNarrators)
+      .innerJoin(schema.narrators, eq(schema.narrators.id, schema.bookNarrators.narratorId))
+      .where(inArray(schema.bookNarrators.bookId, bookIds))
+      .orderBy(asc(schema.bookNarrators.bookId), asc(schema.bookNarrators.displayOrder));
+  }
+
+  async genresByBookIds(bookIds: number[]): Promise<{ bookId: number; name: string }[]> {
+    if (bookIds.length === 0) return [];
+    return this.db
+      .select({ bookId: schema.bookGenres.bookId, name: schema.genres.name })
+      .from(schema.bookGenres)
+      .innerJoin(schema.genres, eq(schema.genres.id, schema.bookGenres.genreId))
+      .where(inArray(schema.bookGenres.bookId, bookIds))
+      .orderBy(asc(schema.bookGenres.bookId), asc(schema.genres.name));
+  }
+
+  async seriesByBookIds(bookIds: number[]): Promise<{ bookId: number; id: number; name: string; sequence: number | null }[]> {
+    if (bookIds.length === 0) return [];
+    return this.db
+      .select({
+        bookId: schema.bookSeriesMemberships.bookId,
+        id: schema.bookSeries.id,
+        name: schema.bookSeries.name,
+        sequence: schema.bookSeriesMemberships.seriesIndex,
+      })
+      .from(schema.bookSeriesMemberships)
+      .innerJoin(schema.bookSeries, eq(schema.bookSeries.id, schema.bookSeriesMemberships.seriesId))
+      .where(inArray(schema.bookSeriesMemberships.bookId, bookIds))
+      .orderBy(asc(schema.bookSeriesMemberships.bookId), asc(schema.bookSeriesMemberships.displayOrder));
+  }
+
+  /** Audio content files for a book, ordered into track order. */
+  async audioFilesByBookId(bookId: number): Promise<AbsAudioFileRow[]> {
+    return this.audioFilesByBookIds([bookId]);
+  }
+
+  async audioFilesByBookIds(bookIds: number[]): Promise<AbsAudioFileRow[]> {
+    if (bookIds.length === 0) return [];
+    return this.db
+      .select({
+        id: schema.bookFiles.id,
+        bookId: schema.bookFiles.bookId,
+        format: schema.bookFiles.format,
+        sortOrder: schema.bookFiles.sortOrder,
+        durationSeconds: schema.bookFiles.durationSeconds,
+        sizeBytes: schema.bookFiles.sizeBytes,
+        absolutePath: schema.bookFiles.absolutePath,
+      })
+      .from(schema.bookFiles)
+      .where(and(inArray(schema.bookFiles.bookId, bookIds), ...this.audioContentFileConditions()))
+      .orderBy(asc(schema.bookFiles.bookId), asc(schema.bookFiles.sortOrder), asc(schema.bookFiles.id));
+  }
+
+  async findBookFileById(fileId: number): Promise<AbsAudioFileRow | null> {
+    const [row] = await this.db
+      .select({
+        id: schema.bookFiles.id,
+        bookId: schema.bookFiles.bookId,
+        format: schema.bookFiles.format,
+        sortOrder: schema.bookFiles.sortOrder,
+        durationSeconds: schema.bookFiles.durationSeconds,
+        sizeBytes: schema.bookFiles.sizeBytes,
+        absolutePath: schema.bookFiles.absolutePath,
+      })
+      .from(schema.bookFiles)
+      .where(eq(schema.bookFiles.id, fileId))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async libraryIdForBook(bookId: number): Promise<number | null> {
+    const [row] = await this.db.select({ libraryId: schema.books.libraryId }).from(schema.books).where(eq(schema.books.id, bookId)).limit(1);
+    return row?.libraryId ?? null;
+  }
+
+  /** The library of any of the author's books (authors are global; ABS Authors carry a libraryId). */
+  async libraryIdForAuthor(authorId: number): Promise<number | null> {
+    const [row] = await this.db
+      .select({ libraryId: schema.books.libraryId })
+      .from(schema.bookAuthors)
+      .innerJoin(schema.books, eq(schema.books.id, schema.bookAuthors.bookId))
+      .where(eq(schema.bookAuthors.authorId, authorId))
+      .limit(1);
+    return row?.libraryId ?? null;
+  }
+
+  /**
+   * Translate a decoded ABS browse filter into a `books.id IN (...)` predicate. Supports the common
+   * id/name groups; unknown or unsupported groups (e.g. per-user `progress`) yield `undefined` so the
+   * caller can fall back to no filtering.
+   */
+  filterWhere(group: string, value: string): SQL | undefined {
+    switch (group) {
+      case 'authors': {
+        const authorId = Number.parseInt(value, 10);
+        if (!Number.isInteger(authorId)) return undefined;
+        return inArray(
+          schema.books.id,
+          this.db.select({ bookId: schema.bookAuthors.bookId }).from(schema.bookAuthors).where(eq(schema.bookAuthors.authorId, authorId)),
+        );
+      }
+      case 'series': {
+        const seriesId = Number.parseInt(value, 10);
+        if (!Number.isInteger(seriesId)) return undefined;
+        return inArray(
+          schema.books.id,
+          this.db
+            .select({ bookId: schema.bookSeriesMemberships.bookId })
+            .from(schema.bookSeriesMemberships)
+            .where(eq(schema.bookSeriesMemberships.seriesId, seriesId)),
+        );
+      }
+      case 'narrators':
+        return inArray(
+          schema.books.id,
+          this.db
+            .select({ bookId: schema.bookNarrators.bookId })
+            .from(schema.bookNarrators)
+            .innerJoin(schema.narrators, eq(schema.narrators.id, schema.bookNarrators.narratorId))
+            .where(eq(schema.narrators.name, value)),
+        );
+      case 'genres':
+        return inArray(
+          schema.books.id,
+          this.db
+            .select({ bookId: schema.bookGenres.bookId })
+            .from(schema.bookGenres)
+            .innerJoin(schema.genres, eq(schema.genres.id, schema.bookGenres.genreId))
+            .where(eq(schema.genres.name, value)),
+        );
+      case 'tags':
+        return inArray(
+          schema.books.id,
+          this.db
+            .select({ bookId: schema.bookTags.bookId })
+            .from(schema.bookTags)
+            .innerJoin(schema.tags, eq(schema.tags.id, schema.bookTags.tagId))
+            .where(eq(schema.tags.name, value)),
+        );
+      case 'languages':
+        return inArray(
+          schema.books.id,
+          this.db.select({ bookId: schema.bookMetadata.bookId }).from(schema.bookMetadata).where(eq(schema.bookMetadata.language, value)),
+        );
+      case 'missing':
+        return this.missingWhere(value);
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * ABS `missing.<field>` — books lacking the given relation or metadata field
+   * (libraryItemsBookFilters: `missing.authors` is a left-join `authors.id IS NULL`; scalar fields
+   * match null-or-empty). Unknown fields yield `undefined` (no filtering), same as ABS.
+   */
+  private missingWhere(field: string): SQL | undefined {
+    switch (field) {
+      case 'authors':
+        return notInArray(schema.books.id, this.db.select({ bookId: schema.bookAuthors.bookId }).from(schema.bookAuthors));
+      case 'series':
+        return notInArray(schema.books.id, this.db.select({ bookId: schema.bookSeriesMemberships.bookId }).from(schema.bookSeriesMemberships));
+      case 'narrators':
+        return notInArray(schema.books.id, this.db.select({ bookId: schema.bookNarrators.bookId }).from(schema.bookNarrators));
+      case 'genres':
+        return notInArray(schema.books.id, this.db.select({ bookId: schema.bookGenres.bookId }).from(schema.bookGenres));
+      case 'tags':
+        return notInArray(schema.books.id, this.db.select({ bookId: schema.bookTags.bookId }).from(schema.bookTags));
+      case 'subtitle':
+        return this.missingMetadataText(schema.bookMetadata.subtitle);
+      case 'description':
+        return this.missingMetadataText(schema.bookMetadata.description);
+      case 'publisher':
+        return this.missingMetadataText(schema.bookMetadata.publisher);
+      case 'language':
+        return this.missingMetadataText(schema.bookMetadata.language);
+      case 'publishedYear':
+        return notInArray(
+          schema.books.id,
+          this.db.select({ bookId: schema.bookMetadata.bookId }).from(schema.bookMetadata).where(isNotNull(schema.bookMetadata.publishedYear)),
+        );
+      case 'isbn':
+        return notInArray(
+          schema.books.id,
+          this.db
+            .select({ bookId: schema.bookMetadata.bookId })
+            .from(schema.bookMetadata)
+            .where(
+              or(
+                and(isNotNull(schema.bookMetadata.isbn10), ne(schema.bookMetadata.isbn10, '')),
+                and(isNotNull(schema.bookMetadata.isbn13), ne(schema.bookMetadata.isbn13, '')),
+              ),
+            ),
+        );
+      default:
+        return undefined;
+    }
+  }
+
+  /** Books whose metadata row lacks the column (null/empty) or that have no metadata row at all. */
+  private missingMetadataText(column: AnyPgColumn): SQL {
+    return notInArray(
+      schema.books.id,
+      this.db
+        .select({ bookId: schema.bookMetadata.bookId })
+        .from(schema.bookMetadata)
+        .where(and(isNotNull(column), ne(column, ''))),
+    );
+  }
+
+  /** Title/author substring search within a library, capped at `limit` rows. */
+  async searchItems(libraryId: number, query: string, limit: number): Promise<AbsItemRow[]> {
+    const term = `%${query}%`;
+    const matchingAuthorBookIds = this.db
+      .select({ bookId: schema.bookAuthors.bookId })
+      .from(schema.bookAuthors)
+      .innerJoin(schema.authors, eq(schema.authors.id, schema.bookAuthors.authorId))
+      .where(ilike(schema.authors.name, term));
+
+    return this.db
+      .select(this.baseItemSelect())
+      .from(schema.books)
+      .leftJoin(schema.bookMetadata, eq(schema.bookMetadata.bookId, schema.books.id))
+      .where(
+        and(
+          eq(schema.books.libraryId, libraryId),
+          ...this.visibleBookConditions(),
+          or(ilike(schema.bookMetadata.title, term), inArray(schema.books.id, matchingAuthorBookIds)),
+        ),
+      )
+      .orderBy(asc(schema.bookMetadata.title), asc(schema.books.id))
+      .limit(limit > 0 ? limit : 25);
+  }
+
+  /** Series present in a library, with their member book ids ordered by series index. */
+  async seriesInLibrary(libraryId: number): Promise<{ id: number; name: string; books: { bookId: number; sequence: number | null }[] }[]> {
+    const rows = await this.db
+      .select({
+        id: schema.bookSeries.id,
+        name: schema.bookSeries.name,
+        bookId: schema.bookSeriesMemberships.bookId,
+        sequence: schema.bookSeriesMemberships.seriesIndex,
+      })
+      .from(schema.bookSeriesMemberships)
+      .innerJoin(schema.bookSeries, eq(schema.bookSeries.id, schema.bookSeriesMemberships.seriesId))
+      .innerJoin(schema.books, eq(schema.books.id, schema.bookSeriesMemberships.bookId))
+      .where(and(eq(schema.books.libraryId, libraryId), ...this.visibleBookConditions()))
+      .orderBy(asc(schema.bookSeries.name), asc(schema.bookSeriesMemberships.seriesIndex), asc(schema.bookSeriesMemberships.bookId));
+
+    const byId = new Map<number, { id: number; name: string; books: { bookId: number; sequence: number | null }[] }>();
+    for (const row of rows) {
+      let series = byId.get(row.id);
+      if (!series) {
+        series = { id: row.id, name: row.name, books: [] };
+        byId.set(row.id, series);
+      }
+      series.books.push({ bookId: row.bookId, sequence: row.sequence });
+    }
+    return [...byId.values()];
+  }
+
+  /** Authors with at least one present book in the library, with their in-library book count. */
+  async authorsInLibrary(libraryId: number): Promise<{ id: number; name: string; description: string | null; numBooks: number }[]> {
+    const bookIdsForLibrary = this.db
+      .select({ id: schema.books.id })
+      .from(schema.books)
+      .where(and(eq(schema.books.libraryId, libraryId), ...this.visibleBookConditions()));
+
+    return this.db
+      .select({
+        id: schema.authors.id,
+        name: schema.authors.name,
+        description: schema.authors.description,
+        numBooks: sql<number>`count(${schema.bookAuthors.bookId})`.mapWith(Number),
+      })
+      .from(schema.authors)
+      .innerJoin(schema.bookAuthors, eq(schema.bookAuthors.authorId, schema.authors.id))
+      .where(inArray(schema.bookAuthors.bookId, bookIdsForLibrary))
+      .groupBy(schema.authors.id)
+      .orderBy(asc(schema.authors.name));
+  }
+
+  async findAuthor(authorId: number): Promise<{ id: number; name: string; description: string | null } | null> {
+    const [row] = await this.db
+      .select({ id: schema.authors.id, name: schema.authors.name, description: schema.authors.description })
+      .from(schema.authors)
+      .where(eq(schema.authors.id, authorId))
+      .limit(1);
+    return row ?? null;
+  }
+
+  /** Present book ids written by an author, ordered by title for stable author-page display. */
+  async bookIdsForAuthor(authorId: number): Promise<number[]> {
+    const rows = await this.db
+      .select({ id: schema.books.id })
+      .from(schema.bookAuthors)
+      .innerJoin(schema.books, eq(schema.books.id, schema.bookAuthors.bookId))
+      .leftJoin(schema.bookMetadata, eq(schema.bookMetadata.bookId, schema.books.id))
+      .where(and(eq(schema.bookAuthors.authorId, authorId), ...this.visibleBookConditions()))
+      .orderBy(asc(schema.bookMetadata.title), asc(schema.books.id));
+    return rows.map((r) => r.id);
+  }
+
+  /** A user's collections, restricted to books in the given library, with member book ids. */
+  async collectionsForUser(
+    userId: number,
+    libraryId: number,
+  ): Promise<{ id: number; name: string; description: string | null; bookIds: number[] }[]> {
+    const cols = await this.db
+      .select({ id: schema.collections.id, name: schema.collections.name, description: schema.collections.description })
+      .from(schema.collections)
+      .where(eq(schema.collections.userId, userId))
+      .orderBy(asc(schema.collections.displayOrder), asc(schema.collections.name));
+    if (cols.length === 0) return [];
+
+    const members = await this.db
+      .select({ collectionId: schema.collectionBooks.collectionId, bookId: schema.collectionBooks.bookId })
+      .from(schema.collectionBooks)
+      .innerJoin(schema.books, eq(schema.books.id, schema.collectionBooks.bookId))
+      .where(
+        and(
+          inArray(
+            schema.collectionBooks.collectionId,
+            cols.map((c) => c.id),
+          ),
+          eq(schema.books.libraryId, libraryId),
+          ...this.visibleBookConditions(),
+        ),
+      )
+      .orderBy(asc(schema.collectionBooks.addedAt));
+
+    const booksByCollection = new Map<number, number[]>();
+    for (const m of members) {
+      const list = booksByCollection.get(m.collectionId);
+      if (list) list.push(m.bookId);
+      else booksByCollection.set(m.collectionId, [m.bookId]);
+    }
+    return cols.map((c) => ({ id: c.id, name: c.name, description: c.description, bookIds: booksByCollection.get(c.id) ?? [] }));
+  }
+
+  /** Distinct filter values for a library (authors/narrators/series/genres/tags/languages). */
+  async filterData(libraryId: number): Promise<{
+    authors: { id: number; name: string }[];
+    narrators: string[];
+    series: { id: number; name: string }[];
+    genres: string[];
+    tags: string[];
+    languages: string[];
+  }> {
+    const bookIdsForLibrary = this.db
+      .select({ id: schema.books.id })
+      .from(schema.books)
+      .where(and(eq(schema.books.libraryId, libraryId), ...this.visibleBookConditions()));
+
+    const [authors, narrators, series, genres, tags, languages] = await Promise.all([
+      this.db
+        .selectDistinct({ id: schema.authors.id, name: schema.authors.name })
+        .from(schema.bookAuthors)
+        .innerJoin(schema.authors, eq(schema.authors.id, schema.bookAuthors.authorId))
+        .where(inArray(schema.bookAuthors.bookId, bookIdsForLibrary))
+        .orderBy(asc(schema.authors.name)),
+      this.db
+        .selectDistinct({ name: schema.narrators.name })
+        .from(schema.bookNarrators)
+        .innerJoin(schema.narrators, eq(schema.narrators.id, schema.bookNarrators.narratorId))
+        .where(inArray(schema.bookNarrators.bookId, bookIdsForLibrary))
+        .orderBy(asc(schema.narrators.name)),
+      this.db
+        .selectDistinct({ id: schema.bookSeries.id, name: schema.bookSeries.name })
+        .from(schema.bookSeriesMemberships)
+        .innerJoin(schema.bookSeries, eq(schema.bookSeries.id, schema.bookSeriesMemberships.seriesId))
+        .where(inArray(schema.bookSeriesMemberships.bookId, bookIdsForLibrary))
+        .orderBy(asc(schema.bookSeries.name)),
+      this.db
+        .selectDistinct({ name: schema.genres.name })
+        .from(schema.bookGenres)
+        .innerJoin(schema.genres, eq(schema.genres.id, schema.bookGenres.genreId))
+        .where(inArray(schema.bookGenres.bookId, bookIdsForLibrary))
+        .orderBy(asc(schema.genres.name)),
+      this.db
+        .selectDistinct({ name: schema.tags.name })
+        .from(schema.bookTags)
+        .innerJoin(schema.tags, eq(schema.tags.id, schema.bookTags.tagId))
+        .where(inArray(schema.bookTags.bookId, bookIdsForLibrary))
+        .orderBy(asc(schema.tags.name)),
+      this.db
+        .selectDistinct({ language: schema.bookMetadata.language })
+        .from(schema.bookMetadata)
+        .where(and(inArray(schema.bookMetadata.bookId, bookIdsForLibrary), sql`${schema.bookMetadata.language} is not null`))
+        .orderBy(asc(schema.bookMetadata.language)),
+    ]);
+
+    return {
+      authors,
+      narrators: narrators.map((n) => n.name),
+      series,
+      genres: genres.map((g) => g.name),
+      tags: tags.map((t) => t.name),
+      languages: languages.map((l) => l.language).filter((l): l is string => l != null),
+    };
+  }
+}

--- a/server/src/modules/abs/abs-route-rewrite.util.test.ts
+++ b/server/src/modules/abs/abs-route-rewrite.util.test.ts
@@ -1,0 +1,51 @@
+import { ABS_EXCLUDED_ROUTES, ABS_INTERNAL_REFRESH_PATH, isAbsRoute, rewriteAbsUrl } from './abs-route-rewrite.util';
+
+describe('rewriteAbsUrl', () => {
+  it('remaps POST /auth/refresh to the private internal path (avoids colliding with BookOrbit auth)', () => {
+    expect(rewriteAbsUrl('/auth/refresh')).toBe(`/${ABS_INTERNAL_REFRESH_PATH}`);
+  });
+
+  it('preserves the query string when remapping refresh', () => {
+    expect(rewriteAbsUrl('/auth/refresh?foo=bar')).toBe(`/${ABS_INTERNAL_REFRESH_PATH}?foo=bar`);
+  });
+
+  it('leaves every other URL untouched', () => {
+    expect(rewriteAbsUrl('/login')).toBe('/login');
+    expect(rewriteAbsUrl('/api/me')).toBe('/api/me');
+    expect(rewriteAbsUrl('/auth/refresh/extra')).toBe('/auth/refresh/extra');
+    expect(rewriteAbsUrl('/public/session/abc/track/0')).toBe('/public/session/abc/track/0');
+  });
+});
+
+describe('ABS_EXCLUDED_ROUTES', () => {
+  it('owns the discovery, auth, api, and public route prefixes at the router root', () => {
+    for (const route of ['status', 'login', 'logout', 'api/me', 'api/libraries', 'api/items', 'api/session', 'public/(.*)']) {
+      expect(ABS_EXCLUDED_ROUTES).toContain(route);
+    }
+  });
+
+  it('routes the internal refresh path past the global prefix', () => {
+    expect(ABS_EXCLUDED_ROUTES).toContain('__abs/(.*)');
+  });
+});
+
+describe('isAbsRoute', () => {
+  it('matches exact and wildcard ABS surface paths', () => {
+    expect(isAbsRoute('/status')).toBe(true);
+    expect(isAbsRoute('/api/me')).toBe(true);
+    expect(isAbsRoute('/api/me/listening-sessions')).toBe(true);
+    expect(isAbsRoute('/public/session/abc/track/0')).toBe(true);
+    expect(isAbsRoute('/hls/abc/output-3.ts')).toBe(true);
+  });
+
+  it('ignores the query string when matching', () => {
+    expect(isAbsRoute('/api/libraries/lib_5/items?filter=narrators.x')).toBe(true);
+  });
+
+  it('does not match BookOrbit native or unrelated routes', () => {
+    expect(isAbsRoute('/api/v1/books/1')).toBe(false);
+    expect(isAbsRoute('/api/kobo/token/library/sync')).toBe(false);
+    expect(isAbsRoute('/foo')).toBe(false);
+    expect(isAbsRoute('/api/men')).toBe(false);
+  });
+});

--- a/server/src/modules/abs/abs-route-rewrite.util.ts
+++ b/server/src/modules/abs/abs-route-rewrite.util.ts
@@ -1,0 +1,74 @@
+/**
+ * ABS exposes refresh at `POST /auth/refresh`, which is the exact path BookOrbit's own auth
+ * controller already declares (served under the `api/v1` prefix). Two controllers cannot share the
+ * `auth/refresh` route path, so the ABS handler is declared at a private internal path and incoming
+ * `/auth/refresh` requests are remapped to it before routing via Fastify's `rewriteUrl` hook.
+ *
+ * Every other ABS path (`/login`, `/logout`, `/status`, `/api/me`, `/public/...`, …) is distinct
+ * from BookOrbit's declared controller paths and is simply excluded from the global prefix instead.
+ */
+export const ABS_INTERNAL_REFRESH_PATH = '__abs/auth/refresh';
+
+export function rewriteAbsUrl(url: string): string {
+  const queryIndex = url.indexOf('?');
+  const path = queryIndex === -1 ? url : url.slice(0, queryIndex);
+  if (path === '/auth/refresh') {
+    const query = queryIndex === -1 ? '' : url.slice(queryIndex);
+    return `/${ABS_INTERNAL_REFRESH_PATH}${query}`;
+  }
+  return url;
+}
+
+/** Route paths (controller-declared, pre-prefix) the ABS adapter owns at the router root. */
+export const ABS_EXCLUDED_ROUTES: string[] = [
+  // Discovery
+  'ping',
+  'healthcheck',
+  'status',
+  'init',
+  // Auth (refresh is reached via rewriteAbsUrl -> ABS_INTERNAL_REFRESH_PATH)
+  'login',
+  'logout',
+  '__abs/(.*)',
+  // OIDC (distinct from BookOrbit's own `api/v1/auth/oidc/*` web flow)
+  'auth/openid',
+  'auth/openid/(.*)',
+  // API surface (distinct from BookOrbit's `api/v1/*` and `api/kobo/*`)
+  'api/me',
+  'api/me/(.*)',
+  'api/libraries',
+  'api/libraries/(.*)',
+  'api/items',
+  'api/items/(.*)',
+  'api/authors',
+  'api/authors/(.*)',
+  'api/session',
+  'api/session/(.*)',
+  'api/sessions',
+  'api/sessions/(.*)',
+  'api/authorize',
+  'api/playlists',
+  'api/playlists/(.*)',
+  // Public (open-session track streaming, shares)
+  'public/(.*)',
+  // HLS transcode playlist/segment streaming
+  'hls/(.*)',
+];
+
+/**
+ * The excluded routes use Fastify route syntax (`(.*)` wildcards); anchored they double as regexes.
+ * Compiled once so {@link isAbsRoute} can test a request path against the whole ABS surface.
+ */
+const ABS_ROUTE_MATCHERS: readonly RegExp[] = ABS_EXCLUDED_ROUTES.map((route) => new RegExp(`^/${route}$`));
+
+/**
+ * True when `url` falls under the ABS adapter surface. Used by the global exception filter to suppress
+ * BookOrbit's `{ statusCode, message, ... }` envelope for ABS paths that never reach a controller (e.g.
+ * unimplemented endpoints 404ing), since the controller-scoped `AbsExceptionFilter` only runs on matched
+ * routes and a foreign envelope breaks strict ABS clients (see abs-exception.filter.ts).
+ */
+export function isAbsRoute(url: string): boolean {
+  const queryIndex = url.indexOf('?');
+  const path = queryIndex === -1 ? url : url.slice(0, queryIndex);
+  return ABS_ROUTE_MATCHERS.some((matcher) => matcher.test(path));
+}

--- a/server/src/modules/abs/abs-socket.gateway.test.ts
+++ b/server/src/modules/abs/abs-socket.gateway.test.ts
@@ -1,0 +1,98 @@
+import type { UserService } from '../user/user.service';
+import { AbsSocketGateway } from './abs-socket.gateway';
+import type { AbsTokenService } from './auth/abs-token.service';
+import { makeAbsUser } from './__testing__/abs-test-helpers';
+
+interface BuildOpts {
+  payload?: { userId: number; username: string } | null;
+  user?: ReturnType<typeof makeAbsUser> | null;
+}
+
+function build(opts: BuildOpts = {}) {
+  const tokenService = { verifyAccessToken: vi.fn().mockReturnValue(opts.payload ?? null) } as unknown as AbsTokenService;
+  const userService = { findByIdWithPermissions: vi.fn().mockResolvedValue(opts.user ?? null) } as unknown as UserService;
+  return { gateway: new AbsSocketGateway(tokenService, userService) };
+}
+
+function makeClient() {
+  return { id: 'sock-1', emit: vi.fn(), join: vi.fn().mockResolvedValue(undefined) } as any;
+}
+
+describe('AbsSocketGateway#handleAuth', () => {
+  it('emits auth_failed("Invalid token") for a bad/non-string token', async () => {
+    const { gateway } = build({ payload: null });
+    const client = makeClient();
+    await gateway.handleAuth(client, 'bad-token');
+    expect(client.emit).toHaveBeenCalledWith('auth_failed', { message: 'Invalid token' });
+  });
+
+  it('emits auth_failed("Invalid user") when the user is missing or inactive', async () => {
+    const { gateway } = build({ payload: { userId: 1, username: 'a' }, user: makeAbsUser({ active: false }) });
+    const client = makeClient();
+    await gateway.handleAuth(client, 'tok');
+    expect(client.emit).toHaveBeenCalledWith('auth_failed', { message: 'Invalid user' });
+  });
+
+  it('joins the user room + the authed-broadcast room and emits init on a valid token', async () => {
+    const { gateway } = build({ payload: { userId: 8, username: 'admin' }, user: makeAbsUser({ id: 8, username: 'admin' }) });
+    const client = makeClient();
+    await gateway.handleAuth(client, 'tok');
+    expect(client.join).toHaveBeenCalledWith('abs:user:8');
+    expect(client.join).toHaveBeenCalledWith('abs:authed');
+    expect(client.emit).toHaveBeenCalledWith('init', { userId: 'usr_8', username: 'admin', usersOnline: [] });
+  });
+});
+
+describe('AbsSocketGateway#handlePing', () => {
+  it('replies pong', () => {
+    const { gateway } = build();
+    const client = makeClient();
+    gateway.handlePing(client);
+    expect(client.emit).toHaveBeenCalledWith('pong');
+  });
+});
+
+describe('AbsSocketGateway server-emitted events', () => {
+  it('emits user_item_progress_updated into the user room', () => {
+    const { gateway } = build();
+    const emit = vi.fn();
+    gateway.server = { to: vi.fn().mockReturnValue({ emit }) } as any;
+    const payload = { id: 'mp-1', sessionId: 's-1', deviceDescription: 'app', data: {} };
+    gateway.emitUserItemProgressUpdated(8, payload);
+    expect(gateway.server.to as any).toHaveBeenCalledWith('abs:user:8');
+    expect(emit).toHaveBeenCalledWith('user_item_progress_updated', payload);
+  });
+
+  it('emits user_session_closed into the user room', () => {
+    const { gateway } = build();
+    const emit = vi.fn();
+    gateway.server = { to: vi.fn().mockReturnValue({ emit }) } as any;
+    gateway.emitUserSessionClosed(8, 'sess-1');
+    expect(emit).toHaveBeenCalledWith('user_session_closed', 'sess-1');
+  });
+});
+
+describe('AbsSocketGateway catalog-change events', () => {
+  function withGateway() {
+    const { gateway } = build();
+    const emit = vi.fn();
+    gateway.server = { to: vi.fn().mockReturnValue({ emit }) } as any;
+    return { gateway, emit, to: gateway.server.to as any };
+  }
+
+  it('broadcasts library_updated to the authed room', () => {
+    const { gateway, emit, to } = withGateway();
+    const library = { id: 'lib_5', name: 'Audiobooks' };
+    gateway.emitLibraryUpdated(library);
+    expect(to).toHaveBeenCalledWith('abs:authed');
+    expect(emit).toHaveBeenCalledWith('library_updated', library);
+  });
+
+  it('broadcasts item_added and items_updated to the authed room', () => {
+    const { gateway, emit } = withGateway();
+    gateway.emitItemAdded({ id: 'li_1' });
+    gateway.emitItemsUpdated([{ id: 'li_1' }, { id: 'li_2' }]);
+    expect(emit).toHaveBeenCalledWith('item_added', { id: 'li_1' });
+    expect(emit).toHaveBeenCalledWith('items_updated', [{ id: 'li_1' }, { id: 'li_2' }]);
+  });
+});

--- a/server/src/modules/abs/abs-socket.gateway.ts
+++ b/server/src/modules/abs/abs-socket.gateway.ts
@@ -1,0 +1,115 @@
+import { Logger } from '@nestjs/common';
+import { OnGatewayConnection, SubscribeMessage, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+
+import { UserService } from '../user/user.service';
+import { encodeAbsId } from './abs-id.util';
+import { AbsTokenService } from './auth/abs-token.service';
+
+function userRoom(userId: number): string {
+  return `abs:user:${userId}`;
+}
+
+/** All authenticated ABS sockets; targets the contract's `emitter` (all authed clients) fan-out. */
+const AUTHED_ROOM = 'abs:authed';
+
+/**
+ * Audiobookshelf Socket.IO contract (REIMPLEMENTATION_GUIDE §6). Unlike BookOrbit's namespaced
+ * gateways (which authenticate via the connection handshake), ABS clients connect to the default
+ * namespace and then **emit `auth`** with their access-token JWT; the server replies `init` (or
+ * `auth_failed`). Subsequent per-user events are emitted into the user's room.
+ */
+@WebSocketGateway({ cors: { origin: '*', methods: ['GET', 'POST'] } })
+export class AbsSocketGateway implements OnGatewayConnection {
+  @WebSocketServer() server: Server;
+  private readonly logger = new Logger(AbsSocketGateway.name);
+
+  constructor(
+    private readonly tokenService: AbsTokenService,
+    private readonly userService: UserService,
+  ) {}
+
+  handleConnection(): void {
+    // No-op: ABS clients authenticate via the explicit `auth` event below, not the handshake.
+  }
+
+  @SubscribeMessage('auth')
+  async handleAuth(client: Socket, token: unknown): Promise<void> {
+    const payload = typeof token === 'string' ? this.tokenService.verifyAccessToken(token) : null;
+    if (!payload) {
+      client.emit('auth_failed', { message: 'Invalid token' });
+      return;
+    }
+
+    const user = await this.userService.findByIdWithPermissions(payload.userId);
+    if (!user || !user.active) {
+      client.emit('auth_failed', { message: 'Invalid user' });
+      return;
+    }
+
+    await client.join(userRoom(user.id));
+    await client.join(AUTHED_ROOM);
+    client.emit('init', { userId: encodeAbsId('user', user.id), username: user.username, usersOnline: [] });
+    this.logger.debug(`[abs.socket] userId=${user.id} socketId=${client.id} authenticated`);
+  }
+
+  @SubscribeMessage('ping')
+  handlePing(client: Socket): void {
+    client.emit('pong');
+  }
+
+  /** Another device updated progress; clients re-sync the now-playing position. */
+  emitUserItemProgressUpdated(
+    userId: number,
+    payload: { id: string; sessionId: string | null; deviceDescription: string; data: Record<string, unknown> },
+  ): void {
+    this.server?.to(userRoom(userId)).emit('user_item_progress_updated', payload);
+  }
+
+  emitUserSessionClosed(userId: number, sessionId: string): void {
+    this.server?.to(userRoom(userId)).emit('user_session_closed', sessionId);
+  }
+
+  /**
+   * The HLS transcoder was re-based after a seek beyond the buffered window (REIMPLEMENTATION_GUIDE
+   * §5.3). The client must restart playback at `startTime`; a client that ignores this "sticks" on seek.
+   */
+  emitStreamReset(userId: number, payload: { streamId: string; startTime: number }): void {
+    this.server?.to(userRoom(userId)).emit('stream_reset', payload);
+  }
+
+  // --- Catalog change events (REIMPLEMENTATION_GUIDE §6.3). Broadcast to all authed clients so
+  //     they refresh their library/item caches; payloads are ABS LibraryItem / Library shapes. ---
+
+  emitItemAdded(item: Record<string, unknown>): void {
+    this.server?.to(AUTHED_ROOM).emit('item_added', item);
+  }
+
+  emitItemUpdated(item: Record<string, unknown>): void {
+    this.server?.to(AUTHED_ROOM).emit('item_updated', item);
+  }
+
+  emitItemRemoved(item: Record<string, unknown>): void {
+    this.server?.to(AUTHED_ROOM).emit('item_removed', item);
+  }
+
+  emitItemsAdded(items: Record<string, unknown>[]): void {
+    this.server?.to(AUTHED_ROOM).emit('items_added', items);
+  }
+
+  emitItemsUpdated(items: Record<string, unknown>[]): void {
+    this.server?.to(AUTHED_ROOM).emit('items_updated', items);
+  }
+
+  emitLibraryAdded(library: Record<string, unknown>): void {
+    this.server?.to(AUTHED_ROOM).emit('library_added', library);
+  }
+
+  emitLibraryUpdated(library: Record<string, unknown>): void {
+    this.server?.to(AUTHED_ROOM).emit('library_updated', library);
+  }
+
+  emitLibraryRemoved(library: Record<string, unknown>): void {
+    this.server?.to(AUTHED_ROOM).emit('library_removed', library);
+  }
+}

--- a/server/src/modules/abs/abs-transcode.util.test.ts
+++ b/server/src/modules/abs/abs-transcode.util.test.ts
@@ -1,0 +1,86 @@
+import {
+  buildVodPlaylist,
+  decideSegmentRequest,
+  isHlsFile,
+  parseSegmentNumber,
+  totalSegments,
+  type SegmentDecisionInput,
+} from './abs-transcode.util';
+
+describe('isHlsFile', () => {
+  it('accepts the playlist and segment filenames', () => {
+    expect(isHlsFile('output.m3u8')).toBe(true);
+    expect(isHlsFile('output-0.ts')).toBe(true);
+    expect(isHlsFile('output-123.ts')).toBe(true);
+  });
+
+  it('rejects path traversal and foreign files', () => {
+    expect(isHlsFile('../secret.ts')).toBe(false);
+    expect(isHlsFile('output-1.ts/../../etc/passwd')).toBe(false);
+    expect(isHlsFile('output.mp4')).toBe(false);
+    expect(isHlsFile('concat.txt')).toBe(false);
+    expect(isHlsFile('output-.ts')).toBe(false);
+  });
+});
+
+describe('parseSegmentNumber', () => {
+  it('extracts the index from a segment filename', () => {
+    expect(parseSegmentNumber('output-0.ts')).toBe(0);
+    expect(parseSegmentNumber('output-42.ts')).toBe(42);
+  });
+
+  it('returns null for non-segment names', () => {
+    expect(parseSegmentNumber('output.m3u8')).toBeNull();
+    expect(parseSegmentNumber('output-x.ts')).toBeNull();
+  });
+});
+
+describe('totalSegments', () => {
+  it('rounds up to cover the whole duration', () => {
+    expect(totalSegments(60, 6)).toBe(10);
+    expect(totalSegments(61, 6)).toBe(11);
+    expect(totalSegments(0, 6)).toBe(0);
+  });
+});
+
+describe('buildVodPlaylist', () => {
+  it('lists every segment with a trailing endlist and a short final segment', () => {
+    const playlist = buildVodPlaylist(15, 6);
+    expect(playlist).toContain('#EXT-X-PLAYLIST-TYPE:VOD');
+    expect(playlist).toContain('output-0.ts');
+    expect(playlist).toContain('output-2.ts');
+    expect(playlist).not.toContain('output-3.ts');
+    expect(playlist).toContain('#EXT-X-ENDLIST');
+    // Final segment is the 3-second remainder, not a full 6s.
+    expect(playlist).toContain('#EXTINF:3.000000,');
+  });
+});
+
+describe('decideSegmentRequest', () => {
+  const base: SegmentDecisionInput = { requestedSegment: 5, windowStart: 0, highestAvailable: 4, total: 100, isResetting: false };
+
+  it('serves a segment that should already exist', () => {
+    expect(decideSegmentRequest({ ...base, requestedSegment: 3, highestAvailable: 4 })).toBe('serve');
+  });
+
+  it('waits while the transcoder catches up to a nearby segment', () => {
+    expect(decideSegmentRequest({ ...base, requestedSegment: 6, highestAvailable: 4 })).toBe('wait');
+  });
+
+  it('waits while the stream is resetting', () => {
+    expect(decideSegmentRequest({ ...base, requestedSegment: 50, highestAvailable: 4, isResetting: true })).toBe('wait');
+  });
+
+  it('resets on a forward seek beyond the lookahead window', () => {
+    expect(decideSegmentRequest({ ...base, requestedSegment: 50, highestAvailable: 4 })).toBe('reset');
+  });
+
+  it('resets on a backward seek before the current window', () => {
+    expect(decideSegmentRequest({ ...base, requestedSegment: 2, windowStart: 10, highestAvailable: 14 })).toBe('reset');
+  });
+
+  it('404s a segment outside the title', () => {
+    expect(decideSegmentRequest({ ...base, requestedSegment: 100, total: 100 })).toBe('not-found');
+    expect(decideSegmentRequest({ ...base, requestedSegment: -1 })).toBe('not-found');
+  });
+});

--- a/server/src/modules/abs/abs-transcode.util.ts
+++ b/server/src/modules/abs/abs-transcode.util.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure helpers for the HLS transcode router (REIMPLEMENTATION_GUIDE §5.3). Kept free of fs/ffmpeg so
+ * the segment-window / seek-reset decision and playlist generation can be unit-tested in isolation.
+ */
+
+/** HLS target segment length in seconds. ffmpeg cuts on keyframes so real segments may vary slightly. */
+export const HLS_SEGMENT_SECONDS = 6;
+
+/**
+ * How many segments ahead of the last produced one a client may request before we treat it as a seek
+ * (rather than "transcoder hasn't caught up yet"). 10 × 6s ≈ a 60s buffer window.
+ */
+export const HLS_SEGMENT_LOOKAHEAD = 10;
+
+/** The single playlist filename the synthetic transcode track points at. */
+export const HLS_PLAYLIST_FILE = 'output.m3u8';
+
+/** ffmpeg writes segments as `output-<n>.ts`; `-start_number` controls the first index. */
+const SEGMENT_RE = /^output-(\d+)\.ts$/;
+const HLS_FILE_RE = /^output(-\d+)?\.(ts|m3u8)$/;
+
+/**
+ * Validate an `:file` path component against the only two shapes we serve (`output.m3u8`,
+ * `output-<n>.ts`). The strict pattern also blocks path traversal — no slashes or `..` can match.
+ */
+export function isHlsFile(file: string): boolean {
+  return HLS_FILE_RE.test(file);
+}
+
+/** Parse the segment index out of `output-<n>.ts`, or null if the name isn't a segment. */
+export function parseSegmentNumber(file: string): number | null {
+  const match = SEGMENT_RE.exec(file);
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+/** Total number of segments needed to cover `duration` seconds at the given segment length. */
+export function totalSegments(duration: number, segmentLength = HLS_SEGMENT_SECONDS): number {
+  if (duration <= 0) return 0;
+  return Math.ceil(duration / segmentLength);
+}
+
+/**
+ * Generate a VOD playlist listing every segment up front. ABS writes the full playlist itself (rather
+ * than letting ffmpeg emit a live one) so the client knows the true total duration and can seek to any
+ * offset; the `.ts` files are produced on demand and `404` until ready.
+ */
+export function buildVodPlaylist(duration: number, segmentLength = HLS_SEGMENT_SECONDS): string {
+  const count = totalSegments(duration, segmentLength);
+  const lines = ['#EXTM3U', '#EXT-X-VERSION:3', `#EXT-X-TARGETDURATION:${segmentLength}`, '#EXT-X-MEDIA-SEQUENCE:0', '#EXT-X-PLAYLIST-TYPE:VOD'];
+  for (let i = 0; i < count; i++) {
+    const remaining = duration - i * segmentLength;
+    const segDuration = Math.min(segmentLength, remaining);
+    lines.push(`#EXTINF:${segDuration.toFixed(6)},`, `output-${i}.ts`);
+  }
+  lines.push('#EXT-X-ENDLIST');
+  return lines.join('\n') + '\n';
+}
+
+export type SegmentAction = 'serve' | 'wait' | 'reset' | 'not-found';
+
+export interface SegmentDecisionInput {
+  /** The segment index the client asked for. */
+  requestedSegment: number;
+  /** The segment index ffmpeg is currently transcoding from (its `-start_number`). */
+  windowStart: number;
+  /** Highest segment index produced on disk so far, or `windowStart - 1` if none yet. */
+  highestAvailable: number;
+  /** Total segments in the title; requests outside `[0, total)` are 404s. */
+  total: number;
+  /** True while ffmpeg is being re-based after a seek (client should just retry). */
+  isResetting: boolean;
+  lookahead?: number;
+}
+
+/**
+ * Mirror of ABS `Stream.checkSegmentNumberRequest` (REIMPLEMENTATION_GUIDE §5.3). Decides what to do
+ * with a `.ts` request whose file isn't on disk:
+ * - `not-found`: index is outside the title.
+ * - `wait`: the transcoder is resetting, or the segment is within reach and just not written yet.
+ * - `reset`: the client seeked outside the transcoded window — re-base ffmpeg and emit `stream_reset`.
+ * - `serve`: the segment should already exist (caller still confirms the file is present).
+ */
+export function decideSegmentRequest(input: SegmentDecisionInput): SegmentAction {
+  const { requestedSegment, windowStart, highestAvailable, total, isResetting } = input;
+  const lookahead = input.lookahead ?? HLS_SEGMENT_LOOKAHEAD;
+
+  if (requestedSegment < 0 || requestedSegment >= total) return 'not-found';
+  if (isResetting) return 'wait';
+  // Seeked backward before what ffmpeg is currently producing.
+  if (requestedSegment < windowStart) return 'reset';
+  // Already produced (or should be) — the caller re-checks the file on disk.
+  if (requestedSegment <= highestAvailable) return 'serve';
+  // Ahead of the produced edge but close: the transcoder will reach it shortly.
+  if (requestedSegment <= highestAvailable + lookahead) return 'wait';
+  // Far ahead — a forward seek beyond the buffer.
+  return 'reset';
+}

--- a/server/src/modules/abs/abs.constants.ts
+++ b/server/src/modules/abs/abs.constants.ts
@@ -1,0 +1,12 @@
+/**
+ * The ABS server identity reported to clients. Clients gate feature availability on
+ * `serverVersion`, so we advertise the ABS version this adapter is built against
+ * (see docs/abs-api). `app` must be the literal "audiobookshelf" the clients expect.
+ */
+export const ABS_APP_NAME = 'audiobookshelf';
+export const ABS_SERVER_VERSION = '2.35.1';
+export const ABS_SOURCE = 'bookorbit';
+export const ABS_DEFAULT_LANGUAGE = 'en-us';
+
+/** BookOrbit has no podcasts; every ABS library/item is reported as a book. */
+export const ABS_MEDIA_TYPE_BOOK = 'book';

--- a/server/src/modules/abs/abs.module.ts
+++ b/server/src/modules/abs/abs.module.ts
@@ -1,0 +1,74 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+
+import { AchievementModule } from '../achievement/achievement.module';
+import { AuthModule } from '../auth/auth.module';
+import { LibraryModule } from '../library/library.module';
+import { UserModule } from '../user/user.module';
+import { AbsEventBridgeService } from './abs-event-bridge.service';
+import { AbsPlaybackSessionRepository } from './abs-playback-session.repository';
+import { AbsReadRepository } from './abs-read.repository';
+import { AbsSocketGateway } from './abs-socket.gateway';
+import { AbsAuthController } from './auth/abs-auth.controller';
+import { AbsAuthGuard } from './auth/abs-auth.guard';
+import { AbsDiscoveryController } from './auth/abs-discovery.controller';
+import { AbsOpenidController } from './auth/abs-openid.controller';
+import { AbsSessionService } from './auth/abs-session.service';
+import { AbsTokenService } from './auth/abs-token.service';
+import { AbsAuthorizeController } from './controllers/abs-authorize.controller';
+import { AbsAuthorsController } from './controllers/abs-authors.controller';
+import { AbsHlsController } from './controllers/abs-hls.controller';
+import { AbsItemsController } from './controllers/abs-items.controller';
+import { AbsLibrariesController } from './controllers/abs-libraries.controller';
+import { AbsMeController } from './controllers/abs-me.controller';
+import { AbsPlaylistsController } from './controllers/abs-playlists.controller';
+import { AbsPublicController } from './controllers/abs-public.controller';
+import { AbsSessionsController } from './controllers/abs-sessions.controller';
+import { AbsBookmarkService } from './services/abs-bookmark.service';
+import { AbsCatalogService } from './services/abs-catalog.service';
+import { AbsPlaybackService } from './services/abs-playback.service';
+import { AbsProgressService } from './services/abs-progress.service';
+import { AbsSessionHistoryService } from './services/abs-session-history.service';
+import { AbsStreamService } from './services/abs-stream.service';
+import { AbsTranscodeService } from './services/abs-transcode.service';
+
+/**
+ * Audiobookshelf-compatible API surface. Self-contained: mounts at the router root (excluded from
+ * the global `api/v1` prefix in main.ts), bypasses the global ValidationPipe / GlobalExceptionFilter
+ * via raw bodies + a controller-scoped AbsExceptionFilter, and reuses BookOrbit services for data.
+ */
+@Module({
+  imports: [JwtModule.register({}), UserModule, LibraryModule, AchievementModule, AuthModule],
+  controllers: [
+    AbsDiscoveryController,
+    AbsAuthController,
+    AbsOpenidController,
+    AbsAuthorizeController,
+    AbsMeController,
+    AbsLibrariesController,
+    AbsItemsController,
+    AbsAuthorsController,
+    AbsSessionsController,
+    AbsPublicController,
+    AbsPlaylistsController,
+    AbsHlsController,
+  ],
+  providers: [
+    AbsTokenService,
+    AbsSessionService,
+    AbsAuthGuard,
+    AbsReadRepository,
+    AbsPlaybackSessionRepository,
+    AbsProgressService,
+    AbsCatalogService,
+    AbsPlaybackService,
+    AbsSessionHistoryService,
+    AbsStreamService,
+    AbsTranscodeService,
+    AbsSocketGateway,
+    AbsBookmarkService,
+    AbsEventBridgeService,
+  ],
+  exports: [AbsTokenService],
+})
+export class AbsModule {}

--- a/server/src/modules/abs/auth/abs-auth.controller.test.ts
+++ b/server/src/modules/abs/auth/abs-auth.controller.test.ts
@@ -1,0 +1,137 @@
+import { hash } from 'bcryptjs';
+
+import type { LibraryService } from '../../library/library.service';
+import type { UserService } from '../../user/user.service';
+import { makeAbsUser, makeRequest, thrownStatus } from '../__testing__/abs-test-helpers';
+import type { AbsProgressService } from '../services/abs-progress.service';
+import { AbsAuthController } from './abs-auth.controller';
+import type { AbsSessionService } from './abs-session.service';
+import type { AbsTokenService } from './abs-token.service';
+
+const PASSWORD = 'correct horse';
+let PASSWORD_HASH: string;
+
+beforeAll(async () => {
+  PASSWORD_HASH = await hash(PASSWORD, 4); // low cost: tests don't need production strength
+});
+
+interface BuildOpts {
+  candidate?: Record<string, unknown> | null;
+  user?: ReturnType<typeof makeAbsUser> | null;
+  accessibleIds?: number[];
+  mediaProgress?: Record<string, unknown>[];
+}
+
+function build(opts: BuildOpts = {}) {
+  const userService = {
+    findByUsername: vi.fn().mockResolvedValue(opts.candidate ?? null),
+    findByIdWithPermissions: vi.fn().mockResolvedValue(opts.user ?? null),
+  } as unknown as UserService;
+  const sessionService = {
+    createSession: vi.fn().mockResolvedValue({ accessToken: 'acc', refreshToken: 'ref' }),
+    rotate: vi.fn().mockResolvedValue({ accessToken: 'acc2', refreshToken: 'ref2' }),
+    invalidate: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AbsSessionService;
+  const tokenService = {
+    verifyRefreshToken: vi.fn().mockReturnValue({ userId: 1, username: 'admin' }),
+  } as unknown as AbsTokenService;
+  const libraryService = {
+    findAccessibleLibraryIds: vi.fn().mockResolvedValue(opts.accessibleIds ?? []),
+  } as unknown as LibraryService;
+  const progressService = {
+    listMediaProgressForUser: vi.fn().mockResolvedValue(opts.mediaProgress ?? []),
+  } as unknown as AbsProgressService;
+  return {
+    controller: new AbsAuthController(userService, sessionService, tokenService, libraryService, progressService),
+    userService,
+    sessionService,
+    tokenService,
+    progressService,
+  };
+}
+
+describe('AbsAuthController#login', () => {
+  it('returns the login payload with tokens in the body on valid credentials (mobile flow)', async () => {
+    const candidate = { id: 1, active: true, lockedUntil: null, passwordHash: PASSWORD_HASH };
+    const { controller, sessionService } = build({ candidate, user: makeAbsUser({ id: 1, isSuperuser: false }), accessibleIds: [4, 9] });
+
+    const payload = await controller.login({ username: 'admin', password: PASSWORD }, makeRequest({ headers: { 'user-agent': 'app' } }));
+    const user = payload.user as Record<string, unknown>;
+    expect(user.accessToken).toBe('acc');
+    expect(user.refreshToken).toBe('ref');
+    expect(payload.userDefaultLibraryId).toBe('lib_4');
+    expect(user.librariesAccessible).toEqual(['lib_4', 'lib_9']);
+    expect(sessionService.createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("embeds the user's mediaProgress in the login payload (clients seed resume positions from it)", async () => {
+    const candidate = { id: 1, active: true, lockedUntil: null, passwordHash: PASSWORD_HASH };
+    const progress = [{ libraryItemId: 'li_9', currentTime: 120 }];
+    const { controller, progressService } = build({ candidate, user: makeAbsUser({ id: 1, isSuperuser: false }), mediaProgress: progress });
+
+    const payload = await controller.login({ username: 'admin', password: PASSWORD }, makeRequest());
+    expect((payload.user as Record<string, unknown>).mediaProgress).toEqual(progress);
+    expect(progressService.listMediaProgressForUser).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects missing credentials with 401', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.login({ username: 'admin' }, makeRequest()))).toBe(401);
+  });
+
+  it('rejects an unknown user with 401', async () => {
+    const { controller } = build({ candidate: null });
+    expect(await thrownStatus(() => controller.login({ username: 'ghost', password: PASSWORD }, makeRequest()))).toBe(401);
+  });
+
+  it('rejects a wrong password with 401', async () => {
+    const candidate = { id: 1, active: true, lockedUntil: null, passwordHash: PASSWORD_HASH };
+    const { controller } = build({ candidate, user: makeAbsUser() });
+    expect(await thrownStatus(() => controller.login({ username: 'admin', password: 'wrong' }, makeRequest()))).toBe(401);
+  });
+
+  it('rejects an inactive account with 401', async () => {
+    const candidate = { id: 1, active: false, lockedUntil: null, passwordHash: PASSWORD_HASH };
+    const { controller } = build({ candidate, user: makeAbsUser() });
+    expect(await thrownStatus(() => controller.login({ username: 'admin', password: PASSWORD }, makeRequest()))).toBe(401);
+  });
+
+  it('rejects a locked account with 401', async () => {
+    const candidate = { id: 1, active: true, lockedUntil: new Date(Date.now() + 60_000), passwordHash: PASSWORD_HASH };
+    const { controller } = build({ candidate, user: makeAbsUser() });
+    expect(await thrownStatus(() => controller.login({ username: 'admin', password: PASSWORD }, makeRequest()))).toBe(401);
+  });
+});
+
+describe('AbsAuthController#refresh', () => {
+  it('rotates tokens when a refresh token is presented on x-refresh-token', async () => {
+    const { controller, sessionService } = build({ user: makeAbsUser({ id: 1 }) });
+    const payload = await controller.refresh(makeRequest({ headers: { 'x-refresh-token': 'old-ref' } }));
+    const user = payload.user as Record<string, unknown>;
+    expect(sessionService.rotate).toHaveBeenCalledWith('old-ref');
+    expect(user.accessToken).toBe('acc2');
+    expect(user.refreshToken).toBe('ref2');
+  });
+
+  it("embeds the user's mediaProgress in the refresh payload", async () => {
+    const progress = [{ libraryItemId: 'li_9', currentTime: 120 }];
+    const { controller, progressService } = build({ user: makeAbsUser({ id: 1 }), mediaProgress: progress });
+    const payload = await controller.refresh(makeRequest({ headers: { 'x-refresh-token': 'old-ref' } }));
+    expect((payload.user as Record<string, unknown>).mediaProgress).toEqual(progress);
+    expect(progressService.listMediaProgressForUser).toHaveBeenCalledWith(1);
+  });
+
+  it('returns 401 JSON when no refresh token header is present', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.refresh(makeRequest()))).toBe(401);
+  });
+});
+
+describe('AbsAuthController#logout', () => {
+  it('invalidates the presented refresh token and returns a null redirect_url', async () => {
+    const { controller, sessionService } = build();
+    const result = await controller.logout(makeRequest({ headers: { 'x-refresh-token': 'ref' } }));
+    expect(result).toEqual({ redirect_url: null });
+    expect(sessionService.invalidate).toHaveBeenCalledWith('ref');
+  });
+});

--- a/server/src/modules/abs/auth/abs-auth.controller.ts
+++ b/server/src/modules/abs/auth/abs-auth.controller.ts
@@ -1,0 +1,114 @@
+import { Body, Controller, HttpCode, Post, Req, UseFilters } from '@nestjs/common';
+import { compare } from 'bcryptjs';
+import type { FastifyRequest } from 'fastify';
+
+import { Public } from '../../../common/decorators/public.decorator';
+import { LibraryService } from '../../library/library.service';
+import { UserService } from '../../user/user.service';
+import { encodeAbsId } from '../abs-id.util';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+import { ABS_INTERNAL_REFRESH_PATH } from '../abs-route-rewrite.util';
+import { toAbsLoginPayload } from '../mappers/abs-user.mapper';
+import { AbsProgressService } from '../services/abs-progress.service';
+import { AbsSessionService } from './abs-session.service';
+import { AbsTokenService } from './abs-token.service';
+
+// Constant-time dummy compare target to avoid leaking whether a username exists.
+const DUMMY_HASH = '$2a$12$LJ3m4ys3Lk0TSwHBbqP8b.3bFfR1oVDMhPzX8KPrPeuMEJBJJPa.G';
+
+interface AbsLoginBody {
+  username?: string;
+  password?: string;
+}
+
+/**
+ * ABS local auth at the router root (REIMPLEMENTATION_GUIDE §2.2–2.4). MVP targets the mobile
+ * header flow: tokens are returned in the response body; the refresh token arrives on
+ * `x-refresh-token`. (Web cookie flow is out of scope.)
+ */
+@Public()
+@UseFilters(AbsExceptionFilter)
+@Controller()
+export class AbsAuthController {
+  constructor(
+    private readonly userService: UserService,
+    private readonly sessionService: AbsSessionService,
+    private readonly tokenService: AbsTokenService,
+    private readonly libraryService: LibraryService,
+    private readonly progressService: AbsProgressService,
+  ) {}
+
+  @Post('login')
+  @HttpCode(200)
+  async login(@Body() body: AbsLoginBody, @Req() req: FastifyRequest): Promise<Record<string, unknown>> {
+    if (!body.username || !body.password) throw AbsHttpException.unauthorized();
+
+    const candidate = await this.userService.findByUsername(body.username);
+    const now = new Date();
+    const isLocked = !!candidate?.lockedUntil && candidate.lockedUntil > now;
+    const passwordValid = await compare(body.password, candidate?.passwordHash ?? DUMMY_HASH);
+    if (!candidate || !candidate.active || isLocked || !passwordValid) {
+      throw AbsHttpException.unauthorized();
+    }
+
+    const user = await this.userService.findByIdWithPermissions(candidate.id);
+    if (!user) throw AbsHttpException.unauthorized();
+
+    const tokens = await this.sessionService.createSession(user.id, user.username, {
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'],
+    });
+
+    // ABS embeds the user's full mediaProgress in every login-shaped payload (`Auth.js`
+    // `getUserLoginResponsePayload` → `toOldJSONForBrowser`); clients like Plappa seed their
+    // cross-device resume positions from it, so an empty array reads as "no progress anywhere".
+    const [accessibleIds, mediaProgress] = await Promise.all([
+      this.libraryService.findAccessibleLibraryIds(user),
+      this.progressService.listMediaProgressForUser(user.id),
+    ]);
+    return toAbsLoginPayload(user, {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      mediaProgress,
+      librariesAccessible: user.isSuperuser ? [] : accessibleIds.map((id) => encodeAbsId('library', id)),
+      userDefaultLibraryId: accessibleIds.length ? encodeAbsId('library', accessibleIds[0]) : null,
+    });
+  }
+
+  // Served at the public path POST /auth/refresh; rewriteAbsUrl maps it to this internal path to
+  // avoid colliding with BookOrbit's own `auth/refresh` route (see abs-route-rewrite.util.ts).
+  @Post(ABS_INTERNAL_REFRESH_PATH)
+  @HttpCode(200)
+  async refresh(@Req() req: FastifyRequest): Promise<Record<string, unknown>> {
+    const presented = req.headers['x-refresh-token'];
+    const token = typeof presented === 'string' ? presented : undefined;
+    if (!token) throw AbsHttpException.json(401, { error: 'No refresh token provided' });
+
+    const tokens = await this.sessionService.rotate(token);
+    const payload = this.tokenService.verifyRefreshToken(tokens.refreshToken);
+    const userId = payload?.userId;
+    const user = userId ? await this.userService.findByIdWithPermissions(userId) : null;
+    if (!user) throw AbsHttpException.json(401, { error: 'Invalid refresh token' });
+
+    const [accessibleIds, mediaProgress] = await Promise.all([
+      this.libraryService.findAccessibleLibraryIds(user),
+      this.progressService.listMediaProgressForUser(user.id),
+    ]);
+    return toAbsLoginPayload(user, {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      mediaProgress,
+      librariesAccessible: user.isSuperuser ? [] : accessibleIds.map((id) => encodeAbsId('library', id)),
+      userDefaultLibraryId: accessibleIds.length ? encodeAbsId('library', accessibleIds[0]) : null,
+    });
+  }
+
+  @Post('logout')
+  @HttpCode(200)
+  async logout(@Req() req: FastifyRequest): Promise<{ redirect_url: null }> {
+    const presented = req.headers['x-refresh-token'];
+    await this.sessionService.invalidate(typeof presented === 'string' ? presented : undefined);
+    return { redirect_url: null };
+  }
+}

--- a/server/src/modules/abs/auth/abs-auth.guard.test.ts
+++ b/server/src/modules/abs/auth/abs-auth.guard.test.ts
@@ -1,0 +1,58 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+import type { UserService } from '../../user/user.service';
+import { makeAbsUser, makeRequest } from '../__testing__/abs-test-helpers';
+import { AbsAuthGuard, extractAbsToken } from './abs-auth.guard';
+import type { AbsTokenService } from './abs-token.service';
+
+function makeContext(request: unknown) {
+  return { switchToHttp: () => ({ getRequest: () => request }) } as any;
+}
+
+describe('extractAbsToken', () => {
+  it('reads a Bearer token from the Authorization header', () => {
+    expect(extractAbsToken(makeRequest({ headers: { authorization: 'Bearer abc.def' } }))).toBe('abc.def');
+  });
+
+  it('reads the ?token= query param (how <img>/<audio> tags authenticate)', () => {
+    expect(extractAbsToken(makeRequest({ query: { token: 'qtok' } }))).toBe('qtok');
+  });
+
+  it('returns null when no token is present or the bearer is empty', () => {
+    expect(extractAbsToken(makeRequest())).toBeNull();
+    expect(extractAbsToken(makeRequest({ headers: { authorization: 'Bearer ' } }))).toBeNull();
+  });
+});
+
+describe('AbsAuthGuard', () => {
+  function build(opts: { payload?: { userId: number; username: string } | null; user?: unknown }) {
+    const tokenService = { verifyAccessToken: vi.fn().mockReturnValue(opts.payload ?? null) } as unknown as AbsTokenService;
+    const userService = { findByIdWithPermissions: vi.fn().mockResolvedValue(opts.user ?? null) } as unknown as UserService;
+    return { guard: new AbsAuthGuard(tokenService, userService), tokenService, userService };
+  }
+
+  it('rejects a request with no token', async () => {
+    const { guard } = build({});
+    await expect(guard.canActivate(makeContext(makeRequest()))).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('rejects an invalid/expired token', async () => {
+    const { guard } = build({ payload: null });
+    const ctx = makeContext(makeRequest({ headers: { authorization: 'Bearer bad' } }));
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('rejects when the user is missing or inactive', async () => {
+    const { guard } = build({ payload: { userId: 1, username: 'a' }, user: makeAbsUser({ active: false }) });
+    const ctx = makeContext(makeRequest({ headers: { authorization: 'Bearer ok' } }));
+    await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('attaches request.user and allows a valid token', async () => {
+    const user = makeAbsUser({ id: 42 });
+    const { guard } = build({ payload: { userId: 42, username: 'admin' }, user });
+    const request = makeRequest({ headers: { authorization: 'Bearer ok' } });
+    await expect(guard.canActivate(makeContext(request))).resolves.toBe(true);
+    expect(request.user).toBe(user);
+  });
+});

--- a/server/src/modules/abs/auth/abs-auth.guard.ts
+++ b/server/src/modules/abs/auth/abs-auth.guard.ts
@@ -1,0 +1,50 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import type { FastifyRequest } from 'fastify';
+
+import { UserService } from '../../user/user.service';
+import { AbsTokenService } from './abs-token.service';
+
+/**
+ * Authenticates ABS API requests. The JWT arrives either as `Authorization: Bearer <jwt>` or as a
+ * `?token=<jwt>` query parameter — the latter is how `<img>`/`<audio>` tags authenticate cover and
+ * track requests (REIMPLEMENTATION_GUIDE §2.1).
+ *
+ * Populates `request.user` with the standard RequestUser so handlers can use `@CurrentUser()`.
+ * ABS controllers are marked `@Public()` to bypass BookOrbit's native global guards, so this guard
+ * is applied explicitly via `@UseGuards(AbsAuthGuard)`.
+ */
+@Injectable()
+export class AbsAuthGuard implements CanActivate {
+  constructor(
+    private readonly tokenService: AbsTokenService,
+    private readonly userService: UserService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<FastifyRequest & { user?: unknown }>();
+    const token = extractAbsToken(request);
+    if (!token) throw new UnauthorizedException();
+
+    const payload = this.tokenService.verifyAccessToken(token);
+    if (!payload) throw new UnauthorizedException();
+
+    const user = await this.userService.findByIdWithPermissions(payload.userId);
+    if (!user || !user.active) throw new UnauthorizedException();
+
+    request.user = user;
+    return true;
+  }
+}
+
+/** Pull the ABS JWT from the Authorization header or the `?token=` query param. */
+export function extractAbsToken(request: FastifyRequest): string | null {
+  const header = request.headers['authorization'];
+  if (typeof header === 'string' && header.startsWith('Bearer ')) {
+    return header.slice('Bearer '.length).trim() || null;
+  }
+  const queryToken = (request.query as Record<string, unknown> | undefined)?.token;
+  if (typeof queryToken === 'string' && queryToken.length > 0) {
+    return queryToken;
+  }
+  return null;
+}

--- a/server/src/modules/abs/auth/abs-discovery.controller.test.ts
+++ b/server/src/modules/abs/auth/abs-discovery.controller.test.ts
@@ -1,0 +1,96 @@
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import * as schema from '../../../db/schema';
+import { OidcService } from '../../auth/oidc/oidc.service';
+import { ABS_APP_NAME, ABS_SERVER_VERSION } from '../abs.constants';
+import { thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsDiscoveryController } from './abs-discovery.controller';
+
+type Db = NodePgDatabase<typeof schema>;
+
+/** OidcService stub; `provider` is what getDesignatedAbsProvider resolves to (null ⇒ OIDC disabled). */
+function makeOidc(provider: { displayName: string } | null = null): OidcService {
+  return { getDesignatedAbsProvider: vi.fn().mockResolvedValue(provider) } as unknown as OidcService;
+}
+
+describe('AbsDiscoveryController', () => {
+  describe('ping / healthcheck', () => {
+    const controller = new AbsDiscoveryController({} as Db, makeOidc());
+
+    it('ping reports liveness', () => {
+      expect(controller.ping()).toEqual({ success: true });
+    });
+
+    it('healthcheck returns an empty 200 body', () => {
+      expect(controller.healthcheck()).toBeUndefined();
+    });
+  });
+
+  describe('GET /status', () => {
+    it('reports isInit=true when at least one user exists', async () => {
+      const db = { $count: vi.fn().mockResolvedValue(3) } as unknown as Db;
+      const status = await new AbsDiscoveryController(db, makeOidc()).status();
+      expect(status).toMatchObject({ app: ABS_APP_NAME, serverVersion: ABS_SERVER_VERSION, isInit: true, authMethods: ['local'] });
+    });
+
+    it('reports isInit=false on a brand-new instance (no users)', async () => {
+      const db = { $count: vi.fn().mockResolvedValue(0) } as unknown as Db;
+      expect((await new AbsDiscoveryController(db, makeOidc()).status()).isInit).toBe(false);
+    });
+
+    it('advertises openid + button text when a provider is enabled', async () => {
+      const db = { $count: vi.fn().mockResolvedValue(1) } as unknown as Db;
+      const status = await new AbsDiscoveryController(db, makeOidc({ displayName: 'Corp SSO' })).status();
+      expect(status.authMethods).toEqual(['local', 'openid']);
+      expect(status.authFormData).toEqual({ authOpenIDButtonText: 'Corp SSO', authOpenIDAutoLaunch: false });
+    });
+
+    it('omits openid when no provider is enabled', async () => {
+      const db = { $count: vi.fn().mockResolvedValue(1) } as unknown as Db;
+      const status = await new AbsDiscoveryController(db, makeOidc(null)).status();
+      expect(status.authMethods).toEqual(['local']);
+      expect(status.authFormData).toEqual({});
+    });
+  });
+
+  describe('POST /init', () => {
+    function dbWithUserCount(total: number, existingUser: unknown = undefined) {
+      const insertValues = vi.fn().mockResolvedValue(undefined);
+      const tx = {
+        select: () => ({ from: () => Promise.resolve([{ total }]) }),
+        query: { users: { findFirst: vi.fn().mockResolvedValue(existingUser) } },
+        insert: () => ({ values: insertValues }),
+      };
+      const db = { transaction: vi.fn((cb: (t: typeof tx) => unknown) => cb(tx)) } as unknown as Db;
+      return { db, insertValues };
+    }
+
+    it('creates the first root user when none exist', async () => {
+      const { db, insertValues } = dbWithUserCount(0);
+      const result = await new AbsDiscoveryController(db, makeOidc()).init({ username: 'root', password: 'pw' });
+      expect(result).toEqual({ success: true });
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ username: 'root', isSuperuser: true }));
+    });
+
+    it('accepts the nested { newRoot } body shape', async () => {
+      const { db, insertValues } = dbWithUserCount(0);
+      await new AbsDiscoveryController(db, makeOidc()).init({ newRoot: { username: 'admin', password: 'pw' } });
+      expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ username: 'admin' }));
+    });
+
+    it('rejects missing credentials with 400', async () => {
+      const { db } = dbWithUserCount(0);
+      expect(await thrownStatus(() => new AbsDiscoveryController(db, makeOidc()).init({ username: 'x' }))).toBe(400);
+    });
+
+    it('returns 500 when a root user already exists (matches ABS)', async () => {
+      const { db } = dbWithUserCount(1);
+      expect(await thrownStatus(() => new AbsDiscoveryController(db, makeOidc()).init({ username: 'root', password: 'pw' }))).toBe(500);
+    });
+
+    it('returns 500 when the username is already taken', async () => {
+      const { db } = dbWithUserCount(0, { id: 1, username: 'root' });
+      expect(await thrownStatus(() => new AbsDiscoveryController(db, makeOidc()).init({ username: 'root', password: 'pw' }))).toBe(500);
+    });
+  });
+});

--- a/server/src/modules/abs/auth/abs-discovery.controller.ts
+++ b/server/src/modules/abs/auth/abs-discovery.controller.ts
@@ -1,0 +1,86 @@
+import { Body, Controller, Get, HttpCode, Inject, Post, UseFilters } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import { hash } from 'bcryptjs';
+import { count, eq, sql } from 'drizzle-orm';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { Public } from '../../../common/decorators/public.decorator';
+import { DB } from '../../../db';
+import * as schema from '../../../db/schema';
+import { OidcService } from '../../auth/oidc/oidc.service';
+import { ABS_APP_NAME, ABS_DEFAULT_LANGUAGE, ABS_SERVER_VERSION } from '../abs.constants';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+
+interface AbsInitBody {
+  newRoot?: { username?: string; password?: string };
+  username?: string;
+  password?: string;
+}
+
+/**
+ * Unauthenticated discovery handshake (REIMPLEMENTATION_GUIDE §1.3). These routes live at the
+ * router root, NOT under `/api`, and are excluded from the global `api/v1` prefix in main.ts.
+ */
+@Public()
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller()
+export class AbsDiscoveryController {
+  constructor(
+    @Inject(DB) private readonly db: NodePgDatabase<typeof schema>,
+    private readonly oidcService: OidcService,
+  ) {}
+
+  @Get('ping')
+  ping(): { success: true } {
+    return { success: true };
+  }
+
+  @Get('healthcheck')
+  @HttpCode(200)
+  healthcheck(): void {
+    // 200 empty — for load balancers.
+  }
+
+  @Get('status')
+  async status(): Promise<Record<string, unknown>> {
+    const [userCount, oidcProvider] = await Promise.all([this.db.$count(schema.users), this.oidcService.getDesignatedAbsProvider()]);
+    const authMethods = oidcProvider ? ['local', 'openid'] : ['local'];
+    const authFormData = oidcProvider ? { authOpenIDButtonText: oidcProvider.displayName, authOpenIDAutoLaunch: false } : {};
+    return {
+      app: ABS_APP_NAME,
+      serverVersion: ABS_SERVER_VERSION,
+      isInit: userCount > 0,
+      language: ABS_DEFAULT_LANGUAGE,
+      authMethods,
+      authFormData,
+    };
+  }
+
+  /**
+   * First-run: create the initial root user. Only valid when no users exist (returns 500 otherwise,
+   * matching ABS). Existing BookOrbit deployments already have users, so this is effectively a
+   * brand-new-instance path.
+   */
+  @Post('init')
+  @HttpCode(200)
+  async init(@Body() body: AbsInitBody): Promise<{ success: true }> {
+    const username = body.newRoot?.username ?? body.username;
+    const password = body.newRoot?.password ?? body.password;
+    if (!username || !password) throw AbsHttpException.text(400, 'Missing username or password');
+
+    await this.db.transaction(async (tx) => {
+      const [{ total }] = await tx.select({ total: count() }).from(schema.users);
+      if (Number(total) > 0) throw AbsHttpException.bare(500);
+
+      const existing = await tx.query.users.findFirst({ where: eq(sql`lower(${schema.users.username})`, username.toLowerCase()) });
+      if (existing) throw AbsHttpException.bare(500);
+
+      const passwordHash = await hash(password, 12);
+      await tx.insert(schema.users).values({ username, name: username, passwordHash, isSuperuser: true, isDefaultPassword: false });
+    });
+
+    return { success: true };
+  }
+}

--- a/server/src/modules/abs/auth/abs-openid.controller.test.ts
+++ b/server/src/modules/abs/auth/abs-openid.controller.test.ts
@@ -1,0 +1,298 @@
+import type { ConfigService } from '@nestjs/config';
+
+import type { OidcService } from '../../auth/oidc/oidc.service';
+import type { LibraryService } from '../../library/library.service';
+import type { UserService } from '../../user/user.service';
+import { makeAbsUser, makeRequest, thrownStatus } from '../__testing__/abs-test-helpers';
+import type { AbsProgressService } from '../services/abs-progress.service';
+import { AbsOpenidController } from './abs-openid.controller';
+import type { AbsSessionService } from './abs-session.service';
+
+const APP_URL = 'https://app.example';
+
+/** Fastify reply mock recording redirect/status/body. */
+function makeReply() {
+  const calls: { redirect?: string; redirectStatus?: number; status: number; body: unknown } = { status: 200, body: undefined };
+  const reply: any = {
+    redirect(url: string, code?: number) {
+      calls.redirect = url;
+      calls.redirectStatus = code;
+      return reply;
+    },
+    status(code: number) {
+      calls.status = code;
+      return reply;
+    },
+    send(body: unknown) {
+      calls.body = body;
+      return reply;
+    },
+  };
+  return { reply, calls };
+}
+
+interface BuildOpts {
+  authorizeUrl?: string;
+  resolve?: { user: { id: number }; authMethod?: string; finalRedirect?: string };
+  mobileAppRedirect?: string | null;
+  user?: ReturnType<typeof makeAbsUser> | null;
+  accessibleIds?: number[];
+  mediaProgress?: Record<string, unknown>[];
+  discoveryDoc?: Record<string, unknown>;
+  allowedAppRedirects?: string[];
+}
+
+function build(opts: BuildOpts = {}) {
+  const oidcService = {
+    beginAbsAuthorization: vi.fn().mockResolvedValue(opts.authorizeUrl ?? 'https://idp.example/authorize?x=1'),
+    resolveAbsLoginUser: vi.fn().mockResolvedValue(opts.resolve ?? { user: { id: 1 }, authMethod: 'openid-mobile' }),
+    getAbsMobileAppRedirect: vi.fn().mockResolvedValue(opts.mobileAppRedirect ?? 'audiobookshelf://oauth'),
+    readDiscoveryDoc: vi.fn().mockResolvedValue(opts.discoveryDoc ?? { issuer: 'https://idp.example' }),
+  } as unknown as OidcService;
+  const userService = {
+    findByIdWithPermissions: vi.fn().mockResolvedValue(opts.user === undefined ? makeAbsUser({ id: 1, isSuperuser: false }) : opts.user),
+  } as unknown as UserService;
+  const sessionService = {
+    createSession: vi.fn().mockResolvedValue({ accessToken: 'acc', refreshToken: 'ref' }),
+  } as unknown as AbsSessionService;
+  const libraryService = {
+    findAccessibleLibraryIds: vi.fn().mockResolvedValue(opts.accessibleIds ?? []),
+  } as unknown as LibraryService;
+  const config = {
+    get: vi.fn((key: string) => (key === 'app.absAllowedAppRedirects' ? (opts.allowedAppRedirects ?? []) : APP_URL)),
+  } as unknown as ConfigService;
+  const progressService = {
+    listMediaProgressForUser: vi.fn().mockResolvedValue(opts.mediaProgress ?? []),
+  } as unknown as AbsProgressService;
+  return {
+    controller: new AbsOpenidController(oidcService, userService, sessionService, libraryService, progressService, config),
+    oidcService,
+    sessionService,
+    progressService,
+  };
+}
+
+describe('AbsOpenidController#begin', () => {
+  it('redirects to the provider authorize URL', async () => {
+    const { controller } = build({ authorizeUrl: 'https://idp.example/authorize?state=s' });
+    const { reply, calls } = makeReply();
+    await controller.begin(makeRequest({ headers: { host: 'abs.example' } }), reply);
+    expect(calls.redirect).toBe('https://idp.example/authorize?state=s');
+    // Must be an explicit 302: Fastify's redirect() reuses the 200 Nest pre-sets otherwise, and a 200
+    // with a Location header isn't followed (iOS shows a blank "openid" download).
+    expect(calls.redirectStatus).toBe(302);
+  });
+
+  it('passes the server callback + mobile-redirect URIs (proxy-aware) for a web flow', async () => {
+    const { controller, oidcService } = build();
+    const { reply } = makeReply();
+    await controller.begin(
+      makeRequest({ headers: { host: 'internal:3000', 'x-forwarded-proto': 'https', 'x-forwarded-host': 'abs.public' } }),
+      reply,
+    );
+    expect(oidcService.beginAbsAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callbackUri: 'https://abs.public/auth/openid/callback',
+        mobileRedirectUri: 'https://abs.public/auth/openid/mobile-redirect',
+        mobile: undefined,
+      }),
+    );
+  });
+
+  it('builds a mobile flow from redirect_uri + code_challenge, preserving client state', async () => {
+    const { controller, oidcService } = build();
+    const { reply } = makeReply();
+    await controller.begin(
+      makeRequest({
+        headers: { host: 'abs.example' },
+        query: { response_type: 'code', redirect_uri: 'audiobookshelf://oauth', code_challenge: 'chal', state: 'client-state' },
+      }),
+      reply,
+    );
+    expect(oidcService.beginAbsAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mobile: { appRedirect: 'audiobookshelf://oauth', clientState: 'client-state', clientCodeChallenge: 'chal' },
+      }),
+    );
+  });
+
+  it('passes the web callback via the ?callback param (not redirect_uri)', async () => {
+    const { controller, oidcService } = build();
+    const { reply } = makeReply();
+    await controller.begin(makeRequest({ headers: { host: 'abs.example' }, query: { callback: `${APP_URL}/cb` } }), reply);
+    expect(oidcService.beginAbsAuthorization).toHaveBeenCalledWith(expect.objectContaining({ mobile: undefined, finalRedirect: `${APP_URL}/cb` }));
+  });
+
+  it('rejects a mobile flow without a code_challenge', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(
+      await thrownStatus(() =>
+        controller.begin(makeRequest({ headers: { host: 'abs.example' }, query: { redirect_uri: 'audiobookshelf://oauth' } }), reply),
+      ),
+    ).toBe(400);
+  });
+
+  it('rejects a mobile redirect_uri that is not the app scheme', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(
+      await thrownStatus(() =>
+        controller.begin(
+          makeRequest({ headers: { host: 'abs.example' }, query: { redirect_uri: 'https://evil.example', code_challenge: 'c' } }),
+          reply,
+        ),
+      ),
+    ).toBe(400);
+  });
+
+  it('rejects a third-party app redirect_uri that is not in the configured allowlist', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(
+      await thrownStatus(() =>
+        controller.begin(makeRequest({ headers: { host: 'abs.example' }, query: { redirect_uri: 'stillapp://oauth', code_challenge: 'c' } }), reply),
+      ),
+    ).toBe(400);
+  });
+
+  it('accepts an operator-allowlisted third-party app redirect_uri', async () => {
+    const { controller, oidcService } = build({ allowedAppRedirects: ['stillapp://oauth'] });
+    const { reply } = makeReply();
+    await controller.begin(
+      makeRequest({ headers: { host: 'abs.example' }, query: { redirect_uri: 'stillapp://oauth', code_challenge: 'chal', state: 's' } }),
+      reply,
+    );
+    expect(oidcService.beginAbsAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({ mobile: { appRedirect: 'stillapp://oauth', clientState: 's', clientCodeChallenge: 'chal' } }),
+    );
+  });
+
+  it('always accepts the built-in audiobookshelf:// app redirect without configuration', async () => {
+    const { controller, oidcService } = build({ allowedAppRedirects: [] });
+    const { reply } = makeReply();
+    await controller.begin(
+      makeRequest({ headers: { host: 'abs.example' }, query: { redirect_uri: 'audiobookshelf://oauth', code_challenge: 'chal' } }),
+      reply,
+    );
+    expect(oidcService.beginAbsAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({ mobile: expect.objectContaining({ appRedirect: 'audiobookshelf://oauth' }) }),
+    );
+  });
+
+  it('rejects a non-code response_type', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(
+      await thrownStatus(() => controller.begin(makeRequest({ headers: { host: 'abs.example' }, query: { response_type: 'token' } }), reply)),
+    ).toBe(400);
+  });
+});
+
+describe('AbsOpenidController#mobileRedirect', () => {
+  it('bounces the code + state to the stashed app link', async () => {
+    const { controller } = build({ mobileAppRedirect: 'audiobookshelf://oauth' });
+    const { reply, calls } = makeReply();
+    await controller.mobileRedirect(makeRequest({ query: { code: 'abc', state: 's' } }), reply);
+    const url = new URL(calls.redirect!);
+    expect(url.protocol).toBe('audiobookshelf:');
+    expect(url.searchParams.get('code')).toBe('abc');
+    expect(url.searchParams.get('state')).toBe('s');
+    expect(url.searchParams.get('accessToken')).toBeNull(); // no token on this hop
+  });
+
+  it('falls back to the default app link when the state is unknown', async () => {
+    const { controller } = build({ mobileAppRedirect: null });
+    const { reply, calls } = makeReply();
+    await controller.mobileRedirect(makeRequest({ query: { code: 'abc', state: 's' } }), reply);
+    expect(calls.redirect).toContain('audiobookshelf://oauth');
+  });
+
+  it('rejects when state is missing', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.mobileRedirect(makeRequest({ query: { code: 'abc' } }), reply))).toBe(400);
+  });
+});
+
+describe('AbsOpenidController#callback', () => {
+  it('returns the login payload with tokens in the body for the mobile flow', async () => {
+    const { controller, sessionService } = build({ resolve: { user: { id: 1 }, authMethod: 'openid-mobile' }, accessibleIds: [4] });
+    const { reply, calls } = makeReply();
+    await controller.callback(makeRequest({ query: { code: 'c', state: 's', code_verifier: 'v' } }), reply);
+    const body = calls.body as Record<string, unknown>;
+    const user = body.user as Record<string, unknown>;
+    expect(user.accessToken).toBe('acc');
+    expect(user.refreshToken).toBe('ref');
+    expect(user.librariesAccessible).toEqual(['lib_4']);
+    expect(calls.status).toBe(200);
+    expect(sessionService.createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("embeds the user's mediaProgress in the login payload (clients seed resume positions from it)", async () => {
+    const progress = [{ libraryItemId: 'li_9', currentTime: 120 }];
+    const { controller, progressService } = build({ resolve: { user: { id: 1 }, authMethod: 'openid-mobile' }, mediaProgress: progress });
+    const { reply, calls } = makeReply();
+    await controller.callback(makeRequest({ query: { code: 'c', state: 's', code_verifier: 'v' } }), reply);
+    const user = (calls.body as Record<string, unknown>).user as Record<string, unknown>;
+    expect(user.mediaProgress).toEqual(progress);
+    expect(progressService.listMediaProgressForUser).toHaveBeenCalledWith(1);
+  });
+
+  it('forwards the client code_verifier to the resolver', async () => {
+    const { controller, oidcService } = build();
+    const { reply } = makeReply();
+    await controller.callback(makeRequest({ query: { code: 'c', state: 's', code_verifier: 'v' } }), reply);
+    expect(oidcService.resolveAbsLoginUser).toHaveBeenCalledWith({ state: 's', code: 'c', clientCodeVerifier: 'v' });
+  });
+
+  it('redirects same-origin with the token for the web flow', async () => {
+    const { controller } = build({ resolve: { user: { id: 1 }, authMethod: 'openid', finalRedirect: `${APP_URL}/cb` } });
+    const { reply, calls } = makeReply();
+    await controller.callback(makeRequest({ query: { code: 'c', state: 's' } }), reply);
+    const url = new URL(calls.redirect!);
+    expect(url.origin).toBe(APP_URL);
+    expect(url.searchParams.get('accessToken')).toBe('acc');
+    expect(url.searchParams.get('state')).toBe('s');
+  });
+
+  it('returns JSON (not a redirect) when a web callback is a foreign origin', async () => {
+    const { controller } = build({ resolve: { user: { id: 1 }, authMethod: 'openid', finalRedirect: 'https://evil.example/grab' } });
+    const { reply, calls } = makeReply();
+    await controller.callback(makeRequest({ query: { code: 'c', state: 's' } }), reply);
+    expect(calls.redirect).toBeUndefined();
+    expect(calls.status).toBe(200);
+    expect((calls.body as Record<string, unknown>).user).toBeDefined();
+  });
+
+  it('rejects a callback missing code or state with 400', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.callback(makeRequest({ query: { state: 's' } }), reply))).toBe(400);
+  });
+
+  it('rejects when the resolved user is inactive', async () => {
+    const { controller } = build({ user: makeAbsUser({ id: 1, active: false }) });
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.callback(makeRequest({ query: { code: 'c', state: 's' } }), reply))).toBe(401);
+  });
+});
+
+describe('AbsOpenidController#config', () => {
+  it('returns the discovery doc for an admin', async () => {
+    const { controller, oidcService } = build({ discoveryDoc: { issuer: 'https://idp.example', tokenEndpoint: 'https://idp.example/token' } });
+    const result = await controller.config(makeAbsUser({ isSuperuser: true }), makeRequest({ query: { issuer: 'https://idp.example' } }));
+    expect(result).toMatchObject({ issuer: 'https://idp.example' });
+    expect(oidcService.readDiscoveryDoc).toHaveBeenCalledWith('https://idp.example');
+  });
+
+  it('returns 403 for a non-admin (matches ABS)', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.config(makeAbsUser({ isSuperuser: false }), makeRequest({ query: { issuer: 'x' } })))).toBe(403);
+  });
+
+  it('returns 400 when issuer is missing', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.config(makeAbsUser({ isSuperuser: true }), makeRequest()))).toBe(400);
+  });
+});

--- a/server/src/modules/abs/auth/abs-openid.controller.ts
+++ b/server/src/modules/abs/auth/abs-openid.controller.ts
@@ -1,0 +1,207 @@
+import { Controller, Get, Req, Res, UseFilters, UseGuards } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { Public } from '../../../common/decorators/public.decorator';
+import type { RequestUser } from '../../../common/types/request-user';
+import { OidcService } from '../../auth/oidc/oidc.service';
+import { LibraryService } from '../../library/library.service';
+import { UserService } from '../../user/user.service';
+import { encodeAbsId } from '../abs-id.util';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+import { toAbsLoginPayload } from '../mappers/abs-user.mapper';
+import { AbsProgressService } from '../services/abs-progress.service';
+import { AbsAuthGuard } from './abs-auth.guard';
+import { AbsSessionService } from './abs-session.service';
+
+type Query = Record<string, string | undefined>;
+
+/**
+ * The official ABS app link the mobile-redirect hop may bounce an authorization code to. Always
+ * allowed (and the fallback when state lookup misses); operators allow additional third-party client
+ * URIs via `ABS_OIDC_MOBILE_REDIRECT_URIS` (see `app.absAllowedAppRedirects`).
+ */
+const DEFAULT_APP_REDIRECT = 'audiobookshelf://oauth';
+
+/**
+ * ABS OpenID Connect routes (REIMPLEMENTATION_GUIDE §2.6; mirrors ABS `OidcAuthStrategy`/`Auth.js`),
+ * served at the router root and excluded from the global `api/v1` prefix. A thin adapter over
+ * BookOrbit's own OIDC stack (`OidcService`): same provider record, claim mapping, and auto-provisioning,
+ * so an ABS OIDC login resolves to the same BookOrbit user as the web flow. Tokens are minted ABS-shaped
+ * via {@link AbsSessionService}.
+ *
+ * Two flows, detected exactly as ABS does (`response_type=code` | `redirect_uri` | `code_challenge`):
+ * - **Web**: IdP `redirect_uri` = `<server>/auth/openid/callback`; server owns PKCE; on success either
+ *   redirects same-origin with the token or returns it as JSON.
+ * - **Mobile**: IdP `redirect_uri` = `<server>/auth/openid/mobile-redirect` (IdPs won't redirect to a
+ *   custom app scheme); native client owns PKCE. The IdP hits mobile-redirect, which bounces the *code*
+ *   to the app (`audiobookshelf://oauth`); the app then calls `/auth/openid/callback` with the
+ *   `code_verifier` and receives tokens in the JSON body.
+ *
+ * Operator note: register `<server>/auth/openid/callback` (web) and/or `<server>/auth/openid/mobile-redirect`
+ * (mobile) as allowed redirect URIs on the IdP client — same client/provider as BookOrbit's web login.
+ */
+@Public()
+@UseFilters(AbsExceptionFilter)
+@Controller('auth/openid')
+export class AbsOpenidController {
+  private readonly appOrigin: string;
+  /** Exact-match allowlist of mobile redirect URIs (RFC 8252 / OAuth Security BCP — no wildcards). */
+  private readonly allowedAppRedirects: Set<string>;
+
+  constructor(
+    private readonly oidcService: OidcService,
+    private readonly userService: UserService,
+    private readonly sessionService: AbsSessionService,
+    private readonly libraryService: LibraryService,
+    private readonly progressService: AbsProgressService,
+    config: ConfigService,
+  ) {
+    this.appOrigin = safeOrigin(config.get<string>('app.appUrl') ?? '');
+    this.allowedAppRedirects = new Set([DEFAULT_APP_REDIRECT, ...(config.get<string[]>('app.absAllowedAppRedirects') ?? [])]);
+  }
+
+  /** Begin OIDC: build the provider authorize URL and 302 to it. */
+  @Get()
+  async begin(@Req() req: FastifyRequest, @Res() reply: FastifyReply): Promise<void> {
+    const q = (req.query ?? {}) as Query;
+
+    if (q.response_type && q.response_type !== 'code') {
+      throw AbsHttpException.text(400, 'Invalid response_type, only code supported');
+    }
+
+    let mobile: { appRedirect: string; clientState?: string; clientCodeChallenge: string } | undefined;
+    if (isMobileFlow(q)) {
+      if (!q.redirect_uri || !this.allowedAppRedirects.has(q.redirect_uri)) {
+        throw AbsHttpException.text(400, 'Invalid redirect_uri');
+      }
+      if (!q.code_challenge) throw AbsHttpException.text(400, 'code_challenge required for mobile flow (PKCE)');
+      if (q.code_challenge_method && q.code_challenge_method !== 'S256') {
+        throw AbsHttpException.text(400, 'Only S256 code_challenge_method supported');
+      }
+      mobile = { appRedirect: q.redirect_uri, clientState: q.state, clientCodeChallenge: q.code_challenge };
+    }
+
+    const authorizeUrl = await this.oidcService.beginAbsAuthorization({
+      callbackUri: this.serverUri(req, 'callback'),
+      mobileRedirectUri: this.serverUri(req, 'mobile-redirect'),
+      mobile,
+      // Web: the same-origin URL to hand the token back to. ABS web uses `?callback=` (not `redirect_uri`,
+      // which would trip mobile detection). Same-origin is enforced when the token is actually emitted.
+      finalRedirect: mobile ? undefined : q.callback,
+    });
+    // Pass the status explicitly: Nest's Fastify adapter pre-sets the reply status to 200, and
+    // Fastify's `redirect()` reuses an already-set status instead of defaulting to 302 — a 200 with a
+    // `Location` header isn't followed (iOS renders the empty body as a blank "openid" download).
+    reply.redirect(authorizeUrl, 302);
+  }
+
+  /**
+   * The IdP-facing hop for the mobile flow: bounce the authorization `code` (single-use, PKCE-bound) to
+   * the app's link, which then completes via `/callback`. Carries no token. Non-consuming on the state.
+   */
+  @Get('mobile-redirect')
+  async mobileRedirect(@Req() req: FastifyRequest, @Res() reply: FastifyReply): Promise<void> {
+    const q = (req.query ?? {}) as Query;
+    if (!q.state) throw AbsHttpException.text(400, 'State parameter mismatch');
+
+    const appRedirect = (await this.oidcService.getAbsMobileAppRedirect(q.state)) ?? DEFAULT_APP_REDIRECT;
+    const target = new URL(appRedirect);
+    // Forward only the protocol params the app needs to complete the exchange.
+    for (const key of ['code', 'state', 'error', 'error_description'] as const) {
+      if (q[key] != null) target.searchParams.set(key, q[key]);
+    }
+    reply.redirect(target.toString(), 302);
+  }
+
+  /** OIDC code exchange. Tokens are returned as JSON for mobile/native; web redirects same-origin. */
+  @Get('callback')
+  async callback(@Req() req: FastifyRequest, @Res() reply: FastifyReply): Promise<void> {
+    const q = (req.query ?? {}) as Query;
+    if (!q.code || !q.state) throw AbsHttpException.text(400, 'Missing code or state');
+
+    const {
+      user: resolved,
+      authMethod,
+      finalRedirect,
+    } = await this.oidcService.resolveAbsLoginUser({
+      state: q.state,
+      code: q.code,
+      clientCodeVerifier: q.code_verifier,
+    });
+
+    const user = await this.userService.findByIdWithPermissions(resolved.id);
+    if (!user || !user.active) throw AbsHttpException.unauthorized();
+
+    const tokens = await this.sessionService.createSession(user.id, user.username, {
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'],
+    });
+
+    // Web flow with a same-origin callback: hand the token back on the query string (ABS `auth_cb`).
+    // Same-origin only — never an arbitrary `redirect_uri`, which would leak the freshly minted tokens.
+    if (authMethod === 'openid' && finalRedirect && this.isSameOriginRedirect(finalRedirect)) {
+      const target = new URL(finalRedirect);
+      target.searchParams.set('setToken', tokens.accessToken);
+      target.searchParams.set('accessToken', tokens.accessToken);
+      target.searchParams.set('state', q.state);
+      reply.redirect(target.toString(), 302);
+      return;
+    }
+
+    // Mobile/native (and web without a usable callback): tokens in the JSON body (mirrors POST /login,
+    // including the user's full mediaProgress — clients seed cross-device resume positions from it).
+    const [accessibleIds, mediaProgress] = await Promise.all([
+      this.libraryService.findAccessibleLibraryIds(user),
+      this.progressService.listMediaProgressForUser(user.id),
+    ]);
+    const payload = toAbsLoginPayload(user, {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      mediaProgress,
+      librariesAccessible: user.isSuperuser ? [] : accessibleIds.map((id) => encodeAbsId('library', id)),
+      userDefaultLibraryId: accessibleIds.length ? encodeAbsId('library', accessibleIds[0]) : null,
+    });
+    reply.status(200).send(payload);
+  }
+
+  /** Admin-only: read a provider's `.well-known/openid-configuration`. Non-admins get 403, matching ABS. */
+  @Get('config')
+  @UseGuards(AbsAuthGuard)
+  config(@CurrentUser() user: RequestUser, @Req() req: FastifyRequest): ReturnType<OidcService['readDiscoveryDoc']> {
+    if (!user.isSuperuser) throw AbsHttpException.forbidden();
+    const issuer = ((req.query ?? {}) as Query).issuer;
+    if (!issuer) throw AbsHttpException.text(400, "Invalid request. Query param 'issuer' is required");
+    return this.oidcService.readDiscoveryDoc(issuer);
+  }
+
+  /** Tokens may be redirected only to BookOrbit's own configured origin (same-origin web callback). */
+  private isSameOriginRedirect(redirect: string): boolean {
+    return this.appOrigin !== '' && safeOrigin(redirect) === this.appOrigin;
+  }
+
+  /** A server route URL (`<origin>/auth/openid/<path>`), honoring proxy headers. */
+  private serverUri(req: FastifyRequest, path: 'callback' | 'mobile-redirect'): string {
+    const forwardedProto = (req.headers['x-forwarded-proto'] as string | undefined)?.split(',')[0]?.trim();
+    const forwardedHost = (req.headers['x-forwarded-host'] as string | undefined)?.split(',')[0]?.trim();
+    const proto = forwardedProto || req.protocol || 'https';
+    const host = forwardedHost || req.headers.host;
+    return `${proto}://${host}/auth/openid/${path}`;
+  }
+}
+
+/** ABS mobile-flow detection: any of `response_type=code`, `redirect_uri`, or `code_challenge`. */
+function isMobileFlow(q: Query): boolean {
+  return q.response_type === 'code' || !!q.redirect_uri || !!q.code_challenge;
+}
+
+/** The `origin` of a URL, or `''` if it can't be parsed (so it never matches an allow-list entry). */
+function safeOrigin(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return '';
+  }
+}

--- a/server/src/modules/abs/auth/abs-session.service.test.ts
+++ b/server/src/modules/abs/auth/abs-session.service.test.ts
@@ -1,0 +1,143 @@
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import * as schema from '../../../db/schema';
+import { thrownStatus } from '../__testing__/abs-test-helpers';
+import { ABS_REFRESH_GRACE_MS, AbsSessionService } from './abs-session.service';
+import { AbsTokenService } from './abs-token.service';
+
+type Db = NodePgDatabase<typeof schema>;
+
+function makeTokenService(): AbsTokenService {
+  const config = { get: (k: string) => (k === 'auth.jwtSecret' ? 'session-secret-12345' : undefined) } as unknown as ConfigService;
+  return new AbsTokenService(new JwtService({}), config);
+}
+
+describe('AbsSessionService#createSession', () => {
+  it('persists a session row and returns the minted token pair', async () => {
+    const values = vi.fn().mockResolvedValue(undefined);
+    const db = { insert: vi.fn(() => ({ values })) } as unknown as Db;
+    const service = new AbsSessionService(makeTokenService(), db);
+
+    const tokens = await service.createSession(7, 'alice', { ipAddress: '1.2.3.4', userAgent: 'app' });
+    expect(tokens.accessToken).toBeTruthy();
+    expect(tokens.refreshToken).toBeTruthy();
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({ userId: 7, refreshToken: tokens.refreshToken }));
+  });
+});
+
+describe('AbsSessionService#rotate', () => {
+  const tokenService = makeTokenService();
+
+  function mintRefresh(userId = 7, username = 'alice'): string {
+    return tokenService.signRefreshToken(userId, username).token;
+  }
+
+  it('rejects an invalid refresh token with 401', async () => {
+    const db = {} as unknown as Db;
+    const service = new AbsSessionService(tokenService, db);
+    expect(await thrownStatus(() => service.rotate('not-a-jwt'))).toBe(401);
+  });
+
+  it('rejects a well-formed token with no matching session with 401', async () => {
+    const db = { query: { absSessions: { findFirst: vi.fn().mockResolvedValue(undefined) } } } as unknown as Db;
+    const service = new AbsSessionService(tokenService, db);
+    expect(await thrownStatus(() => service.rotate(mintRefresh()))).toBe(401);
+  });
+
+  it('rotates the current token, issuing a brand-new refresh token', async () => {
+    const presented = mintRefresh();
+    const session = { id: 1, refreshToken: presented, lastRefreshToken: null, expiresAt: new Date(Date.now() + 1_000_000) };
+    const where = vi.fn().mockResolvedValue({ rowCount: 1 });
+    const db = {
+      query: { absSessions: { findFirst: vi.fn().mockResolvedValue(session) } },
+      update: vi.fn(() => ({ set: () => ({ where }) })),
+    } as unknown as Db;
+    const service = new AbsSessionService(tokenService, db);
+
+    const tokens = await service.rotate(presented);
+    expect(tokens.refreshToken).not.toBe(presented); // rotated
+    expect(tokenService.verifyRefreshToken(tokens.refreshToken)).toMatchObject({ userId: 7 });
+    expect(where).toHaveBeenCalledTimes(1);
+  });
+
+  it('reissues without re-rotating when the previous token is presented inside the grace window', async () => {
+    const previous = mintRefresh();
+    const session = {
+      id: 1,
+      refreshToken: 'current-token',
+      lastRefreshToken: previous,
+      lastRefreshTokenExpiresAt: new Date(Date.now() + ABS_REFRESH_GRACE_MS),
+      expiresAt: new Date(Date.now() + 1_000_000),
+    };
+    const update = vi.fn();
+    const db = { query: { absSessions: { findFirst: vi.fn().mockResolvedValue(session) } }, update } as unknown as Db;
+    const service = new AbsSessionService(tokenService, db);
+
+    const tokens = await service.rotate(previous);
+    expect(tokens.refreshToken).toBe('current-token'); // the now-current token, not a new one
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('rejects the previous token once the grace window has elapsed', async () => {
+    const previous = mintRefresh();
+    const session = {
+      id: 1,
+      refreshToken: 'current-token',
+      lastRefreshToken: previous,
+      lastRefreshTokenExpiresAt: new Date(Date.now() - 1),
+      expiresAt: new Date(Date.now() + 1_000_000),
+    };
+    const db = { query: { absSessions: { findFirst: vi.fn().mockResolvedValue(session) } } } as unknown as Db;
+    const service = new AbsSessionService(tokenService, db);
+    expect(await thrownStatus(() => service.rotate(previous))).toBe(401);
+  });
+
+  it('destroys an expired session and returns 401', async () => {
+    const presented = mintRefresh();
+    const session = { id: 1, refreshToken: presented, lastRefreshToken: null, expiresAt: new Date(Date.now() - 1) };
+    const deleteWhere = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      query: { absSessions: { findFirst: vi.fn().mockResolvedValue(session) } },
+      delete: vi.fn(() => ({ where: deleteWhere })),
+    } as unknown as Db;
+    const service = new AbsSessionService(tokenService, db);
+
+    expect(await thrownStatus(() => service.rotate(presented))).toBe(401);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('on a lost rotation race (0 rows updated) re-reads and returns the now-current refresh token', async () => {
+    const presented = mintRefresh();
+    const session = { id: 1, refreshToken: presented, lastRefreshToken: null, expiresAt: new Date(Date.now() + 1_000_000) };
+    const findFirst = vi
+      .fn()
+      .mockResolvedValueOnce(session)
+      .mockResolvedValueOnce({ ...session, refreshToken: 'winner-token' });
+    const db = {
+      query: { absSessions: { findFirst } },
+      update: vi.fn(() => ({ set: () => ({ where: vi.fn().mockResolvedValue({ rowCount: 0 }) }) })),
+    } as unknown as Db;
+    const service = new AbsSessionService(tokenService, db);
+
+    const tokens = await service.rotate(presented);
+    expect(tokens.refreshToken).toBe('winner-token');
+  });
+});
+
+describe('AbsSessionService#invalidate', () => {
+  it('is a no-op when no token is supplied', async () => {
+    const del = vi.fn();
+    const service = new AbsSessionService(makeTokenService(), { delete: del } as unknown as Db);
+    await service.invalidate(undefined);
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('deletes the session matching the presented token', async () => {
+    const where = vi.fn().mockResolvedValue(undefined);
+    const db = { delete: vi.fn(() => ({ where })) } as unknown as Db;
+    await new AbsSessionService(makeTokenService(), db).invalidate('ref');
+    expect(where).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/modules/abs/auth/abs-session.service.ts
+++ b/server/src/modules/abs/auth/abs-session.service.ts
@@ -1,0 +1,113 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { and, eq, or } from 'drizzle-orm';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { DB } from '../../../db';
+import * as schema from '../../../db/schema';
+import { AbsHttpException } from '../abs-errors';
+import { AbsTokenService } from './abs-token.service';
+
+/** ABS honors the previous refresh token for 1 minute after rotation (REIMPLEMENTATION_GUIDE §2.3). */
+export const ABS_REFRESH_GRACE_MS = 60_000;
+
+export interface AbsTokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface AbsSessionContext {
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+/**
+ * Server-side session store for the ABS refresh flow. Implements rotation with a 1-minute grace
+ * window backed by `abs_sessions` rows, so aggressively- or concurrently-refreshing mobile clients
+ * are not spuriously logged out. Mirrors ABS `TokenManager.rotateTokensForSession`.
+ */
+@Injectable()
+export class AbsSessionService {
+  private readonly logger = new Logger(AbsSessionService.name);
+
+  constructor(
+    private readonly tokenService: AbsTokenService,
+    @Inject(DB) private readonly db: NodePgDatabase<typeof schema>,
+  ) {}
+
+  /** Mint a fresh access+refresh pair and persist a new session row (login). */
+  async createSession(userId: number, username: string, ctx: AbsSessionContext): Promise<AbsTokenPair> {
+    const accessToken = this.tokenService.signAccessToken(userId, username);
+    const { token: refreshToken, expiresAt } = this.tokenService.signRefreshToken(userId, username);
+    await this.db.insert(schema.absSessions).values({
+      userId,
+      refreshToken,
+      expiresAt,
+      ipAddress: ctx.ipAddress?.slice(0, 64),
+      userAgent: ctx.userAgent?.slice(0, 512),
+    });
+    return { accessToken, refreshToken };
+  }
+
+  /**
+   * Rotate tokens for the session matching `presentedToken`, honoring the grace window.
+   * Throws `AbsHttpException` (401, `{ error }`) on any failure, matching the ABS auth-route shape.
+   */
+  async rotate(presentedToken: string): Promise<AbsTokenPair> {
+    const payload = this.tokenService.verifyRefreshToken(presentedToken);
+    if (!payload) throw AbsHttpException.json(401, { error: 'Invalid refresh token' });
+
+    const session = await this.db.query.absSessions.findFirst({
+      where: or(eq(schema.absSessions.refreshToken, presentedToken), eq(schema.absSessions.lastRefreshToken, presentedToken)),
+    });
+    if (!session) throw AbsHttpException.json(401, { error: 'Invalid refresh token' });
+
+    // Case A: the previous token, still inside the grace window — reissue without re-rotating.
+    if (session.lastRefreshToken === presentedToken && session.refreshToken !== presentedToken) {
+      const graceOk = session.lastRefreshTokenExpiresAt && session.lastRefreshTokenExpiresAt.getTime() > Date.now();
+      if (graceOk) {
+        const accessToken = this.tokenService.signAccessToken(payload.userId, payload.username);
+        return { accessToken, refreshToken: session.refreshToken };
+      }
+      throw AbsHttpException.json(401, { error: 'Invalid refresh token' });
+    }
+
+    // Case B: the current token. Enforce DB expiry, then rotate.
+    if (session.expiresAt.getTime() <= Date.now()) {
+      await this.db.delete(schema.absSessions).where(eq(schema.absSessions.id, session.id));
+      throw AbsHttpException.json(401, { error: 'Refresh token expired' });
+    }
+
+    const accessToken = this.tokenService.signAccessToken(payload.userId, payload.username);
+    const { token: newRefreshToken, expiresAt } = this.tokenService.signRefreshToken(payload.userId, payload.username);
+
+    // Optimistic concurrency: only rotate if the current token is still the one we read.
+    const result = await this.db
+      .update(schema.absSessions)
+      .set({
+        refreshToken: newRefreshToken,
+        lastRefreshToken: presentedToken,
+        lastRefreshTokenExpiresAt: new Date(Date.now() + ABS_REFRESH_GRACE_MS),
+        expiresAt,
+      })
+      .where(and(eq(schema.absSessions.id, session.id), eq(schema.absSessions.refreshToken, presentedToken)));
+
+    if ((result.rowCount ?? 0) === 0) {
+      // Lost the race to a concurrent refresh; re-read and return the now-current refresh token
+      // with a fresh access token instead of forcing a logout.
+      const current = await this.db.query.absSessions.findFirst({ where: eq(schema.absSessions.id, session.id) });
+      if (!current) throw AbsHttpException.json(401, { error: 'Invalid refresh token' });
+      this.logger.log(`[abs.refresh] userId=${payload.userId} reason="rotation-race" - reissued from current session token`);
+      return { accessToken, refreshToken: current.refreshToken };
+    }
+
+    return { accessToken, refreshToken: newRefreshToken };
+  }
+
+  /** Destroy the session matching the presented refresh token (logout). Best-effort. */
+  async invalidate(presentedToken: string | undefined | null): Promise<void> {
+    if (!presentedToken) return;
+    await this.db
+      .delete(schema.absSessions)
+      .where(or(eq(schema.absSessions.refreshToken, presentedToken), eq(schema.absSessions.lastRefreshToken, presentedToken)));
+  }
+}

--- a/server/src/modules/abs/auth/abs-token.service.test.ts
+++ b/server/src/modules/abs/auth/abs-token.service.test.ts
@@ -1,0 +1,39 @@
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+
+import { AbsTokenService } from './abs-token.service';
+
+function buildService(secret = 'test-secret-1234567890'): AbsTokenService {
+  const config = { get: (key: string) => (key === 'auth.jwtSecret' ? secret : undefined) } as unknown as ConfigService;
+  return new AbsTokenService(new JwtService({}), config);
+}
+
+describe('AbsTokenService', () => {
+  it('mints and verifies an access token carrying the ABS payload', () => {
+    const service = buildService();
+    const token = service.signAccessToken(5, 'alice');
+    const payload = service.verifyAccessToken(token);
+    expect(payload).toMatchObject({ userId: 5, username: 'alice', type: 'access' });
+    expect(payload?.jti).toBeTruthy();
+    expect(payload?.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it('mints a refresh token with a ~30d expiry and rejects it as an access token', () => {
+    const service = buildService();
+    const { token, expiresAt } = service.signRefreshToken(5, 'alice');
+    expect(service.verifyRefreshToken(token)).toMatchObject({ userId: 5, type: 'refresh' });
+    expect(service.verifyAccessToken(token)).toBeNull(); // type mismatch
+    expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('rejects tokens signed with a different secret', () => {
+    const minted = buildService('secret-a-1234567890').signAccessToken(1, 'bob');
+    expect(buildService('secret-b-1234567890').verifyAccessToken(minted)).toBeNull();
+  });
+
+  it('returns null for malformed tokens', () => {
+    const service = buildService();
+    expect(service.verifyAccessToken('not.a.jwt')).toBeNull();
+    expect(service.verifyRefreshToken('')).toBeNull();
+  });
+});

--- a/server/src/modules/abs/auth/abs-token.service.ts
+++ b/server/src/modules/abs/auth/abs-token.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { randomUUID } from 'crypto';
+
+/**
+ * ABS access tokens live ~1h and refresh tokens ~30d (REIMPLEMENTATION_GUIDE §2.1). These are
+ * fixed by the wire contract and intentionally independent of BookOrbit's own JWT lifetimes.
+ */
+export const ABS_ACCESS_TOKEN_EXPIRY_SECONDS = 60 * 60; // 1h
+export const ABS_REFRESH_TOKEN_EXPIRY_SECONDS = 60 * 60 * 24 * 30; // 30d
+
+export type AbsTokenType = 'access' | 'refresh';
+
+export interface AbsTokenPayload {
+  userId: number;
+  username: string;
+  jti: string;
+  type: AbsTokenType;
+  iat?: number;
+  exp?: number;
+}
+
+/**
+ * Mints and verifies the `{ userId, username, jti, type, exp }` HS256 JWTs that ABS clients carry.
+ * Signed with BookOrbit's `JWT_SECRET` so a single secret governs the deployment.
+ */
+@Injectable()
+export class AbsTokenService {
+  private readonly secret: string;
+
+  constructor(
+    private readonly jwtService: JwtService,
+    config: ConfigService,
+  ) {
+    this.secret = config.get<string>('auth.jwtSecret') ?? 'change-me-in-production';
+  }
+
+  signAccessToken(userId: number, username: string): string {
+    return this.sign(userId, username, 'access', ABS_ACCESS_TOKEN_EXPIRY_SECONDS);
+  }
+
+  /** Returns the refresh JWT and the absolute expiry used to stamp the session row. */
+  signRefreshToken(userId: number, username: string): { token: string; expiresAt: Date } {
+    const token = this.sign(userId, username, 'refresh', ABS_REFRESH_TOKEN_EXPIRY_SECONDS);
+    const expiresAt = new Date(Date.now() + ABS_REFRESH_TOKEN_EXPIRY_SECONDS * 1000);
+    return { token, expiresAt };
+  }
+
+  /** Verify signature + expiry; returns null on any failure so callers map to the right status. */
+  verifyAccessToken(token: string): AbsTokenPayload | null {
+    const payload = this.verify(token);
+    return payload && payload.type === 'access' ? payload : null;
+  }
+
+  verifyRefreshToken(token: string): AbsTokenPayload | null {
+    const payload = this.verify(token);
+    return payload && payload.type === 'refresh' ? payload : null;
+  }
+
+  private sign(userId: number, username: string, type: AbsTokenType, expiresInSeconds: number): string {
+    return this.jwtService.sign(
+      { userId, username, type },
+      { secret: this.secret, algorithm: 'HS256', expiresIn: expiresInSeconds, jwtid: randomUUID() },
+    );
+  }
+
+  private verify(token: string): AbsTokenPayload | null {
+    try {
+      return this.jwtService.verify<AbsTokenPayload>(token, { secret: this.secret, algorithms: ['HS256'] });
+    } catch {
+      return null;
+    }
+  }
+}

--- a/server/src/modules/abs/controllers/abs-authorize.controller.test.ts
+++ b/server/src/modules/abs/controllers/abs-authorize.controller.test.ts
@@ -1,0 +1,89 @@
+import type { FastifyRequest } from 'fastify';
+
+import type { RequestUser } from '../../../common/types/request-user';
+import type { LibraryService } from '../../library/library.service';
+import type { AbsProgressService } from '../services/abs-progress.service';
+import { AbsAuthorizeController } from './abs-authorize.controller';
+
+function makeUser(overrides: Partial<RequestUser> = {}): RequestUser {
+  return {
+    id: 1,
+    username: 'admin',
+    name: 'admin',
+    email: null,
+    active: true,
+    isSuperuser: true,
+    isDefaultPassword: false,
+    tokenVersion: 0,
+    settings: {},
+    avatarUrl: null,
+    provisioningMethod: 'local',
+    permissions: [],
+    contentFilters: { rules: [] } as unknown as RequestUser['contentFilters'],
+    ...overrides,
+  };
+}
+
+function makeRequest(token: string | undefined): FastifyRequest {
+  return {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    query: {},
+  } as unknown as FastifyRequest;
+}
+
+function build(progress: Record<string, unknown>[], accessibleIds: number[]) {
+  const progressService = {
+    listMediaProgressForUser: vi.fn().mockResolvedValue(progress),
+  } as unknown as AbsProgressService;
+  const libraryService = {
+    findAccessibleLibraryIds: vi.fn().mockResolvedValue(accessibleIds),
+  } as unknown as LibraryService;
+  return { controller: new AbsAuthorizeController(progressService, libraryService), progressService, libraryService };
+}
+
+describe('AbsAuthorizeController', () => {
+  it('returns the full login payload echoing the presented access token', async () => {
+    const { controller } = build([{ id: 'usr_1-li_3' }], [3]);
+
+    const payload = await controller.authorize(makeUser(), makeRequest('echo-token'));
+    const user = payload.user as Record<string, unknown>;
+
+    // Same shape as POST /login (REIMPLEMENTATION_GUIDE §2.2).
+    expect(payload.Source).toBe('bookorbit');
+    expect(payload.serverSettings).toBeDefined();
+    expect(payload.ereaderDevices).toEqual([]);
+    // Echoes the bearer token rather than minting a new one; no new refresh token is issued.
+    expect(user.accessToken).toBe('echo-token');
+    expect(user.token).toBe('echo-token');
+    expect(user.refreshToken).toBeNull();
+    expect(user.mediaProgress).toEqual([{ id: 'usr_1-li_3' }]);
+  });
+
+  it('uses the first accessible library as the default and hides the list for superusers', async () => {
+    const { controller } = build([], [3, 7]);
+
+    const payload = await controller.authorize(makeUser({ isSuperuser: true }), makeRequest('t'));
+    const user = payload.user as Record<string, unknown>;
+
+    expect(payload.userDefaultLibraryId).toBe('lib_3');
+    expect(user.librariesAccessible).toEqual([]); // superuser => "all"
+  });
+
+  it('exposes encoded accessible library ids for non-superusers', async () => {
+    const { controller } = build([], [3, 7]);
+
+    const payload = await controller.authorize(makeUser({ isSuperuser: false }), makeRequest('t'));
+    const user = payload.user as Record<string, unknown>;
+
+    expect(payload.userDefaultLibraryId).toBe('lib_3');
+    expect(user.librariesAccessible).toEqual(['lib_3', 'lib_7']);
+  });
+
+  it('returns a null default library when none are accessible', async () => {
+    const { controller } = build([], []);
+
+    const payload = await controller.authorize(makeUser({ isSuperuser: false }), makeRequest('t'));
+
+    expect(payload.userDefaultLibraryId).toBeNull();
+  });
+});

--- a/server/src/modules/abs/controllers/abs-authorize.controller.ts
+++ b/server/src/modules/abs/controllers/abs-authorize.controller.ts
@@ -1,0 +1,48 @@
+import { Controller, HttpCode, Post, Req, UseFilters, UseGuards } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import type { FastifyRequest } from 'fastify';
+
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { Public } from '../../../common/decorators/public.decorator';
+import type { RequestUser } from '../../../common/types/request-user';
+import { LibraryService } from '../../library/library.service';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { encodeAbsId } from '../abs-id.util';
+import { AbsAuthGuard, extractAbsToken } from '../auth/abs-auth.guard';
+import { toAbsLoginPayload } from '../mappers/abs-user.mapper';
+import { AbsProgressService } from '../services/abs-progress.service';
+
+/**
+ * `POST /api/authorize` — re-derives the full login payload from a bearer token without
+ * re-authenticating (ENDPOINTS.md §24). ABS clients (e.g. Prologue) call this right after connecting
+ * to validate a stored token, so it must return the same body shape as `POST /login`. Unlike login it
+ * mints no new session: it echoes the presented access token and returns no refresh token (the client
+ * already holds those).
+ */
+@Public()
+@UseGuards(AbsAuthGuard)
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller('api/authorize')
+export class AbsAuthorizeController {
+  constructor(
+    private readonly progressService: AbsProgressService,
+    private readonly libraryService: LibraryService,
+  ) {}
+
+  @Post()
+  @HttpCode(200)
+  async authorize(@CurrentUser() user: RequestUser, @Req() req: FastifyRequest): Promise<Record<string, unknown>> {
+    const [mediaProgress, accessibleIds] = await Promise.all([
+      this.progressService.listMediaProgressForUser(user.id),
+      this.libraryService.findAccessibleLibraryIds(user),
+    ]);
+    return toAbsLoginPayload(user, {
+      accessToken: extractAbsToken(req) ?? '',
+      refreshToken: null,
+      mediaProgress,
+      librariesAccessible: user.isSuperuser ? [] : accessibleIds.map((id) => encodeAbsId('library', id)),
+      userDefaultLibraryId: accessibleIds.length ? encodeAbsId('library', accessibleIds[0]) : null,
+    });
+  }
+}

--- a/server/src/modules/abs/controllers/abs-authors.controller.test.ts
+++ b/server/src/modules/abs/controllers/abs-authors.controller.test.ts
@@ -1,0 +1,27 @@
+import type { AbsCatalogService } from '../services/abs-catalog.service';
+import { makeAbsUser, thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsAuthorsController } from './abs-authors.controller';
+
+function build() {
+  const catalogService = { getAuthor: vi.fn().mockResolvedValue({ id: 'aut_1', name: 'Andy Weir' }) } as unknown as AbsCatalogService;
+  return { controller: new AbsAuthorsController(catalogService), catalogService };
+}
+
+describe('AbsAuthorsController#getOne', () => {
+  it('404s on a malformed author id', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.getOne(makeAbsUser(), 'bogus', {}))).toBe(404);
+  });
+
+  it('parses the include csv and delegates to the catalog service', async () => {
+    const { controller, catalogService } = build();
+    await controller.getOne(makeAbsUser(), 'aut_1', { include: 'items, series' });
+    expect(catalogService.getAuthor).toHaveBeenCalledWith(expect.anything(), 1, ['items', 'series']);
+  });
+
+  it('passes an empty include list when the param is absent', async () => {
+    const { controller, catalogService } = build();
+    await controller.getOne(makeAbsUser(), 'aut_1', {});
+    expect(catalogService.getAuthor).toHaveBeenCalledWith(expect.anything(), 1, []);
+  });
+});

--- a/server/src/modules/abs/controllers/abs-authors.controller.ts
+++ b/server/src/modules/abs/controllers/abs-authors.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Param, Query, UseFilters, UseGuards } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { Public } from '../../../common/decorators/public.decorator';
+import type { RequestUser } from '../../../common/types/request-user';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+import { decodeAbsId } from '../abs-id.util';
+import { AbsAuthGuard } from '../auth/abs-auth.guard';
+import { AbsCatalogService } from '../services/abs-catalog.service';
+
+/** Author detail (ENDPOINTS.md §8). `?include=items,series` eager-loads the author's books. */
+@Public()
+@UseGuards(AbsAuthGuard)
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller('api/authors')
+export class AbsAuthorsController {
+  constructor(private readonly catalogService: AbsCatalogService) {}
+
+  @Get(':id')
+  async getOne(@CurrentUser() user: RequestUser, @Param('id') id: string, @Query() query: Record<string, string>): Promise<Record<string, unknown>> {
+    const authorId = decodeAbsId('author', id);
+    if (authorId === null) throw AbsHttpException.notFound();
+    const include = (query.include ?? '')
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean);
+    return this.catalogService.getAuthor(user, authorId, include);
+  }
+}

--- a/server/src/modules/abs/controllers/abs-hls.controller.test.ts
+++ b/server/src/modules/abs/controllers/abs-hls.controller.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import type { AbsTranscodeService } from '../services/abs-transcode.service';
+import { makeReply, thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsHlsController } from './abs-hls.controller';
+
+function build(overrides: Partial<AbsTranscodeService> = {}) {
+  const transcodeService = {
+    playlist: vi.fn().mockReturnValue('#EXTM3U\n#EXT-X-ENDLIST\n'),
+    resolveSegment: vi.fn().mockResolvedValue({ action: 'not-found' }),
+    ...overrides,
+  } as unknown as AbsTranscodeService;
+  return { controller: new AbsHlsController(transcodeService), transcodeService };
+}
+
+describe('AbsHlsController#streamFile', () => {
+  it('400s a filename outside the allowed HLS shapes (blocks traversal)', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.streamFile('s1', '../etc/passwd', reply))).toBe(400);
+  });
+
+  it('serves the playlist with the HLS content type', async () => {
+    const { controller } = build();
+    const { reply, captured } = makeReply();
+    await controller.streamFile('s1', 'output.m3u8', reply);
+    expect(captured.statusCode).toBe(200);
+    expect(captured.headers['Content-Type']).toBe('application/vnd.apple.mpegurl');
+    expect(captured.body).toContain('#EXT-X-ENDLIST');
+  });
+
+  it('404s the playlist for an unknown stream', async () => {
+    const { controller } = build({ playlist: vi.fn().mockReturnValue(null) });
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.streamFile('missing', 'output.m3u8', reply))).toBe(404);
+  });
+
+  it('serves a ready segment as video/mp2t', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'abs-hls-'));
+    const filePath = join(dir, 'output-0.ts');
+    await writeFile(filePath, 'ts');
+    const { controller } = build({ resolveSegment: vi.fn().mockResolvedValue({ action: 'serve', filePath }) });
+    const { reply, captured } = makeReply();
+    await controller.streamFile('s1', 'output-0.ts', reply);
+    expect(captured.statusCode).toBe(200);
+    expect(captured.headers['Content-Type']).toBe('video/mp2t');
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('404s a segment that is waiting, resetting, or missing', async () => {
+    for (const action of ['wait', 'reset', 'not-found']) {
+      const { controller } = build({ resolveSegment: vi.fn().mockResolvedValue({ action }) });
+      const { reply } = makeReply();
+      expect(await thrownStatus(() => controller.streamFile('s1', 'output-9.ts', reply))).toBe(404);
+    }
+  });
+});

--- a/server/src/modules/abs/controllers/abs-hls.controller.ts
+++ b/server/src/modules/abs/controllers/abs-hls.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Param, Res, UseFilters } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import { createReadStream } from 'fs';
+import type { FastifyReply } from 'fastify';
+
+import { Public } from '../../../common/decorators/public.decorator';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+import { HLS_PLAYLIST_FILE, isHlsFile } from '../abs-transcode.util';
+import { AbsTranscodeService } from '../services/abs-transcode.service';
+
+const PLAYLIST_CONTENT_TYPE = 'application/vnd.apple.mpegurl';
+const SEGMENT_CONTENT_TYPE = 'video/mp2t';
+
+/**
+ * HLS playlist/segment streaming for transcode sessions (REIMPLEMENTATION_GUIDE §5.3). Like the
+ * direct-track endpoint, authorization is by the opaque stream id baked into the URL, so the route is
+ * unauthenticated. Seeking outside the transcoded window yields a `404` plus a `stream_reset` socket
+ * event; the client restarts playback at the new offset.
+ */
+@Public()
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller('hls')
+export class AbsHlsController {
+  constructor(private readonly transcodeService: AbsTranscodeService) {}
+
+  @Get(':stream/:file')
+  async streamFile(@Param('stream') streamId: string, @Param('file') file: string, @Res() reply: FastifyReply): Promise<void> {
+    // Reject anything but our two filename shapes — this also blocks path traversal.
+    if (!isHlsFile(file)) throw AbsHttpException.bare(400);
+
+    if (file === HLS_PLAYLIST_FILE) {
+      const playlist = this.transcodeService.playlist(streamId);
+      if (playlist === null) throw AbsHttpException.notFound();
+      reply.header('Content-Type', PLAYLIST_CONTENT_TYPE);
+      reply.status(200).send(playlist);
+      return;
+    }
+
+    const { action, filePath } = await this.transcodeService.resolveSegment(streamId, file);
+    if (action !== 'serve' || !filePath) throw AbsHttpException.notFound();
+
+    reply.header('Content-Type', SEGMENT_CONTENT_TYPE);
+    reply.status(200).send(createReadStream(filePath));
+  }
+}

--- a/server/src/modules/abs/controllers/abs-items.controller.test.ts
+++ b/server/src/modules/abs/controllers/abs-items.controller.test.ts
@@ -1,0 +1,164 @@
+import { ConfigService } from '@nestjs/config';
+import { rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { PassThrough } from 'stream';
+
+import type { AbsCatalogService } from '../services/abs-catalog.service';
+import type { AbsPlaybackService } from '../services/abs-playback.service';
+import type { AbsStreamService } from '../services/abs-stream.service';
+import { makeAbsUser, makeReply, makeRequest, thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsItemsController } from './abs-items.controller';
+
+function build() {
+  const catalogService = {
+    getLibraryItem: vi.fn().mockResolvedValue({ id: 'li_3' }),
+    getItemFile: vi.fn().mockResolvedValue({ id: 7, bookId: 3, format: 'm4b', absolutePath: '/audio/Book Title.m4b' }),
+    getDownloadFile: vi.fn().mockResolvedValue({ id: 7, bookId: 3, format: 'm4b', absolutePath: '/audio/Book Title.m4b' }),
+    getDownloadBundle: vi.fn().mockResolvedValue({ title: 'Book Title', files: [{ absolutePath: '/audio/Book Title.m4b' }] }),
+  } as unknown as AbsCatalogService;
+  const playbackService = { startSession: vi.fn().mockResolvedValue({ id: 'sess-1', playMethod: 0 }) } as unknown as AbsPlaybackService;
+  const streamService = { streamFile: vi.fn().mockResolvedValue(undefined) } as unknown as AbsStreamService;
+  const config = { get: () => tmpdir() } as unknown as ConfigService;
+  return {
+    controller: new AbsItemsController(catalogService, playbackService, streamService, config),
+    catalogService,
+    playbackService,
+    streamService,
+  };
+}
+
+/** A reply mock whose `raw` is a real writable stream so the zip-download path can pipe into it. */
+function makeRawReply() {
+  const chunks: Buffer[] = [];
+  const raw = new PassThrough();
+  raw.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+  const headers: Record<string, unknown> = {};
+  (raw as unknown as { setHeader: (k: string, v: unknown) => void; headers: Record<string, unknown> }).setHeader = (k, v) => {
+    headers[k] = v;
+  };
+  return { reply: { raw } as any, raw, chunks, headers };
+}
+
+describe('AbsItemsController#getItem', () => {
+  it('404s on a malformed item id', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.getItem(makeAbsUser(), 'nope', {}))).toBe(404);
+  });
+
+  it('delegates to the catalog service, passing minified through', async () => {
+    const { controller, catalogService } = build();
+    await controller.getItem(makeAbsUser(), 'li_3', { minified: '1' });
+    expect(catalogService.getLibraryItem).toHaveBeenCalledWith(expect.anything(), 3, true, false);
+  });
+
+  it('requests progress attachment only when include contains progress', async () => {
+    const { controller, catalogService } = build();
+    await controller.getItem(makeAbsUser(), 'li_3', { expanded: '1', include: 'authors,progress' });
+    expect(catalogService.getLibraryItem).toHaveBeenCalledWith(expect.anything(), 3, false, true);
+  });
+});
+
+describe('AbsItemsController#play', () => {
+  it('404s on a malformed item id', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.play(makeAbsUser(), 'nope', {}, makeRequest()))).toBe(404);
+  });
+
+  it('starts a playback session for a valid item, threading the caller ip for deviceInfo', async () => {
+    const { controller, playbackService } = build();
+    const body = { supportedMimeTypes: ['audio/mpeg'] };
+    const session = await controller.play(makeAbsUser(), 'li_3', body, makeRequest());
+    expect(playbackService.startSession).toHaveBeenCalledWith(expect.anything(), 3, body, undefined);
+    expect(session).toMatchObject({ id: 'sess-1' });
+  });
+});
+
+describe('AbsItemsController#cover', () => {
+  it('404s on a malformed item id', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.cover('nope', makeRequest(), reply))).toBe(404);
+  });
+
+  it('404s when no cover file exists for the item', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    // appDataPath points at an empty tmp dir, so the cover directory does not exist -> 404.
+    expect(await thrownStatus(() => controller.cover('li_999999', makeRequest(), reply))).toBe(404);
+  });
+});
+
+describe('AbsItemsController#streamFileInline', () => {
+  it('404s on a malformed item id', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.streamFileInline(makeAbsUser(), 'nope', '7', makeRequest(), reply))).toBe(404);
+  });
+
+  it('404s on a non-numeric file id', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.streamFileInline(makeAbsUser(), 'li_3', 'abc', makeRequest(), reply))).toBe(404);
+  });
+
+  it('resolves the file and streams it inline (no attachment disposition)', async () => {
+    const { controller, catalogService, streamService } = build();
+    const { reply, captured } = makeReply();
+    await controller.streamFileInline(makeAbsUser(), 'li_3', '7', makeRequest(), reply);
+    expect(catalogService.getItemFile).toHaveBeenCalledWith(expect.anything(), 3, 7);
+    expect(captured.headers['Content-Disposition']).toBeUndefined();
+    expect(streamService.streamFile).toHaveBeenCalledWith(expect.anything(), reply, '/audio/Book Title.m4b', 'm4b');
+  });
+});
+
+describe('AbsItemsController#downloadFile', () => {
+  it('404s on a malformed item id', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.downloadFile(makeAbsUser(), 'nope', '7', makeRequest(), reply))).toBe(404);
+  });
+
+  it('404s on a non-numeric file id', async () => {
+    const { controller } = build();
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.downloadFile(makeAbsUser(), 'li_3', 'abc', makeRequest(), reply))).toBe(404);
+  });
+
+  it('resolves the file and streams it with an attachment Content-Disposition', async () => {
+    const { controller, catalogService, streamService } = build();
+    const { reply, captured } = makeReply();
+    await controller.downloadFile(makeAbsUser(), 'li_3', '7', makeRequest(), reply);
+    expect(catalogService.getDownloadFile).toHaveBeenCalledWith(expect.anything(), 3, 7);
+    expect(captured.headers['Content-Disposition']).toContain('attachment');
+    expect(captured.headers['Content-Disposition']).toContain('Book Title.m4b');
+    expect(streamService.streamFile).toHaveBeenCalledWith(expect.anything(), reply, '/audio/Book Title.m4b', 'm4b');
+  });
+});
+
+describe('AbsItemsController#downloadItem', () => {
+  it('404s on a malformed item id', async () => {
+    const { controller } = build();
+    const { reply } = makeRawReply();
+    expect(await thrownStatus(() => controller.downloadItem(makeAbsUser(), 'nope', reply))).toBe(404);
+  });
+
+  it('zips the item content files into the response', async () => {
+    const filePath = join(tmpdir(), `abs-download-${Date.now()}.m4b`);
+    writeFileSync(filePath, 'fake audio bytes');
+    try {
+      const { controller, catalogService } = build();
+      (catalogService.getDownloadBundle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        title: 'Book Title',
+        files: [{ absolutePath: filePath }],
+      });
+      const { reply, headers, chunks } = makeRawReply();
+      await controller.downloadItem(makeAbsUser(), 'li_3', reply);
+      expect(headers['Content-Type']).toBe('application/zip');
+      expect(String(headers['Content-Disposition'])).toContain('Book Title.zip');
+      expect(chunks.length).toBeGreaterThan(0);
+    } finally {
+      rmSync(filePath, { force: true });
+    }
+  });
+});

--- a/server/src/modules/abs/controllers/abs-items.controller.ts
+++ b/server/src/modules/abs/controllers/abs-items.controller.ts
@@ -1,0 +1,201 @@
+import { Body, Controller, Get, HttpCode, Param, Post, Query, Req, Res, UseFilters, UseGuards } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SkipThrottle } from '@nestjs/throttler';
+import { ZipArchive } from 'archiver';
+import { createReadStream } from 'fs';
+import { readdir, stat } from 'fs/promises';
+import { basename, join } from 'path';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { bookCoverDirPath, findPreferredBookCoverFileName } from '../../../common/book-cover-storage';
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { Public } from '../../../common/decorators/public.decorator';
+import { imageContentTypeFromPath } from '../../../common/image-content-type';
+import type { RequestUser } from '../../../common/types/request-user';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+import { decodeAbsId } from '../abs-id.util';
+import { AbsAuthGuard } from '../auth/abs-auth.guard';
+import { AbsCatalogService } from '../services/abs-catalog.service';
+import { AbsPlaybackService, type StartSessionBody } from '../services/abs-playback.service';
+import { AbsStreamService } from '../services/abs-stream.service';
+
+interface BatchGetBody {
+  libraryItemIds?: string[];
+}
+
+/** Build an RFC 6266 `Content-Disposition: attachment` value with an ASCII fallback + UTF-8 form. */
+function attachmentDisposition(filename: string): string {
+  const ascii = filename.replace(/[^\x20-\x7E]|["\\]/g, '_') || 'download';
+  const encoded = encodeURIComponent(filename).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${encoded}`;
+}
+
+/** Item detail + cover (REIMPLEMENTATION_GUIDE §5). Cover is unauthenticated (in the ignore list). */
+@Public()
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller('api/items')
+export class AbsItemsController {
+  private readonly appDataPath: string;
+
+  constructor(
+    private readonly catalogService: AbsCatalogService,
+    private readonly playbackService: AbsPlaybackService,
+    private readonly streamService: AbsStreamService,
+    config: ConfigService,
+  ) {
+    this.appDataPath = config.get<string>('storage.appDataPath')!;
+  }
+
+  /** Fetch many items by id (access-filtered). */
+  @Post('batch/get')
+  @HttpCode(200)
+  @UseGuards(AbsAuthGuard)
+  async batchGet(@CurrentUser() user: RequestUser, @Body() body: BatchGetBody): Promise<Record<string, unknown>> {
+    const bookIds = (body?.libraryItemIds ?? []).map((id) => decodeAbsId('libraryItem', id)).filter((id): id is number => id !== null);
+    const libraryItems = await this.catalogService.getLibraryItemsBatch(user, bookIds);
+    return { libraryItems };
+  }
+
+  @Get(':id')
+  @UseGuards(AbsAuthGuard)
+  async getItem(@CurrentUser() user: RequestUser, @Param('id') id: string, @Query() query: Record<string, string>): Promise<Record<string, unknown>> {
+    const bookId = decodeAbsId('libraryItem', id);
+    if (bookId === null) throw AbsHttpException.notFound();
+    const includeProgress = (query.include ?? '').split(',').includes('progress');
+    return this.catalogService.getLibraryItem(user, bookId, query.minified === '1', includeProgress);
+  }
+
+  /** Start a playback session (direct-play, book). Podcast `/play/:episodeId` is out of scope. */
+  @Post(':id/play')
+  @HttpCode(200)
+  @UseGuards(AbsAuthGuard)
+  async play(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Body() body: StartSessionBody,
+    @Req() req: FastifyRequest,
+  ): Promise<Record<string, unknown>> {
+    const bookId = decodeAbsId('libraryItem', id);
+    if (bookId === null) throw AbsHttpException.notFound();
+    return this.playbackService.startSession(user, bookId, body ?? {}, req.ip);
+  }
+
+  /**
+   * Stream a single item file inline (ENDPOINTS.md §2 — `jwt`). Same resolution as the download
+   * variant but without forcing an attachment disposition, and gated only on library access (not
+   * `canDownload`) since this is the in-app playback/preview path. Range-aware via the stream service.
+   */
+  @Get(':id/file/:fileid')
+  @UseGuards(AbsAuthGuard)
+  async streamFileInline(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Param('fileid') fileid: string,
+    @Req() req: FastifyRequest,
+    @Res() reply: FastifyReply,
+  ): Promise<void> {
+    const bookId = decodeAbsId('libraryItem', id);
+    const fileId = Number.parseInt(fileid, 10);
+    if (bookId === null || !Number.isInteger(fileId)) throw AbsHttpException.notFound();
+
+    const file = await this.catalogService.getItemFile(user, bookId, fileId);
+    await this.streamService.streamFile(req, reply, file.absolutePath, file.format);
+  }
+
+  /**
+   * Download a single item file (ENDPOINTS.md §2 — `jwt+canDownload`). `fileid` is the audio file's
+   * `ino`. Streamed with HTTP Range support so download managers can resume. Auth accepts `?token=`
+   * since download managers cannot set an Authorization header (REIMPLEMENTATION_GUIDE §2.1).
+   */
+  @Get(':id/file/:fileid/download')
+  @UseGuards(AbsAuthGuard)
+  async downloadFile(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Param('fileid') fileid: string,
+    @Req() req: FastifyRequest,
+    @Res() reply: FastifyReply,
+  ): Promise<void> {
+    const bookId = decodeAbsId('libraryItem', id);
+    const fileId = Number.parseInt(fileid, 10);
+    if (bookId === null || !Number.isInteger(fileId)) throw AbsHttpException.notFound();
+
+    const file = await this.catalogService.getDownloadFile(user, bookId, fileId);
+    reply.header('Content-Disposition', attachmentDisposition(basename(file.absolutePath)));
+    await this.streamService.streamFile(req, reply, file.absolutePath, file.format);
+  }
+
+  /** Download a whole item as a zip of its content files (ENDPOINTS.md §2 — `jwt+canDownload`). */
+  @Get(':id/download')
+  @UseGuards(AbsAuthGuard)
+  async downloadItem(@CurrentUser() user: RequestUser, @Param('id') id: string, @Res() reply: FastifyReply): Promise<void> {
+    const bookId = decodeAbsId('libraryItem', id);
+    if (bookId === null) throw AbsHttpException.notFound();
+
+    const { title, files } = await this.catalogService.getDownloadBundle(user, bookId);
+
+    const archive = new ZipArchive({ zlib: { level: 0 } });
+    let aborted = false;
+    const abort = () => {
+      aborted = true;
+      archive.abort();
+    };
+    reply.raw.on('close', abort);
+    reply.raw.on('aborted', abort);
+    const failure = new Promise<never>((_, reject) => {
+      archive.on('warning', reject);
+      archive.on('error', reject);
+    });
+
+    reply.raw.setHeader('Content-Type', 'application/zip');
+    reply.raw.setHeader('Content-Disposition', attachmentDisposition(`${title}.zip`));
+    archive.pipe(reply.raw);
+
+    const seen = new Map<string, number>();
+    for (const file of files) {
+      let name = basename(file.absolutePath);
+      const count = seen.get(name) ?? 0;
+      seen.set(name, count + 1);
+      // Disambiguate duplicate basenames coming from different source folders.
+      if (count > 0) name = `${count}-${name}`;
+      archive.file(file.absolutePath, { name });
+    }
+
+    try {
+      await Promise.race([archive.finalize(), failure]);
+    } catch (err) {
+      if (!aborted) throw err;
+    }
+  }
+
+  /** Unauthenticated cover image (token optional). Serves the stored cover with ETag caching. */
+  @Get(':id/cover')
+  async cover(@Param('id') id: string, @Req() req: FastifyRequest, @Res() reply: FastifyReply): Promise<void> {
+    const bookId = decodeAbsId('libraryItem', id);
+    if (bookId === null) throw AbsHttpException.notFound();
+
+    reply.header('Cross-Origin-Resource-Policy', 'cross-origin');
+    const dir = bookCoverDirPath(this.appDataPath, bookId);
+    try {
+      const files = await readdir(dir);
+      const cover = findPreferredBookCoverFileName(files);
+      if (!cover) throw AbsHttpException.notFound();
+      const coverPath = join(dir, cover);
+      const { mtimeMs } = await stat(coverPath);
+      const etag = `"${Math.floor(mtimeMs)}"`;
+      if (req.headers['if-none-match'] === etag) {
+        reply.status(304).send();
+        return;
+      }
+      reply.header('Cache-Control', 'no-cache');
+      reply.header('ETag', etag);
+      reply.type(imageContentTypeFromPath(coverPath));
+      reply.send(createReadStream(coverPath));
+    } catch (err) {
+      if (err instanceof AbsHttpException) throw err;
+      throw AbsHttpException.notFound();
+    }
+  }
+}

--- a/server/src/modules/abs/controllers/abs-libraries.controller.test.ts
+++ b/server/src/modules/abs/controllers/abs-libraries.controller.test.ts
@@ -1,0 +1,103 @@
+import type { LibraryService } from '../../library/library.service';
+import type { AbsCatalogService } from '../services/abs-catalog.service';
+import { makeAbsUser, thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsLibrariesController } from './abs-libraries.controller';
+
+interface BuildOpts {
+  libraries?: { id: number; name: string }[];
+  accessibleIds?: number[];
+  findOne?: unknown;
+}
+
+function build(opts: BuildOpts = {}) {
+  const libraryService = {
+    findAll: vi.fn().mockResolvedValue(opts.libraries ?? []),
+    findAccessibleLibraryIds: vi.fn().mockResolvedValue(opts.accessibleIds ?? []),
+    findOne: vi.fn().mockResolvedValue(opts.findOne ?? null),
+  } as unknown as LibraryService;
+  const catalogService = {
+    listLibraryItems: vi.fn().mockResolvedValue({ results: [], total: 0 }),
+    listAuthors: vi.fn().mockResolvedValue({ authors: [] }),
+  } as unknown as AbsCatalogService;
+  return { controller: new AbsLibrariesController(libraryService, catalogService), libraryService, catalogService };
+}
+
+describe('AbsLibrariesController#list', () => {
+  it('returns mapped libraries under a { libraries } envelope', async () => {
+    const { controller } = build({ libraries: [{ id: 1, name: 'Audiobooks' }] });
+    const result = await controller.list(makeAbsUser());
+    const libraries = result.libraries as Record<string, unknown>[];
+    expect(libraries).toHaveLength(1);
+    expect(libraries[0].id).toBe('lib_1');
+  });
+});
+
+describe('AbsLibrariesController#getOne', () => {
+  it('404s on a malformed library id', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.getOne(makeAbsUser(), 'bogus'))).toBe(404);
+  });
+
+  it('404s when a scoped user cannot access the library (no existence leak)', async () => {
+    const { controller } = build({ accessibleIds: [9] });
+    expect(await thrownStatus(() => controller.getOne(makeAbsUser({ isSuperuser: false }), 'lib_2'))).toBe(404);
+  });
+
+  it('404s when the library does not exist', async () => {
+    const { controller } = build({ accessibleIds: [2], findOne: null });
+    expect(await thrownStatus(() => controller.getOne(makeAbsUser({ isSuperuser: false }), 'lib_2'))).toBe(404);
+  });
+
+  it('returns the mapped library for an accessible id', async () => {
+    const { controller } = build({ accessibleIds: [2], findOne: { id: 2, name: 'Audiobooks' } });
+    const lib = await controller.getOne(makeAbsUser({ isSuperuser: false }), 'lib_2');
+    expect(lib.id).toBe('lib_2');
+  });
+});
+
+describe('AbsLibrariesController#items', () => {
+  it('404s on a malformed library id', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.items(makeAbsUser(), 'bogus', {}))).toBe(404);
+  });
+
+  it('parses pagination/sort flags and delegates to the catalog service', async () => {
+    const { controller, catalogService } = build();
+    await controller.items(makeAbsUser(), 'lib_5', { limit: '25', page: '2', sort: 'media.metadata.title', desc: '1', minified: '1' });
+    expect(catalogService.listLibraryItems).toHaveBeenCalledWith(expect.anything(), 5, {
+      limit: 25,
+      page: 2,
+      sort: 'title',
+      rawSort: 'media.metadata.title',
+      desc: true,
+      minified: true,
+      filter: undefined,
+    });
+  });
+
+  it('defaults to limit 0 (no limit), page 0, addedAt sort, ascending', async () => {
+    const { controller, catalogService } = build();
+    await controller.items(makeAbsUser(), 'lib_5', {});
+    expect(catalogService.listLibraryItems).toHaveBeenCalledWith(expect.anything(), 5, {
+      limit: 0,
+      page: 0,
+      sort: 'addedAt',
+      desc: false,
+      minified: false,
+    });
+  });
+});
+
+describe('AbsLibrariesController#authors', () => {
+  it('404s on a malformed library id', async () => {
+    const { controller } = build();
+    expect(await thrownStatus(() => controller.authors(makeAbsUser(), 'bogus', {}))).toBe(404);
+  });
+
+  it('delegates to the catalog service with the decoded library id and query', async () => {
+    const { controller, catalogService } = build();
+    const result = await controller.authors(makeAbsUser(), 'lib_5', { limit: '50', page: '0' });
+    expect(catalogService.listAuthors).toHaveBeenCalledWith(expect.anything(), 5, { limit: '50', page: '0' });
+    expect(result).toEqual({ authors: [] });
+  });
+});

--- a/server/src/modules/abs/controllers/abs-libraries.controller.ts
+++ b/server/src/modules/abs/controllers/abs-libraries.controller.ts
@@ -1,0 +1,119 @@
+import { Controller, Get, Param, Query, UseFilters, UseGuards } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { Public } from '../../../common/decorators/public.decorator';
+import type { RequestUser } from '../../../common/types/request-user';
+import { LibraryService } from '../../library/library.service';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+import { decodeAbsId } from '../abs-id.util';
+import { AbsAuthGuard } from '../auth/abs-auth.guard';
+import { toAbsLibrary } from '../mappers/abs-library.mapper';
+import { AbsCatalogService, parseAbsSort } from '../services/abs-catalog.service';
+
+function toInt(value: string | undefined, fallback: number): number {
+  const n = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/** Library list/detail + the primary browse endpoint (REIMPLEMENTATION_GUIDE §4). */
+@Public()
+@UseGuards(AbsAuthGuard)
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller('api/libraries')
+export class AbsLibrariesController {
+  constructor(
+    private readonly libraryService: LibraryService,
+    private readonly catalogService: AbsCatalogService,
+  ) {}
+
+  @Get()
+  async list(@CurrentUser() user: RequestUser): Promise<Record<string, unknown>> {
+    const libraries = await this.libraryService.findAll(user);
+    return { libraries: libraries.map(toAbsLibrary) };
+  }
+
+  @Get(':id')
+  async getOne(@CurrentUser() user: RequestUser, @Param('id') id: string): Promise<Record<string, unknown>> {
+    const libraryId = decodeAbsId('library', id);
+    if (libraryId === null) throw AbsHttpException.notFound();
+    const accessible = await this.libraryService.findAccessibleLibraryIds(user);
+    if (!user.isSuperuser && !accessible.includes(libraryId)) throw AbsHttpException.notFound();
+
+    const library = await this.libraryService.findOne(libraryId).catch(() => null);
+    if (!library) throw AbsHttpException.notFound();
+    return toAbsLibrary(library);
+  }
+
+  @Get(':id/items')
+  async items(@CurrentUser() user: RequestUser, @Param('id') id: string, @Query() query: Record<string, string>): Promise<Record<string, unknown>> {
+    return this.catalogService.listLibraryItems(user, this.requireLibraryId(id), this.parseQuery(query));
+  }
+
+  /** Home-screen shelves. */
+  @Get(':id/personalized')
+  async personalized(@CurrentUser() user: RequestUser, @Param('id') id: string): Promise<Record<string, unknown>[]> {
+    return this.catalogService.personalized(user, this.requireLibraryId(id));
+  }
+
+  /** Authors with a book in the library — the primary browse axis for author-centric clients. */
+  @Get(':id/authors')
+  async authors(@CurrentUser() user: RequestUser, @Param('id') id: string, @Query() query: Record<string, string>): Promise<Record<string, unknown>> {
+    return this.catalogService.listAuthors(user, this.requireLibraryId(id), query);
+  }
+
+  /** Valid filter values/ids for the library. */
+  @Get(':id/filterdata')
+  async filterdata(@CurrentUser() user: RequestUser, @Param('id') id: string): Promise<Record<string, unknown>> {
+    return this.catalogService.filterData(user, this.requireLibraryId(id));
+  }
+
+  /** Title/author search within the library. */
+  @Get(':id/search')
+  async search(@CurrentUser() user: RequestUser, @Param('id') id: string, @Query() query: Record<string, string>): Promise<Record<string, unknown>> {
+    return this.catalogService.search(user, this.requireLibraryId(id), query.q ?? '', Math.max(0, toInt(query.limit, 12)));
+  }
+
+  /** Series in the library (paginated). */
+  @Get(':id/series')
+  async series(@CurrentUser() user: RequestUser, @Param('id') id: string, @Query() query: Record<string, string>): Promise<Record<string, unknown>> {
+    return this.catalogService.listSeries(user, this.requireLibraryId(id), this.parseQuery(query));
+  }
+
+  /** User collections, restricted to this library (paginated). */
+  @Get(':id/collections')
+  async collections(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Query() query: Record<string, string>,
+  ): Promise<Record<string, unknown>> {
+    return this.catalogService.listCollections(user, this.requireLibraryId(id), this.parseQuery(query));
+  }
+
+  /** Playlists are not modelled in BookOrbit; return an empty paginated envelope. */
+  @Get(':id/playlists')
+  playlists(@Param('id') id: string): Record<string, unknown> {
+    this.requireLibraryId(id);
+    return { results: [], total: 0, limit: 0, page: 0 };
+  }
+
+  private requireLibraryId(id: string): number {
+    const libraryId = decodeAbsId('library', id);
+    if (libraryId === null) throw AbsHttpException.notFound();
+    return libraryId;
+  }
+
+  private parseQuery(query: Record<string, string>) {
+    return {
+      limit: Math.max(0, toInt(query.limit, 0)),
+      page: Math.max(0, toInt(query.page, 0)),
+      sort: parseAbsSort(query.sort),
+      rawSort: query.sort,
+      desc: query.desc === '1',
+      minified: query.minified === '1',
+      filter: query.filter,
+    };
+  }
+}

--- a/server/src/modules/abs/controllers/abs-me.controller.test.ts
+++ b/server/src/modules/abs/controllers/abs-me.controller.test.ts
@@ -1,0 +1,326 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { Permission } from '@bookorbit/types';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import type { AuthService } from '../../auth/auth.service';
+import type { LibraryService } from '../../library/library.service';
+import type { AbsBookmarkService } from '../services/abs-bookmark.service';
+import type { AbsCatalogService } from '../services/abs-catalog.service';
+import type { AbsProgressService } from '../services/abs-progress.service';
+import type { AbsSessionHistoryService } from '../services/abs-session-history.service';
+import { makeAbsUser, thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsMeController } from './abs-me.controller';
+
+const noopAuthService = {} as unknown as AuthService;
+const noopHistoryService = {} as unknown as AbsSessionHistoryService;
+
+function build(progress: Record<string, unknown>[], accessibleIds: number[]) {
+  const progressService = { listMediaProgressForUser: vi.fn().mockResolvedValue(progress) } as unknown as AbsProgressService;
+  const libraryService = { findAccessibleLibraryIds: vi.fn().mockResolvedValue(accessibleIds) } as unknown as LibraryService;
+  const catalogService = {} as unknown as AbsCatalogService;
+  const bookmarkService = { listForUser: vi.fn().mockResolvedValue([]) } as unknown as AbsBookmarkService;
+  return {
+    controller: new AbsMeController(progressService, libraryService, catalogService, bookmarkService, noopAuthService, noopHistoryService),
+    progressService,
+  };
+}
+
+describe('AbsMeController#deleteProgress', () => {
+  function build(removed = true) {
+    const progressService = { deleteProgress: vi.fn().mockResolvedValue(removed) } as unknown as AbsProgressService;
+    const controller = new AbsMeController(
+      progressService,
+      {} as unknown as LibraryService,
+      {} as unknown as AbsCatalogService,
+      {} as unknown as AbsBookmarkService,
+      noopAuthService,
+      noopHistoryService,
+    );
+    return { controller, progressService };
+  }
+
+  it('deletes by the composite progress id, decoding the library item half', async () => {
+    const { controller, progressService } = build();
+    await controller.deleteProgress(makeAbsUser({ id: 8 }), 'usr_8-li_42');
+    expect(progressService.deleteProgress).toHaveBeenCalledWith(8, 42);
+  });
+
+  it('also accepts a bare library item id', async () => {
+    const { controller, progressService } = build();
+    await controller.deleteProgress(makeAbsUser({ id: 8 }), 'li_42');
+    expect(progressService.deleteProgress).toHaveBeenCalledWith(8, 42);
+  });
+
+  it('404s when the composite id names a different user', async () => {
+    const { controller, progressService } = build();
+    await expect(controller.deleteProgress(makeAbsUser({ id: 8 }), 'usr_9-li_42')).rejects.toMatchObject({});
+    expect(progressService.deleteProgress).not.toHaveBeenCalled();
+  });
+
+  it('404s on a malformed id', async () => {
+    const { controller } = build();
+    await expect(controller.deleteProgress(makeAbsUser({ id: 8 }), 'not-an-id')).rejects.toMatchObject({});
+  });
+
+  it('404s when there was no progress to remove', async () => {
+    const { controller } = build(false);
+    await expect(controller.deleteProgress(makeAbsUser({ id: 8 }), 'usr_8-li_42')).rejects.toMatchObject({});
+  });
+});
+
+describe('AbsMeController#removeFromContinueListening', () => {
+  const meReq = { headers: { authorization: 'Bearer abs-jwt' } } as unknown as FastifyRequest;
+
+  function build(hidden = true) {
+    const progressService = {
+      hideFromContinueListening: vi.fn().mockResolvedValue(hidden),
+      listMediaProgressForUser: vi.fn().mockResolvedValue([{ id: 'usr_8-li_42', hideFromContinueListening: true }]),
+    } as unknown as AbsProgressService;
+    const libraryService = { findAccessibleLibraryIds: vi.fn().mockResolvedValue([3]) } as unknown as LibraryService;
+    const bookmarkService = { listForUser: vi.fn().mockResolvedValue([]) } as unknown as AbsBookmarkService;
+    const controller = new AbsMeController(
+      progressService,
+      libraryService,
+      {} as unknown as AbsCatalogService,
+      bookmarkService,
+      noopAuthService,
+      noopHistoryService,
+    );
+    return { controller, progressService };
+  }
+
+  it('hides by the composite progress id and responds with the full user JSON, like ABS', async () => {
+    const { controller, progressService } = build();
+    const user = await controller.removeFromContinueListening(makeAbsUser({ id: 8, isSuperuser: false }), 'usr_8-li_42', meReq);
+    expect(progressService.hideFromContinueListening).toHaveBeenCalledWith(8, 42);
+    expect(user.id).toBe('usr_8');
+    expect(user.mediaProgress).toEqual([{ id: 'usr_8-li_42', hideFromContinueListening: true }]);
+  });
+
+  it('also accepts a bare library item id', async () => {
+    const { controller, progressService } = build();
+    await controller.removeFromContinueListening(makeAbsUser({ id: 8 }), 'li_42', meReq);
+    expect(progressService.hideFromContinueListening).toHaveBeenCalledWith(8, 42);
+  });
+
+  it('404s when the composite id names a different user', async () => {
+    const { controller, progressService } = build();
+    await expect(thrownStatus(() => controller.removeFromContinueListening(makeAbsUser({ id: 8 }), 'usr_9-li_42', meReq))).resolves.toBe(404);
+    expect(progressService.hideFromContinueListening).not.toHaveBeenCalled();
+  });
+
+  it('404s when there is no progress row to hide', async () => {
+    const { controller } = build(false);
+    await expect(thrownStatus(() => controller.removeFromContinueListening(makeAbsUser({ id: 8 }), 'usr_8-li_42', meReq))).resolves.toBe(404);
+  });
+});
+
+describe('AbsMeController history/stats endpoints (delegation to AbsSessionHistoryService)', () => {
+  function build() {
+    const historyService = {
+      listeningSessions: vi.fn().mockResolvedValue({ total: 0, numPages: 0, page: 0, itemsPerPage: 10, sessions: [] }),
+      itemListeningSessions: vi.fn().mockResolvedValue({ total: 0, numPages: 0, page: 0, itemsPerPage: 10, sessions: [] }),
+      listeningStats: vi.fn().mockResolvedValue({ totalTime: 0 }),
+      statsForYear: vi.fn().mockResolvedValue({ totalListeningTime: 0 }),
+    } as unknown as AbsSessionHistoryService;
+    const controller = new AbsMeController(
+      {} as unknown as AbsProgressService,
+      {} as unknown as LibraryService,
+      {} as unknown as AbsCatalogService,
+      {} as unknown as AbsBookmarkService,
+      noopAuthService,
+      historyService,
+    );
+    return { controller, historyService };
+  }
+
+  it('listening-sessions passes the caller and query through', async () => {
+    const { controller, historyService } = build();
+    const query = { page: '2', itemsPerPage: '25' };
+    await controller.listeningSessions(makeAbsUser({ id: 8 }), query);
+    expect(historyService.listeningSessions).toHaveBeenCalledWith(expect.objectContaining({ id: 8 }), query);
+  });
+
+  it('item listening-sessions passes the raw item id for the service to decode/404', async () => {
+    const { controller, historyService } = build();
+    await controller.itemListeningSessions(makeAbsUser({ id: 8 }), 'li_42', {});
+    expect(historyService.itemListeningSessions).toHaveBeenCalledWith(expect.objectContaining({ id: 8 }), 'li_42', {});
+  });
+
+  it('listening-stats delegates for the caller', async () => {
+    const { controller, historyService } = build();
+    await controller.listeningStats(makeAbsUser({ id: 8 }));
+    expect(historyService.listeningStats).toHaveBeenCalledWith(expect.objectContaining({ id: 8 }));
+  });
+
+  it('stats/year parses the year and coerces garbage to an empty year', async () => {
+    const { controller, historyService } = build();
+    await controller.statsForYear(makeAbsUser({ id: 8 }), '2026');
+    expect(historyService.statsForYear).toHaveBeenCalledWith(expect.objectContaining({ id: 8 }), 2026);
+    await controller.statsForYear(makeAbsUser({ id: 8 }), 'nope');
+    expect(historyService.statsForYear).toHaveBeenLastCalledWith(expect.anything(), 0);
+  });
+});
+
+describe('AbsMeController#me', () => {
+  const meReq = { headers: { authorization: 'Bearer abs-jwt' } } as any;
+
+  it('returns the current user with their media progress', async () => {
+    const { controller, progressService } = build([{ id: 'mp1' }], [3]);
+    const user = await controller.me(makeAbsUser({ id: 8, isSuperuser: false }), meReq);
+    expect(user.id).toBe('usr_8');
+    expect(user.mediaProgress).toEqual([{ id: 'mp1' }]);
+    expect(progressService.listMediaProgressForUser).toHaveBeenCalledWith(8);
+  });
+
+  it('echoes the caller bearer as the legacy token (live ABS never sends null there)', async () => {
+    const { controller } = build([], [3]);
+    const user = await controller.me(makeAbsUser({ id: 8, isSuperuser: false }), meReq);
+    expect(user.token).toBe('abs-jwt');
+  });
+
+  it('exposes encoded accessible library ids for scoped users', async () => {
+    const { controller } = build([], [3, 7]);
+    const user = await controller.me(makeAbsUser({ isSuperuser: false }), meReq);
+    expect(user.librariesAccessible).toEqual(['lib_3', 'lib_7']);
+  });
+
+  it('hides the library list for superusers (empty array means "all")', async () => {
+    const { controller } = build([], [3, 7]);
+    const user = await controller.me(makeAbsUser({ isSuperuser: true }), meReq);
+    expect(user.librariesAccessible).toEqual([]);
+  });
+
+  it('includes the user bookmarks in the /me payload', async () => {
+    const progressService = { listMediaProgressForUser: vi.fn().mockResolvedValue([]) } as unknown as AbsProgressService;
+    const libraryService = { findAccessibleLibraryIds: vi.fn().mockResolvedValue([]) } as unknown as LibraryService;
+    const bookmarks = [{ libraryItemId: 'li_3', title: 'A quote', time: 120, createdAt: 0 }];
+    const bookmarkService = { listForUser: vi.fn().mockResolvedValue(bookmarks) } as unknown as AbsBookmarkService;
+    const controller = new AbsMeController(
+      progressService,
+      libraryService,
+      {} as unknown as AbsCatalogService,
+      bookmarkService,
+      noopAuthService,
+      noopHistoryService,
+    );
+
+    const user = await controller.me(makeAbsUser({ id: 8 }), meReq);
+    expect(user.bookmarks).toEqual(bookmarks);
+  });
+});
+
+describe('AbsMeController bookmarks', () => {
+  function build() {
+    const bookmarkService = {
+      create: vi.fn().mockResolvedValue({ libraryItemId: 'li_3', title: 'T', time: 90, createdAt: 0 }),
+      update: vi.fn().mockResolvedValue({ libraryItemId: 'li_3', title: 'New', time: 90, createdAt: 0 }),
+      remove: vi.fn().mockResolvedValue(true),
+    } as unknown as AbsBookmarkService;
+    const controller = new AbsMeController(
+      {} as unknown as AbsProgressService,
+      {} as unknown as LibraryService,
+      {} as unknown as AbsCatalogService,
+      bookmarkService,
+      noopAuthService,
+    );
+    return { controller, bookmarkService };
+  }
+
+  it('creates a bookmark, decoding the library item id and forwarding time/title', async () => {
+    const { controller, bookmarkService } = build();
+    const result = await controller.createBookmark(makeAbsUser({ id: 8 }), 'li_3', { time: 90, title: 'T' });
+    expect(bookmarkService.create).toHaveBeenCalledWith(8, 3, 90, 'T');
+    expect(result.libraryItemId).toBe('li_3');
+  });
+
+  it('rejects a bookmark create with no time (404)', async () => {
+    const { controller } = build();
+    await expect(controller.createBookmark(makeAbsUser(), 'li_3', {})).rejects.toMatchObject({});
+  });
+
+  it('rejects a bad library item id (404)', async () => {
+    const { controller } = build();
+    await expect(controller.createBookmark(makeAbsUser(), 'not-an-id', { time: 1 })).rejects.toMatchObject({});
+  });
+
+  it('deletes the bookmark at :time', async () => {
+    const { controller, bookmarkService } = build();
+    await controller.deleteBookmark(makeAbsUser({ id: 8 }), 'li_3', '90');
+    expect(bookmarkService.remove).toHaveBeenCalledWith(8, 3, 90);
+  });
+
+  it('404s deleting a bookmark that does not exist', async () => {
+    const { controller, bookmarkService } = build();
+    (bookmarkService.remove as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    await expect(controller.deleteBookmark(makeAbsUser(), 'li_3', '90')).rejects.toMatchObject({});
+  });
+});
+
+describe('AbsMeController#changePassword', () => {
+  function build() {
+    const authService = { changePassword: vi.fn().mockResolvedValue(undefined) } as unknown as AuthService;
+    const controller = new AbsMeController(
+      {} as unknown as AbsProgressService,
+      {} as unknown as LibraryService,
+      {} as unknown as AbsCatalogService,
+      {} as unknown as AbsBookmarkService,
+      authService,
+    );
+    return { controller, authService };
+  }
+
+  const reply = {} as unknown as FastifyReply;
+  const req = { ip: '1.2.3.4' } as unknown as FastifyRequest;
+  const strong = 'NewPassw0rd';
+
+  it('delegates to AuthService.changePassword and returns 200 (no body)', async () => {
+    const { controller, authService } = build();
+    await expect(controller.changePassword(makeAbsUser({ id: 8 }), { password: 'old', newPassword: strong }, req, reply)).resolves.toBeUndefined();
+    expect(authService.changePassword).toHaveBeenCalledWith(8, { currentPassword: 'old', newPassword: strong }, reply, '1.2.3.4');
+  });
+
+  it('403s a demo-restricted account before touching AuthService', async () => {
+    const { controller, authService } = build();
+    await expect(
+      thrownStatus(() =>
+        controller.changePassword(makeAbsUser({ permissions: [Permission.DemoRestricted] }), { password: 'old', newPassword: strong }, req, reply),
+      ),
+    ).resolves.toBe(403);
+    expect(authService.changePassword).not.toHaveBeenCalled();
+  });
+
+  it('400s when either field is missing or not a string', async () => {
+    const { controller } = build();
+    await expect(thrownStatus(() => controller.changePassword(makeAbsUser(), { newPassword: strong }, req, reply))).resolves.toBe(400);
+    await expect(
+      thrownStatus(() => controller.changePassword(makeAbsUser(), { password: 'old', newPassword: 123 as unknown as string }, req, reply)),
+    ).resolves.toBe(400);
+  });
+
+  it('400s a new password that fails the BookOrbit complexity policy', async () => {
+    const { controller, authService } = build();
+    await expect(thrownStatus(() => controller.changePassword(makeAbsUser(), { password: 'old', newPassword: 'weak' }, req, reply))).resolves.toBe(
+      400,
+    );
+    expect(authService.changePassword).not.toHaveBeenCalled();
+  });
+
+  it('maps a wrong current password (UnauthorizedException) to 400', async () => {
+    const { controller, authService } = build();
+    (authService.changePassword as ReturnType<typeof vi.fn>).mockRejectedValue(new UnauthorizedException('Current password is incorrect'));
+    await expect(thrownStatus(() => controller.changePassword(makeAbsUser(), { password: 'wrong', newPassword: strong }, req, reply))).resolves.toBe(
+      400,
+    );
+  });
+
+  it('maps an OIDC/shared rejection (BadRequestException) to 400', async () => {
+    const { controller, authService } = build();
+    (authService.changePassword as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new BadRequestException('OIDC accounts cannot change their password here'),
+    );
+    await expect(thrownStatus(() => controller.changePassword(makeAbsUser(), { password: 'old', newPassword: strong }, req, reply))).resolves.toBe(
+      400,
+    );
+  });
+});

--- a/server/src/modules/abs/controllers/abs-me.controller.ts
+++ b/server/src/modules/abs/controllers/abs-me.controller.ts
@@ -1,0 +1,272 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  Res,
+  UnauthorizedException,
+  UseFilters,
+  UseGuards,
+} from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import { Permission } from '@bookorbit/types';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { Public } from '../../../common/decorators/public.decorator';
+import type { RequestUser } from '../../../common/types/request-user';
+import { AuthService } from '../../auth/auth.service';
+import { LibraryService } from '../../library/library.service';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+import { ABS_ID_PREFIX, decodeAbsId, encodeAbsId } from '../abs-id.util';
+import { AbsAuthGuard, extractAbsToken } from '../auth/abs-auth.guard';
+import { toAbsUser } from '../mappers/abs-user.mapper';
+import { AbsBookmarkService } from '../services/abs-bookmark.service';
+import { AbsCatalogService } from '../services/abs-catalog.service';
+import { AbsProgressService, type AbsProgressBody } from '../services/abs-progress.service';
+import { AbsSessionHistoryService } from '../services/abs-session-history.service';
+
+interface BookmarkBody {
+  time?: number;
+  title?: string;
+}
+
+interface ChangePasswordBody {
+  password?: string;
+  newPassword?: string;
+}
+
+/**
+ * BookOrbit's native password policy (mirrors `auth/dto/change-password.dto.ts`): at least 8 chars
+ * with an upper, a lower, and a digit. ABS upstream accepts any password, but we keep the platform
+ * invariant so the ABS route isn't a weak-password side door.
+ */
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_COMPLEXITY = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/;
+
+/** Current-user endpoint + progress upserts (REIMPLEMENTATION_GUIDE §3, §7.1). */
+@Public()
+@UseGuards(AbsAuthGuard)
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller('api/me')
+export class AbsMeController {
+  constructor(
+    private readonly progressService: AbsProgressService,
+    private readonly libraryService: LibraryService,
+    private readonly catalogService: AbsCatalogService,
+    private readonly bookmarkService: AbsBookmarkService,
+    private readonly authService: AuthService,
+    private readonly sessionHistoryService: AbsSessionHistoryService,
+  ) {}
+
+  @Get()
+  async me(@CurrentUser() user: RequestUser, @Req() req: FastifyRequest): Promise<Record<string, unknown>> {
+    const [mediaProgress, bookmarks, accessibleIds] = await Promise.all([
+      this.progressService.listMediaProgressForUser(user.id),
+      this.bookmarkService.listForUser(user.id),
+      this.libraryService.findAccessibleLibraryIds(user),
+    ]);
+    return toAbsUser(user, {
+      mediaProgress,
+      bookmarks,
+      librariesAccessible: user.isSuperuser ? [] : accessibleIds.map((id) => encodeAbsId('library', id)),
+      // Live ABS always sends a token string on /api/me; echo the caller's bearer so the legacy
+      // `token` field is never null (a null fails non-optional String decodes in strict clients).
+      legacyToken: extractAbsToken(req) ?? undefined,
+    });
+  }
+
+  /** Continue-listening shelf. */
+  @Get('items-in-progress')
+  async itemsInProgress(@CurrentUser() user: RequestUser): Promise<Record<string, unknown>> {
+    const libraryItems = await this.catalogService.itemsInProgress(user);
+    return { libraryItems };
+  }
+
+  /** Paginated listening history from the persisted session log (REIMPLEMENTATION_GUIDE §7/§8). */
+  @Get('listening-sessions')
+  async listeningSessions(@CurrentUser() user: RequestUser, @Query() query: Record<string, string>): Promise<Record<string, unknown>> {
+    return this.sessionHistoryService.listeningSessions(user, query ?? {});
+  }
+
+  /**
+   * "Remove from Continue Listening" (ABS `MeController.removeItemFromContinueListening`). Marks the
+   * progress row hidden and, like ABS, responds with the full `/api/me` user JSON. 404 when the id is
+   * malformed, names another user, or there is no progress row. Declared before `progress/:id/:episodeId?`
+   * so the static tail segment wins the route match.
+   */
+  @Get('progress/:id/remove-from-continue-listening')
+  async removeFromContinueListening(
+    @CurrentUser() user: RequestUser,
+    @Param('id') id: string,
+    @Req() req: FastifyRequest,
+  ): Promise<Record<string, unknown>> {
+    const bookId = this.resolveProgressBookId(user, id);
+    if (bookId === null) throw AbsHttpException.notFound();
+    const hidden = await this.progressService.hideFromContinueListening(user.id, bookId);
+    if (!hidden) throw AbsHttpException.notFound();
+    return this.me(user, req);
+  }
+
+  /** Read one MediaProgress; 404 when there is none. Episode segment is ignored (no podcasts). */
+  @Get('progress/:id/:episodeId?')
+  async getProgress(@CurrentUser() user: RequestUser, @Param('id') id: string): Promise<Record<string, unknown>> {
+    const bookId = decodeAbsId('libraryItem', id);
+    if (bookId === null) throw AbsHttpException.notFound();
+    const progress = await this.progressService.getMediaProgressByBook(user.id, bookId);
+    if (!progress) throw AbsHttpException.notFound();
+    return progress;
+  }
+
+  /** Stateless upsert of one MediaProgress. */
+  @Patch('progress/:libraryItemId/:episodeId?')
+  @HttpCode(200)
+  async updateProgress(
+    @CurrentUser() user: RequestUser,
+    @Param('libraryItemId') libraryItemId: string,
+    @Body() body: AbsProgressBody,
+  ): Promise<Record<string, unknown>> {
+    const bookId = decodeAbsId('libraryItem', libraryItemId);
+    if (bookId === null) throw AbsHttpException.notFound();
+    const progress = await this.progressService.upsertFromBody(user.id, bookId, body ?? {});
+    if (!progress) throw AbsHttpException.notFound();
+    return progress;
+  }
+
+  /** Batch upsert; each entry carries its own `libraryItemId`. Best-effort, returns 200. */
+  @Patch('progress/batch/update')
+  @HttpCode(200)
+  async batchUpdateProgress(@CurrentUser() user: RequestUser, @Body() body: Array<AbsProgressBody & { libraryItemId?: string }>): Promise<void> {
+    if (!Array.isArray(body)) return;
+    for (const entry of body) {
+      const bookId = entry.libraryItemId ? decodeAbsId('libraryItem', entry.libraryItemId) : null;
+      if (bookId === null) continue;
+      await this.progressService.upsertFromBody(user.id, bookId, entry);
+    }
+  }
+
+  /**
+   * Delete a MediaProgress. ABS addresses it by the composite progress id (`usr_<u>-li_<b>`, as built
+   * in `AbsProgressService#toMediaProgress`); we also accept a bare `li_<b>`. The user segment, when
+   * present, must match the caller so one user can't clear another's progress. 404 when nothing exists.
+   */
+  @Delete('progress/:id')
+  @HttpCode(200)
+  async deleteProgress(@CurrentUser() user: RequestUser, @Param('id') id: string): Promise<void> {
+    const bookId = this.resolveProgressBookId(user, id);
+    if (bookId === null) throw AbsHttpException.notFound();
+    const removed = await this.progressService.deleteProgress(user.id, bookId);
+    if (!removed) throw AbsHttpException.notFound();
+  }
+
+  /**
+   * Change the caller's password (ABS `MeController.updatePassword`). Body is `{ password, newPassword }`.
+   * Delegates to BookOrbit's `AuthService.changePassword` for the single source of truth (hashing,
+   * audit event, web-session revocation, OIDC/shared blocking), then maps failures onto ABS's wire
+   * shapes: demo accounts → 403 bare, bad input / wrong current password → 400 text, success → 200.
+   * The ABS access token survives the change (it carries no `tokenVersion`), so the client stays in.
+   */
+  @Patch('password')
+  @HttpCode(200)
+  async changePassword(
+    @CurrentUser() user: RequestUser,
+    @Body() body: ChangePasswordBody,
+    @Req() req: FastifyRequest,
+    @Res({ passthrough: true }) reply: FastifyReply,
+  ): Promise<void> {
+    if (user.permissions.includes(Permission.DemoRestricted)) throw AbsHttpException.forbidden();
+
+    const { password, newPassword } = body ?? {};
+    if (typeof password !== 'string' || typeof newPassword !== 'string') {
+      throw AbsHttpException.text(400, 'Missing or invalid password or new password');
+    }
+    if (newPassword.length < PASSWORD_MIN_LENGTH || !PASSWORD_COMPLEXITY.test(newPassword)) {
+      throw AbsHttpException.text(
+        400,
+        'Invalid new password - must be at least 8 characters with an uppercase letter, a lowercase letter, and a digit',
+      );
+    }
+
+    try {
+      await this.authService.changePassword(user.id, { currentPassword: password, newPassword }, reply, req.ip);
+    } catch (err) {
+      if (err instanceof UnauthorizedException) throw AbsHttpException.text(400, 'Invalid password');
+      if (err instanceof BadRequestException) throw AbsHttpException.text(400, err.message);
+      throw err;
+    }
+  }
+
+  /** Per-item listening history; 404s on garbage/unknown ids (episode segment ignored — no podcasts). */
+  @Get('item/listening-sessions/:libraryItemId/:episodeId?')
+  async itemListeningSessions(
+    @CurrentUser() user: RequestUser,
+    @Param('libraryItemId') libraryItemId: string,
+    @Query() query: Record<string, string>,
+  ): Promise<Record<string, unknown>> {
+    return this.sessionHistoryService.itemListeningSessions(user, libraryItemId, query ?? {});
+  }
+
+  /** Aggregate listening stats over the persisted session log. */
+  @Get('listening-stats')
+  async listeningStats(@CurrentUser() user: RequestUser): Promise<Record<string, unknown>> {
+    return this.sessionHistoryService.listeningStats(user);
+  }
+
+  /** Year-in-review stats. Bad years behave like empty years (ABS returns zeroed stats too). */
+  @Get('stats/year/:year')
+  async statsForYear(@CurrentUser() user: RequestUser, @Param('year') year: string): Promise<Record<string, unknown>> {
+    const parsedYear = Number.parseInt(year, 10);
+    return this.sessionHistoryService.statsForYear(user, Number.isFinite(parsedYear) ? parsedYear : 0);
+  }
+
+  /** Create (or rename in place) an audio bookmark at `{ time, title }`. */
+  @Post('item/:id/bookmark')
+  async createBookmark(@CurrentUser() user: RequestUser, @Param('id') id: string, @Body() body: BookmarkBody): Promise<Record<string, unknown>> {
+    const bookId = decodeAbsId('libraryItem', id);
+    if (bookId === null || typeof body?.time !== 'number') throw AbsHttpException.notFound();
+    return this.bookmarkService.create(user.id, bookId, body.time, body.title ?? '');
+  }
+
+  /** Rename the bookmark at `{ time }`. */
+  @Patch('item/:id/bookmark')
+  async updateBookmark(@CurrentUser() user: RequestUser, @Param('id') id: string, @Body() body: BookmarkBody): Promise<Record<string, unknown>> {
+    const bookId = decodeAbsId('libraryItem', id);
+    if (bookId === null || typeof body?.time !== 'number') throw AbsHttpException.notFound();
+    const updated = await this.bookmarkService.update(user.id, bookId, body.time, body.title ?? '');
+    if (!updated) throw AbsHttpException.notFound();
+    return updated;
+  }
+
+  /** Remove the bookmark at `:time`. */
+  @Delete('item/:id/bookmark/:time')
+  @HttpCode(200)
+  async deleteBookmark(@CurrentUser() user: RequestUser, @Param('id') id: string, @Param('time') time: string): Promise<void> {
+    const bookId = decodeAbsId('libraryItem', id);
+    const seconds = Number.parseFloat(time);
+    if (bookId === null || !Number.isFinite(seconds)) throw AbsHttpException.notFound();
+    const removed = await this.bookmarkService.remove(user.id, bookId, seconds);
+    if (!removed) throw AbsHttpException.notFound();
+  }
+
+  /**
+   * Resolve the book id targeted by a delete-progress request. Accepts the composite progress id
+   * `usr_<u>-li_<b>` or a bare `li_<b>`. Returns null (→ 404) on malformed input or when the user
+   * segment names someone other than the caller.
+   */
+  private resolveProgressBookId(user: RequestUser, rawId: string): number | null {
+    const segments = rawId.split('-');
+    const userSegment = segments.find((seg) => seg.startsWith(`${ABS_ID_PREFIX.user}_`));
+    if (userSegment !== undefined && decodeAbsId('user', userSegment) !== user.id) return null;
+    const itemSegment = segments.find((seg) => seg.startsWith(`${ABS_ID_PREFIX.libraryItem}_`)) ?? rawId;
+    return decodeAbsId('libraryItem', itemSegment);
+  }
+}

--- a/server/src/modules/abs/controllers/abs-playlists.controller.ts
+++ b/server/src/modules/abs/controllers/abs-playlists.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, UseFilters, UseGuards } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+
+import { Public } from '../../../common/decorators/public.decorator';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsAuthGuard } from '../auth/abs-auth.guard';
+
+/**
+ * Playlists are not modelled in BookOrbit (its collections are filtered views, not ordered queues),
+ * so the list is intentionally empty. The route exists because clients call it on startup.
+ */
+@Public()
+@UseGuards(AbsAuthGuard)
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller('api/playlists')
+export class AbsPlaylistsController {
+  @Get()
+  list(): Record<string, unknown> {
+    return { results: [], total: 0, limit: 0, page: 0 };
+  }
+}

--- a/server/src/modules/abs/controllers/abs-public.controller.test.ts
+++ b/server/src/modules/abs/controllers/abs-public.controller.test.ts
@@ -1,0 +1,49 @@
+import type { AbsAudioFileRow } from '../abs-read.repository';
+import type { AbsPlaybackService } from '../services/abs-playback.service';
+import type { AbsStreamService } from '../services/abs-stream.service';
+import { makeReply, makeRequest, thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsPublicController } from './abs-public.controller';
+
+const FILE: AbsAudioFileRow = {
+  id: 10,
+  bookId: 3,
+  format: 'mp3',
+  sortOrder: 0,
+  durationSeconds: 100,
+  sizeBytes: 1000,
+  absolutePath: '/books/3/10.mp3',
+};
+
+function build(trackFile: AbsAudioFileRow | null) {
+  const playbackService = { trackFile: vi.fn().mockReturnValue(trackFile) } as unknown as AbsPlaybackService;
+  const streamService = { streamFile: vi.fn().mockResolvedValue(undefined) } as unknown as AbsStreamService;
+  return { controller: new AbsPublicController(playbackService, streamService), playbackService, streamService };
+}
+
+describe('AbsPublicController#track', () => {
+  it('404s on a non-numeric track index', async () => {
+    const { controller } = build(FILE);
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.track('sess-1', 'abc', makeRequest(), reply))).toBe(404);
+  });
+
+  it('404s on a negative track index', async () => {
+    const { controller } = build(FILE);
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.track('sess-1', '-1', makeRequest(), reply))).toBe(404);
+  });
+
+  it('404s when the session/track cannot be resolved', async () => {
+    const { controller } = build(null);
+    const { reply } = makeReply();
+    expect(await thrownStatus(() => controller.track('sess-1', '0', makeRequest(), reply))).toBe(404);
+  });
+
+  it('streams the resolved track file with range support', async () => {
+    const { controller, streamService } = build(FILE);
+    const { reply } = makeReply();
+    const req = makeRequest({ headers: { range: 'bytes=0-100' } });
+    await controller.track('sess-1', '0', req, reply);
+    expect(streamService.streamFile).toHaveBeenCalledWith(req, reply, FILE.absolutePath, FILE.format);
+  });
+});

--- a/server/src/modules/abs/controllers/abs-public.controller.ts
+++ b/server/src/modules/abs/controllers/abs-public.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Param, Req, Res, UseFilters } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { Public } from '../../../common/decorators/public.decorator';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+import { AbsPlaybackService } from '../services/abs-playback.service';
+import { AbsStreamService } from '../services/abs-stream.service';
+
+/**
+ * Direct-track byte streaming for an open session (REIMPLEMENTATION_GUIDE §5.4). Authorized by the
+ * opaque open-session id rather than a JWT, so this route is unauthenticated.
+ */
+@Public()
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller('public/session')
+export class AbsPublicController {
+  constructor(
+    private readonly playbackService: AbsPlaybackService,
+    private readonly streamService: AbsStreamService,
+  ) {}
+
+  @Get(':id/track/:index')
+  async track(@Param('id') id: string, @Param('index') index: string, @Req() req: FastifyRequest, @Res() reply: FastifyReply): Promise<void> {
+    const trackIndex = Number.parseInt(index, 10);
+    if (!Number.isInteger(trackIndex) || trackIndex < 0) throw AbsHttpException.notFound();
+
+    const file = this.playbackService.trackFile(id, trackIndex);
+    if (!file) throw AbsHttpException.notFound();
+
+    await this.streamService.streamFile(req, reply, file.absolutePath, file.format);
+  }
+}

--- a/server/src/modules/abs/controllers/abs-sessions.controller.test.ts
+++ b/server/src/modules/abs/controllers/abs-sessions.controller.test.ts
@@ -1,0 +1,43 @@
+import type { AbsPlaybackService } from '../services/abs-playback.service';
+import { makeAbsUser } from '../__testing__/abs-test-helpers';
+import { AbsSessionsController } from './abs-sessions.controller';
+
+function build() {
+  const playbackService = {
+    getSession: vi.fn().mockReturnValue({ id: 'sess-1' }),
+    sync: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AbsPlaybackService;
+  return { controller: new AbsSessionsController(playbackService), playbackService };
+}
+
+describe('AbsSessionsController', () => {
+  it('getSession returns the open session for the owner', () => {
+    const { controller, playbackService } = build();
+    const user = makeAbsUser();
+    expect(controller.getSession(user, 'sess-1')).toEqual({ id: 'sess-1' });
+    expect(playbackService.getSession).toHaveBeenCalledWith('sess-1', user);
+  });
+
+  it('sync forwards the body to the playback service (200 on success)', async () => {
+    const { controller, playbackService } = build();
+    const user = makeAbsUser();
+    const body = { currentTime: 120, timeListened: 30 };
+    await controller.sync(user, 'sess-1', body);
+    expect(playbackService.sync).toHaveBeenCalledWith('sess-1', user, body);
+  });
+
+  it('sync tolerates an empty body', async () => {
+    const { controller, playbackService } = build();
+    await controller.sync(makeAbsUser(), 'sess-1', undefined as never);
+    expect(playbackService.sync).toHaveBeenCalledWith('sess-1', expect.anything(), {});
+  });
+
+  it('close forwards the optional final sync body', async () => {
+    const { controller, playbackService } = build();
+    const user = makeAbsUser();
+    const body = { currentTime: 300 };
+    await controller.close(user, 'sess-1', body);
+    expect(playbackService.close).toHaveBeenCalledWith('sess-1', user, body);
+  });
+});

--- a/server/src/modules/abs/controllers/abs-sessions.controller.ts
+++ b/server/src/modules/abs/controllers/abs-sessions.controller.ts
@@ -1,0 +1,63 @@
+import { Body, Controller, Get, HttpCode, Param, Post, Req, UseFilters, UseGuards } from '@nestjs/common';
+import { SkipThrottle } from '@nestjs/throttler';
+import type { FastifyRequest } from 'fastify';
+
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { Public } from '../../../common/decorators/public.decorator';
+import type { RequestUser } from '../../../common/types/request-user';
+import { AbsExceptionFilter } from '../abs-exception.filter';
+import { AbsHttpException } from '../abs-errors';
+import { AbsAuthGuard } from '../auth/abs-auth.guard';
+import { AbsPlaybackService, type LocalSessionBody, type SyncBody } from '../services/abs-playback.service';
+
+/** Open playback-session sync/close lifecycle + offline reconciliation (REIMPLEMENTATION_GUIDE §7). */
+@Public()
+@UseGuards(AbsAuthGuard)
+@UseFilters(AbsExceptionFilter)
+@SkipThrottle()
+@Controller('api/session')
+export class AbsSessionsController {
+  constructor(private readonly playbackService: AbsPlaybackService) {}
+
+  /**
+   * Sync one offline-recorded session (newest-updatedAt-wins). ABS responds with a bare
+   * `sendStatus(200)` ("OK") on success and a 500 text on failure — no result JSON here.
+   */
+  @Post('local')
+  @HttpCode(200)
+  async syncLocal(@CurrentUser() user: RequestUser, @Body() body: LocalSessionBody, @Req() req: FastifyRequest): Promise<string> {
+    const result = await this.playbackService.syncLocalSession(user, body ?? {}, { ipAddress: req.ip });
+    if (result.success !== true) {
+      throw AbsHttpException.text(500, typeof result.error === 'string' ? result.error : 'Failed to sync local session');
+    }
+    return 'OK';
+  }
+
+  /** Sync many offline-recorded sessions ⇒ `{ results: [...] }`. */
+  @Post('local-all')
+  @HttpCode(200)
+  async syncLocalAll(
+    @CurrentUser() user: RequestUser,
+    @Body() body: { sessions?: LocalSessionBody[]; deviceInfo?: Record<string, unknown> },
+    @Req() req: FastifyRequest,
+  ): Promise<Record<string, unknown>> {
+    return this.playbackService.syncLocalSessions(user, body?.sessions ?? [], { deviceInfo: body?.deviceInfo, ipAddress: req.ip });
+  }
+
+  @Get(':id')
+  getSession(@CurrentUser() user: RequestUser, @Param('id') id: string): Record<string, unknown> {
+    return this.playbackService.getSession(id, user);
+  }
+
+  @Post(':id/sync')
+  @HttpCode(200)
+  async sync(@CurrentUser() user: RequestUser, @Param('id') id: string, @Body() body: SyncBody): Promise<void> {
+    await this.playbackService.sync(id, user, body ?? {});
+  }
+
+  @Post(':id/close')
+  @HttpCode(200)
+  async close(@CurrentUser() user: RequestUser, @Param('id') id: string, @Body() body: SyncBody): Promise<void> {
+    await this.playbackService.close(id, user, body);
+  }
+}

--- a/server/src/modules/abs/mappers/abs-author.mapper.test.ts
+++ b/server/src/modules/abs/mappers/abs-author.mapper.test.ts
@@ -1,0 +1,27 @@
+import { toAbsAuthor } from './abs-author.mapper';
+
+describe('toAbsAuthor', () => {
+  it('maps an author to the ABS shape with an encoded id and the listing libraryId', () => {
+    expect(toAbsAuthor({ id: 1, name: 'Andy Weir', description: 'bio', numBooks: 3 }, 'lib_4')).toEqual({
+      id: 'aut_1',
+      asin: null,
+      name: 'Andy Weir',
+      description: 'bio',
+      imagePath: null,
+      libraryId: 'lib_4',
+      addedAt: 0,
+      updatedAt: 0,
+      numBooks: 3,
+      lastFirst: 'Weir, Andy',
+    });
+  });
+
+  it('defaults numBooks to 0 and description to null when absent', () => {
+    expect(toAbsAuthor({ id: 2, name: 'Brandon Sanderson', description: null }, 'lib_4')).toMatchObject({
+      id: 'aut_2',
+      description: null,
+      libraryId: 'lib_4',
+      numBooks: 0,
+    });
+  });
+});

--- a/server/src/modules/abs/mappers/abs-author.mapper.ts
+++ b/server/src/modules/abs/mappers/abs-author.mapper.ts
@@ -1,0 +1,40 @@
+import { encodeAbsId } from '../abs-id.util';
+
+export interface AbsAuthorRow {
+  id: number;
+  name: string;
+  description: string | null;
+  numBooks?: number;
+}
+
+/** ABS sorts/indexes authors by a "Last, First" key; mirror its basic split on the final space. */
+export function toLastFirst(name: string): string {
+  const trimmed = name.trim();
+  const idx = trimmed.lastIndexOf(' ');
+  return idx === -1 ? trimmed : `${trimmed.slice(idx + 1)}, ${trimmed.slice(0, idx)}`;
+}
+
+/**
+ * Map a BookOrbit author to the ABS Author shape (`LibraryController.getAuthors` /
+ * `AuthorController.findOne`, mirroring `Author.toOldJSONExpanded`). BookOrbit has no
+ * ASIN/timestamps/image-path for authors, so those are emitted as the nullable/zero defaults ABS
+ * uses for unknown values. The full field set matters: author-centric clients (e.g. Prologue) decode
+ * the Author model with non-optional keys — notably `libraryId` and `numBooks` — and drop the entire
+ * authors list (blanking the library) if any is absent. `lastFirst` drives the client's A–Z index.
+ * BookOrbit authors are global (linked to libraries only via books), so `libraryAbsId` is the library
+ * the author is being listed under.
+ */
+export function toAbsAuthor(author: AbsAuthorRow, libraryAbsId: string): Record<string, unknown> {
+  return {
+    id: encodeAbsId('author', author.id),
+    asin: null,
+    name: author.name,
+    description: author.description ?? null,
+    imagePath: null,
+    libraryId: libraryAbsId,
+    addedAt: 0,
+    updatedAt: 0,
+    numBooks: author.numBooks ?? 0,
+    lastFirst: toLastFirst(author.name),
+  };
+}

--- a/server/src/modules/abs/mappers/abs-item.mapper.test.ts
+++ b/server/src/modules/abs/mappers/abs-item.mapper.test.ts
@@ -1,0 +1,166 @@
+import type { AbsAudioFileRow, AbsItemRow } from '../abs-read.repository';
+import { buildDirectPlayTracks, toAbsLibraryItem, type AbsItemRelations } from './abs-item.mapper';
+
+function makeItem(overrides: Partial<AbsItemRow> = {}): AbsItemRow {
+  return {
+    id: 3,
+    libraryId: 5,
+    status: 'ready',
+    addedAt: new Date('2024-01-01T00:00:00Z'),
+    updatedAt: new Date('2024-02-01T00:00:00Z'),
+    title: 'The Hobbit',
+    subtitle: null,
+    description: 'A tale',
+    publishedYear: 1937,
+    publisher: 'Allen & Unwin',
+    language: 'en',
+    isbn13: '9780000000001',
+    isbn10: null,
+    seriesName: null,
+    seriesIndex: null,
+    durationSeconds: null,
+    chapters: [{ start: 0, end: 60, title: 'One' }],
+    ...overrides,
+  };
+}
+
+function file(id: number, durationSeconds: number, sizeBytes: number): AbsAudioFileRow {
+  return { id, bookId: 3, format: 'mp3', sortOrder: id, durationSeconds, sizeBytes, absolutePath: `/books/3/${id}.mp3` };
+}
+
+const relations: AbsItemRelations = {
+  authors: [{ id: 1, name: 'Tolkien' }],
+  narrators: [{ name: 'Rob Inglis' }],
+  series: [{ id: 2, name: 'Middle Earth', sequence: 1 }],
+  audioFiles: [file(10, 100, 1000), file(11, 200, 2000)],
+};
+
+describe('toAbsLibraryItem', () => {
+  it('builds an expanded item with audio files, chapters, and summed duration/size', () => {
+    const item = toAbsLibraryItem(makeItem(), relations);
+    expect(item.id).toBe('li_3');
+    expect(item.ino).toBe('3');
+    expect(item.libraryId).toBe('lib_5');
+    expect(item.mediaType).toBe('book');
+    // ABS always emits oldLibraryItemId (null); omitting the key makes Swift's decode(String?.self)
+    // throw on absence, so strict clients (Prologue) silently drop every item. Must be present.
+    expect('oldLibraryItemId' in item).toBe(true);
+    expect(item.oldLibraryItemId).toBeNull();
+
+    const media = item.media as Record<string, unknown>;
+    expect(media.id).toBe('bk_3');
+    expect(media.duration).toBe(300); // 100 + 200
+    expect(media.size).toBe(3000);
+    expect(Array.isArray(media.audioFiles)).toBe(true);
+    expect((media.audioFiles as unknown[]).length).toBe(2);
+    expect(media.chapters).toEqual([{ id: 0, start: 0, end: 60, title: 'One' }]);
+
+    // Book.toOldJSONExpanded carries tracks (Prologue's "book contents") — audio-file JSON plus
+    // title/startOffset/contentUrl — and no numTracks count.
+    expect(media.numTracks).toBeUndefined();
+    const tracks = media.tracks as Record<string, unknown>[];
+    expect(tracks).toHaveLength(2);
+    expect(tracks[0]).toMatchObject({ index: 1, startOffset: 0, duration: 100, contentUrl: '/api/items/li_3/file/10', title: '10.mp3' });
+    expect(tracks[1]).toMatchObject({ index: 2, startOffset: 100, duration: 200, contentUrl: '/api/items/li_3/file/11' });
+
+    // LibraryItem.toOldJSONExpanded: scan info + full libraryFiles, no numFiles count.
+    expect(item.numFiles).toBeUndefined();
+    expect(item.lastScan).toBeDefined();
+    expect(item.scanVersion).toBeDefined();
+    const libraryFiles = item.libraryFiles as Record<string, unknown>[];
+    expect(libraryFiles).toHaveLength(2);
+    expect(libraryFiles[0]).toMatchObject({ ino: '10', fileType: 'audio', isSupplementary: null });
+    expect((libraryFiles[0].metadata as Record<string, unknown>).filename).toBe('10.mp3');
+
+    // Real ABS files always carry probe tags; clients surface tagTitle/tagArtist directly (e.g.
+    // Prologue's download queue), so audio files get the book's title/author, never empty tags.
+    const audioFile = (media.audioFiles as Record<string, unknown>[])[0];
+    expect(audioFile.metaTags).toEqual({ tagAlbum: 'The Hobbit', tagArtist: 'Tolkien', tagTitle: 'The Hobbit' });
+    expect(audioFile.invalid).toBeUndefined();
+    expect(audioFile.addedAt).toBe(new Date('2024-01-01T00:00:00Z').getTime());
+
+    const metadata = media.metadata as Record<string, unknown>;
+    expect(metadata.title).toBe('The Hobbit');
+    expect(metadata.authorName).toBe('Tolkien');
+    expect(metadata.narratorName).toBe('Rob Inglis');
+    expect(metadata.seriesName).toBe('Middle Earth #1');
+    expect(metadata.isbn).toBe('9780000000001');
+  });
+
+  it('minified media/metadata carry exactly the ABS toOldJSONMinified key sets', () => {
+    const item = toAbsLibraryItem(makeItem(), relations, { minified: true });
+    const media = item.media as Record<string, unknown>;
+    // Book.toOldJSONMinified: no audioFiles, no libraryItemId, no part counts (extra keys break
+    // strict Codable clients whose optional properties decode stricter shapes than we send).
+    expect(Object.keys(media).sort()).toEqual([
+      'coverPath',
+      'duration',
+      'id',
+      'metadata',
+      'numAudioFiles',
+      'numChapters',
+      'numTracks',
+      'size',
+      'tags',
+    ]);
+    expect(media.numTracks).toBe(2);
+    expect(media.duration).toBe(300);
+    // oldMetadataToJSONMinified: flattened name strings only — never authors/narrators/series arrays.
+    const metadata = media.metadata as Record<string, unknown>;
+    expect(metadata.authors).toBeUndefined();
+    expect(metadata.narrators).toBeUndefined();
+    expect(metadata.series).toBeUndefined();
+    expect(metadata.authorName).toBeDefined();
+    expect(metadata.narratorName).toBeDefined();
+    expect(metadata.seriesName).toBeDefined();
+  });
+
+  it('formats authorNameLF as "Last, First" joined across authors', () => {
+    const rel = {
+      ...relations,
+      authors: [
+        { id: 1, name: 'Adrian Tchaikovsky' },
+        { id: 2, name: 'Dennis E. Taylor' },
+      ],
+    };
+    const item = toAbsLibraryItem(makeItem(), rel, { minified: true });
+    const metadata = (item.media as Record<string, unknown>).metadata as Record<string, unknown>;
+    expect(metadata.authorName).toBe('Adrian Tchaikovsky, Dennis E. Taylor');
+    expect(metadata.authorNameLF).toBe('Tchaikovsky, Adrian, Taylor, Dennis E.');
+  });
+
+  it('attaches userMediaProgress when supplied, including explicit null (ABS include=progress)', () => {
+    const withProgress = toAbsLibraryItem(makeItem(), relations, { mediaProgress: { progress: 0.5 } });
+    expect(withProgress.userMediaProgress).toEqual({ progress: 0.5 });
+    // ?include=progress with no progress row: ABS emits the key with an explicit null.
+    const withNull = toAbsLibraryItem(makeItem(), relations, { mediaProgress: null });
+    expect('userMediaProgress' in withNull).toBe(true);
+    expect(withNull.userMediaProgress).toBeNull();
+    const without = toAbsLibraryItem(makeItem(), relations);
+    expect('userMediaProgress' in without).toBe(false);
+  });
+
+  it('flags missing items via isMissing', () => {
+    expect(toAbsLibraryItem(makeItem({ status: 'missing' }), relations).isMissing).toBe(true);
+    expect(toAbsLibraryItem(makeItem({ status: 'ready' }), relations).isMissing).toBe(false);
+  });
+});
+
+describe('buildDirectPlayTracks', () => {
+  it('produces one track per file with cumulative startOffset and open-session contentUrls', () => {
+    const tracks = buildDirectPlayTracks('sess-1', relations.audioFiles);
+    expect(tracks).toHaveLength(2);
+    expect(tracks[0]).toMatchObject({
+      index: 0,
+      startOffset: 0,
+      duration: 100,
+      contentUrl: '/public/session/sess-1/track/0',
+      mimeType: 'audio/mpeg',
+    });
+    expect(tracks[1]).toMatchObject({ index: 1, startOffset: 100, duration: 200, contentUrl: '/public/session/sess-1/track/1' });
+  });
+
+  it('returns an empty list when there are no audio files', () => {
+    expect(buildDirectPlayTracks('sess-1', [])).toEqual([]);
+  });
+});

--- a/server/src/modules/abs/mappers/abs-item.mapper.ts
+++ b/server/src/modules/abs/mappers/abs-item.mapper.ts
@@ -1,0 +1,298 @@
+import { ABS_MEDIA_TYPE_BOOK, ABS_SERVER_VERSION } from '../abs.constants';
+import { encodeAbsId } from '../abs-id.util';
+import { audioMimeType, normalizeChapters, type AbsChapter } from '../abs-media.util';
+import type { AbsAudioFileRow, AbsItemRow } from '../abs-read.repository';
+import { toLastFirst } from './abs-author.mapper';
+
+export interface AbsItemRelations {
+  authors: { id: number; name: string }[];
+  narrators: { name: string }[];
+  series: { id: number; name: string; sequence: number | null }[];
+  audioFiles: AbsAudioFileRow[];
+}
+
+function toEpochMs(value: Date | string | null | undefined): number {
+  if (!value) return 0;
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}
+
+function basename(path: string): string {
+  const idx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  return idx === -1 ? path : path.slice(idx + 1);
+}
+
+/**
+ * ABS metadata block. The minified shape (`Book.oldMetadataToJSONMinified`) carries ONLY the
+ * flattened name strings — real ABS never emits the `authors`/`narrators`/`series` arrays there.
+ * Sending them as a "harmless superset" breaks strict Codable clients (Prologue): an optional
+ * `authors` property decoded with decodeIfPresent is skipped when the key is absent (real ABS) but
+ * THROWS when present with fewer keys than the client's Author model requires — dropping the whole
+ * item page. The expanded shape (`oldMetadataToJSONExpanded`) has arrays AND flattened strings.
+ */
+function buildMetadata(item: AbsItemRow, rel: AbsItemRelations, minified: boolean): Record<string, unknown> {
+  const authorName = rel.authors.map((a) => a.name).join(', ');
+  const flattened = {
+    title: item.title ?? '',
+    titleIgnorePrefix: item.title ?? '',
+    subtitle: item.subtitle ?? null,
+    authorName,
+    authorNameLF: rel.authors.map((a) => toLastFirst(a.name)).join(', '),
+    narratorName: rel.narrators.map((n) => n.name).join(', '),
+    seriesName: rel.series.map((s) => (s.sequence != null ? `${s.name} #${s.sequence}` : s.name)).join(', '),
+  };
+  const shared = {
+    genres: [],
+    publishedYear: item.publishedYear != null ? String(item.publishedYear) : null,
+    publishedDate: null,
+    publisher: item.publisher ?? null,
+    description: item.description ?? null,
+    isbn: item.isbn13 ?? item.isbn10 ?? null,
+    asin: null,
+    language: item.language ?? null,
+    explicit: false,
+    abridged: false,
+  };
+  if (minified) return { ...flattened, ...shared };
+  return {
+    ...flattened,
+    authors: rel.authors.map((a) => ({ id: encodeAbsId('author', a.id), name: a.name })),
+    narrators: rel.narrators.map((n) => n.name),
+    series: rel.series.map((s) => ({ id: encodeAbsId('series', s.id), name: s.name, sequence: s.sequence != null ? String(s.sequence) : null })),
+    ...shared,
+    descriptionPlain: item.description != null ? item.description.replace(/<[^>]*>/g, '') : null,
+  };
+}
+
+/**
+ * Book-level context for file-shaped objects. Real ABS files always carry probe/tag data and real
+ * timestamps; clients surface these directly (e.g. a download-queue row titled by `tagTitle`), so
+ * emitting empty tags or zero times degrades UI even though it decodes.
+ */
+interface AbsFileContext {
+  title: string;
+  authorName: string;
+  addedAtMs: number;
+  updatedAtMs: number;
+}
+
+/** ABS FileMetadata block, shared by audioFiles, tracks, and libraryFiles. */
+function toAbsFileMetadata(file: AbsAudioFileRow, ctx: AbsFileContext): Record<string, unknown> {
+  return {
+    filename: basename(file.absolutePath),
+    ext: file.format ? `.${file.format.toLowerCase()}` : '',
+    path: file.absolutePath,
+    relPath: basename(file.absolutePath),
+    size: file.sizeBytes ?? 0,
+    mtimeMs: ctx.updatedAtMs,
+    ctimeMs: ctx.updatedAtMs,
+    birthtimeMs: ctx.addedAtMs,
+  };
+}
+
+function toAbsAudioFile(file: AbsAudioFileRow, index: number, ctx: AbsFileContext): Record<string, unknown> {
+  return {
+    // ABS AudioFile.index is 1-based (first file is index 1).
+    index: index + 1,
+    ino: String(file.id),
+    metadata: toAbsFileMetadata(file, ctx),
+    addedAt: ctx.addedAtMs,
+    updatedAt: ctx.updatedAtMs,
+    trackNumFromMeta: index + 1,
+    discNumFromMeta: null,
+    trackNumFromFilename: null,
+    discNumFromFilename: null,
+    manuallyVerified: false,
+    exclude: false,
+    error: null,
+    format: file.format ?? '',
+    duration: file.durationSeconds ?? 0,
+    bitRate: 0,
+    language: null,
+    codec: file.format ?? '',
+    timeBase: '1/1000',
+    channels: 2,
+    channelLayout: 'stereo',
+    chapters: [],
+    embeddedCoverArt: null,
+    metaTags: {
+      tagAlbum: ctx.title,
+      tagArtist: ctx.authorName,
+      tagTitle: ctx.title,
+    },
+    mimeType: audioMimeType(file.format),
+  };
+}
+
+/**
+ * Build a direct-play AudioTrack list (playMethod=0). `startOffset` is cumulative so the client can
+ * seek across the whole book; `contentUrl` points at the open-session track endpoint, which streams
+ * raw bytes with HTTP Range support (REIMPLEMENTATION_GUIDE §5.2, §5.4).
+ */
+export function buildDirectPlayTracks(sessionId: string, audioFiles: AbsAudioFileRow[]): Record<string, unknown>[] {
+  let startOffset = 0;
+  return audioFiles.map((file, index) => {
+    const duration = file.durationSeconds ?? 0;
+    const track = {
+      index,
+      startOffset,
+      duration,
+      title: basename(file.absolutePath),
+      contentUrl: `/public/session/${sessionId}/track/${index}`,
+      mimeType: audioMimeType(file.format),
+      codec: file.format ?? '',
+      metadata: {
+        filename: basename(file.absolutePath),
+        ext: file.format ? `.${file.format.toLowerCase()}` : '',
+        path: file.absolutePath,
+        relPath: basename(file.absolutePath),
+        size: file.sizeBytes ?? 0,
+      },
+    };
+    startOffset += duration;
+    return track;
+  });
+}
+
+/**
+ * Build the single synthetic AudioTrack for a transcode session (playMethod=2). `contentUrl` is the
+ * HLS playlist under `/hls/:streamId`; the client plays the whole book as one stream
+ * (REIMPLEMENTATION_GUIDE §5.2).
+ */
+export function buildTranscodeTrack(streamId: string, duration: number): Record<string, unknown> {
+  return {
+    index: 0,
+    startOffset: 0,
+    duration,
+    title: `${streamId}.m3u8`,
+    contentUrl: `/hls/${streamId}/output.m3u8`,
+    mimeType: 'application/vnd.apple.mpegurl',
+    codec: 'aac',
+    metadata: null,
+  };
+}
+
+export interface ToAbsLibraryItemOptions {
+  minified?: boolean;
+  /**
+   * ABS MediaProgress for the current user. Pass a value (or explicit null) to emit the
+   * userMediaProgress key — ABS emits `userMediaProgress: null` on `?include=progress` when the
+   * user has none, and omits the key entirely without the include. Leave undefined to omit.
+   */
+  mediaProgress?: Record<string, unknown> | null;
+}
+
+/** Map a BookOrbit book to an ABS LibraryItem (expanded by default, minified on request). */
+export function toAbsLibraryItem(item: AbsItemRow, rel: AbsItemRelations, opts: ToAbsLibraryItemOptions = {}): Record<string, unknown> {
+  const libraryItemId = encodeAbsId('libraryItem', item.id);
+  const bookAbsId = encodeAbsId('book', item.id);
+  const duration = rel.audioFiles.reduce((sum, f) => sum + (f.durationSeconds ?? 0), 0);
+  const size = rel.audioFiles.reduce((sum, f) => sum + (f.sizeBytes ?? 0), 0);
+  const numTracks = rel.audioFiles.length;
+  const metadata = buildMetadata(item, rel, opts.minified ?? false);
+  const coverPath = `/metadata/items/${item.id}/cover`;
+  const chapters = buildItemChapters(item.chapters, duration);
+  const fileCtx: AbsFileContext = {
+    title: item.title ?? '',
+    authorName: rel.authors.map((a) => a.name).join(', '),
+    addedAtMs: toEpochMs(item.addedAt),
+    updatedAtMs: toEpochMs(item.updatedAt),
+  };
+
+  // Minified media is EXACTLY ABS `Book.toOldJSONMinified`: no libraryItemId, no part counts
+  // (`ebookFormat` is omitted for audiobooks, matching ABS's undefined-key behavior). Expanded
+  // media is EXACTLY `Book.toOldJSONExpanded`: audioFiles + chapters + ebookFile + tracks, and no
+  // numTracks/numAudioFiles counts. Prologue reads the book's playable contents from `tracks` —
+  // without it the detail screen shows "Unable to load book contents" and play is disabled.
+  const media: Record<string, unknown> = opts.minified
+    ? {
+        id: bookAbsId,
+        metadata,
+        coverPath,
+        tags: [],
+        numTracks,
+        numAudioFiles: numTracks,
+        numChapters: chapters.length,
+        duration,
+        size,
+      }
+    : {
+        id: bookAbsId,
+        libraryItemId,
+        metadata,
+        coverPath,
+        tags: [],
+        audioFiles: rel.audioFiles.map((f, i) => toAbsAudioFile(f, i, fileCtx)),
+        chapters,
+        ebookFile: null,
+        duration,
+        size,
+        tracks: buildItemTracks(libraryItemId, rel.audioFiles, fileCtx),
+      };
+
+  const result: Record<string, unknown> = {
+    id: libraryItemId,
+    ino: String(item.id),
+    // ABS always emits oldLibraryItemId (null when absent). Swift's `decode(String?.self, forKey:)`
+    // throws on a MISSING key even though it accepts an explicit null, so omitting it makes strict
+    // clients (Prologue) silently drop every item — empty grid, no cover fetches. Always send it.
+    oldLibraryItemId: null,
+    libraryId: encodeAbsId('library', item.libraryId),
+    folderId: '',
+    path: '',
+    relPath: '',
+    isFile: false,
+    mtimeMs: toEpochMs(item.updatedAt),
+    ctimeMs: toEpochMs(item.updatedAt),
+    birthtimeMs: toEpochMs(item.addedAt),
+    addedAt: toEpochMs(item.addedAt),
+    updatedAt: toEpochMs(item.updatedAt),
+    isMissing: item.status === 'missing',
+    isInvalid: false,
+    mediaType: ABS_MEDIA_TYPE_BOOK,
+    media,
+  };
+
+  if (opts.minified) {
+    // LibraryItem.toOldJSONMinified: numFiles + size, no scan info or file list.
+    result.numFiles = numTracks;
+    result.size = size;
+  } else {
+    // LibraryItem.toOldJSONExpanded: lastScan/scanVersion + full libraryFiles list.
+    result.lastScan = toEpochMs(item.updatedAt);
+    result.scanVersion = ABS_SERVER_VERSION;
+    result.libraryFiles = rel.audioFiles.map((f) => ({
+      ino: String(f.id),
+      metadata: toAbsFileMetadata(f, fileCtx),
+      isSupplementary: null,
+      addedAt: fileCtx.addedAtMs,
+      updatedAt: fileCtx.updatedAtMs,
+      fileType: 'audio',
+    }));
+    result.size = size;
+  }
+
+  if (opts.mediaProgress !== undefined) result.userMediaProgress = opts.mediaProgress;
+  return result;
+}
+
+/**
+ * ABS `Book.getTracklist`: each track is the AudioFile JSON plus title/startOffset/contentUrl,
+ * with contentUrl pointing at the inline file-stream route (`GET /api/items/:id/file/:ino`).
+ */
+function buildItemTracks(libraryItemAbsId: string, audioFiles: AbsAudioFileRow[], ctx: AbsFileContext): Record<string, unknown>[] {
+  let startOffset = 0;
+  return audioFiles.map((file, index) => {
+    const track = {
+      ...toAbsAudioFile(file, index, ctx),
+      title: basename(file.absolutePath),
+      startOffset,
+      contentUrl: `/api/items/${libraryItemAbsId}/file/${file.id}`,
+    };
+    startOffset += file.durationSeconds ?? 0;
+    return track;
+  });
+}
+
+function buildItemChapters(raw: unknown, duration: number): AbsChapter[] {
+  return normalizeChapters(raw, duration);
+}

--- a/server/src/modules/abs/mappers/abs-library.mapper.test.ts
+++ b/server/src/modules/abs/mappers/abs-library.mapper.test.ts
@@ -1,0 +1,68 @@
+import { toAbsLibrary } from './abs-library.mapper';
+
+describe('toAbsLibrary', () => {
+  it('encodes the id, maps folders, and reports mediaType book', () => {
+    const createdAt = new Date('2024-01-02T03:04:05.000Z');
+    const lib = toAbsLibrary({
+      id: 5,
+      name: 'Audiobooks',
+      icon: 'headphones',
+      displayOrder: 2,
+      coverAspectRatio: '1.6',
+      createdAt,
+      updatedAt: createdAt,
+      folders: [{ id: 11, path: '/data/audiobooks', createdAt }],
+    });
+
+    expect(lib.id).toBe('lib_5');
+    expect(lib.name).toBe('Audiobooks');
+    expect(lib.mediaType).toBe('book');
+    expect(lib.icon).toBe('headphones');
+    // ABS display order is 1-based; BookOrbit's 0-based value shifts up by one.
+    expect(lib.displayOrder).toBe(3);
+    expect(lib.createdAt).toBe(createdAt.getTime());
+    expect(lib.folders).toEqual([{ id: '11', fullPath: '/data/audiobooks', libraryId: 'lib_5', addedAt: createdAt.getTime() }]);
+    // ABS Library.toOldJSON always carries lastScan/lastScanVersion; strict clients may read a null
+    // lastScan as "never scanned" and hide content, so we mirror updatedAt as the effective scan.
+    expect(lib.lastScan).toBe(createdAt.getTime());
+    expect(lib.lastScanVersion).toEqual(expect.any(String));
+  });
+
+  it('maps a square cover aspect ratio to flag 1 and a standard one to flag 0 (ABS BookCoverAspectRatio)', () => {
+    expect((toAbsLibrary({ id: 1, name: 'a', coverAspectRatio: '1/1' }).settings as any).coverAspectRatio).toBe(1);
+    expect((toAbsLibrary({ id: 1, name: 'a', coverAspectRatio: '1' }).settings as any).coverAspectRatio).toBe(1);
+    expect((toAbsLibrary({ id: 1, name: 'a', coverAspectRatio: '1.6' }).settings as any).coverAspectRatio).toBe(0);
+  });
+
+  it('emits the full ABS 2.35.1 LibrarySettings field set', () => {
+    const settings = toAbsLibrary({ id: 1, name: 'a' }).settings as Record<string, unknown>;
+    expect(Object.keys(settings).sort()).toEqual([
+      'audiobooksOnly',
+      'autoScanCronExpression',
+      'coverAspectRatio',
+      'disableWatcher',
+      'epubsAllowScriptedContent',
+      'hideSingleBookSeries',
+      'markAsFinishedPercentComplete',
+      'markAsFinishedTimeRemaining',
+      'metadataPrecedence',
+      'onlyShowLaterBooksInContinueSeries',
+      'skipMatchingMediaWithAsin',
+      'skipMatchingMediaWithIsbn',
+    ]);
+  });
+
+  it('normalizes non-ABS icon values to the ABS icon set', () => {
+    expect(toAbsLibrary({ id: 1, name: 'a', icon: 'Mic' }).icon).toBe('microphone-1');
+    expect(toAbsLibrary({ id: 1, name: 'a', icon: 'BookOpen' }).icon).toBe('book-1');
+    expect(toAbsLibrary({ id: 1, name: 'a', icon: 'SomethingElse' }).icon).toBe('database');
+  });
+
+  it('applies sensible defaults when optional fields are absent', () => {
+    const lib = toAbsLibrary({ id: 7, name: 'Bare' });
+    expect(lib.folders).toEqual([]);
+    expect(lib.displayOrder).toBe(1);
+    expect(lib.icon).toBe('database');
+    expect(lib.createdAt).toBe(0);
+  });
+});

--- a/server/src/modules/abs/mappers/abs-library.mapper.ts
+++ b/server/src/modules/abs/mappers/abs-library.mapper.ts
@@ -1,0 +1,104 @@
+import { ABS_MEDIA_TYPE_BOOK, ABS_SERVER_VERSION } from '../abs.constants';
+import { encodeAbsId } from '../abs-id.util';
+
+interface LibraryFolderLike {
+  id: number;
+  path: string;
+  createdAt?: Date | string | null;
+}
+
+interface LibraryLike {
+  id: number;
+  name: string;
+  icon?: string | null;
+  displayOrder?: number | null;
+  coverAspectRatio?: string | null;
+  createdAt?: Date | string | null;
+  updatedAt?: Date | string | null;
+  folders?: LibraryFolderLike[];
+}
+
+function toEpochMs(value: Date | string | null | undefined): number {
+  if (!value) return 0;
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}
+
+/** ABS settings.coverAspectRatio (constants.BookCoverAspectRatio): 0 = standard 1.6:1, 1 = square. */
+function coverAspectRatioFlag(ratio: string | null | undefined): number {
+  return ratio === '1/1' || ratio === '1' ? 1 : 0;
+}
+
+/**
+ * ABS library icons are a fixed lowercase set (web client's icon picker); clients may decode the
+ * value as an enum, so an unknown value like BookOrbit's "Mic" can fail the whole libraries decode.
+ */
+const ABS_LIBRARY_ICONS = new Set([
+  'database',
+  'audiobookshelf',
+  'books-1',
+  'books-2',
+  'book-1',
+  'microphone-1',
+  'microphone-3',
+  'radio',
+  'podcast',
+  'rss',
+  'headphones',
+  'music',
+  'file-picture',
+  'rocket',
+  'power',
+  'star',
+  'heart',
+]);
+
+function toAbsIcon(icon: string | null | undefined): string {
+  if (!icon) return 'database';
+  const lower = icon.toLowerCase();
+  if (ABS_LIBRARY_ICONS.has(lower)) return lower;
+  if (lower === 'mic' || lower === 'microphone') return 'microphone-1';
+  if (lower.startsWith('book')) return 'book-1';
+  return 'database';
+}
+
+/** Map a BookOrbit library (as returned by LibraryService.findAll/findOne) to the ABS Library shape. */
+export function toAbsLibrary(library: LibraryLike): Record<string, unknown> {
+  const libraryAbsId = encodeAbsId('library', library.id);
+  return {
+    id: libraryAbsId,
+    name: library.name,
+    folders: (library.folders ?? []).map((folder) => ({
+      id: String(folder.id),
+      fullPath: folder.path,
+      libraryId: libraryAbsId,
+      addedAt: toEpochMs(folder.createdAt),
+    })),
+    // ABS display order is 1-based; BookOrbit's starts at 0.
+    displayOrder: (library.displayOrder ?? 0) + 1,
+    icon: toAbsIcon(library.icon),
+    mediaType: ABS_MEDIA_TYPE_BOOK,
+    provider: 'google',
+    // Full LibrarySettings field set as emitted by live ABS 2.35.1 — strict clients may decode
+    // this object with non-optional keys. Values are ABS defaults where BookOrbit has no concept.
+    settings: {
+      coverAspectRatio: coverAspectRatioFlag(library.coverAspectRatio),
+      disableWatcher: true,
+      skipMatchingMediaWithAsin: false,
+      skipMatchingMediaWithIsbn: false,
+      autoScanCronExpression: null,
+      audiobooksOnly: false,
+      epubsAllowScriptedContent: false,
+      hideSingleBookSeries: false,
+      onlyShowLaterBooksInContinueSeries: false,
+      metadataPrecedence: ['folderStructure', 'audioMetatags', 'nfoFile', 'txtFiles', 'opfFile', 'absMetadata'],
+      markAsFinishedPercentComplete: null,
+      markAsFinishedTimeRemaining: 10,
+    },
+    // ABS Library.toOldJSON always carries these; a null lastScan can read as "never scanned" to
+    // strict clients. BookOrbit has no scan concept, so mirror updatedAt as the effective last scan.
+    lastScan: toEpochMs(library.updatedAt) || null,
+    lastScanVersion: ABS_SERVER_VERSION,
+    createdAt: toEpochMs(library.createdAt),
+    lastUpdate: toEpochMs(library.updatedAt),
+  };
+}

--- a/server/src/modules/abs/mappers/abs-session.mapper.test.ts
+++ b/server/src/modules/abs/mappers/abs-session.mapper.test.ts
@@ -1,0 +1,119 @@
+import type { AbsPlaybackSessionRow } from '../../../db/schema';
+import { absDateParts, buildAbsDeviceInfo, toAbsSessionJson } from './abs-session.mapper';
+
+function row(overrides: Partial<AbsPlaybackSessionRow> = {}): AbsPlaybackSessionRow {
+  return {
+    id: 'f1e2d3c4-0000-4000-8000-000000000001',
+    userId: 3,
+    libraryId: 4,
+    bookId: 42,
+    displayTitle: 'The Hobbit',
+    displayAuthor: 'J.R.R. Tolkien',
+    coverPath: '/metadata/items/42/cover',
+    mediaMetadata: { title: 'The Hobbit' },
+    chapters: [],
+    duration: 300,
+    playMethod: 0,
+    mediaPlayer: 'AVPlayer',
+    deviceInfo: { deviceId: 'dev-1' },
+    serverVersion: '2.35.1',
+    date: '2026-07-12',
+    dayOfWeek: 'Sunday',
+    timeListening: 120,
+    startTimeSeconds: 10,
+    currentTimeSeconds: 130,
+    startedAt: new Date(1_700_000_000_000),
+    createdAt: new Date(1_700_000_000_000),
+    updatedAt: new Date(1_700_000_100_000),
+    ...overrides,
+  };
+}
+
+describe('toAbsSessionJson', () => {
+  it('emits EXACTLY the ABS PlaybackSession.toJSON key set (strict-Codable clients)', () => {
+    const json = toAbsSessionJson(row());
+    expect(Object.keys(json).sort()).toEqual(
+      [
+        'id',
+        'userId',
+        'libraryId',
+        'libraryItemId',
+        'bookId',
+        'episodeId',
+        'mediaType',
+        'mediaMetadata',
+        'chapters',
+        'displayTitle',
+        'displayAuthor',
+        'coverPath',
+        'duration',
+        'playMethod',
+        'mediaPlayer',
+        'deviceInfo',
+        'serverVersion',
+        'date',
+        'dayOfWeek',
+        'timeListening',
+        'startTime',
+        'currentTime',
+        'startedAt',
+        'updatedAt',
+      ].sort(),
+    );
+    // No toJSONForClient extras on history rows:
+    expect(json).not.toHaveProperty('audioTracks');
+    expect(json).not.toHaveProperty('libraryItem');
+  });
+
+  it('encodes ids, keeps books podcast-free, and emits ms epochs', () => {
+    const json = toAbsSessionJson(row());
+    expect(json.userId).toBe('usr_3');
+    expect(json.libraryId).toBe('lib_4');
+    expect(json.libraryItemId).toBe('li_42');
+    expect(json.bookId).toBe('bk_42');
+    expect(json.episodeId).toBeNull();
+    expect(json.mediaType).toBe('book');
+    expect(json.startedAt).toBe(1_700_000_000_000);
+    expect(json.updatedAt).toBe(1_700_000_100_000);
+    expect(json.startTime).toBe(10);
+    expect(json.currentTime).toBe(130);
+  });
+
+  it('passes a null libraryId through (deleted library) instead of encoding it', () => {
+    expect(toAbsSessionJson(row({ libraryId: null })).libraryId).toBeNull();
+  });
+});
+
+describe('absDateParts', () => {
+  it('formats the server-local calendar date and English weekday', () => {
+    const { date, dayOfWeek } = absDateParts(new Date(2026, 6, 12, 9, 30));
+    expect(date).toBe('2026-07-12');
+    expect(dayOfWeek).toBe('Sunday');
+  });
+});
+
+describe('buildAbsDeviceInfo', () => {
+  it('infers Abs Android from sdkVersion and builds deviceName like ABS', () => {
+    const info = buildAbsDeviceInfo(3, { deviceId: 'dev-1', manufacturer: 'Google', model: 'Pixel 8', sdkVersion: 34 });
+    expect(info.clientName).toBe('Abs Android');
+    expect(info.sdkVersion).toBe('34');
+    expect(info.deviceName).toBe('Google Pixel 8');
+    expect(info.userId).toBe('usr_3');
+    expect(info.deviceId).toBe('dev-1');
+  });
+
+  it('strips null fields and falls back deviceId to the generated id', () => {
+    const info = buildAbsDeviceInfo(3, undefined, undefined);
+    expect(info).not.toHaveProperty('manufacturer');
+    expect(info).not.toHaveProperty('model');
+    expect(info).not.toHaveProperty('ipAddress');
+    expect(info).not.toHaveProperty('deviceName');
+    expect(info.clientName).toBe('Unknown');
+    expect(info.deviceId).toBe(info.id);
+    expect(typeof info.clientVersion).toBe('string'); // server-version fallback
+  });
+
+  it('keeps the caller ip when provided', () => {
+    expect(buildAbsDeviceInfo(3, {}, '10.1.1.2').ipAddress).toBe('10.1.1.2');
+  });
+});

--- a/server/src/modules/abs/mappers/abs-session.mapper.ts
+++ b/server/src/modules/abs/mappers/abs-session.mapper.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'crypto';
+
+import type { AbsPlaybackSessionRow } from '../../../db/schema';
+import { ABS_MEDIA_TYPE_BOOK, ABS_SERVER_VERSION } from '../abs.constants';
+import { encodeAbsId } from '../abs-id.util';
+
+/**
+ * ABS stamps sessions with the SERVER's local calendar (`date-fns format('yyyy-MM-dd')` /
+ * `'EEEE'`), not UTC — these buckets feed the listening-stats days/dayOfWeek maps.
+ */
+export function absDateParts(at: Date): { date: string; dayOfWeek: string } {
+  const date = `${at.getFullYear()}-${String(at.getMonth() + 1).padStart(2, '0')}-${String(at.getDate()).padStart(2, '0')}`;
+  const dayOfWeek = at.toLocaleDateString('en-US', { weekday: 'long' });
+  return { date, dayOfWeek };
+}
+
+/**
+ * Normalize a client-supplied deviceInfo payload into ABS `DeviceInfo.toJSON()` output: client
+ * fields passed through, `clientVersion` falling back to the server version, `clientName` /
+ * `deviceName` inferred exactly like `DeviceInfo.setData` (sdkVersion ⇒ Android, model ⇒ iOS),
+ * and — like ABS — every null/undefined key stripped from the result.
+ */
+export function buildAbsDeviceInfo(userId: number, client: Record<string, unknown> | undefined, ipAddress?: string): Record<string, unknown> {
+  const str = (v: unknown): string | null => (typeof v === 'string' && v.length > 0 ? v : null);
+  const id = randomUUID();
+  const manufacturer = str(client?.manufacturer);
+  const model = str(client?.model);
+  const sdkVersion = typeof client?.sdkVersion === 'number' ? String(client.sdkVersion) : str(client?.sdkVersion);
+  let clientName = str(client?.clientName);
+  let deviceName: string | null = null;
+  if (sdkVersion) {
+    clientName ??= 'Abs Android';
+    deviceName = `${manufacturer ?? 'Unknown'} ${model ?? ''}`;
+  } else if (model) {
+    clientName ??= 'Abs iOS';
+    deviceName = `${manufacturer ?? 'Unknown'} ${model ?? ''}`;
+  } else {
+    clientName ??= 'Unknown';
+  }
+  const obj: Record<string, string | null> = {
+    id,
+    userId: encodeAbsId('user', userId),
+    deviceId: str(client?.deviceId) ?? id,
+    ipAddress: ipAddress ?? null,
+    clientVersion: str(client?.clientVersion) ?? ABS_SERVER_VERSION,
+    manufacturer,
+    model,
+    sdkVersion,
+    clientName,
+    deviceName,
+  };
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== null && v !== undefined));
+}
+
+/**
+ * A persisted session row as ABS `PlaybackSession.toJSON()` — the shape history endpoints return
+ * (`/me/listening-sessions`, stats `recentSessions`). No `audioTracks`/`libraryItem` here; those
+ * belong to `toJSONForClient`, which only open sessions (play response, `GET /api/session/:id`)
+ * carry.
+ */
+export function toAbsSessionJson(row: AbsPlaybackSessionRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    userId: encodeAbsId('user', row.userId),
+    libraryId: row.libraryId === null ? null : encodeAbsId('library', row.libraryId),
+    libraryItemId: encodeAbsId('libraryItem', row.bookId),
+    bookId: encodeAbsId('book', row.bookId),
+    episodeId: null,
+    mediaType: ABS_MEDIA_TYPE_BOOK,
+    mediaMetadata: row.mediaMetadata,
+    chapters: row.chapters,
+    displayTitle: row.displayTitle,
+    displayAuthor: row.displayAuthor,
+    coverPath: row.coverPath,
+    duration: row.duration,
+    playMethod: row.playMethod,
+    mediaPlayer: row.mediaPlayer,
+    deviceInfo: row.deviceInfo ?? null,
+    serverVersion: row.serverVersion,
+    date: row.date,
+    dayOfWeek: row.dayOfWeek,
+    timeListening: row.timeListening,
+    startTime: row.startTimeSeconds,
+    currentTime: row.currentTimeSeconds,
+    startedAt: row.startedAt.getTime(),
+    updatedAt: row.updatedAt.getTime(),
+  };
+}

--- a/server/src/modules/abs/mappers/abs-user.mapper.test.ts
+++ b/server/src/modules/abs/mappers/abs-user.mapper.test.ts
@@ -1,0 +1,83 @@
+import { ABS_SERVER_VERSION } from '../abs.constants';
+import { ALL_LIBRARY_PERMISSIONS, makeAbsUser } from '../__testing__/abs-test-helpers';
+import { buildAbsServerSettings, toAbsLoginPayload, toAbsUser } from './abs-user.mapper';
+
+describe('toAbsUser', () => {
+  it('encodes the id and reports superusers as ABS type "root"', () => {
+    const u = toAbsUser(makeAbsUser({ id: 9, username: 'root', isSuperuser: true }));
+    expect(u.id).toBe('usr_9');
+    expect(u.username).toBe('root');
+    expect(u.type).toBe('root');
+  });
+
+  it('reports non-superusers as ABS type "user"', () => {
+    expect(toAbsUser(makeAbsUser({ isSuperuser: false })).type).toBe('user');
+  });
+
+  it('emits the full ABS user contract strict clients require (email/isOldToken/itemTagsSelected/hasOpenIDLink)', () => {
+    const u = toAbsUser(makeAbsUser({ email: 'a@b.c' }));
+    expect(u.email).toBe('a@b.c');
+    expect(u.isOldToken).toBe(false);
+    expect(u.hasOpenIDLink).toBe(false);
+    // ABS names this `itemTagsSelected`, not `itemTagsAccessible`
+    expect(u.itemTagsSelected).toEqual([]);
+    expect(u).not.toHaveProperty('itemTagsAccessible');
+  });
+
+  it('emits the access token in both `token` (legacy) and `accessToken`; refresh defaults to null', () => {
+    const u = toAbsUser(makeAbsUser(), { accessToken: 'acc' });
+    expect(u.token).toBe('acc');
+    expect(u.accessToken).toBe('acc');
+    expect(u.refreshToken).toBeNull();
+  });
+
+  it('grants superusers every permission and an empty librariesAccessible ("all")', () => {
+    const u = toAbsUser(makeAbsUser({ isSuperuser: true }), { librariesAccessible: ['lib_1'] });
+    expect(u.permissions).toMatchObject({ download: true, update: true, delete: true, upload: true, accessAllLibraries: true });
+    expect(u.librariesAccessible).toEqual([]); // superuser => "all", supplied list ignored
+  });
+
+  it('maps a plain user with no permissions to all-false library perms', () => {
+    const u = toAbsUser(makeAbsUser({ isSuperuser: false, permissions: [] }), { librariesAccessible: ['lib_3'] });
+    expect(u.permissions).toMatchObject({ download: false, update: false, delete: false, upload: false, accessAllLibraries: false });
+    expect(u.librariesAccessible).toEqual(['lib_3']);
+  });
+
+  it('reflects granted permissions for a scoped user', () => {
+    const u = toAbsUser(makeAbsUser({ isSuperuser: false, permissions: ALL_LIBRARY_PERMISSIONS }));
+    expect(u.permissions).toMatchObject({ download: true, update: true, delete: true, upload: true });
+  });
+});
+
+describe('toAbsLoginPayload', () => {
+  it('produces the full login body (user + serverSettings + Source + ereaderDevices)', () => {
+    const payload = toAbsLoginPayload(makeAbsUser(), {
+      accessToken: 'acc',
+      refreshToken: 'ref',
+      userDefaultLibraryId: 'lib_2',
+    });
+    expect(payload.Source).toBe('bookorbit');
+    expect(payload.userDefaultLibraryId).toBe('lib_2');
+    expect(payload.ereaderDevices).toEqual([]);
+    expect(payload.serverSettings).toBeDefined();
+    const user = payload.user as Record<string, unknown>;
+    expect(user.accessToken).toBe('acc');
+    // the mobile flow returns the refresh token in the body (REIMPLEMENTATION_GUIDE §2.2)
+    expect(user.refreshToken).toBe('ref');
+  });
+
+  it('defaults userDefaultLibraryId to null when not provided', () => {
+    const payload = toAbsLoginPayload(makeAbsUser(), { accessToken: 'a', refreshToken: null });
+    expect(payload.userDefaultLibraryId).toBeNull();
+  });
+});
+
+describe('buildAbsServerSettings', () => {
+  it('advertises the ABS server version this adapter targets', () => {
+    expect(buildAbsServerSettings().version).toBe(ABS_SERVER_VERSION);
+  });
+
+  it('reports only local auth via authActiveAuthMethods (required by strict clients)', () => {
+    expect(buildAbsServerSettings().authActiveAuthMethods).toEqual(['local']);
+  });
+});

--- a/server/src/modules/abs/mappers/abs-user.mapper.ts
+++ b/server/src/modules/abs/mappers/abs-user.mapper.ts
@@ -1,0 +1,158 @@
+import { Permission } from '@bookorbit/types';
+
+import type { RequestUser } from '../../../common/types/request-user';
+import { ABS_DEFAULT_LANGUAGE, ABS_SERVER_VERSION, ABS_SOURCE } from '../abs.constants';
+import { encodeAbsId } from '../abs-id.util';
+
+export interface AbsUserExtras {
+  /** Pre-mapped ABS MediaProgress objects (empty until the progress service populates them). */
+  mediaProgress?: Record<string, unknown>[];
+  /** Pre-mapped ABS AudioBookmark objects. */
+  bookmarks?: Record<string, unknown>[];
+  /** ABS library id strings the user can access; empty array means "all". */
+  librariesAccessible?: string[];
+  accessToken?: string;
+  refreshToken?: string | null;
+  /**
+   * Value for the legacy `token` field when `accessToken` isn't attached (e.g. `GET /api/me`).
+   * Live ABS 2.35.1 always sends a real token string here — a null fails clients that decode it
+   * as a non-optional String.
+   */
+  legacyToken?: string;
+}
+
+function has(user: RequestUser, permission: Permission): boolean {
+  return user.isSuperuser || user.permissions.includes(permission);
+}
+
+/** ABS user `type`. BookOrbit superusers map to root; everyone else is a regular user. */
+function absUserType(user: RequestUser): string {
+  return user.isSuperuser ? 'root' : 'user';
+}
+
+function absPermissions(user: RequestUser): Record<string, boolean> {
+  return {
+    download: has(user, Permission.LibraryDownload),
+    update: has(user, Permission.LibraryEditMetadata),
+    delete: has(user, Permission.LibraryDeleteBooks),
+    upload: has(user, Permission.LibraryUpload),
+    accessAllLibraries: user.isSuperuser,
+    accessAllTags: true,
+    accessExplicitContent: true,
+    createEreader: false,
+    // ABS `tagsAreDenylist` — always present in live 2.35.1 payloads; BookOrbit has no tag ACLs.
+    selectedTagsNotAccessible: false,
+  };
+}
+
+/**
+ * The ABS user object embedded in the login payload and returned by `GET /api/me`.
+ * `accessToken`/`refreshToken` are only attached on login/refresh (REIMPLEMENTATION_GUIDE §2.2).
+ */
+export function toAbsUser(user: RequestUser, extras: AbsUserExtras = {}): Record<string, unknown> {
+  const accessAllLibraries = user.isSuperuser;
+  return {
+    id: encodeAbsId('user', user.id),
+    username: user.username,
+    email: user.email, // ABS sends this (nullable); strict clients (e.g. Prologue) require the key
+    type: absUserType(user),
+    token: extras.accessToken ?? extras.legacyToken ?? null, // legacy field; old clients read user.token
+    // ABS sets this flag in jwtAuthCheck to flag pre-2.26 tokens; we never issue old tokens.
+    isOldToken: false,
+    accessToken: extras.accessToken,
+    refreshToken: extras.refreshToken ?? null,
+    mediaProgress: extras.mediaProgress ?? [],
+    seriesHideFromContinueListening: [],
+    bookmarks: extras.bookmarks ?? [],
+    isActive: user.active,
+    isLocked: false,
+    lastSeen: Date.now(),
+    createdAt: Date.now(),
+    permissions: absPermissions(user),
+    librariesAccessible: accessAllLibraries ? [] : (extras.librariesAccessible ?? []),
+    // ABS calls this `itemTagsSelected` (not `itemTagsAccessible`); BookOrbit has no per-tag ACLs.
+    itemTagsSelected: [],
+    hasOpenIDLink: false, // BookOrbit has no OIDC linking; ABS always emits this boolean
+  };
+}
+
+/**
+ * Structurally-complete ServerSettings mirroring ABS `ServerSettings.toJSONForBrowser()`
+ * (v2.35.1). The full field set matters: strict clients (e.g. Prologue) decode this object with a
+ * non-optional model, so an omitted key — notably `authActiveAuthMethods` — fails the whole login
+ * decode. We keep the secret-bearing OIDC fields ABS strips in `toJSONForBrowser` out, and report
+ * only `local` auth since BookOrbit has no OIDC flow.
+ */
+export function buildAbsServerSettings(): Record<string, unknown> {
+  return {
+    id: 'server-settings',
+    scannerFindCovers: false,
+    scannerCoverProvider: 'google',
+    scannerParseSubtitle: false,
+    scannerPreferMatchedMetadata: false,
+    scannerDisableWatcher: true,
+    storeCoverWithItem: false,
+    storeMetadataWithItem: false,
+    metadataFileFormat: 'json',
+    rateLimitLoginRequests: 10,
+    rateLimitLoginWindow: 600000,
+    allowIframe: false,
+    backupPath: '/metadata/backups',
+    backupSchedule: false,
+    backupsToKeep: 2,
+    maxBackupSize: 1,
+    loggerDailyLogsToKeep: 7,
+    loggerScannerLogsToKeep: 2,
+    homeBookshelfView: 1,
+    bookshelfView: 1,
+    podcastEpisodeSchedule: '0 * * * *',
+    sortingIgnorePrefix: false,
+    sortingPrefixes: ['the', 'a'],
+    chromecastEnabled: false,
+    dateFormat: 'MM/dd/yyyy',
+    timeFormat: 'HH:mm',
+    language: ABS_DEFAULT_LANGUAGE,
+    allowedOrigins: [],
+    logLevel: 2,
+    version: ABS_SERVER_VERSION,
+    buildNumber: 0,
+    authLoginCustomMessage: null,
+    authActiveAuthMethods: ['local'],
+    authOpenIDIssuerURL: null,
+    authOpenIDAuthorizationURL: null,
+    authOpenIDTokenURL: null,
+    authOpenIDUserInfoURL: null,
+    authOpenIDJwksURL: null,
+    authOpenIDLogoutURL: null,
+    authOpenIDTokenSigningAlgorithm: 'RS256',
+    authOpenIDButtonText: 'Login with OpenId',
+    authOpenIDAutoLaunch: false,
+    authOpenIDAutoRegister: false,
+    authOpenIDMatchExistingBy: null,
+    authOpenIDSubfolderForRedirectURLs: null,
+  };
+}
+
+export interface AbsLoginPayloadOptions {
+  accessToken: string;
+  refreshToken: string | null;
+  mediaProgress?: Record<string, unknown>[];
+  librariesAccessible?: string[];
+  userDefaultLibraryId?: string | null;
+}
+
+/** The full body returned by `POST /login` and `POST /auth/refresh` (REIMPLEMENTATION_GUIDE §2.2). */
+export function toAbsLoginPayload(user: RequestUser, opts: AbsLoginPayloadOptions): Record<string, unknown> {
+  return {
+    user: toAbsUser(user, {
+      accessToken: opts.accessToken,
+      refreshToken: opts.refreshToken,
+      mediaProgress: opts.mediaProgress,
+      librariesAccessible: opts.librariesAccessible,
+    }),
+    userDefaultLibraryId: opts.userDefaultLibraryId ?? null,
+    serverSettings: buildAbsServerSettings(),
+    ereaderDevices: [],
+    Source: ABS_SOURCE,
+  };
+}

--- a/server/src/modules/abs/services/abs-bookmark.service.ts
+++ b/server/src/modules/abs/services/abs-bookmark.service.ts
@@ -1,0 +1,80 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { and, asc, eq, isNull } from 'drizzle-orm';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { DB } from '../../../db';
+import * as schema from '../../../db/schema';
+import { encodeAbsId } from '../abs-id.util';
+
+/** An ABS AudioBookmark: `{ libraryItemId, title, time, createdAt }` (epoch ms). */
+function toAbsBookmark(row: schema.BookmarkRow): Record<string, unknown> {
+  return {
+    libraryItemId: encodeAbsId('libraryItem', row.bookId),
+    title: row.title,
+    time: row.positionSeconds ?? 0,
+    createdAt: row.createdAt.getTime(),
+  };
+}
+
+/**
+ * Audio bookmarks (REIMPLEMENTATION_GUIDE §3 / ENDPOINTS §3). Backed by BookOrbit's `bookmarks`
+ * table; audio bookmarks carry an absolute `positionSeconds` (the ABS `time`) and a null `cfi`.
+ * Identity for update/delete is the (user, book, time) triple, matching ABS's delete-by-time route.
+ */
+@Injectable()
+export class AbsBookmarkService {
+  constructor(@Inject(DB) private readonly db: NodePgDatabase<typeof schema>) {}
+
+  /** All of a user's audio bookmarks, for the `GET /api/me` user object. */
+  async listForUser(userId: number): Promise<Record<string, unknown>[]> {
+    const rows = await this.db
+      .select()
+      .from(schema.bookmarks)
+      .where(and(eq(schema.bookmarks.userId, userId), isNull(schema.bookmarks.cfi)))
+      .orderBy(asc(schema.bookmarks.bookId), asc(schema.bookmarks.positionSeconds));
+    return rows.map(toAbsBookmark);
+  }
+
+  /** Create (or rename in place) a bookmark at `time`; returns the resulting ABS bookmark. */
+  async create(userId: number, bookId: number, time: number, title: string): Promise<Record<string, unknown>> {
+    const existing = await this.findAt(userId, bookId, time);
+    if (existing) {
+      const [updated] = await this.db.update(schema.bookmarks).set({ title }).where(eq(schema.bookmarks.id, existing.id)).returning();
+      return toAbsBookmark(updated);
+    }
+    const [row] = await this.db.insert(schema.bookmarks).values({ userId, bookId, title, positionSeconds: time, cfi: null }).returning();
+    return toAbsBookmark(row);
+  }
+
+  /** Rename the bookmark at `time`; returns null when none exists. */
+  async update(userId: number, bookId: number, time: number, title: string): Promise<Record<string, unknown> | null> {
+    const existing = await this.findAt(userId, bookId, time);
+    if (!existing) return null;
+    const [updated] = await this.db.update(schema.bookmarks).set({ title }).where(eq(schema.bookmarks.id, existing.id)).returning();
+    return toAbsBookmark(updated);
+  }
+
+  /** Delete the bookmark at `time`; returns true when one was removed. */
+  async remove(userId: number, bookId: number, time: number): Promise<boolean> {
+    const existing = await this.findAt(userId, bookId, time);
+    if (!existing) return false;
+    await this.db.delete(schema.bookmarks).where(eq(schema.bookmarks.id, existing.id));
+    return true;
+  }
+
+  private async findAt(userId: number, bookId: number, time: number): Promise<schema.BookmarkRow | null> {
+    const [row] = await this.db
+      .select()
+      .from(schema.bookmarks)
+      .where(
+        and(
+          eq(schema.bookmarks.userId, userId),
+          eq(schema.bookmarks.bookId, bookId),
+          isNull(schema.bookmarks.cfi),
+          eq(schema.bookmarks.positionSeconds, time),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  }
+}

--- a/server/src/modules/abs/services/abs-catalog.service.test.ts
+++ b/server/src/modules/abs/services/abs-catalog.service.test.ts
@@ -1,0 +1,299 @@
+import { Permission } from '@bookorbit/types';
+
+import type { LibraryService } from '../../library/library.service';
+import type { AbsAudioFileRow, AbsItemRow, AbsReadRepository } from '../abs-read.repository';
+import { makeAbsUser, thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsCatalogService, parseAbsSort } from './abs-catalog.service';
+import type { AbsProgressService } from './abs-progress.service';
+
+function item(overrides: Partial<AbsItemRow> = {}): AbsItemRow {
+  return {
+    id: 3,
+    libraryId: 5,
+    status: 'ready',
+    addedAt: new Date(),
+    updatedAt: new Date(),
+    title: 'The Hobbit',
+    subtitle: null,
+    description: null,
+    publishedYear: null,
+    publisher: null,
+    language: 'en',
+    isbn13: null,
+    isbn10: null,
+    seriesName: null,
+    seriesIndex: null,
+    durationSeconds: null,
+    chapters: [],
+    ...overrides,
+  };
+}
+
+function audioFile(overrides: Partial<AbsAudioFileRow> = {}): AbsAudioFileRow {
+  return { id: 7, bookId: 3, format: 'm4b', sortOrder: 0, durationSeconds: 100, sizeBytes: 1000, absolutePath: '/audio/hobbit.m4b', ...overrides };
+}
+
+interface BuildOpts {
+  listItems?: { rows: AbsItemRow[]; total: number };
+  findItem?: AbsItemRow | null;
+  findItemsByIds?: AbsItemRow[];
+  accessibleIds?: number[];
+  findBookFileById?: AbsAudioFileRow | null;
+  libraryIdForBook?: number | null;
+  audioFilesByBookId?: AbsAudioFileRow[];
+  authorsInLibrary?: { id: number; name: string; description: string | null; numBooks: number }[];
+  findAuthor?: { id: number; name: string; description: string | null } | null;
+  bookIdsForAuthor?: number[];
+  libraryIdForAuthor?: number | null;
+}
+
+function build(opts: BuildOpts = {}) {
+  const readRepo = {
+    listItems: vi.fn().mockResolvedValue(opts.listItems ?? { rows: [], total: 0 }),
+    findItem: vi.fn().mockResolvedValue(opts.findItem === undefined ? item() : opts.findItem),
+    findItemsByIds: vi.fn().mockResolvedValue(opts.findItemsByIds ?? []),
+    authorsByBookIds: vi.fn().mockResolvedValue([]),
+    narratorsByBookIds: vi.fn().mockResolvedValue([]),
+    seriesByBookIds: vi.fn().mockResolvedValue([]),
+    audioFilesByBookIds: vi.fn().mockResolvedValue([]),
+    findBookFileById: vi.fn().mockResolvedValue(opts.findBookFileById === undefined ? audioFile() : opts.findBookFileById),
+    libraryIdForBook: vi.fn().mockResolvedValue(opts.libraryIdForBook === undefined ? 5 : opts.libraryIdForBook),
+    audioFilesByBookId: vi.fn().mockResolvedValue(opts.audioFilesByBookId ?? [audioFile()]),
+    authorsInLibrary: vi.fn().mockResolvedValue(opts.authorsInLibrary ?? []),
+    findAuthor: vi.fn().mockResolvedValue(opts.findAuthor === undefined ? { id: 1, name: 'Andy Weir', description: null } : opts.findAuthor),
+    bookIdsForAuthor: vi.fn().mockResolvedValue(opts.bookIdsForAuthor ?? []),
+    libraryIdForAuthor: vi.fn().mockResolvedValue(opts.libraryIdForAuthor === undefined ? 5 : opts.libraryIdForAuthor),
+  } as unknown as AbsReadRepository;
+  const progressService = {
+    listMediaProgressForUser: vi.fn().mockResolvedValue([]),
+    getMediaProgress: vi.fn().mockResolvedValue(null),
+  } as unknown as AbsProgressService;
+  const libraryService = { findAccessibleLibraryIds: vi.fn().mockResolvedValue(opts.accessibleIds ?? [5]) } as unknown as LibraryService;
+  return { service: new AbsCatalogService(readRepo, progressService, libraryService), readRepo };
+}
+
+describe('parseAbsSort', () => {
+  it('maps ABS sort strings to repository columns, defaulting to addedAt', () => {
+    expect(parseAbsSort(undefined)).toBe('addedAt');
+    expect(parseAbsSort('media.metadata.title')).toBe('title');
+    expect(parseAbsSort('media.metadata.publishedYear')).toBe('publishedYear');
+    expect(parseAbsSort('unknown.field')).toBe('addedAt');
+  });
+});
+
+describe('AbsCatalogService#listLibraryItems', () => {
+  const query = { limit: 10, page: 1, sort: 'addedAt' as const, desc: true, minified: false };
+
+  it('404s when a scoped user cannot access the library', async () => {
+    const { service } = build({ accessibleIds: [99] });
+    expect(await thrownStatus(() => service.listLibraryItems(makeAbsUser({ isSuperuser: false }), 5, query))).toBe(404);
+  });
+
+  it('returns the ABS browse envelope with computed offset', async () => {
+    const { service } = build({ listItems: { rows: [item()], total: 1 } });
+    const result = await service.listLibraryItems(makeAbsUser(), 5, query);
+    expect(result).toMatchObject({ total: 1, limit: 10, page: 1, offset: 10, mediaType: 'book', sortDesc: true });
+    expect((result.results as unknown[]).length).toBe(1);
+  });
+
+  it('uses offset 0 when limit is 0 (no-limit browse)', async () => {
+    const { service, readRepo } = build();
+    await service.listLibraryItems(makeAbsUser(), 5, { ...query, limit: 0, page: 3 });
+    expect(readRepo.listItems).toHaveBeenCalledWith(expect.objectContaining({ offset: 0 }));
+  });
+
+  it('always emits minified item media regardless of the query minified flag (matches ABS getLibraryItems)', async () => {
+    const { service } = build({ listItems: { rows: [item()], total: 1 } });
+    const result = await service.listLibraryItems(makeAbsUser(), 5, { ...query, minified: false });
+    const media = (result.results as Array<{ media: Record<string, unknown> }>)[0].media;
+    // Minified Book shape carries these counts; the expanded shape Prologue cannot decode does not.
+    expect(media).toHaveProperty('numAudioFiles');
+    expect(media).toHaveProperty('numChapters');
+    expect(media).not.toHaveProperty('audioFiles');
+  });
+});
+
+describe('AbsCatalogService#getLibraryItem', () => {
+  it('404s when the item is missing', async () => {
+    const { service } = build({ findItem: null });
+    expect(await thrownStatus(() => service.getLibraryItem(makeAbsUser(), 3))).toBe(404);
+  });
+
+  it('404s when the item is still processing', async () => {
+    const { service } = build({ findItem: item({ status: 'processing' }) });
+    expect(await thrownStatus(() => service.getLibraryItem(makeAbsUser(), 3))).toBe(404);
+  });
+
+  it('maps an accessible item', async () => {
+    const { service } = build({ findItem: item() });
+    const result = await service.getLibraryItem(makeAbsUser(), 3);
+    expect(result.id).toBe('li_3');
+  });
+});
+
+describe('AbsCatalogService#getLibraryItemsBatch', () => {
+  it('filters out processing and inaccessible items', async () => {
+    const items = [item({ id: 3, libraryId: 5 }), item({ id: 4, libraryId: 5, status: 'processing' }), item({ id: 5, libraryId: 99 })];
+    const { service } = build({ findItemsByIds: items, accessibleIds: [5] });
+    const result = await service.getLibraryItemsBatch(makeAbsUser({ isSuperuser: false }), [3, 4, 5]);
+    expect(result.map((r) => r.id)).toEqual(['li_3']);
+  });
+
+  it('returns all non-processing items for a superuser', async () => {
+    const items = [item({ id: 3, libraryId: 5 }), item({ id: 5, libraryId: 99 })];
+    const { service } = build({ findItemsByIds: items });
+    const result = await service.getLibraryItemsBatch(makeAbsUser({ isSuperuser: true }), [3, 5]);
+    expect(result.map((r) => r.id)).toEqual(['li_3', 'li_5']);
+  });
+});
+
+describe('AbsCatalogService#listAuthors', () => {
+  it('404s when a scoped user cannot access the library', async () => {
+    const { service } = build({ accessibleIds: [99] });
+    expect(await thrownStatus(() => service.listAuthors(makeAbsUser({ isSuperuser: false }), 5))).toBe(404);
+  });
+
+  it('returns the bare { authors } envelope for a non-paginated request, each carrying libraryId', async () => {
+    const { service } = build({
+      authorsInLibrary: [{ id: 1, name: 'Andy Weir', description: 'bio', numBooks: 2 }],
+    });
+    const result = await service.listAuthors(makeAbsUser(), 5);
+    expect(result).toEqual({ authors: [expect.objectContaining({ id: 'aut_1', name: 'Andy Weir', numBooks: 2, libraryId: 'lib_5' })] });
+  });
+
+  // Regression: ABS returns the paginated { results } envelope when limit+page are present, and each
+  // author carries a non-optional libraryId. Prologue sends limit=50&page=0, reads `.results`, and
+  // strict-decodes the Author objects — a missing libraryId (or a bare { authors }) blanks the library.
+  it('returns a paginated { results } envelope with libraryId-bearing authors when limit+page supplied', async () => {
+    const { service } = build({
+      authorsInLibrary: [
+        { id: 1, name: 'Andy Weir', description: null, numBooks: 2 },
+        { id: 2, name: 'Brandon Sanderson', description: null, numBooks: 3 },
+      ],
+    });
+    const result = await service.listAuthors(makeAbsUser(), 5, { limit: '50', page: '0' });
+    expect(result.authors).toBeUndefined();
+    expect(result.total).toBe(2);
+    expect(result.limit).toBe(50);
+    expect(result.page).toBe(0);
+    expect(result.results).toEqual([
+      expect.objectContaining({ id: 'aut_1', name: 'Andy Weir', lastFirst: 'Weir, Andy', libraryId: 'lib_5' }),
+      expect.objectContaining({ id: 'aut_2', name: 'Brandon Sanderson', lastFirst: 'Sanderson, Brandon', libraryId: 'lib_5' }),
+    ]);
+  });
+
+  it('slices the paginated results by limit and page', async () => {
+    const { service } = build({
+      authorsInLibrary: [
+        { id: 1, name: 'A A', description: null, numBooks: 1 },
+        { id: 2, name: 'B B', description: null, numBooks: 1 },
+        { id: 3, name: 'C C', description: null, numBooks: 1 },
+      ],
+    });
+    const result = await service.listAuthors(makeAbsUser(), 5, { limit: '2', page: '1' });
+    expect(result.total).toBe(3);
+    expect((result.results as unknown[]).length).toBe(1);
+    expect(result.results).toEqual([expect.objectContaining({ id: 'aut_3' })]);
+  });
+});
+
+describe('AbsCatalogService#getAuthor', () => {
+  it('404s when the author does not exist', async () => {
+    const { service } = build({ findAuthor: null });
+    expect(await thrownStatus(() => service.getAuthor(makeAbsUser(), 1, []))).toBe(404);
+  });
+
+  it('returns the bare author when items are not requested', async () => {
+    const { service, readRepo } = build();
+    const result = await service.getAuthor(makeAbsUser(), 1, []);
+    expect(result).toMatchObject({ id: 'aut_1', name: 'Andy Weir' });
+    expect(result.libraryItems).toBeUndefined();
+    expect(readRepo.bookIdsForAuthor).not.toHaveBeenCalled();
+  });
+
+  it('eager-loads access-filtered items and recomputes numBooks when include=items', async () => {
+    const { service } = build({
+      bookIdsForAuthor: [3, 5],
+      findItemsByIds: [item({ id: 3, libraryId: 5 }), item({ id: 5, libraryId: 99 })],
+      accessibleIds: [5],
+    });
+    const result = await service.getAuthor(makeAbsUser({ isSuperuser: false }), 1, ['items']);
+    const items = result.libraryItems as { id: string }[];
+    expect(items.map((i) => i.id)).toEqual(['li_3']);
+    expect(result.numBooks).toBe(1);
+  });
+});
+
+describe('AbsCatalogService#getDownloadFile', () => {
+  const downloader = makeAbsUser({ isSuperuser: false, permissions: [Permission.LibraryDownload] });
+
+  it('returns the file for an authorized downloader', async () => {
+    const { service } = build();
+    const file = await service.getDownloadFile(downloader, 3, 7);
+    expect(file.absolutePath).toBe('/audio/hobbit.m4b');
+  });
+
+  it('404s when the file does not exist', async () => {
+    const { service } = build({ findBookFileById: null });
+    expect(await thrownStatus(() => service.getDownloadFile(downloader, 3, 7))).toBe(404);
+  });
+
+  it('404s when the file belongs to a different book', async () => {
+    const { service } = build({ findBookFileById: audioFile({ bookId: 99 }) });
+    expect(await thrownStatus(() => service.getDownloadFile(downloader, 3, 7))).toBe(404);
+  });
+
+  it('404s when the user cannot access the library', async () => {
+    const { service } = build({ accessibleIds: [99] });
+    expect(await thrownStatus(() => service.getDownloadFile(downloader, 3, 7))).toBe(404);
+  });
+
+  it('403s when the user lacks the download permission', async () => {
+    const { service } = build();
+    expect(await thrownStatus(() => service.getDownloadFile(makeAbsUser({ isSuperuser: false, permissions: [] }), 3, 7))).toBe(403);
+  });
+});
+
+describe('AbsCatalogService#getItemFile', () => {
+  it('returns the file without requiring the download permission', async () => {
+    const { service } = build();
+    const file = await service.getItemFile(makeAbsUser({ isSuperuser: false, permissions: [] }), 3, 7);
+    expect(file.absolutePath).toBe('/audio/hobbit.m4b');
+  });
+
+  it('404s when the file does not exist', async () => {
+    const { service } = build({ findBookFileById: null });
+    expect(await thrownStatus(() => service.getItemFile(makeAbsUser(), 3, 7))).toBe(404);
+  });
+
+  it('404s when the file belongs to a different book', async () => {
+    const { service } = build({ findBookFileById: audioFile({ bookId: 99 }) });
+    expect(await thrownStatus(() => service.getItemFile(makeAbsUser(), 3, 7))).toBe(404);
+  });
+
+  it('404s when the user cannot access the library', async () => {
+    const { service } = build({ accessibleIds: [99] });
+    expect(await thrownStatus(() => service.getItemFile(makeAbsUser({ isSuperuser: false }), 3, 7))).toBe(404);
+  });
+});
+
+describe('AbsCatalogService#getDownloadBundle', () => {
+  const downloader = makeAbsUser({ isSuperuser: false, permissions: [Permission.LibraryDownload] });
+
+  it('returns the title and content files for an authorized downloader', async () => {
+    const { service } = build();
+    const bundle = await service.getDownloadBundle(downloader, 3);
+    expect(bundle.title).toBe('The Hobbit');
+    expect(bundle.files).toHaveLength(1);
+  });
+
+  it('404s when the item has no content files', async () => {
+    const { service } = build({ audioFilesByBookId: [] });
+    expect(await thrownStatus(() => service.getDownloadBundle(downloader, 3))).toBe(404);
+  });
+
+  it('403s when the user lacks the download permission', async () => {
+    const { service } = build();
+    expect(await thrownStatus(() => service.getDownloadBundle(makeAbsUser({ isSuperuser: false, permissions: [] }), 3))).toBe(403);
+  });
+});

--- a/server/src/modules/abs/services/abs-catalog.service.ts
+++ b/server/src/modules/abs/services/abs-catalog.service.ts
@@ -1,0 +1,487 @@
+import { Injectable } from '@nestjs/common';
+import { type SQL } from 'drizzle-orm';
+
+import { Permission } from '@bookorbit/types';
+
+import type { RequestUser } from '../../../common/types/request-user';
+import { LibraryService } from '../../library/library.service';
+import { AbsHttpException } from '../abs-errors';
+import { decodeAbsFilter } from '../abs-filter.util';
+import { decodeAbsId, encodeAbsId } from '../abs-id.util';
+import { AbsReadRepository, type AbsAudioFileRow, type AbsItemRow, type AbsItemSortField } from '../abs-read.repository';
+import { toAbsAuthor } from '../mappers/abs-author.mapper';
+import { toAbsLibraryItem, type AbsItemRelations } from '../mappers/abs-item.mapper';
+import { AbsProgressService } from './abs-progress.service';
+
+export interface AbsItemQuery {
+  limit: number;
+  page: number;
+  sort: AbsItemSortField;
+  /**
+   * The raw `sort` query param. ABS echoes it verbatim as `sortBy` and OMITS the key when the
+   * client sent no sort — envelopes must mirror that (undefined is dropped by JSON.stringify).
+   */
+  rawSort?: string;
+  desc: boolean;
+  minified: boolean;
+  /** Raw `filter=group.base64url(value)` browse filter (REIMPLEMENTATION_GUIDE §4.2). */
+  filter?: string;
+}
+
+function groupBy<T, K>(items: T[], keyFn: (item: T) => K): Map<K, T[]> {
+  const map = new Map<K, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const list = map.get(key);
+    if (list) list.push(item);
+    else map.set(key, [item]);
+  }
+  return map;
+}
+
+/** Reorder fetched rows to match a desired book-id order (e.g. most-recently-updated first). */
+function orderByIds(rows: AbsItemRow[], order: number[]): AbsItemRow[] {
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  return order.map((id) => byId.get(id)).filter((r): r is AbsItemRow => r != null);
+}
+
+/**
+ * Group an author's already-assembled LibraryItems by the series they belong to, mirroring ABS's
+ * `AuthorController` `include=series` shape (`{ id, name, items }`). Series come off each item's
+ * mapped `media.metadata.series` so we don't re-query.
+ */
+function buildAuthorSeries(items: Record<string, unknown>[]): Record<string, unknown>[] {
+  const byId = new Map<string, { id: string; name: string; items: Record<string, unknown>[] }>();
+  for (const item of items) {
+    const metadata = (item.media as Record<string, unknown> | undefined)?.metadata as Record<string, unknown> | undefined;
+    const series = (metadata?.series as { id: string; name: string }[] | undefined) ?? [];
+    for (const s of series) {
+      let entry = byId.get(s.id);
+      if (!entry) {
+        entry = { id: s.id, name: s.name, items: [] };
+        byId.set(s.id, entry);
+      }
+      entry.items.push(item);
+    }
+  }
+  return [...byId.values()];
+}
+
+/** Maps ABS sort query strings to the columns the read repository can order by. */
+export function parseAbsSort(sort: string | undefined): AbsItemSortField {
+  if (!sort) return 'addedAt';
+  if (sort.includes('title')) return 'title';
+  if (sort.includes('publishedYear')) return 'publishedYear';
+  return 'addedAt';
+}
+
+/** Assembles ABS LibraryItems from BookOrbit data, enforcing the user's library access. */
+@Injectable()
+export class AbsCatalogService {
+  constructor(
+    private readonly readRepo: AbsReadRepository,
+    private readonly progressService: AbsProgressService,
+    private readonly libraryService: LibraryService,
+  ) {}
+
+  private async assertLibraryAccess(user: RequestUser, libraryId: number): Promise<void> {
+    if (user.isSuperuser) return;
+    const accessible = await this.libraryService.findAccessibleLibraryIds(user);
+    if (!accessible.includes(libraryId)) throw AbsHttpException.notFound();
+  }
+
+  /** ABS download routes are gated on `canDownload` (ENDPOINTS.md §2 — `jwt+canDownload`). */
+  private assertCanDownload(user: RequestUser): void {
+    if (user.isSuperuser || user.permissions.includes(Permission.LibraryDownload)) return;
+    throw AbsHttpException.forbidden();
+  }
+
+  /** Decode a `group.base64` browse filter into a SQL predicate (id-based groups carry ABS ids). */
+  private buildFilterWhere(raw: string | undefined): SQL | undefined {
+    const decoded = decodeAbsFilter(raw);
+    if (!decoded) return undefined;
+
+    let value = decoded.value;
+    if (decoded.group === 'authors') {
+      const id = decodeAbsId('author', value);
+      value = id != null ? String(id) : '';
+    } else if (decoded.group === 'series') {
+      const id = decodeAbsId('series', value);
+      value = id != null ? String(id) : '';
+    }
+    return value ? this.readRepo.filterWhere(decoded.group, value) : undefined;
+  }
+
+  private async relationsFor(rows: AbsItemRow[]): Promise<Map<number, AbsItemRelations>> {
+    const bookIds = rows.map((r) => r.id);
+    const [authors, narrators, series, audioFiles] = await Promise.all([
+      this.readRepo.authorsByBookIds(bookIds),
+      this.readRepo.narratorsByBookIds(bookIds),
+      this.readRepo.seriesByBookIds(bookIds),
+      this.readRepo.audioFilesByBookIds(bookIds),
+    ]);
+    const authorsByBook = groupBy(authors, (a) => a.bookId);
+    const narratorsByBook = groupBy(narrators, (n) => n.bookId);
+    const seriesByBook = groupBy(series, (s) => s.bookId);
+    const filesByBook = groupBy(audioFiles, (f) => f.bookId);
+
+    const relations = new Map<number, AbsItemRelations>();
+    for (const row of rows) {
+      relations.set(row.id, {
+        authors: authorsByBook.get(row.id) ?? [],
+        narrators: narratorsByBook.get(row.id) ?? [],
+        series: seriesByBook.get(row.id) ?? [],
+        audioFiles: filesByBook.get(row.id) ?? [],
+      });
+    }
+    return relations;
+  }
+
+  /** `GET /api/libraries/:id/items` — the primary browse endpoint envelope. */
+  async listLibraryItems(user: RequestUser, libraryId: number, query: AbsItemQuery): Promise<Record<string, unknown>> {
+    await this.assertLibraryAccess(user, libraryId);
+
+    const offset = query.limit > 0 ? query.page * query.limit : 0;
+    const { rows, total } = await this.readRepo.listItems({
+      libraryId,
+      limit: query.limit,
+      offset,
+      sort: query.sort,
+      desc: query.desc,
+      extraWhere: this.buildFilterWhere(query.filter),
+    });
+    const relations = await this.relationsFor(rows);
+
+    // ABS's getLibraryItems always serializes list rows via toOldJSONMinified() regardless of the
+    // `minified` query param, and never attaches userMediaProgress to list rows — clients read
+    // progress from /api/me. Extra keys are as dangerous to strict Codable clients as missing ones.
+    const results = rows.map((row) => toAbsLibraryItem(row, relations.get(row.id)!, { minified: true }));
+
+    // Envelope mirrors ABS LibraryController.getLibraryItems exactly: sortBy/filterBy echo the raw
+    // query params and are OMITTED (not null) when the client didn't send them.
+    return {
+      results,
+      total,
+      limit: query.limit,
+      page: query.page,
+      sortBy: query.rawSort,
+      sortDesc: query.desc,
+      filterBy: query.filter,
+      mediaType: 'book',
+      minified: query.minified,
+      collapseseries: false,
+      include: '',
+      offset,
+    };
+  }
+
+  /**
+   * `GET /api/items/:id` — single expanded (or minified) item. With `?include=progress` ABS emits
+   * the userMediaProgress key even when the user has none (explicit null); without it, no key.
+   */
+  async getLibraryItem(user: RequestUser, bookId: number, minified = false, includeProgress = false): Promise<Record<string, unknown>> {
+    const item = await this.readRepo.findItem(bookId);
+    if (!item || item.status === 'processing') throw AbsHttpException.notFound();
+    await this.assertLibraryAccess(user, item.libraryId);
+
+    const [relations, progress] = await Promise.all([
+      this.relationsFor([item]),
+      this.progressService.getMediaProgress(user.id, bookId, item.libraryId),
+    ]);
+    return toAbsLibraryItem(item, relations.get(item.id)!, {
+      minified,
+      mediaProgress: includeProgress ? (progress ?? null) : undefined,
+    });
+  }
+
+  /** `POST /api/items/batch/get` — fetch many items by id, access-filtered (no progress, as ABS). */
+  async getLibraryItemsBatch(user: RequestUser, bookIds: number[]): Promise<Record<string, unknown>[]> {
+    const items = await this.readRepo.findItemsByIds(bookIds);
+    const accessible = user.isSuperuser ? null : new Set(await this.libraryService.findAccessibleLibraryIds(user));
+    const visible = items.filter((i) => i.status !== 'processing' && (!accessible || accessible.has(i.libraryId)));
+    const relations = await this.relationsFor(visible);
+    return visible.map((row) => toAbsLibraryItem(row, relations.get(row.id)!, {}));
+  }
+
+  /**
+   * Assemble ABS LibraryItems for a set of already-fetched rows. Like ABS, list-shaped responses
+   * (browse, series books, search, shelves) never attach userMediaProgress — only the single-item
+   * detail endpoint does.
+   */
+  private async assembleItems(rows: AbsItemRow[], minified: boolean): Promise<Record<string, unknown>[]> {
+    if (rows.length === 0) return [];
+    const relations = await this.relationsFor(rows);
+    return rows.map((row) => toAbsLibraryItem(row, relations.get(row.id)!, { minified }));
+  }
+
+  /** `GET /api/libraries/:id/search` — title/author search; client reads the `book` array. */
+  async search(user: RequestUser, libraryId: number, query: string, limit: number): Promise<Record<string, unknown>> {
+    await this.assertLibraryAccess(user, libraryId);
+    const term = query.trim();
+    if (!term) return { book: [], tags: [], authors: [], series: [] };
+
+    const rows = await this.readRepo.searchItems(libraryId, term, limit);
+    const items = await this.assembleItems(rows, true);
+    return {
+      book: items.map((libraryItem, i) => ({ libraryItem, matchKey: 'title', matchText: rows[i].title ?? '' })),
+      tags: [],
+      authors: [],
+      series: [],
+    };
+  }
+
+  /** `GET /api/libraries/:id/series` — paginated series with their books. */
+  async listSeries(user: RequestUser, libraryId: number, query: AbsItemQuery): Promise<Record<string, unknown>> {
+    await this.assertLibraryAccess(user, libraryId);
+    const all = await this.readRepo.seriesInLibrary(libraryId);
+    const total = all.length;
+    const offset = query.limit > 0 ? query.page * query.limit : 0;
+    const pageSeries = query.limit > 0 ? all.slice(offset, offset + query.limit) : all;
+
+    const bookIds = [...new Set(pageSeries.flatMap((s) => s.books.map((b) => b.bookId)))];
+    const rows = await this.readRepo.findItemsByIds(bookIds);
+    // ABS serializes series books via toOldJSONMinified() (seriesFilters.getFilteredSeries),
+    // regardless of the request's `minified` flag — match it so Prologue's minified decode succeeds.
+    const itemsByBook = new Map((await this.assembleItems(rows, true)).map((it, i) => [rows[i].id, it]));
+
+    // Element shape is EXACTLY ABS Series.toOldJSON + books (seriesFilters.getFilteredSeries):
+    // no libraryItemIds, and totalDuration only exists when sorting by it — extra keys break strict
+    // Codable clients whose optional properties decode stricter shapes than we'd send. BookOrbit has
+    // no series description/timestamps, so those are null/0 (keys present, values empty).
+    const libraryAbsId = encodeAbsId('library', libraryId);
+    const results = pageSeries.map((s) => ({
+      id: encodeAbsId('series', s.id),
+      name: s.name,
+      nameIgnorePrefix: s.name,
+      description: null,
+      addedAt: 0,
+      updatedAt: 0,
+      libraryId: libraryAbsId,
+      books: s.books.map((b) => itemsByBook.get(b.bookId)).filter((it): it is Record<string, unknown> => it != null),
+    }));
+
+    // Envelope mirrors ABS getAllSeriesForLibrary: no offset key; sortBy/filterBy echo the raw
+    // query params (omitted when absent); include is always present.
+    return {
+      results,
+      total,
+      limit: query.limit,
+      page: query.page,
+      sortBy: query.rawSort,
+      sortDesc: query.desc,
+      filterBy: query.filter,
+      minified: query.minified,
+      include: '',
+    };
+  }
+
+  /** `GET /api/libraries/:id/collections` — paginated user collections with their books. */
+  async listCollections(user: RequestUser, libraryId: number, query: AbsItemQuery): Promise<Record<string, unknown>> {
+    await this.assertLibraryAccess(user, libraryId);
+    const all = await this.readRepo.collectionsForUser(user.id, libraryId);
+    const total = all.length;
+    const offset = query.limit > 0 ? query.page * query.limit : 0;
+    const page = query.limit > 0 ? all.slice(offset, offset + query.limit) : all;
+
+    const bookIds = [...new Set(page.flatMap((c) => c.bookIds))];
+    const rows = await this.readRepo.findItemsByIds(bookIds);
+    // ABS serializes collection books via toOldJSONExpanded() (Collection.toOldJSONExpanded),
+    // regardless of the request's `minified` flag — match it for a consistent strict-decode shape.
+    const itemsByBook = new Map((await this.assembleItems(rows, false)).map((it, i) => [rows[i].id, it]));
+
+    const results = page.map((c) => ({
+      id: encodeAbsId('collection', c.id),
+      libraryId: encodeAbsId('library', libraryId),
+      name: c.name,
+      description: c.description,
+      books: c.bookIds.map((id) => itemsByBook.get(id)).filter((it): it is Record<string, unknown> => it != null),
+      lastUpdate: 0,
+      createdAt: 0,
+    }));
+
+    // Envelope mirrors ABS's library collections endpoint: no offset key, sortBy echoes the raw
+    // query param (omitted when the client sent no sort), include always present.
+    return {
+      results,
+      total,
+      limit: query.limit,
+      page: query.page,
+      sortBy: query.rawSort,
+      sortDesc: query.desc,
+      minified: query.minified,
+      include: '',
+    };
+  }
+
+  /** `GET /api/libraries/:id/filterdata` — valid filter values/ids for the library. */
+  async filterData(user: RequestUser, libraryId: number): Promise<Record<string, unknown>> {
+    await this.assertLibraryAccess(user, libraryId);
+    const data = await this.readRepo.filterData(libraryId);
+    return {
+      authors: data.authors.map((a) => ({ id: encodeAbsId('author', a.id), name: a.name })),
+      genres: data.genres,
+      tags: data.tags,
+      series: data.series.map((s) => ({ id: encodeAbsId('series', s.id), name: s.name })),
+      narrators: data.narrators,
+      languages: data.languages,
+      publishers: [],
+    };
+  }
+
+  /**
+   * `GET /api/libraries/:id/authors` — authors with a book in the library. Mirrors
+   * `LibraryController.getAuthors`: a `limit`+`page` request (author-centric clients like Prologue
+   * send `limit=50&page=0`) returns the paginated `{ results, … }` envelope and reads `.results`;
+   * otherwise a bare `{ authors }`.
+   */
+  async listAuthors(user: RequestUser, libraryId: number, query: Record<string, string> = {}): Promise<Record<string, unknown>> {
+    await this.assertLibraryAccess(user, libraryId);
+    const libraryAbsId = encodeAbsId('library', libraryId);
+    const authors = (await this.readRepo.authorsInLibrary(libraryId)).map((a) => toAbsAuthor(a, libraryAbsId));
+
+    const isPaginated = query.limit != null && query.limit !== '' && !Number.isNaN(Number(query.limit)) && !Number.isNaN(Number(query.page));
+    if (!isPaginated) return { authors };
+
+    const limit = Number(query.limit);
+    const page = Number(query.page);
+    const start = limit > 0 ? page * limit : 0;
+    return {
+      results: limit > 0 ? authors.slice(start, start + limit) : authors,
+      total: authors.length,
+      limit,
+      page,
+      sortBy: query.sort,
+      sortDesc: query.desc === '1',
+      filterBy: query.filter,
+      minified: query.minified === '1',
+      // ABS echoes req.query.include verbatim — the key is OMITTED when the client sent none.
+      include: query.include,
+    };
+  }
+
+  /** `GET /api/authors/:id` — one author; `?include=items,series` eager-loads the author's books. */
+  async getAuthor(user: RequestUser, authorId: number, include: string[]): Promise<Record<string, unknown>> {
+    const author = await this.readRepo.findAuthor(authorId);
+    if (!author) throw AbsHttpException.notFound();
+
+    // BookOrbit authors are global; surface the library of any of the author's books so the ABS
+    // Author object carries the non-optional libraryId strict clients require.
+    const authorLibraryId = await this.readRepo.libraryIdForAuthor(authorId);
+    const result = toAbsAuthor(author, authorLibraryId != null ? encodeAbsId('library', authorLibraryId) : '');
+    if (include.includes('items')) {
+      const bookIds = await this.readRepo.bookIdsForAuthor(authorId);
+      const libraryItems = await this.itemsForBookIds(user, bookIds, true);
+      result.numBooks = libraryItems.length;
+      if (include.includes('series')) result.series = buildAuthorSeries(libraryItems);
+      result.libraryItems = libraryItems;
+    }
+    return result;
+  }
+
+  /** `GET /api/libraries/:id/personalized` — home-screen shelves. */
+  async personalized(user: RequestUser, libraryId: number): Promise<Record<string, unknown>[]> {
+    await this.assertLibraryAccess(user, libraryId);
+
+    const inProgress = await this.itemsInProgressForLibrary(user, libraryId);
+    const { rows: recentRows } = await this.readRepo.listItems({ libraryId, limit: 10, offset: 0, sort: 'addedAt', desc: true });
+    const recent = await this.assembleItems(recentRows, true);
+
+    const shelves: Record<string, unknown>[] = [];
+    if (inProgress.length > 0) {
+      shelves.push({
+        id: 'continue-listening',
+        label: 'Continue Listening',
+        labelStringKey: 'LabelContinueListening',
+        type: 'book',
+        entities: inProgress,
+      });
+    }
+    shelves.push({ id: 'recently-added', label: 'Recently Added', labelStringKey: 'LabelRecentlyAdded', type: 'book', entities: recent });
+    return shelves;
+  }
+
+  /** `GET /api/me/items-in-progress` — Continue-listening shelf across all accessible libraries. */
+  async itemsInProgress(user: RequestUser): Promise<Record<string, unknown>[]> {
+    const bookIds = await this.progressService.listInProgressBookIds(user.id);
+    return this.itemsForBookIds(user, bookIds, true);
+  }
+
+  private async itemsInProgressForLibrary(user: RequestUser, libraryId: number): Promise<Record<string, unknown>[]> {
+    // ABS respects hideFromContinueListening only on the home-page shelves, not items-in-progress.
+    const bookIds = await this.progressService.listInProgressBookIds(user.id, { excludeHidden: true });
+    const rows = (await this.readRepo.findItemsByIds(bookIds)).filter((r) => r.libraryId === libraryId);
+    const ordered = orderByIds(rows, bookIds);
+    return this.assembleItems(ordered, true);
+  }
+
+  private async itemsForBookIds(user: RequestUser, bookIds: number[], minified: boolean): Promise<Record<string, unknown>[]> {
+    const items = await this.readRepo.findItemsByIds(bookIds);
+    const accessible = user.isSuperuser ? null : new Set(await this.libraryService.findAccessibleLibraryIds(user));
+    const visible = orderByIds(
+      items.filter((i) => i.status !== 'processing' && (!accessible || accessible.has(i.libraryId))),
+      bookIds,
+    );
+    return this.assembleItems(visible, minified);
+  }
+
+  private async progressMap(userId: number, rows: AbsItemRow[]): Promise<Map<number, Record<string, unknown>>> {
+    const all = await this.progressService.listMediaProgressForUser(userId);
+    const wanted = new Set(rows.map((r) => encodeAbsId('libraryItem', r.id)));
+    const byBook = new Map<number, Record<string, unknown>>();
+    for (const mp of all) {
+      if (wanted.has(mp.libraryItemId as string)) {
+        const idStr = mp.libraryItemId as string;
+        const bookId = Number.parseInt(idStr.slice(idStr.indexOf('_') + 1), 10);
+        byBook.set(bookId, mp);
+      }
+    }
+    return byBook;
+  }
+
+  /** Audio files for playback (used by the playback service). */
+  audioFiles(bookId: number): Promise<AbsAudioFileRow[]> {
+    return this.readRepo.audioFilesByBookId(bookId);
+  }
+
+  /**
+   * Resolve a single file for `GET /api/items/:id/file/:fileid/download`. The `fileid` is the audio
+   * file's `ino` (its book-file row id). Enforces library access and the `canDownload` permission.
+   */
+  async getDownloadFile(user: RequestUser, bookId: number, fileId: number): Promise<AbsAudioFileRow> {
+    const file = await this.readRepo.findBookFileById(fileId);
+    if (!file || file.bookId !== bookId) throw AbsHttpException.notFound();
+    const libraryId = await this.readRepo.libraryIdForBook(bookId);
+    if (libraryId === null) throw AbsHttpException.notFound();
+    await this.assertLibraryAccess(user, libraryId);
+    this.assertCanDownload(user);
+    return file;
+  }
+
+  /**
+   * Resolve a single file for the inline stream `GET /api/items/:id/file/:fileid` (ENDPOINTS.md §2 —
+   * `jwt`). Mirrors {@link getDownloadFile} but is gated only on library access: the inline route is
+   * for in-app playback/preview and is not subject to the `canDownload` permission.
+   */
+  async getItemFile(user: RequestUser, bookId: number, fileId: number): Promise<AbsAudioFileRow> {
+    const file = await this.readRepo.findBookFileById(fileId);
+    if (!file || file.bookId !== bookId) throw AbsHttpException.notFound();
+    const libraryId = await this.readRepo.libraryIdForBook(bookId);
+    if (libraryId === null) throw AbsHttpException.notFound();
+    await this.assertLibraryAccess(user, libraryId);
+    return file;
+  }
+
+  /**
+   * Resolve the content files + title for `GET /api/items/:id/download` (zip of the whole item).
+   * Enforces library access and the `canDownload` permission.
+   */
+  async getDownloadBundle(user: RequestUser, bookId: number): Promise<{ title: string; files: AbsAudioFileRow[] }> {
+    const item = await this.readRepo.findItem(bookId);
+    if (!item || item.status === 'processing') throw AbsHttpException.notFound();
+    await this.assertLibraryAccess(user, item.libraryId);
+    this.assertCanDownload(user);
+    const files = await this.readRepo.audioFilesByBookId(bookId);
+    if (files.length === 0) throw AbsHttpException.notFound();
+    return { title: item.title ?? `item-${bookId}`, files };
+  }
+}

--- a/server/src/modules/abs/services/abs-playback.service.test.ts
+++ b/server/src/modules/abs/services/abs-playback.service.test.ts
@@ -1,0 +1,411 @@
+import type { LibraryService } from '../../library/library.service';
+import type { AbsPlaybackSessionRepository } from '../abs-playback-session.repository';
+import type { AbsAudioFileRow, AbsItemRow, AbsReadRepository } from '../abs-read.repository';
+import type { AbsSocketGateway } from '../abs-socket.gateway';
+import { makeAbsUser, thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsPlaybackService } from './abs-playback.service';
+import type { AbsProgressService } from './abs-progress.service';
+import type { AbsTranscodeService } from './abs-transcode.service';
+
+function item(overrides: Partial<AbsItemRow> = {}): AbsItemRow {
+  return {
+    id: 3,
+    libraryId: 5,
+    status: 'ready',
+    addedAt: new Date(),
+    updatedAt: new Date(),
+    title: 'The Hobbit',
+    subtitle: null,
+    description: null,
+    publishedYear: null,
+    publisher: null,
+    language: 'en',
+    isbn13: null,
+    isbn10: null,
+    seriesName: null,
+    seriesIndex: null,
+    durationSeconds: null,
+    chapters: [],
+    ...overrides,
+  };
+}
+
+function file(id: number, durationSeconds: number): AbsAudioFileRow {
+  return { id, bookId: 3, format: 'mp3', sortOrder: id, durationSeconds, sizeBytes: 1000, absolutePath: `/books/3/${id}.mp3` };
+}
+
+interface BuildOpts {
+  item?: AbsItemRow | null;
+  audioFiles?: AbsAudioFileRow[];
+  progress?: Record<string, unknown> | null;
+  accessibleIds?: number[];
+  existingRow?: Record<string, unknown> | null;
+  mergeResult?: { progressSynced: boolean; mediaProgress: Record<string, unknown> | null };
+}
+
+function build(opts: BuildOpts = {}) {
+  const audioFiles = opts.audioFiles ?? [file(10, 100), file(11, 200)];
+  const readRepo = {
+    findItem: vi.fn().mockResolvedValue(opts.item === undefined ? item() : opts.item),
+    audioFilesByBookId: vi.fn().mockResolvedValue(audioFiles),
+    authorsByBookIds: vi.fn().mockResolvedValue([{ bookId: 3, id: 1, name: 'Tolkien' }]),
+    narratorsByBookIds: vi.fn().mockResolvedValue([]),
+    seriesByBookIds: vi.fn().mockResolvedValue([]),
+    genresByBookIds: vi.fn().mockResolvedValue([{ bookId: 3, name: 'Fantasy' }]),
+  } as unknown as AbsReadRepository;
+  const progressService = {
+    getMediaProgress: vi.fn().mockResolvedValue(opts.progress ?? null),
+    upsertFromCurrentTime: vi.fn().mockResolvedValue({ id: 'mp-1', progress: 0.5 }),
+    mergeOfflineProgress: vi.fn().mockResolvedValue(opts.mergeResult ?? { progressSynced: true, mediaProgress: { id: 'mp-1' } }),
+  } as unknown as AbsProgressService;
+  const socketGateway = {
+    emitUserItemProgressUpdated: vi.fn(),
+    emitUserSessionClosed: vi.fn(),
+  } as unknown as AbsSocketGateway;
+  const libraryService = { findAccessibleLibraryIds: vi.fn().mockResolvedValue(opts.accessibleIds ?? [5]) } as unknown as LibraryService;
+  const transcodeService = {
+    createStream: vi.fn().mockResolvedValue('/hls/stream/output.m3u8'),
+    closeStream: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AbsTranscodeService;
+  const sessionRepo = {
+    insert: vi.fn().mockResolvedValue(undefined),
+    updateSync: vi.fn().mockResolvedValue(undefined),
+    updateFromLocal: vi.fn().mockResolvedValue(undefined),
+    findById: vi.fn().mockResolvedValue(opts.existingRow ?? null),
+  } as unknown as AbsPlaybackSessionRepository;
+  const service = new AbsPlaybackService(readRepo, progressService, socketGateway, libraryService, transcodeService, sessionRepo);
+  return { service, readRepo, progressService, socketGateway, transcodeService, sessionRepo };
+}
+
+describe('AbsPlaybackService#startSession', () => {
+  it('404s when the item is missing or still processing', async () => {
+    expect(await thrownStatus(() => build({ item: null }).service.startSession(makeAbsUser(), 3, {}))).toBe(404);
+    expect(await thrownStatus(() => build({ item: item({ status: 'processing' }) }).service.startSession(makeAbsUser(), 3, {}))).toBe(404);
+  });
+
+  it('404s when a scoped user cannot access the item library', async () => {
+    const { service } = build({ accessibleIds: [99] });
+    expect(await thrownStatus(() => service.startSession(makeAbsUser({ isSuperuser: false }), 3, {}))).toBe(404);
+  });
+
+  it('404s when the book has no audio files', async () => {
+    const { service } = build({ audioFiles: [] });
+    expect(await thrownStatus(() => service.startSession(makeAbsUser(), 3, {}))).toBe(404);
+  });
+
+  it('returns a direct-play session (playMethod 0) with one track per audio file', async () => {
+    const { service } = build();
+    const session = await service.startSession(makeAbsUser(), 3, {});
+    expect(session.playMethod).toBe(0);
+    expect(session.mediaType).toBe('book');
+    expect(session.libraryItemId).toBe('li_3');
+    expect(session.duration).toBe(300);
+    expect((session.audioTracks as unknown[]).length).toBe(2);
+  });
+
+  it('returns a transcode session (playMethod 2) with a single HLS track when forced', async () => {
+    const { service, transcodeService } = build();
+    const session = await service.startSession(makeAbsUser(), 3, { forceTranscode: true });
+    expect(session.playMethod).toBe(2);
+    expect((session.audioTracks as unknown[]).length).toBe(1);
+    expect(transcodeService.createStream).toHaveBeenCalledOnce();
+    const track = (session.audioTracks as Record<string, unknown>[])[0];
+    expect(track.contentUrl).toBe(`/hls/${session.id as string}/output.m3u8`);
+  });
+
+  it('transcodes when the client cannot direct-play the files (mime not supported)', async () => {
+    const { service } = build();
+    const session = await service.startSession(makeAbsUser(), 3, { supportedMimeTypes: ['audio/flac'] });
+    expect(session.playMethod).toBe(2);
+  });
+
+  it('direct-plays when the client supports the file mime types', async () => {
+    const { service } = build();
+    const session = await service.startSession(makeAbsUser(), 3, { supportedMimeTypes: ['audio/mpeg'] });
+    expect(session.playMethod).toBe(0);
+  });
+
+  it('closes the transcode stream when a transcode session is closed', async () => {
+    const { service, transcodeService } = build();
+    const user = makeAbsUser({ id: 1 });
+    const started = await service.startSession(user, 3, { forceTranscode: true });
+    await service.close(started.id as string, user);
+    expect(transcodeService.closeStream).toHaveBeenCalledWith(started.id);
+  });
+
+  it('seeds the resume point from saved progress', async () => {
+    const { service } = build({ progress: { currentTime: 42, isFinished: false } });
+    const session = await service.startSession(makeAbsUser(), 3, {});
+    expect(session.startTime).toBe(42);
+    expect(session.currentTime).toBe(42);
+  });
+
+  it('restarts a finished book at position 0', async () => {
+    const { service } = build({ progress: { currentTime: 290, isFinished: true } });
+    const session = await service.startSession(makeAbsUser(), 3, {});
+    expect(session.startTime).toBe(0);
+  });
+});
+
+describe('AbsPlaybackService session lifecycle', () => {
+  it('getSession returns the open session to its owner', async () => {
+    const { service } = build();
+    const user = makeAbsUser({ id: 1 });
+    const started = await service.startSession(user, 3, {});
+    expect(service.getSession(started.id as string, user).id).toBe(started.id);
+  });
+
+  it('404s an unknown session id', async () => {
+    const { service } = build();
+    expect(await thrownStatus(() => service.getSession('missing', makeAbsUser()))).toBe(404);
+  });
+
+  it('404s when a different non-owner user requests the session', async () => {
+    const { service } = build();
+    const started = await service.startSession(makeAbsUser({ id: 1 }), 3, {});
+    const other = makeAbsUser({ id: 2, isSuperuser: false });
+    expect(await thrownStatus(() => service.getSession(started.id as string, other))).toBe(404);
+  });
+
+  it('sync sets currentTime, accumulates timeListening, and emits progress to other devices', async () => {
+    const { service, socketGateway } = build();
+    const user = makeAbsUser({ id: 1 });
+    const started = await service.startSession(user, 3, {});
+    const id = started.id as string;
+
+    await service.sync(id, user, { currentTime: 50, timeListened: 20 });
+    await service.sync(id, user, { currentTime: 80, timeListened: 15 });
+
+    const current = service.getSession(id, user);
+    expect(current.currentTime).toBe(80);
+    expect(current.timeListening).toBe(35); // 20 + 15, accumulated
+    expect(socketGateway.emitUserItemProgressUpdated).toHaveBeenCalledTimes(2);
+  });
+
+  it('close removes the session and emits user_session_closed', async () => {
+    const { service, socketGateway } = build();
+    const user = makeAbsUser({ id: 1 });
+    const started = await service.startSession(user, 3, {});
+    const id = started.id as string;
+
+    await service.close(id, user);
+    expect(socketGateway.emitUserSessionClosed).toHaveBeenCalledWith(1, id);
+    expect(await thrownStatus(() => service.getSession(id, user))).toBe(404); // gone
+  });
+
+  it('close performs a final sync when a body is supplied', async () => {
+    const { service, progressService } = build();
+    const user = makeAbsUser({ id: 1 });
+    const started = await service.startSession(user, 3, {});
+    await service.close(started.id as string, user, { currentTime: 300, timeListened: 10 });
+    expect(progressService.upsertFromCurrentTime).toHaveBeenCalled();
+  });
+
+  it('starting a session for a device closes the previous session on that device', async () => {
+    const { service } = build();
+    const user = makeAbsUser({ id: 1 });
+    const first = await service.startSession(user, 3, { deviceInfo: { deviceId: 'dev-1' } });
+    const second = await service.startSession(user, 3, { deviceInfo: { deviceId: 'dev-1' } });
+    expect(await thrownStatus(() => service.getSession(first.id as string, user))).toBe(404);
+    expect(service.getSession(second.id as string, user).id).toBe(second.id);
+  });
+});
+
+describe('AbsPlaybackService session persistence (ABS saveSession semantics)', () => {
+  it('persists nothing while timeListening is 0 (play + zero-listen sync + close)', async () => {
+    const { service, sessionRepo } = build();
+    const user = makeAbsUser({ id: 1 });
+    const started = await service.startSession(user, 3, {});
+    await service.sync(started.id as string, user, { currentTime: 10 }); // no timeListened
+    await service.close(started.id as string, user);
+    expect(sessionRepo.insert).not.toHaveBeenCalled();
+    expect(sessionRepo.updateSync).not.toHaveBeenCalled();
+  });
+
+  it('first save inserts the row, later saves update it', async () => {
+    const { service, sessionRepo } = build();
+    const user = makeAbsUser({ id: 1 });
+    const started = await service.startSession(user, 3, {});
+    const id = started.id as string;
+
+    await service.sync(id, user, { currentTime: 50, timeListened: 20 });
+    expect(sessionRepo.insert).toHaveBeenCalledTimes(1);
+    expect(sessionRepo.updateSync).not.toHaveBeenCalled();
+
+    await service.sync(id, user, { currentTime: 80, timeListened: 15 });
+    expect(sessionRepo.insert).toHaveBeenCalledTimes(1);
+    expect(sessionRepo.updateSync).toHaveBeenCalledTimes(1);
+    const update = (sessionRepo.updateSync as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(update[0]).toBe(id);
+    expect(update[1]).toMatchObject({ currentTime: 80, timeListening: 35 });
+  });
+
+  it('the inserted row snapshots the full ABS oldMetadataToJSON media metadata', async () => {
+    const { service, sessionRepo } = build();
+    const user = makeAbsUser({ id: 1 });
+    const started = await service.startSession(user, 3, { mediaPlayer: 'AVPlayer', deviceInfo: { deviceId: 'dev-1', model: 'iPhone' } });
+    await service.sync(started.id as string, user, { currentTime: 5, timeListened: 5 });
+
+    const row = (sessionRepo.insert as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+    expect(row.id).toBe(started.id);
+    expect(row.userId).toBe(1);
+    expect(row.bookId).toBe(3);
+    expect(row.mediaPlayer).toBe('AVPlayer');
+    const meta = row.mediaMetadata as Record<string, unknown>;
+    expect(Object.keys(meta).sort()).toEqual(
+      [
+        'title',
+        'subtitle',
+        'authors',
+        'narrators',
+        'series',
+        'genres',
+        'publishedYear',
+        'publishedDate',
+        'publisher',
+        'description',
+        'isbn',
+        'asin',
+        'language',
+        'explicit',
+        'abridged',
+      ].sort(),
+    );
+    expect(meta.authors).toEqual([{ id: 'aut_1', name: 'Tolkien' }]);
+    expect(meta.genres).toEqual(['Fantasy']);
+    const deviceInfo = row.deviceInfo as Record<string, unknown>;
+    expect(deviceInfo.deviceId).toBe('dev-1');
+    expect(deviceInfo.clientName).toBe('Abs iOS'); // inferred from model, like ABS DeviceInfo.setData
+    expect(deviceInfo).not.toHaveProperty('manufacturer'); // nulls stripped
+  });
+
+  it('close without a sync body still saves an unsaved listened session', async () => {
+    const { service, sessionRepo } = build();
+    const user = makeAbsUser({ id: 1 });
+    const started = await service.startSession(user, 3, {});
+    const id = started.id as string;
+    // accumulate listening but sabotage the sync-path save by making it a no-op first:
+    await service.sync(id, user, { currentTime: 50, timeListened: 20 });
+    (sessionRepo.insert as ReturnType<typeof vi.fn>).mockClear();
+    await service.close(id, user); // no body → close's own saveSession runs (update path)
+    expect(sessionRepo.updateSync).toHaveBeenCalled();
+  });
+
+  it('device takeover saves the displaced session before dropping it', async () => {
+    const { service, sessionRepo } = build();
+    const user = makeAbsUser({ id: 1 });
+    const first = await service.startSession(user, 3, { deviceInfo: { deviceId: 'dev-1' } });
+    await service.sync(first.id as string, user, { currentTime: 50, timeListened: 20 });
+    (sessionRepo.insert as ReturnType<typeof vi.fn>).mockClear();
+    (sessionRepo.updateSync as ReturnType<typeof vi.fn>).mockClear();
+
+    await service.startSession(user, 3, { deviceInfo: { deviceId: 'dev-1' } });
+    expect(sessionRepo.updateSync).toHaveBeenCalledTimes(1); // displaced session saved
+  });
+
+  it('stale-session pruning does NOT save (matches ABS removeSession-only sweep)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { service, sessionRepo } = build();
+      const user = makeAbsUser({ id: 1 });
+      const started = await service.startSession(user, 3, {});
+      await service.sync(started.id as string, user, { currentTime: 50, timeListened: 20 });
+      (sessionRepo.insert as ReturnType<typeof vi.fn>).mockClear();
+      (sessionRepo.updateSync as ReturnType<typeof vi.fn>).mockClear();
+
+      vi.advanceTimersByTime(37 * 60 * 60 * 1000);
+      service.pruneStaleSessions();
+      expect(await thrownStatus(() => service.getSession(started.id as string, user))).toBe(404);
+      expect(sessionRepo.insert).not.toHaveBeenCalled();
+      expect(sessionRepo.updateSync).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('AbsPlaybackService#syncLocalSession (offline upsert)', () => {
+  it('rejects malformed payloads without touching the DB', async () => {
+    const { service, sessionRepo } = build();
+    const result = await service.syncLocalSession(makeAbsUser(), { libraryItemId: 'li_3' }); // no currentTime
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Invalid local session');
+    expect(sessionRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it('reports "Media item not found" for an unknown book (ABS error string)', async () => {
+    const { service } = build({ item: null });
+    const result = await service.syncLocalSession(makeAbsUser(), { id: 's-1', libraryItemId: 'li_3', currentTime: 10 });
+    expect(result).toMatchObject({ id: 's-1', success: false, error: 'Media item not found' });
+  });
+
+  it('creates a new history row from the client payload, snapshotting server metadata', async () => {
+    const { service, sessionRepo } = build();
+    const result = await service.syncLocalSession(makeAbsUser({ id: 1 }), {
+      id: 's-local-1',
+      libraryItemId: 'li_3',
+      currentTime: 120,
+      timeListening: 90,
+      duration: 300,
+      startedAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_100_000,
+      mediaPlayer: 'ExoPlayer',
+    });
+    expect(result).toMatchObject({ id: 's-local-1', success: true, progressSynced: true });
+    const row = (sessionRepo.insert as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+    expect(row.id).toBe('s-local-1');
+    expect(row.playMethod).toBe(3); // PlayMethod.LOCAL default
+    expect(row.timeListening).toBe(90);
+    expect(row.currentTimeSeconds).toBe(120);
+    expect((row.startedAt as Date).getTime()).toBe(1_700_000_000_000);
+    expect((row.createdAt as Date).getTime()).toBe(1_700_000_000_000); // createdAt := startedAt, like ABS
+    expect((row.updatedAt as Date).getTime()).toBe(1_700_000_100_000);
+    expect((row.mediaMetadata as Record<string, unknown>).title).toBe('The Hobbit'); // server snapshot wins
+  });
+
+  it('updates an existing row by the client session id, recomputing the date buckets', async () => {
+    const updatedAt = Date.UTC(2026, 6, 12, 12, 0, 0);
+    const { service, sessionRepo } = build({ existingRow: { id: 's-1', userId: 1, timeListening: 10 } });
+    const result = await service.syncLocalSession(makeAbsUser({ id: 1 }), {
+      id: 's-1',
+      libraryItemId: 'li_3',
+      currentTime: 200,
+      timeListening: 44,
+      updatedAt,
+    });
+    expect(result.success).toBe(true);
+    expect(sessionRepo.insert).not.toHaveBeenCalled();
+    const [id, values] = (sessionRepo.updateFromLocal as ReturnType<typeof vi.fn>).mock.calls[0] as [string, Record<string, unknown>];
+    expect(id).toBe('s-1');
+    expect(values.currentTime).toBe(200);
+    expect(values.timeListening).toBe(44);
+    expect((values.updatedAt as Date).getTime()).toBe(updatedAt);
+    expect(values.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(typeof values.dayOfWeek).toBe('string');
+  });
+
+  it("refuses to overwrite another user's session row", async () => {
+    const { service, sessionRepo } = build({ existingRow: { id: 's-1', userId: 99, timeListening: 10 } });
+    const result = await service.syncLocalSession(makeAbsUser({ id: 1 }), { id: 's-1', libraryItemId: 'li_3', currentTime: 10 });
+    expect(result.success).toBe(false);
+    expect(sessionRepo.updateFromLocal).not.toHaveBeenCalled();
+  });
+});
+
+describe('AbsPlaybackService#trackFile', () => {
+  it('returns the audio file at the given index', async () => {
+    const { service } = build();
+    const started = await service.startSession(makeAbsUser({ id: 1 }), 3, {});
+    expect(service.trackFile(started.id as string, 1)?.id).toBe(11);
+  });
+
+  it('falls back to the first track for an out-of-range index (podcast index-0 quirk)', async () => {
+    const { service } = build();
+    const started = await service.startSession(makeAbsUser({ id: 1 }), 3, {});
+    expect(service.trackFile(started.id as string, 99)?.id).toBe(10);
+  });
+
+  it('returns null for an unknown session', () => {
+    expect(build().service.trackFile('missing', 0)).toBeNull();
+  });
+});

--- a/server/src/modules/abs/services/abs-playback.service.ts
+++ b/server/src/modules/abs/services/abs-playback.service.ts
@@ -1,0 +1,454 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+import type { RequestUser } from '../../../common/types/request-user';
+import type { AbsPlaybackSessionRow } from '../../../db/schema';
+import { LibraryService } from '../../library/library.service';
+import { ABS_SERVER_VERSION } from '../abs.constants';
+import { AbsHttpException } from '../abs-errors';
+import { decodeAbsId, encodeAbsId } from '../abs-id.util';
+import { canDirectPlay, normalizeChapters } from '../abs-media.util';
+import { AbsPlaybackSessionRepository } from '../abs-playback-session.repository';
+import { AbsReadRepository, type AbsAudioFileRow, type AbsItemRow } from '../abs-read.repository';
+import { AbsSocketGateway } from '../abs-socket.gateway';
+import { buildDirectPlayTracks, buildTranscodeTrack } from '../mappers/abs-item.mapper';
+import { absDateParts, buildAbsDeviceInfo, toAbsSessionJson } from '../mappers/abs-session.mapper';
+import { AbsProgressService } from './abs-progress.service';
+import { AbsTranscodeService } from './abs-transcode.service';
+
+const PLAY_METHOD_DIRECT = 0;
+const PLAY_METHOD_TRANSCODE = 2;
+/** Offline sessions uploaded via `/session/local[-all]` (ABS `PlayMethod.LOCAL`). */
+const PLAY_METHOD_LOCAL = 3;
+/** Open sessions with no update for this long are dropped (REIMPLEMENTATION_GUIDE §7.2). */
+const STALE_SESSION_MS = 36 * 60 * 60 * 1000;
+
+interface AbsPlaybackSession {
+  id: string;
+  userId: number;
+  libraryId: number;
+  bookId: number;
+  deviceId: string | null;
+  displayTitle: string;
+  displayAuthor: string;
+  mediaMetadata: Record<string, unknown>;
+  chapters: Record<string, unknown>[];
+  audioFiles: AbsAudioFileRow[];
+  audioTracks: Record<string, unknown>[];
+  duration: number;
+  deviceInfo: Record<string, unknown>;
+  playMethod: number;
+  mediaPlayer: string;
+  /** Set for transcode sessions (`playMethod=2`); the HLS stream id (== session id). */
+  streamId: string | null;
+  date: string;
+  dayOfWeek: string;
+  startTime: number;
+  currentTime: number;
+  timeListening: number;
+  startedAt: number;
+  updatedAt: number;
+  /** Whether a history row exists yet (ABS `lastSave`): first save inserts, later saves update. */
+  persisted: boolean;
+}
+
+export interface StartSessionBody {
+  deviceInfo?: Record<string, unknown>;
+  mediaPlayer?: string;
+  forceDirectPlay?: boolean;
+  forceTranscode?: boolean;
+  supportedMimeTypes?: string[];
+}
+
+export interface SyncBody {
+  currentTime?: number;
+  timeListened?: number;
+  duration?: number;
+}
+
+/** An offline-recorded session uploaded by the mobile app (REIMPLEMENTATION_GUIDE §7.3). */
+export interface LocalSessionBody {
+  id?: string;
+  libraryItemId?: string;
+  displayTitle?: string;
+  displayAuthor?: string;
+  mediaPlayer?: string;
+  deviceInfo?: Record<string, unknown>;
+  playMethod?: number;
+  duration?: number;
+  timeListening?: number;
+  startTime?: number;
+  currentTime?: number;
+  startedAt?: number;
+  updatedAt?: number;
+  date?: string;
+  dayOfWeek?: string;
+}
+
+/** Request-level context threaded into session writes (deviceInfo fidelity only). */
+export interface LocalSessionContext {
+  deviceInfo?: Record<string, unknown>;
+  ipAddress?: string;
+}
+
+/**
+ * In-memory playback-session manager (mirrors ABS `PlaybackSessionManager`). Negotiates direct-play
+ * vs transcode (REIMPLEMENTATION_GUIDE §5.1): direct-play (`playMethod=0`) tracks point at
+ * `/public/session/:id/track/:index` and the client seeks via HTTP Range; transcode (`playMethod=2`)
+ * hands off to {@link AbsTranscodeService} for an HLS stream under `/hls/:streamId`. Progress is
+ * persisted to `audiobook_progress` on sync/close, and — like ABS — the session itself is persisted
+ * to `abs_playback_sessions` once it has accumulated listening time, feeding the history/stats
+ * endpoints. Open state stays memory-only: a restart loses open sessions but keeps their history.
+ */
+@Injectable()
+export class AbsPlaybackService {
+  private readonly logger = new Logger(AbsPlaybackService.name);
+  private readonly sessions = new Map<string, AbsPlaybackSession>();
+
+  constructor(
+    private readonly readRepo: AbsReadRepository,
+    private readonly progressService: AbsProgressService,
+    private readonly socketGateway: AbsSocketGateway,
+    private readonly libraryService: LibraryService,
+    private readonly transcodeService: AbsTranscodeService,
+    private readonly sessionRepo: AbsPlaybackSessionRepository,
+  ) {}
+
+  async startSession(user: RequestUser, bookId: number, body: StartSessionBody, ipAddress?: string): Promise<Record<string, unknown>> {
+    const item = await this.readRepo.findItem(bookId);
+    if (!item || item.status === 'processing') throw AbsHttpException.notFound();
+    if (!user.isSuperuser) {
+      const accessible = await this.libraryService.findAccessibleLibraryIds(user);
+      if (!accessible.includes(item.libraryId)) throw AbsHttpException.notFound();
+    }
+
+    const audioFiles = await this.readRepo.audioFilesByBookId(bookId);
+    if (audioFiles.length === 0) throw AbsHttpException.notFound();
+
+    const { mediaMetadata, authorName } = await this.mediaSnapshot(item);
+
+    const deviceId = typeof body.deviceInfo?.deviceId === 'string' ? body.deviceInfo.deviceId : null;
+    await this.closeOpenSessionsForDevice(user.id, deviceId);
+
+    // Resume point: saved position unless the book is already finished (then restart at 0).
+    const progress = await this.progressService.getMediaProgress(user.id, bookId, item.libraryId);
+    const isFinished = !!progress?.isFinished;
+    const resumeAt = isFinished ? 0 : ((progress?.currentTime as number) ?? 0);
+
+    const sessionId = randomUUID();
+    const duration = AbsProgressService.totalDuration(audioFiles);
+
+    // Direct play unless the client forces transcode or its supportedMimeTypes can't cover the files.
+    const directPlay =
+      body.forceDirectPlay ||
+      (!body.forceTranscode &&
+        canDirectPlay(
+          audioFiles.map((f) => f.format),
+          body.supportedMimeTypes,
+        ));
+
+    let audioTracks: Record<string, unknown>[];
+    let streamId: string | null = null;
+    if (directPlay) {
+      audioTracks = buildDirectPlayTracks(sessionId, audioFiles);
+    } else {
+      streamId = sessionId;
+      await this.transcodeService.createStream({ streamId, userId: user.id, audioFiles, duration, startTime: resumeAt });
+      audioTracks = [buildTranscodeTrack(streamId, duration)];
+    }
+
+    const now = Date.now();
+    const session: AbsPlaybackSession = {
+      id: sessionId,
+      userId: user.id,
+      libraryId: item.libraryId,
+      bookId,
+      deviceId,
+      displayTitle: item.title ?? '',
+      displayAuthor: authorName,
+      mediaMetadata,
+      chapters: normalizeChapters(item.chapters, duration) as unknown as Record<string, unknown>[],
+      audioFiles,
+      audioTracks,
+      duration,
+      deviceInfo: buildAbsDeviceInfo(user.id, body.deviceInfo, ipAddress),
+      playMethod: directPlay ? PLAY_METHOD_DIRECT : PLAY_METHOD_TRANSCODE,
+      mediaPlayer: body.mediaPlayer ?? 'unknown',
+      streamId,
+      ...absDateParts(new Date(now)),
+      startTime: resumeAt,
+      currentTime: resumeAt,
+      timeListening: 0,
+      startedAt: now,
+      updatedAt: now,
+      persisted: false,
+    };
+    this.sessions.set(sessionId, session);
+    return this.toClientJSON(session);
+  }
+
+  getSession(sessionId: string, user: RequestUser): Record<string, unknown> {
+    const session = this.requireOwnedSession(sessionId, user);
+    return this.toClientJSON(session);
+  }
+
+  /** Returns the audio file backing a track index for the open-session track endpoint. */
+  trackFile(sessionId: string, index: number): AbsAudioFileRow | null {
+    const session = this.sessions.get(sessionId);
+    if (!session) return null;
+    // Podcast quirk: index 0 falls back to the first track. Books are 0-based already.
+    return session.audioFiles[index] ?? session.audioFiles[0] ?? null;
+  }
+
+  async sync(sessionId: string, user: RequestUser, body: SyncBody): Promise<void> {
+    const session = this.requireOwnedSession(sessionId, user);
+    if (typeof body.currentTime === 'number') session.currentTime = body.currentTime;
+    if (typeof body.timeListened === 'number') session.timeListening += body.timeListened;
+    session.updatedAt = Date.now();
+
+    const mediaProgress = await this.progressService.upsertFromCurrentTime(session.userId, session.bookId, session.libraryId, {
+      currentTime: session.currentTime,
+      duration: body.duration ?? session.duration,
+    });
+    if (mediaProgress) {
+      this.socketGateway.emitUserItemProgressUpdated(session.userId, {
+        id: mediaProgress.id as string,
+        sessionId,
+        deviceDescription: (session.deviceInfo?.clientName as string) ?? 'BookOrbit',
+        data: mediaProgress,
+      });
+    }
+    await this.saveSession(session);
+  }
+
+  async close(sessionId: string, user: RequestUser, body?: SyncBody): Promise<void> {
+    const session = this.requireOwnedSession(sessionId, user);
+    if (body && (typeof body.currentTime === 'number' || typeof body.timeListened === 'number')) {
+      await this.sync(sessionId, user, body); // saves
+    } else {
+      await this.saveSession(session);
+    }
+    this.sessions.delete(sessionId);
+    if (session.streamId) await this.transcodeService.closeStream(session.streamId);
+    this.socketGateway.emitUserSessionClosed(session.userId, sessionId);
+  }
+
+  /**
+   * Reconcile one offline-recorded session: upsert the history row by the CLIENT's session id
+   * (ABS `PlaybackSessionManager.syncLocalSession`), then merge progress newest-`updatedAt`-wins
+   * (REIMPLEMENTATION_GUIDE §7.3). Returns a per-session result; never throws on bad input.
+   */
+  async syncLocalSession(user: RequestUser, body: LocalSessionBody, ctx: LocalSessionContext = {}): Promise<Record<string, unknown>> {
+    const id = body.id ?? randomUUID();
+    const bookId = body.libraryItemId ? decodeAbsId('libraryItem', body.libraryItemId) : null;
+    if (bookId === null || typeof body.currentTime !== 'number') {
+      return { id, success: false, error: 'Invalid local session' };
+    }
+    const item = await this.readRepo.findItem(bookId);
+    if (!item || item.status === 'processing') {
+      return { id, success: false, error: 'Media item not found' };
+    }
+
+    try {
+      await this.upsertLocalSessionRow(user, id, bookId, item, body, ctx);
+    } catch (err) {
+      this.logger.warn(`Failed to persist local session ${id}: ${(err as Error).message}`);
+      return { id, success: false, error: 'Failed to save session' };
+    }
+
+    const { progressSynced, mediaProgress } = await this.progressService.mergeOfflineProgress(user.id, bookId, {
+      currentTime: body.currentTime,
+      duration: body.duration,
+      updatedAt: body.updatedAt,
+    });
+
+    if (progressSynced && mediaProgress) {
+      this.socketGateway.emitUserItemProgressUpdated(user.id, {
+        id: mediaProgress.id as string,
+        sessionId: id,
+        deviceDescription: 'BookOrbit',
+        data: mediaProgress,
+      });
+    }
+    return { id, success: true, progressSynced };
+  }
+
+  /** Batch offline reconciliation: `{ results: [{ id, success, progressSynced, error? }] }`. */
+  async syncLocalSessions(user: RequestUser, sessions: LocalSessionBody[], ctx: LocalSessionContext = {}): Promise<Record<string, unknown>> {
+    const results: Record<string, unknown>[] = [];
+    for (const session of sessions ?? []) {
+      results.push(await this.syncLocalSession(user, session, ctx));
+    }
+    return { results };
+  }
+
+  private async upsertLocalSessionRow(
+    user: RequestUser,
+    id: string,
+    bookId: number,
+    item: AbsItemRow,
+    body: LocalSessionBody,
+    ctx: LocalSessionContext,
+  ): Promise<void> {
+    const currentTime = body.currentTime as number;
+    const updatedAtMs = typeof body.updatedAt === 'number' ? body.updatedAt : Date.now();
+    const updatedAt = new Date(updatedAtMs);
+    const dateParts = absDateParts(updatedAt);
+
+    const existing = await this.sessionRepo.findById(id);
+    if (existing) {
+      // The id is client-controlled; never let one user rewrite another's history row.
+      if (existing.userId !== user.id) throw new Error('session id belongs to another user');
+      await this.sessionRepo.updateFromLocal(id, {
+        currentTime,
+        timeListening: typeof body.timeListening === 'number' ? body.timeListening : existing.timeListening,
+        updatedAt,
+        ...dateParts,
+      });
+      return;
+    }
+
+    // New row: like ABS, snapshot metadata from the CURRENT server item, not the client payload.
+    const { mediaMetadata, authorName } = await this.mediaSnapshot(item);
+    const audioFiles = await this.readRepo.audioFilesByBookId(bookId);
+    const duration = typeof body.duration === 'number' ? body.duration : AbsProgressService.totalDuration(audioFiles);
+    const startedAtMs = typeof body.startedAt === 'number' ? body.startedAt : updatedAtMs;
+    await this.sessionRepo.insert({
+      id,
+      userId: user.id,
+      libraryId: item.libraryId,
+      bookId,
+      displayTitle: body.displayTitle ?? item.title ?? '',
+      displayAuthor: body.displayAuthor ?? authorName,
+      coverPath: `/metadata/items/${bookId}/cover`,
+      mediaMetadata,
+      chapters: normalizeChapters(item.chapters, duration) as unknown as Record<string, unknown>[],
+      duration,
+      playMethod: typeof body.playMethod === 'number' ? body.playMethod : PLAY_METHOD_LOCAL,
+      mediaPlayer: body.mediaPlayer ?? 'unknown',
+      deviceInfo: buildAbsDeviceInfo(user.id, body.deviceInfo ?? ctx.deviceInfo, ctx.ipAddress),
+      serverVersion: ABS_SERVER_VERSION,
+      date: body.date ?? dateParts.date,
+      dayOfWeek: body.dayOfWeek ?? dateParts.dayOfWeek,
+      timeListening: typeof body.timeListening === 'number' ? body.timeListening : 0,
+      startTimeSeconds: typeof body.startTime === 'number' ? body.startTime : 0,
+      currentTimeSeconds: currentTime,
+      startedAt: new Date(startedAtMs),
+      // ABS maps the row's createdAt to the session's startedAt (year-stats bucket by createdAt).
+      createdAt: new Date(startedAtMs),
+      updatedAt,
+    });
+  }
+
+  /**
+   * Persist an open session's current state (ABS `saveSession`): nothing is written until the
+   * session has accumulated listening time; the first save inserts, later saves update.
+   */
+  private async saveSession(session: AbsPlaybackSession): Promise<void> {
+    if (session.timeListening <= 0) return;
+    if (session.persisted) {
+      await this.sessionRepo.updateSync(session.id, {
+        currentTime: session.currentTime,
+        timeListening: session.timeListening,
+        updatedAt: new Date(session.updatedAt),
+      });
+    } else {
+      await this.sessionRepo.insert(this.toRow(session));
+      session.persisted = true;
+    }
+  }
+
+  /** The ABS `oldMetadataToJSON` snapshot stored on sessions (and echoed by the play response). */
+  private async mediaSnapshot(item: AbsItemRow): Promise<{ mediaMetadata: Record<string, unknown>; authorName: string }> {
+    const [authors, narrators, series, genres] = await Promise.all([
+      this.readRepo.authorsByBookIds([item.id]),
+      this.readRepo.narratorsByBookIds([item.id]),
+      this.readRepo.seriesByBookIds([item.id]),
+      this.readRepo.genresByBookIds([item.id]),
+    ]);
+    const authorName = authors.map((a) => a.name).join(', ');
+    const mediaMetadata = {
+      title: item.title ?? '',
+      subtitle: item.subtitle ?? null,
+      authors: authors.map((a) => ({ id: encodeAbsId('author', a.id), name: a.name })),
+      narrators: narrators.map((n) => n.name),
+      series: series.map((s) => ({ id: encodeAbsId('series', s.id), name: s.name, sequence: s.sequence != null ? String(s.sequence) : null })),
+      genres: genres.map((g) => g.name),
+      publishedYear: item.publishedYear != null ? String(item.publishedYear) : null,
+      publishedDate: null,
+      publisher: item.publisher ?? null,
+      description: item.description ?? null,
+      isbn: item.isbn13 ?? item.isbn10 ?? null,
+      asin: null,
+      language: item.language ?? null,
+      explicit: false,
+      abridged: false,
+    };
+    return { mediaMetadata, authorName };
+  }
+
+  private requireOwnedSession(sessionId: string, user: RequestUser): AbsPlaybackSession {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw AbsHttpException.notFound();
+    if (session.userId !== user.id && !user.isSuperuser) throw AbsHttpException.notFound();
+    return session;
+  }
+
+  /** Device takeover: ABS routes this through `closeSession`, so the dropped session is saved. */
+  private async closeOpenSessionsForDevice(userId: number, deviceId: string | null): Promise<void> {
+    for (const [id, session] of this.sessions) {
+      if (session.userId !== userId) continue;
+      if (deviceId && session.deviceId !== deviceId) continue;
+      this.sessions.delete(id);
+      await this.saveSession(session);
+      if (session.streamId) void this.transcodeService.closeStream(session.streamId);
+    }
+  }
+
+  /**
+   * Drop stale open sessions (no sync in 36h). Invoked opportunistically. No save here — ABS's
+   * stale sweep only evicts from memory; the last sync already persisted anything worth keeping.
+   */
+  pruneStaleSessions(): void {
+    const cutoff = Date.now() - STALE_SESSION_MS;
+    for (const [id, session] of this.sessions) {
+      if (session.updatedAt < cutoff) {
+        this.sessions.delete(id);
+        if (session.streamId) void this.transcodeService.closeStream(session.streamId);
+      }
+    }
+  }
+
+  /** The in-memory session as a history row (also the base of the client JSON). */
+  private toRow(session: AbsPlaybackSession): AbsPlaybackSessionRow {
+    return {
+      id: session.id,
+      userId: session.userId,
+      libraryId: session.libraryId,
+      bookId: session.bookId,
+      displayTitle: session.displayTitle,
+      displayAuthor: session.displayAuthor,
+      coverPath: `/metadata/items/${session.bookId}/cover`,
+      mediaMetadata: session.mediaMetadata,
+      chapters: session.chapters,
+      duration: session.duration,
+      playMethod: session.playMethod,
+      mediaPlayer: session.mediaPlayer,
+      deviceInfo: session.deviceInfo,
+      serverVersion: ABS_SERVER_VERSION,
+      date: session.date,
+      dayOfWeek: session.dayOfWeek,
+      timeListening: session.timeListening,
+      startTimeSeconds: session.startTime,
+      currentTimeSeconds: session.currentTime,
+      startedAt: new Date(session.startedAt),
+      createdAt: new Date(session.startedAt),
+      updatedAt: new Date(session.updatedAt),
+    };
+  }
+
+  /** ABS `toJSONForClient`: the `toJSON` wire shape plus the playable `audioTracks`. */
+  private toClientJSON(session: AbsPlaybackSession): Record<string, unknown> {
+    return { ...toAbsSessionJson(this.toRow(session)), audioTracks: session.audioTracks };
+  }
+}

--- a/server/src/modules/abs/services/abs-progress.service.test.ts
+++ b/server/src/modules/abs/services/abs-progress.service.test.ts
@@ -1,0 +1,156 @@
+import { AbsProgressService } from './abs-progress.service';
+import * as schema from '../../../db/schema';
+import { encodeAbsId } from '../abs-id.util';
+import type { AbsAudioFileRow, AbsReadRepository } from '../abs-read.repository';
+
+function file(id: number, durationSeconds: number): AbsAudioFileRow {
+  return { id, bookId: 1, format: 'mp3', sortOrder: id, durationSeconds, sizeBytes: 1000, absolutePath: `/x/${id}.mp3` };
+}
+
+describe('AbsProgressService progress math', () => {
+  const files = [file(10, 100), file(11, 200), file(12, 50)]; // total 350s
+
+  it('sums total duration', () => {
+    expect(AbsProgressService.totalDuration(files)).toBe(350);
+    expect(AbsProgressService.totalDuration([])).toBe(0);
+  });
+
+  it('computes absolute current time across files', () => {
+    expect(AbsProgressService.absoluteCurrentTime(files, 10, 30)).toBe(30); // first file
+    expect(AbsProgressService.absoluteCurrentTime(files, 11, 30)).toBe(130); // 100 + 30
+    expect(AbsProgressService.absoluteCurrentTime(files, 12, 10)).toBe(310); // 100 + 200 + 10
+  });
+
+  it('resolves an absolute position back to (file, offset)', () => {
+    expect(AbsProgressService.resolveFileAndOffset(files, 30)).toEqual({ fileId: 10, positionSeconds: 30 });
+    expect(AbsProgressService.resolveFileAndOffset(files, 130)).toEqual({ fileId: 11, positionSeconds: 30 });
+    expect(AbsProgressService.resolveFileAndOffset(files, 310)).toEqual({ fileId: 12, positionSeconds: 10 });
+  });
+
+  it('round-trips absoluteCurrentTime <-> resolveFileAndOffset', () => {
+    for (const t of [0, 50, 100, 250, 349]) {
+      const placement = AbsProgressService.resolveFileAndOffset(files, t)!;
+      expect(AbsProgressService.absoluteCurrentTime(files, placement.fileId, placement.positionSeconds)).toBe(t);
+    }
+  });
+
+  it('pins a past-the-end position to the last file end', () => {
+    expect(AbsProgressService.resolveFileAndOffset(files, 9999)).toEqual({ fileId: 12, positionSeconds: 50 });
+  });
+
+  it('returns null when there are no audio files', () => {
+    expect(AbsProgressService.resolveFileAndOffset([], 10)).toBeNull();
+  });
+});
+
+describe('AbsProgressService#toMediaProgress shape', () => {
+  // Stub deps: toMediaProgress is pure given its args and touches neither.
+  const service = new AbsProgressService(undefined as never, undefined as never);
+  const row = {
+    userId: 3,
+    bookId: 427,
+    percentage: 1,
+    currentFileId: 10,
+    positionSeconds: 30,
+    hideFromContinueListening: false,
+    updatedAt: new Date('2026-06-01T00:00:00Z'),
+  } as schema.AudiobookProgress;
+
+  // Regression: ABS MediaProgress carries non-nullable createdAt/updatedAt. Omitting them fails
+  // Prologue's strict Codable decode of /api/me and silently blanks the entire library.
+  it('emits every key ABS MediaProgress requires, incl. createdAt/updatedAt', () => {
+    const progress = (
+      service as unknown as {
+        toMediaProgress: (b: number, r: schema.AudiobookProgress, f: AbsAudioFileRow[], p: number) => Record<string, unknown>;
+      }
+    ).toMediaProgress(427, row, [file(10, 100), file(11, 200)], 98);
+
+    expect(Object.keys(progress).sort()).toEqual(
+      [
+        'createdAt',
+        'currentTime',
+        'duration',
+        'ebookLocation',
+        'ebookProgress',
+        'episodeId',
+        'finishedAt',
+        'hideFromContinueListening',
+        'id',
+        'isFinished',
+        'lastUpdate',
+        'libraryItemId',
+        'mediaItemId',
+        'mediaItemType',
+        'progress',
+        'startedAt',
+        'updatedAt',
+        'userId',
+      ].sort(),
+    );
+    const updatedMs = row.updatedAt.getTime();
+    expect(progress.createdAt).toBe(updatedMs);
+    expect(progress.updatedAt).toBe(updatedMs);
+    // Verified against live ABS 2.35.1: userId is always present and ebookProgress is a number
+    // (0 for audio), never null — strict clients decode both.
+    expect(progress.userId).toBe(`usr_${row.userId}`);
+    expect(progress.ebookProgress).toBe(0);
+  });
+
+  // "Remove from Continue Listening" persists on the row; the mapper must mirror it, not hardcode false.
+  it('mirrors the persisted hideFromContinueListening flag', () => {
+    const hiddenRow = { ...row, hideFromContinueListening: true } as schema.AudiobookProgress;
+    const progress = (
+      service as unknown as {
+        toMediaProgress: (b: number, r: schema.AudiobookProgress, f: AbsAudioFileRow[], p: number) => Record<string, unknown>;
+      }
+    ).toMediaProgress(427, hiddenRow, [file(10, 100)], 98);
+    expect(progress.hideFromContinueListening).toBe(true);
+  });
+});
+
+describe('AbsProgressService#listMediaProgressForUser', () => {
+  /** Chainable select stub: each `db.select()` resolves to the next queued result set. */
+  function fakeDb(results: unknown[][]): never {
+    let call = 0;
+    const chain = (result: unknown[]) => {
+      const q = {
+        from: () => q,
+        where: () => q,
+        limit: () => q,
+        then: (onFulfilled: (rows: unknown[]) => unknown) => Promise.resolve(result).then(onFulfilled),
+      };
+      return q;
+    };
+    return { select: () => chain(results[call++]) } as never;
+  }
+
+  function progressRow(bookId: number): schema.AudiobookProgress {
+    return {
+      userId: 3,
+      bookId,
+      percentage: 10,
+      currentFileId: 10,
+      positionSeconds: 30,
+      updatedAt: new Date('2026-06-01T00:00:00Z'),
+    } as schema.AudiobookProgress;
+  }
+
+  it('drops progress rows for books the read repository no longer returns (e.g. ebook-only)', async () => {
+    // Book 1 is a visible audiobook; book 2 has a progress row but is hidden by the repository's
+    // playable-audio gate, so findItemsByIds omits it — its progress must not reach /api/me.
+    const readRepo = {
+      audioFilesByBookIds: vi.fn().mockResolvedValue([file(10, 100)]),
+      findItemsByIds: vi.fn().mockResolvedValue([{ id: 1, libraryId: 5 }]),
+    } as unknown as AbsReadRepository;
+    const db = fakeDb([
+      [progressRow(1), progressRow(2)], // audiobook_progress rows
+      [{ markAsFinishedPercentComplete: 98 }], // finishPercentForLibrary(5)
+    ]);
+
+    const service = new AbsProgressService(readRepo, db);
+    const result = await service.listMediaProgressForUser(3);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].libraryItemId).toBe(encodeAbsId('libraryItem', 1));
+  });
+});

--- a/server/src/modules/abs/services/abs-progress.service.ts
+++ b/server/src/modules/abs/services/abs-progress.service.ts
@@ -1,0 +1,330 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { and, desc, eq, gt, lt, sql } from 'drizzle-orm';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+
+import { DB } from '../../../db';
+import * as schema from '../../../db/schema';
+import { encodeAbsId } from '../abs-id.util';
+import { AbsReadRepository, type AbsAudioFileRow } from '../abs-read.repository';
+
+const DEFAULT_FINISH_PERCENT = 98;
+
+export interface AbsProgressInput {
+  /** Absolute position across the whole book, in seconds. */
+  currentTime: number;
+  /** Total book duration in seconds (falls back to summed file durations). */
+  duration?: number;
+  /** Explicit finished flag (e.g. "mark as finished" from the client). */
+  isFinished?: boolean;
+  /** Explicit hide-from-continue flag; when absent, an existing hide resets once the position moves. */
+  hideFromContinueListening?: boolean;
+}
+
+/** Raw PATCH /me/progress body — `progress` (0..1) is accepted as an alternative to `currentTime`. */
+export interface AbsProgressBody {
+  currentTime?: number;
+  duration?: number;
+  progress?: number;
+  isFinished?: boolean;
+  hideFromContinueListening?: boolean;
+}
+
+/**
+ * Bridges BookOrbit's per-file `audiobook_progress` (currentFileId + positionSeconds + percentage)
+ * and ABS's per-item `MediaProgress` (absolute currentTime / duration / progress 0..1 / isFinished).
+ * Auto-finish uses the owning library's `markAsFinishedPercentComplete` (REIMPLEMENTATION_GUIDE §3.2).
+ */
+@Injectable()
+export class AbsProgressService {
+  constructor(
+    private readonly readRepo: AbsReadRepository,
+    @Inject(DB) private readonly db: NodePgDatabase<typeof schema>,
+  ) {}
+
+  /** Total duration from the ordered audio files (seconds). */
+  static totalDuration(audioFiles: AbsAudioFileRow[]): number {
+    return audioFiles.reduce((sum, f) => sum + (f.durationSeconds ?? 0), 0);
+  }
+
+  /** Absolute position = sum of durations before currentFile + positionSeconds. */
+  static absoluteCurrentTime(audioFiles: AbsAudioFileRow[], currentFileId: number, positionSeconds: number): number {
+    let preceding = 0;
+    for (const file of audioFiles) {
+      if (file.id === currentFileId) break;
+      preceding += file.durationSeconds ?? 0;
+    }
+    return preceding + positionSeconds;
+  }
+
+  /** Inverse: map an absolute position back to a (file, offset-within-file). */
+  static resolveFileAndOffset(audioFiles: AbsAudioFileRow[], currentTime: number): { fileId: number; positionSeconds: number } | null {
+    if (audioFiles.length === 0) return null;
+    let consumed = 0;
+    for (const file of audioFiles) {
+      const dur = file.durationSeconds ?? 0;
+      if (currentTime < consumed + dur || dur === 0) {
+        return { fileId: file.id, positionSeconds: Math.max(0, currentTime - consumed) };
+      }
+      consumed += dur;
+    }
+    // Past the end: pin to the last file's end.
+    const last = audioFiles[audioFiles.length - 1];
+    return { fileId: last.id, positionSeconds: last.durationSeconds ?? 0 };
+  }
+
+  private async finishPercentForLibrary(libraryId: number): Promise<number> {
+    const [lib] = await this.db
+      .select({ markAsFinishedPercentComplete: schema.libraries.markAsFinishedPercentComplete })
+      .from(schema.libraries)
+      .where(eq(schema.libraries.id, libraryId))
+      .limit(1);
+    return lib?.markAsFinishedPercentComplete ?? DEFAULT_FINISH_PERCENT;
+  }
+
+  /** Build the ABS MediaProgress object for one book, or null if there's no progress row. */
+  async getMediaProgress(userId: number, bookId: number, libraryId: number): Promise<Record<string, unknown> | null> {
+    const [row] = await this.db
+      .select()
+      .from(schema.audiobookProgress)
+      .where(and(eq(schema.audiobookProgress.userId, userId), eq(schema.audiobookProgress.bookId, bookId)))
+      .limit(1);
+    if (!row) return null;
+
+    const audioFiles = await this.readRepo.audioFilesByBookId(bookId);
+    const finishPercent = await this.finishPercentForLibrary(libraryId);
+    return this.toMediaProgress(bookId, row, audioFiles, finishPercent);
+  }
+
+  /** All of a user's audiobook progress, mapped to ABS MediaProgress (for /api/me and login). */
+  async listMediaProgressForUser(userId: number): Promise<Record<string, unknown>[]> {
+    const rows = await this.db.select().from(schema.audiobookProgress).where(eq(schema.audiobookProgress.userId, userId));
+    if (rows.length === 0) return [];
+
+    const bookIds = rows.map((r) => r.bookId);
+    const [audioFiles, items] = await Promise.all([this.readRepo.audioFilesByBookIds(bookIds), this.readRepo.findItemsByIds(bookIds)]);
+    const filesByBook = groupBy(audioFiles, (f) => f.bookId);
+    const libraryByBook = new Map(items.map((i) => [i.id, i.libraryId]));
+
+    const finishPercentByLibrary = new Map<number, number>();
+    const result: Record<string, unknown>[] = [];
+    for (const row of rows) {
+      const libraryId = libraryByBook.get(row.bookId);
+      if (libraryId === undefined) continue;
+      if (!finishPercentByLibrary.has(libraryId)) finishPercentByLibrary.set(libraryId, await this.finishPercentForLibrary(libraryId));
+      result.push(this.toMediaProgress(row.bookId, row, filesByBook.get(row.bookId) ?? [], finishPercentByLibrary.get(libraryId)!));
+    }
+    return result;
+  }
+
+  private toMediaProgress(
+    bookId: number,
+    row: schema.AudiobookProgress,
+    audioFiles: AbsAudioFileRow[],
+    finishPercent: number,
+  ): Record<string, unknown> {
+    const duration = AbsProgressService.totalDuration(audioFiles);
+    const currentTime = AbsProgressService.absoluteCurrentTime(audioFiles, row.currentFileId, row.positionSeconds);
+    const isFinished = row.percentage >= finishPercent;
+    const progress = duration > 0 ? Math.min(1, Math.max(0, currentTime / duration)) : 0;
+    const updatedMs = row.updatedAt.getTime();
+    const libraryItemId = encodeAbsId('libraryItem', bookId);
+    return {
+      id: `${encodeAbsId('user', row.userId)}-${libraryItemId}`,
+      // ABS MediaProgress always carries the owning user's id (verified against a live 2.35.1
+      // /api/me capture); strict clients may require it.
+      userId: encodeAbsId('user', row.userId),
+      libraryItemId,
+      episodeId: null,
+      mediaItemId: encodeAbsId('book', bookId),
+      mediaItemType: 'book',
+      duration,
+      currentTime,
+      progress: isFinished ? 1 : progress,
+      isFinished,
+      hideFromContinueListening: row.hideFromContinueListening,
+      // ABS always emits these; strict Codable clients (e.g. Prologue) decode the whole
+      // MediaProgress object and drop the entire item list if a required key is absent. Live ABS
+      // 2.35.1 sends ebookLocation null but ebookProgress 0 for audio (it coalesces null to 0 on
+      // write), so a non-optional Double decode is satisfied only by the number.
+      ebookLocation: null,
+      ebookProgress: 0,
+      lastUpdate: updatedMs,
+      startedAt: updatedMs,
+      finishedAt: isFinished ? updatedMs : null,
+      // ABS MediaProgress carries non-nullable createdAt/updatedAt; omitting them fails Prologue's
+      // strict decode of /api/me, which silently blanks the whole library. BookOrbit tracks only one
+      // timestamp on the progress row, so both mirror it (as startedAt/lastUpdate already do).
+      createdAt: updatedMs,
+      updatedAt: updatedMs,
+    };
+  }
+
+  /**
+   * Upsert progress from an absolute position (open-session sync, /me/progress, offline merge).
+   * Returns the resulting ABS MediaProgress, or null when the book has no audio files.
+   */
+  async upsertFromCurrentTime(userId: number, bookId: number, libraryId: number, input: AbsProgressInput): Promise<Record<string, unknown> | null> {
+    const audioFiles = await this.readRepo.audioFilesByBookId(bookId);
+    const placement = AbsProgressService.resolveFileAndOffset(audioFiles, input.currentTime);
+    if (!placement) return null;
+
+    const duration = input.duration && input.duration > 0 ? input.duration : AbsProgressService.totalDuration(audioFiles);
+    const finishPercent = await this.finishPercentForLibrary(libraryId);
+    let percentage = duration > 0 ? Math.min(100, Math.max(0, (input.currentTime / duration) * 100)) : 0;
+    if (input.isFinished) percentage = 100;
+
+    // ABS `MediaProgress.applyProgressUpdate`: an explicit flag in the payload wins; otherwise an
+    // existing hide is cleared only when the position actually moved (so idle re-syncs of the same
+    // position don't resurface a hidden item on the Continue shelf).
+    const hideFromContinueListening =
+      input.hideFromContinueListening ??
+      sql<boolean>`case
+        when ${schema.audiobookProgress.currentFileId} <> ${placement.fileId}
+          or ${schema.audiobookProgress.positionSeconds} <> ${placement.positionSeconds}
+        then false
+        else ${schema.audiobookProgress.hideFromContinueListening}
+      end`;
+
+    await this.db
+      .insert(schema.audiobookProgress)
+      .values({
+        userId,
+        bookId,
+        percentage,
+        currentFileId: placement.fileId,
+        positionSeconds: placement.positionSeconds,
+        hideFromContinueListening: input.hideFromContinueListening ?? false,
+      })
+      .onConflictDoUpdate({
+        target: [schema.audiobookProgress.userId, schema.audiobookProgress.bookId],
+        set: {
+          percentage,
+          currentFileId: placement.fileId,
+          positionSeconds: placement.positionSeconds,
+          hideFromContinueListening,
+          updatedAt: new Date(),
+        },
+      });
+
+    const [row] = await this.db
+      .select()
+      .from(schema.audiobookProgress)
+      .where(and(eq(schema.audiobookProgress.userId, userId), eq(schema.audiobookProgress.bookId, bookId)))
+      .limit(1);
+    return row ? this.toMediaProgress(bookId, row, audioFiles, finishPercent) : null;
+  }
+
+  /** Current persisted updatedAt for a (user, book), for the offline newest-wins merge. */
+  async getProgressUpdatedAt(userId: number, bookId: number): Promise<Date | null> {
+    const [row] = await this.db
+      .select({ updatedAt: schema.audiobookProgress.updatedAt })
+      .from(schema.audiobookProgress)
+      .where(and(eq(schema.audiobookProgress.userId, userId), eq(schema.audiobookProgress.bookId, bookId)))
+      .limit(1);
+    return row?.updatedAt ?? null;
+  }
+
+  /**
+   * Book ids the user has started but not completed, most-recently-updated first (Continue shelf).
+   * `excludeHidden` mirrors ABS, which respects `hideFromContinueListening` only on the home-page
+   * shelves (`/personalized`), not on `/me/items-in-progress`.
+   */
+  async listInProgressBookIds(userId: number, opts: { excludeHidden?: boolean } = {}): Promise<number[]> {
+    const rows = await this.db
+      .select({ bookId: schema.audiobookProgress.bookId })
+      .from(schema.audiobookProgress)
+      .where(
+        and(
+          eq(schema.audiobookProgress.userId, userId),
+          gt(schema.audiobookProgress.percentage, 0),
+          lt(schema.audiobookProgress.percentage, 100),
+          opts.excludeHidden ? eq(schema.audiobookProgress.hideFromContinueListening, false) : undefined,
+        ),
+      )
+      .orderBy(desc(schema.audiobookProgress.updatedAt));
+    return rows.map((r) => r.bookId);
+  }
+
+  /**
+   * "Remove from Continue Listening": mark the progress row hidden (ABS
+   * `MeController.removeItemFromContinueListening`). Returns false when there is no row (→ 404).
+   */
+  async hideFromContinueListening(userId: number, bookId: number): Promise<boolean> {
+    const updated = await this.db
+      .update(schema.audiobookProgress)
+      .set({ hideFromContinueListening: true })
+      .where(and(eq(schema.audiobookProgress.userId, userId), eq(schema.audiobookProgress.bookId, bookId)))
+      .returning({ bookId: schema.audiobookProgress.bookId });
+    return updated.length > 0;
+  }
+
+  /** Delete a user's progress for one book. Returns false when there was no row to remove (→ 404). */
+  async deleteProgress(userId: number, bookId: number): Promise<boolean> {
+    const deleted = await this.db
+      .delete(schema.audiobookProgress)
+      .where(and(eq(schema.audiobookProgress.userId, userId), eq(schema.audiobookProgress.bookId, bookId)))
+      .returning({ bookId: schema.audiobookProgress.bookId });
+    return deleted.length > 0;
+  }
+
+  /** Build ABS MediaProgress for a book, resolving the owning library automatically. */
+  async getMediaProgressByBook(userId: number, bookId: number): Promise<Record<string, unknown> | null> {
+    const libraryId = await this.readRepo.libraryIdForBook(bookId);
+    if (libraryId === null) return null;
+    return this.getMediaProgress(userId, bookId, libraryId);
+  }
+
+  /**
+   * Stateless upsert from a raw PATCH /me/progress body. Resolves `currentTime` from `progress`
+   * (0..1) when only the latter is supplied, and looks up the owning library for the finish rule.
+   */
+  async upsertFromBody(userId: number, bookId: number, body: AbsProgressBody): Promise<Record<string, unknown> | null> {
+    const libraryId = await this.readRepo.libraryIdForBook(bookId);
+    if (libraryId === null) return null;
+
+    let currentTime = body.currentTime;
+    if (currentTime === undefined && typeof body.progress === 'number') {
+      const duration =
+        body.duration && body.duration > 0 ? body.duration : AbsProgressService.totalDuration(await this.readRepo.audioFilesByBookId(bookId));
+      currentTime = Math.max(0, Math.min(1, body.progress)) * duration;
+    }
+    if (currentTime === undefined && !body.isFinished) return null;
+
+    return this.upsertFromCurrentTime(userId, bookId, libraryId, {
+      currentTime: currentTime ?? 0,
+      duration: body.duration,
+      isFinished: body.isFinished,
+      hideFromContinueListening: body.hideFromContinueListening,
+    });
+  }
+
+  /**
+   * Offline reconciliation merge (REIMPLEMENTATION_GUIDE §7.3): newest `updatedAt` wins. Skips the
+   * upsert when the stored progress is newer than the incoming offline session.
+   */
+  async mergeOfflineProgress(
+    userId: number,
+    bookId: number,
+    input: AbsProgressInput & { updatedAt?: number },
+  ): Promise<{ progressSynced: boolean; mediaProgress: Record<string, unknown> | null }> {
+    const existing = await this.getProgressUpdatedAt(userId, bookId);
+    if (existing && input.updatedAt && existing.getTime() > input.updatedAt) {
+      return { progressSynced: false, mediaProgress: await this.getMediaProgressByBook(userId, bookId) };
+    }
+    const libraryId = await this.readRepo.libraryIdForBook(bookId);
+    if (libraryId === null) return { progressSynced: false, mediaProgress: null };
+    const mediaProgress = await this.upsertFromCurrentTime(userId, bookId, libraryId, input);
+    return { progressSynced: mediaProgress != null, mediaProgress };
+  }
+}
+
+function groupBy<T, K>(items: T[], keyFn: (item: T) => K): Map<K, T[]> {
+  const map = new Map<K, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const list = map.get(key);
+    if (list) list.push(item);
+    else map.set(key, [item]);
+  }
+  return map;
+}

--- a/server/src/modules/abs/services/abs-session-history.service.test.ts
+++ b/server/src/modules/abs/services/abs-session-history.service.test.ts
@@ -1,0 +1,223 @@
+import type { AbsPlaybackSessionRow } from '../../../db/schema';
+import type { AbsPlaybackSessionRepository } from '../abs-playback-session.repository';
+import type { AbsItemRow, AbsReadRepository } from '../abs-read.repository';
+import { makeAbsUser, thrownStatus } from '../__testing__/abs-test-helpers';
+import { AbsSessionHistoryService } from './abs-session-history.service';
+import type { AbsProgressService } from './abs-progress.service';
+
+function row(overrides: Partial<AbsPlaybackSessionRow> = {}): AbsPlaybackSessionRow {
+  return {
+    id: `s-${Math.random().toString(36).slice(2)}`,
+    userId: 1,
+    libraryId: 4,
+    bookId: 42,
+    displayTitle: 'The Hobbit',
+    displayAuthor: 'Tolkien',
+    coverPath: '/metadata/items/42/cover',
+    mediaMetadata: { title: 'The Hobbit', authors: [{ id: 'aut_1', name: 'Tolkien' }], narrators: ['Serkis'], genres: ['Fantasy', 'Audiobook'] },
+    chapters: [],
+    duration: 300,
+    playMethod: 0,
+    mediaPlayer: 'AVPlayer',
+    deviceInfo: {},
+    serverVersion: '2.35.1',
+    date: '2026-07-10',
+    dayOfWeek: 'Friday',
+    timeListening: 60,
+    startTimeSeconds: 0,
+    currentTimeSeconds: 60,
+    startedAt: new Date(2026, 6, 10, 9, 0),
+    createdAt: new Date(2026, 6, 10, 9, 0),
+    updatedAt: new Date(2026, 6, 10, 9, 5),
+    ...overrides,
+  };
+}
+
+function item(id: number, overrides: Partial<AbsItemRow> = {}): AbsItemRow {
+  return {
+    id,
+    libraryId: 4,
+    status: 'ready',
+    addedAt: new Date(),
+    updatedAt: new Date(),
+    title: `Book ${id}`,
+    subtitle: null,
+    description: null,
+    publishedYear: null,
+    publisher: null,
+    language: null,
+    isbn13: null,
+    isbn10: null,
+    seriesName: null,
+    seriesIndex: null,
+    durationSeconds: null,
+    chapters: [],
+    ...overrides,
+  };
+}
+
+interface BuildOpts {
+  rows?: AbsPlaybackSessionRow[];
+  yearRows?: AbsPlaybackSessionRow[];
+  items?: AbsItemRow[];
+  progress?: Record<string, unknown>[];
+  findItem?: AbsItemRow | null;
+}
+
+function build(opts: BuildOpts = {}) {
+  const sessionRepo = {
+    listForUser: vi.fn().mockResolvedValue(opts.rows ?? []),
+    listForUserCreatedInYear: vi.fn().mockResolvedValue(opts.yearRows ?? []),
+  } as unknown as AbsPlaybackSessionRepository;
+  const readRepo = {
+    findItem: vi.fn().mockResolvedValue(opts.findItem === undefined ? item(42) : opts.findItem),
+    findItemsByIds: vi.fn().mockResolvedValue(opts.items ?? [item(42)]),
+  } as unknown as AbsReadRepository;
+  const progressService = {
+    listMediaProgressForUser: vi.fn().mockResolvedValue(opts.progress ?? []),
+  } as unknown as AbsProgressService;
+  return { service: new AbsSessionHistoryService(sessionRepo, readRepo, progressService), sessionRepo, readRepo };
+}
+
+describe('AbsSessionHistoryService#listeningSessions', () => {
+  it('returns the ABS empty envelope when there is no history', async () => {
+    const { service } = build();
+    expect(await service.listeningSessions(makeAbsUser(), {})).toEqual({
+      total: 0,
+      numPages: 0,
+      page: 0,
+      itemsPerPage: 10,
+      sessions: [],
+    });
+  });
+
+  it('paginates with the ABS envelope math and maps sessions to the wire shape', async () => {
+    const rows = Array.from({ length: 12 }, (_, i) => row({ id: `s-${i}` }));
+    const { service } = build({ rows });
+    const first = await service.listeningSessions(makeAbsUser(), {});
+    expect(first).toMatchObject({ total: 12, numPages: 2, page: 0, itemsPerPage: 10 });
+    expect((first.sessions as unknown[]).length).toBe(10);
+    const sessionJson = (first.sessions as Record<string, unknown>[])[0];
+    expect(sessionJson.libraryItemId).toBe('li_42');
+    expect(sessionJson.episodeId).toBeNull();
+    expect(typeof sessionJson.startedAt).toBe('number');
+
+    const second = await service.listeningSessions(makeAbsUser(), { page: '1', itemsPerPage: '10' });
+    expect((second.sessions as unknown[]).length).toBe(2);
+  });
+});
+
+describe('AbsSessionHistoryService#itemListeningSessions', () => {
+  it('404s on a malformed id and on an unknown item', async () => {
+    expect(await thrownStatus(() => build().service.itemListeningSessions(makeAbsUser(), 'nope', {}))).toBe(404);
+    expect(await thrownStatus(() => build({ findItem: null }).service.itemListeningSessions(makeAbsUser(), 'li_42', {}))).toBe(404);
+  });
+
+  it('filters the history by book id', async () => {
+    const { service, sessionRepo } = build({ rows: [row()] });
+    const result = await service.itemListeningSessions(makeAbsUser({ id: 1 }), 'li_42', {});
+    expect(sessionRepo.listForUser).toHaveBeenCalledWith(1, { bookId: 42 });
+    expect(result.total).toBe(1);
+  });
+});
+
+describe('AbsSessionHistoryService#listeningStats', () => {
+  it('returns the zeroed ABS shape when there is no history', async () => {
+    const { service } = build();
+    expect(await service.listeningStats(makeAbsUser())).toEqual({
+      totalTime: 0,
+      items: {},
+      days: {},
+      dayOfWeek: {},
+      today: 0,
+      recentSessions: [],
+    });
+  });
+
+  it('accumulates totals, day buckets, and per-item entries WITHOUT a lastUpdate key', async () => {
+    const today = new Date();
+    const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    const rows = [
+      row({ id: 's-1', timeListening: 60, date: todayStr, dayOfWeek: 'Sunday' }),
+      row({ id: 's-2', timeListening: 40, date: '2026-07-10', dayOfWeek: 'Friday' }),
+      row({ id: 's-3', bookId: 7, timeListening: 5, date: '2026-07-10', dayOfWeek: 'Friday' }),
+    ];
+    const { service } = build({ rows });
+    const stats = await service.listeningStats(makeAbsUser());
+    expect(stats.totalTime).toBe(105);
+    expect(stats.today).toBe(60);
+    expect(stats.days).toEqual({ [todayStr]: 60, '2026-07-10': 45 });
+    expect(stats.dayOfWeek).toEqual({ Sunday: 60, Friday: 45 });
+    const items = stats.items as Record<string, Record<string, unknown>>;
+    expect(items.li_42.timeListening).toBe(100);
+    expect(items.li_7.timeListening).toBe(5);
+    expect(items.li_42).not.toHaveProperty('lastUpdate'); // ABS 2.35.1 drops the key (undefined)
+    expect((stats.recentSessions as unknown[]).length).toBe(3);
+  });
+});
+
+describe('AbsSessionHistoryService#statsForYear', () => {
+  it('returns the zeroed ABS shape for an empty year', async () => {
+    const { service } = build();
+    const stats = await service.statsForYear(makeAbsUser(), 2026);
+    expect(stats).toEqual({
+      totalListeningSessions: 0,
+      totalListeningTime: 0,
+      totalBookListeningTime: 0,
+      totalPodcastListeningTime: 0,
+      topAuthors: [],
+      topGenres: [],
+      mostListenedNarrator: null,
+      mostListenedMonth: null,
+      numBooksFinished: 0,
+      numBooksListened: 0,
+      longestAudiobookFinished: null,
+      booksWithCovers: [],
+      finishedBooksWithCovers: [],
+    });
+  });
+
+  it('aggregates authors/genres/narrators/months from session metadata, filtering junk genres by substring', async () => {
+    const yearRows = [
+      row({ id: 's-1', timeListening: 100, createdAt: new Date(2026, 2, 1) }),
+      row({
+        id: 's-2',
+        bookId: 7,
+        displayTitle: 'Dune',
+        timeListening: 50,
+        createdAt: new Date(2026, 5, 1),
+        mediaMetadata: { title: 'Dune', authors: [{ id: 'aut_2', name: 'Herbert' }], narrators: [], genres: ['Sci-Fi Audiobooks'] },
+      }),
+    ];
+    const { service } = build({ yearRows, items: [item(42), item(7)] });
+    const stats = await service.statsForYear(makeAbsUser(), 2026);
+    expect(stats.totalListeningSessions).toBe(2);
+    expect(stats.totalListeningTime).toBe(150);
+    expect(stats.topAuthors).toEqual([
+      { name: 'Tolkien', time: 100 },
+      { name: 'Herbert', time: 50 },
+    ]);
+    // 'Audiobook' and 'Sci-Fi Audiobooks' are both filtered by the SUBSTRING rule:
+    expect(stats.topGenres).toEqual([{ genre: 'Fantasy', time: 100 }]);
+    expect(stats.mostListenedNarrator).toEqual({ name: 'Serkis', time: 100 });
+    expect(stats.mostListenedMonth).toEqual({ month: 2, time: 100 });
+    expect(stats.numBooksListened).toBe(2); // distinct display titles
+    expect(stats.booksWithCovers).toEqual(['li_42', 'li_7']);
+  });
+
+  it('computes the finished side from MediaProgress finishedAt within the year', async () => {
+    const inYear = Date.UTC(2026, 3, 1);
+    const outOfYear = Date.UTC(2025, 3, 1);
+    const progress = [
+      { libraryItemId: 'li_42', isFinished: true, finishedAt: inYear, duration: 300 },
+      { libraryItemId: 'li_7', isFinished: true, finishedAt: outOfYear, duration: 900 },
+      { libraryItemId: 'li_9', isFinished: false, finishedAt: null, duration: 100 },
+    ];
+    const { service } = build({ progress, items: [item(42, { title: 'The Hobbit' })] });
+    const stats = await service.statsForYear(makeAbsUser(), 2026);
+    expect(stats.numBooksFinished).toBe(1);
+    expect(stats.finishedBooksWithCovers).toEqual(['li_42']);
+    expect(stats.longestAudiobookFinished).toMatchObject({ id: 'bk_42', title: 'The Hobbit', duration: 300 });
+    expect(typeof (stats.longestAudiobookFinished as Record<string, unknown>).finishedAt).toBe('string'); // ISO, like ABS
+  });
+});

--- a/server/src/modules/abs/services/abs-session-history.service.ts
+++ b/server/src/modules/abs/services/abs-session-history.service.ts
@@ -1,0 +1,215 @@
+import { Injectable } from '@nestjs/common';
+
+import type { RequestUser } from '../../../common/types/request-user';
+import type { AbsPlaybackSessionRow } from '../../../db/schema';
+import { AbsHttpException } from '../abs-errors';
+import { decodeAbsId, encodeAbsId } from '../abs-id.util';
+import { AbsPlaybackSessionRepository } from '../abs-playback-session.repository';
+import { AbsReadRepository } from '../abs-read.repository';
+import { absDateParts, toAbsSessionJson } from '../mappers/abs-session.mapper';
+import { AbsProgressService } from './abs-progress.service';
+
+/**
+ * Read side of the persisted listening-session log: `/me/listening-sessions` (+ per-item variant),
+ * `/me/listening-stats`, `/me/stats/year/:year`. Each reduction mirrors its ABS counterpart
+ * (`ApiRouter.getUserListeningStatsHelpers`, `utils/queries/userStats.js getStatsForYear`)
+ * bug-for-bug, since strict clients decode these payloads verbatim.
+ */
+@Injectable()
+export class AbsSessionHistoryService {
+  constructor(
+    private readonly sessionRepo: AbsPlaybackSessionRepository,
+    private readonly readRepo: AbsReadRepository,
+    private readonly progressService: AbsProgressService,
+  ) {}
+
+  /** Paginated history envelope (ABS `MeController.getListeningSessions`). */
+  async listeningSessions(user: RequestUser, query: Record<string, string>): Promise<Record<string, unknown>> {
+    const rows = await this.sessionRepo.listForUser(user.id);
+    return this.paginate(rows, query);
+  }
+
+  /** Per-item history; 404s when the item does not exist (ABS looks the item up first). */
+  async itemListeningSessions(user: RequestUser, libraryItemId: string, query: Record<string, string>): Promise<Record<string, unknown>> {
+    const bookId = decodeAbsId('libraryItem', libraryItemId);
+    if (bookId === null) throw AbsHttpException.notFound();
+    const item = await this.readRepo.findItem(bookId);
+    if (!item) throw AbsHttpException.notFound();
+    const rows = await this.sessionRepo.listForUser(user.id, { bookId });
+    return this.paginate(rows, query);
+  }
+
+  /** Aggregate stats (ABS `ApiRouter.getUserListeningStatsHelpers`). */
+  async listeningStats(user: RequestUser): Promise<Record<string, unknown>> {
+    const rows = await this.sessionRepo.listForUser(user.id); // already updatedAt desc
+    const today = absDateParts(new Date()).date;
+
+    let totalTime = 0;
+    const items: Record<string, Record<string, unknown>> = {};
+    const days: Record<string, number> = {};
+    const dayOfWeek: Record<string, number> = {};
+    let todayTime = 0;
+
+    for (const s of rows) {
+      const time = s.timeListening;
+      if (s.dayOfWeek) dayOfWeek[s.dayOfWeek] = (dayOfWeek[s.dayOfWeek] ?? 0) + time;
+      if (s.date && time > 0) {
+        days[s.date] = (days[s.date] ?? 0) + time;
+        if (s.date === today) todayTime += time;
+      }
+      const itemId = encodeAbsId('libraryItem', s.bookId);
+      if (!items[itemId]) {
+        // NOTE: no `lastUpdate` key — ABS 2.35.1 reads it off an object where it is undefined,
+        // so the serialized JSON drops the key entirely. Match that, don't invent a value.
+        items[itemId] = { id: itemId, timeListening: time, mediaMetadata: s.mediaMetadata };
+      } else {
+        items[itemId].timeListening = (items[itemId].timeListening as number) + time;
+      }
+      totalTime += time;
+    }
+
+    return {
+      totalTime,
+      items,
+      days,
+      dayOfWeek,
+      today: todayTime,
+      recentSessions: rows.slice(0, 10).map(toAbsSessionJson),
+    };
+  }
+
+  /** Year-in-review (ABS `userStats.js getStatsForYear`), books-only. */
+  async statsForYear(user: RequestUser, year: number): Promise<Record<string, unknown>> {
+    const sessions = await this.sessionRepo.listForUserCreatedInYear(user.id, year);
+
+    // Finished side: BookOrbit has no persisted finishedAt, so the MediaProgress mapping's
+    // approximation (finishedAt := progress row updatedAt once past the library finish threshold)
+    // stands in for ABS's real finished timestamps.
+    const yearStart = new Date(year, 0, 1).getTime();
+    const yearEnd = new Date(year + 1, 0, 1).getTime();
+    const allProgress = await this.progressService.listMediaProgressForUser(user.id);
+    const finishedAll = allProgress.filter(
+      (p) => p.isFinished === true && typeof p.finishedAt === 'number' && p.finishedAt >= yearStart && p.finishedAt < yearEnd,
+    );
+
+    const finishedBookIds = finishedAll.map((p) => decodeAbsId('libraryItem', String(p.libraryItemId))).filter((id): id is number => id !== null);
+    const finishedItems = new Map((await this.readRepo.findItemsByIds(finishedBookIds)).map((i) => [i.id, i]));
+    // ABS inner-joins the book row, so progress for since-deleted books drops out entirely.
+    const finished = finishedAll.filter((p) => {
+      const bookId = decodeAbsId('libraryItem', String(p.libraryItemId));
+      return bookId !== null && finishedItems.has(bookId);
+    });
+
+    const finishedBooksWithCovers: string[] = [];
+    let longestAudiobookFinished: Record<string, unknown> | null = null;
+    for (const p of finished) {
+      const bookId = decodeAbsId('libraryItem', String(p.libraryItemId));
+      const item = finishedItems.get(bookId as number)!;
+      const itemId = String(p.libraryItemId);
+      // Cover-file existence isn't checked (ABS does); an existing book row is the approximation.
+      if (finishedBooksWithCovers.length < 5 && !finishedBooksWithCovers.includes(itemId)) {
+        finishedBooksWithCovers.push(itemId);
+      }
+      const duration = typeof p.duration === 'number' ? p.duration : 0;
+      if (duration > 0 && (!longestAudiobookFinished || duration > (longestAudiobookFinished.duration as number))) {
+        longestAudiobookFinished = {
+          id: encodeAbsId('book', item.id),
+          title: item.title ?? '',
+          duration: Math.round(duration),
+          // ABS serializes the Sequelize DATE straight into the payload → ISO string.
+          finishedAt: new Date(p.finishedAt as number).toISOString(),
+        };
+      }
+    }
+
+    let totalListeningTime = 0;
+    const authorMap: Record<string, number> = {};
+    const genreMap: Record<string, number> = {};
+    const narratorMap: Record<string, number> = {};
+    const monthMap: Record<number, number> = {};
+    const bookMap: Record<string, number> = {};
+    const booksWithCovers: string[] = [];
+    const sessionBookIds = [...new Set(sessions.map((s) => s.bookId))];
+    const sessionItems = new Map((await this.readRepo.findItemsByIds(sessionBookIds)).map((i) => [i.id, i]));
+
+    for (const s of sessions) {
+      const itemId = encodeAbsId('libraryItem', s.bookId);
+      if (
+        sessionItems.has(s.bookId) &&
+        !booksWithCovers.includes(itemId) &&
+        !finishedBooksWithCovers.includes(itemId) &&
+        booksWithCovers.length < 25
+      ) {
+        booksWithCovers.push(itemId);
+      }
+
+      const time = s.timeListening || 0;
+      const month = s.createdAt.getMonth();
+      monthMap[month] = (monthMap[month] ?? 0) + time;
+      totalListeningTime += time;
+
+      if (s.displayTitle) bookMap[s.displayTitle] = (bookMap[s.displayTitle] ?? 0) + time;
+
+      const meta = s.mediaMetadata as { authors?: { name: string }[]; narrators?: string[]; genres?: string[] };
+      for (const au of meta.authors ?? []) authorMap[au.name] = (authorMap[au.name] ?? 0) + time;
+      for (const narrator of meta.narrators ?? []) narratorMap[narrator] = (narratorMap[narrator] ?? 0) + time;
+      // ABS filters out junk genres by SUBSTRING match, not equality.
+      const genres = (meta.genres ?? []).filter((g) => g && !g.toLowerCase().includes('audiobook') && !g.toLowerCase().includes('audio book'));
+      for (const genre of genres) genreMap[genre] = (genreMap[genre] ?? 0) + time;
+    }
+
+    const topAuthors = Object.keys(authorMap)
+      .map((name) => ({ name, time: Math.round(authorMap[name]) }))
+      .sort((a, b) => b.time - a.time)
+      .slice(0, 3);
+    const topGenres = Object.keys(genreMap)
+      .map((genre) => ({ genre, time: Math.round(genreMap[genre]) }))
+      .sort((a, b) => b.time - a.time)
+      .slice(0, 3);
+
+    let mostListenedNarrator: Record<string, unknown> | null = null;
+    for (const name of Object.keys(narratorMap)) {
+      if (!mostListenedNarrator || narratorMap[name] > (mostListenedNarrator.time as number)) {
+        mostListenedNarrator = { time: Math.round(narratorMap[name]), name };
+      }
+    }
+    let mostListenedMonth: Record<string, unknown> | null = null;
+    for (const month of Object.keys(monthMap)) {
+      if (!mostListenedMonth || monthMap[Number(month)] > (mostListenedMonth.time as number)) {
+        mostListenedMonth = { month: Number(month), time: Math.round(monthMap[Number(month)]) };
+      }
+    }
+
+    return {
+      totalListeningSessions: sessions.length,
+      totalListeningTime: Math.round(totalListeningTime),
+      totalBookListeningTime: Math.round(totalListeningTime), // books-only server
+      totalPodcastListeningTime: 0,
+      topAuthors,
+      topGenres,
+      mostListenedNarrator,
+      mostListenedMonth,
+      numBooksFinished: finished.length,
+      numBooksListened: Object.keys(bookMap).length,
+      longestAudiobookFinished,
+      booksWithCovers,
+      finishedBooksWithCovers,
+    };
+  }
+
+  /** ABS pagination: `itemsPerPage` default 10, `page` default 0, envelope with `numPages`. */
+  private paginate(rows: AbsPlaybackSessionRow[], query: Record<string, string>): Record<string, unknown> {
+    const parsed = Number.parseInt(query.itemsPerPage ?? '', 10);
+    const itemsPerPage = Number.isFinite(parsed) && parsed > 0 ? parsed : 10;
+    const parsedPage = Number.parseInt(query.page ?? '', 10);
+    const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 0;
+    const start = page * itemsPerPage;
+    return {
+      total: rows.length,
+      numPages: Math.ceil(rows.length / itemsPerPage),
+      page,
+      itemsPerPage,
+      sessions: rows.slice(start, start + itemsPerPage).map(toAbsSessionJson),
+    };
+  }
+}

--- a/server/src/modules/abs/services/abs-stream.service.test.ts
+++ b/server/src/modules/abs/services/abs-stream.service.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { makeReply, makeRequest } from '../__testing__/abs-test-helpers';
+import { AbsStreamService } from './abs-stream.service';
+
+describe('AbsStreamService#streamFile', () => {
+  let dir: string;
+  let filePath: string;
+  const CONTENT = 'abcdefghij'; // 10 bytes
+  const service = new AbsStreamService();
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'abs-stream-'));
+    filePath = join(dir, 'track.mp3');
+    await writeFile(filePath, CONTENT);
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('404s when the file does not exist', async () => {
+    const { reply, captured } = makeReply();
+    await service.streamFile(makeRequest(), reply, join(dir, 'missing.mp3'), 'mp3');
+    expect(captured.statusCode).toBe(404);
+  });
+
+  it('serves the whole file as 200 with Content-Length and audio mime type', async () => {
+    const { reply, captured } = makeReply();
+    await service.streamFile(makeRequest(), reply, filePath, 'mp3');
+    expect(captured.statusCode).toBe(200);
+    expect(captured.headers['Content-Length']).toBe(10);
+    expect(captured.headers['Content-Type']).toBe('audio/mpeg');
+    expect(captured.headers['Accept-Ranges']).toBe('bytes');
+  });
+
+  it('honors a byte range with a 206 + Content-Range', async () => {
+    const { reply, captured } = makeReply();
+    await service.streamFile(makeRequest({ headers: { range: 'bytes=2-5' } }), reply, filePath, 'mp3');
+    expect(captured.statusCode).toBe(206);
+    expect(captured.headers['Content-Range']).toBe('bytes 2-5/10');
+    expect(captured.headers['Content-Length']).toBe(4); // bytes 2,3,4,5
+  });
+
+  it('honors an open-ended range (bytes=5-)', async () => {
+    const { reply, captured } = makeReply();
+    await service.streamFile(makeRequest({ headers: { range: 'bytes=5-' } }), reply, filePath, 'mp3');
+    expect(captured.statusCode).toBe(206);
+    expect(captured.headers['Content-Range']).toBe('bytes 5-9/10');
+  });
+
+  it('honors a suffix range (last N bytes)', async () => {
+    const { reply, captured } = makeReply();
+    await service.streamFile(makeRequest({ headers: { range: 'bytes=-3' } }), reply, filePath, 'mp3');
+    expect(captured.statusCode).toBe(206);
+    expect(captured.headers['Content-Range']).toBe('bytes 7-9/10');
+  });
+
+  it('returns 416 for an unsatisfiable range', async () => {
+    const { reply, captured } = makeReply();
+    await service.streamFile(makeRequest({ headers: { range: 'bytes=50-60' } }), reply, filePath, 'mp3');
+    expect(captured.statusCode).toBe(416);
+    expect(captured.headers['Content-Range']).toBe('bytes */10');
+  });
+});

--- a/server/src/modules/abs/services/abs-stream.service.ts
+++ b/server/src/modules/abs/services/abs-stream.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { createReadStream } from 'fs';
+import { stat } from 'fs/promises';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { audioMimeType } from '../abs-media.util';
+
+/**
+ * Streams an audio file with real HTTP Range (206) support so ABS clients can seek during
+ * direct play. BookOrbit's existing download handler only declares `Accept-Ranges` without
+ * honoring ranges, so this is built fresh (REIMPLEMENTATION_GUIDE §5.4).
+ */
+@Injectable()
+export class AbsStreamService {
+  async streamFile(req: FastifyRequest, reply: FastifyReply, absolutePath: string, format: string | null): Promise<void> {
+    let size: number;
+    try {
+      size = (await stat(absolutePath)).size;
+    } catch {
+      reply.status(404).send();
+      return;
+    }
+
+    const contentType = audioMimeType(format);
+    reply.header('Accept-Ranges', 'bytes');
+    reply.header('Content-Type', contentType);
+
+    const range = this.parseRange(req.headers['range'], size);
+    if (!range) {
+      reply.header('Content-Length', size);
+      reply.status(200).send(createReadStream(absolutePath));
+      return;
+    }
+
+    if (range === 'unsatisfiable') {
+      reply.header('Content-Range', `bytes */${size}`);
+      reply.status(416).send();
+      return;
+    }
+
+    const { start, end } = range;
+    reply.header('Content-Range', `bytes ${start}-${end}/${size}`);
+    reply.header('Content-Length', end - start + 1);
+    reply.status(206).send(createReadStream(absolutePath, { start, end }));
+  }
+
+  /** Parse a single-range `bytes=start-end` header. Returns null for no range. */
+  private parseRange(header: string | undefined, size: number): { start: number; end: number } | 'unsatisfiable' | null {
+    if (!header || !header.startsWith('bytes=')) return null;
+    const spec = header.slice('bytes='.length).split(',')[0]?.trim();
+    if (!spec) return null;
+
+    const [startRaw, endRaw] = spec.split('-');
+    let start: number;
+    let end: number;
+    if (startRaw === '') {
+      // Suffix range: last N bytes.
+      const suffix = Number.parseInt(endRaw, 10);
+      if (!Number.isFinite(suffix) || suffix <= 0) return 'unsatisfiable';
+      start = Math.max(0, size - suffix);
+      end = size - 1;
+    } else {
+      start = Number.parseInt(startRaw, 10);
+      end = endRaw === '' || endRaw === undefined ? size - 1 : Number.parseInt(endRaw, 10);
+    }
+
+    if (!Number.isFinite(start) || !Number.isFinite(end) || start > end || start >= size) return 'unsatisfiable';
+    return { start, end: Math.min(end, size - 1) };
+  }
+}

--- a/server/src/modules/abs/services/abs-transcode.service.test.ts
+++ b/server/src/modules/abs/services/abs-transcode.service.test.ts
@@ -1,0 +1,93 @@
+import { mkdtemp, readdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { ConfigService } from '@nestjs/config';
+
+import type { AbsAudioFileRow } from '../abs-read.repository';
+import type { AbsSocketGateway } from '../abs-socket.gateway';
+import { AbsTranscodeService } from './abs-transcode.service';
+
+function audioFile(id: number): AbsAudioFileRow {
+  return { id, bookId: 3, format: 'mp3', sortOrder: id, durationSeconds: 60, sizeBytes: 1000, absolutePath: `/books/3/${id}.mp3` };
+}
+
+describe('AbsTranscodeService', () => {
+  let appDataPath: string;
+  let service: AbsTranscodeService;
+  let emitStreamReset: ReturnType<typeof vi.fn>;
+  let launchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    appDataPath = await mkdtemp(join(tmpdir(), 'abs-transcode-'));
+    emitStreamReset = vi.fn();
+    const config = { get: vi.fn().mockReturnValue(appDataPath) } as unknown as ConfigService;
+    const socketGateway = { emitStreamReset } as unknown as AbsSocketGateway;
+    service = new AbsTranscodeService(config, socketGateway);
+    // Stub the real ffmpeg spawn; tests drive segment availability by writing files directly.
+    launchSpy = vi.spyOn(service as unknown as { launchFfmpeg: () => void }, 'launchFfmpeg').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    await rm(appDataPath, { recursive: true, force: true });
+  });
+
+  async function open(streamId: string, duration: number, startTime = 0): Promise<string> {
+    return service.createStream({ streamId, userId: 1, audioFiles: [audioFile(10), audioFile(11)], duration, startTime });
+  }
+
+  function segPath(streamId: string, n: number): string {
+    return join(appDataPath, 'abs', 'streams', streamId, `output-${n}.ts`);
+  }
+
+  it('creates a stream, writes a concat list + playlist, and returns the HLS url', async () => {
+    const url = await open('s1', 60);
+    expect(url).toBe('/hls/s1/output.m3u8');
+    expect(launchSpy).toHaveBeenCalledOnce();
+    const files = await readdir(join(appDataPath, 'abs', 'streams', 's1'));
+    expect(files).toContain('concat.txt');
+    expect(files).toContain('output.m3u8');
+  });
+
+  it('serves the playlist for an open stream and null for an unknown one', async () => {
+    await open('s1', 60);
+    expect(service.playlist('s1')).toContain('#EXT-X-ENDLIST');
+    expect(service.playlist('missing')).toBeNull();
+  });
+
+  it('serves a segment that exists on disk', async () => {
+    await open('s1', 60);
+    await writeFile(segPath('s1', 0), 'ts-bytes');
+    const result = await service.resolveSegment('s1', 'output-0.ts');
+    expect(result.action).toBe('serve');
+    expect(result.filePath).toBe(segPath('s1', 0));
+  });
+
+  it('waits for a not-yet-produced segment within the window', async () => {
+    await open('s1', 600);
+    const result = await service.resolveSegment('s1', 'output-1.ts');
+    expect(result.action).toBe('wait');
+    expect(emitStreamReset).not.toHaveBeenCalled();
+  });
+
+  it('resets ffmpeg and emits stream_reset on a forward seek beyond the window', async () => {
+    await open('s1', 600); // 100 segments
+    const result = await service.resolveSegment('s1', 'output-80.ts');
+    expect(result.action).toBe('reset');
+    expect(launchSpy).toHaveBeenCalledTimes(2); // initial + reset
+    expect(emitStreamReset).toHaveBeenCalledWith(1, { streamId: 's1', startTime: 80 * 6 });
+  });
+
+  it('404s a segment outside the title and unknown streams', async () => {
+    await open('s1', 60); // 10 segments
+    expect((await service.resolveSegment('s1', 'output-99.ts')).action).toBe('not-found');
+    expect((await service.resolveSegment('missing', 'output-0.ts')).action).toBe('not-found');
+  });
+
+  it('closeStream removes the stream dir and forgets the stream', async () => {
+    await open('s1', 60);
+    await service.closeStream('s1');
+    expect(service.hasStream('s1')).toBe(false);
+    expect(service.playlist('s1')).toBeNull();
+    await expect(readdir(join(appDataPath, 'abs', 'streams', 's1'))).rejects.toThrow();
+  });
+});

--- a/server/src/modules/abs/services/abs-transcode.service.ts
+++ b/server/src/modules/abs/services/abs-transcode.service.ts
@@ -1,0 +1,258 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ChildProcess, spawn } from 'child_process';
+import { mkdir, readdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+import type { AbsAudioFileRow } from '../abs-read.repository';
+import { AbsSocketGateway } from '../abs-socket.gateway';
+import {
+  buildVodPlaylist,
+  decideSegmentRequest,
+  HLS_SEGMENT_SECONDS,
+  parseSegmentNumber,
+  type SegmentAction,
+  totalSegments,
+} from '../abs-transcode.util';
+
+const FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg';
+/** Open transcode streams idle for this long are torn down (mirrors the playback session TTL). */
+const STALE_STREAM_MS = 36 * 60 * 60 * 1000;
+
+interface TranscodeStream {
+  id: string;
+  userId: number;
+  streamDir: string;
+  concatPath: string;
+  audioFiles: AbsAudioFileRow[];
+  duration: number;
+  segmentLength: number;
+  total: number;
+  /** Segment index ffmpeg's current invocation started from (`-start_number`). */
+  windowStart: number;
+  /** True between kicking ffmpeg to a new offset and its first segment landing on disk. */
+  isResetting: boolean;
+  process: ChildProcess | null;
+  updatedAt: number;
+}
+
+export interface SegmentResolution {
+  action: SegmentAction;
+  /** Absolute path to serve, set only when `action === 'serve'`. */
+  filePath?: string;
+}
+
+/**
+ * Manages HLS transcode streams for `playMethod=2` sessions (REIMPLEMENTATION_GUIDE §5.3). Each stream
+ * owns a temp dir, a concat list of the item's audio files, and a running ffmpeg that emits
+ * `output-<n>.ts` segments. We generate the VOD playlist ourselves; seeking outside the transcoded
+ * window re-bases ffmpeg and notifies the client over the socket via `stream_reset`.
+ */
+@Injectable()
+export class AbsTranscodeService {
+  private readonly logger = new Logger(AbsTranscodeService.name);
+  private readonly streams = new Map<string, TranscodeStream>();
+  private readonly streamsRoot: string;
+
+  constructor(
+    config: ConfigService,
+    private readonly socketGateway: AbsSocketGateway,
+  ) {
+    const appDataPath = config.get<string>('storage.appDataPath')!;
+    this.streamsRoot = join(appDataPath, 'abs', 'streams');
+  }
+
+  /**
+   * Spin up a transcode stream for an open session and return the playlist URL the synthetic
+   * audio track points at. ffmpeg is started from the segment covering `startTime` so resume
+   * playback doesn't transcode from the top of a long book.
+   */
+  async createStream(opts: {
+    streamId: string;
+    userId: number;
+    audioFiles: AbsAudioFileRow[];
+    duration: number;
+    startTime: number;
+  }): Promise<string> {
+    const segmentLength = HLS_SEGMENT_SECONDS;
+    const streamDir = join(this.streamsRoot, opts.streamId);
+    await mkdir(streamDir, { recursive: true });
+
+    const concatPath = join(streamDir, 'concat.txt');
+    await writeFile(concatPath, this.buildConcatList(opts.audioFiles));
+    await writeFile(join(streamDir, 'output.m3u8'), buildVodPlaylist(opts.duration, segmentLength));
+
+    const total = totalSegments(opts.duration, segmentLength);
+    const windowStart = total > 0 ? Math.min(Math.max(0, Math.floor(opts.startTime / segmentLength)), total - 1) : 0;
+
+    const stream: TranscodeStream = {
+      id: opts.streamId,
+      userId: opts.userId,
+      streamDir,
+      concatPath,
+      audioFiles: opts.audioFiles,
+      duration: opts.duration,
+      segmentLength,
+      total,
+      windowStart,
+      isResetting: false,
+      process: null,
+      updatedAt: Date.now(),
+    };
+    this.streams.set(opts.streamId, stream);
+    this.launchFfmpeg(stream, windowStart);
+    return `/hls/${opts.streamId}/output.m3u8`;
+  }
+
+  hasStream(streamId: string): boolean {
+    return this.streams.has(streamId);
+  }
+
+  /** Generated VOD playlist for an open stream, or null when the stream id is unknown. */
+  playlist(streamId: string): string | null {
+    const stream = this.streams.get(streamId);
+    if (!stream) return null;
+    stream.updatedAt = Date.now();
+    return buildVodPlaylist(stream.duration, stream.segmentLength);
+  }
+
+  /**
+   * Resolve a `.ts` segment request. Serves the file when ready; on a seek outside the transcoded
+   * window it re-bases ffmpeg, emits `stream_reset`, and reports `reset` so the caller `404`s.
+   */
+  async resolveSegment(streamId: string, file: string): Promise<SegmentResolution> {
+    const stream = this.streams.get(streamId);
+    if (!stream) return { action: 'not-found' };
+    stream.updatedAt = Date.now();
+
+    const requestedSegment = parseSegmentNumber(file);
+    if (requestedSegment === null) return { action: 'not-found' };
+
+    const filePath = join(stream.streamDir, file);
+    const highestAvailable = await this.highestAvailableSegment(stream);
+
+    const action = decideSegmentRequest({
+      requestedSegment,
+      windowStart: stream.windowStart,
+      highestAvailable,
+      total: stream.total,
+      isResetting: stream.isResetting,
+    });
+
+    if (action === 'serve') {
+      // The decision says it should exist; confirm and otherwise let the client retry.
+      return requestedSegment <= highestAvailable ? { action: 'serve', filePath } : { action: 'wait' };
+    }
+
+    if (action === 'reset') {
+      this.resetTo(stream, requestedSegment);
+      return { action: 'reset' };
+    }
+
+    return { action };
+  }
+
+  /** Tear down a stream: kill ffmpeg and remove its temp dir. Safe to call for unknown ids. */
+  async closeStream(streamId: string): Promise<void> {
+    const stream = this.streams.get(streamId);
+    if (!stream) return;
+    this.streams.delete(streamId);
+    stream.process?.kill('SIGKILL');
+    await rm(stream.streamDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+
+  /** Drop transcode streams with no activity in 36h. Invoked opportunistically. */
+  pruneStaleStreams(): void {
+    const cutoff = Date.now() - STALE_STREAM_MS;
+    for (const [id, stream] of this.streams) {
+      if (stream.updatedAt < cutoff) void this.closeStream(id);
+    }
+  }
+
+  /** Re-base ffmpeg to start at `segment` and notify the client to restart playback there. */
+  private resetTo(stream: TranscodeStream, segment: number): void {
+    stream.process?.kill('SIGKILL');
+    stream.windowStart = segment;
+    stream.isResetting = true;
+    this.launchFfmpeg(stream, segment);
+    this.socketGateway.emitStreamReset(stream.userId, {
+      streamId: stream.id,
+      startTime: segment * stream.segmentLength,
+    });
+  }
+
+  /** Highest `output-<n>.ts` index currently on disk, or `windowStart - 1` when none exist yet. */
+  private async highestAvailableSegment(stream: TranscodeStream): Promise<number> {
+    let highest = stream.windowStart - 1;
+    let entries: string[];
+    try {
+      entries = await readdir(stream.streamDir);
+    } catch {
+      return highest;
+    }
+    for (const entry of entries) {
+      const n = parseSegmentNumber(entry);
+      if (n !== null && n > highest) highest = n;
+    }
+    return highest;
+  }
+
+  /** ffmpeg concat-demuxer manifest listing every audio file in play order. */
+  private buildConcatList(audioFiles: AbsAudioFileRow[]): string {
+    // `file '...'`; single quotes inside paths are escaped per the concat demuxer's quoting rules.
+    return audioFiles.map((f) => `file '${f.absolutePath.replace(/'/g, "'\\''")}'`).join('\n') + '\n';
+  }
+
+  /**
+   * Spawn ffmpeg to transcode the concatenated audio to AAC HLS, writing `output-<n>.ts` from
+   * `startSegment`. Input-seeks to the segment's start offset so a reset produces the right window.
+   * Isolated into one method so tests can stub it without a real ffmpeg binary.
+   */
+  private launchFfmpeg(stream: TranscodeStream, startSegment: number): void {
+    const startTime = startSegment * stream.segmentLength;
+    const args = [
+      '-y',
+      '-ss',
+      String(startTime),
+      '-f',
+      'concat',
+      '-safe',
+      '0',
+      '-i',
+      stream.concatPath,
+      '-map',
+      '0:a',
+      '-c:a',
+      'aac',
+      '-b:a',
+      '128k',
+      '-ac',
+      '2',
+      '-f',
+      'segment',
+      '-segment_time',
+      String(stream.segmentLength),
+      '-segment_start_number',
+      String(startSegment),
+      '-segment_format',
+      'mpegts',
+      '-reset_timestamps',
+      '1',
+      join(stream.streamDir, 'output-%d.ts'),
+    ];
+
+    const proc = spawn(FFMPEG_PATH, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    stream.process = proc;
+    // Once ffmpeg starts emitting (any stderr progress), the reset window is live again.
+    proc.stderr?.on('data', () => {
+      if (stream.process === proc) stream.isResetting = false;
+    });
+    proc.on('error', (err) => this.logger.warn(`[abs.hls] ffmpeg failed for stream ${stream.id}: ${err.message}`));
+    proc.on('close', () => {
+      if (stream.process === proc) {
+        stream.process = null;
+        stream.isResetting = false;
+      }
+    });
+  }
+}

--- a/server/src/modules/auth/auth.module.ts
+++ b/server/src/modules/auth/auth.module.ts
@@ -60,6 +60,6 @@ import { OidcTokenValidatorService } from './oidc/oidc-token-validator.service';
     OidcCleanupService,
     OidcCleanupJob,
   ],
-  exports: [AuthService],
+  exports: [AuthService, OidcService],
 })
 export class AuthModule {}

--- a/server/src/modules/auth/oidc/oidc-state.service.test.ts
+++ b/server/src/modules/auth/oidc/oidc-state.service.test.ts
@@ -2,11 +2,16 @@ import { OidcStateService } from './oidc-state.service';
 
 const mockConfig = { get: vi.fn().mockReturnValue(undefined) };
 
+/** `values()` returns an `onConflictDoUpdate`-chainable to mirror the idempotent upsert in `generate`. */
+function makeValuesMock() {
+  return vi.fn().mockReturnValue({ onConflictDoUpdate: vi.fn().mockResolvedValue(undefined) });
+}
+
 function makeDb(overrides: Partial<ReturnType<typeof makeDb>> = {}) {
   const deleteMock = vi.fn().mockReturnThis();
   const db = {
     delete: vi.fn().mockReturnValue({ where: deleteMock }),
-    insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+    insert: vi.fn().mockReturnValue({ values: makeValuesMock() }),
     ...overrides,
   };
   return { db, deleteMock };
@@ -36,7 +41,7 @@ describe('OidcStateService', () => {
     });
 
     it('inserts state with meta=null when no meta passed', async () => {
-      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      const valuesMock = makeValuesMock();
       const insertMock = vi.fn().mockReturnValue({ values: valuesMock });
       const db = {
         delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
@@ -54,7 +59,7 @@ describe('OidcStateService', () => {
     });
 
     it('inserts state with serialized meta when meta passed', async () => {
-      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      const valuesMock = makeValuesMock();
       const insertMock = vi.fn().mockReturnValue({ values: valuesMock });
       const db = {
         delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
@@ -70,7 +75,7 @@ describe('OidcStateService', () => {
     });
 
     it('inserts state into the database with an expiry', async () => {
-      const valuesMock = vi.fn().mockResolvedValue(undefined);
+      const valuesMock = makeValuesMock();
       const insertMock = vi.fn().mockReturnValue({ values: valuesMock });
       const db = {
         delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
@@ -92,7 +97,7 @@ describe('OidcStateService', () => {
       const whereMock = vi.fn().mockResolvedValue(undefined);
       const db = {
         delete: vi.fn().mockReturnValue({ where: whereMock }),
-        insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
+        insert: vi.fn().mockReturnValue({ values: makeValuesMock() }),
       };
       const service = new OidcStateService(db as never, mockConfig as never);
 
@@ -100,6 +105,61 @@ describe('OidcStateService', () => {
 
       expect(db.delete).toHaveBeenCalled();
       expect(whereMock).toHaveBeenCalled();
+    });
+
+    it('uses an explicit state value when provided (ABS mobile preserves the client state)', async () => {
+      const valuesMock = makeValuesMock();
+      const db = {
+        delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+        insert: vi.fn().mockReturnValue({ values: valuesMock }),
+      };
+      const service = new OidcStateService(db as never, mockConfig as never);
+
+      const state = await service.generate(1, undefined, 'client-supplied-state');
+
+      expect(state).toBe('client-supplied-state');
+      expect(valuesMock.mock.calls[0][0].state).toBe('client-supplied-state');
+    });
+
+    it('upserts on the state primary key so a replayed pinned state does not collide', async () => {
+      // iOS ABS clients re-issue the /auth/openid navigation with the same client `state`; a plain
+      // insert would throw a PK violation that surfaces as a blank "openid" page. The row must be
+      // refreshed (onConflictDoUpdate) instead.
+      const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+      const valuesMock = vi.fn().mockReturnValue({ onConflictDoUpdate });
+      const db = {
+        delete: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+        insert: vi.fn().mockReturnValue({ values: valuesMock }),
+      };
+      const service = new OidcStateService(db as never, mockConfig as never);
+
+      await service.generate(7, { mode: 'abs' }, 'replayed-state');
+
+      expect(onConflictDoUpdate).toHaveBeenCalledOnce();
+      const [{ target, set }] = onConflictDoUpdate.mock.calls[0];
+      expect(target).toBeDefined();
+      expect(set.providerId).toBe(7);
+      expect(JSON.parse(set.meta as string)).toEqual({ mode: 'abs' });
+    });
+  });
+
+  describe('peek', () => {
+    function dbWithRow(row: unknown) {
+      return { query: { oidcStates: { findFirst: vi.fn().mockResolvedValue(row) } } };
+    }
+
+    it('returns the row meta without consuming it (no delete)', async () => {
+      const db = dbWithRow({ state: 's', providerId: 1, meta: JSON.stringify({ mode: 'abs', appRedirect: 'audiobookshelf://oauth' }) });
+      const service = new OidcStateService(db as never, mockConfig as never);
+
+      const result = await service.peek('s');
+      expect(result).toEqual({ valid: true, providerId: 1, meta: { mode: 'abs', appRedirect: 'audiobookshelf://oauth' } });
+    });
+
+    it('returns { valid: false } for an unknown/expired state', async () => {
+      const db = dbWithRow(undefined);
+      const service = new OidcStateService(db as never, mockConfig as never);
+      expect(await service.peek('nope')).toEqual({ valid: false });
     });
   });
 

--- a/server/src/modules/auth/oidc/oidc-state.service.ts
+++ b/server/src/modules/auth/oidc/oidc-state.service.ts
@@ -20,16 +20,43 @@ export class OidcStateService {
     this.ttlMs = this.configService.get<number>('oidcRuntime.stateTtlMs') ?? 5 * 60 * 1000;
   }
 
-  async generate(providerId: number, meta?: Record<string, unknown>): Promise<string> {
-    const state = randomBytes(32).toString('base64url');
+  /**
+   * Create a single-use state row. `explicitState` lets a caller pin the value — needed for the ABS
+   * mobile OIDC flow, which round-trips the client-supplied `state` so the native app can match it.
+   */
+  async generate(providerId: number, meta?: Record<string, unknown>, explicitState?: string): Promise<string> {
+    const state = explicitState ?? randomBytes(32).toString('base64url');
     const expiresAt = new Date(Date.now() + this.ttlMs);
+    const metaJson = meta ? JSON.stringify(meta) : null;
 
     await Promise.all([
       this.db.delete(schema.oidcStates).where(lt(schema.oidcStates.expiresAt, new Date())),
-      this.db.insert(schema.oidcStates).values({ state, providerId, expiresAt, meta: meta ? JSON.stringify(meta) : null }),
+      // Upsert on the `state` primary key. A caller-pinned `explicitState` (the ABS mobile flow
+      // round-trips the client's `state`) can be replayed within the TTL — iOS clients re-issue the
+      // `/auth/openid` navigation with the same state — and a plain insert would throw a PK violation,
+      // which the ABS filter surfaces as an empty-body 500 that iOS renders as a blank "openid" file.
+      // Refreshing the row keeps the latest authorize attempt authoritative.
+      this.db
+        .insert(schema.oidcStates)
+        .values({ state, providerId, expiresAt, meta: metaJson })
+        .onConflictDoUpdate({ target: schema.oidcStates.state, set: { providerId, expiresAt, meta: metaJson } }),
     ]);
 
     return state;
+  }
+
+  /**
+   * Read a live state row's meta WITHOUT consuming it (the row is still consumed later at callback).
+   * Used by the ABS `/auth/openid/mobile-redirect` hop, which only needs to forward the code to the
+   * app and must not invalidate the state the subsequent `/callback` exchange depends on.
+   */
+  async peek(state: string): Promise<{ valid: boolean; providerId?: number; meta?: Record<string, unknown> }> {
+    const row = await this.db.query.oidcStates.findFirst({
+      where: and(eq(schema.oidcStates.state, state), gt(schema.oidcStates.expiresAt, new Date())),
+    });
+    if (!row) return { valid: false };
+    const meta = row.meta ? (JSON.parse(row.meta) as Record<string, unknown>) : undefined;
+    return { valid: true, providerId: row.providerId, meta };
   }
 
   async validateAndConsume(state: string): Promise<{ valid: boolean; providerId?: number; meta?: Record<string, unknown> }> {

--- a/server/src/modules/auth/oidc/oidc.service.test.ts
+++ b/server/src/modules/auth/oidc/oidc.service.test.ts
@@ -27,6 +27,7 @@ function makeService() {
     findBySlugOrFail: vi.fn().mockResolvedValue(PROVIDER),
     findByIdOrFail: vi.fn().mockResolvedValue(PROVIDER),
     findByIssuerUri: vi.fn().mockResolvedValue(PROVIDER),
+    findEnabled: vi.fn().mockResolvedValue([PROVIDER]),
   };
   const discovery = {
     getDiscoveryDoc: vi.fn().mockResolvedValue({
@@ -49,6 +50,7 @@ function makeService() {
   const stateService = {
     generate: vi.fn().mockResolvedValue('state-token'),
     validateAndConsume: vi.fn().mockResolvedValue({ valid: true, providerId: 1 }),
+    peek: vi.fn().mockResolvedValue({ valid: false }),
   };
   const sessionRepo = {
     create: vi.fn().mockResolvedValue(undefined),
@@ -118,6 +120,7 @@ function makeService() {
     stateService,
     auditEvents,
     discovery,
+    tokenClient,
     tokenValidator,
     identityRepo,
     groupMapping,
@@ -271,6 +274,123 @@ describe('OidcService', () => {
       await service.unlinkIdentity(5, 1, 'correct-password');
       expect(identityRepo.remove).toHaveBeenCalledWith(5, 1);
       expect(auditEvents.emit).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ action: 'auth.oidc.identity_unlinked' }));
+    });
+  });
+
+  describe('getDesignatedAbsProvider', () => {
+    it('returns the first enabled provider', async () => {
+      const { service } = makeService();
+      expect(await service.getDesignatedAbsProvider()).toBe(PROVIDER);
+    });
+
+    it('returns null when no provider is enabled', async () => {
+      const { service, providerService } = makeService();
+      providerService.findEnabled.mockResolvedValue([]);
+      expect(await service.getDesignatedAbsProvider()).toBeNull();
+    });
+  });
+
+  const CALLBACK_URI = 'https://abs.example/auth/openid/callback';
+  const MOBILE_REDIRECT_URI = 'https://abs.example/auth/openid/mobile-redirect';
+
+  describe('beginAbsAuthorization', () => {
+    it('web flow: server-owned PKCE, IdP redirect_uri = callback, verifier stashed in state', async () => {
+      const { service, stateService } = makeService();
+      const url = new URL(await service.beginAbsAuthorization({ callbackUri: CALLBACK_URI, mobileRedirectUri: MOBILE_REDIRECT_URI }));
+
+      expect(url.origin + url.pathname).toBe('https://issuer.example/auth');
+      expect(url.searchParams.get('client_id')).toBe('client-id');
+      expect(url.searchParams.get('redirect_uri')).toBe(CALLBACK_URI);
+      expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(url.searchParams.get('code_challenge')).toBeTruthy();
+
+      const meta = stateService.generate.mock.calls[0][1];
+      expect(meta).toMatchObject({ mode: 'abs', authMethod: 'openid', redirectUri: CALLBACK_URI });
+      expect(typeof meta.codeVerifier).toBe('string'); // server owns the verifier
+    });
+
+    it('mobile flow: IdP redirect_uri = mobile-redirect, relays client challenge, preserves client state, stashes app redirect', async () => {
+      const { service, stateService } = makeService();
+      const url = new URL(
+        await service.beginAbsAuthorization({
+          callbackUri: CALLBACK_URI,
+          mobileRedirectUri: MOBILE_REDIRECT_URI,
+          mobile: { appRedirect: 'audiobookshelf://oauth', clientState: 'client-state', clientCodeChallenge: 'client-chal' },
+        }),
+      );
+      expect(url.searchParams.get('redirect_uri')).toBe(MOBILE_REDIRECT_URI);
+      expect(url.searchParams.get('code_challenge')).toBe('client-chal');
+
+      const [, meta, explicitState] = stateService.generate.mock.calls[0];
+      expect(explicitState).toBe('client-state'); // client state preserved so the app can match it
+      expect(meta).toMatchObject({ authMethod: 'openid-mobile', redirectUri: MOBILE_REDIRECT_URI, appRedirect: 'audiobookshelf://oauth' });
+      expect(meta.codeVerifier).toBeUndefined();
+    });
+
+    it('throws when OIDC is not configured', async () => {
+      const { service, providerService } = makeService();
+      providerService.findEnabled.mockResolvedValue([]);
+      await expect(service.beginAbsAuthorization({ callbackUri: CALLBACK_URI, mobileRedirectUri: MOBILE_REDIRECT_URI })).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('getAbsMobileAppRedirect', () => {
+    it('returns the stashed app redirect without consuming the state', async () => {
+      const { service, stateService } = makeService();
+      stateService.peek = vi.fn().mockResolvedValue({ valid: true, providerId: 1, meta: { mode: 'abs', appRedirect: 'audiobookshelf://oauth' } });
+      expect(await service.getAbsMobileAppRedirect('state')).toBe('audiobookshelf://oauth');
+      expect(stateService.peek).toHaveBeenCalledWith('state');
+    });
+
+    it('returns null for an unknown/expired or non-ABS state', async () => {
+      const { service, stateService } = makeService();
+      stateService.peek = vi.fn().mockResolvedValue({ valid: false });
+      expect(await service.getAbsMobileAppRedirect('state')).toBeNull();
+    });
+  });
+
+  describe('resolveAbsLoginUser', () => {
+    const ABS_META = {
+      mode: 'abs',
+      codeVerifier: 'verifier',
+      nonce: 'nonce',
+      redirectUri: CALLBACK_URI,
+      authMethod: 'openid-mobile',
+    };
+
+    it('exchanges the code and resolves the user, returning the stashed auth method', async () => {
+      const { service, stateService, identityRepo, userService } = makeService();
+      stateService.validateAndConsume.mockResolvedValue({ valid: true, providerId: 1, meta: ABS_META });
+      identityRepo.findByProviderAndSubject.mockResolvedValue({ userId: 5 });
+      userService.findById.mockResolvedValue({ id: 5, username: 'u1', active: true, permissions: [] });
+
+      const result = await service.resolveAbsLoginUser({ state: 'state', code: 'code' });
+      expect(result.user).toMatchObject({ id: 5 });
+      expect(result.authMethod).toBe('openid-mobile');
+    });
+
+    it('rejects a non-ABS or expired state', async () => {
+      const { service, stateService } = makeService();
+      stateService.validateAndConsume.mockResolvedValue({ valid: true, providerId: 1, meta: { mode: 'login' } });
+      await expect(service.resolveAbsLoginUser({ state: 'state', code: 'code' })).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('requires a code_verifier when none was stashed (client did not forward one)', async () => {
+      const { service, stateService } = makeService();
+      stateService.validateAndConsume.mockResolvedValue({ valid: true, providerId: 1, meta: { ...ABS_META, codeVerifier: undefined } });
+      await expect(service.resolveAbsLoginUser({ state: 'state', code: 'code' })).rejects.toThrow(BadRequestException);
+    });
+
+    it('accepts a client-forwarded code_verifier when none was stashed', async () => {
+      const { service, stateService, identityRepo, userService, tokenClient } = makeService();
+      stateService.validateAndConsume.mockResolvedValue({ valid: true, providerId: 1, meta: { ...ABS_META, codeVerifier: undefined } });
+      identityRepo.findByProviderAndSubject.mockResolvedValue({ userId: 5 });
+      userService.findById.mockResolvedValue({ id: 5, username: 'u1', active: true, permissions: [] });
+
+      await service.resolveAbsLoginUser({ state: 'state', code: 'code', clientCodeVerifier: 'client-verifier' });
+      expect(tokenClient.exchangeCode).toHaveBeenCalledWith(expect.objectContaining({ codeVerifier: 'client-verifier' }));
     });
   });
 });

--- a/server/src/modules/auth/oidc/oidc.service.ts
+++ b/server/src/modules/auth/oidc/oidc.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { compare } from 'bcryptjs';
+import { createHash, randomBytes } from 'crypto';
 import type { FastifyReply } from 'fastify';
 import { AuditAction, AuditResource, OidcCallbackResponse, OidcErrorCode, Permission } from '@bookorbit/types';
 import type { OidcAutoProvision, OidcClaimMapping } from '@bookorbit/types';
@@ -162,53 +163,15 @@ export class OidcService {
     const provider = await this.providerService.findByIdOrFail(stateResult.providerId);
     if (!provider.enabled) throw new UnauthorizedException('OIDC provider is not enabled');
 
-    const claimMapping = provider.claimMapping as OidcClaimMapping;
     const autoProvision = provider.autoProvision as OidcAutoProvision;
 
-    const allowedRedirectUri = `${this.appUrl}/oauth2-callback`;
-    if (normalizeRedirectUri(params.redirectUri) !== normalizeRedirectUri(allowedRedirectUri)) {
-      throw new BadRequestException(`Redirect URI is not allowed: ${params.redirectUri}`);
-    }
-
-    const disc = await this.discovery.getDiscoveryDoc(provider.issuerUri);
-
-    let tokens: Awaited<ReturnType<typeof this.tokenClient.exchangeCode>>;
-    try {
-      tokens = await this.tokenClient.exchangeCode({
-        code: params.code,
-        codeVerifier: params.codeVerifier,
-        redirectUri: params.redirectUri,
-        tokenEndpoint: disc.tokenEndpoint,
-        clientId: provider.clientId,
-        clientSecret: provider.clientSecret ?? '',
-      });
-    } catch {
-      throw new UnauthorizedException({
-        message: 'Could not complete sign-in with your provider. Please try again or contact your administrator.',
-        errorCode: OidcErrorCode.TOKEN_EXCHANGE_FAILED,
-      });
-    }
-
-    const idTokenClaims = await this.tokenValidator.validateIdToken(tokens.idToken, {
-      issuer: disc.issuer,
-      clientId: provider.clientId,
+    const { disc, tokens, idTokenClaims, userInfoClaims, claims } = await this.runCodeExchange(provider, {
+      code: params.code,
+      codeVerifier: params.codeVerifier,
       nonce: params.nonce,
-      jwksUri: disc.jwksUri,
+      redirectUri: params.redirectUri,
+      allowedRedirectUri: `${this.appUrl}/oauth2-callback`,
     });
-
-    let userInfoClaims: Record<string, unknown> = {};
-    if (disc.userinfoEndpoint) {
-      userInfoClaims = await this.tokenClient.fetchUserInfo(disc.userinfoEndpoint, tokens.accessToken);
-    }
-
-    const claims = this.claimExtractor.extract(idTokenClaims as Record<string, unknown>, userInfoClaims, claimMapping);
-    if (!claims.subject) {
-      this.logger.warn('[auth.oidc_callback] [fail] errorClass=UnauthorizedException error="missing sub claim" - OIDC callback failed');
-      throw new UnauthorizedException({
-        message: 'Could not complete sign-in with your provider. Please try again or contact your administrator.',
-        errorCode: OidcErrorCode.TOKEN_EXCHANGE_FAILED,
-      });
-    }
 
     const mode = (stateResult.meta?.mode as string) ?? 'login';
 
@@ -249,9 +212,205 @@ export class OidcService {
     }
 
     // Default: login flow
+    const user = await this.resolveAndSessionUser(provider, disc, claims, tokens, idTokenClaims, autoProvision);
+    const authResult = await this.authService.issueTokensForUser(user.id, reply);
+    return { mode: 'login' as const, ...authResult } as OidcCallbackResponse;
+  }
+
+  // --- ABS adapter surface (server/src/modules/abs/auth/abs-openid.controller.ts) ---------------
+  // ABS's protocol is server-driven (it owns PKCE/nonce), unlike BookOrbit's client-driven web flow,
+  // so the ABS routes call these instead of generateState/handleCallback. They reuse the same provider
+  // records, claim mapping, and auto-provisioning — an ABS OIDC login resolves to the same user.
+
+  /** The single provider ABS advertises (it has no provider-selection in its protocol): first enabled. */
+  async getDesignatedAbsProvider(): Promise<Awaited<ReturnType<OidcProviderService['findEnabled']>>[number] | null> {
+    const enabled = await this.providerService.findEnabled();
+    return enabled[0] ?? null;
+  }
+
+  /**
+   * Begin the ABS authorize flow and return the provider authorize URL to 302 to (ABS
+   * `OidcAuthStrategy.getAuthorizationUrl`). Two shapes, keyed by `mobile`:
+   *
+   * - **Web** (`mobile` absent): the IdP `redirect_uri` is the server `/auth/openid/callback`; the
+   *   server owns PKCE (verifier stashed in the state row) and generates the `state`.
+   * - **Mobile** (`mobile` set): the IdP `redirect_uri` is the server `/auth/openid/mobile-redirect`
+   *   (custom app schemes can't be IdP redirect targets); the native client owns PKCE and forwards its
+   *   `code_challenge`; the client-supplied `state` is preserved so the app can match it on return. The
+   *   app's own redirect (`appRedirect`, e.g. `audiobookshelf://oauth`) is stashed for mobile-redirect.
+   */
+  async beginAbsAuthorization(opts: {
+    callbackUri: string;
+    mobileRedirectUri: string;
+    mobile?: { appRedirect: string; clientState?: string; clientCodeChallenge: string };
+    finalRedirect?: string;
+  }): Promise<string> {
+    const provider = await this.getDesignatedAbsProvider();
+    if (!provider) throw new UnauthorizedException('OIDC is not configured');
+
+    const disc = await this.discovery.getDiscoveryDoc(provider.issuerUri);
+    const nonce = randomBytes(16).toString('base64url');
+    const isMobile = !!opts.mobile;
+
+    // Mobile: the native client owns PKCE and presents the verifier at callback; the IdP redirects to
+    // the server mobile-redirect hop. Web: the server owns PKCE and the IdP redirects to the callback.
+    const idpRedirectUri = isMobile ? opts.mobileRedirectUri : opts.callbackUri;
+    const codeVerifier = isMobile ? undefined : randomBytes(32).toString('base64url');
+    const codeChallenge = opts.mobile?.clientCodeChallenge ?? createHash('sha256').update(codeVerifier!).digest('base64url');
+
+    const state = await this.stateService.generate(
+      provider.id,
+      {
+        mode: 'abs',
+        authMethod: isMobile ? 'openid-mobile' : 'openid',
+        codeVerifier, // undefined ⇒ client owns the verifier and presents it at callback
+        nonce,
+        redirectUri: idpRedirectUri, // must match the token-exchange redirect_uri
+        appRedirect: opts.mobile?.appRedirect, // where mobile-redirect bounces the code
+        finalRedirect: opts.finalRedirect, // web: same-origin URL to hand tokens back to
+      },
+      opts.mobile?.clientState,
+    );
+
+    const url = new URL(disc.authorizationEndpoint);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', provider.clientId);
+    url.searchParams.set('redirect_uri', idpRedirectUri);
+    url.searchParams.set('scope', provider.scopes);
+    url.searchParams.set('state', state);
+    url.searchParams.set('nonce', nonce);
+    url.searchParams.set('code_challenge', codeChallenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+    return url.toString();
+  }
+
+  /**
+   * The app redirect stashed for an in-flight ABS mobile `state` (e.g. `audiobookshelf://oauth`).
+   * Non-consuming: the subsequent `/auth/openid/callback` exchange still consumes the state. Returns
+   * null if the state is unknown/expired or wasn't a mobile ABS flow.
+   */
+  async getAbsMobileAppRedirect(state: string): Promise<string | null> {
+    const result = await this.stateService.peek(state);
+    if (!result.valid || result.meta?.mode !== 'abs') return null;
+    const appRedirect = result.meta.appRedirect;
+    return typeof appRedirect === 'string' ? appRedirect : null;
+  }
+
+  /**
+   * Complete the ABS callback: consume the `state` row, exchange the code (with the PKCE verifier
+   * either stashed at authorize time or forwarded by a native client), and resolve the user — applying
+   * the same provisioning/group-mapping as the web login. The caller mints ABS-shaped tokens. Returns
+   * the resolved user plus the stashed `authMethod`/`finalRedirect` so the caller can shape the response.
+   */
+  async resolveAbsLoginUser(params: { state: string; code: string; clientCodeVerifier?: string }) {
+    const stateResult = await this.stateService.validateAndConsume(params.state);
+    if (!stateResult.valid || !stateResult.providerId || stateResult.meta?.mode !== 'abs') {
+      throw new UnauthorizedException({
+        message: 'Your login session expired. Please try signing in again.',
+        errorCode: OidcErrorCode.STATE_EXPIRED,
+      });
+    }
+
+    const meta = stateResult.meta;
+    const codeVerifier = (meta.codeVerifier as string | undefined) ?? params.clientCodeVerifier;
+    if (!codeVerifier) throw new BadRequestException('Missing code_verifier');
+
+    const provider = await this.providerService.findByIdOrFail(stateResult.providerId);
+    if (!provider.enabled) throw new UnauthorizedException('OIDC provider is not enabled');
+    const autoProvision = provider.autoProvision as OidcAutoProvision;
+
+    const { disc, tokens, idTokenClaims, claims } = await this.runCodeExchange(provider, {
+      code: params.code,
+      codeVerifier,
+      nonce: meta.nonce as string,
+      redirectUri: meta.redirectUri as string,
+      // ABS's authorize and callback use the same server callback URL; it is the allowed redirect.
+      allowedRedirectUri: meta.redirectUri as string,
+    });
+
+    const user = await this.resolveAndSessionUser(provider, disc, claims, tokens, idTokenClaims, autoProvision);
+    return { user, authMethod: meta.authMethod as string | undefined, finalRedirect: meta.finalRedirect as string | undefined };
+  }
+
+  /** Admin helper backing `GET /auth/openid/config` — read a provider's discovery document. */
+  readDiscoveryDoc(issuerUri: string): Promise<Awaited<ReturnType<OidcDiscoveryService['getDiscoveryDoc']>>> {
+    return this.discovery.getDiscoveryDoc(issuerUri);
+  }
+
+  /**
+   * Exchange an authorization code and resolve the mapped OIDC claims. Shared by the web callback and
+   * the ABS adapter (`server/src/modules/abs/auth/abs-openid.controller.ts`). Performs the redirect-URI
+   * allow-check, code exchange (PKCE), ID-token validation, optional userinfo fetch, and claim mapping.
+   */
+  private async runCodeExchange(
+    provider: Awaited<ReturnType<OidcProviderService['findByIdOrFail']>>,
+    params: { code: string; codeVerifier: string; nonce: string; redirectUri: string; allowedRedirectUri: string },
+  ): Promise<{
+    disc: Awaited<ReturnType<OidcDiscoveryService['getDiscoveryDoc']>>;
+    tokens: Awaited<ReturnType<OidcTokenClientService['exchangeCode']>>;
+    idTokenClaims: Record<string, unknown>;
+    userInfoClaims: Record<string, unknown>;
+    claims: ReturnType<OidcClaimExtractorService['extract']>;
+  }> {
+    if (normalizeRedirectUri(params.redirectUri) !== normalizeRedirectUri(params.allowedRedirectUri)) {
+      throw new BadRequestException(`Redirect URI is not allowed: ${params.redirectUri}`);
+    }
+
+    const disc = await this.discovery.getDiscoveryDoc(provider.issuerUri);
+
+    let tokens: Awaited<ReturnType<OidcTokenClientService['exchangeCode']>>;
+    try {
+      tokens = await this.tokenClient.exchangeCode({
+        code: params.code,
+        codeVerifier: params.codeVerifier,
+        redirectUri: params.redirectUri,
+        tokenEndpoint: disc.tokenEndpoint,
+        clientId: provider.clientId,
+        clientSecret: provider.clientSecret ?? '',
+      });
+    } catch {
+      throw new UnauthorizedException({
+        message: 'Could not complete sign-in with your provider. Please try again or contact your administrator.',
+        errorCode: OidcErrorCode.TOKEN_EXCHANGE_FAILED,
+      });
+    }
+
+    const idTokenClaims = (await this.tokenValidator.validateIdToken(tokens.idToken, {
+      issuer: disc.issuer,
+      clientId: provider.clientId,
+      nonce: params.nonce,
+      jwksUri: disc.jwksUri,
+    })) as Record<string, unknown>;
+
+    let userInfoClaims: Record<string, unknown> = {};
+    if (disc.userinfoEndpoint) {
+      userInfoClaims = await this.tokenClient.fetchUserInfo(disc.userinfoEndpoint, tokens.accessToken);
+    }
+
+    const claims = this.claimExtractor.extract(idTokenClaims, userInfoClaims, provider.claimMapping as OidcClaimMapping);
+    if (!claims.subject) {
+      this.logger.warn('[auth.oidc_callback] [fail] errorClass=UnauthorizedException error="missing sub claim" - OIDC callback failed');
+      throw new UnauthorizedException({
+        message: 'Could not complete sign-in with your provider. Please try again or contact your administrator.',
+        errorCode: OidcErrorCode.TOKEN_EXCHANGE_FAILED,
+      });
+    }
+
+    return { disc, tokens, idTokenClaims, userInfoClaims, claims };
+  }
+
+  /** Provision/link the user for a successful login, persist the OIDC session row, and audit. */
+  private async resolveAndSessionUser(
+    provider: Awaited<ReturnType<OidcProviderService['findByIdOrFail']>>,
+    disc: Awaited<ReturnType<OidcDiscoveryService['getDiscoveryDoc']>>,
+    claims: ReturnType<OidcClaimExtractorService['extract']>,
+    tokens: Awaited<ReturnType<OidcTokenClientService['exchangeCode']>>,
+    idTokenClaims: Record<string, unknown>,
+    autoProvision: OidcAutoProvision,
+  ) {
     const user = await this.findOrProvisionUser(claims, provider, disc.issuer, autoProvision);
 
-    const sid = (idTokenClaims as Record<string, unknown>).sid ? String((idTokenClaims as Record<string, unknown>).sid) : undefined;
+    const sid = typeof idTokenClaims.sid === 'string' ? idTokenClaims.sid : undefined;
     await this.sessionRepo.create({
       userId: user.id,
       providerId: provider.id,
@@ -272,8 +431,7 @@ export class OidcService {
       description: `User logged in via OIDC (issuer: ${disc.issuer})`,
     });
 
-    const authResult = await this.authService.issueTokensForUser(user.id, reply);
-    return { mode: 'login' as const, ...authResult } as OidcCallbackResponse;
+    return user;
   }
 
   private async findOrProvisionUser(

--- a/tools/abs-capture-proxy/README.md
+++ b/tools/abs-capture-proxy/README.md
@@ -1,0 +1,47 @@
+# abs-capture-proxy
+
+Standalone developer/debugging utility. Not part of the build — run directly with `node` (or via the
+`pnpm abs:capture` script).
+
+A zero-dependency logging reverse proxy for debugging external Audiobookshelf (ABS) clients
+(Prologue, Still, etc.) against a BookOrbit server. It forwards every HTTP request — and the
+Socket.IO websocket upgrade — to a target server and logs exactly what the client sends and
+receives, so you can see the real request flow a client uses (paths, query params, headers, status
+codes, body sizes) rather than guessing.
+
+Originally built to diagnose Prologue showing empty libraries (it browses via
+`GET /api/libraries/:id/authors`, not `/items`).
+
+### Usage
+
+The upstream target is **required** — set the `UPSTREAM` env var or pass `--upstream=<url>`:
+
+```bash
+UPSTREAM=http://localhost:3000 pnpm abs:capture                            # from the repo root
+# or:
+node ./tools/abs-capture-proxy/abs-capture-proxy.mjs --upstream=https://my-server.example
+```
+
+Then point the client's server URL at `http://<your-machine-LAN-ip>:9000` (same network; the device
+must be able to reach your machine — check the OS firewall). The proxy forwards to the upstream and
+logs each exchange.
+
+### Env knobs / flags
+
+| Var / flag                 | Default      | Purpose                                                                            |
+| -------------------------- | ------------ | ---------------------------------------------------------------------------------- |
+| `UPSTREAM` / `--upstream=` | _(required)_ | Target server to forward to (no default; the proxy exits if unset)                 |
+| `PORT`                     | `9000`       | Listen port                                                                        |
+| `DUMP`                     | _(off)_      | `DUMP=1` also writes each JSON response body to `./abs-capture/` (gzip/br decoded) |
+
+Example against a local dev server with body dumps:
+
+```bash
+UPSTREAM=http://localhost:3000 PORT=9000 DUMP=1 pnpm abs:capture
+```
+
+### Notes
+
+- Read-only forwarding — it does not modify requests or responses, only observes.
+- For 4xx/5xx responses it prints a snippet of the body to surface error envelopes.
+- TLS upstreams are connected with `rejectUnauthorized: false` so self-signed/proxy certs work.

--- a/tools/abs-capture-proxy/abs-capture-proxy.mjs
+++ b/tools/abs-capture-proxy/abs-capture-proxy.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// ABS traffic-capture proxy for debugging external Audiobookshelf clients (Prologue, Still, …).
+// Point the client's server URL at this proxy (http://<your-LAN-ip>:9000) and it forwards every
+// request — plus the Socket.IO websocket upgrade — to the upstream, logging exactly what the
+// client sends/receives. See ./README.md for details.
+//
+//   UPSTREAM=http://localhost:3000 pnpm abs:capture                    # from the repo root
+//   node ./tools/abs-capture-proxy/abs-capture-proxy.mjs --upstream=https://my-server.example
+//
+// The upstream target is REQUIRED (no default) — set the UPSTREAM env var or pass --upstream=<url>.
+//
+// Env knobs:
+//   UPSTREAM=<url>  (required)         target server to forward to (or --upstream=<url> flag)
+//   PORT=9000                          listen port
+//   DUMP=1                             also write each response body to ./abs-capture/ (cwd)
+
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import tls from 'node:tls';
+import zlib from 'node:zlib';
+import fs from 'node:fs';
+import path from 'node:path';
+import { URL } from 'node:url';
+
+const PORT = Number(process.env.PORT ?? 9000);
+
+/** Resolve the (required) upstream target from UPSTREAM, a --upstream=<url> flag, or a bare arg. */
+function resolveUpstream() {
+  const args = process.argv.slice(2);
+  const flag = args.find((a) => a.startsWith('--upstream='));
+  const positional = args.find((a) => !a.startsWith('-'));
+  const raw = process.env.UPSTREAM ?? (flag ? flag.slice('--upstream='.length) : positional);
+  if (!raw) {
+    console.error(
+      'Error: no upstream server specified. The target is required (no default).\n\n' +
+        'Set the UPSTREAM env var or pass --upstream=<url>, e.g.\n' +
+        '  UPSTREAM=http://localhost:3000 pnpm abs:capture\n' +
+        '  node ./tools/abs-capture-proxy/abs-capture-proxy.mjs --upstream=https://my-server.example',
+    );
+    process.exit(1);
+  }
+  try {
+    return new URL(raw);
+  } catch {
+    console.error(`Error: invalid upstream URL: ${raw}`);
+    process.exit(1);
+  }
+}
+
+const UPSTREAM = resolveUpstream();
+const DUMP = process.env.DUMP === '1';
+const upstreamPort = UPSTREAM.port ? Number(UPSTREAM.port) : UPSTREAM.protocol === 'https:' ? 443 : 80;
+const agent = UPSTREAM.protocol === 'https:' ? https : http;
+
+if (DUMP) fs.mkdirSync(path.join(process.cwd(), 'abs-capture'), { recursive: true });
+
+let seq = 0;
+const ts = () => new Date().toISOString().slice(11, 23);
+const shortAuth = (h) => (!h ? '-' : /^Bearer /.test(h) ? `Bearer …${h.slice(-6)}` : h.slice(0, 12));
+
+function decodeBody(buf, encoding) {
+  try {
+    if (encoding === 'gzip') return zlib.gunzipSync(buf);
+    if (encoding === 'br') return zlib.brotliDecompressSync(buf);
+    if (encoding === 'deflate') return zlib.inflateSync(buf);
+  } catch {
+    return buf;
+  }
+  return buf;
+}
+
+const server = http.createServer((req, res) => {
+  const id = ++seq;
+  const started = Date.now();
+  const headers = { ...req.headers, host: UPSTREAM.host };
+
+  const upReq = agent.request(
+    {
+      protocol: UPSTREAM.protocol,
+      hostname: UPSTREAM.hostname,
+      port: upstreamPort,
+      method: req.method,
+      path: req.url,
+      headers,
+      servername: UPSTREAM.hostname,
+    },
+    (upRes) => {
+      const ctype = upRes.headers['content-type'] ?? '';
+      // Media/binary bodies (covers, audiobook range streams) pass through unbuffered — buffering a
+      // 300MB+ range response delays the first byte by seconds and stalls AVPlayer playback.
+      if (!/json|xml|text|mpegurl/i.test(ctype)) {
+        console.log(
+          `[${ts()}] #${id} ${req.method} ${req.url}\n` +
+            `        ← ${upRes.statusCode} ${ctype} (streamed) range=${req.headers['range'] ?? '-'} len=${upRes.headers['content-length'] ?? '?'}`,
+        );
+        res.writeHead(upRes.statusCode, upRes.headers);
+        upRes.pipe(res);
+        return;
+      }
+      const chunks = [];
+      upRes.on('data', (c) => chunks.push(c));
+      upRes.on('end', () => {
+        const raw = Buffer.concat(chunks);
+        const enc = upRes.headers['content-encoding'];
+        const ms = Date.now() - started;
+        const ctype = upRes.headers['content-type'] ?? '';
+        console.log(
+          `[${ts()}] #${id} ${req.method} ${req.url}\n` +
+            `        ← ${upRes.statusCode} ${ctype} ${enc ? `(${enc}) ` : ''}${raw.length}B ${ms}ms\n` +
+            `        UA=${req.headers['user-agent'] ?? '-'} AE=${req.headers['accept-encoding'] ?? '-'} Auth=${shortAuth(req.headers.authorization)}`,
+        );
+        // Flag suspicious bodies: a non-2xx, or a JSON error envelope that isn't ABS-shaped.
+        if (upRes.statusCode >= 400) {
+          const body = decodeBody(raw, enc).toString('utf8').slice(0, 300);
+          if (body) console.log(`        ⚠ body: ${body}`);
+        }
+        if (DUMP && /json/.test(ctype)) {
+          const safe = req.url.replace(/[^a-z0-9]+/gi, '_').slice(0, 80);
+          fs.writeFileSync(path.join('abs-capture', `${String(id).padStart(4, '0')}_${req.method}_${safe}.json`), decodeBody(raw, enc));
+        }
+        res.writeHead(upRes.statusCode, upRes.headers);
+        res.end(raw);
+      });
+    },
+  );
+  upReq.on('error', (e) => {
+    console.log(`[${ts()}] #${id} ${req.method} ${req.url}  ✖ upstream error: ${e.message}`);
+    if (!res.headersSent) res.writeHead(502).end(`proxy upstream error: ${e.message}`);
+  });
+  // AVPlayer opens/cancels range requests aggressively; stop pulling from upstream when it hangs up.
+  res.on('close', () => {
+    if (!res.writableEnded) upReq.destroy();
+  });
+  req.pipe(upReq);
+});
+
+// Transparently tunnel the Socket.IO websocket upgrade so Prologue's realtime works.
+server.on('upgrade', (req, clientSocket, head) => {
+  console.log(`[${ts()}] WS upgrade ${req.url}`);
+  const isTls = UPSTREAM.protocol === 'https:';
+  const upSocket = isTls
+    ? tls.connect({ host: UPSTREAM.hostname, port: upstreamPort, servername: UPSTREAM.hostname, rejectUnauthorized: false })
+    : net.connect({ host: UPSTREAM.hostname, port: upstreamPort });
+  upSocket.on(isTls ? 'secureConnect' : 'connect', () => {
+    const reqLines = [`${req.method} ${req.url} HTTP/1.1`, `Host: ${UPSTREAM.host}`];
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (k.toLowerCase() === 'host') continue;
+      reqLines.push(`${k}: ${v}`);
+    }
+    upSocket.write(reqLines.join('\r\n') + '\r\n\r\n');
+    if (head && head.length) upSocket.write(head);
+    upSocket.pipe(clientSocket);
+    clientSocket.pipe(upSocket);
+  });
+  upSocket.on('error', () => clientSocket.destroy());
+  clientSocket.on('error', () => upSocket.destroy());
+});
+
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`ABS capture proxy on http://0.0.0.0:${PORT}  ->  ${UPSTREAM.origin}`);
+  console.log('Point Prologue at  http://<your-mac-LAN-ip>:' + PORT + (DUMP ? '   (DUMP on -> ./abs-capture/)' : ''));
+});

--- a/tools/abs-capture-proxy/abs-id-rewrite-proxy.mjs
+++ b/tools/abs-capture-proxy/abs-id-rewrite-proxy.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// Hypothesis-test proxy for ABS client debugging: presents BookOrbit's ABS ids (li_413, aut_363, …)
+// to the client as UUID-shaped strings and reverse-maps them on requests. Real ABS ids are UUIDs;
+// if a client (e.g. Prologue) persists items keyed by UUID(uuidString:), BookOrbit's prefixed ids
+// decode fine over the wire but fail at the persistence layer — silently, with healthy traffic.
+// If the client renders books through this proxy but not directly, that hypothesis is confirmed.
+//
+//   UPSTREAM=http://127.0.0.1:9000 PORT=9002 node abs-id-rewrite-proxy.mjs
+//
+// Chain through the capture proxy (:9000) so DUMP captures keep working, or point straight at the
+// server. Binary responses (covers/audio) stream through untouched; Range requests work.
+
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import tls from 'node:tls';
+import zlib from 'node:zlib';
+import { URL } from 'node:url';
+
+const PORT = Number(process.env.PORT ?? 9002);
+const UPSTREAM = new URL(process.env.UPSTREAM ?? 'http://127.0.0.1:9000');
+const upstreamPort = UPSTREAM.port ? Number(UPSTREAM.port) : UPSTREAM.protocol === 'https:' ? 443 : 80;
+const agent = UPSTREAM.protocol === 'https:' ? https : http;
+
+const ts = () => new Date().toISOString().slice(11, 23);
+
+// prefix <-> 2-hex type code (keep in sync with server/src/modules/abs/abs-id.util.ts prefixes)
+const TYPE_CODES = { usr: '01', lib: '02', li: '03', bk: '04', aut: '05', ser: '06', col: '07', pl: '08', bf: '09' };
+const CODE_TO_PREFIX = Object.fromEntries(Object.entries(TYPE_CODES).map(([p, c]) => [c, p]));
+
+function toUuid(prefix, num) {
+  const hex = Number(num).toString(16).padStart(12, '0');
+  return `00000000-00${TYPE_CODES[prefix]}-4000-8000-${hex}`;
+}
+
+// server-side text -> client-side text (prefix ids become uuids)
+function rewriteResponseText(text) {
+  return text.replace(/\b(usr|lib|li|bk|aut|ser|col|pl|bf)_(\d+)\b/g, (m, p, n) => toUuid(p, n));
+}
+
+// client-side text -> server-side text (uuids back to prefix ids)
+const UUID_RE = /00000000-00([0-9a-f]{2})-4000-8000-([0-9a-f]{12})/gi;
+function rewriteRequestText(text) {
+  return text.replace(UUID_RE, (m, code, hex) => {
+    const prefix = CODE_TO_PREFIX[code.toLowerCase()];
+    if (!prefix) return m;
+    return `${prefix}_${parseInt(hex, 16)}`;
+  });
+}
+
+const b64 = { enc: (s) => Buffer.from(s, 'utf8').toString('base64'), dec: (s) => Buffer.from(s, 'base64').toString('utf8') };
+
+/** Reverse-map ids inside the URL path and query (incl. base64-encoded filter values). */
+function rewriteRequestUrl(rawUrl) {
+  let u;
+  try {
+    u = new URL(rawUrl, 'http://x');
+  } catch {
+    return rewriteRequestText(rawUrl);
+  }
+  const pathname = rewriteRequestText(decodeURIComponent(u.pathname));
+  const params = new URLSearchParams(u.search);
+  for (const [k, v] of [...params.entries()]) {
+    if (k === 'filter' && v.includes('.')) {
+      const dot = v.indexOf('.');
+      const group = v.slice(0, dot);
+      try {
+        const decoded = b64.dec(v.slice(dot + 1));
+        const mapped = rewriteRequestText(decoded);
+        if (mapped !== decoded) params.set(k, `${group}.${b64.enc(mapped)}`);
+      } catch {
+        /* leave as-is */
+      }
+    } else {
+      const mapped = rewriteRequestText(v);
+      if (mapped !== v) params.set(k, mapped);
+    }
+  }
+  const qs = params.toString();
+  return encodeURI(pathname) + (qs ? `?${qs}` : '');
+}
+
+function decodeBody(buf, encoding) {
+  try {
+    if (encoding === 'gzip') return zlib.gunzipSync(buf);
+    if (encoding === 'br') return zlib.brotliDecompressSync(buf);
+    if (encoding === 'deflate') return zlib.inflateSync(buf);
+  } catch {
+    return buf;
+  }
+  return buf;
+}
+
+const server = http.createServer((req, res) => {
+  const targetPath = rewriteRequestUrl(req.url);
+  const method = req.method;
+  const isBodyText = /json/.test(req.headers['content-type'] ?? '');
+
+  const reqChunks = [];
+  req.on('data', (c) => reqChunks.push(c));
+  req.on('end', () => {
+    let body = Buffer.concat(reqChunks);
+    if (isBodyText && body.length) body = Buffer.from(rewriteRequestText(body.toString('utf8')), 'utf8');
+
+    const headers = { ...req.headers, host: UPSTREAM.host, 'accept-encoding': 'identity' };
+    delete headers['content-length'];
+    if (body.length) headers['content-length'] = String(body.length);
+
+    const upReq = agent.request(
+      { protocol: UPSTREAM.protocol, hostname: UPSTREAM.hostname, port: upstreamPort, method, path: targetPath, headers, servername: UPSTREAM.hostname },
+      (upRes) => {
+        const ctype = upRes.headers['content-type'] ?? '';
+        const rewritable = /json|xml|mpegurl|text/i.test(ctype);
+        if (!rewritable) {
+          // binary (covers/audio): stream through untouched
+          res.writeHead(upRes.statusCode, upRes.headers);
+          upRes.pipe(res);
+          return;
+        }
+        const chunks = [];
+        upRes.on('data', (c) => chunks.push(c));
+        upRes.on('end', () => {
+          const raw = decodeBody(Buffer.concat(chunks), upRes.headers['content-encoding']);
+          const out = Buffer.from(rewriteResponseText(raw.toString('utf8')), 'utf8');
+          const outHeaders = { ...upRes.headers };
+          delete outHeaders['content-encoding'];
+          delete outHeaders['transfer-encoding'];
+          outHeaders['content-length'] = String(out.length);
+          console.log(`[${ts()}] ${method} ${req.url} -> ${targetPath}  ${upRes.statusCode} ${out.length}B`);
+          res.writeHead(upRes.statusCode, outHeaders);
+          res.end(out);
+        });
+      },
+    );
+    upReq.on('error', (e) => {
+      console.log(`[${ts()}] ${method} ${req.url}  upstream error: ${e.message}`);
+      res.writeHead(502).end(`id-rewrite proxy upstream error: ${e.message}`);
+    });
+    upReq.end(body.length ? body : undefined);
+  });
+});
+
+// Transparently tunnel the Socket.IO websocket upgrade like the capture proxy does.
+server.on('upgrade', (req, clientSocket, head) => {
+  const isTls = UPSTREAM.protocol === 'https:';
+  const upSocket = isTls
+    ? tls.connect({ host: UPSTREAM.hostname, port: upstreamPort, servername: UPSTREAM.hostname, rejectUnauthorized: false })
+    : net.connect({ host: UPSTREAM.hostname, port: upstreamPort });
+  upSocket.on(isTls ? 'secureConnect' : 'connect', () => {
+    const reqLines = [`${req.method} ${req.url} HTTP/1.1`, `Host: ${UPSTREAM.host}`];
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (k.toLowerCase() === 'host') continue;
+    reqLines.push(`${k}: ${v}`);
+    }
+    upSocket.write(reqLines.join('\r\n') + '\r\n\r\n');
+    if (head && head.length) upSocket.write(head);
+    upSocket.pipe(clientSocket);
+    clientSocket.pipe(upSocket);
+  });
+  upSocket.on('error', () => clientSocket.destroy());
+  clientSocket.on('error', () => upSocket.destroy());
+});
+
+server.listen(PORT, '0.0.0.0', () => {
+  console.log(`ABS id-rewrite proxy on http://0.0.0.0:${PORT} -> ${UPSTREAM.origin}`);
+  console.log('Point Prologue at http://<mac-LAN-ip>:' + PORT);
+});


### PR DESCRIPTION
## What does this PR do?

Adds an Audiobookshelf-compatible API layer so that ABS clients (the official apps, Prologue, Plappa, etc.) can connect to BookOrbit and use it as an audiobook server. Clients can browse libraries, play books with progress sync, and resume across devices.

Closes #650

What's included:

- `server/src/modules/abs`: a module implementing a subset of the ABS 2.35.x surface, media progress sync, session history and stats, and direct file streaming with an HLS transcode fallback
- Routing: ABS clients expect routes at the server root, not under `/api/v1`, so the module mounts via a Fastify pre-routing URL rewrite. The ABS `/auth/refresh` route is remapped before routing to avoid colliding with BookOrbit's own refresh endpoint.
- DB: one generated migration adding `abs_sessions`, `abs_playback_sessions`, and a `hide_from_continue_listening` flag on `audiobook_progress`.
- OIDC: extends the existing flow for ABS mobile login. Mobile redirect URIs for third-party clients must be added via `ABS_OIDC_MOBILE_REDIRECT_URIS` (same as Audiobookshelf).
- Docs: `docs/abs-api/` is a re-implementation reference of the ABS server contract plus a coverage matrix and TODO list for the remaining gaps. The [actual ABS API docs](https://api.audiobookshelf.org) are pretty out of date.
- Tooling: `tools/abs-capture-proxy`, a logging reverse proxy used to diff BookOrbit responses against a real ABS instance while testing clients.

## How did you test this?

I tested login, library browse, playback, and progress sync with three iOS Audiobookshelf clients: Prologue, Plappa, and Still. No Android clients have been tested yet (help needed). I ran the capture proxy tool against both a real Audiobookshelf server and BookOrbit while running the same client, and diffed the responses. There's also a large unit test suite.

## Screenshots

Backend only change, no UI changes.

## Anything non-obvious in the diff?

- Strict-Codable clients (like iOS clients I tested) reject unexpected keys as well as missing ones, so the mappers emit the exact ABS key set per context. Don't remove seemingly redundant fields in the mappers without checking against a real client.
- The global exception filter skips BookOrbit's error envelope on ABS paths, since clients expect ABS-style plain-text/JSON errors.
- Ebooks are automatically omitted from the catalog so clients don't try to play audio-less items.
- The iOS clients reject 303 redirects on the callback leg, hence the explicit 302.
- The large `meta/0055_snapshot.json` is Drizzle Kit generated output.
- `docs/abs-api/TODO.md` tracks the remaining gaps in the API. This PR covers the core stuff, anything required for login, browsing, playback, and progress sync. Collections, playlists, etc. are out of scope for now.

## Checklist

- [x] I've read through my own diff
- [x] This PR was discussed in an issue: #650
- [ ] This PR has maintainer approval (for new features)
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)

## AI Disclosure

Implementing this feature employed heavy use of Claude (as you can probably guess given the size of it).

## Other Notes

I'm keeping this PR in draft until I get maintainer approval for this feature. The feature request (#650) is only a week old, but work on this started about a month ago.