### PR TITLE
fix(metadata): bound ffprobe/ffmpeg/pdftoppm subprocess calls during scanning

### DIFF
--- a/server/src/modules/metadata/extractors/audio.extractor.test.ts
+++ b/server/src/modules/metadata/extractors/audio.extractor.test.ts
@@ -36,15 +36,21 @@ function makeProbeOutput(overrides: FfprobeOutput = {}): string {
 
 type ExecFileCallback = (err: Error | null, result: { stdout: string; stderr: string } | string) => void;
 
+// execFile is called as either (bin, args, callback) or (bin, args, options, callback),
+// so resolve the callback from whichever position it lands in.
+function resolveExecFileCallback(optionsOrCallback: unknown, maybeCallback?: unknown): ExecFileCallback {
+  return (typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback) as ExecFileCallback;
+}
+
 function makeExecFileSuccess(stdout: string) {
-  mockExecFile.mockImplementation((_bin: string, _args: string[], callback: ExecFileCallback) => {
-    callback(null, { stdout, stderr: '' });
+  mockExecFile.mockImplementation((_bin: string, _args: string[], optionsOrCallback: unknown, maybeCallback?: unknown) => {
+    resolveExecFileCallback(optionsOrCallback, maybeCallback)(null, { stdout, stderr: '' });
   });
 }
 
 function makeExecFileError(message: string) {
-  mockExecFile.mockImplementation((_bin: string, _args: string[], callback: ExecFileCallback) => {
-    callback(new Error(message), '');
+  mockExecFile.mockImplementation((_bin: string, _args: string[], optionsOrCallback: unknown, maybeCallback?: unknown) => {
+    resolveExecFileCallback(optionsOrCallback, maybeCallback)(new Error(message), '');
   });
 }
 
@@ -654,6 +660,7 @@ describe('extractAudioMetadata — failure tolerance', () => {
     expect(mockExecFile).toHaveBeenCalledWith(
       'ffprobe',
       ['-v', 'quiet', '-print_format', 'json', '-show_format', '-show_chapters', '-show_streams', '/books/my-audiobook.m4b'],
+      expect.objectContaining({ timeout: expect.any(Number), maxBuffer: expect.any(Number) }),
       expect.any(Function),
     );
   });
@@ -704,6 +711,7 @@ describe('parseAudioDuration', () => {
     expect(mockExecFile).toHaveBeenCalledWith(
       'ffprobe',
       ['-v', 'quiet', '-print_format', 'json', '-show_format', '/books/test.mp3'],
+      expect.objectContaining({ timeout: expect.any(Number), maxBuffer: expect.any(Number) }),
       expect.any(Function),
     );
   });
@@ -886,7 +894,8 @@ describe('binary path env var override', () => {
     vi.resetModules();
 
     const { execFile: execFileMock, spawn: spawnMock } = await import('child_process');
-    (execFileMock as unknown as Mock).mockImplementation((_bin: string, _args: string[], cb: (err: null, r: { stdout: string }) => void) => {
+    (execFileMock as unknown as Mock).mockImplementation((_bin: string, _args: string[], o: unknown, c?: unknown) => {
+      const cb = resolveExecFileCallback(o, c) as unknown as (err: null, r: { stdout: string }) => void;
       cb(null, { stdout: JSON.stringify({ format: { duration: '100', tags: {} }, streams: [], chapters: [] }) });
     });
     (spawnMock as unknown as Mock).mockReturnValue(makeSpawnProcess(null));
@@ -894,7 +903,7 @@ describe('binary path env var override', () => {
     const { extractAudioMetadata: extract } = await import('./audio.extractor');
     await extract('/path/test.m4b');
 
-    expect(execFileMock).toHaveBeenCalledWith('/opt/bin/ffprobe', expect.any(Array), expect.any(Function));
+    expect(execFileMock).toHaveBeenCalledWith('/opt/bin/ffprobe', expect.any(Array), expect.any(Object), expect.any(Function));
   });
 
   it('uses FFMPEG_PATH env var when set', async () => {
@@ -902,7 +911,8 @@ describe('binary path env var override', () => {
     vi.resetModules();
 
     const { execFile: execFileMock, spawn: spawnMock } = await import('child_process');
-    (execFileMock as unknown as Mock).mockImplementation((_bin: string, _args: string[], cb: (err: null, r: { stdout: string }) => void) => {
+    (execFileMock as unknown as Mock).mockImplementation((_bin: string, _args: string[], o: unknown, c?: unknown) => {
+      const cb = resolveExecFileCallback(o, c) as unknown as (err: null, r: { stdout: string }) => void;
       cb(null, {
         stdout: JSON.stringify({
           format: { duration: '100', tags: {} },
@@ -928,7 +938,8 @@ describe('binary path env var override', () => {
     vi.resetModules();
 
     const { execFile: execFileMock, spawn: spawnMock } = await import('child_process');
-    (execFileMock as unknown as Mock).mockImplementation((_bin: string, _args: string[], cb: (err: null, r: { stdout: string }) => void) => {
+    (execFileMock as unknown as Mock).mockImplementation((_bin: string, _args: string[], o: unknown, c?: unknown) => {
+      const cb = resolveExecFileCallback(o, c) as unknown as (err: null, r: { stdout: string }) => void;
       cb(null, { stdout: JSON.stringify({ format: { duration: '100', tags: {} }, streams: [], chapters: [] }) });
     });
     (spawnMock as unknown as Mock).mockReturnValue(makeSpawnProcess(null));
@@ -936,6 +947,6 @@ describe('binary path env var override', () => {
     const { extractAudioMetadata: extract } = await import('./audio.extractor');
     await extract('/path/test.m4b');
 
-    expect(execFileMock).toHaveBeenCalledWith('ffprobe', expect.any(Array), expect.any(Function));
+    expect(execFileMock).toHaveBeenCalledWith('ffprobe', expect.any(Array), expect.any(Object), expect.any(Function));
   });
 });

--- a/server/src/modules/metadata/extractors/audio.extractor.test.ts
+++ b/server/src/modules/metadata/extractors/audio.extractor.test.ts
@@ -660,7 +660,7 @@ describe('extractAudioMetadata — failure tolerance', () => {
     expect(mockExecFile).toHaveBeenCalledWith(
       'ffprobe',
       ['-v', 'quiet', '-print_format', 'json', '-show_format', '-show_chapters', '-show_streams', '/books/my-audiobook.m4b'],
-      expect.objectContaining({ timeout: expect.any(Number), maxBuffer: expect.any(Number) }),
+      { maxBuffer: 10 * 1024 * 1024, timeout: 60_000 },
       expect.any(Function),
     );
   });
@@ -711,7 +711,7 @@ describe('parseAudioDuration', () => {
     expect(mockExecFile).toHaveBeenCalledWith(
       'ffprobe',
       ['-v', 'quiet', '-print_format', 'json', '-show_format', '/books/test.mp3'],
-      expect.objectContaining({ timeout: expect.any(Number), maxBuffer: expect.any(Number) }),
+      { maxBuffer: 10 * 1024 * 1024, timeout: 60_000 },
       expect.any(Function),
     );
   });

--- a/server/src/modules/metadata/extractors/audio.extractor.ts
+++ b/server/src/modules/metadata/extractors/audio.extractor.ts
@@ -8,6 +8,14 @@ const execFile = promisify(execFileCallback);
 const FFPROBE_PATH = process.env.FFPROBE_PATH || 'ffprobe';
 const FFMPEG_PATH = process.env.FFMPEG_PATH || 'ffmpeg';
 
+// These subprocesses run against untrusted library files during scanning, so bound
+// both their runtime and their output. Mirrors the limits already applied in
+// file-write/formats/audio/audio-metadata-embedder.ts.
+const FFPROBE_OUTPUT_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const FFPROBE_TIMEOUT_MS = 60_000;
+const FFMPEG_TIMEOUT_MS = 60_000;
+const FFMPEG_COVER_MAX_BYTES = 10 * 1024 * 1024;
+
 export interface AudioExtractResult {
   title: string | null;
   subtitle: string | null;
@@ -50,16 +58,11 @@ interface FfprobeOutput {
 
 export async function extractAudioMetadata(absolutePath: string): Promise<AudioExtractResult> {
   try {
-    const { stdout } = await execFile(FFPROBE_PATH, [
-      '-v',
-      'quiet',
-      '-print_format',
-      'json',
-      '-show_format',
-      '-show_chapters',
-      '-show_streams',
-      absolutePath,
-    ]);
+    const { stdout } = await execFile(
+      FFPROBE_PATH,
+      ['-v', 'quiet', '-print_format', 'json', '-show_format', '-show_chapters', '-show_streams', absolutePath],
+      { maxBuffer: FFPROBE_OUTPUT_MAX_BUFFER_BYTES, timeout: FFPROBE_TIMEOUT_MS },
+    );
 
     const data: FfprobeOutput = JSON.parse(stdout);
     const tags = normalizeTags(data.format?.tags ?? {});
@@ -140,7 +143,10 @@ export async function extractAudioMetadata(absolutePath: string): Promise<AudioE
 
 export async function parseAudioDuration(absolutePath: string): Promise<number | null> {
   try {
-    const { stdout } = await execFile(FFPROBE_PATH, ['-v', 'quiet', '-print_format', 'json', '-show_format', absolutePath]);
+    const { stdout } = await execFile(FFPROBE_PATH, ['-v', 'quiet', '-print_format', 'json', '-show_format', absolutePath], {
+      maxBuffer: FFPROBE_OUTPUT_MAX_BUFFER_BYTES,
+      timeout: FFPROBE_TIMEOUT_MS,
+    });
     const data: FfprobeOutput = JSON.parse(stdout);
     return parseDurationSeconds(data.format?.duration);
   } catch {
@@ -154,13 +160,25 @@ async function extractCoverBytes(absolutePath: string, streams: FfprobeStream[])
 
   return new Promise<Buffer | null>((resolve) => {
     const chunks: Buffer[] = [];
+    let total = 0;
+    let aborted = false;
     const proc = spawn(FFMPEG_PATH, ['-y', '-i', absolutePath, '-map', '0:v', '-frames:v', '1', '-f', 'image2pipe', '-vcodec', 'mjpeg', 'pipe:1'], {
       stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: FFMPEG_TIMEOUT_MS,
     });
 
-    proc.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
+    proc.stdout.on('data', (chunk: Buffer) => {
+      if (aborted) return;
+      total += chunk.length;
+      if (total > FFMPEG_COVER_MAX_BYTES) {
+        aborted = true;
+        proc.kill();
+        return;
+      }
+      chunks.push(chunk);
+    });
     proc.on('close', (code) => {
-      if (code === 0 && chunks.length > 0) {
+      if (!aborted && code === 0 && chunks.length > 0) {
         resolve(Buffer.concat(chunks));
       } else {
         resolve(null);

--- a/server/src/modules/metadata/lib/pdf-cover.test.ts
+++ b/server/src/modules/metadata/lib/pdf-cover.test.ts
@@ -45,6 +45,23 @@ describe('extractPdfCover', () => {
     expect(mockRm).toHaveBeenCalledWith('/tmp/pdf-cover-abc', { recursive: true, force: true });
   });
 
+  it('invokes pdftoppm with a bounded timeout and maxBuffer', async () => {
+    mockExecFile.mockImplementation((_file, _args, optionsOrCallback, maybeCallback) => {
+      const callback = (typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback) as (
+        err: Error | null,
+        stdout: string,
+        stderr: string,
+      ) => void;
+      callback?.(null, '', '');
+      return {} as never;
+    });
+    mockReadFile.mockResolvedValue(Buffer.from('cover-bytes'));
+
+    await extractPdfCover('/books/test.pdf');
+
+    expect(mockExecFile).toHaveBeenCalledWith('pdftoppm', expect.any(Array), { maxBuffer: 10 * 1024 * 1024, timeout: 60_000 }, expect.any(Function));
+  });
+
   it('cleans up temp directory even when pdftoppm fails', async () => {
     mockExecFile.mockImplementation((_file, _args, optionsOrCallback, maybeCallback) => {
       const callback = (typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback) as (

--- a/server/src/modules/metadata/lib/pdf-cover.test.ts
+++ b/server/src/modules/metadata/lib/pdf-cover.test.ts
@@ -27,9 +27,14 @@ describe('extractPdfCover', () => {
 
   it('extracts first-page jpeg bytes and always cleans up temp directory', async () => {
     const coverBytes = Buffer.from('cover-bytes');
-    mockExecFile.mockImplementation((file, args, callback) => {
+    mockExecFile.mockImplementation((file, args, optionsOrCallback, maybeCallback) => {
       expect(file).toBe('pdftoppm');
       expect(args).toEqual(['-jpeg', '-singlefile', '-r', '150', '-f', '1', '-l', '1', '/books/test.pdf', '/tmp/pdf-cover-abc/cover']);
+      const callback = (typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback) as (
+        err: Error | null,
+        stdout: string,
+        stderr: string,
+      ) => void;
       callback?.(null, '', '');
       return {} as never;
     });
@@ -41,7 +46,12 @@ describe('extractPdfCover', () => {
   });
 
   it('cleans up temp directory even when pdftoppm fails', async () => {
-    mockExecFile.mockImplementation((_file, _args, callback) => {
+    mockExecFile.mockImplementation((_file, _args, optionsOrCallback, maybeCallback) => {
+      const callback = (typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback) as (
+        err: Error | null,
+        stdout: string,
+        stderr: string,
+      ) => void;
       callback?.(new Error('pdftoppm missing'), '', '');
       return {} as never;
     });

--- a/server/src/modules/metadata/lib/pdf-cover.ts
+++ b/server/src/modules/metadata/lib/pdf-cover.ts
@@ -6,12 +6,20 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
+// pdftoppm runs against untrusted library files during scanning, so bound both its
+// runtime and its output rather than letting a malformed PDF stall a scan worker.
+const PDFTOPPM_OUTPUT_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const PDFTOPPM_TIMEOUT_MS = 60_000;
+
 export async function extractPdfCover(absolutePath: string): Promise<Buffer | null> {
   const tmpDir = await mkdtemp(join(tmpdir(), 'pdf-cover-'));
   const outPrefix = join(tmpDir, 'cover');
 
   try {
-    await execFileAsync('pdftoppm', ['-jpeg', '-singlefile', '-r', '150', '-f', '1', '-l', '1', absolutePath, outPrefix]);
+    await execFileAsync('pdftoppm', ['-jpeg', '-singlefile', '-r', '150', '-f', '1', '-l', '1', absolutePath, outPrefix], {
+      maxBuffer: PDFTOPPM_OUTPUT_MAX_BUFFER_BYTES,
+      timeout: PDFTOPPM_TIMEOUT_MS,
+    });
     return await readFile(`${outPrefix}.jpg`);
   } finally {
     await rm(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## What does this PR do?

Closes #821

Four call sites invoke external binaries against untrusted library files during scanning, with no timeout and no output limit:

| Location | Binary | Missing |
|---|---|---|
| `metadata/extractors/audio.extractor.ts` → `extractAudioMetadata` | ffprobe | `timeout`, `maxBuffer` |
| `metadata/extractors/audio.extractor.ts` → `parseAudioDuration` | ffprobe | `timeout`, `maxBuffer` |
| `metadata/extractors/audio.extractor.ts` → `extractCoverBytes` | ffmpeg (`spawn`) | `timeout`, output cap |
| `metadata/lib/pdf-cover.ts` → `extractPdfCover` | pdftoppm | `timeout`, `maxBuffer` |

Since these run automatically on every scanned/watched audio and PDF file, a malformed or adversarial file that makes the binary hang can stall a scan worker indefinitely, and unbounded stdout can accumulate in memory.

`file-write/formats/audio/audio-metadata-embedder.ts` already gets this right (60s timeout, 10MB output cap). This applies the same limits to the paths that lack them, rather than introducing a new convention. All limits are module-level constants, easy to tune.

## How did you test this?

Verified against `main`:

- `pnpm --filter server type-check` — clean
- `eslint` on the changed files — clean
- `vitest run src/modules/metadata` — **8 failed / 1204 passed both before and after**, i.e. no change. Those 8 are pre-existing failures unrelated to this PR (POSIX-vs-Windows path-separator assertions), reproducible on an unmodified checkout on Windows.

New tests assert that `timeout` and `maxBuffer` are actually passed for the ffprobe and pdftoppm calls.

## Screenshots

Not applicable — no UI changes.

## Anything non-obvious in the diff?

Two things worth a reviewer's attention:

1. **The `spawn` case is handled differently from `execFile`.** `spawn` has no `maxBuffer`, so Node's `timeout` option covers the hang and an accumulated-bytes guard kills the process if output exceeds the cap. On either condition the existing `close` handler resolves `null`, so the behaviour on a bad file is unchanged: no cover, scan continues.

2. **The test mocks changed shape.** The `execFile` mocks in `audio.extractor.test.ts` and `pdf-cover.test.ts` assumed the 3-arg `(bin, args, callback)` form; passing an options object shifts the callback to the 4th position. They now resolve the callback from either position, so they no longer depend on whether options are passed.

## Checklist

- [x] I've read through my own diff
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)
- [ ] This PR was discussed in an issue and has maintainer approval — see the process note below

---

*Process note: I opened this PR before filing the issue, which is backwards per `docs/CONTRIBUTING.md` ("issue first, PR second"). #821 now describes the bug on its own terms. If you'd rather triage the issue first, I'm happy for this to sit as a draft or be closed and reopened after approval — just say the word.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added execution timeouts and output-size limits for audio (`ffprobe`) and PDF (`pdftoppm`) metadata extraction to prevent stalls and excessive memory usage.
  * Strengthened cover extraction controls for untrusted media by enforcing stricter limits on captured output and aborting oversized transfers.
* **Tests**
  * Updated mocks and assertions to handle multiple subprocess callback invocation patterns.
  * Added/adjusted tests to verify `timeout` and `maxBuffer` are passed for ffprobe and pdftoppm calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
