### PR TITLE
fix(reader): support opf:-prefixed OPF elements and bound structural XML reads

### DIFF
--- a/server/src/modules/reader/epub/epub.service.test.ts
+++ b/server/src/modules/reader/epub/epub.service.test.ts
@@ -26,7 +26,17 @@ function zipEntry(spec: ZipEntrySpec) {
     path: spec.path,
     uncompressedSize: spec.uncompressedSize ?? content.length,
     buffer: spec.bufferError ? vi.fn().mockRejectedValue(spec.bufferError) : vi.fn().mockResolvedValue(content),
-    stream: vi.fn(() => Readable.from(streamContent)),
+    // bufferError models "this entry cannot be read", so it must fail the stream path
+    // too — structural XML entries are read via stream() rather than buffer().
+    stream: vi.fn(() =>
+      spec.bufferError
+        ? new Readable({
+            read() {
+              this.destroy(spec.bufferError);
+            },
+          })
+        : Readable.from(streamContent),
+    ),
   };
 }
 
@@ -74,6 +84,23 @@ const OPF_XML = `
     <itemref idref="chap2" linear="no" />
   </spine>
 </package>
+`;
+
+// Same package as OPF_XML but with every structural element carrying an explicit
+// `opf:` namespace prefix, which is valid per the EPUB spec.
+const OPF_XML_NAMESPACED = `
+<opf:package xmlns:opf="http://www.idpf.org/2007/opf" version="3.0">
+  <opf:metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Reader Test</dc:title>
+  </opf:metadata>
+  <opf:manifest>
+    <opf:item id="chap1" href="text/ch1.xhtml" media-type="application/xhtml+xml" />
+    <opf:item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+  </opf:manifest>
+  <opf:spine>
+    <opf:itemref idref="chap1" />
+  </opf:spine>
+</opf:package>
 `;
 
 const NAV_XHTML = `
@@ -204,6 +231,32 @@ describe('EpubService', () => {
       }),
     );
     expect(libraryService.verifyUserAccess).toHaveBeenCalledWith(10, 3, false);
+  });
+
+  it('parses an OPF whose package/manifest/spine elements use an explicit opf: prefix', async () => {
+    mockOpenFile.mockResolvedValueOnce(
+      makeArchive([
+        { path: 'META-INF/container.xml', content: CONTAINER_XML },
+        { path: 'OPS/content.opf', content: OPF_XML_NAMESPACED },
+        { path: 'OPS/toc.ncx', content: NCX_XML },
+        { path: 'OPS/text/ch1.xhtml', content: '<h1>ch1</h1>' },
+      ]) as any,
+    );
+
+    const info = await service.getBookInfo(99, undefined, user);
+
+    expect(info.metadata).toEqual(expect.objectContaining({ title: 'Reader Test' }));
+    expect(info.manifest.map((m) => m.id)).toEqual(['chap1', 'ncx']);
+    expect(info.spine.map((s) => s.href)).toEqual(['OPS/text/ch1.xhtml']);
+  });
+
+  it('rejects a structural XML entry that exceeds the size cap instead of buffering it', async () => {
+    const oversized = Buffer.alloc(11 * 1024 * 1024, 0x20);
+    mockOpenFile.mockResolvedValueOnce(
+      makeArchive([{ path: 'META-INF/container.xml', content: oversized, uncompressedSize: oversized.length }]) as any,
+    );
+
+    await expect(service.getBookInfo(99, undefined, user)).rejects.toThrow(/exceeds maximum allowed size/);
   });
 
   it('falls back to NCX TOC when nav parsing fails', async () => {

--- a/server/src/modules/reader/epub/epub.service.test.ts
+++ b/server/src/modules/reader/epub/epub.service.test.ts
@@ -1,7 +1,7 @@
 vi.mock('fs/promises', () => ({ stat: vi.fn() }));
 vi.mock('unzipper', () => ({ Open: { file: vi.fn() } }));
 
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { stat } from 'fs/promises';
 import { Readable } from 'stream';
 import * as unzipper from 'unzipper';
@@ -27,7 +27,7 @@ function zipEntry(spec: ZipEntrySpec) {
     uncompressedSize: spec.uncompressedSize ?? content.length,
     buffer: spec.bufferError ? vi.fn().mockRejectedValue(spec.bufferError) : vi.fn().mockResolvedValue(content),
     // bufferError models "this entry cannot be read", so it must fail the stream path
-    // too — structural XML entries are read via stream() rather than buffer().
+    // too, because structural XML entries are read via stream() rather than buffer().
     stream: vi.fn(() =>
       spec.bufferError
         ? new Readable({
@@ -92,10 +92,12 @@ const OPF_XML_NAMESPACED = `
 <opf:package xmlns:opf="http://www.idpf.org/2007/opf" version="3.0">
   <opf:metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:title>Reader Test</dc:title>
+    <opf:meta name="cover" content="cover-image" />
   </opf:metadata>
   <opf:manifest>
     <opf:item id="chap1" href="text/ch1.xhtml" media-type="application/xhtml+xml" />
     <opf:item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
+    <opf:item id="cover-image" href="images/cover.jpg" media-type="image/jpeg" />
   </opf:manifest>
   <opf:spine>
     <opf:itemref idref="chap1" />
@@ -246,8 +248,10 @@ describe('EpubService', () => {
     const info = await service.getBookInfo(99, undefined, user);
 
     expect(info.metadata).toEqual(expect.objectContaining({ title: 'Reader Test' }));
-    expect(info.manifest.map((m) => m.id)).toEqual(['chap1', 'ncx']);
+    expect(info.manifest.map((m) => m.id)).toEqual(['chap1', 'ncx', 'cover-image']);
     expect(info.spine.map((s) => s.href)).toEqual(['OPS/text/ch1.xhtml']);
+    // legacy <opf:meta name="cover"> must resolve too, not just the unprefixed form
+    expect(info.coverPath).toBe('OPS/images/cover.jpg');
   });
 
   it('rejects a structural XML entry that exceeds the size cap instead of buffering it', async () => {
@@ -256,7 +260,7 @@ describe('EpubService', () => {
       makeArchive([{ path: 'META-INF/container.xml', content: oversized, uncompressedSize: oversized.length }]) as any,
     );
 
-    await expect(service.getBookInfo(99, undefined, user)).rejects.toThrow(/exceeds maximum allowed size/);
+    await expect(service.getBookInfo(99, undefined, user)).rejects.toBeInstanceOf(UnprocessableEntityException);
   });
 
   it('falls back to NCX TOC when nav parsing fails', async () => {

--- a/server/src/modules/reader/epub/epub.service.ts
+++ b/server/src/modules/reader/epub/epub.service.ts
@@ -35,6 +35,10 @@ const CONTENT_TYPES: Record<string, string> = {
 };
 
 const MAX_CACHE = 50;
+// container.xml / OPF / NCX / nav are structural XML files that are a few KB in real
+// EPUBs. Cap them so a crafted archive cannot point one of these roles at a
+// decompression bomb and exhaust memory during parsing.
+const MAX_XML_ENTRY_BYTES = 10 * 1024 * 1024;
 const OPTIONAL_META_INF_FILES = [
   'META-INF/encryption.xml',
   'META-INF/com.apple.ibooks.display-options.xml',
@@ -69,6 +73,26 @@ function getText(v: unknown): string | null {
     if (typeof text === 'number') return String(text);
   }
   return null;
+}
+
+/**
+ * Reads a zip entry fully into memory, aborting if it exceeds `maxBytes`.
+ * `entry.buffer()` inflates the whole entry with no ceiling, so structural XML
+ * entries are read through this instead.
+ */
+async function readEntryBounded(entry: unzipper.File, maxBytes: number): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const stream = entry.stream();
+  for await (const chunk of stream as AsyncIterable<Buffer>) {
+    total += chunk.length;
+    if (total > maxBytes) {
+      stream.destroy();
+      throw new Error(`EPUB entry exceeds maximum allowed size of ${maxBytes} bytes: ${entry.path}`);
+    }
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
 }
 
 function findInZip(files: unzipper.File[], path: string): unzipper.File | undefined {
@@ -166,7 +190,7 @@ async function parseEpub(epubPath: string): Promise<EpubBookInfo> {
 
   const containerEntry = findInZip(zip.files, 'META-INF/container.xml');
   if (!containerEntry) throw new Error('Missing META-INF/container.xml');
-  const containerDoc = xmlParser.parse(await containerEntry.buffer()) as Record<string, unknown>;
+  const containerDoc = xmlParser.parse(await readEntryBounded(containerEntry, MAX_XML_ENTRY_BYTES)) as Record<string, unknown>;
 
   const container = containerDoc['container'] as Record<string, unknown>;
   const rootfiles = (container?.rootfiles as Record<string, unknown>)?.rootfile;
@@ -178,14 +202,14 @@ async function parseEpub(epubPath: string): Promise<EpubBookInfo> {
 
   const opfEntry = findInZip(zip.files, opfPath);
   if (!opfEntry) throw new Error(`OPF not found: ${opfPath}`);
-  const opfDoc = xmlParser.parse(await opfEntry.buffer()) as Record<string, unknown>;
-  const pkg = (opfDoc['package'] ?? opfDoc) as Record<string, unknown>;
-  const manifestEl = pkg['manifest'] as Record<string, unknown> | undefined;
-  const spineEl = pkg['spine'] as Record<string, unknown> | undefined;
-  const metadataEl = pkg['metadata'] as Record<string, unknown> | undefined;
+  const opfDoc = xmlParser.parse(await readEntryBounded(opfEntry, MAX_XML_ENTRY_BYTES)) as Record<string, unknown>;
+  const pkg = (opfDoc['package'] ?? opfDoc['opf:package'] ?? opfDoc) as Record<string, unknown>;
+  const manifestEl = (pkg['manifest'] ?? pkg['opf:manifest']) as Record<string, unknown> | undefined;
+  const spineEl = (pkg['spine'] ?? pkg['opf:spine']) as Record<string, unknown> | undefined;
+  const metadataEl = (pkg['metadata'] ?? pkg['opf:metadata']) as Record<string, unknown> | undefined;
 
   const manifestById = new Map<string, EpubManifestItem>();
-  const manifest: EpubManifestItem[] = toArray(manifestEl?.item as any).map((item: any) => {
+  const manifest: EpubManifestItem[] = toArray((manifestEl?.item ?? manifestEl?.['opf:item']) as any).map((item: any) => {
     const id = item['@_id'];
     const relHref = item['@_href'];
     const mediaType = item['@_media-type'] ?? 'application/octet-stream';
@@ -198,7 +222,7 @@ async function parseEpub(epubPath: string): Promise<EpubBookInfo> {
     return manifestItem;
   });
 
-  const spine: EpubSpineItem[] = toArray(spineEl?.itemref as any).reduce<EpubSpineItem[]>((acc, itemref: any) => {
+  const spine: EpubSpineItem[] = toArray((spineEl?.itemref ?? spineEl?.['opf:itemref']) as any).reduce<EpubSpineItem[]>((acc, itemref: any) => {
     const idref = itemref['@_idref'];
     const m = manifestById.get(idref);
     if (m) acc.push({ idref, href: m.href, mediaType: m.mediaType, linear: itemref['@_linear'] !== 'no' });
@@ -234,7 +258,7 @@ async function parseEpub(epubPath: string): Promise<EpubBookInfo> {
     try {
       const navEntry = findInZip(zip.files, navItem.href);
       if (navEntry) {
-        const navDoc = xmlParser.parse(await navEntry.buffer()) as Record<string, unknown>;
+        const navDoc = xmlParser.parse(await readEntryBounded(navEntry, MAX_XML_ENTRY_BYTES)) as Record<string, unknown>;
         const navDir = navItem.href.includes('/') ? navItem.href.slice(0, navItem.href.lastIndexOf('/') + 1) : rootPath;
         const html = (navDoc['html'] ?? navDoc) as Record<string, unknown>;
         const body = html['body'] as Record<string, unknown> | undefined;
@@ -259,7 +283,7 @@ async function parseEpub(epubPath: string): Promise<EpubBookInfo> {
       try {
         const ncxEntry = findInZip(zip.files, ncxItem.href);
         if (ncxEntry) {
-          const ncxDoc = xmlParser.parse(await ncxEntry.buffer()) as Record<string, unknown>;
+          const ncxDoc = xmlParser.parse(await readEntryBounded(ncxEntry, MAX_XML_ENTRY_BYTES)) as Record<string, unknown>;
           const ncxDir = ncxItem.href.includes('/') ? ncxItem.href.slice(0, ncxItem.href.lastIndexOf('/') + 1) : rootPath;
           const ncx = (ncxDoc['ncx'] ?? ncxDoc) as Record<string, unknown>;
           const navMap = ncx['navMap'] as Record<string, unknown> | undefined;

--- a/server/src/modules/reader/epub/epub.service.ts
+++ b/server/src/modules/reader/epub/epub.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, Logger, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { stat } from 'fs/promises';
 import * as unzipper from 'unzipper';
 import { XMLParser } from 'fast-xml-parser';
@@ -88,7 +88,7 @@ async function readEntryBounded(entry: unzipper.File, maxBytes: number): Promise
     total += chunk.length;
     if (total > maxBytes) {
       stream.destroy();
-      throw new Error(`EPUB entry exceeds maximum allowed size of ${maxBytes} bytes: ${entry.path}`);
+      throw new UnprocessableEntityException(`EPUB entry exceeds maximum allowed size of ${maxBytes} bytes: ${entry.path}`);
     }
     chunks.push(chunk);
   }
@@ -247,7 +247,7 @@ async function parseEpub(epubPath: string): Promise<EpubBookInfo> {
 
   let coverPath: string | null = manifest.find((m) => m.properties?.includes('cover-image'))?.href ?? null;
   if (!coverPath && metadataEl) {
-    const coverMeta = toArray(metadataEl['meta'] as any).find((m: any) => m['@_name'] === 'cover');
+    const coverMeta = toArray((metadataEl['meta'] ?? metadataEl['opf:meta']) as any).find((m: any) => m['@_name'] === 'cover');
     if (coverMeta) coverPath = manifestById.get((coverMeta as any)['@_content'])?.href ?? null;
   }
 


### PR DESCRIPTION
## What does this PR do?

Closes #822

Two independent robustness issues in the EPUB parser. Happy to split into separate PRs if you'd prefer — they're in the same function, so I kept them together.

### 1. `opf:`-prefixed OPF elements parse as an empty book

`parseEpub` resolves `package`, `manifest`, `spine`, `metadata`, `item` and `itemref` under their unprefixed names only:

```ts
const pkg = (opfDoc['package'] ?? opfDoc) as Record<string, unknown>;
const manifestEl = pkg['manifest'] as Record<string, unknown> | undefined;
```

Declaring an explicit `opf:` prefix on those elements is valid per the EPUB spec, and some producers do it. With such a file, `manifestEl` and `spineEl` are `undefined`, so the manifest and spine come back empty and the book opens with no readable content — no error, just a blank reader.

Each lookup now falls back to the `opf:`-prefixed name.

### 2. Structural XML entries are read with no size ceiling

container.xml, the OPF, the NCX and the nav document were read via `entry.buffer()`, which inflates the entire entry into memory unbounded.

This is attacker-influenced: container.xml names the OPF path, and the OPF names the nav/NCX hrefs. A crafted EPUB can therefore point any of these "small XML" roles at a highly-compressible entry, so opening the book inflates gigabytes from a few KB of archive.

Those four reads now go through `readEntryBounded()`, which streams the entry and throws past a 10MB cap. Real container/OPF/NCX/nav files are a few KB, so the cap is generous.

## How did you test this?

Verified against `main`:

- `pnpm --filter server type-check` — clean
- `eslint` on changed files — clean
- `vitest run src/modules/reader` — **73 passed before, 75 passed after**, zero failures either way

Two regression tests added: one parses an OPF with `opf:`-prefixed elements and asserts manifest/spine/metadata come through; one asserts an oversized entry is rejected rather than buffered.

## Screenshots

Not applicable — no UI changes. The user-visible effect of fix 1 is that an affected EPUB opens with its content instead of blank.

## Anything non-obvious in the diff?

**Only the four structural reads are changed** — content/resource serving is untouched, so this doesn't put a ceiling on legitimately large chapter or image entries.

**One existing test helper changed semantics.** The `zipEntry` helper's `bufferError` previously failed only `buffer()`, leaving `stream()` working — so it was coupled to the read method rather than expressing "this entry cannot be read". Since the production code now streams instead of buffering, that helper would have silently stopped exercising the failure path. It now fails both paths, which keeps the existing "falls back to NCX TOC when nav parsing fails" test meaningful.

## Checklist

- [x] I've read through my own diff
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)
- [ ] This PR was discussed in an issue and has maintainer approval — see the process note below

---

*Process note: I opened this PR before filing the issue, which is backwards per `docs/CONTRIBUTING.md` ("issue first, PR second"). #822 now describes both bugs on their own terms. If you'd rather triage the issue first, I'm happy for this to sit as a draft or be closed and reopened after approval — just say the word.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EPUB metadata parsing when OPF uses explicit `opf:` namespace prefixes.
  * Added protections to prevent overly large structural EPUB XML from being loaded into memory.
  * Enhanced EPUB parsing robustness by handling stream-reading failures more reliably.
  * Kept the existing table-of-contents fallback behavior when navigation data can’t be read.
* **Tests**
  * Expanded EPUB test coverage for namespaced OPF and for oversized container XML handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
