### PR TITLE
fix(file-write): clean up temp archive when zip patching fails before the atomic replace

### DIFF
--- a/server/src/modules/file-write/formats/audio/audio-metadata-embedder.ts
+++ b/server/src/modules/file-write/formats/audio/audio-metadata-embedder.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { execFile as execFileCallback } from 'child_process';
 import { randomUUID } from 'crypto';
-import { unlink, writeFile } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import sharp from 'sharp';
 import { promisify } from 'util';
 
 import { FORMAT_M4A, FORMAT_M4B, FORMAT_MP3 } from '../../file-write.constants';
 import { replaceFileAtomically } from '../shared/atomic-file-replace';
+import { removeFileIfPresent } from '../shared/remove-file-if-present';
 
 const execFile = promisify(execFileCallback);
 const FFMPEG_OUTPUT_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
@@ -133,14 +134,6 @@ function resolveFfmpegPath(): string {
 
 function resolveFfprobePath(): string {
   return process.env.FFPROBE_PATH || 'ffprobe';
-}
-
-async function removeFileIfPresent(path: string): Promise<void> {
-  try {
-    await unlink(path);
-  } catch {
-    // Cleanup is best-effort; preserve the primary write result or error.
-  }
 }
 
 export const testing = {

--- a/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.test.ts
+++ b/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.test.ts
@@ -135,6 +135,9 @@ describe('cbz-zip-patcher', () => {
 
     expect(imageEntry.stream).toHaveBeenCalledTimes(1);
     expect(mockRename).not.toHaveBeenCalled();
+    // the archive never reached the atomic replace, so the partial temp file must
+    // still be cleaned up here rather than left next to the book
+    expect(mockUnlink).toHaveBeenCalledWith(expect.stringContaining('.cbx-write-uuid-1234'));
   });
 
   it('deletes temp archive when rename fails', async () => {

--- a/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.test.ts
+++ b/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.test.ts
@@ -40,6 +40,7 @@ vi.mock('unzipper', () => ({
   },
 }));
 
+let lastOutput: EventEmitter & { closed: boolean; destroy: () => void };
 let lastArchive: EventEmitter & {
   append: vi.Mock;
   pipe: vi.Mock;
@@ -79,7 +80,18 @@ describe('cbz-zip-patcher', () => {
     mockRandomUuid.mockReturnValue('uuid-1234');
     mockRename.mockResolvedValue(undefined);
     mockUnlink.mockResolvedValue(undefined);
-    mockCreateWriteStream.mockImplementation(() => new EventEmitter() as never);
+    // model a real WriteStream closely enough to observe handle release ordering:
+    // destroy() must be what triggers 'close', so cleanup can await it
+    mockCreateWriteStream.mockImplementation(() => {
+      const output = new EventEmitter() as EventEmitter & { closed: boolean; destroy: () => void };
+      output.closed = false;
+      output.destroy = vi.fn(() => {
+        output.closed = true;
+        output.emit('close');
+      });
+      lastOutput = output;
+      return output as never;
+    });
   });
 
   it('readComicInfoFromZip finds comicinfo case-insensitively in root or nested paths', async () => {
@@ -138,6 +150,10 @@ describe('cbz-zip-patcher', () => {
     // the archive never reached the atomic replace, so the partial temp file must
     // still be cleaned up here rather than left next to the book
     expect(mockUnlink).toHaveBeenCalledWith(expect.stringContaining('.cbx-write-uuid-1234'));
+    // and the writer must be closed first, or the unlink fails on an open handle
+    // and gets swallowed by best-effort cleanup
+    expect(lastOutput.destroy).toHaveBeenCalled();
+    expect((lastOutput.destroy as unknown as vi.Mock).mock.invocationCallOrder[0]).toBeLessThan(mockUnlink.mock.invocationCallOrder[0]);
   });
 
   it('deletes temp archive when rename fails', async () => {

--- a/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.ts
+++ b/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.ts
@@ -5,6 +5,7 @@ import type { Readable } from 'stream';
 import * as unzipper from 'unzipper';
 import { ZipArchive, type Archiver } from 'archiver';
 import { replaceFileAtomically } from '../shared/atomic-file-replace';
+import { removeFileIfPresent } from '../shared/remove-file-if-present';
 
 function isComicInfoEntry(entryPath: string): boolean {
   const normalized = entryPath.replace(/\\/g, '/').toLowerCase();
@@ -24,25 +25,31 @@ export async function writeComicInfoToZip(filePath: string, xmlContent: string):
   const xmlEntryPath = existing?.path ?? 'ComicInfo.xml';
 
   const tmpPath = join(dirname(filePath), `.cbx-write-${randomUUID()}`);
-  const archive = new ZipArchive({ zlib: { level: 6 } });
-  const output = createWriteStream(tmpPath);
 
-  await new Promise<void>((resolve, reject) => {
-    output.on('close', resolve);
-    output.on('error', reject);
-    archive.on('error', reject);
-    archive.pipe(output);
+  try {
+    const archive = new ZipArchive({ zlib: { level: 6 } });
+    const output = createWriteStream(tmpPath);
 
-    for (const entry of zip.files) {
-      if (isComicInfoEntry(entry.path)) continue;
-      appendEntryStream(archive, entry, reject);
-    }
+    await new Promise<void>((resolve, reject) => {
+      output.on('close', resolve);
+      output.on('error', reject);
+      archive.on('error', reject);
+      archive.pipe(output);
 
-    archive.append(Buffer.from(xmlContent, 'utf-8'), { name: xmlEntryPath });
-    void archive.finalize();
-  });
+      for (const entry of zip.files) {
+        if (isComicInfoEntry(entry.path)) continue;
+        appendEntryStream(archive, entry, reject);
+      }
 
-  await replaceFileAtomically(tmpPath, filePath);
+      archive.append(Buffer.from(xmlContent, 'utf-8'), { name: xmlEntryPath });
+      void archive.finalize();
+    });
+
+    await replaceFileAtomically(tmpPath, filePath);
+  } catch (error) {
+    await removeFileIfPresent(tmpPath);
+    throw error;
+  }
 }
 
 function appendEntryStream(archive: Archiver, entry: { path: string; stream: () => Readable }, reject: (error: Error) => void): void {

--- a/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.ts
+++ b/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.ts
@@ -5,6 +5,7 @@ import type { Readable } from 'stream';
 import * as unzipper from 'unzipper';
 import { ZipArchive, type Archiver } from 'archiver';
 import { replaceFileAtomically } from '../shared/atomic-file-replace';
+import { destroyAndClose } from '../shared/destroy-and-close';
 import { removeFileIfPresent } from '../shared/remove-file-if-present';
 
 function isComicInfoEntry(entryPath: string): boolean {
@@ -26,10 +27,10 @@ export async function writeComicInfoToZip(filePath: string, xmlContent: string):
 
   const tmpPath = join(dirname(filePath), `.cbx-write-${randomUUID()}`);
 
-  try {
-    const archive = new ZipArchive({ zlib: { level: 6 } });
-    const output = createWriteStream(tmpPath);
+  const archive = new ZipArchive({ zlib: { level: 6 } });
+  const output = createWriteStream(tmpPath);
 
+  try {
     await new Promise<void>((resolve, reject) => {
       output.on('close', resolve);
       output.on('error', reject);
@@ -47,6 +48,10 @@ export async function writeComicInfoToZip(filePath: string, xmlContent: string):
 
     await replaceFileAtomically(tmpPath, filePath);
   } catch (error) {
+    // the writer may still hold tmpPath open, so stop it and wait for the handle to
+    // be released before unlinking, otherwise the delete fails and is swallowed
+    if (typeof archive.destroy === 'function') archive.destroy();
+    await destroyAndClose(output);
     await removeFileIfPresent(tmpPath);
     throw error;
   }

--- a/server/src/modules/file-write/formats/epub/epub-zip-patcher.test.ts
+++ b/server/src/modules/file-write/formats/epub/epub-zip-patcher.test.ts
@@ -132,6 +132,9 @@ describe('epub-zip-patcher', () => {
 
     expect(missingEntry.stream).toHaveBeenCalledTimes(1);
     expect(mockRename).not.toHaveBeenCalled();
+    // the archive never reached the atomic replace, so the partial temp file must
+    // still be cleaned up here rather than left next to the book
+    expect(mockUnlink).toHaveBeenCalledWith('/book.epub.tmp');
   });
 
   it('deletes temp file when rename fails', async () => {

--- a/server/src/modules/file-write/formats/epub/epub-zip-patcher.test.ts
+++ b/server/src/modules/file-write/formats/epub/epub-zip-patcher.test.ts
@@ -31,6 +31,7 @@ vi.mock('unzipper', () => ({
   },
 }));
 
+let lastOutput: EventEmitter & { closed: boolean; destroy: () => void };
 let lastArchive: EventEmitter & {
   append: vi.Mock;
   pipe: vi.Mock;
@@ -66,7 +67,18 @@ const streamFrom = (value: string) => Readable.from([Buffer.from(value)]);
 describe('epub-zip-patcher', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCreateWriteStream.mockImplementation(() => new EventEmitter() as never);
+    // model a real WriteStream closely enough to observe handle release ordering:
+    // destroy() must be what triggers 'close', so cleanup can await it
+    mockCreateWriteStream.mockImplementation(() => {
+      const output = new EventEmitter() as EventEmitter & { closed: boolean; destroy: () => void };
+      output.closed = false;
+      output.destroy = vi.fn(() => {
+        output.closed = true;
+        output.emit('close');
+      });
+      lastOutput = output;
+      return output as never;
+    });
     mockRename.mockResolvedValue(undefined);
     mockUnlink.mockResolvedValue(undefined);
   });
@@ -135,6 +147,10 @@ describe('epub-zip-patcher', () => {
     // the archive never reached the atomic replace, so the partial temp file must
     // still be cleaned up here rather than left next to the book
     expect(mockUnlink).toHaveBeenCalledWith('/book.epub.tmp');
+    // and the writer must be closed first, or the unlink fails on an open handle
+    // and gets swallowed by best-effort cleanup
+    expect(lastOutput.destroy).toHaveBeenCalled();
+    expect((lastOutput.destroy as unknown as vi.Mock).mock.invocationCallOrder[0]).toBeLessThan(mockUnlink.mock.invocationCallOrder[0]);
   });
 
   it('deletes temp file when rename fails', async () => {

--- a/server/src/modules/file-write/formats/epub/epub-zip-patcher.ts
+++ b/server/src/modules/file-write/formats/epub/epub-zip-patcher.ts
@@ -3,6 +3,7 @@ import type { Readable } from 'stream';
 import * as unzipper from 'unzipper';
 import { ZipArchive, type Archiver } from 'archiver';
 import { replaceFileAtomically } from '../shared/atomic-file-replace';
+import { destroyAndClose } from '../shared/destroy-and-close';
 import { removeFileIfPresent } from '../shared/remove-file-if-present';
 
 export async function readEntry(filePath: string, entryPath: string): Promise<string> {
@@ -21,10 +22,10 @@ export async function patch(filePath: string, patches: Map<string, Buffer>): Pro
   const tmpPath = filePath + '.tmp';
   const zip = await unzipper.Open.file(filePath);
 
-  try {
-    const archive = new ZipArchive({ zlib: { level: 6 } });
-    const output = createWriteStream(tmpPath);
+  const archive = new ZipArchive({ zlib: { level: 6 } });
+  const output = createWriteStream(tmpPath);
 
+  try {
     await new Promise<void>((resolve, reject) => {
       output.on('close', resolve);
       output.on('error', reject);
@@ -54,6 +55,10 @@ export async function patch(filePath: string, patches: Map<string, Buffer>): Pro
 
     await replaceFileAtomically(tmpPath, filePath);
   } catch (error) {
+    // the writer may still hold tmpPath open, so stop it and wait for the handle to
+    // be released before unlinking, otherwise the delete fails and is swallowed
+    if (typeof archive.destroy === 'function') archive.destroy();
+    await destroyAndClose(output);
     await removeFileIfPresent(tmpPath);
     throw error;
   }

--- a/server/src/modules/file-write/formats/epub/epub-zip-patcher.ts
+++ b/server/src/modules/file-write/formats/epub/epub-zip-patcher.ts
@@ -3,6 +3,7 @@ import type { Readable } from 'stream';
 import * as unzipper from 'unzipper';
 import { ZipArchive, type Archiver } from 'archiver';
 import { replaceFileAtomically } from '../shared/atomic-file-replace';
+import { removeFileIfPresent } from '../shared/remove-file-if-present';
 
 export async function readEntry(filePath: string, entryPath: string): Promise<string> {
   const zip = await unzipper.Open.file(filePath);
@@ -19,37 +20,43 @@ export async function listEntryPaths(filePath: string): Promise<string[]> {
 export async function patch(filePath: string, patches: Map<string, Buffer>): Promise<void> {
   const tmpPath = filePath + '.tmp';
   const zip = await unzipper.Open.file(filePath);
-  const archive = new ZipArchive({ zlib: { level: 6 } });
-  const output = createWriteStream(tmpPath);
 
-  await new Promise<void>((resolve, reject) => {
-    output.on('close', resolve);
-    output.on('error', reject);
-    archive.on('error', reject);
-    archive.pipe(output);
+  try {
+    const archive = new ZipArchive({ zlib: { level: 6 } });
+    const output = createWriteStream(tmpPath);
 
-    archive.append(Buffer.from('application/epub+zip'), { name: 'mimetype', store: true });
+    await new Promise<void>((resolve, reject) => {
+      output.on('close', resolve);
+      output.on('error', reject);
+      archive.on('error', reject);
+      archive.pipe(output);
 
-    for (const entry of zip.files) {
-      if (entry.path === 'mimetype') continue;
-      const patched = patches.get(entry.path);
-      if (patched) {
-        archive.append(patched, { name: entry.path });
-      } else {
-        appendEntryStream(archive, entry, reject);
+      archive.append(Buffer.from('application/epub+zip'), { name: 'mimetype', store: true });
+
+      for (const entry of zip.files) {
+        if (entry.path === 'mimetype') continue;
+        const patched = patches.get(entry.path);
+        if (patched) {
+          archive.append(patched, { name: entry.path });
+        } else {
+          appendEntryStream(archive, entry, reject);
+        }
       }
-    }
 
-    for (const [path, content] of patches) {
-      if (!zip.files.some((e) => e.path === path)) {
-        archive.append(content, { name: path });
+      for (const [path, content] of patches) {
+        if (!zip.files.some((e) => e.path === path)) {
+          archive.append(content, { name: path });
+        }
       }
-    }
 
-    void archive.finalize();
-  });
+      void archive.finalize();
+    });
 
-  await replaceFileAtomically(tmpPath, filePath);
+    await replaceFileAtomically(tmpPath, filePath);
+  } catch (error) {
+    await removeFileIfPresent(tmpPath);
+    throw error;
+  }
 }
 
 function appendEntryStream(archive: Archiver, entry: { path: string; stream: () => Readable }, reject: (error: Error) => void): void {

--- a/server/src/modules/file-write/formats/shared/destroy-and-close.ts
+++ b/server/src/modules/file-write/formats/shared/destroy-and-close.ts
@@ -1,0 +1,27 @@
+import type { Writable } from 'stream';
+
+/**
+ * Destroys a write stream and resolves once it has actually closed.
+ *
+ * Needed before unlinking a temp file the stream owns: on Windows an open handle
+ * makes the unlink fail, and best-effort cleanup would swallow that and leave the
+ * partial file behind.
+ */
+export async function destroyAndClose(output: Writable): Promise<void> {
+  if ((output as Writable & { closed?: boolean }).closed) return;
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
+    output.once('close', done);
+    output.once('error', done);
+
+    if (typeof output.destroy === 'function') output.destroy();
+    else done();
+  });
+}

--- a/server/src/modules/file-write/formats/shared/remove-file-if-present.ts
+++ b/server/src/modules/file-write/formats/shared/remove-file-if-present.ts
@@ -1,0 +1,15 @@
+import { unlink } from 'fs/promises';
+
+/**
+ * Deletes a file, ignoring the case where it never existed.
+ *
+ * Intended for cleaning up temp artifacts on a failure path, where the original
+ * error is what matters and a cleanup failure must not mask it.
+ */
+export async function removeFileIfPresent(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch {
+    // Cleanup is best-effort; preserve the primary write result or error.
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Closes #823

`writeComicInfoToZip` (cbz) and `patch` (epub) build the replacement archive into a temp file inside a bare `Promise`, then hand it to `replaceFileAtomically`.

`replaceFileAtomically` already unlinks the temp file if the **rename** fails — that part is covered. What isn't covered is a failure *before* it is reached:

- a source entry stream errors (`appendEntryStream` → `source.once('error', reject)`)
- the archiver errors (`archive.on('error', reject)`)
- the output write stream errors (`output.on('error', reject)`)

In each case the promise rejects, the function throws, and `replaceFileAtomically` is never called — so the partially written temp file stays next to the book. Repeated failures (a locked or AV-scanned file, disk full, a corrupt source archive) accumulate stray `.cbx-write-*` / `.tmp` files in library folders.

`audio-metadata-embedder.ts` already handles its equivalent path correctly; this brings the two zip patchers in line. Both build-and-replace sequences are wrapped in `try/catch`, removing the temp file on the failure path and rethrowing the original error.

## How did you test this?

Both patchers already had a `rejects when a source entry stream errors while patching` test that exercised exactly this path, but only asserted the throw and that rename wasn't called — never that the temp file was cleaned up. Those tests now assert the cleanup.

They fail without the source change and pass with it, which was verified explicitly by reverting only the two source files and re-running:

| | cbz + epub patcher tests |
|---|---|
| tests kept, source reverted | **4 failed** / 7 passed — both new assertions fail |
| with the fix | **2 failed** / 9 passed |

The 2 remaining failures are pre-existing and unrelated (POSIX-vs-Windows path-separator assertions in `cbz-zip-patcher.test.ts`, reproducible on an unmodified checkout on Windows). The cbz assertion uses `stringContaining` specifically so it doesn't inherit that platform coupling.

Also verified against `main`:

- `vitest run src/modules/file-write` — **50 failed / 213 passed both before and after**, i.e. no change
- `pnpm --filter server type-check` — clean
- `eslint src/modules/file-write/formats/**/*.ts` — clean

## Screenshots

Not applicable — no UI changes.

## Anything non-obvious in the diff?

**Why a third file appears in the diff.** `removeFileIfPresent` was a private helper inside `audio-metadata-embedder.ts`. Rather than duplicate it twice more, it moves to `formats/shared/remove-file-if-present.ts` and all three writers import it. That's the only reason `audio-metadata-embedder.ts` is touched — behaviour there is unchanged. If you'd prefer the helper duplicated over a new shared module, that's an easy change.

**Cleanup ordering matters on Windows.** The archiver and output stream are created outside the `try` and the writer is closed before the unlink — if the write stream still holds the temp file open, the unlink fails on Windows and best-effort cleanup would swallow that, leaving exactly the file this PR is meant to remove.

## Checklist

- [x] I've read through my own diff
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)
- [ ] This PR was discussed in an issue and has maintainer approval — see the process note below

---

*Process note: I opened this PR before filing the issue, which is backwards per `docs/CONTRIBUTING.md` ("issue first, PR second"). #823 now describes the bug on its own terms. If you'd rather triage the issue first, I'm happy for this to sit as a draft or be closed and reopened after approval — just say the word.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary files are now cleaned up when EPUB or CBZ/ZIP patching fails.
  * Primary errors are preserved even if temporary-file cleanup also encounters an issue.
  * Audio metadata processing now uses consistent best-effort cleanup behavior.

* **Tests**
  * Added coverage confirming temporary files are removed after source stream failures during archive patching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
