### PR TITLE
i18n(client): add Spanish, French, Italian, and Polish locales

### DIFF
--- a/client/src/i18n/icu.spec.ts
+++ b/client/src/i18n/icu.spec.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 import de from '@/locales/de.json'
 import en from '@/locales/en.json'
+import spanish from '@/locales/es.json'
+import french from '@/locales/fr.json'
+import italian from '@/locales/it.json'
 import nl from '@/locales/nl.json'
+import polish from '@/locales/pl.json'
 import pt from '@/locales/pt.json'
 import sl from '@/locales/sl.json'
 import { compileIcuCatalog, icuCountValues, isIcuPluralMessage, splitIcuCount } from './icu'
@@ -71,7 +75,11 @@ describe('ICU message compilation', () => {
   it.each([
     ['en', en, [0, 1, 2, 1_234]],
     ['de', de, [0, 1, 2, 1_234]],
+    ['es', spanish, [0, 1, 2, 1_000_000]],
+    ['fr', french, [0, 1, 2, 1_000_000]],
+    ['it', italian, [0, 1, 2, 1_000_000]],
     ['nl', nl, [0, 1, 2, 1_234]],
+    ['pl', polish, [0, 1, 2, 5, 1_000_000]],
     ['pt', pt, [0, 1, 2, 1_234]],
     ['sl', sl, [0, 1, 2, 3, 5, 1_234]],
   ] as const)('isolates the styled count in both dialogs for %s', (locale, catalog, counts) => {
@@ -126,7 +134,16 @@ describe('ICU message compilation', () => {
   it.each([
     ['en', en, [0, 1, 2], ['No duplicate groups', 'One duplicate group', '2 duplicate groups']],
     ['de', de, [0, 1, 2], ['Keine duplizierten Gruppen', 'Eine duplizierte Gruppe', '2 duplizierte Gruppen']],
+    ['es', spanish, [0, 1, 1_000_000], ['No hay grupos duplicados', 'Un grupo duplicado', '1.000.000 grupos duplicados']],
+    ['fr', french, [0, 1, 1_000_000], ['Pas de groupes en double', 'Un groupe en double', '1 000 000 groupes en double']],
+    ['it', italian, [0, 1, 1_000_000], ['Nessun gruppo duplicato', 'Un gruppo duplicato', '1.000.000 gruppi duplicati']],
     ['nl', nl, [0, 1, 2], ['No duplicate groups', 'One duplicate group', '2 duplicate groups']],
+    [
+      'pl',
+      polish,
+      [0, 1, 2, 5, 1_000_000],
+      ['Brak zduplikowanych grup', 'Jedna zduplikowana grupa', '2 zduplikowane grupy', '5 zduplikowanych grup', '1 000 000 zduplikowanych grup'],
+    ],
     ['pt', pt, [0, 1, 1_000_000], ['Sem grupos duplicados', 'Um grupo duplicado', '1.000.000 grupos duplicados']],
     ['sl', sl, [0, 1, 2, 3, 5], ['No duplicate groups', 'One duplicate group', '2 duplicate groups', '3 duplicate groups', '5 duplicate groups']],
   ] as const)('renders migrated Book Duplicates messages for %s', (locale, catalog, counts, expectedGroups) => {
@@ -155,7 +172,11 @@ describe('ICU message compilation', () => {
   it.each([
     ['en', en, [1, 2], ['1 failure', '2 failures']],
     ['de', de, [1, 2], ['1 Fehler', '2 Fehler']],
+    ['es', spanish, [1, 1_000_000], ['1 fracaso', '1.000.000 fracasos']],
+    ['fr', french, [1, 1_000_000], ['1 échec', '1 000 000 échecs']],
+    ['it', italian, [1, 1_000_000], ['1 fallimento', '1.000.000 fallimenti']],
     ['nl', nl, [1, 2], ['1 fout', '2 fouten']],
+    ['pl', polish, [1, 2, 5, 1_000_000], ['1 porażka', '2 niepowodzenia', '5 niepowodzeń', '1 000 000 niepowodzeń']],
     ['pt', pt, [1, 1_000_000], ['1 falha', '1.000.000 falhas']],
     ['sl', sl, [1, 2, 3, 5], ['1 napaka', '2 napaki', '3 napak', '5 napak']],
   ] as const)('renders migrated Kobo activity plurals for %s', (locale, catalog, counts, expected) => {
@@ -172,7 +193,16 @@ describe('ICU message compilation', () => {
   it.each([
     ['en', en, [0, 1, 2], ['no files ready', '1 file ready', '2 files ready']],
     ['de', de, [0, 1, 2], ['keine Dateien bereit', '1 Datei bereit', '2 Dateien bereit']],
+    ['es', spanish, [0, 1, 1_000_000], ['no hay archivos listos', '1 archivo listo', '1.000.000 archivos listos']],
+    ['fr', french, [0, 1, 1_000_000], ["aucun fichier n'est prêt", '1 fichier prêt', '1 000 000 fichiers prêts']],
+    ['it', italian, [0, 1, 1_000_000], ['nessun file pronto', '1 file pronto', '1.000.000 file pronti']],
     ['nl', nl, [0, 1, 2], ['geen bestanden gereed', '1 bestand gereed', '2 bestanden gereed']],
+    [
+      'pl',
+      polish,
+      [0, 1, 2, 5, 1_000_000],
+      ['brak gotowych plików', '1 plik gotowy', '2 pliki gotowe', '5 plików gotowych', '1 000 000 plików gotowych'],
+    ],
     ['pt', pt, [0, 1, 1_000_000], ['nenhum arquivo pronto', '1 arquivo pronto', '1.000.000 arquivos prontos']],
     [
       'sl',
@@ -208,7 +238,11 @@ describe('ICU message compilation', () => {
   it.each([
     ['en', en, [0, 1, 2]],
     ['de', de, [0, 1, 2]],
+    ['es', spanish, [0, 1, 2, 1_000_000]],
+    ['fr', french, [0, 1, 2, 1_000_000]],
+    ['it', italian, [0, 1, 2, 1_000_000]],
     ['nl', nl, [0, 1, 2]],
+    ['pl', polish, [0, 1, 2, 5, 1_000_000]],
     ['pt', pt, [0, 1, 2, 1_000_000]],
     ['sl', sl, [0, 1, 2, 3, 5]],
   ] as const)('formats every ICU message for all relevant plural categories in %s', (locale, catalog, counts) => {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -467,7 +467,7 @@
       },
       "feedback": {
         "unsavedChanges": "Cambios no guardados",
-        "allSaved": "Todos los cambios guardados"
+        "discard": "Descartar"
       },
       "profile": {
         "securityHeading": "Perfil y seguridad",
@@ -484,7 +484,11 @@
         "accountTypeLocal": "Local",
         "nameRequired": "El nombre es obligatorio",
         "updateFailed": "No se pudo actualizar el perfil",
-        "updated": "Perfil actualizado"
+        "updated": "Perfil actualizado",
+        "usernameHint": "Tu nombre de usuario no se puede cambiar.",
+        "passwordHint": "Cambia la contraseña que usas para iniciar sesión.",
+        "passwordHintOidc": "Tu contraseña la gestiona tu proveedor de identidad.",
+        "passwordHintShared": "Las cuentas compartidas inician sesión mediante un enlace mágico y no tienen contraseña."
       },
       "readingPreferences": {
         "title": "Preferencias de lectura",
@@ -492,7 +496,10 @@
         "timezone": "Zona horaria",
         "save": "Guardar preferencias",
         "enableAchievements": "Habilitar logros",
-        "enableAchievementsHint": "Realice un seguimiento del progreso de los logros y muestre la interfaz relacionada con los logros. Administre las notificaciones de logros por separado en Notificaciones."
+        "enableAchievementsHint": "Realice un seguimiento del progreso de los logros y muestre la interfaz relacionada con los logros. Administre las notificaciones de logros por separado en Notificaciones.",
+        "achievementsEnabled": "Logros habilitados",
+        "achievementsDisabled": "Logros deshabilitados",
+        "achievementsSaveFailed": "No se pudo actualizar la preferencia de logros"
       },
       "preferences": {
         "saveFailed": "No se pudieron guardar las preferencias",
@@ -534,7 +541,9 @@
           "title": "¿Desvincular la identidad {provider}?",
           "description": "Ingrese su contraseña para confirmar. Ya no podrás iniciar sesión con este proveedor.",
           "currentPassword": "Contraseña actual"
-        }
+        },
+        "description": "Inicia sesión con un proveedor de identidad externo vinculado a esta cuenta.",
+        "unlinkAria": "Desvincular {provider}"
       },
       "tour": {
         "title": "Visita guiada",
@@ -563,6 +572,11 @@
           "title": "Géneros bloqueados",
           "description": "Los libros con cualquiera de estos géneros están ocultos para usted."
         }
+      },
+      "groups": {
+        "profile": "Perfil",
+        "preferences": "Preferencias",
+        "security": "Seguridad y acceso"
       }
     },
     "magicLinks": {
@@ -596,10 +610,10 @@
         "createdBy": "Creado por",
         "expires": "Vence",
         "uses": "Usos",
-        "lastUsed": "último usado",
         "created": "Creado",
         "status": "Estado",
-        "totalUses": "Usos totales"
+        "totalUses": "Usos totales",
+        "actions": "Acciones"
       },
       "createDialog": {
         "title": "Crear enlace mágico",
@@ -627,7 +641,12 @@
       "emptyTitle": "Aún no se han creado enlaces mágicos",
       "emptyHint": "Haga clic en \"{action}\" para generar un inicio de sesión compartible URL.",
       "noActiveTitle": "No hay enlaces mágicos activos",
-      "noActiveHint": "Todos los enlaces mágicos generados para esta página han caducado o han sido revocados."
+      "noActiveHint": "Todos los enlaces mágicos generados para esta página han caducado o han sido revocados.",
+      "copyLinkAria": "Copiar el enlace de {label}",
+      "pauseAria": "Pausar {label}",
+      "resumeAria": "Reanudar {label}",
+      "revokeAria": "Revocar {label}",
+      "lastUsedLabel": "Último uso: {date}"
     },
     "oidc": {
       "title": "OIDC/SSO",
@@ -1692,9 +1711,6 @@
         "subtitle": "Controle cómo se organizan los archivos en el disco cuando se cargan y cómo se nombran cuando se descargan mediante tokens de marcador de posición.",
         "copy": "Copiar",
         "previewLabel": "Vista previa:",
-        "fileAsBookPreview": "Archivo como vista previa del libro",
-        "folderAsBookPreview": "Carpeta como vista previa del libro",
-        "downloadPreview": "Descargar vista previa",
         "globalDefaults": "Valores predeterminados globales",
         "crossPlatform": "Desinfección de rutas multiplataforma",
         "crossPlatformHint": "Haga que los nombres de archivos y carpetas generados sean seguros en Windows reemplazando caracteres no válidos y nombres reservados, y eliminando puntos y espacios al final. Desactívelo solo para configuraciones de Linux que mantienen intencionalmente esos caracteres.",
@@ -1711,15 +1727,10 @@
         "orgFolderAsBook": "Carpeta como libro",
         "orgFileAsBook": "Archivar como libro",
         "resetToDefault": "Restablecer los valores predeterminados",
-        "patternReference": "Referencia de patrón",
-        "placeholderReference": "Referencia de marcador de posición",
-        "placeholderReferenceHint": "- guía para crear patrones de nombres personalizados",
         "tokens": "Fichas",
-        "tokensHint": "Copie marcadores de posición rápidamente",
         "clickTokenHint": "Haga clic en cualquier token para copiarlo a su portapapeles.",
         "copyValue": "Copiar {value}",
         "modifiers": "Modificadores",
-        "modifiersHint": "Transformar valores de token",
         "modifiersExplain": "Agregue un modificador dentro de un token para transformar su valor:",
         "modFirst": "Solo primer valor",
         "modSort": "Último, primer formato",
@@ -1728,14 +1739,10 @@
         "folderOnlyPrefix": "Terminar un patrón con",
         "folderOnlySuffix": "para especificar solo una carpeta. El nombre del archivo original se conservará en su interior.",
         "conditionalLogic": "Lógica condicional",
-        "conditionalLogicHint": "Segmentos opcionales y alternativas",
         "conditionalPart1": "Envolver",
         "conditionalPart2": "para omitir un segmento cuando su token está vacío. uso",
         "conditionalPart3": "para un valor predeterminado.",
         "examples": "Ejemplos",
-        "patternExamples": "Ejemplos de patrones",
-        "patternExamplesHint": "Patrones listos para usar para estilos de biblioteca comunes",
-        "copyPatternTooltip": "Copiar patrón al portapapeles",
         "exCalibre": "Calibre-estilo predeterminado",
         "exSeriesReader": "Lector de series",
         "exCleanDownload": "Limpiar el nombre del archivo de descarga",
@@ -1763,7 +1770,37 @@
         "patternCopied": "Patrón copiado al portapapeles",
         "copyPatternFailed": "No se pudo copiar el patrón",
         "labelCopied": "{label} copiado al portapapeles",
-        "copyLabelFailed": "No se pudo copiar {label}"
+        "copyLabelFailed": "No se pudo copiar {label}",
+        "patternHelp": "Ayuda sobre patrones",
+        "patternHelpDescription": "Tokens, modificadores y patrones listos para copiar en cualquier campo.",
+        "copyPreview": "Copiar {label}",
+        "copyExample": "Copiar el patrón {label}",
+        "invalidCharacters": "El patrón contiene caracteres no válidos",
+        "fileAsBookSaved": "Valor predeterminado de Archivar como libro guardado",
+        "folderAsBookSaved": "Valor predeterminado de Carpeta como libro guardado",
+        "downloadPatternSaved": "Patrón de descarga guardado",
+        "savePatternFailed": "No se pudo guardar el patrón",
+        "saveDownloadPatternFailed": "No se pudo guardar el patrón de descarga",
+        "crossPlatformEnabled": "Desinfección de rutas multiplataforma habilitada",
+        "crossPlatformDisabled": "Desinfección de rutas multiplataforma deshabilitada",
+        "crossPlatformSaveFailed": "No se pudo guardar la desinfección de rutas multiplataforma",
+        "librarySaved": "Patrón guardado para {name}",
+        "librarySaveFailed": "No se pudo guardar el patrón de la biblioteca",
+        "saveLibraryPattern": "Guardar patrón para {name}",
+        "resetLibraryPattern": "Restablecer {name} al patrón predeterminado",
+        "tokenTitle": "Título del libro",
+        "tokenSubtitle": "Subtítulo del libro",
+        "tokenAuthors": "Autor(es), separados por comas",
+        "tokenYear": "Año de publicación",
+        "tokenSeries": "Nombre de la serie",
+        "tokenSeriesIndex": "Índice de la serie (con ceros a la izquierda)",
+        "tokenPublisher": "Editorial",
+        "tokenIsbn": "ISBN-13",
+        "tokenLanguage": "Idioma",
+        "tokenOriginalFilename": "Nombre de archivo original (sin extensión)",
+        "tokenExtension": "Extensión de archivo (sin punto)",
+        "patternHelpIntro": "Los patrones usan tokens como {titleToken} y {authorsToken}, además de modificadores y segmentos opcionales.",
+        "browseTokensAndExamples": "Explorar tokens y ejemplos"
       },
       "kobo": {
         "title": "Kobo Sincronización",
@@ -2451,19 +2488,15 @@
     },
     "usersPage": {
       "usersTitle": "Usuarios",
-      "magicLinksTitle": "Enlaces mágicos",
       "usersSubtitle": "Administrar cuentas de usuario y asignaciones de permisos.",
-      "magicLinksSubtitle": "Cree enlaces de inicio de sesión que se puedan compartir para cuentas compartidas.",
       "createUser": "Crear usuario",
-      "createLink": "Crear enlace",
-      "usersTab": "Usuarios",
-      "magicLinksTab": "Enlaces mágicos",
       "columns": {
         "name": "Nombre",
         "username": "Nombre de usuario",
         "email": "Correo electrónico",
         "access": "Acceso",
-        "status": "Estado"
+        "status": "Estado",
+        "actions": "Acciones"
       },
       "adminBadge": "administrador",
       "permissionCount": "{count, plural, =0 {sin permisos} one {un permiso} other {# permisos} many {# permisos}}",
@@ -2481,11 +2514,10 @@
       "deleteDialogBody": "Eliminar usuario \"{username}\". Esta acción no se puede deshacer.",
       "deleting": "Eliminando...",
       "errors": {
-        "loadData": "No se pudieron cargar los datos",
         "load": "No se pudo cargar",
-        "deleteUser": "No se pudo eliminar el usuario"
+        "deleteUser": "No se pudo eliminar el usuario",
+        "resetPassword": "No se pudo crear un enlace para restablecer la contraseña"
       },
-      "currentUsers": "Usuarios actuales",
       "defaultLibraryAccess": {
         "title": "Acceso predeterminado a la biblioteca",
         "subtitle": "Acceso de espectador otorgado a usuarios registrados automáticamente y proporcionados por OIDC.",
@@ -2493,9 +2525,37 @@
         "noLibraries": "No hay bibliotecas disponibles.",
         "save": "Guardar valores predeterminados",
         "saving": "Guardando...",
-        "saved": "Acceso predeterminado a la biblioteca guardado.",
         "saveError": "No se pudo guardar el acceso predeterminado a la biblioteca"
-      }
+      },
+      "filters": {
+        "search": "Buscar usuarios",
+        "searchPlaceholder": "Buscar por nombre, nombre de usuario o correo electrónico",
+        "sort": "Ordenar usuarios",
+        "usernameAsc": "Nombre de usuario A-Z",
+        "nameAsc": "Nombre A-Z",
+        "newest": "Más recientes primero",
+        "oldest": "Más antiguos primero",
+        "apply": "Aplicar",
+        "clear": "Borrar",
+        "state": "Filtrar usuarios",
+        "allUsers": "Todos los usuarios",
+        "admins": "Administradores",
+        "active": "Activo",
+        "inactive": "Inactivo"
+      },
+      "empty": {
+        "title": "Aún no hay usuarios",
+        "description": "Crea la primera cuenta para empezar.",
+        "filtered": "Ningún usuario coincide con la búsqueda y los filtros actuales."
+      },
+      "pagination": {
+        "label": "Paginación de usuarios",
+        "page": "Página {page} de {totalPages}"
+      },
+      "editUserAria": "Editar {name}",
+      "resetPasswordAria": "Restablecer la contraseña de {name}",
+      "deleteUserAria": "Eliminar {name}",
+      "moreActionsAria": "Más acciones para {name}"
     }
   },
   "annotations": {
@@ -4298,17 +4358,17 @@
         "title": "¿Estás disfrutando de BookOrbit?",
         "body": "Si BookOrbit está ayudando con su biblioteca, considere destacar el proyecto en GitHub. Ayuda a que más personas descubran la aplicación y respalda el desarrollo continuo.",
         "cta": "Estrella BookOrbit en GitHub"
-      }
+      },
+      "surfaceOpacity": "Opacidad de la superficie",
+      "surfaceOpacityValue": "{value}%"
     },
     "sidebar": {
-      "tagline": "Tu espacio de lectura",
       "dashboard": "Panel de control",
       "authors": "Autores",
       "series": "Serie",
       "tools": "Herramientas",
       "libraries": "Bibliotecas",
       "newLibrary": "Nueva biblioteca",
-      "libraryScanning": "{name} - Escaneando {pct}%",
       "scanProgress": "{processed} / {total} libros",
       "smartScopes": "Visores inteligentes",
       "newSmartScope": "Nuevo alcance inteligente",
@@ -4316,15 +4376,41 @@
       "collections": "Colecciones",
       "newCollection": "Nueva colección",
       "noCollections": "Aún no hay colecciones",
-      "latest": "Último {version}",
       "newReleaseNotes": "Nuevas notas de la versión disponibles",
       "support": "Soporte BookOrbit",
-      "supportShort": "Soporte",
       "supportAria": "Soporte BookOrbit en Ko-fi",
       "sectionHeader": {
         "add": "Añadir",
+        "showAll": "Mostrar todo",
+        "showCount": "Mostrar {count}",
+        "rowsShown": "Filas mostradas",
+        "menuAria": "Opciones de sección para {section}",
         "reorder": "Reordenar",
         "doneReordering": "Hecho de reordenar"
+      },
+      "noLibraries": "Aún no hay bibliotecas",
+      "clearFilter": "Borrar filtro",
+      "filterSummary": "{shown} de {total} mostrados",
+      "filterLibraries": "Filtrar bibliotecas",
+      "filterLibrariesPlaceholder": "Filtrar bibliotecas...",
+      "filterSmartScopes": "Filtrar visores inteligentes",
+      "filterSmartScopesPlaceholder": "Filtrar visores inteligentes...",
+      "filterCollections": "Filtrar colecciones",
+      "filterCollectionsPlaceholder": "Filtrar colecciones...",
+      "seeAllLibraries": "Ver todas las bibliotecas ({count})",
+      "seeAllSmartScopes": "Ver todos los visores inteligentes ({count})",
+      "seeAllCollections": "Ver todas las colecciones ({count})",
+      "updateAvailable": "Actualizar {version}",
+      "zones": {
+        "browse": "Explorar"
+      },
+      "reorder": {
+        "gripAria": "Reordenar {name}",
+        "lifted": "{name} elevado, posición {position} de {total}. Usa las teclas de flecha para moverlo.",
+        "moved": "{name}, posición {position} de {total}",
+        "dropped": "{name} soltado en la posición {position} de {total}",
+        "cancelled": "Reordenación cancelada. {name} volvió a la posición {position} de {total}.",
+        "filteredHint": "Borra el filtro para reordenar"
       }
     },
     "selectionActionBar": {
@@ -4424,6 +4510,24 @@
         "typeAndEnter": "Escribe y presiona Enter para agregar",
         "pressEnter": "Presione Entrar para agregar"
       }
+    },
+    "entityIndex": {
+      "sortBy": "Ordenar por",
+      "sort": {
+        "custom": "Orden personalizado",
+        "name": "Nombre",
+        "bookCount": "Número de libros"
+      },
+      "ascending": "Ascendente",
+      "descending": "Descendente",
+      "clearSearch": "Borrar búsqueda",
+      "resultCount": "{shown} de {total}",
+      "noMatches": "Sin coincidencias",
+      "noMatchesHint": "Prueba con otro término de búsqueda.",
+      "bookCount": "Libros: {count}",
+      "librariesEmptyHint": "Crea una biblioteca para empezar a añadir libros.",
+      "smartScopesEmptyHint": "Los visores inteligentes guardan un conjunto de filtros que usas a menudo.",
+      "collectionsEmptyHint": "Las colecciones agrupan libros que eliges manualmente."
     }
   },
   "customIcons": {
@@ -5552,7 +5656,61 @@
       "saveFailed": "No se pudieron guardar las preferencias",
       "savePreferenceFailed": "No se pudo guardar la preferencia",
       "whatsNewToggle": "Mostrar \"Novedades\" después de las actualizaciones",
-      "whatsNewToggleHint": "Una ventana emergente que destaca nuevas funciones después de las actualizaciones de la aplicación. El archivo permanece disponible de cualquier manera."
+      "whatsNewToggleHint": "Una ventana emergente que destaca nuevas funciones después de las actualizaciones de la aplicación. El archivo permanece disponible de cualquier manera.",
+      "groups": {
+        "library": "Biblioteca",
+        "files": "Archivos",
+        "integrations": "Integraciones",
+        "personal": "Personal",
+        "app": "Actualizaciones de la aplicación"
+      },
+      "enabledCount": "{enabled} de {total} habilitados",
+      "categories": {
+        "scanning": {
+          "label": "Escaneo de la biblioteca",
+          "description": "Cuando un escaneo de la biblioteca termina, falla o encuentra libros que faltan."
+        },
+        "metadata": {
+          "label": "Obtención de metadatos",
+          "description": "Cuando las búsquedas de metadatos de tus libros se completan o fallan."
+        },
+        "authorEnrichment": {
+          "label": "Enriquecimiento de autores",
+          "description": "Cuando termina la obtención de biografías y fotos de autores."
+        },
+        "fileWriteBack": {
+          "label": "Escritura en archivos",
+          "description": "Cuando los metadatos editados se vuelven a escribir en los archivos de los libros en el disco."
+        },
+        "fileRename": {
+          "label": "Cambio de nombre de archivo",
+          "description": "Cuando se cambia el nombre de un archivo de libro para que coincida con tu patrón de nombres."
+        },
+        "bulkRename": {
+          "label": "Cambio de nombre masivo",
+          "description": "Cuando un cambio de nombre masivo en muchos libros se completa o falla."
+        },
+        "migration": {
+          "label": "Migración de datos",
+          "description": "Cuando una importación desde otra herramienta de biblioteca se completa o falla."
+        },
+        "bookDock": {
+          "label": "Book Dock",
+          "description": "Cuando los archivos soltados en el dock están listos para revisar o se finalizan."
+        },
+        "koboSync": {
+          "label": "Sincronización de Kobo",
+          "description": "Cuando un dispositivo Kobo termina de sincronizarse con tu biblioteca."
+        },
+        "email": {
+          "label": "Envío por correo electrónico",
+          "description": "Cuando el envío de un libro a una dirección de correo electrónico se realiza correctamente o falla."
+        },
+        "achievements": {
+          "label": "Logros",
+          "description": "Cuando desbloqueas un nuevo logro de lectura."
+        }
+      }
     }
   },
   "reader": {
@@ -6628,6 +6786,8 @@
       "privacy": "Privacidad y uso compartido",
       "notifications": "Notificaciones",
       "restrictions": "Restricciones de contenido"
-    }
+    },
+    "smartScopes": "Visores inteligentes",
+    "collections": "Colecciones"
   }
 }

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -1,0 +1,6633 @@
+{
+  "common": {
+    "resetSortAria": "Restablecer la clasificación a la predeterminada",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "confirm": "Confirmar",
+    "loading": "Cargando...",
+    "search": "Buscar",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "previous": "Anterior",
+    "retry": "Reintentar",
+    "yes": "si",
+    "no": "No"
+  },
+  "settings": {
+    "privacySharing": {
+      "title": "Privacidad y uso compartido",
+      "subtitle": "Controle si los administradores pueden ver un resumen identificable de su actividad de lectura.",
+      "levelLegend": "Nivel de intercambio de conocimientos de lectura",
+      "current": "Configuración actual",
+      "levels": {
+        "private": {
+          "title": "Privado",
+          "description": "Sólo tú puedes ver tus estadísticas de lectura."
+        },
+        "summary": {
+          "title": "Compartir resumen",
+          "description": "Comparta hábitos agregados sin títulos de libros, autores, series o narradores."
+        },
+        "detailed": {
+          "title": "Comparta información detallada",
+          "description": "Comparta también libros, autores, series, géneros y narradores recientes y destacados."
+        }
+      },
+      "fields": {
+        "frequency": "Frecuencia de lectura y días activos.",
+        "completion": "Libros agregados iniciados y completados",
+        "formats": "Distribución de formato",
+        "genres": "Amplia distribución de géneros",
+        "trend": "Tendencia de lectura agregada",
+        "books": "Títulos de libros actuales, recientes y más leídos",
+        "authors": "Autores principales",
+        "series": "Serie superior",
+        "narrators": "Narradores principales"
+      },
+      "confirm": {
+        "shareTitle": "¿Habilitar {level}?",
+        "shareDescription": "Los administradores con permiso podrán ver la siguiente información.",
+        "stopTitle": "¿Dejar de compartir ideas de lectura?",
+        "stopDescription": "El acceso del administrador se bloqueará inmediatamente. Los registros de acceso existentes permanecen en su historial.",
+        "recordedNotice": "Cada vista del perfil de administrador se registra y aparece en su historial de acceso."
+      },
+      "preview": {
+        "title": "Vista previa de su perfil compartido",
+        "description": "Consulte la información disponible actualmente para los administradores autorizados.",
+        "action": "Cargar vista previa",
+        "readingTime": "tiempo de lectura",
+        "activeDays": "Días activos",
+        "started": "libros comenzados",
+        "completed": "Libros completados",
+        "topBooks": "mejores libros"
+      },
+      "history": {
+        "title": "Historial de acceso al perfil",
+        "description": "Vistas recientes del administrador de su perfil de lectura compartido.",
+        "empty": "Ningún administrador ha visto su perfil de lectura compartido.",
+        "paginationLabel": "Páginas del historial de acceso al perfil"
+      },
+      "durationMinutes": "{count, plural, one {# minuto} other {# minutos} many {# minutos}}",
+      "durationHours": "{count} horas",
+      "unknownTitle": "Libro sin título",
+      "errors": {
+        "load": "No se pudo cargar la configuración para compartir.",
+        "save": "No se pudo actualizar la configuración para compartir.",
+        "preview": "No se pudo cargar la vista previa del perfil compartido."
+      }
+    },
+    "appearance": {
+      "language": {
+        "title": "Idioma",
+        "description": "Elija el idioma utilizado en la interfaz.",
+        "label": "Idioma de la interfaz",
+        "loadError": "No se pudo cargar el idioma seleccionado",
+        "saveError": "No se pudo guardar la preferencia de idioma"
+      },
+      "pageTitle": "Visualización",
+      "pageSubtitle": "Controle los temas, las portadas, el diseño y cómo se presenta su biblioteca.",
+      "mobileSummary": "Tema: {theme} • Acento: {accent} • Fondo: {background}",
+      "themeMode": {
+        "light": "Luz",
+        "dark": "oscuro",
+        "system": "Sistema"
+      },
+      "theme": {
+        "title": "Tema",
+        "colorScheme": {
+          "label": "esquema de color",
+          "hint": "Interfaz clara u oscura"
+        },
+        "accents": {
+          "grey": "gris",
+          "scarlet": "escarlata",
+          "vermilion": "bermellón",
+          "rose": "rosa",
+          "copper": "Cobre",
+          "orange": "naranja",
+          "chartreuse": "Chartreuse",
+          "marigold": "caléndula",
+          "wasabi": "wasabi",
+          "amber": "ámbar",
+          "malachite": "malaquita",
+          "yellow": "amarillo",
+          "viridian": "viridiano",
+          "turquoise": "turquesa",
+          "lime": "lima",
+          "green": "Verde",
+          "acid-green": "Verde ácido",
+          "emerald": "Esmeralda",
+          "teal": "verde azulado",
+          "electric-blue": "Azul eléctrico",
+          "cyan": "cian",
+          "jade": "jade",
+          "ultramarine": "ultramarino",
+          "iris": "Iris",
+          "purple": "Púrpura",
+          "blue": "azul",
+          "indigo": "índigo",
+          "violet": "violeta",
+          "amethyst": "amatista",
+          "fuchsia": "fucsia",
+          "raspberry": "frambuesa",
+          "pink": "rosa",
+          "white": "blanco",
+          "rosewater": "agua de rosas",
+          "salmon": "Salmón",
+          "coral": "Corales",
+          "sand": "arena",
+          "peach": "durazno",
+          "pear": "pera",
+          "flax": "lino",
+          "sprout": "Brotar",
+          "butter": "mantequilla",
+          "aloe": "Áloe",
+          "lemon": "limon",
+          "foam": "Espuma",
+          "aqua": "aguamarina",
+          "celadon": "celadón",
+          "sage": "sabio",
+          "pistachio": "pistacho",
+          "mint": "menta",
+          "seafoam": "espuma de mar",
+          "baby-blue": "azul bebe",
+          "powder": "polvo",
+          "sea-glass": "Vidrio de mar",
+          "bluebell": "Campanilla",
+          "cornflower": "aciano",
+          "thistle": "cardo",
+          "periwinkle": "Bígaro",
+          "wisteria": "glicina",
+          "lavender": "lavanda",
+          "mauve": "malva",
+          "orchid": "orquídea",
+          "rose-quartz": "Cuarzo Rosa",
+          "blush": "rubor"
+        },
+        "accentColor": {
+          "label": "Color de acento",
+          "hint": "Controla aspectos destacados y elementos interactivos."
+        },
+        "cornerRadius": {
+          "label": "Radio de esquina",
+          "hint": "Redondez de tarjetas y elementos de la interfaz de usuario."
+        },
+        "surfaceBrightness": {
+          "label": "Brillo de la superficie",
+          "hint": "Aclarar superficies en modo oscuro",
+          "reset": "Reiniciar"
+        },
+        "libraryBackground": {
+          "title": "Fondo de la biblioteca",
+          "pattern": {
+            "label": "Patrón de fondo",
+            "hint": "Patrón mostrado detrás de la cuadrícula del libro."
+          }
+        },
+        "backgroundGroups": {
+          "fundamental": "Fundamental",
+          "structural": "estructural",
+          "ambient": "ambiente",
+          "refractive": "refractivo"
+        }
+      },
+      "storage": {
+        "title": "Dónde guardar las preferencias de apariencia",
+        "active": "Activo",
+        "notAvailable": "No disponible",
+        "device": {
+          "title": "Este dispositivo solo",
+          "description": "Las preferencias permanecen en su navegador. Lo mejor si quieres una apariencia diferente en diferentes dispositivos."
+        },
+        "account": {
+          "title": "mi cuenta",
+          "description": "Las preferencias se guardan en su cuenta. Lo mejor es si quieres la misma apariencia en todos los dispositivos."
+        },
+        "toasts": {
+          "synced": "Las preferencias ahora se sincronizarán",
+          "local": "Las preferencias permanecerán en este dispositivo"
+        },
+        "errors": {
+          "demoRestricted": "La cuenta restringida de demostración no puede cambiar el modo de almacenamiento del tema",
+          "update": "No se pudo actualizar el modo de almacenamiento",
+          "generic": "Se produjo un error al actualizar el modo de almacenamiento."
+        }
+      },
+      "bookCovers": {
+        "title": "Portadas de libros",
+        "displayMode": {
+          "title": "Modo de visualización de portada",
+          "hint": "Controla cómo encajan las portadas reales dentro de las ranuras para libros cuando las relaciones de aspecto difieren",
+          "blurredFit": {
+            "label": "ajuste borroso",
+            "hint": "Muestra la portada completa con un relleno borroso detrás"
+          },
+          "fillCrop": {
+            "label": "llenar tarjeta",
+            "hint": "Llene toda la ranura recortando los bordes cuando las relaciones de aspecto difieran"
+          },
+          "naturalBottom": {
+            "label": "fondo natural",
+            "hint": "Mantenga la proporción de cubierta original y ancle la cubierta al fondo."
+          }
+        },
+        "spine": {
+          "title": "Superposición del lomo del libro",
+          "hint": "Agrega un lomo estilizado y un efecto brillante a las tarjetas de portada.",
+          "off": {
+            "label": "Apagado",
+            "hint": "Sin efecto lomo/brillo en las cubiertas"
+          },
+          "subtle": {
+            "label": "sutil",
+            "hint": "Lomo y brillo claros, más cercanos al aspecto predeterminado"
+          },
+          "strong": {
+            "label": "fuerte",
+            "hint": "Tratamiento de lomo y brillo más pronunciado."
+          }
+        },
+        "showSpineOnComics": {
+          "label": "Mostrar lomo en cómics",
+          "hint": "Aplicar el efecto de lomo y brillo a las portadas de cómics (cbz, cbr, cb7)"
+        },
+        "shadow": {
+          "title": "Cubrir la fuerza de la sombra",
+          "hint": "Controla la profundidad debajo de las cubiertas en miniaturas de cuadrículas, listas, tablas y paneles.",
+          "default": {
+            "label": "Predeterminado",
+            "hint": "Elevación y profundidad actuales"
+          },
+          "strong": {
+            "label": "fuerte",
+            "hint": "Sombra paralela más pesada en forma de estante debajo de las sábanas"
+          }
+        },
+        "overlays": {
+          "title": "Superposiciones de tarjetas",
+          "hint": "Elija los metadatos que se muestran directamente en las tarjetas de portada del libro.",
+          "progressBar": {
+            "label": "Barra de progreso",
+            "hint": "Línea fina de color a lo largo del borde inferior."
+          },
+          "format": {
+            "label": "Formato de archivo",
+            "hint": "Insignia EPUB, PDF, CBZ codificada por colores en la parte inferior derecha"
+          },
+          "rating": {
+            "label": "Calificación",
+            "hint": "Indicador de calificación de estrellas en la parte inferior izquierda"
+          },
+          "readStatus": {
+            "label": "Estado de lectura",
+            "hint": "Icono de color que muestra el estado de lectura actual en la parte superior izquierda"
+          },
+          "seriesPosition": {
+            "label": "Número de serie",
+            "hint": "Insignia que muestra la posición del libro en su serie en la parte superior derecha (por ejemplo, #3, #1.5)"
+          },
+          "lockStatus": {
+            "label": "Estado de bloqueo",
+            "hint": "Icono de bloqueo de metadatos en la parte superior derecha: naranja cuando está bloqueado, verde cuando está desbloqueado"
+          }
+        }
+      },
+      "layout": {
+        "coverSize": "Tamaño de la cubierta",
+        "gridSpacing": "Espaciado de cuadrícula",
+        "gridLayout": {
+          "title": "Diseño de cuadrícula de biblioteca"
+        },
+        "coverSizeBehavior": {
+          "label": "Comportamiento del tamaño de la portada",
+          "hint": "Controle si los tamaños vertical/cuadrado y el espaciado de la cuadrícula se comparten en todas las vistas o se mantienen por vista",
+          "perViewHint": "Modo por vista: ajuste el tamaño y el espaciado de la portada desde el panel de visualización de cada vista.",
+          "syncAll": "Sincronizar todas las vistas",
+          "perView": "Tamaños por vista"
+        },
+        "portraitCoverSize": {
+          "label": "Tamaño de portada vertical",
+          "hint": "Se utiliza para vistas y bibliotecas de retratos."
+        },
+        "squareCoverSize": {
+          "label": "Tamaño de la cubierta cuadrada",
+          "hint": "Se utiliza para bibliotecas y vistas cuadradas."
+        },
+        "portraitGridSpacing": {
+          "label": "Espaciado de cuadrícula vertical",
+          "hint": "Espacio entre portadas de retratos"
+        },
+        "squareGridSpacing": {
+          "label": "Espaciado de cuadrícula cuadrada",
+          "hint": "Espacio entre cubiertas cuadradas"
+        },
+        "cardInfoMode": {
+          "label": "Modo de información de tarjeta",
+          "hint": "Dónde mostrar el título del libro y el autor en las tarjetas de cuadrícula",
+          "onHover": "Al pasar el mouse",
+          "belowCover": "Debajo de la cubierta",
+          "off": "Apagado"
+        },
+        "primaryCardLabel": {
+          "label": "Etiqueta de tarjeta primaria",
+          "hint": "Texto que se muestra debajo de la portada de cada libro (primera línea)"
+        },
+        "secondaryCardLabel": {
+          "label": "Etiqueta de tarjeta secundaria",
+          "hint": "Texto adicional debajo de la etiqueta principal (segunda línea)"
+        },
+        "labelField": {
+          "hidden": "Oculto",
+          "bookTitle": "Título del libro",
+          "seriesTitle": "Título de la serie",
+          "seriesTitlePosition": "Título de la serie + posición",
+          "author": "Autor"
+        },
+        "seriesDisplay": {
+          "title": "Pantalla de serie",
+          "collapsedCover": {
+            "label": "Portada de serie contraída",
+            "hint": "Elija qué portada mostrar cuando las series estén colapsadas en la cuadrícula del libro"
+          },
+          "stack": "pila",
+          "mosaic": "mosaico",
+          "first": "primero",
+          "latest": "Lo último",
+          "firstUnread": "Primera no leída"
+        },
+        "authorGrid": {
+          "title": "Cuadrícula de autor",
+          "coverSize": {
+            "label": "Tamaño de la cubierta",
+            "hint": "Ancho de las portadas del autor en la cuadrícula."
+          },
+          "coverShape": {
+            "label": "Forma de la cubierta",
+            "hint": "Forma de portadas de autor en la cuadrícula."
+          },
+          "circle": "circulo",
+          "square": "cuadrado"
+        },
+        "listTableViews": {
+          "title": "Vistas de lista y tabla"
+        },
+        "zebraStriping": {
+          "label": "rayas de cebra",
+          "hint": "Colores de fondo de fila alternativos para facilitar el escaneo"
+        }
+      },
+      "behavior": {
+        "title": "Comportamiento de la biblioteca",
+        "thumbnailClicks": {
+          "label": "Clics en miniatura",
+          "hint": "Elija qué sucede al abrir un libro desde las vistas de cuadrícula y lista",
+          "readFirst": "Leer primero",
+          "readFirstHint": "Abra el lector cuando exista un archivo legible",
+          "openDetails": "Abrir detalles",
+          "openDetailsHint": "Vaya a la página de detalles del libro desde la cuadrícula y las miniaturas de la lista."
+        },
+        "filterPreview": {
+          "label": "Mostrar vista previa del filtro de forma predeterminada",
+          "hint": "Expanda el filtro activo y ordene el resumen al abrir un smartScope"
+        },
+        "collapseSeries": {
+          "label": "Contraer serie por defecto",
+          "hint": "Agrupe libros de la misma serie en una sola tarjeta en las vistas de biblioteca y colección"
+        }
+      },
+      "icons": {
+        "title": "Iconos personalizados",
+        "uploadIcons": "Subir iconos",
+        "uploadedCount": "{count, plural, =0 {no se han subido iconos} one {# icono subido} other {# iconos subidos} many {# iconos subidos}}",
+        "searchPlaceholder": "Iconos de búsqueda",
+        "sort": {
+          "newest": "Lo más nuevo",
+          "name": "Nombre"
+        },
+        "selectedCount": "{count} seleccionado",
+        "clear": "Borrar",
+        "deleteSelected": "Eliminar seleccionado",
+        "loading": "Cargando iconos...",
+        "emptySearch": "Ningún icono coincide con tu búsqueda.",
+        "emptyNoIcons": "Aún no se han subido iconos personalizados.",
+        "namePlaceholder": "Nombre",
+        "checkingUsage": "Comprobando uso...",
+        "usedBy": "Utilizado por {count}",
+        "notUsedYet": "Aún no usado",
+        "rename": "Cambiar nombre",
+        "replace": "Reemplazar",
+        "usage": {
+          "libraries": "{count, plural, =0 {sin bibliotecas} one {# biblioteca} other {# bibliotecas} many {# bibliotecas}}",
+          "collections": "{count, plural, =0 {sin colecciones} one {# colección} other {# colecciones} many {# colecciones}}",
+          "smartScopes": "{count, plural, =0 {sin miras inteligentes} one {# alcance inteligente} other {# alcances inteligentes} many {# alcances inteligentes}}"
+        },
+        "confirm": {
+          "deleteOne": "¿Eliminar \"{name}\"? Los usos existentes volverán a su icono predeterminado.",
+          "deleteMany": "{count, plural, =0 {¿Eliminar ningún ícono?} one {Eliminar # icono? Los usos existentes volverán a su icono predeterminado.} other {Eliminar # iconos? Los usos existentes volverán a su icono predeterminado.} many {Eliminar # iconos? Los usos existentes volverán a su icono predeterminado.}}"
+        },
+        "toasts": {
+          "saved": "Icono guardado",
+          "updated": "Icono actualizado",
+          "deleted": "Icono eliminado",
+          "bulkDeleted": "{count, plural, =0 {Eliminado sin iconos} one {Eliminado # icono} other {Eliminado # iconos} many {Eliminado # iconos}}",
+          "bulkDeletePartial": "Eliminado {deleted}, {failed} falló"
+        },
+        "errors": {
+          "load": "No se pudieron cargar los iconos",
+          "save": "No se pudo guardar el ícono",
+          "replace": "No se pudo reemplazar el ícono",
+          "delete": "No se pudo eliminar el ícono",
+          "bulkDelete": "No se pudieron eliminar los íconos"
+        }
+      },
+      "tabs": {
+        "theme": "Tema",
+        "book-covers": "Portadas de libros",
+        "icons": "Iconos",
+        "layout": "Diseño",
+        "behavior": "Comportamiento"
+      }
+    },
+    "account": {
+      "title": "cuenta",
+      "subtitle": "Administre la configuración de su perfil personal.",
+      "subtitleAll": "Administre su perfil y preferencias de notificación.",
+      "tabs": {
+        "profile": "Perfil",
+        "privacy": "Privacidad y uso compartido",
+        "notifications": "Notificaciones",
+        "restrictions": "Restricciones"
+      },
+      "demoRestricted": {
+        "cannotEdit": "La cuenta restringida de demostración no puede editar la configuración de la cuenta",
+        "notice": "Cuenta restringida de demostración: la edición de perfil, contraseña, avatar e identidades vinculadas está deshabilitada."
+      },
+      "feedback": {
+        "unsavedChanges": "Cambios no guardados",
+        "allSaved": "Todos los cambios guardados"
+      },
+      "profile": {
+        "securityHeading": "Perfil y seguridad",
+        "username": "Nombre de usuario",
+        "fullName": "nombre completo",
+        "email": "Correo electrónico",
+        "emailHint": "Póngase en contacto con un administrador para cambiar su dirección de correo electrónico.",
+        "save": "Guardar perfil",
+        "saving": "Guardando...",
+        "changePassword": "Cambiar contraseña",
+        "accountType": "Tipo de cuenta:",
+        "accountTypeOidc": "OIDC/SSO",
+        "accountTypeShared": "Compartido",
+        "accountTypeLocal": "Local",
+        "nameRequired": "El nombre es obligatorio",
+        "updateFailed": "No se pudo actualizar el perfil",
+        "updated": "Perfil actualizado"
+      },
+      "readingPreferences": {
+        "title": "Preferencias de lectura",
+        "timezoneHint": "La zona horaria se utiliza para logros urgentes como Early Bird y All-nighter.",
+        "timezone": "Zona horaria",
+        "save": "Guardar preferencias",
+        "enableAchievements": "Habilitar logros",
+        "enableAchievementsHint": "Realice un seguimiento del progreso de los logros y muestre la interfaz relacionada con los logros. Administre las notificaciones de logros por separado en Notificaciones."
+      },
+      "preferences": {
+        "saveFailed": "No se pudieron guardar las preferencias",
+        "saved": "Preferencias guardadas"
+      },
+      "avatar": {
+        "title": "Foto de perfil",
+        "unknownUser": "Usuario desconocido",
+        "formatHint": "PNG/JPEG/WEBP hasta {size} MB",
+        "upload": "Subir foto",
+        "replace": "Reemplazar imagen",
+        "uploading": "Subiendo...",
+        "remove": "Quitar imagen",
+        "removing": "Eliminando...",
+        "updated": "Foto de perfil actualizada",
+        "uploadFailed": "No se pudo cargar la foto de perfil",
+        "removed": "Foto de perfil eliminada",
+        "removeFailed": "No se pudo eliminar la foto de perfil",
+        "removeConfirm": {
+          "title": "¿Quitar foto de perfil?",
+          "description": "Tu avatar será eliminado y reemplazado con iniciales.",
+          "confirm": "Quitar"
+        }
+      },
+      "connectedAccounts": {
+        "title": "Cuentas conectadas",
+        "unlink": "Desvincular",
+        "unlinking": "Desvinculando...",
+        "linkAdditional": "Vincular proveedores adicionales:",
+        "linkProvider": "Vincular {provider}",
+        "redirecting": "Redirigiendo...",
+        "noneConfigured": "No hay proveedores OIDC configurados. Pídale a un administrador que configure SSO.",
+        "linkStateFailed": "No se pudo generar el estado del enlace",
+        "startLinkFailed": "No se pudo iniciar el enlace OIDC",
+        "unlinkFailed": "No se pudo desvincular",
+        "unlinked": "Identidad desvinculada",
+        "unlinkIdentityFailed": "No se pudo desvincular la identidad",
+        "unlinkDialog": {
+          "title": "¿Desvincular la identidad {provider}?",
+          "description": "Ingrese su contraseña para confirmar. Ya no podrás iniciar sesión con este proveedor.",
+          "currentPassword": "Contraseña actual"
+        }
+      },
+      "tour": {
+        "title": "Visita guiada",
+        "description": "Vuelva a reproducir el tutorial que destaca las características clave de la aplicación.",
+        "action": "Haz el recorrido nuevamente"
+      },
+      "restrictions": {
+        "none": {
+          "title": "Sin restricciones de contenido",
+          "description": "Su cuenta tiene acceso completo a todo el contenido dentro de sus bibliotecas asignadas."
+        },
+        "banner": "Su cuenta tiene restricciones de contenido aplicadas por un administrador. Es posible que algunos libros no sean visibles para usted.",
+        "allowedTags": {
+          "title": "Etiquetas permitidas",
+          "description": "Sólo se muestran los libros que tienen al menos una de estas etiquetas."
+        },
+        "blockedTags": {
+          "title": "Etiquetas bloqueadas",
+          "description": "Los libros con cualquiera de estas etiquetas están ocultos para usted."
+        },
+        "allowedGenres": {
+          "title": "Géneros permitidos",
+          "description": "Sólo se le muestran libros que tienen al menos uno de estos géneros."
+        },
+        "blockedGenres": {
+          "title": "Géneros bloqueados",
+          "description": "Los libros con cualquiera de estos géneros están ocultos para usted."
+        }
+      }
+    },
+    "magicLinks": {
+      "title": "Enlaces mágicos",
+      "subtitle": "Cree enlaces de inicio de sesión que se puedan compartir para cuentas compartidas.",
+      "createLink": "Crear enlace",
+      "noSharedAccounts": "No se encontraron cuentas compartidas",
+      "noSharedAccountsHint": "Primero cree una cuenta compartida desde {usersPage} para generar enlaces mágicos.",
+      "activeLinks": "Enlaces activos",
+      "inactiveLinks": "Enlaces inactivos",
+      "paused": "En pausa",
+      "deletedUser": "Usuario eliminado",
+      "expiredPrefix": "Caducado ",
+      "never": "No hay actividad registrada",
+      "noExpiry": "Sin caducidad",
+      "expired": "Caducado",
+      "expiresOn": "Vence {date}",
+      "revokedOn": "Revocado {date}",
+      "expiredOn": "Caducado {date}",
+      "usesCount": "{count, plural, =0 {sin usos} one {un uso} other {# usos} many {# usos}}",
+      "copied": "¡Copiado!",
+      "copyLink": "Copiar enlace",
+      "pause": "Pausa",
+      "resume": "Reanudar",
+      "revoke": "Revocar",
+      "revoking": "Revocando...",
+      "emptyState": "Aún no se han creado enlaces mágicos. Haga clic en \"{action}\" para generar un inicio de sesión compartible URL.",
+      "columns": {
+        "label": "Etiqueta",
+        "account": "cuenta",
+        "createdBy": "Creado por",
+        "expires": "Vence",
+        "uses": "Usos",
+        "lastUsed": "último usado",
+        "created": "Creado",
+        "status": "Estado",
+        "totalUses": "Usos totales"
+      },
+      "createDialog": {
+        "title": "Crear enlace mágico",
+        "description": "Genere un inicio de sesión compartible URL para una cuenta compartida.",
+        "sharedAccount": "cuenta compartida",
+        "selectAccount": "Seleccione una cuenta compartida",
+        "label": "Etiqueta",
+        "labelPlaceholder": "por ej. Enlace de demostración para la conferencia",
+        "expiresAt": "Vence en",
+        "optional": "(opcional)",
+        "create": "crear",
+        "creating": "Creando..."
+      },
+      "revokeDialog": {
+        "title": "¿Revocar enlace mágico?",
+        "description": "Esto invalidará inmediatamente el vínculo y finalizará todas las sesiones activas de la cuenta vinculada."
+      },
+      "errors": {
+        "create": "No se pudo crear",
+        "copy": "No se pudo copiar el enlace mágico",
+        "update": "No se pudo actualizar el enlace mágico",
+        "revoke": "No se pudo revocar"
+      },
+      "usersPage": "pagina de usuarios",
+      "emptyTitle": "Aún no se han creado enlaces mágicos",
+      "emptyHint": "Haga clic en \"{action}\" para generar un inicio de sesión compartible URL.",
+      "noActiveTitle": "No hay enlaces mágicos activos",
+      "noActiveHint": "Todos los enlaces mágicos generados para esta página han caducado o han sido revocados."
+    },
+    "oidc": {
+      "title": "OIDC/SSO",
+      "subtitle": "Administre proveedores de OpenID Connect para inicio de sesión único.",
+      "providers": "Proveedores",
+      "addProvider": "Agregar proveedor",
+      "editProvider": "Editar proveedor",
+      "configureNew": "Configure un nuevo proveedor OIDC.",
+      "editing": "Editando {slug}",
+      "enabled": "Habilitado",
+      "disabled": "Discapacitado",
+      "empty": {
+        "title": "Aún no hay proveedores",
+        "description": "Agregue un proveedor OIDC para habilitar el inicio de sesión único para sus usuarios."
+      },
+      "form": {
+        "status": "Estado",
+        "enableProvider": "Habilitar proveedor",
+        "enableProviderHint": "Muestre este proveedor en la página de inicio de sesión.",
+        "identity": "Identidad del proveedor",
+        "slug": "babosa",
+        "slugHint": "Identificador único (minúsculas, guiones). No se puede cambiar más tarde.",
+        "displayName": "Nombre para mostrar",
+        "displayNameHint": "Se muestra en el botón de inicio de sesión.",
+        "iconUrl": "Icono URL",
+        "iconUrlHint": "Logotipo opcional que se muestra junto al botón de inicio de sesión.",
+        "iconPreviewAlt": "vista previa del icono",
+        "connection": "Conexión",
+        "issuerUri": "URI del emisor",
+        "issuerUriHint": "La base del proveedor URL.",
+        "test": "prueba",
+        "testing": "Probando...",
+        "clientId": "ID de cliente",
+        "clientSecret": "Secreto del cliente",
+        "clientSecretPlaceholder": "Déjelo en blanco para seguir existiendo",
+        "scopes": "Alcances",
+        "claimMapping": "Mapeo de reclamos",
+        "previewClaims": "Vista previa de reclamaciones",
+        "redirecting": "Redirigiendo...",
+        "mappedClaims": "Reclamaciones mapeadas",
+        "rawClaims": "Reclamaciones crudas",
+        "usernameClaim": "Reclamación de nombre de usuario",
+        "nameClaim": "Reclamación de nombre",
+        "emailClaim": "Reclamo por correo electrónico",
+        "groupsClaim": "Reclamación de grupos",
+        "autoProvisioning": "Aprovisionamiento automático",
+        "autoProvisionUsers": "Usuarios de aprovisionamiento automático",
+        "autoProvisionUsersHint": "Cree cuentas en el primer inicio de sesión OIDC si el usuario no existe.",
+        "allowLocalLinking": "Permitir vinculación de cuentas locales",
+        "allowLocalLinkingHint": "Vincular la identidad OIDC a una cuenta local existente mediante coincidencia de nombre de usuario.",
+        "defaultPermissions": "Permisos predeterminados",
+        "defaultPermissionsHint": "Permisos otorgados a nuevos usuarios en el primer inicio de sesión OIDC.",
+        "createProvider": "Crear proveedor",
+        "saveChanges": "Guardar cambios",
+        "saving": "Guardando...",
+        "deleteProvider": "Eliminar proveedor",
+        "deleting": "Eliminando..."
+      },
+      "test": {
+        "connected": "Conectado - {issuer}",
+        "connectionFailed": "La conexión falló",
+        "hide": "Ocultar",
+        "details": "Detalles",
+        "supported": "apoyado",
+        "notSupported": "no soportado"
+      },
+      "groupMappings": {
+        "title": "Asignaciones de grupo",
+        "description": "Asigne OIDC reclamaciones de grupo a permisos BookOrbit. Sincronizado en cada inicio de sesión.",
+        "noPermission": "Sin permiso",
+        "empty": "No hay asignaciones de grupo configuradas.",
+        "addMapping": "Agregar mapeo",
+        "claimPlaceholder": "OIDC reclamo de grupo (por ejemplo, administradores)",
+        "add": "Añadir",
+        "adding": "Añadiendo..."
+      },
+      "toasts": {
+        "providerCreated": "Proveedor creado",
+        "providerSaved": "Proveedor guardado",
+        "providerDeleted": "Proveedor eliminado",
+        "mappingAdded": "Se agregó mapeo de grupo",
+        "mappingRemoved": "Se eliminó el mapeo de grupo"
+      },
+      "errors": {
+        "loadProvider": "No se pudo cargar el proveedor",
+        "createProvider": "No se pudo crear el proveedor",
+        "save": "No se pudo guardar",
+        "delete": "No se pudo eliminar",
+        "deleteProvider": "No se pudo eliminar el proveedor",
+        "requestFailed": "Solicitud fallida",
+        "previewState": "No se pudo generar el estado de vista previa",
+        "startPreview": "No se pudo iniciar la vista previa",
+        "addMapping": "No se pudo agregar el mapeo",
+        "removeMapping": "No se pudo eliminar la asignación de grupo"
+      }
+    },
+    "admin": {
+      "title": "administrador",
+      "subtitle": "Administrar usuarios y configuraciones de autenticación.",
+      "system": {
+        "title": "Sistema",
+        "subtitle": "Configuración de organización, ingesta y mantenimiento de archivos."
+      },
+      "maintenance": {
+        "title": "Mantenimiento",
+        "subtitle": "Administre tareas en segundo plano, índices del sistema y operaciones de mantenimiento.",
+        "importGroup": "Importar",
+        "recommendationsGroup": "Recomendaciones",
+        "achievementsGroup": "Logros",
+        "updatesGroup": "Actualizaciones",
+        "importFromBooklore": "Importar desde Booklore",
+        "bookloreImportConfigured": "Importación de libros configurada",
+        "migrationRunning": "Migración en ejecución",
+        "migrationCompleted": "Migración completada",
+        "migrationFailed": "La migración falló",
+        "importDescription": "Importación única de libros, metadatos y progreso de lectura de una instalación anterior de Booklore.",
+        "configuredDescription": "Fuente: {name}. Aún no se ha ejecutado la migración; continúe con la configuración para ejecutar la importación.",
+        "runningDescription": "Etapa: {stage} - iniciada {started}",
+        "completedDescription": "De {name} - completado {date}",
+        "migrationErrorGeneric": "Se produjo un error durante la migración.",
+        "stageInitializing": "inicializando",
+        "recently": "recientemente",
+        "getStarted": "Empezar",
+        "continueSetup": "Continuar configuración",
+        "viewDetails": "Ver detalles",
+        "refreshRecommendationIndex": "Actualizar índice de recomendaciones",
+        "refreshRecommendationHint": "Actualice el motor de recomendaciones con los últimos cambios de la biblioteca. Este proceso se ejecuta en segundo plano.",
+        "booksQueuedForProcessing": "{count, plural, =0 {no hay libros en cola para procesamiento} one {# libro en cola para procesamiento} other {# libros en cola para procesamiento} many {# libros en cola para procesamiento}}",
+        "run": "correr",
+        "running": "Corriendo...",
+        "backfillAchievements": "Rellenar logros",
+        "backfillAchievementsHint": "Vuelva a evaluar los logros de todos los usuarios.",
+        "backfillResult": "Usuarios {users} procesados; concedió {awards} premios.",
+        "runBackfill": "Ejecutar reabastecimiento",
+        "checkForUpdates": "Buscar actualizaciones",
+        "checkForUpdatesHint": "Verifique automáticamente en GitHub una nueva versión al inicio y muestre un indicador en la barra lateral cuando haya una disponible.",
+        "updateChecksEnabled": "Comprobaciones de actualización habilitadas",
+        "updateChecksDisabled": "Comprobaciones de actualización deshabilitadas",
+        "updateSettingFailed": "No se pudo actualizar la configuración",
+        "booksQueuedForEmbedding": "{count, plural, =0 {no hay libros en cola para insertar} one {# libro en cola para incrustar} other {# libros en cola para ser incrustados} many {# libros en cola para ser incrustados}}",
+        "failed": "Fallido",
+        "unknownError": "Error desconocido",
+        "rebuildEmbeddingsFailed": "No se pudieron reconstruir las incrustaciones: {error}",
+        "achievementBackfillConfirm": "¿Ejecutar el reabastecimiento de logros para todos los logros de todos los usuarios? Esto puede tardar un poco.",
+        "achievementBackfillComplete": "Relleno de logros completado: {count} premios otorgados",
+        "backfillRunFailed": "No se pudo ejecutar el reabastecimiento",
+        "achievementBackfillFailed": "No se pudo ejecutar el reabastecimiento de logros: {error}",
+        "uploadsGroup": "Subidas",
+        "maxUploadSize": "Límite de tamaño máximo de archivo de carga",
+        "maxUploadSizeHint": "Configure el límite de tamaño máximo para la carga de archivos en todo el sistema.",
+        "save": "Guardar",
+        "uploadSizeInvalid": "El límite de tamaño de carga debe ser mayor que 0",
+        "uploadSizeUpdated": "Límite de tamaño de carga actualizado"
+      },
+      "migration": {
+        "title": "Migración",
+        "subtitle": "Importación única de Booklore: conecte la fuente, asigne usuarios, realice un ensayo, inicie la migración y exporte un informe.",
+        "progress": "Progreso",
+        "stepSourceConnection": "Conexión de origen",
+        "stepUserPathMapping": "Mapeo de usuarios y rutas",
+        "stepDryRun": "Ejecución en seco",
+        "stepDryRunTitle": "Ejecución en seco",
+        "stepRunMigration": "Ejecutar migración",
+        "stepReport": "Informe",
+        "stepReportTitle": "Informe de migración",
+        "subtitleSource": "Configure la conexión de la base de datos a su instancia de Booklore de origen.",
+        "subtitleMappings": "Asigne usuarios de origen a usuarios de destino y traduzca rutas de archivos.",
+        "subtitleDryRun": "Obtenga una vista previa de lo que se importará antes de ejecutar la migración en vivo.",
+        "subtitleRun": "Inicie la importación en vivo y supervise su progreso.",
+        "subtitleReport": "Revise lo que se importó y exporte un informe detallado.",
+        "continueToMappings": "Continuar a Asignaciones",
+        "continueToDryRun": "Continuar con el funcionamiento en seco",
+        "continueToMigration": "Continuar con la migración",
+        "viewReport": "Ver informe",
+        "badgeValidated": "Validado",
+        "badgeSaved": "Guardado",
+        "badgeUpToDate": "actualizado",
+        "badgeCompleted": "Completado",
+        "badgeRunning": "corriendo",
+        "badgeFailed": "Fallido",
+        "mediaPathRequired": "Requerido para migrar portadas de libros.",
+        "mediaPathAbsolute": "Utilice una ruta absoluta (por ejemplo: /libros). No se admiten rutas relativas.",
+        "mediaPathConfigured": "Ruta de importación de portada configurada. Utilice Test Connection para verificar el acceso y la estructura de carpetas de imágenes de Booklore.",
+        "issueSaveSource": "Guardar la configuración de conexión de origen",
+        "issueValidateSource": "Validar conexión de origen",
+        "issueSaveMappings": "Guardar asignaciones de usuarios y rutas",
+        "issueSavePathMappings": "Guarde asignaciones de rutas para validarlas",
+        "issueFreshDryRun": "Realizar un nuevo ensayo",
+        "issueResolveDuplicates": "Resolver coincidencias de libros de destino duplicados en el ensayo",
+        "issueWaitActiveRun": "Espere a que finalice la ejecución activa",
+        "sourceRecordId": "ID de registro de origen n.º {id}",
+        "byAuthorWithId": "por {author} (ID: {id})",
+        "filePathWithId": "{path} (ID: {id})",
+        "bookloreSourceId": "ID de fuente del libro: {id}",
+        "libraryBookNum": "Libro de la biblioteca #{id}",
+        "errorInitialize": "No se pudo inicializar la configuración de migración",
+        "errorLoadSourceTypes": "No se pudieron cargar los tipos de origen de migración admitidos",
+        "errorLoadTargetUsers": "No se pudieron cargar los usuarios de destino",
+        "errorLoadLibraryFolders": "No se pudieron cargar las carpetas de la biblioteca de destino",
+        "noSourceUsersReturned": "No se devolvieron usuarios de origen",
+        "userMappingSuggestionsLoaded": "Sugerencias de mapeo de usuario cargadas",
+        "errorLoadSuggestions": "No se pudieron cargar las sugerencias de mapeo del usuario",
+        "requiredFields": "Se requieren host, usuario, base de datos y nombre de fuente",
+        "connectionTestPassedWithWarnings": "Prueba de conexión superada con advertencias.",
+        "connectionTestPassedWithCount": "La prueba de conexión pasó con {count} advertencia(s). Primero: {first}",
+        "connectionTestPassed": "Prueba de conexión superada",
+        "connectionOkMissingTables": "La conexión es correcta, pero faltan {count} tablas requeridas",
+        "cannotTestMediaPathActiveRun": "No se puede probar la ruta del medio mientras hay una ejecución activa",
+        "mediaRootPathRequiredCover": "Se requiere Media Root Path para importar la portada.",
+        "useAbsolutePath": "Utilice una ruta absoluta (por ejemplo: /libros).",
+        "mediaPathVerified": "Ruta de medios verificada.",
+        "mediaPathValidReadable": "La ruta del medio es válida y legible.",
+        "mediaPathValidationFailed": "Error en la validación de la ruta del medio.",
+        "connectionFailedBeforeMediaPath": "La prueba de conexión falló antes de que se pudiera completar la validación de la ruta del medio.",
+        "cannotModifySourceActiveRun": "No se puede modificar la fuente mientras una ejecución está activa",
+        "sourceSavedValidatedWarnings": "Fuente guardada y validada con {count} advertencia(s)",
+        "sourceSavedValidated": "Fuente guardada y validada",
+        "errorSaveValidateSource": "No se pudo guardar o validar la fuente",
+        "cannotSaveMappingsActiveRun": "No se pueden guardar asignaciones mientras una ejecución está activa",
+        "saveSourceFirst": "Guardar la fuente primero",
+        "mapAtLeastOneUser": "Asigne al menos un usuario de origen a un usuario de destino",
+        "mapEveryUser": "Asigne cada usuario de origen antes de guardar",
+        "pathValidationFailedProfileSaved": "La validación de la ruta falló, pero el perfil aún se guardará",
+        "mappingsSaved": "Asignaciones guardadas",
+        "errorSaveMappings": "No se pudieron guardar las asignaciones",
+        "cannotRunDryRunActiveRun": "No se puede realizar un ensayo en seco mientras hay una ejecución activa",
+        "saveMappingsFirst": "Guarde las asignaciones primero",
+        "dryRunCompleted": "Ejecución en seco completada: {matched} coincidente, {unresolved} sin resolver",
+        "dryRunFailed": "Error en el ensayo",
+        "selectSourceForAllGroups": "Seleccione un libro fuente para todos los {count} grupos duplicados",
+        "duplicatesResolved": "Coincidencias duplicadas resueltas",
+        "errorResolveDuplicates": "No se pudieron resolver duplicados",
+        "preflightNotReady": "La verificación previa a la migración no está lista",
+        "runDryRunFirst": "Ejecute primero el ensayo",
+        "runStarted": "Se inició la ejecución de migración",
+        "errorStartMigration": "No se pudo iniciar la migración",
+        "runCancelled": "Ejecución de migración cancelada",
+        "errorCancelMigration": "No se pudo cancelar la migración",
+        "runRetried": "Se ha reintentado la ejecución de la migración: se reanuda desde la última etapa completada",
+        "errorRetryMigration": "No se pudo volver a intentar la migración",
+        "errorLoadRunProgress": "No se pudo cargar el progreso de la ejecución",
+        "startMigrationFirst": "Iniciar la migración primero",
+        "reportRefreshed": "Ejecutar informe actualizado",
+        "errorLoadReport": "No se pudo cargar el informe de ejecución",
+        "reportExported": "Informe exportado como {format}",
+        "errorExportReport": "No se pudo exportar el informe de migración",
+        "reasonNoTitleAuthorMatch": "No se encontró ningún libro coincidente por título o autor",
+        "reasonNoFilePathMatch": "La ruta del archivo no coincide con ningún libro de esta biblioteca.",
+        "reasonNoFileHashMatch": "El hash del archivo no coincide con ningún libro de esta biblioteca",
+        "reasonNoIsbnMatch": "ISBN no coincide con ningún libro de esta biblioteca",
+        "reasonInsufficientSourceData": "No hay suficientes metadatos para intentar hacer coincidir",
+        "reasonAmbiguousIsbnMatch": "Varios libros coincidieron con el mismo ISBN",
+        "reasonAmbiguousFileHashMatch": "Varios libros coincidieron con el mismo hash de archivo",
+        "reasonAmbiguousFilePathMatch": "Varios libros coincidieron con la misma ruta de archivo",
+        "reasonAmbiguousTitleAuthorMatch": "Varios libros coincidían con el mismo título y autor",
+        "reasonUnknown": "No se pudo determinar el motivo",
+        "strategyIsbn": "Emparejado por ISBN",
+        "strategyFileHash": "Coincidencia por hash de archivo",
+        "strategyPathMapping": "Coincidencia por ruta de archivo asignada",
+        "strategyTitleAuthor": "Emparejado por título y autor",
+        "strategyUnavailable": "Estrategia de partido no disponible",
+        "userPreviewCounts": "{statuses} estados, {progress} entradas de progreso, {bookmarks} marcadores, {annotations} anotaciones, {collections} entradas de colección",
+        "connErrorUnreachable": "No se pudo acceder al servidor de la base de datos. Verifique el host y el puerto.",
+        "connErrorAuth": "La autenticación falló. Verifique el nombre de usuario y la contraseña.",
+        "connErrorUnknownDatabase": "Base de datos no encontrada. Verifique el nombre de la base de datos.",
+        "connErrorTimeout": "Se agotó el tiempo de conexión. Verifique la configuración del host y del firewall.",
+        "connErrorGeneric": "La prueba de conexión falló",
+        "sourceType": "Tipo de fuente",
+        "sourceName": "Nombre de fuente",
+        "host": "Anfitrión",
+        "port": "Puerto",
+        "user": "Usuario",
+        "password": "Contraseña",
+        "passwordSavedPlaceholder": "Guardado - dejar sin cambios",
+        "passwordEmptyPlaceholder": "No se ha establecido ninguna contraseña",
+        "database": "Base de datos",
+        "mediaRootPath": "Ruta raíz de medios",
+        "pathOk": "Camino correcto",
+        "pathIssue": "Problema de ruta",
+        "testPath": "Ruta de prueba",
+        "useTls": "Usar TLS/SSL",
+        "testConnection": "Conexión de prueba",
+        "saveAndValidate": "Guardar y validar",
+        "sourceValidatedWithWarnings": "Fuente validada con advertencias.",
+        "lastValidationSnapshot": "Última instantánea de validación",
+        "sourceVersion": "Versión fuente: {version}",
+        "unknown": "Desconocido",
+        "missingRequiredTables": "Faltan tablas requeridas: {tables}",
+        "suggestionsAutoLoad": "Las sugerencias de los usuarios se cargan automáticamente después de la validación de la fuente.",
+        "refresh": "Actualizar",
+        "sourceUser": "Usuario fuente",
+        "targetUser": "Usuario objetivo",
+        "noSourceUsersLoaded": "Aún no se han cargado usuarios de origen.",
+        "noActiveTargetUsers": "No se encontraron usuarios objetivo activos. Cree o vuelva a habilitar un usuario BookOrbit antes de realizar la asignación.",
+        "pathPrefixMappings": "Asignaciones de prefijos de ruta",
+        "addMapping": "Agregar mapeo",
+        "pathMappingsHelp1": "Las asignaciones de rutas traducen las rutas de los archivos de origen en rutas de destino para que los libros puedan coincidir según la ubicación del archivo. Por ejemplo, si su biblioteca Booklore almacenó archivos en",
+        "pathMappingsHelp2": "y los mismos archivos ahora viven bajo",
+        "pathMappingsHelp3": ", agregue ese mapeo aquí. Los libros también coinciden mediante ISBN, hash de archivo y título/autor, independientemente de las asignaciones de rutas; la asignación de rutas es solo una de cuatro estrategias y no limita qué libros fuente se incluyen en la migración.",
+        "noPrefixesFound": "No se encontraron prefijos: primero valide la fuente",
+        "selectSourcePrefix": "Seleccione el prefijo de origen...",
+        "selectTargetFolder": "Seleccione la carpeta de destino...",
+        "remove": "Quitar",
+        "pathValidation": "Validación de ruta",
+        "pathValidationMapped": "{mapped} de {total} libros fuente tienen una ruta asignada",
+        "pathValidationUnmatched": "{count} rutas asignadas no encontradas en el disco; esos libros recurrirán a ISBN/coincidencia de título",
+        "pathValidationAllMatched": "Todas las {count} rutas asignadas encontradas en el disco",
+        "saveMappings": "Guardar asignaciones",
+        "runDryRun": "Ejecutar funcionamiento en seco",
+        "matched": "Emparejado:",
+        "unresolved": "Sin resolver:",
+        "duplicateMatches": "Coincidencias duplicadas:",
+        "unresolvedSummary": "Resumen no resuelto",
+        "resolveDuplicateMatches": "Resolver coincidencias de objetivos duplicados",
+        "resolveDuplicateHint": "Para cada libro de destino, elija un libro de origen para conservar. Las opciones recomendadas se preseleccionan cuando hay una coincidencia más fuerte.",
+        "remainingGroups": "Grupos restantes:",
+        "ofCount": "de {count}",
+        "targetBookNum": "Libro de destino #{id}",
+        "recommended": "Recomendado",
+        "resolveDuplicatesButton": "{count, plural, =0 {resolver # duplicar} one {resolver # duplicar} other {resolver # duplicados} many {resolver # duplicados}}",
+        "preflightChecks": "Comprobaciones previas al vuelo",
+        "allChecksPassed": "Todas las comprobaciones pasaron: listo para migrar",
+        "checkSourceValidated": "Fuente validada",
+        "checkSaveValidateSource": "Guardar y validar la conexión de origen",
+        "checkValidateSource": "Validar conexión de origen",
+        "checkMappingsSaved": "Asignaciones guardadas",
+        "checkSaveMappings": "Guardar asignaciones de usuarios y rutas",
+        "checkPathMappingsValidated": "Asignaciones de rutas validadas",
+        "checkSavePathMappings": "Guarde asignaciones de rutas para validarlas",
+        "checkDryRunUpToDate": "El ensayo está actualizado.",
+        "checkFreshDryRun": "Realizar un nuevo ensayo",
+        "startConfirmPrompt": "Esto iniciará la migración en vivo. ¿Está seguro?",
+        "confirmStart": "Confirmar inicio",
+        "startMigration": "Iniciar la migración",
+        "cancelRun": "Cancelar ejecución",
+        "refreshStatus": "Actualizar estado",
+        "statusPollingStopped": "El sondeo de estado se detuvo debido a un error.",
+        "retry": "Reintentar",
+        "stageLabel": "Etapa: {stage}",
+        "stageInitializing": "inicializando",
+        "endedLabel": "Finalizado {date}",
+        "stageCompleted": "Completado",
+        "stageInit": "Inicializando",
+        "stageSharedOverlays": "Importando metadatos",
+        "stageBookCovers": "Importación de portadas",
+        "stageUserState": "Importar datos de usuario",
+        "noRunYet": "Aún no se ha realizado ninguna migración. Complete los pasos anteriores para comenzar.",
+        "runNum": "Ejecute #{id}",
+        "notStarted": "No iniciado",
+        "reloadReport": "Recargar informe",
+        "loadFullReport": "Cargar informe completo",
+        "exportJson": "Exportar JSON",
+        "exportCsv": "Exportar CSV",
+        "migrationFailed": "La migración falló",
+        "retryFromLastStage": "Reintentar desde la última etapa completada",
+        "booksCard": "Libros",
+        "metadataOverlaysApplied": "Superposiciones de metadatos aplicadas",
+        "authorMappingsReplaced": "Se reemplazaron las asignaciones de autor",
+        "narratorMappingsReplaced": "Se reemplazaron las asignaciones del narrador",
+        "genreMappingsReplaced": "Se reemplazaron las asignaciones de género",
+        "tagMappingsReplaced": "Asignaciones de etiquetas reemplazadas",
+        "coversImported": "Cubiertas importadas",
+        "coverImportSkipped": "Se omitió la importación de la portada: la ruta raíz del medio no está configurada en el origen",
+        "couldNotMatch": "No se pudo coincidir",
+        "userDataCard": "Datos de usuario",
+        "readingStatuses": "Estados de lectura",
+        "readingProgressEntries": "Lectura de entradas de progreso",
+        "audiobookProgressEntries": "Entradas de progreso del audiolibro",
+        "bookmarksLabel": "Marcadores",
+        "annotationsLabel": "Anotaciones",
+        "collectionEntries": "Entradas de colección",
+        "loadFullReportHint": "Haga clic en \"Cargar informe completo\" para incluir el resumen del partido de prueba en el informe exportado.",
+        "completedNoIssues": "La migración se completó sin libros ni fallas sin resolver.",
+        "matchedBooksHeading": "Libros coincidentes ({count})",
+        "matchedBooksHint": "Estas coincidencias de prueba se utilizaron para decidir qué libros de la biblioteca recibieron datos importados.",
+        "sourceBookFallback": "Libro de consulta {id}",
+        "libraryBookFallback": "Libro de la biblioteca {id}",
+        "unresolvedBooksHeading": "Libros sin resolver ({count})",
+        "unresolvedBooksHint": "Estos libros existen en la fuente, pero no se pueden relacionar con ningún libro de su biblioteca.",
+        "mappedUsersHeading": "Usuarios asignados ({count})",
+        "mappedUsersHint": "Los totales por usuario provienen de la vista previa de prueba almacenada en caché con el plan de migración.",
+        "coverImportsFailed": "{count} falló la importación de portada. Las filas de errores detalladas no se almacenan.",
+        "backToSetup": "Volver a la configuración"
+      },
+      "libraries": {
+        "title": "Bibliotecas",
+        "subtitle": "Administre sus bibliotecas multimedia y active escaneos de contenido.",
+        "scanAll": "Escanear todo",
+        "scanning": "Escaneando...",
+        "addLibrary": "Agregar biblioteca",
+        "scan": "Escanear",
+        "editLibrary": "Editar biblioteca",
+        "refreshCovers": "Actualizar portadas",
+        "syncMetadataToFiles": "Sincronizar metadatos con archivos",
+        "deleteLibrary": "Eliminar biblioteca",
+        "bookCount": "{count, plural, =0 {sin libros} one {# libro} other {# libros} many {# libros}}",
+        "addedDate": "Añadido {date}",
+        "fileMode": "Modo de archivo",
+        "folderMode": "Modo carpeta",
+        "folderCount": "{count, plural, =0 {sin carpetas} one {# carpeta} other {# carpetas} many {# carpetas}}",
+        "watching": "mirando",
+        "fileWrite": "Escritura de archivo",
+        "fileRename": "cambiar el nombre del archivo",
+        "emptyTitle": "Aún no hay bibliotecas",
+        "emptyHint": "Agregue una biblioteca para comenzar a organizar sus libros.",
+        "addFirstLibrary": "Añade tu primera biblioteca",
+        "deleteConfirmTitle": "¿Eliminar \"{name}\"?",
+        "deleteConfirmBody": "Esto eliminará permanentemente todos los libros, metadatos, progreso de lectura, marcadores y anotaciones de esta biblioteca. Esto no se puede deshacer.",
+        "deleteConfirmTypeName": "Escriba el nombre de la biblioteca para confirmar:",
+        "deleting": "Eliminando...",
+        "deleteLibraryButton": "Eliminar biblioteca",
+        "syncConfirmTitle": "¿Sincronizar metadatos con archivos?",
+        "syncConfirmBodyPrefix": "Esto sobrescribirá los metadatos dentro de cada archivo compatible en",
+        "syncConfirmBodySuffix": "directamente en el disco. Esto no se puede deshacer.",
+        "syncFiles": "Sincronizar archivos",
+        "metadataSynced": "Metadatos sincronizados con archivos para \"{name}\"",
+        "fileWriteNotEnabled": "La escritura de archivos de metadatos no está habilitada para esta biblioteca. Habilítelo en la configuración de la biblioteca.",
+        "fileSyncFailed": "Error de sincronización de archivos para \"{name}\"",
+        "scanStarted": "Se inició el análisis de \"{name}\"",
+        "scanStartFailed": "No se pudo iniciar el análisis de \"{name}\"",
+        "refreshCoversFailed": "No se pudieron actualizar las portadas de \"{name}\"",
+        "scanStartedAll": "Escaneo iniciado para todas las bibliotecas",
+        "librariesFailedToStart": "{count, plural, =0 {ninguna biblioteca no pudo iniciarse} one {# la biblioteca no pudo iniciarse} other {# las bibliotecas no pudieron iniciarse} many {# las bibliotecas no pudieron iniciarse}}",
+        "scansStartFailed": "No se pudieron iniciar los análisis",
+        "libraryCreated": "Biblioteca \"{name}\" creada",
+        "libraryUpdated": "Biblioteca \"{name}\" actualizada",
+        "libraryDeleted": "\"{name}\" eliminado",
+        "deleteFailed": "No se pudo eliminar la biblioteca",
+        "scanningProgress": "Escaneando {pct}% ({processed}/{total})",
+        "scanDone": "Listo: {added} agregado, {updated} actualizado",
+        "scanFailedWithError": "Error: {error}",
+        "scanFailed": "Error de escaneo",
+        "refreshingCovers": "Cubiertas refrescantes {pct}% ({processed}/{total})",
+        "coversRefreshed": "Cubiertas actualizadas ({count} procesadas)"
+      },
+      "authorEnrichment": {
+        "configuration": "Configuración",
+        "saving": "Guardando...",
+        "running": "Corriendo...",
+        "runEligibleShort": "Ejecutar elegible",
+        "runAllShort": "ejecutar todo",
+        "enableTitle": "Habilitar el enriquecimiento automático de autores",
+        "enableHint": "Obtenga automáticamente biografías de autores y fotografías de perfil cuando se agreguen o actualicen libros.",
+        "updateStrategyTitle": "Estrategia de actualización",
+        "updateStrategyHint": "Qué hacer cuando un autor ya tiene una biografía o una foto.",
+        "writeModeMissingOnly": "Complete solo los datos faltantes (recomendado)",
+        "writeModeAlwaysRefetch": "Actualizar siempre los datos existentes",
+        "triggerOnImportTitle": "Activar al importar",
+        "triggerOnImportHint": "Ponga en cola a los autores para enriquecerlos cuando los libros se agregan por primera vez a una biblioteca.",
+        "eligibilityTitle": "Condiciones de elegibilidad",
+        "eligibilityHint": "Un autor es elegible si cumple con alguna condición habilitada.",
+        "neverEnrichedTitle": "Nunca enriquecido",
+        "neverEnrichedHint": "Enriquecer a autores que nunca han tenido un enriquecimiento exitoso.",
+        "missingBioTitle": "Falta biografía",
+        "missingBioHint": "Enriquecer si el autor no tiene biografía.",
+        "missingPhotoTitle": "foto faltante",
+        "missingPhotoHint": "Enriquecer si el autor no tiene foto de perfil.",
+        "runForEligibleAuthors": "Ejecutar para autores elegibles",
+        "eligibleCount": "~{count} elegible",
+        "runForAllAuthors": "Ejecutar para todos los autores.",
+        "saved": "Configuración de enriquecimiento de autor guardada",
+        "saveFailed": "No se pudo guardar la configuración de enriquecimiento del autor",
+        "noEligibleAuthors": "No se encontraron autores elegibles",
+        "noAuthorsToEnrich": "No hay autores para enriquecer",
+        "queueFailed": "No se pudo poner en cola el reabastecimiento del autor"
+      },
+      "scoreWeights": {
+        "groupLabel": "Pesos de puntuación",
+        "assignHintPrefix": "Asigne un peso a cada campo. Peso total:",
+        "areYouSure": "¿Estás seguro?",
+        "resetToDefaultsButton": "Restablecer los valores predeterminados",
+        "recalculateAll": "Recalcular todo",
+        "confirmReset": "Confirmar reinicio",
+        "reset": "Reiniciar",
+        "recalculate": "Recalcular",
+        "subtotal": "subtotal: {count}",
+        "savedRecalculating": "Pesos de puntuación guardados. Recalculando las puntuaciones de la biblioteca...",
+        "saveFailed": "No se pudieron guardar los pesos de puntuación",
+        "recalcStarted": "El nuevo cálculo de la puntuación se inició en segundo plano.",
+        "recalcFailed": "El recálculo falló",
+        "resetToDefaults": "Los pesos se restablecen a los valores predeterminados. Guardar para aplicar."
+      },
+      "tabs": {
+        "users": "Usuarios",
+        "account-activity": "Actividad de la cuenta",
+        "magic-links": "Enlaces mágicos",
+        "oidc": "OIDC/SSO"
+      }
+    },
+    "common": {
+      "nav": {
+        "libraries": "Bibliotecas",
+        "display": "Visualización",
+        "reader": "Lector",
+        "metadata": "Metadatos",
+        "email": "Correo electrónico",
+        "opds": "OPDS",
+        "kobo": "Kobo",
+        "koreader": "KOReader",
+        "hardcover": "Hardcover",
+        "admin": "administrador",
+        "system": "Sistema",
+        "account": "cuenta"
+      }
+    },
+    "metadata": {
+      "title": "Metadatos",
+      "noPermission": "No tienes permiso para administrar la configuración de metadatos.",
+      "fields": {
+        "title": "Título",
+        "subtitle": "Subtítulo",
+        "description": "Descripción",
+        "cover": "Portada",
+        "authors": "Autores",
+        "publisher": "Editor",
+        "publishedYear": "Año de publicación",
+        "language": "Idioma",
+        "pageCount": "Recuento de páginas",
+        "communityRating": "Calificación de la comunidad",
+        "seriesName": "Nombre de la serie",
+        "seriesIndex": "Índice de series",
+        "genres": "Géneros",
+        "narrators": "Narradores",
+        "duration": "Duración",
+        "abridged": "abreviado"
+      },
+      "mergeStrategy": {
+        "fillMissing": {
+          "label": "Falta llenar",
+          "description": "Escribe solo si el campo está actualmente vacío"
+        },
+        "overwriteIfProvided": {
+          "label": "Sobrescribir si se proporciona",
+          "description": "Escribir si el proveedor devolvió un valor"
+        },
+        "overwrite": {
+          "label": "Sobrescribir siempre",
+          "description": "Reemplace siempre el valor existente"
+        }
+      },
+      "autoFetch": {
+        "globalSettings": "Configuración global",
+        "perLibraryOverrides": "Configuraciones por biblioteca",
+        "saving": "Guardando...",
+        "running": "Corriendo...",
+        "runNow": "Corre ahora",
+        "runForEligible": "Corre por libros elegibles",
+        "enable": {
+          "label": "Habilitar la búsqueda automática",
+          "hint": "Obtenga metadatos automáticamente para libros elegibles."
+        },
+        "triggerOnImport": {
+          "label": "Activar al importar",
+          "hint": "Ponga en cola los libros elegibles cuando se agregan por primera vez a una biblioteca."
+        },
+        "status": {
+          "inQueuePaused": "{count} en cola - pausado",
+          "remaining": "{count} restantes",
+          "eligible": "~{count} elegible"
+        },
+        "trigger": {
+          "queued": "{count, plural, one {En cola # libro} other {En cola # libros} many {En cola # libros}}",
+          "noneFound": "No se encontraron libros elegibles"
+        },
+        "lastRun": {
+          "justNow": "justo ahora",
+          "minutesAgo": "Hace {count}m",
+          "hoursAgo": "Hace {count}h",
+          "yesterday": "ayer",
+          "daysAgo": "Hace {count} días",
+          "label": "Última ejecución: {when}",
+          "labelQueued": "Última ejecución: {when} - {count} libros en cola",
+          "labelNoneEligible": "Última ejecución: {when}: no hay libros elegibles"
+        },
+        "conditions": {
+          "title": "Condiciones de elegibilidad",
+          "hint": "Un libro es elegible si cumple con alguna condición habilitada.",
+          "noneEnabled": "Ninguna condición habilitada",
+          "neverFetched": {
+            "label": "nunca recuperado",
+            "hint": "Busque libros que nunca hayan tenido un intento de recuperación de metadatos.",
+            "summary": "nunca recuperado"
+          },
+          "scoreThreshold": {
+            "label": "Puntuación de metadatos baja",
+            "hint": "Recuperar si la puntuación de los metadatos está por debajo de un umbral.",
+            "scoreBelow": "Puntuación a continuación",
+            "summary": "Puntuación < {threshold}"
+          },
+          "missingFields": {
+            "label": "Campos faltantes",
+            "hint": "Recuperar si alguno de los campos seleccionados está vacío.",
+            "summary": "{count, plural, one {desaparecido # campo} other {desaparecido # campos} many {desaparecido # campos}}"
+          }
+        },
+        "library": {
+          "inheritingGlobal": "Heredar valores predeterminados globales",
+          "inheritFromGlobal": "Heredar de global",
+          "usingGlobalDefaults": "Usando valores predeterminados globales.",
+          "saveOverride": "Guardar anulación"
+        }
+      },
+      "providers": {
+        "availableSources": "Fuentes disponibles",
+        "saveChanges": "Guardar cambios",
+        "test": "prueba",
+        "testing": "Probando...",
+        "enabled": "Habilitado",
+        "retryIn": "Reintentar en {duration}",
+        "runTestBeforeEnabling": "Ejecutar prueba antes de habilitar",
+        "hardcoverEnableHint": "Ejecute la prueba con el token actual para desbloquear el interruptor de habilitación.",
+        "badge": {
+          "setupRequired": "Configuración requerida",
+          "throttled": "estrangulado",
+          "ready": "Listo"
+        },
+        "fields": {
+          "apiKey": "API Clave",
+          "region": "Región",
+          "cookie": "galleta",
+          "coverResolution": "Resolución de portada",
+          "country": "País",
+          "language": "Idioma",
+          "ttbKey": "Clave TTB"
+        },
+        "helpers": {
+          "googleApiKey": "Google Books API clave de Google Cloud."
+        },
+        "hints": {
+          "google": "Amplia cobertura del índice de libros de Google. Google Books ahora requiere una clave API antes de que se pueda habilitar este proveedor.",
+          "amazon": "Se recomienda la cookie de sesión. Pegue sólo el valor de la cookie (sin \"Cookie:\").",
+          "goodreads": "La comunidad de lectura más grande de la web. No se requiere configuración.",
+          "hardcover": "Una alternativa moderna a Goodreads. Token de hardcover.app/account/api. El prefijo \"Bearer\" es opcional.",
+          "openLibrary": "El catálogo de libros gratuito de Internet Archive. No se requiere configuración.",
+          "itunes": "El catálogo de libros digitales de Apple. Elija si desea buscar portadas de resolución alta o estándar.",
+          "kobo": "Elimina las páginas del libro público de Kobo. El país y el idioma deben coincidir con las rutas Kobo URL; La protección contra bots puede bloquear solicitudes.",
+          "audible": "Extrae metadatos de audiolibros de Audible. No se requiere configuración adicional.",
+          "audnexus": "Metadatos de audiolibros impulsados por la comunidad. No se requiere configuración.",
+          "comicvine": "Metadatos de cómics de ComicVine. Se requiere una clave API gratuita de comicvine.gamespot.com.",
+          "ranobedb": "Metadatos de novelas ligeras japonesas de RanobeDB. No se requiere configuración.",
+          "lubimyczytac": "Catálogo de libros polacos (lubimyczytac.pl). Raspa páginas de libros públicos. No se requiere configuración.",
+          "aladin": "Metadatos de libros coreanos de Aladin (알라딘). Se requiere una clave TTB de aladin.co.kr."
+        },
+        "blocked": {
+          "google": "Google Books requiere una clave API antes de poder habilitarse",
+          "hardcover": "Hardcover requiere una clave API antes de poder habilitarse",
+          "hardcoverTest": "El token Hardcover debe pasar la prueba antes de poder habilitarse",
+          "comicvine": "ComicVine requiere una clave API antes de poder habilitarse",
+          "aladin": "Aladin requiere una clave TTB antes de poder habilitarse"
+        }
+      },
+      "fieldRules": {
+        "clearAllProviders": "Borrar todos los proveedores",
+        "clearAll": "Borrar todo",
+        "resetToDefault": "Restablecer los valores predeterminados",
+        "reset": "Reiniciar",
+        "dragProvidersHint": "Arrastre proveedores desde aquí a cualquier campo para agregarlos",
+        "dragProviderHere": "arrastra un proveedor aquí",
+        "howItWorks": {
+          "title": "Cómo funcionan las reglas de campo",
+          "priorityOrder": {
+            "title": "Orden de prioridad",
+            "body": "Arrastre proveedores en la lista para reordenarlos. El proveedor principal que devuelva un resultado será la fuente principal de ese campo."
+          },
+          "mergeStrategy": {
+            "title": "Estrategia de fusión",
+            "fillMissingTerm": "Falta el relleno:",
+            "fillMissingBody": "Escriba solo si el valor actual está vacío.",
+            "overwriteTerm": "Sobrescribir:",
+            "overwriteBody": "Reemplazar cada vez que un proveedor tenga datos."
+          }
+        },
+        "libraryOverrides": {
+          "title": "Anulaciones de biblioteca",
+          "hint": "Amplíe una biblioteca para personalizar campos individuales. Los campos no anulados heredan los valores predeterminados globales."
+        },
+        "global": {
+          "title": "Valores predeterminados globales",
+          "hint": "Reglas predeterminadas aplicadas a cada biblioteca. Anule por biblioteca a continuación.",
+          "saveDefaults": "Guardar valores predeterminados",
+          "clearAllConfirm": "¿Eliminar todos los proveedores activos de todos los campos? Esto se guardará inmediatamente y no se podrá deshacer.",
+          "resetConfirm": "¿Restablecer todas las reglas de campo globales a los valores predeterminados del sistema? Esto sobrescribirá su configuración actual."
+        },
+        "advanced": {
+          "title": "Comportamiento de búsqueda avanzado",
+          "combineGenres": {
+            "label": "Combina géneros de todos los proveedores seleccionados.",
+            "hint": "Recopile y elimine los duplicados de géneros de cada proveedor asignado al campo Géneros, en lugar de detenerse en el primer resultado."
+          },
+          "storeProviderIds": {
+            "label": "Almacenar ID de proveedores en libros",
+            "hint": "Al recuperar metadatos, guarde los ID de proveedor devueltos (ISBN, ASIN, Goodreads ID, etc.) en el registro del libro para realizar búsquedas futuras más precisas."
+          }
+        },
+        "library": {
+          "primary": "Principal:",
+          "overrideCount": "{count, plural, one {# Anular} other {# Anulaciones} many {# Anulaciones}}",
+          "unsavedSuffix": "(no guardado)",
+          "unsavedChanges": "Cambios no guardados",
+          "globalDefaults": "Valores predeterminados globales",
+          "overriding": "Anulación: {fields}",
+          "inheritingAll": "Heredar todas las reglas globales de metadatos",
+          "subHint": "Los campos no anulados heredan los valores predeterminados globales.",
+          "resetTooltip": "Eliminar todas las anulaciones y heredar los valores predeterminados globales",
+          "clearAllConfirm": "¿Eliminar todos los proveedores activos de cada campo en \"{library}\"?",
+          "resetConfirm": "¿Restablecer \"{library}\" a los valores predeterminados globales? Se eliminarán todas las anulaciones de biblioteca."
+        },
+        "groups": {
+          "core": "Núcleo",
+          "contributors": "Colaboradores",
+          "publication": "Publicación",
+          "series": "Serie",
+          "classification": "Clasificación",
+          "audiobook": "Audiolibro"
+        },
+        "groupSummary": {
+          "base": "{fields} campos · {enabled} habilitado",
+          "withOverrides": "{base} · {overrides} anula"
+        },
+        "table": {
+          "field": "campo",
+          "activeProviders": "Proveedores activos (ordenados por prioridad)",
+          "mergeStrategy": "Estrategia de fusión",
+          "status": "Estado"
+        },
+        "field": {
+          "noProviders": "Habilitado pero no tiene proveedores.",
+          "empty": "vacio",
+          "config": "configuración",
+          "custom": "personalizado",
+          "default": "Predeterminado",
+          "resetToDefault": "Restablecer los valores predeterminados"
+        },
+        "reservoir": {
+          "disabled": "{provider} - deshabilitado",
+          "notConfigured": "{provider} - no configurado",
+          "dragToAssign": "Arrastre para asignar {provider} a un campo"
+        },
+        "sheet": {
+          "subtitle": "Toque proveedores para asignar, use flechas para reordenar",
+          "enableField": "Habilite este campo durante la actualización",
+          "providers": "Proveedores",
+          "statusDisabled": "discapacitado",
+          "statusNotConfigured": "no configurado",
+          "done": "Hecho"
+        }
+      },
+      "genreBlocklist": {
+        "heading": "Exclusiones globales de género",
+        "hint": "Los valores exactos de género en esta lista se eliminan de los resultados del proveedor antes de que se escriban los metadatos.",
+        "saving": "Ahorro",
+        "genreValueLabel": "Valor de género",
+        "addPlaceholder": "Agregue un valor de género, por ejemplo Audiolibro",
+        "duplicate": "Este género ya está bloqueado.",
+        "add": "Añadir",
+        "filterPlaceholder": "Filtrar lista de bloqueo",
+        "entryCount": "{count, plural, one {# entrada} other {# entradas} many {# entradas}}",
+        "filteredCount": "{shown} de {total}",
+        "noFilterMatch": "Ningún género bloqueado coincide con el filtro actual.",
+        "emptyTitle": "Sin géneros bloqueados",
+        "emptyHint": "Agregue valores exactos como Audiolibro o Adulto para mantenerlos fuera de los metadatos recuperados.",
+        "removeLabel": "Eliminar {genre}"
+      },
+      "customFields": {
+        "label": "Etiqueta",
+        "labelPlaceholder": "por ej. Título original",
+        "labelTooLong": "La etiqueta debe tener 255 caracteres o menos.",
+        "labelDuplicate": "Ya existe un campo con esta etiqueta",
+        "type": "Tipo",
+        "usage": "{count, plural, one {Utilizado por # libro} other {Utilizado por # libros} many {Utilizado por # libros}}",
+        "newField": {
+          "title": "Nuevo campo",
+          "hint": "Defina un campo de metadatos personalizado y elija qué bibliotecas lo utilizan."
+        },
+        "previewToggle": "Vista previa de cómo aparece este campo al editar un libro",
+        "untitledField": "Campo sin título",
+        "addField": "Agregar campo",
+        "fields": "Campos",
+        "fieldsHint": "Arrastre para reordenar, editar etiquetas, alternar bibliotecas o archivar campos que ya no necesite.",
+        "searchPlaceholder": "Campos de búsqueda",
+        "searchAriaLabel": "Buscar campos personalizados",
+        "emptyTitle": "Aún no hay campos personalizados",
+        "emptyHint": "Utilice el formulario anterior para definir su primer campo de metadatos personalizado.",
+        "noMatchTitle": "Ningún campo coincide con \"{query}\"",
+        "noMatchHint": "Pruebe con una etiqueta, clave o tipo diferente.",
+        "clearSearchToReorder": "Borrar búsqueda para reordenar",
+        "dragToReorder": "Arrastra para reordenar",
+        "dragToReorderField": "Arrastrar para reordenar el campo",
+        "unsaved": "No guardado",
+        "archive": "Archivo",
+        "archivedFields": "Campos archivados",
+        "archivedSummary": "{count, plural, one {# campo archivado: restaurar o eliminar permanentemente.} other {# campos archivados: restaurar o eliminar permanentemente.} many {# campos archivados: restaurar o eliminar permanentemente.}}",
+        "archivedAt": "Archivado {when}",
+        "restore": "Restaurar",
+        "deleteForever": "Eliminar para siempre",
+        "deleteDialog": {
+          "title": "Eliminar campo permanentemente",
+          "bodyBefore": "Esto eliminará permanentemente",
+          "bodyMiddle": "y eliminar sus valores almacenados de",
+          "bodyAfter": ". Esto no se puede deshacer.",
+          "confirmBefore": "Tipo",
+          "confirmAfter": "para confirmar",
+          "confirmPlaceholder": "Escriba la etiqueta del campo para confirmar"
+        },
+        "preview": "Vista previa",
+        "sampleValue": "Valor de muestra",
+        "enabledLibraries": "Bibliotecas habilitadas",
+        "countOf": "{selected} de {total}",
+        "selectAll": "Seleccionar todo",
+        "clear": "Borrar",
+        "noLibraries": "Aún no hay bibliotecas disponibles.",
+        "allLibraries": "Todas las bibliotecas"
+      },
+      "tabs": {
+        "providers": "Proveedores",
+        "field-rules": "Reglas de campo",
+        "custom-fields": "Campos personalizados",
+        "genre-blocklist": "Lista de bloqueo de género",
+        "score": "Puntuación",
+        "auto-fetch": "Libros",
+        "authors": "Autores"
+      },
+      "tabTitles": {
+        "providers": "Proveedores",
+        "field-rules": "Reglas a nivel de campo",
+        "custom-fields": "Metadatos personalizados",
+        "genre-blocklist": "Lista de bloqueo de género",
+        "score": "Puntuación de confianza",
+        "auto-fetch": "Búsqueda automática de libros",
+        "authors": "Recuperación automática del autor"
+      },
+      "tabSubtitles": {
+        "providers": "Habilite fuentes de metadatos externas y configure sus credenciales.",
+        "field-rules": "Controle qué proveedor proporciona cada campo de metadatos y cómo se combinan los valores en sus bibliotecas.",
+        "custom-fields": "Defina campos de metadatos personalizados y elija qué bibliotecas los utilizan.",
+        "genre-blocklist": "Evite que se escriban en libros valores de género de proveedores no deseados.",
+        "score": "Asigne pesos a los campos de metadatos para calcular en qué medida confiar en los resultados obtenidos.",
+        "auto-fetch": "Obtenga automáticamente portadas, descripciones y otros detalles cuando se agreguen libros nuevos a su biblioteca.",
+        "authors": "Obtenga automáticamente biografías y fotos de perfil cuando aparezcan nuevos autores en su biblioteca."
+      }
+    },
+    "reader": {
+      "resetToDefaults": "Restablecer los valores predeterminados",
+      "all": {
+        "title": "Lector",
+        "subtitle": "Configure los valores predeterminados para todos los modos de lectura en un solo lugar."
+      },
+      "general": {
+        "title": "leyendo",
+        "subtitle": "Comportamiento general que se aplica a todos los tipos de lectores.",
+        "storageLabel": "Dónde guardar las preferencias del lector",
+        "deviceOnly": "Este dispositivo solo",
+        "deviceOnlyHint": "Las preferencias permanecen en su navegador. Lo mejor es que siempre leas en este dispositivo o quieras configuraciones diferentes para cada dispositivo.",
+        "myAccount": "mi cuenta",
+        "myAccountHint": "Las preferencias se guardan en su cuenta. Lo mejor es si inicias sesión desde varios dispositivos y deseas una experiencia consistente en todas partes.",
+        "active": "Activo",
+        "notAvailable": "No disponible",
+        "demoCannotChangeStorage": "La cuenta restringida de demostración no puede cambiar el modo de almacenamiento del lector",
+        "preferencesSynced": "Las preferencias ahora se sincronizarán",
+        "preferencesLocal": "Las preferencias permanecerán en este dispositivo",
+        "storageUpdateFailed": "No se pudo actualizar el modo de almacenamiento",
+        "storageUpdateError": "Se produjo un error al actualizar el modo de almacenamiento."
+      },
+      "ebook": {
+        "title": "Lector de libros electrónicos",
+        "subtitle": "La configuración predeterminada se aplica al abrir archivos EPUB, MOBI, FB2 y TXT.",
+        "newBooks": "Libros nuevos",
+        "applySettings": "Aplicar mi configuración a libros nuevos",
+        "applySettingsHint": "Cuando está desactivado, se abren libros nuevos con las fuentes y el diseño propios del editor. Tu configuración solo se aplica una vez que cambias algo en el lector.",
+        "layout": "Diseño",
+        "readingFlow": "Flujo de lectura",
+        "readingFlowHint": "Paginado voltea páginas; el desplazamiento fluye continuamente",
+        "paginated": "paginado",
+        "scrolled": "Desplazado",
+        "fixedLayoutSpread": "Pliegos de página con diseño fijo",
+        "fixedLayoutSpreadHint": "Predeterminado para manga, cómics y EPUB basados en imágenes",
+        "bookDefault": "Reservar por defecto",
+        "singlePage": "Una sola página",
+        "columns": "columnas",
+        "columnsHint": "Número de columnas de texto por página",
+        "theme": "Tema",
+        "darkMode": "modo oscuro",
+        "darkModeHint": "Utilice la variante oscura del tema seleccionado.",
+        "typography": "tipografía",
+        "font": "fuente",
+        "fontHint": "Tipo de letra utilizado para el cuerpo del texto.",
+        "builtInFonts": "Fuentes incorporadas",
+        "yourFonts": "Tus fuentes",
+        "fontSize": "Tamaño de fuente",
+        "fontSizeHint": "Tamaño del texto base en píxeles",
+        "lineHeight": "altura de la línea",
+        "lineHeightHint": "Espaciado vertical entre líneas",
+        "justify": "Justificar texto",
+        "justifyHint": "Alinear el texto a ambos márgenes",
+        "hyphenation": "Separación de sílabas",
+        "hyphenationHint": "Divide automáticamente palabras largas con guiones",
+        "advanced": "Avanzado",
+        "maxContentWidth": "Ancho máximo del contenido",
+        "maxContentWidthHint": "Ancho máximo del área de texto en píxeles",
+        "columnGap": "Espacio de columna",
+        "columnGapHint": "Relleno horizontal a cada lado del área de texto"
+      },
+      "pdf": {
+        "title": "PDF Lector",
+        "subtitle": "La configuración predeterminada se aplica al abrir archivos PDF.",
+        "layout": "Diseño",
+        "scrollMode": "Modo de desplazamiento",
+        "scrollModeHint": "La página pasa de una en una; desplazamiento continuo a través de todas las páginas",
+        "page": "Página",
+        "scrolled": "Desplazado",
+        "pageSpread": "Extensión de página",
+        "pageSpreadHint": "¿Qué número de página comienza a la derecha en la vista de dos páginas?",
+        "spreadNone": "Ninguno",
+        "spreadOdd": "impar",
+        "spreadEven": "Pares",
+        "zoom": "Ampliar",
+        "defaultFit": "Ajuste predeterminado",
+        "defaultFitHint": "Cómo se escalan las páginas cuando se abre un PDF",
+        "fitPage": "Ajustar página",
+        "fitWidth": "Ancho de ajuste",
+        "custom": "personalizado",
+        "zoomLevel": "Nivel de zoom",
+        "zoomLevelHint": "Factor de escala para el modo de zoom personalizado"
+      },
+      "comics": {
+        "title": "Lector de cómics",
+        "subtitle": "La configuración predeterminada se aplica al abrir archivos CBZ, CBR y CB7.",
+        "view": "Ver",
+        "readingMode": "Modo de lectura",
+        "readingModeHint": "Cómo se navega por las páginas: utilice \"Infinito (sin espacios)\" para los webtoons",
+        "paginated": "paginado",
+        "infiniteSpaced": "Infinito (espaciado)",
+        "infiniteNoGaps": "Infinito (sin espacios)",
+        "pageView": "Vista de página",
+        "pageViewHint": "Mostrar una o dos páginas una al lado de la otra",
+        "single": "soltero",
+        "twoPage": "dos páginas",
+        "fitMode": "Modo de ajuste",
+        "fitModeHint": "Cómo se escalan las páginas para que se ajusten a la pantalla",
+        "fitPage": "Página",
+        "fitWidth": "Ancho",
+        "fitHeight": "altura",
+        "fitActual": "real",
+        "readingDirection": "dirección de lectura",
+        "readingDirectionHint": "De izquierda a derecha para los cómics occidentales; de derecha a izquierda para manga",
+        "ltr": "De izquierda a derecha",
+        "rtl": "De derecha a izquierda",
+        "spreadAlignment": "Alineación extendida",
+        "spreadAlignmentHint": "Cambie el emparejamiento una página después de la portada para escaneos uno por uno",
+        "alignmentNormal": "normales",
+        "alignmentShifted": "desplazado",
+        "spreadGap": "Brecha de propagación",
+        "spreadGapHint": "Espacio entre páginas en vista de dos páginas",
+        "spreadGapValue": "{value}px",
+        "widePageHandling": "Manejo de páginas anchas",
+        "widePageHandlingHint": "Auto muestra escaneos amplios solos en modo paginado de dos páginas",
+        "widePageAuto": "Automático",
+        "widePageDisable": "Desactivar",
+        "forceTwoPage": "Forzar dos páginas en pantallas pequeñas",
+        "forceTwoPageHint": "Omitir el respaldo automático móvil cuando se selecciona el modo paginado de dos páginas",
+        "off": "Apagado",
+        "on": "encendido",
+        "display": "Visualización",
+        "backgroundColor": "Color de fondo",
+        "backgroundColorHint": "Color del lienzo detrás de las páginas.",
+        "bgBlack": "negro",
+        "bgGray": "gris",
+        "bgWhite": "blanco"
+      },
+      "audio": {
+        "title": "Reproductor de audiolibros",
+        "subtitle": "La configuración predeterminada se aplica al reproducir M4B, MP3 y otros formatos de audio.",
+        "playback": "Reproducción",
+        "playbackSpeed": "Velocidad de reproducción predeterminada",
+        "playbackSpeedHint": "Multiplicador de velocidad aplicado al abrir un nuevo audiolibro",
+        "volume": "Volumen predeterminado",
+        "volumeHint": "Nivel de volumen inicial (0 a 100%)",
+        "skipControls": "Saltar controles",
+        "skipBack": "Saltar la duración hacia atrás",
+        "skipBackHint": "Segundos rebobinados al presionar skip-back",
+        "skipForward": "Saltar duración hacia adelante",
+        "skipForwardHint": "Segundos avanzados al presionar saltar hacia adelante"
+      },
+      "fonts": {
+        "title": "Fuentes",
+        "subtitle": "Cargue fuentes personalizadas para usar en el lector de libros electrónicos.",
+        "uploadFonts": "Cargar fuentes",
+        "notAvailableDemo": "No disponible para cuentas demo",
+        "uploading": "Subiendo...",
+        "dropFilesHere": "Suelta archivos aquí",
+        "dragFontsPrefix": "Arrastre los archivos de fuentes aquí, o",
+        "browse": "navegar",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2: máximo 10 MB cada uno",
+        "yourFonts": "Tus fuentes",
+        "fontsUsed": "{count} / {max} usado",
+        "noFontsYet": "Aún no se han subido fuentes",
+        "noFontsHint": "Arrastre un archivo de fuente arriba para comenzar.",
+        "fileCount": "{count, plural, =0 {sin archivos} one {# archivo} other {# archivos} many {# archivos}}",
+        "pangram": "El rápido zorro marrón salta sobre el perro perezoso.",
+        "renameFamily": "Cambiar nombre de familia",
+        "deleteFamily": "Eliminar familia",
+        "editVariant": "Editar peso/estilo",
+        "deleteVariant": "Eliminar variante",
+        "styleNormal": "normales",
+        "styleItalic": "cursiva",
+        "weightThin": "delgado",
+        "weightExtraLight": "Luz adicional",
+        "weightLight": "Luz",
+        "weightRegular": "regular",
+        "weightMedium": "Medio",
+        "weightSemiBold": "Semi negrita",
+        "weightBold": "Negrita",
+        "weightExtraBold": "Extra negrita",
+        "weightBlack": "negro",
+        "renameFamilyFailed": "No se pudo cambiar el nombre de la familia de fuentes",
+        "renamedTo": "Renombrado a \"{name}\"",
+        "updateVariantFailed": "No se pudo actualizar la variante de fuente",
+        "deleteFontFailed": "No se pudo eliminar la fuente",
+        "deleteFamilyFailed": "No se pudo eliminar la familia de fuentes",
+        "demoCannotManage": "La cuenta restringida de demostración no puede administrar fuentes",
+        "fileAdded": "\"{name}\" añadido",
+        "uploadFailed": "Error al subir"
+      },
+      "bookDock": {
+        "title": "Book Dock",
+        "subtitle": "Configure cómo se procesan los archivos cuando ingresan a Book Dock.",
+        "dropFolder": "Carpeta desplegable",
+        "containerPath": "Ruta del contenedor",
+        "containerPathHint": "Copie o mueva archivos de libros a esta carpeta y Book Dock los recogerá y procesará automáticamente. Se admiten subdirectorios.",
+        "changePathPrefix": "Para cambiar esta ruta, establezca",
+        "changePathMiddle": "en tu",
+        "changePathSuffix": "archivo.",
+        "metadata": "Metadatos",
+        "autoFetch": "Obtener metadatos automáticamente de los proveedores",
+        "autoFetchHint": "Obtenga automáticamente metadatos de proveedores configurados (Google Books, iTunes, Open Library, etc.) después de agregar un archivo a Book Dock.",
+        "autoFinalize": "Finalizar automáticamente",
+        "enableAutoFinalize": "Habilitar la finalización automática",
+        "enableAutoFinalizeHint": "Los archivos con una puntuación de confianza de metadatos igual o superior al umbral se finalizarán automáticamente.",
+        "confidenceThreshold": "Umbral de confianza: {value}%",
+        "thresholdIgnored": "(ignorado en modo solo integrado)",
+        "destinationLibrary": "Biblioteca de destino",
+        "selectLibrary": "Seleccione una biblioteca...",
+        "metadataMode": "Modo de metadatos",
+        "metadataModeSafeMerge": "Fusión segura (recomendado)",
+        "metadataModeFetchedOnly": "Solo obtenido",
+        "metadataModeEmbeddedOnly": "Sólo integrado",
+        "destinationFolder": "Carpeta de destino",
+        "selectFolder": "Seleccione una carpeta...",
+        "saveSettingFailed": "No se pudo guardar la configuración",
+        "updateSettingFailed": "No se pudo actualizar la configuración",
+        "autoFetchEnabled": "Recuperación automática habilitada",
+        "autoFetchDisabled": "Recuperación automática deshabilitada",
+        "autoFinalizeEnabled": "Finalización automática habilitada",
+        "autoFinalizeDisabled": "Finalización automática deshabilitada",
+        "destinationLibraryUpdated": "Biblioteca de destino actualizada",
+        "destinationFolderUpdated": "Carpeta de destino actualizada",
+        "confidenceThresholdUpdated": "Umbral de confianza actualizado",
+        "metadataModeUpdated": "Modo de metadatos actualizado"
+      },
+      "fileNaming": {
+        "title": "Nomenclatura de archivos",
+        "subtitle": "Controle cómo se organizan los archivos en el disco cuando se cargan y cómo se nombran cuando se descargan mediante tokens de marcador de posición.",
+        "copy": "Copiar",
+        "previewLabel": "Vista previa:",
+        "fileAsBookPreview": "Archivo como vista previa del libro",
+        "folderAsBookPreview": "Carpeta como vista previa del libro",
+        "downloadPreview": "Descargar vista previa",
+        "globalDefaults": "Valores predeterminados globales",
+        "crossPlatform": "Desinfección de rutas multiplataforma",
+        "crossPlatformHint": "Haga que los nombres de archivos y carpetas generados sean seguros en Windows reemplazando caracteres no válidos y nombres reservados, y eliminando puntos y espacios al final. Desactívelo solo para configuraciones de Linux que mantienen intencionalmente esos caracteres.",
+        "fileAsBookDefault": "Archivo como libro predeterminado",
+        "fileAsBookDefaultHint": "Cargue el patrón para las bibliotecas que utilizan el modo Archivo como libro. Cada archivo es un libro.",
+        "folderAsBookDefault": "Carpeta como libro predeterminado",
+        "folderAsBookDefaultHint": "Cargue el patrón para las bibliotecas que utilizan el modo Carpeta como libro. Cada libro debe estar en su propia carpeta.",
+        "downloadPattern": "Descargar patrón",
+        "downloadPatternHint": "Nombres de archivos sugeridos para descargas de un solo archivo y archivos dentro de ZIP de exportación.",
+        "libraryOverrides": "Anulaciones de biblioteca",
+        "noLibraries": "No hay bibliotecas configuradas. Cree uno en la configuración de la biblioteca para establecer patrones de nombres personalizados.",
+        "badgeCustom": "personalizado",
+        "badgeDefault": "Predeterminado",
+        "orgFolderAsBook": "Carpeta como libro",
+        "orgFileAsBook": "Archivar como libro",
+        "resetToDefault": "Restablecer los valores predeterminados",
+        "patternReference": "Referencia de patrón",
+        "placeholderReference": "Referencia de marcador de posición",
+        "placeholderReferenceHint": "- guía para crear patrones de nombres personalizados",
+        "tokens": "Fichas",
+        "tokensHint": "Copie marcadores de posición rápidamente",
+        "clickTokenHint": "Haga clic en cualquier token para copiarlo a su portapapeles.",
+        "copyValue": "Copiar {value}",
+        "modifiers": "Modificadores",
+        "modifiersHint": "Transformar valores de token",
+        "modifiersExplain": "Agregue un modificador dentro de un token para transformar su valor:",
+        "modFirst": "Solo primer valor",
+        "modSort": "Último, primer formato",
+        "modInitial": "solo la primera letra",
+        "modFixed2": "Dos decimales",
+        "folderOnlyPrefix": "Terminar un patrón con",
+        "folderOnlySuffix": "para especificar solo una carpeta. El nombre del archivo original se conservará en su interior.",
+        "conditionalLogic": "Lógica condicional",
+        "conditionalLogicHint": "Segmentos opcionales y alternativas",
+        "conditionalPart1": "Envolver",
+        "conditionalPart2": "para omitir un segmento cuando su token está vacío. uso",
+        "conditionalPart3": "para un valor predeterminado.",
+        "examples": "Ejemplos",
+        "patternExamples": "Ejemplos de patrones",
+        "patternExamplesHint": "Patrones listos para usar para estilos de biblioteca comunes",
+        "copyPatternTooltip": "Copiar patrón al portapapeles",
+        "exCalibre": "Calibre-estilo predeterminado",
+        "exSeriesReader": "Lector de series",
+        "exCleanDownload": "Limpiar el nombre del archivo de descarga",
+        "exAlphabetical": "Agrupación alfabética con series",
+        "exSeriesFallback": "Reserva en serie o independiente",
+        "exOptionalSubtitle": "Descargar con subtítulo opcional",
+        "exMultilingual": "Biblioteca multilingüe",
+        "exPublisher": "Organizado por el editor",
+        "exStacked": "Carpetas opcionales apiladas",
+        "exFolderDrop": "Colocación de carpeta con nombre de clasificación",
+        "caseWithYear": "con año",
+        "caseNoYear": "ningún año",
+        "caseInSeries": "en serie",
+        "caseStandalone": "independiente",
+        "caseNoSeries": "ninguna serie",
+        "caseFull": "lleno",
+        "caseMinimal": "mínimo",
+        "caseWithLanguage": "con lenguaje",
+        "caseNoLanguage": "sin idioma",
+        "caseWithPublisher": "con editor",
+        "caseNoPublisher": "sin editor",
+        "caseAllSet": "todo listo",
+        "copiedToClipboard": "{value} copiado al portapapeles",
+        "copyTokenFailed": "No se pudo copiar el token",
+        "patternCopied": "Patrón copiado al portapapeles",
+        "copyPatternFailed": "No se pudo copiar el patrón",
+        "labelCopied": "{label} copiado al portapapeles",
+        "copyLabelFailed": "No se pudo copiar {label}"
+      },
+      "kobo": {
+        "title": "Kobo Sincronización",
+        "subtitle": "Empareje su dispositivo Kobo para sincronizar su biblioteca.",
+        "copy": "Copiar",
+        "never": "nunca",
+        "justNow": "Justo ahora",
+        "minutesAgo": "Hace {count}m",
+        "hoursAgo": "Hace {count}h",
+        "daysAgo": "Hace {count}d",
+        "loadFailed": "No se pudo cargar",
+        "devicePaired": "Dispositivo emparejado exitosamente",
+        "devicePairedHint": "Estás listo para configurar tu Kobo. Siga las instrucciones a continuación.",
+        "syncUrl": "Sincronizar URL",
+        "urlNotShownAgain": "Este URL no se volverá a mostrar. Mantenlo en privado.",
+        "registeredDevices": "Dispositivos registrados",
+        "addDevice": "Agregar dispositivo",
+        "deviceName": "Nombre del dispositivo",
+        "deviceNamePlaceholder": "por ej. Mi Kobo Libra",
+        "creating": "Creando...",
+        "createDevice": "Crear dispositivo",
+        "createDeviceFailed": "No se pudo crear el dispositivo",
+        "deviceRegistered": "Dispositivo \"{name}\" registrado",
+        "noDevicesYet": "Aún no hay dispositivos",
+        "noDevicesHint": "Agrega un dispositivo para comenzar a sincronizar tus libros con tu Kobo.",
+        "lastSync": "Última sincronización: {time}",
+        "renameDevice": "Cambiar nombre del dispositivo",
+        "revokeAccess": "Revocar acceso",
+        "deviceRenamed": "Dispositivo renombrado",
+        "renameDeviceFailed": "No se pudo cambiar el nombre del dispositivo",
+        "revokeConfirm": "¿Revocar el acceso a \"{name}\"? El dispositivo no podrá sincronizarse hasta que se vuelva a emparejar.",
+        "accessRevoked": "Acceso revocado para \"{name}\"",
+        "revokeFailed": "No se pudo revocar el acceso",
+        "syncUrlCopied": "Sincronizar URL copiado al portapapeles",
+        "syncUrlCopyFailed": "No se pudo copiar la sincronización URL",
+        "syncPreferences": "Preferencias de sincronización",
+        "twoWaySync": "Sincronización de progreso bidireccional",
+        "twoWaySyncHint": "Sincronizar la posición de lectura entre BookOrbit y Kobo. Requiere entrega KEPUB para ubicaciones precisas y restauración de página confiable.",
+        "syncHighlights": "Sincronizar BookOrbit aspectos destacados con Kobo",
+        "syncHighlightsHint": "Envía los momentos destacados realizados en BookOrbit o KOReader a tu Kobo. Kobo los aspectos destacados se importan a BookOrbit incluso cuando esto está desactivado. Las anotaciones vinculadas sincronizan las ediciones y eliminaciones en ambos sentidos. Requiere entrega KEPUB; el libro en Kobo debe ser el KEPUB descargado de BookOrbit.",
+        "convertKepub": "Convertir a KEPUB",
+        "convertKepubHint": "Envíe EPUB elegibles como KEPUB. Esto permanece activado cuando la sincronización de progreso o los aspectos destacados de BookOrbit-to-Kobo están habilitados. En la siguiente sincronización Kobo, los libros afectados se ofrecen nuevamente como descargas de KEPUB; elimine cualquier copia antigua de EPUB si Kobo sigue abriéndola.",
+        "forceHyphenation": "Forzar separación de palabras",
+        "forceHyphenationHint": "Garantiza una justificación coherente del texto. Esto regenerará los KEPUB almacenados en caché.",
+        "progressThresholds": "Umbrales de progreso",
+        "progressThresholdsHint": "Defina cuándo el progreso de lectura de Kobo actualiza el estado de su biblioteca.",
+        "markAsReading": "Marcar como lectura",
+        "markAsReadingHint": "Porcentaje mínimo para mover un libro a \"Lectura\".",
+        "markAsFinished": "Marcar como terminado",
+        "markAsFinishedHint": "Umbral de porcentaje para marcar un libro como \"Terminado\".",
+        "kepubLimit": "Límite de conversión de KEPUB",
+        "kepubLimitHint": "Los libros que superan este límite se envían como EPUB normales, por lo que BookOrbit no sincronizará su posición de lector con Kobo.",
+        "changesMustBeSaved": "Los cambios deben guardarse para que surtan efecto.",
+        "saving": "Guardando...",
+        "saveSyncSettings": "Guardar configuración de sincronización",
+        "thresholdOrderError": "El umbral de lectura debe ser menor que el umbral final",
+        "saveSettingsFailed": "No se pudo guardar la configuración",
+        "settingsSaved": "Kobo configuración de sincronización guardada",
+        "saveFailed": "No se pudo guardar",
+        "activity": {
+          "waitingForActivity": "esperando actividad",
+          "needsAttention": "necesita atencion",
+          "syncHealthy": "Sincronización saludable",
+          "never": "nunca",
+          "none": "Ninguno",
+          "unknown": "Desconocido",
+          "failureCount": "{count, plural, one {# fracaso} other {# fracasos} many {# fracasos}}",
+          "noActivityRecorded": "No se ha registrado ninguna actividad de sincronización Kobo.",
+          "lastSuccess": "Último éxito {time}",
+          "lastFailure": "Último fallo {time}",
+          "noFailedActivity": "No hay actividad Kobo fallida en el historial reciente.",
+          "noActivityYet": "Aún no hay actividad Kobo.",
+          "event": {
+            "librarySync": "Biblioteca revisada en busca de actualizaciones",
+            "bookDownload": "Libro descargado",
+            "progressUpdate": "Posición de lectura actualizada",
+            "annotationsPull": "Destacados enviados a Kobo",
+            "annotationsPush": "Destacados recibidos de Kobo"
+          },
+          "outcome": {
+            "failed": "Fallido",
+            "noUpdates": "Sin actualizaciones",
+            "noChanges": "Sin cambios",
+            "pending": "Pendiente",
+            "completed": "Completado",
+            "downloaded": "Descargado",
+            "updated": "Actualizado",
+            "sent": "Enviado",
+            "imported": "Importado"
+          },
+          "failure": {
+            "librarySync": "La verificación de la biblioteca no se completó",
+            "bookDownload": "La descarga no se completó",
+            "progressUpdate": "La posición de lectura no se actualizó",
+            "annotationsPull": "Los aspectos más destacados no fueron enviados",
+            "annotationsPush": "Los aspectos más destacados no se importaron."
+          },
+          "chip": {
+            "morePending": "Más pendientes",
+            "noUpdatesPending": "No hay actualizaciones pendientes",
+            "bookCount": "{count, plural, one {# libro} other {# libros} many {# libros}}",
+            "deletedAnnotations": "{count} anotaciones eliminadas",
+            "deviceAlreadyCurrent": "Dispositivo ya actual",
+            "freshHighlightData": "Datos destacados nuevos",
+            "created": "{count} creado",
+            "updated": "{count} actualizado",
+            "deleted": "{count} eliminado",
+            "unchanged": "{count} sin cambios"
+          },
+          "readingPositionSyncedTitle": "Posición de lectura sincronizada: {title}",
+          "readingPositionSynced": "Posición de lectura sincronizada",
+          "labelWithTitle": "{label}: {title}",
+          "updateCount": "{count, plural, one {# actualizar} other {# actualizaciones} many {# actualizaciones}}",
+          "directionToKobo": "BookOrbit -> Kobo",
+          "directionToBookOrbit": "Kobo -> BookOrbit",
+          "twoWaySyncEnabled": "Sincronización bidireccional habilitada",
+          "deviceProgressSaved": "Progreso del dispositivo guardado",
+          "summary": {
+            "noLibraryUpdatesPending": "No hay actualizaciones de biblioteca pendientes para este dispositivo",
+            "libraryUpdatesPrepared": "{count, plural, one {# Actualización de biblioteca preparada para el dispositivo.} other {# actualizaciones de biblioteca preparadas para el dispositivo} many {# actualizaciones de biblioteca preparadas para el dispositivo}}",
+            "bookDownloadedBy": "{title} fue descargado por {device}",
+            "booksDownloaded": "{count, plural, one {# libro descargado} other {# libros descargados} many {# libros descargados}}",
+            "progressUpdatesSyncedFor": "{count, plural, one {# actualización de progreso sincronizada para {title}} other {# actualizaciones de progreso sincronizadas para {title}} many {# actualizaciones de progreso sincronizadas para {title}}}",
+            "progressUpdatesSynced": "{count, plural, one {# actualización de progreso sincronizada} other {# actualizaciones de progreso sincronizadas} many {# actualizaciones de progreso sincronizadas}}",
+            "newReadingPositionFor": "Kobo informó una nueva posición de lectura para {title}",
+            "newReadingPosition": "Kobo informó una nueva posición de lectura",
+            "noHighlightChangesNeededFor": "No se necesitan cambios destacados para {title}",
+            "noHighlightChangesNeeded": "No se necesitan cambios destacados",
+            "highlightsSentToKoboFor": "{count, plural, one {# resaltado enviado a Kobo para {title}} other {# destacados enviados a Kobo para {title}} many {# destacados enviados a Kobo para {title}}}",
+            "highlightsSentToKobo": "{count, plural, one {# resaltado enviado a Kobo} other {# destacados enviados a Kobo} many {# destacados enviados a Kobo}}",
+            "noKoboHighlightChangesFor": "No hay cambios destacados de Kobo para {title}",
+            "noKoboHighlightChanges": "No hay cambios destacados de Kobo",
+            "highlightsImportedFromKoboFor": "{count, plural, one {# resaltado importado de Kobo para {title}} other {# aspectos destacados importados de Kobo para {title}} many {# aspectos destacados importados de Kobo para {title}}}",
+            "highlightsImportedFromKobo": "{count, plural, one {# resaltado importado de Kobo} other {# aspectos destacados importados de Kobo} many {# aspectos destacados importados de Kobo}}"
+          },
+          "timeRange": "{from} a {to}",
+          "eventsGrouped": "{count, plural, one {# evento agrupado} other {# eventos agrupados} many {# eventos agrupados}}",
+          "removedDevice": "Dispositivo eliminado",
+          "loadMoreFailed": "No se pudo cargar más historial",
+          "historyRefreshed": "Kobo historial de sincronización actualizado",
+          "refreshFailed": "No se pudo actualizar el historial",
+          "recentActivity": "Actividad reciente de Kobo",
+          "filterAll": "Todos",
+          "filterFailures": "Fallos",
+          "refresh": "Actualizar",
+          "loadingActivity": "Cargando actividad Kobo...",
+          "noActivityHint": "La actividad de sincronización reciente aparecerá después de que un Kobo contacto contacte a BookOrbit.",
+          "error": "error",
+          "loading": "Cargando...",
+          "loadMore": "Cargar más actividad"
+        },
+        "howBooksSynced": {
+          "title": "Cómo se sincronizan los libros",
+          "body": "Para enviar libros a su dispositivo Kobo, debe habilitar {syncToKobo} en las colecciones que contienen esos libros. Abra cualquier colección desde la barra lateral, haga clic en el ícono Editar y active {syncToKobo}. Los libros que no forman parte de una colección habilitada no se sincronizarán."
+        },
+        "nextSteps": {
+          "title": "Próximos pasos",
+          "step1": "1. Configure su dispositivo Kobo para sincronizarlo con la sincronización URL anterior.",
+          "step2": "2. En BookOrbit, vaya a cualquier colección de la barra lateral, haga clic en el ícono Editar y habilite {syncToKobo}. Solo los libros dentro de colecciones habilitadas para sincronización se descargarán en su dispositivo."
+        },
+        "syncToKobo": "Sincronizar con Kobo",
+        "tabs": {
+          "syncSettings": "Configuración de sincronización",
+          "activityLog": "Registro de actividad"
+        }
+      },
+      "koreader": {
+        "title": "KOReader Sincronización",
+        "subtitle": "Explore su catálogo BookOrbit en KOReader y sincronice el progreso, la actividad de lectura, los aspectos destacados y los cambios de anotaciones.",
+        "tabs": {
+          "sync": "Configuración de sincronización",
+          "fileNaming": "Nomenclatura de archivos"
+        },
+        "fileNaming": {
+          "accountTitle": "Patrón KOReader predeterminado de la cuenta",
+          "accountDescription": "Establece la carpeta relativa predeterminada y el nombre de archivo utilizado por las descargas del complemento BookOrbit para su cuenta KOReader. Las reglas específicas del dispositivo pueden anularlo a continuación.",
+          "defaultPattern": "Patrón de ruta de libro predeterminado",
+          "accountHelp": "Su cuenta es la predeterminada para las descargas de complementos KOReader, a menos que un dispositivo tenga una regla personalizada.",
+          "accountHint": "Utilizado por sus dispositivos KOReader que no tienen una anulación personalizada.",
+          "preview": "Vista previa",
+          "saveAccount": "Guardar cuenta predeterminada",
+          "deviceTitle": "KOReader anulaciones de dispositivos",
+          "deviceDescription": "Personalice cualquier combinación de rutas predeterminadas, en serie e independientes. Las filas vacías específicas del dispositivo heredan el valor predeterminado del dispositivo, que a su vez puede heredar el patrón KOReader predeterminado de la cuenta.",
+          "noDevices": "Los dispositivos aparecen aquí después de sincronizarse con BookOrbit.",
+          "customOrganization": "Organización personalizada",
+          "usingAccountDefault": "Usando la cuenta predeterminada",
+          "deviceDefaultHelp": "Respaldo para este dispositivo. Déjelo igual al valor predeterminado de la cuenta para heredar los cambios futuros automáticamente.",
+          "seriesBooks": "Libros en una serie.",
+          "seriesHelp": "Ruta opcional utilizada solo para libros con metadatos de series. Déjelo vacío para usar el patrón de ruta predeterminado de este dispositivo.",
+          "standaloneBooks": "Libros sin serie.",
+          "standaloneHelp": "Ruta opcional utilizada solo para libros sin metadatos de serie. Déjelo vacío para usar el patrón de ruta predeterminado de este dispositivo.",
+          "inheritPlaceholder": "Déjelo vacío para usar el patrón predeterminado de este dispositivo",
+          "useAccount": "Usar cuenta predeterminada",
+          "saveOverride": "Guardar anulación",
+          "loadFailed": "No se pudo cargar la configuración de organización de archivos",
+          "accountRequired": "Ingrese un patrón de ruta de libro predeterminado antes de guardar.",
+          "accountSaved": "Patrón KOReader predeterminado de la cuenta guardado",
+          "accountSaveFailed": "No se pudo guardar la configuración de organización de archivos",
+          "deviceUsesAccount": "El dispositivo ahora usa el patrón predeterminado de la cuenta KOReader",
+          "deviceSaved": "Anulación de la organización del dispositivo guardada",
+          "deviceSaveFailed": "No se pudo guardar la anulación del dispositivo",
+          "deviceResetFailed": "No se pudo restablecer la anulación del dispositivo"
+        },
+        "loadingSettings": "Cargando configuración de KOReader...",
+        "loadFailed": "No se pudo cargar la configuración de KOReader",
+        "never": "nunca",
+        "justNow": "Justo ahora",
+        "minutesAgo": "Hace {count}m",
+        "hoursAgo": "Hace {count}h",
+        "daysAgo": "Hace {count}d",
+        "unknown": "Desconocido",
+        "updateAvailable": "Actualización disponible",
+        "upToDate": "actualizado",
+        "versionUnknown": "Versión desconocida",
+        "latestPlugin": "Complemento más reciente: v{version}",
+        "latestPluginUnavailable": "El último complemento no está disponible",
+        "notConfigured": "La sincronización KOReader no está configurada",
+        "notConfiguredHint": "Cree un conjunto de credenciales de sincronización y luego úselas con el complemento BookOrbit KOReader para navegar, descargar, progresar, leer eventos, resaltar y eliminar.",
+        "createCredentials": "Crear credenciales",
+        "createFormTitle": "Crear KOReader credenciales de sincronización",
+        "createFormHint": "Estas credenciales autentican sus dispositivos KOReader con BookOrbit.",
+        "username": "Nombre de usuario",
+        "usernamePlaceholder": "por ej. mi lector",
+        "password": "Contraseña",
+        "passwordPlaceholder": "Mínimo 6 caracteres",
+        "creating": "Creando...",
+        "create": "crear",
+        "credentialsCreated": "KOReader credenciales de sincronización creadas",
+        "createCredentialsFailed": "No se pudieron crear las credenciales",
+        "status": "KOReader Estado",
+        "refresh": "Actualizar",
+        "progressSync": "Sincronización de progreso",
+        "progressSyncHint": "Permita que los dispositivos KOReader sincronicen el progreso, la actividad de lectura, los aspectos destacados y la eliminación de anotaciones con BookOrbit.",
+        "lastSync": "Última sincronización",
+        "syncedBooks": "Libros sincronizados",
+        "bookCount": "{count, plural, =0 {sin libros} one {# libro} other {# libros} many {# libros}}",
+        "devices": "Dispositivos",
+        "deviceCount": "{count, plural, =0 {sin dispositivos} one {# dispositivo} other {# dispositivos} many {# dispositivos}}",
+        "credentialsCreatedLabel": "Credenciales creadas",
+        "setup": "Configuración",
+        "pluginServerUrl": "Servidor de complementos URL",
+        "copied": "Copiado",
+        "copyUrl": "Copiar URL",
+        "preconfiguredPlugin": "Complemento BookOrbit preconfigurado",
+        "preconfiguredPluginHintPrefix": "Descargue un zip con el servidor URL y su inicio de sesión de sincronización ya configurado. El complemento incluye navegación y sincronización del catálogo. Copie la carpeta a",
+        "preconfiguredPluginHintSuffix": "y reinicie KOReader.",
+        "latestPluginNote": "{label}. Las actualizaciones de dispositivos se ejecutan desde el menú BookOrbit en KOReader.",
+        "preparing": "Preparando...",
+        "downloadPlugin": "Descargar complemento",
+        "noDevicesSynced": "Aún no se han sincronizado ningún dispositivo",
+        "noDevicesSyncedHint": "Instale el complemento BookOrbit para una sincronización completa o configure la sincronización del progreso del stock de KOReader para actualizaciones de solo progreso.",
+        "lastSyncLabel": "Última sincronización:",
+        "lastBookLabel": "Último libro:",
+        "noneYet": "Ninguno todavía",
+        "pluginActivity": "Actividad del complemento",
+        "noPluginActivity": "Aún no se ha informado ninguna actividad de complementos.",
+        "lastFullSync": "Última sincronización completa: {time}",
+        "latestPluginSuffix": "- último complemento v{version}",
+        "matchedBooks": "Libros emparejados",
+        "readingEvents": "Eventos de lectura",
+        "highlights": "Lo más destacado",
+        "syncedTotals": "Totales sincronizados",
+        "trashedHighlights": "Destacados destrozados",
+        "pendingDeletes": "{count, plural, =0 {no hay elementos destacados eliminados en espera de reconocimiento del complemento KOReader.} one {# resaltado eliminado en espera de reconocimiento del complemento KOReader.} other {# aspectos destacados eliminados en espera de reconocimiento del complemento KOReader.} many {# aspectos destacados eliminados en espera de reconocimiento del complemento KOReader.}}",
+        "failedPositions": "{count, plural, =0 {ninguna posición destacada necesita atención.} one {# La posición destacada necesita atención.} other {# Las posiciones destacadas necesitan atención.} many {# Las posiciones destacadas necesitan atención.}}",
+        "setupGuide": "Guía de configuración",
+        "setupSteps": "KOReader pasos de configuración",
+        "setupStepsHint": "Utilice el complemento BookOrbit para explorar catálogos, descargas, progreso, lectura de eventos y aspectos destacados. Utilice el complemento estándar solo para progresar.",
+        "pluginGuideTitle": "Complemento BookOrbit",
+        "pluginStep1": "Descargue el complemento preconfigurado arriba.",
+        "pluginStep2Prefix": "Descomprimirlo y copiar",
+        "pluginStep2Middle": "a",
+        "pluginStep2Suffix": "en tu dispositivo.",
+        "pluginStep3": "Reinicie KOReader. El servidor y el inicio de sesión se configuran automáticamente.",
+        "pluginStep4Prefix": "Abierto",
+        "pluginStep4Suffix": "para buscar, descargar y vincular libros para sincronizar.",
+        "stockGuideTitle": "Complemento de sincronización de progreso de stock",
+        "stockStep1Prefix": "En su dispositivo KOReader, vaya a",
+        "stockStep1Suffix": ".",
+        "stockStep2": "Configure el servidor de sincronización personalizado en el URL que se muestra arriba.",
+        "stockStep3": "Ingrese el nombre de usuario y la contraseña que creó, luego toque Iniciar sesión.",
+        "locationNote": "BookOrbit guarda ubicaciones EPUB compatibles con KOReader del lector web. La restauración debe aterrizar cerca de la misma posición, aunque la ubicación exacta de la línea puede variar según el lector y el diseño de EPUB.",
+        "dangerZone": "Zona de peligro",
+        "deleteCredentials": "Eliminar KOReader credenciales",
+        "deleteCredentialsHint": "Elimine las credenciales de sincronización y desconecte todos los dispositivos. Se conservarán los datos de progreso.",
+        "credentialsDeleted": "KOReader credenciales eliminadas",
+        "deleteCredentialsFailed": "No se pudieron eliminar las credenciales",
+        "deleteConfirmTitle": "¿Eliminar KOReader credenciales?",
+        "deleteConfirmBody": "Esto eliminará sus credenciales de sincronización y desconectará todos los KOReader dispositivos. Se conservarán los datos de progreso existentes.",
+        "syncEnabled": "KOReader sincronización habilitada",
+        "syncDisabled": "KOReader sincronización deshabilitada",
+        "toggleSyncFailed": "No se pudo alternar la sincronización",
+        "syncUrlCopied": "Sincronizar URL copiado al portapapeles",
+        "syncUrlCopyFailed": "No se pudo copiar la sincronización URL",
+        "statusRefreshed": "Estado de sincronización actualizado",
+        "refreshFailed": "No se pudo actualizar",
+        "pluginDownloaded": "Complemento descargado. Copie bookorbit.koplugin del zip a koreader/plugins/ en su dispositivo.",
+        "pluginDownloadFailed": "No se pudo descargar el complemento",
+        "hashLinks": {
+          "unmatchedTitle": "Libros KOReader inigualables",
+          "unmatchedBooks": "Libros inigualables",
+          "manualTitle": "Manual KOReader Enlaces",
+          "refresh": "Actualizar",
+          "link": "Enlace",
+          "change": "Cambiar",
+          "unlink": "Desvincular",
+          "hash": "Hash:",
+          "lastOpened": "Última apertura:",
+          "firstSeen": "Visto por primera vez:",
+          "lastSeen": "Visto por última vez:",
+          "linked": "Vinculado:",
+          "updated": "Actualizado:",
+          "linkedTo": "Vinculado a {title}",
+          "loadingUnmatched": "Cargando libros inigualables...",
+          "loadingManual": "Cargando enlaces hash manuales...",
+          "noUnmatched": "No hay libros KOReader incomparables.",
+          "noManual": "No hay enlaces manuales KOReader.",
+          "pageOf": "Página {page} de {total}",
+          "showingRange": "Mostrando {start}-{end} de {total}",
+          "unknownFile": "Archivo KOReader desconocido {hash}",
+          "unknownAuthor": "Autor desconocido",
+          "noTitleOrAuthor": "No se reporta título ni autor",
+          "bookNumber": "BookOrbit libro #{id}",
+          "toast": {
+            "unmatchedRefreshed": "Libros inigualables actualizados",
+            "unmatchedRefreshFailed": "No se pudieron actualizar los libros no coincidentes",
+            "manualRefreshed": "Enlaces hash manuales actualizados",
+            "manualRefreshFailed": "No se pudieron actualizar los enlaces hash manuales",
+            "bookLinked": "Libro vinculado",
+            "linkUpdated": "Enlace actualizado",
+            "linkFailed": "No se pudo vincular el libro",
+            "linkRemoved": "Enlace eliminado",
+            "unlinkFailed": "No se pudo desvincular el libro",
+            "unmatchedDismissed": "Libro inigualable descartado",
+            "dismissFailed": "No se pudo descartar el libro no coincidente",
+            "allDismissed": "{count, plural, =0 {No se han descartado libros sin igual} one {Despedido # libro inigualable} other {Despedido # libros inigualables} many {Despedido # libros inigualables}}",
+            "dismissAllFailed": "No se pudieron descartar todos los libros no coincidentes"
+          },
+          "modal": {
+            "linkTitle": "Enlace KOReader libro",
+            "changeTitle": "Cambiar enlace KOReader",
+            "bookOrbitBook": "BookOrbit libro",
+            "searchPlaceholder": "Busque en su biblioteca BookOrbit",
+            "minChars": "Introduzca al menos 2 caracteres.",
+            "searching": "Buscando...",
+            "noBooksFound": "No se encontraron libros.",
+            "untitledBook": "Libro sin título",
+            "selected": "Seleccionado",
+            "select": "Seleccionar",
+            "loadMore": "Cargar más",
+            "confirmTitle": "Confirmar enlace KOReader",
+            "koreader": "KOReader",
+            "bookOrbit": "BookOrbit",
+            "bookId": "ID del libro: {id}",
+            "syncedStatsNote": "Las estadísticas ya sincronizadas permanecerán en su libro BookOrbit actual.",
+            "chooseDifferent": "Elige diferente",
+            "saving": "Guardando...",
+            "confirmLink": "Confirmar enlace",
+            "unlinkTitle": "¿Desvincular el libro KOReader?",
+            "unlinkBody": "Las sincronizaciones futuras de este hash dejarán de resolverse en {title} hasta que se vuelva a vincular. Las estadísticas ya sincronizadas permanecerán en su libro BookOrbit actual.",
+            "unlinking": "Desvinculando..."
+          },
+          "dismiss": "Descartar",
+          "dismissAll": "Descartar todo",
+          "dismissing": "Descartando...",
+          "unlinking": "Desvinculando...",
+          "unlinkConfirmTitle": "¿Desvincular el libro KOReader?",
+          "unlinkConfirmBody": "Las sincronizaciones futuras de este hash dejarán de resolverse en {title} hasta que se vuelva a vincular. Las estadísticas ya sincronizadas permanecerán en su libro BookOrbit actual.",
+          "dismissConfirmTitle": "¿Descartar {title}?",
+          "dismissConfirmBody": "Esto lo elimina de su lista de libros no coincidentes. Si algún dispositivo vuelve a informar este hash, reaparecerá como una nueva entrada.",
+          "dismissAllConfirmTitle": "{count, plural, =0 {no hay libros incomparables} one {Descartar todo # libro inigualable?} other {Descartar todo # ¿Libros incomparables?} many {Descartar todo # ¿Libros incomparables?}}",
+          "dismissAllConfirmBody": "Esto borra toda la lista de libros no coincidentes, no solo la página actual. Si algún dispositivo vuelve a informar uno de estos hashes, reaparecerá como una nueva entrada.",
+          "changeLinkTitle": "Cambiar enlace KOReader",
+          "linkBookTitle": "Enlace KOReader libro",
+          "bookOrbitBook": "BookOrbit libro",
+          "searchLibraryPlaceholder": "Busque en su biblioteca BookOrbit",
+          "enterMinChars": "Introduzca al menos 2 caracteres.",
+          "searching": "Buscando...",
+          "noBooksFound": "No se encontraron libros.",
+          "untitledBook": "Libro sin título",
+          "selected": "Seleccionado",
+          "select": "Seleccionar",
+          "loadMore": "Cargar más",
+          "loadingMore": "Cargando...",
+          "confirmLinkTitle": "Confirmar enlace KOReader",
+          "bookId": "ID del libro: {id}",
+          "syncedStatsNote": "Las estadísticas ya sincronizadas permanecerán en su libro BookOrbit actual.",
+          "chooseDifferent": "Elige diferente",
+          "saving": "Guardando...",
+          "confirmLink": "Confirmar enlace"
+        },
+        "remove": "Quitar",
+        "removing": "Eliminando...",
+        "unmatchedBooks": "Libros inigualables",
+        "deviceRemoved": "Dispositivo eliminado",
+        "removeDeviceFailed": "No se pudo eliminar el dispositivo",
+        "removeDeviceConfirmTitle": "¿Eliminar {device}?",
+        "removeDeviceConfirmBody": "Esto elimina permanentemente el progreso sincronizado de este dispositivo, la actividad de lectura y cualquier entrada de libros no coincidentes que ya no haya sido reportada por otro dispositivo. Si el dispositivo se sincroniza nuevamente más tarde, volverá a aparecer como una nueva entrada."
+      },
+      "opds": {
+        "title": "OPDS",
+        "subtitle": "Conecte aplicaciones de lectura compatibles con OPDS como KOReader o Thorium Reader a su biblioteca.",
+        "copy": "Copiar",
+        "loadFailed": "No se pudo cargar",
+        "server": "Servidor",
+        "catalogServer": "OPDS Servidor de catálogo",
+        "catalogServerHint": "Permitir que los clientes OPDS busquen y descarguen libros",
+        "endpoint": "Punto final",
+        "accounts": "OPDS Cuentas",
+        "add": "Añadir",
+        "addAccount": "Agregar cuenta",
+        "username": "Nombre de usuario",
+        "usernameLabel": "Nombre de usuario",
+        "usernamePlaceholder": "por ej. lector coreano",
+        "password": "Contraseña",
+        "passwordPlaceholder": "Mínimo 8 caracteres",
+        "defaultSort": "Orden predeterminado",
+        "sortLabel": "Ordenar",
+        "creating": "Creando...",
+        "create": "crear",
+        "noAccounts": "Aún no hay cuentas OPDS. Cree uno para comenzar a usar OPDS clientes.",
+        "hideDetails": "Ocultar detalles",
+        "showDetails": "Mostrar detalles",
+        "copyUsername": "Copiar nombre de usuario",
+        "notes": "OPDS Notas",
+        "notesBody": "Utilice cuentas OPDS en aplicaciones de lectura. Mantenga las credenciales privadas y rote las contraseñas si se comparten accidentalmente.",
+        "deleteConfirmTitle": "¿Eliminar la cuenta OPDS?",
+        "deleteConfirmBody": "Eliminar \"{username}\". Esta acción no se puede deshacer.",
+        "sortRecent": "Agregado recientemente",
+        "sortTitleAsc": "Título (A-Z)",
+        "sortTitleDesc": "Título (Z-A)",
+        "sortAuthorAsc": "Autor (A-Z)",
+        "sortAuthorDesc": "Autor (Z-A)",
+        "sortSeriesAsc": "Serie (A-Z)",
+        "sortSeriesDesc": "Serie (Z-A)",
+        "serverEnabled": "Servidor OPDS habilitado",
+        "serverDisabled": "OPDS servidor deshabilitado",
+        "updateSettingsFailed": "No se pudo actualizar la configuración de OPDS",
+        "urlCopied": "OPDS URL copiado al portapapeles",
+        "urlCopyFailed": "No se pudo copiar OPDS URL",
+        "createUserFailed": "No se pudo crear el usuario OPDS",
+        "userCreated": "OPDS usuario \"{username}\" creado",
+        "sortOrderUpdated": "Orden de clasificación actualizado para \"{username}\"",
+        "updateSortFailed": "No se pudo actualizar el orden de clasificación",
+        "userDeleted": "OPDS usuario \"{username}\" eliminado",
+        "deleteUserFailed": "No se pudo eliminar el usuario OPDS",
+        "labelCopied": "{label} copiado",
+        "copyLabelFailed": "No se pudo copiar {label}"
+      },
+      "tabs": {
+        "general": "generales",
+        "ebook": "libro electrónico",
+        "pdf": "PDF",
+        "comics": "Cómics",
+        "audio": "Audiolibro",
+        "fonts": "Fuentes"
+      }
+    },
+    "system": {
+      "tabs": {
+        "file-naming": "Nomenclatura de archivos",
+        "book-dock": "Book Dock",
+        "maintenance": "Mantenimiento",
+        "audit-log": "Registro de auditoría"
+      }
+    }
+  },
+  "achievements": {
+    "title": "Logros",
+    "tiersCount": "{earned} / {total} niveles",
+    "loadFailed": "No se pudieron cargar los logros",
+    "tryAgain": "Inténtalo de nuevo",
+    "noMatchFilter": "Ningún logro coincide con este filtro",
+    "secretAchievement": "Logro secreto",
+    "earnedOn": "Obtuvo {date}",
+    "whileReading": "Mientras lee “{title}”",
+    "tierProgress": "Nivel {earned} de {total}",
+    "progressToNext": "{current} / {threshold} a {name}",
+    "rarity": {
+      "common": "común",
+      "rare": "raro",
+      "epic": "Épico",
+      "legendary": "Legendario"
+    },
+    "filter": {
+      "all": "Todos",
+      "earned": "Obtenido ({count})",
+      "inProgress": "En curso ({count})",
+      "locked": "Bloqueado ({count})"
+    }
+  },
+  "adminFeature": {
+    "accountActivity": {
+      "title": "Actividad de la cuenta",
+      "subtitle": "Revise la actividad de autenticación de la cuenta sin exponer el historial de lectura.",
+      "privacyNotice": "Esta página informa únicamente los inicios de sesión y las actualizaciones de autenticación. No utiliza el historial de lectura, el progreso del libro ni la actividad de la biblioteca.",
+      "privacyLabel": "Acerca de la privacidad de la actividad de la cuenta",
+      "never": "nunca",
+      "openInsightsFor": "Abrir información de lectura compartida para {name}",
+      "permissionLabel": "Ver actividad del usuario",
+      "states": {
+        "recent": "Activo recientemente",
+        "dormant": "latente",
+        "never": "No hay actividad registrada",
+        "disabled": "Discapacitado"
+      },
+      "filters": {
+        "search": "Buscar cuentas",
+        "searchPlaceholder": "Buscar nombre o nombre de usuario",
+        "state": "Estado de actividad",
+        "allStates": "Todos los estados de actividad",
+        "provisioning": "Método de autenticación",
+        "allMethods": "Todos los métodos de autenticación",
+        "sort": "ordenar cuentas",
+        "mostRecent": "Activo más reciente",
+        "leastRecent": "Menos activo recientemente",
+        "lastLogin": "Inicio de sesión más reciente",
+        "newest": "Cuentas más recientes",
+        "oldest": "Cuentas más antiguas",
+        "name": "Nombre",
+        "apply": "Aplicar",
+        "clear": "Borrar"
+      },
+      "methods": {
+        "local": "Local",
+        "manual": "Creado por el administrador",
+        "oidc": "OIDC/SSO",
+        "shared": "Enlace mágico compartido"
+      },
+      "columns": {
+        "user": "Usuario",
+        "state": "Estado de la cuenta",
+        "lastLogin": "Último inicio de sesión",
+        "lastAuthenticated": "Último autenticado",
+        "created": "Creado",
+        "readingInsights": "Ideas de lectura"
+      },
+      "sharing": {
+        "private": "No compartido",
+        "summary": "Resumen compartido",
+        "detailed": "Detallado compartido"
+      },
+      "empty": {
+        "title": "No se encontraron cuentas",
+        "description": "Intente cambiar o borrar los filtros actuales."
+      },
+      "pagination": {
+        "label": "Páginas de actividad de la cuenta",
+        "page": "Página {page} de {totalPages}"
+      },
+      "errors": {
+        "load": "No se pudo cargar la actividad de la cuenta."
+      }
+    },
+    "sharedInsights": {
+      "title": "Ideas de lectura compartidas",
+      "subtitle": "Leyendo información que este usuario decidió compartir voluntariamente.",
+      "auditNotice": "El acceso a este perfil queda registrado y es visible para el usuario.",
+      "period": "Período del informe",
+      "periodDays": "Últimos {count} días",
+      "durationMinutes": "{count, plural, one {# minuto} other {# minutos} many {# minutos}}",
+      "durationHours": "{count} horas",
+      "metrics": {
+        "sessions": "Sesiones",
+        "readingTime": "tiempo de lectura",
+        "activeDays": "Días activos",
+        "started": "libros comenzados",
+        "completed": "Libros completados"
+      },
+      "trend": "Tendencia de lectura diaria",
+      "emptyTitle": "No hay actividad de lectura en este período.",
+      "noData": "No hay datos de lectura registrados para este período.",
+      "sourceNames": {
+        "web": "Lector web",
+        "koreader": "KOReader",
+        "manual": "Manual",
+        "kobo": "Kobo",
+        "unknown": "Desconocido"
+      },
+      "formats": "Formatos",
+      "genres": "Géneros",
+      "broadGenres": {
+        "science_fiction": "Ciencia ficcion",
+        "fantasy": "fantasía",
+        "mystery_thriller": "Misterio y suspense",
+        "romance": "romance",
+        "horror": "Terror",
+        "history_biography": "Historia y biografía",
+        "science_technology": "Ciencia y tecnología",
+        "business_economics": "Negocios y economía",
+        "self_development": "Autodesarrollo",
+        "society_culture": "Sociedad y cultura",
+        "children_young_adult": "Niños y adultos jóvenes",
+        "comics_graphic_novels": "Cómics y novelas gráficas",
+        "poetry": "poesía",
+        "other": "Otro"
+      },
+      "sources": "Fuentes de datos",
+      "topBooks": "Libros más leídos",
+      "recentBooks": "leído recientemente",
+      "unknownTitle": "Libro sin título",
+      "top": {
+        "authors": "Autores principales",
+        "genres": "Géneros principales",
+        "series": "Serie superior",
+        "narrators": "Narradores principales"
+      },
+      "errors": {
+        "READING_INSIGHTS_PRIVATE": "Este usuario no comparte información de lectura.",
+        "READING_INSIGHTS_SUMMARY_ONLY": "Este usuario solo comparte información resumida.",
+        "READING_INSIGHTS_VIEW_SESSION_REQUIRED": "Se requiere una sesión de visualización de perfil.",
+        "READING_INSIGHTS_VIEW_SESSION_INVALID": "Esta vista de perfil expiró o ya no es válida.",
+        "LOAD_FAILED": "No se pudieron cargar las ideas de lectura compartidas.",
+        "cleared": "No se muestra ninguna información de perfil cargada previamente."
+      }
+    },
+    "resetLink": {
+      "title": "Enlace para restablecer contraseña",
+      "description": "Comparte este enlace con el usuario. Caduca en 15 minutos.",
+      "copy": "Copiar",
+      "copied": "¡Copiado!",
+      "copyFailed": "Copia fallida",
+      "notShownAgain": "Este enlace no se volverá a mostrar."
+    },
+    "userForm": {
+      "editUser": "Editar usuario",
+      "createUser": "Crear usuario",
+      "createSharedAccount": "Crear cuenta compartida",
+      "sharedBadge": "Compartido",
+      "active": "Activo",
+      "suspended": "suspendido",
+      "tabs": {
+        "general": "generales",
+        "access": "acceso",
+        "restrictions": "restricciones"
+      },
+      "sharedAccount": "cuenta compartida",
+      "sharedAccountHint": "Sin contraseña. El acceso se otorga únicamente a través de enlaces mágicos.",
+      "sharedAccountManageHint": "Administre los enlaces de inicio de sesión desde Configuración - Enlaces mágicos.",
+      "username": "Nombre de usuario",
+      "fullName": "nombre completo",
+      "email": "Correo electrónico",
+      "optional": "(opcional)",
+      "libraryAccess": "Acceso a la biblioteca",
+      "noLibrariesSelected": "No hay bibliotecas seleccionadas. El usuario no puede ver ningún libro.",
+      "permissions": "Permisos",
+      "presetStandard": "Estándar",
+      "presetAdmin": "administrador",
+      "presetClearAll": "Borrar todo",
+      "permissionGroups": {
+        "content": "Contenido",
+        "devicesAccess": "Dispositivos y acceso",
+        "email": "Correo electrónico",
+        "administration": "administración",
+        "notifications": "Notificaciones",
+        "restrictions": "Restricciones"
+      },
+      "superuserTarget": "Objetivo de superusuario",
+      "superuserTargetHint": "No se pueden aplicar restricciones de contenido a los superusuarios.",
+      "noRestrictions": "Sin restricciones de contenido",
+      "noRestrictionsHint": "Este usuario tiene acceso completo a todos los libros de sus bibliotecas asignadas.",
+      "addRestrictions": "+ Agregar restricciones de contenido",
+      "contentRestrictions": "Restricciones de contenido",
+      "remove": "Quitar",
+      "includeTags": "Incluir etiquetas",
+      "includeTagsHint": "(mostrar sólo libros con estas etiquetas)",
+      "excludeTags": "Excluir etiquetas",
+      "excludeTagsHint": "(ocultar libros con estas etiquetas)",
+      "includeGenres": "Incluir géneros",
+      "includeGenresHint": "(mostrar sólo libros con estos géneros)",
+      "excludeGenres": "Excluir géneros",
+      "excludeGenresHint": "(ocultar libros con estos géneros)",
+      "searchTagsPlaceholder": "Buscar etiquetas...",
+      "searchGenresPlaceholder": "Buscar géneros...",
+      "saving": "Guardando...",
+      "errors": {
+        "updateUser": "No se pudo actualizar el usuario",
+        "updatePermissions": "No se pudieron actualizar los permisos",
+        "updateLibraryAccess": "No se pudo actualizar el acceso a la biblioteca",
+        "updateContentFilters": "No se pudieron actualizar los filtros de contenido",
+        "emailRequired": "Se requiere correo electrónico",
+        "createSharedAccount": "No se pudo crear una cuenta compartida",
+        "createUser": "No se pudo crear el usuario"
+      }
+    },
+    "usersPage": {
+      "usersTitle": "Usuarios",
+      "magicLinksTitle": "Enlaces mágicos",
+      "usersSubtitle": "Administrar cuentas de usuario y asignaciones de permisos.",
+      "magicLinksSubtitle": "Cree enlaces de inicio de sesión que se puedan compartir para cuentas compartidas.",
+      "createUser": "Crear usuario",
+      "createLink": "Crear enlace",
+      "usersTab": "Usuarios",
+      "magicLinksTab": "Enlaces mágicos",
+      "columns": {
+        "name": "Nombre",
+        "username": "Nombre de usuario",
+        "email": "Correo electrónico",
+        "access": "Acceso",
+        "status": "Estado"
+      },
+      "adminBadge": "administrador",
+      "permissionCount": "{count, plural, =0 {sin permisos} one {un permiso} other {# permisos} many {# permisos}}",
+      "filteredBadge": "Filtrado",
+      "contentRestrictionsActive": "Restricciones de contenido activas",
+      "statusActive": "Activo",
+      "statusInactive": "Inactivo",
+      "resetPassword": "Restablecer contraseña",
+      "resetPasswordOidcHint": "OIDC usuarios restablecen contraseñas en su proveedor de identidad",
+      "resetPasswordSharedHint": "Las cuentas compartidas no tienen contraseñas",
+      "resetPasswordOidcHintFull": "OIDC usuarios restablecen contraseñas en su proveedor de identidad.",
+      "resetPasswordSharedHintFull": "Las cuentas compartidas no tienen contraseñas.",
+      "deleteUserAction": "Eliminar usuario",
+      "deleteDialogTitle": "¿Eliminar usuario?",
+      "deleteDialogBody": "Eliminar usuario \"{username}\". Esta acción no se puede deshacer.",
+      "deleting": "Eliminando...",
+      "errors": {
+        "loadData": "No se pudieron cargar los datos",
+        "load": "No se pudo cargar",
+        "deleteUser": "No se pudo eliminar el usuario"
+      },
+      "currentUsers": "Usuarios actuales",
+      "defaultLibraryAccess": {
+        "title": "Acceso predeterminado a la biblioteca",
+        "subtitle": "Acceso de espectador otorgado a usuarios registrados automáticamente y proporcionados por OIDC.",
+        "description": "Seleccione las bibliotecas asignadas automáticamente a los nuevos usuarios.",
+        "noLibraries": "No hay bibliotecas disponibles.",
+        "save": "Guardar valores predeterminados",
+        "saving": "Guardando...",
+        "saved": "Acceso predeterminado a la biblioteca guardado.",
+        "saveError": "No se pudo guardar el acceso predeterminado a la biblioteca"
+      }
+    }
+  },
+  "annotations": {
+    "unknownBook": "libro desconocido",
+    "styles": {
+      "highlight": "Resaltar",
+      "underline": "subrayado",
+      "strike": "Tachado",
+      "squiggle": "Ondulado",
+      "invert": "invertir"
+    },
+    "combobox": {
+      "filterByBook": "Filtrar por libro",
+      "allBooks": "Todos los libros",
+      "clearBookFilter": "Borrar filtro de libro",
+      "searching": "Buscando...",
+      "noBooksFound": "No se encontraron libros"
+    },
+    "bulk": {
+      "countSelected": "{count} seleccionado",
+      "pageSelected": "Página seleccionada",
+      "selectPage": "Seleccionar página",
+      "clear": "Borrar",
+      "recolorTo": "Cambiar el color a {color}",
+      "restyleTo": "Cambiar el estilo a {style}"
+    },
+    "chips": {
+      "active": "Activo:",
+      "removeFilter": "Quitar filtro {label}",
+      "clearAll": "Borrar todo"
+    },
+    "filters": {
+      "colors": "Colores",
+      "dateRange": "Rango de fechas",
+      "fromDate": "Desde la fecha",
+      "toDate": "hasta la fecha",
+      "to": "a",
+      "clearDateRange": "Borrar rango de fechas",
+      "clearAll": "Borrar todo"
+    },
+    "pagination": {
+      "showing": "Mostrando {start}-{end} de {total}",
+      "pageOf": "Página {page} de {totalPages}",
+      "firstPage": "Primera pagina",
+      "previousPage": "Pagina anterior",
+      "nextPage": "Página siguiente",
+      "lastPage": "Última página"
+    },
+    "sync": {
+      "loading": "Cargando detalles de sincronización",
+      "positions": "Posiciones",
+      "devices": "Dispositivos",
+      "retryConversion": "Reintentar la conversión",
+      "noStoredPositions": "No hay posiciones almacenadas.",
+      "notSynced": "Aún no sincronizado con ningún dispositivo.",
+      "upToDate": "actualizado",
+      "pendingVersion": "Pendiente v{version}",
+      "syncedAt": "sincronizado {date}",
+      "format": {
+        "webReader": "Lector web",
+        "koreader": "KOReader",
+        "pdf": "PDF",
+        "kobo": "Kobo"
+      },
+      "status": {
+        "exact": "exacto",
+        "repaired": "reparado",
+        "failed": "Fallido",
+        "pending": "Pendiente"
+      }
+    },
+    "toolbar": {
+      "searchPlaceholder": "Buscar texto y notas",
+      "filters": "Filtros",
+      "sortOrder": "orden de clasificación",
+      "switchToCompact": "Cambiar a vista compacta",
+      "switchToComfortable": "Cambiar a vista cómoda",
+      "compactView": "Vista compacta",
+      "comfortableView": "Vista cómoda"
+    },
+    "listItem": {
+      "pageNumber": "pág. {page}",
+      "chapterNumber": "capítulo {chapter}",
+      "selectAnnotation": "Seleccionar anotación",
+      "collapse": "Colapso",
+      "expand": "Expandir",
+      "hideSyncDetail": "Ocultar detalles de sincronización",
+      "showSyncDetail": "Mostrar detalles de sincronización",
+      "exactPositionUnavailable": "La posición exacta del lector no está disponible",
+      "saving": "Ahorro",
+      "bookDetails": "Detalles del libro",
+      "openInReader": "Abrir en lector",
+      "restore": "Restaurar",
+      "deleteForever": "Eliminar para siempre",
+      "editNote": "Editar nota",
+      "addNote": "Agregar nota",
+      "colorAndStyle": "Color y estilo",
+      "copied": "Copiado",
+      "copyText": "Copiar texto",
+      "trash": "basura",
+      "moveToTrash": "Mover a la papelera"
+    },
+    "hub": {
+      "title": "Anotaciones",
+      "totalCount": "{count} total",
+      "bookCount": "{count, plural, =0 {sin libros} one {# libro} other {# libros} many {# libros}}",
+      "noteCount": "{count, plural, =0 {sin notas} one {# nota} other {# notas} many {# notas}}",
+      "export": "Exportar",
+      "exportMarkdown": "Rebaja",
+      "exportCsv": "CSV",
+      "exportJson": "JSON",
+      "notesOnly": "Sólo notas",
+      "style": "Estilo",
+      "source": "Fuente",
+      "bulkTrash": "basura",
+      "bulkRestore": "Restaurar",
+      "tabs": {
+        "highlights": "Lo más destacado",
+        "trash": "basura"
+      },
+      "empty": {
+        "noMatch": "Ningún resaltado coincide con tus filtros.",
+        "resetFilters": "Restablecer filtros",
+        "trashEmpty": "la papelera esta vacia",
+        "noAnnotations": "Aún no hay anotaciones. Los aspectos destacados que crea en la web o en su lector electrónico aparecen aquí."
+      },
+      "toast": {
+        "movedToTrash": "Movido a la basura",
+        "annotationRestored": "Anotación restaurada",
+        "annotationDeletedForever": "Anotación eliminada para siempre",
+        "failedToDelete": "No se pudo eliminar",
+        "bulkTrashed": "{count, plural, =0 {No se movieron anotaciones a la papelera} one {movido # anotación a la papelera} other {movido # anotaciones a la papelera} many {movido # anotaciones a la papelera}}",
+        "bulkRestored": "{count, plural, =0 {Restaurado sin anotaciones} one {Restaurado # anotación} other {Restaurado # anotaciones} many {Restaurado # anotaciones}}",
+        "bulkRecolored": "{count, plural, =0 {Recoloreado sin anotaciones} one {recoloreado # anotación} other {recoloreado # anotaciones} many {recoloreado # anotaciones}}",
+        "bulkRestyled": "{count, plural, =0 {Rediseñado sin anotaciones} one {rediseñado # anotación} other {rediseñado # anotaciones} many {rediseñado # anotaciones}}"
+      }
+    }
+  },
+  "audit": {
+    "pageTitle": "Registro de auditoría",
+    "pageSubtitle": "Un registro de acciones importantes para el administrador realizadas en todo el sistema.",
+    "filters": "Filtros",
+    "noActiveFilters": "Sin filtros activos",
+    "clear": "Borrar",
+    "empty": "No se encontraron registros de auditoría",
+    "showMore": "Mostrar más",
+    "showLess": "Mostrar menos",
+    "details": "Detalles",
+    "hideDetails": "Ocultar detalles",
+    "refresh": "Actualizar el registro de auditoría",
+    "loadError": "No se pudieron cargar los eventos de auditoría.",
+    "removeFilter": "Quitar filtro: {value}",
+    "allActions": "Todas las acciones",
+    "allEventTypes": "Todo tipo de eventos",
+    "allActors": "Todos los actores",
+    "noActionsFound": "No hay acciones coincidentes",
+    "noActorsFound": "No hay actores coincidentes",
+    "noResourcesFound": "No hay tipos de destino coincidentes",
+    "unknownAction": "Acción desconocida",
+    "unknownResource": "Otro tipo de objetivo",
+    "allResources": "Todos los recursos",
+    "allTargetTypes": "Todos los tipos de objetivos",
+    "quickDates": "citas rapidas",
+    "today": "hoy",
+    "sevenDays": "7 dias",
+    "thirtyDays": "30 dias",
+    "userId": "Usuario #{id}",
+    "userIdCompact": "#{id}",
+    "targetAdditional": "y {count, plural, one {# más objetivo} other {# más objetivos} many {# más objetivos}}",
+    "bookImpact": "{count, plural, one {# libro} other {# libros} many {# libros}}",
+    "entryDetailsLabel": "Detalles del evento de auditoría n.º {id}",
+    "detailEventId": "ID de evento",
+    "detailOccurredAt": "Ocurrió",
+    "detailActor": "Actor",
+    "detailCategory": "categoría",
+    "detailActionLabel": "acción",
+    "detailEventTypeLabel": "Tipo de evento",
+    "detailIpLabel": "dirección IP",
+    "detailResourceLabel": "Recurso",
+    "detailResourceIdLabel": "ID de recurso",
+    "detailTargetTypeLabel": "Tipo de objetivo",
+    "detailTargetIdLabel": "ID de objetivo",
+    "detailAction": "Acción: {value}",
+    "detailIp": "IP: {value}",
+    "detailResource": "Recurso: {value}",
+    "detailResourceId": "ID de recurso: {value}",
+    "deletedBooks": "Libros eliminados",
+    "deletedBookDetail": "{title} (libro #{id})",
+    "untitledBook": "Sin título",
+    "deletedBooksOmitted": "{count, plural, one {# libro adicional omitido} other {# libros adicionales omitidos} many {# libros adicionales omitidos}}",
+    "showing": "Mostrando {from}-{to} de {total}",
+    "prev": "Anterior",
+    "chips": {
+      "search": "Buscar: {value}",
+      "action": "Acción: {value}",
+      "eventType": "Tipo de evento: {value}",
+      "actor": "Actor: {value}",
+      "resource": "Recurso: {value}",
+      "targetType": "Tipo de objetivo: {value}",
+      "user": "Usuario: {value}",
+      "from": "De: {value}",
+      "to": "Para: {value}"
+    },
+    "filterLabels": {
+      "search": "Buscar eventos",
+      "action": "acción",
+      "eventType": "Tipo de evento (qué pasó)",
+      "actor": "Actor",
+      "resource": "Recurso",
+      "targetType": "Tipo de objetivo (lo que se vio afectado)",
+      "userId": "ID de usuario",
+      "from": "De",
+      "to": "a"
+    },
+    "filterPlaceholders": {
+      "search": "Descripción, actor, objetivo o ID",
+      "actor": "Nombre de usuario",
+      "action": "por ej. autenticación.iniciar sesión",
+      "userId": "por ej. 1"
+    },
+    "columns": {
+      "when": "cuando",
+      "actor": "Actor",
+      "event": "Evento",
+      "target": "Objetivo",
+      "impact": "Impacto",
+      "user": "Usuario",
+      "action": "acción",
+      "description": "Descripción",
+      "ip": "IP"
+    },
+    "categories": {
+      "authentication": "Autenticación",
+      "books": "Libros",
+      "users": "Usuarios",
+      "libraries": "Bibliotecas",
+      "collections": "Colecciones",
+      "integrations": "Integraciones",
+      "settings": "Configuración",
+      "other": "Otro"
+    },
+    "resourceLabels": {
+      "User": "Usuario",
+      "Library": "Biblioteca",
+      "Book": "Libro",
+      "Collection": "Colección",
+      "SmartScope": "Alcance inteligente",
+      "BookDockFile": "Archivo de Book Dock",
+      "Author": "Autor",
+      "AppSettings": "Configuración de la aplicación",
+      "Genre": "Género",
+      "Tag": "Etiqueta",
+      "KoboDevice": "Kobo dispositivo",
+      "EmailProvider": "Proveedor de correo electrónico",
+      "EmailTemplate": "Plantilla de correo electrónico",
+      "EmailRecipient": "Destinatario del correo electrónico",
+      "EmailRecipientGroup": "Grupo de destinatarios de correo electrónico",
+      "Narrator": "Narrador",
+      "Publisher": "Editor",
+      "Language": "Idioma",
+      "Series": "Serie",
+      "OidcIdentity": "OIDC identidad",
+      "MagicLinkToken": "enlace magico",
+      "ReadingInsightsProfile": "Perfil de conocimientos de lectura"
+    },
+    "actionLabels": {
+      "AuthRegister": "Registrar cuenta",
+      "AuthLogin": "Iniciar sesión",
+      "AuthLoginFailed": "Inicio de sesión fallido",
+      "AuthLogout": "Cerrar sesión",
+      "AuthPasswordChange": "Cambiar contraseña",
+      "AuthPasswordResetRequest": "Solicitar restablecimiento de contraseña",
+      "AuthPasswordReset": "Restablecer contraseña",
+      "AuthPasswordAdminReset": "Restablecer contraseña de usuario",
+      "AuthSessionRevoke": "Revocar sesión",
+      "MagicLinkCreate": "Crear enlace mágico",
+      "MagicLinkLogin": "Iniciar sesión con enlace mágico",
+      "MagicLinkRevoke": "Revocar enlace mágico",
+      "MagicLinkActivate": "Activar enlace mágico",
+      "MagicLinkDeactivate": "Desactivar enlace mágico",
+      "OidcLogin": "Inicia sesión con OIDC",
+      "OidcUserProvisioned": "Aprovisionar usuario OIDC",
+      "OidcIdentityLinked": "Enlace OIDC identidad",
+      "OidcIdentityUnlinked": "Desvincular identidad OIDC",
+      "UserCreate": "Crear usuario",
+      "UserUpdate": "Actualizar usuario",
+      "UserSelfUpdate": "Actualizar propio perfil",
+      "UserDelete": "Eliminar usuario",
+      "UserPermissionSet": "Actualizar permisos de usuario",
+      "UserSuperuserEnable": "Habilitar el acceso de superusuario",
+      "UserSuperuserDisable": "Deshabilitar el acceso de superusuario",
+      "UserContentFiltersSet": "Actualizar filtros de contenido",
+      "ReadingInsightsSharingUpdate": "Actualizar el intercambio de conocimientos",
+      "ReadingInsightsProfileView": "Ver información compartida",
+      "LibraryCreate": "Crear biblioteca",
+      "LibraryUpdate": "Actualizar biblioteca",
+      "LibraryDelete": "Eliminar biblioteca",
+      "LibraryFolderAdd": "Agregar carpeta de biblioteca",
+      "LibraryFolderRemove": "Eliminar carpeta de biblioteca",
+      "LibraryAccessGrant": "Conceder acceso a la biblioteca",
+      "LibraryAccessUpdate": "Actualizar el acceso a la biblioteca",
+      "LibraryAccessRevoke": "Revocar el acceso a la biblioteca",
+      "LibraryWriteMetadataToFiles": "Escribir metadatos en archivos",
+      "LibraryBulkRename": "Cambiar el nombre de los archivos de la biblioteca",
+      "BookUpload": "Subir libro",
+      "BookMetadataUpdate": "Actualizar metadatos del libro",
+      "BookMetadataLocksUpdate": "Actualizar bloqueos de metadatos",
+      "BookDelete": "Eliminar libro",
+      "BookBulkMetadataRefresh": "Actualizar metadatos del libro",
+      "BookBulkDelete": "Eliminar libros",
+      "BookBulkCoverReextract": "Volver a extraer portadas de libros",
+      "BookBulkSetStatus": "Establecer estado del libro",
+      "BookBulkSetRating": "Establecer calificación de libro",
+      "BookBulkSetMetadata": "Establecer metadatos del libro",
+      "BookBulkUpdateTags": "Actualizar etiquetas de libros",
+      "BookBulkSetMetadataLock": "Establecer bloqueos de metadatos",
+      "BookBulkEditMetadata": "Editar metadatos del libro",
+      "BookReadingStateReset": "Restablecer el estado de lectura",
+      "BookWriteAndRename": "Escribir metadatos y cambiar el nombre del archivo.",
+      "CollectionCreate": "Crear colección",
+      "CollectionUpdate": "Colección de actualizaciones",
+      "CollectionDelete": "Eliminar colección",
+      "CollectionBooksAdd": "Agregar libros a la colección",
+      "CollectionBooksRemove": "Quitar libros de la colección",
+      "SmartScopeCreate": "Crear alcance inteligente",
+      "SmartScopeUpdate": "Actualizar alcance inteligente",
+      "SmartScopeDelete": "Eliminar alcance inteligente",
+      "BookDockFinalize": "Finalizar archivo de Book Dock",
+      "AuthorUpdate": "Actualizar autor",
+      "AuthorDelete": "Eliminar autor",
+      "AuthorMerge": "Fusionar autores",
+      "AuthorEnrichmentConfigUpdate": "Actualizar enriquecimiento del autor",
+      "AuthorEnrichmentPause": "Pausar el enriquecimiento del autor",
+      "AuthorEnrichmentResume": "Enriquecimiento del autor del currículum",
+      "AuthorEnrichmentCancel": "Cancelar el enriquecimiento del autor",
+      "EntityManagerMerge": "Fusionar entidades",
+      "EntityManagerRename": "Cambiar nombre de entidad",
+      "EntityManagerDelete": "Eliminar entidad",
+      "EntityManagerSplit": "Entidad dividida",
+      "EntityManagerDismiss": "Descartar duplicado",
+      "EntityManagerUndismiss": "Restaurar duplicado descartado",
+      "AppSettingsUpdate": "Actualizar la configuración de la aplicación",
+      "KoboDeviceRegister": "Registrar dispositivo Kobo",
+      "KoboDeviceRename": "Cambiar el nombre del dispositivo Kobo",
+      "KoboDeviceRemove": "Eliminar dispositivo Kobo",
+      "EmailProviderCreate": "Crear proveedor de correo electrónico",
+      "EmailProviderUpdate": "Actualizar proveedor de correo electrónico",
+      "EmailProviderDelete": "Eliminar proveedor de correo electrónico",
+      "EmailProviderSetDefault": "Establecer proveedor de correo electrónico predeterminado",
+      "EmailProviderSetSystem": "Establecer proveedor de correo electrónico del sistema",
+      "EmailProviderClearSystem": "Borrar proveedor de correo electrónico del sistema",
+      "EmailTemplateCreate": "Crear plantilla de correo electrónico",
+      "EmailTemplateUpdate": "Actualizar plantilla de correo electrónico",
+      "EmailTemplateDelete": "Eliminar plantilla de correo electrónico",
+      "EmailTemplateSetDefault": "Establecer plantilla de correo electrónico predeterminada",
+      "EmailRecipientCreate": "Crear destinatario de correo electrónico",
+      "EmailRecipientUpdate": "Actualizar destinatario de correo electrónico",
+      "EmailRecipientDelete": "Eliminar destinatario de correo electrónico",
+      "EmailRecipientGroupCreate": "Crear grupo de destinatarios",
+      "EmailRecipientGroupUpdate": "Actualizar grupo de destinatarios",
+      "EmailRecipientGroupDelete": "Eliminar grupo de destinatarios",
+      "EmailRecipientGroupMemberAdd": "Agregar destinatario al grupo",
+      "EmailRecipientGroupMemberRemove": "Eliminar destinatario del grupo"
+    }
+  },
+  "auth": {
+    "backToSignIn": "Volver para iniciar sesión",
+    "themePicker": {
+      "switchToLight": "Cambiar a luz",
+      "switchToDark": "Cambiar a oscuro",
+      "changeRadius": "Cambiar radio de esquina",
+      "changeBackground": "Cambiar fondo",
+      "changeAccent": "Cambiar color de acento"
+    },
+    "fields": {
+      "username": "Nombre de usuario",
+      "password": "Contraseña",
+      "email": "Correo electrónico",
+      "emailAddress": "Dirección de correo electrónico",
+      "fullName": "nombre completo",
+      "newPassword": "Nueva contraseña",
+      "confirmPassword": "Confirmar contraseña",
+      "confirmNewPassword": "Confirmar nueva contraseña",
+      "currentPassword": "Contraseña actual",
+      "passwordHint": "Mín. 8 caracteres con mayúsculas, minúsculas y un dígito"
+    },
+    "errors": {
+      "generic": "Algo salió mal. Por favor inténtalo de nuevo.",
+      "passwordsDoNotMatch": "Las contraseñas no coinciden"
+    },
+    "login": {
+      "subtitle": "Inicia sesión en tu cuenta",
+      "signIn": "Iniciar sesión",
+      "signingIn": "Iniciando sesión...",
+      "orDivider": "o",
+      "forgotPassword": "¿Olvidaste tu contraseña?",
+      "errors": {
+        "invalidCredentials": "Nombre de usuario o contraseña no válidos",
+        "tooManyAttempts": "Demasiados intentos de inicio de sesión. Espere un minuto e inténtelo de nuevo."
+      }
+    },
+    "oidc": {
+      "loginFailed": "OIDC error de inicio de sesión",
+      "redirecting": "Redirigiendo...",
+      "signInWith": "Inicia sesión con {provider}",
+      "completingSignIn": "Completando el inicio de sesión...",
+      "tryAgain": "Inténtalo de nuevo",
+      "errors": {
+        "stateExpired": "Su sesión de inicio de sesión expiró. Intente iniciar sesión nuevamente.",
+        "tokenExchangeFailed": "No se pudo completar el inicio de sesión con su proveedor. Inténtelo de nuevo o comuníquese con su administrador.",
+        "userNotProvisioned": "Su cuenta no ha sido configurada. Póngase en contacto con su administrador para obtener acceso.",
+        "userInactive": "Su cuenta ha sido desactivada. Póngase en contacto con su administrador.",
+        "providerError": "Su proveedor de identidad devolvió un error. Por favor inténtalo de nuevo.",
+        "missingCodeOrState": "Falta código o parámetro de estado"
+      },
+      "providerErrors": {
+        "accessDenied": "El acceso fue denegado por el proveedor de identidad.",
+        "loginRequired": "Se requiere autenticación. Por favor inicia sesión nuevamente.",
+        "interactionRequired": "Se requiere interacción adicional del usuario."
+      }
+    },
+    "forgotPassword": {
+      "subtitle": "Restablece tu contraseña",
+      "submitted": "Si existe una cuenta con ese correo electrónico, se ha enviado un enlace de restablecimiento. Revisa tu bandeja de entrada.",
+      "sending": "Enviando...",
+      "sendResetLink": "Enviar enlace de reinicio",
+      "errors": {
+        "emailUnavailable": "El restablecimiento de contraseña por correo electrónico no está disponible. Póngase en contacto con su administrador."
+      }
+    },
+    "resetPassword": {
+      "subtitle": "Establecer una nueva contraseña",
+      "saving": "Guardando...",
+      "setNewPassword": "Establecer nueva contraseña",
+      "errors": {
+        "invalidLink": "Enlace de reinicio no válido. Por favor solicite uno nuevo.",
+        "invalidOrExpired": "Enlace de restablecimiento no válido o caducado. Por favor solicite uno nuevo."
+      }
+    },
+    "setup": {
+      "title": "Configuración inicial",
+      "subtitle": "Crea la primera cuenta de administrador.",
+      "setupToken": "Token de configuración",
+      "setupTokenHint": "(requerido en producción)",
+      "creatingAccount": "Creando cuenta...",
+      "createAccount": "Crear cuenta de administrador",
+      "errors": {
+        "failed": "No se pudo completar la configuración"
+      }
+    },
+    "changePassword": {
+      "title": "Cambiar contraseña",
+      "saving": "Guardando…",
+      "forcedNotice": "Debe establecer una nueva contraseña antes de continuar.",
+      "errors": {
+        "failed": "No se pudo cambiar la contraseña"
+      }
+    },
+    "magicLink": {
+      "signingIn": "Registrándote...",
+      "loginFailed": "Error al iniciar sesión",
+      "goToLogin": "Ir a iniciar sesión",
+      "errors": {
+        "noToken": "No se proporciona ningún token"
+      }
+    }
+  },
+  "author": {
+    "card": {
+      "portraitAlt": "{name} retrato",
+      "viewDetails": "Ver detalles del autor",
+      "refreshMetadata": "Actualizar metadatos",
+      "deleteAuthor": "Eliminar autor"
+    },
+    "listRow": {
+      "noRecentAdditions": "No hay adiciones recientes",
+      "portraitAlt": "{name} retrato"
+    },
+    "filters": {
+      "title": "Filtros de autor",
+      "clearAll": "Borrar todo",
+      "allLibraries": "Todas las bibliotecas",
+      "allAuthors": "Todos los autores",
+      "hasPhoto": "tiene foto",
+      "missingPhoto": "foto faltante",
+      "minBooks": "libros mínimos",
+      "anyPlaceholder": "Cualquiera"
+    },
+    "header": {
+      "never": "nunca",
+      "portraitAlt": "{name} retrato",
+      "actions": "Acciones",
+      "editAuthor": "Editar autor",
+      "mergeAuthors": "Fusionar autores",
+      "refreshing": "Refrescante...",
+      "refreshMetadata": "Actualizar metadatos",
+      "deleteAuthor": "Eliminar autor",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar más",
+      "lookingUpMetadata": "Buscando metadatos del autor...",
+      "noBiography": "No hay biografía disponible. Utilice el menú para actualizar los metadatos.",
+      "previewFrom": "Vista previa de {provider}. Guarde los metadatos para conservarlos.",
+      "booksLabel": "Libros",
+      "lastAdded": "Último agregado"
+    },
+    "list": {
+      "title": "Autores",
+      "showControlsAria": "Mostrar controles de autor",
+      "searchPlaceholder": "Buscar autores",
+      "sortButton": "Ordenar",
+      "sortBy": "Ordenar por",
+      "ascending": "Ascendente",
+      "descending": "Descendente",
+      "asc": "asc",
+      "desc": "Descripción",
+      "filters": "Filtros",
+      "clear": "Borrar",
+      "allLoaded": "Todos los {total} autores cargados",
+      "sort": {
+        "name": "Nombre",
+        "sortName": "Ordenar nombre",
+        "bookCount": "Conteo de libros",
+        "recentAdditions": "Adiciones recientes",
+        "lastEnriched": "Último enriquecido"
+      },
+      "empty": {
+        "title": "No se encontraron autores",
+        "hint": "Intente cambiar el texto de búsqueda, la clasificación o el filtro de biblioteca."
+      },
+      "deleteDialog": {
+        "titleOne": "¿Eliminar autor?",
+        "titleMany": "¿Eliminar {count} autores?",
+        "descriptionOne": "Esto elimina al autor del catálogo y lo desvincula de los libros asociados. Esta acción no se puede deshacer.",
+        "descriptionMany": "Esto elimina los autores seleccionados del catálogo y los desvincula de los libros asociados. Esta acción no se puede deshacer."
+      },
+      "selection": {
+        "selectVisible": "Seleccionar visible",
+        "refreshMetadata": "Actualizar metadatos",
+        "refreshingMetadata": "Actualizando metadatos...",
+        "deleteSelected": "Eliminar seleccionado",
+        "deleting": "Eliminando...",
+        "exitSelection": "Salir de la selección",
+        "confirmDeleteCount": "{count, plural, =0 {Eliminar # autor?} one {Eliminar # autor?} other {Eliminar # autores?} many {Eliminar # autores?}}"
+      },
+      "toast": {
+        "refreshed": "Metadatos del autor actualizados",
+        "refreshedNoImage": "Se actualizaron los metadatos, pero no se encontró ninguna imagen del autor.",
+        "refreshFailed": "No se pudieron actualizar los metadatos del autor",
+        "bulkRefreshPartial": "Autor(es) {updated} actualizado, {failed} falló",
+        "bulkRefreshSuccess": "Metadatos actualizados para {updated} autor(es)",
+        "bulkRefreshFailed": "No se pudo actualizar los autores seleccionados",
+        "deleteSuccess": "{count, plural, =0 {Eliminados # autores; {books} libros afectados} one {Eliminado # autor; {books} libros afectados} other {Eliminados # autores; {books} libros afectados} many {Eliminados # autores; {books} libros afectados}}",
+        "deleteFailed": "No se pudo eliminar el autor(es)"
+      }
+    },
+    "detail": {
+      "pageTitle": "Autor",
+      "pageTitleNamed": "Autor · {name}",
+      "pageTitleId": "Autor #{id}",
+      "entityName": "Autor",
+      "loadingAuthor": "Cargando autor...",
+      "previewError": "No se pudieron cargar los metadatos de vista previa del autor externo en este momento.",
+      "edit": {
+        "name": "Nombre",
+        "sortName": "Ordenar nombre",
+        "description": "Descripción",
+        "image": "Imagen",
+        "uploading": "Subiendo...",
+        "replaceImage": "Reemplazar imagen",
+        "uploadImage": "Subir imagen",
+        "removing": "Eliminando...",
+        "removeImage": "Quitar imagen",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP hasta {size} MB",
+        "saving": "Guardando..."
+      },
+      "merge": {
+        "searchPlaceholder": "Buscar autores para fusionarlos con este autor",
+        "searching": "Buscando...",
+        "bookCount": "{count, plural, =0 {sin libros} one {# libro} other {# libros} many {# libros}}",
+        "selectedSummary": "{count} autor(es) seleccionado(s), aprox. {books} libros afectados.",
+        "merging": "Fusionando...",
+        "mergeSelected": "Fusionar seleccionado",
+        "confirmLabel": "fusionar"
+      },
+      "mergeDialog": {
+        "title": "¿Fusionar {count} autor(es) en \"{name}\"?",
+        "titleFallback": "¿Fusionar autores seleccionados?",
+        "description": "Esto fusionará los autores seleccionados con el autor actual y volverá a vincular los libros asociados. Esta acción no se puede deshacer.",
+        "descriptionEmpty": "Esta acción no se puede deshacer."
+      },
+      "deleteDialog": {
+        "title": "¿Eliminar autor?",
+        "description": "Esto elimina al autor del catálogo y lo desvincula de los libros asociados. Esta acción no se puede deshacer."
+      },
+      "books": {
+        "heading": "Libros",
+        "allLibraries": "Todas las bibliotecas",
+        "asc": "asc",
+        "desc": "Descripción",
+        "ascending": "Ascendente",
+        "descending": "Descendente",
+        "allLoaded": "Todos los {total} libros cargados",
+        "sort": {
+          "recentlyAdded": "Agregado recientemente",
+          "title": "Título",
+          "publishedYear": "Año de publicación"
+        },
+        "empty": {
+          "title": "No se encontraron libros para este autor.",
+          "hint": "Intente cambiar la clasificación/orden o seleccione otra biblioteca."
+        }
+      },
+      "toast": {
+        "refreshed": "Metadatos del autor actualizados",
+        "refreshedNoImage": "Se actualizaron los metadatos, pero no se encontró ninguna imagen del autor.",
+        "refreshFailed": "No se pudieron actualizar los metadatos del autor",
+        "nameRequired": "El nombre del autor es obligatorio.",
+        "updated": "Autor actualizado",
+        "updateFailed": "No se pudo actualizar el autor",
+        "imageUpdated": "Imagen del autor actualizada.",
+        "imageUploadFailed": "No se pudo cargar la imagen del autor",
+        "imageRemoved": "Imagen del autor eliminada",
+        "imageRemoveFailed": "No se pudo eliminar la imagen del autor",
+        "mergeSuccess": "Autor(es) {count} fusionados; {books} libros afectados",
+        "mergeFailed": "No se han podido fusionar autores",
+        "deleteSuccess": "Autor eliminado; {books} libros afectados",
+        "deleteFailed": "No se pudo eliminar el autor"
+      }
+    }
+  },
+  "book": {
+    "untitled": "Sin título",
+    "unknownFormat": "desconocido",
+    "collapsedSeries": {
+      "label": "Serie",
+      "bookCount": "{count, plural, =0 {sin libros} one {# libro} other {# libros} many {# libros}}",
+      "readCount": "{count} leer"
+    },
+    "card": {
+      "missing": "desaparecido"
+    },
+    "file": {
+      "primary": "Principal",
+      "audiobook": "Audiolibro"
+    },
+    "actions": {
+      "read": "Marcar como leído",
+      "listen": "Escuchar",
+      "peek": "vistazo",
+      "quickView": "Vista rápida",
+      "details": "Detalles",
+      "bookDetails": "Detalles del libro",
+      "download": "Descargar",
+      "metadata": "Metadatos",
+      "editMetadata": "Editar metadatos",
+      "refreshMetadata": "Actualizar metadatos",
+      "regenerateCover": "Regenerar cubierta",
+      "addToCollection": "Añadir a la colección",
+      "setStatus": "Establecer estado",
+      "sendViaEmail": "Enviar por correo electrónico",
+      "rate": "Califica {star}",
+      "openAs": "Abrir como {format}"
+    },
+    "readStatus": {
+      "unread": "No leído",
+      "wantToRead": "quiero leer",
+      "reading": "leyendo",
+      "onHold": "En espera",
+      "rereading": "Releyendo",
+      "read": "Leído",
+      "skimmed": "desnatado",
+      "abandoned": "abandonado"
+    },
+    "download": {
+      "action": "Descargar",
+      "audiobookZip": "Audiolibro (ZIP)",
+      "allFormatsZip": "Todos los formatos (ZIP)",
+      "primaryOnlyZip": "Solo primaria (ZIP)"
+    },
+    "sort": {
+      "moveUp": "Subir",
+      "moveDown": "Bajar",
+      "ascending": "Ascendente",
+      "descending": "Descendente",
+      "remove": "Quitar",
+      "emptyState": "No hay clasificación configurada. Se utilizará título ascendente.",
+      "addLevel": "Agregar nivel de clasificación"
+    },
+    "filter": {
+      "match": "Coincidencia",
+      "all": "TODOS",
+      "any": "CUALQUIER",
+      "ofFollowingRules": "de las siguientes reglas",
+      "anyProvider": "Cualquier proveedor",
+      "communityRatingProvider": "Proveedor de calificación comunitaria",
+      "loadingLibraries": "Cargando bibliotecas...",
+      "noLibrariesAvailable": "No hay bibliotecas disponibles",
+      "selectLibrary": "Seleccionar biblioteca...",
+      "selectStatus": "Seleccionar estado...",
+      "withinLastPlaceholder": "por ej. 7",
+      "unit": {
+        "days": "dias",
+        "weeks": "semanas",
+        "months": "meses"
+      },
+      "scorePreset": {
+        "outstanding": "Excelente",
+        "good": "Bueno",
+        "fair": "Aceptable",
+        "poor": "Bajo"
+      },
+      "scoreRangePlaceholder": "0-100",
+      "valuePlaceholder": "valor",
+      "maxPlaceholder": "máximo",
+      "to": "a",
+      "group": "grupo",
+      "addRule": "Agregar regla",
+      "addGroup": "Agregar grupo",
+      "typeToSearch": "Escribe para buscar..."
+    },
+    "deleteDialog": {
+      "title": "¿Eliminar libro?",
+      "description": "Esto eliminará permanentemente el libro y todos sus metadatos, archivos, progreso de lectura y marcadores. Esto no se puede deshacer."
+    },
+    "bulkEdit": {
+      "title": "{count, plural, =0 {Editar metadatos - # libro} one {Editar metadatos - # libro} other {Editar metadatos - # libros} many {Editar metadatos - # libros}}",
+      "instructions": "Cambie los campos para editar y luego configure los valores. Sólo se cambiarán los campos alternados.",
+      "invalidYear": "Ingrese un año válido (solo números)",
+      "clearWarning": "Esto eliminará todos los {field} de los libros seleccionados.",
+      "searchPlaceholder": "Buscar {field}...",
+      "enterPlaceholder": "Ingrese {field}",
+      "yearPlaceholder": "por ej. 2024",
+      "leaveEmptyHint": "Déjelo vacío para borrar este campo en todos los libros seleccionados.",
+      "applying": "Aplicando...",
+      "apply": "Aplicar",
+      "mode": {
+        "add": "Añadir",
+        "remove": "Quitar",
+        "replace": "Reemplazar",
+        "clear": "Borrar"
+      }
+    },
+    "export": {
+      "title": "Exportar metadatos",
+      "scope": "Alcance",
+      "selectedRows": "Filas seleccionadas",
+      "currentlySelected": "{count} actualmente seleccionado",
+      "allMatchingRows": "Todas las filas coincidentes",
+      "rowsInResult": "{count} filas en el resultado actual",
+      "format": "Formato",
+      "csvDescription": "Compatible con hojas de cálculo, lista de materiales UTF-8 incluida",
+      "jsonDescription": "Exportación estructurada con contexto de metadatos",
+      "columns": "columnas",
+      "canonicalSchema": "Esquema canónico estable",
+      "visibleColumns": "Columnas visibles actuales",
+      "options": "Opciones",
+      "includePersonalData": "Incluir datos personales de lectura",
+      "includeFilePaths": "Incluir rutas de archivos (avanzado)",
+      "includeContextMeta": "Incluir metadatos de contexto",
+      "preflight": "verificación previa",
+      "scopeLabel": "Alcance: {summary}",
+      "calculatingSize": "Calculando el tamaño de la exportación...",
+      "estimatedSize": "Tamaño estimado:",
+      "fileLabel": "Archivo: {fileName}",
+      "exportAction": "Exportar",
+      "selectedRowsSummary": "{count, plural, =0 {# fila seleccionada} one {# fila seleccionada} other {# filas seleccionadas} many {# filas seleccionadas}}",
+      "matchingRowsSummary": "{count, plural, =0 {# fila coincidente} one {# fila coincidente} other {# filas coincidentes} many {# filas coincidentes}}",
+      "prepareFailed": "No se pudo preparar la exportación",
+      "exportStarted": "Se inició la exportación de metadatos: {fileName}",
+      "exportFailed": "Error al exportar metadatos"
+    },
+    "columnPanel": {
+      "columnsHeading": "columnas",
+      "reset": "Reiniciar",
+      "tableDensity": "Densidad de la mesa",
+      "density": {
+        "compact": "Compacto",
+        "comfortable": "Cómodo",
+        "roomy": "Espacioso"
+      },
+      "presets": "Preajustes",
+      "exportBackup": "Exportar ajustes preestablecidos y vistas guardadas",
+      "importBackup": "Importar ajustes preestablecidos y vistas guardadas",
+      "rename": "Cambiar nombre",
+      "renamePrompt": "Introduzca un nuevo nombre",
+      "builtIn": "Construido en",
+      "saveCurrentPreset": "Guardar preajuste actual",
+      "savedViews": "Vistas guardadas",
+      "savedViewsEmpty": "Guarde filtros de clasificación, diseño y visualización específicos para reutilizarlos rápidamente.",
+      "saveCurrentView": "Guardar vista actual",
+      "pinnedLeft": "Fijado a la izquierda",
+      "pinnedRight": "Fijado a la derecha",
+      "columns": {
+        "cover": "Portada",
+        "read": "Leído",
+        "actions": "Acciones"
+      }
+    },
+    "shortcuts": {
+      "title": "Atajos de teclado",
+      "navigation": {
+        "title": "Navegación",
+        "moveFocusVertical": "Mover el foco arriba/abajo",
+        "moveFocusHorizontal": "Mover el foco hacia la izquierda/derecha",
+        "jumpFirstColumn": "Saltar a la primera columna",
+        "jumpLastColumn": "Saltar a la última columna",
+        "jumpFirstRow": "Saltar a la primera fila",
+        "jumpLastRow": "Saltar a la última fila"
+      },
+      "actions": {
+        "title": "Acciones",
+        "editCell": "Editar celda enfocada",
+        "cancelEditing": "Cancelar edición/Cerrar superposición",
+        "toggleRowSelection": "Alternar selección de fila",
+        "copyCell": "Copiar valor de celda",
+        "copyRow": "Copiar fila enfocada"
+      },
+      "general": {
+        "title": "generales",
+        "toggleHelp": "Alternar esta superposición de ayuda"
+      }
+    },
+    "jumpRail": {
+      "jumpToSection": "Saltar a la sección",
+      "jumpTo": "Saltar a {label}",
+      "unknownDate": "fecha desconocida",
+      "unknownValue": "Valor desconocido"
+    },
+    "quickView": {
+      "title": "Reservar vista rápida",
+      "titleFor": "Vista rápida de {title}",
+      "description": "Obtenga una vista previa de los detalles del libro y ejecute acciones rápidas.",
+      "openIn": "Abrir en {provider}",
+      "pages": "{count, plural, =0 {# página} one {# página} other {# paginas} many {# paginas}}",
+      "primaryFile": "Archivo primario",
+      "fileNumber": "Archivo #{id}",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar más",
+      "collections": "Colecciones",
+      "noDescription": "No hay descripción disponible.",
+      "openMetadataEditor": "Abrir editor de metadatos",
+      "coverPreview": "Vista previa de la portada del libro",
+      "coverPreviewFor": "{title} vista previa de portada",
+      "coverPreviewDescription": "Cuadro de diálogo de vista previa de la imagen de portada ampliada."
+    },
+    "tableView": {
+      "openBookDetails": "Detalles del libro abierto",
+      "openSeries": "Serie abierta",
+      "metadataRefreshFailed": "Error al actualizar los metadatos",
+      "booksSelected": "{count, plural, =0 {# libro seleccionado} one {# libro seleccionado} other {# libros seleccionados} many {# libros seleccionados}}",
+      "loadingMoreBooks": "Cargando más libros",
+      "sort": "Ordenar",
+      "refreshingMetadata": "Actualizando metadatos {processed} / {total}",
+      "failedCount": "{count} falló",
+      "remainingCount": "{count} restantes",
+      "readOnlyNotice": "La edición de tablas está deshabilitada en pantallas más pequeñas. Cambie a lista o cuadrícula para acciones más rápidas.",
+      "fetching": "Recuperando...",
+      "updated": "Actualizado",
+      "failed": "Fallido",
+      "noBooks": "No hay libros para mostrar",
+      "scrollToTop": "Desplazarse hacia arriba",
+      "selectedStatus": "{count} seleccionado",
+      "filtered": "Filtrado",
+      "loadedStatus": "{loaded} de {total} cargado",
+      "bookCount": "{count, plural, =0 {# libro} one {# libro} other {# libros} many {# libros}}",
+      "keyboardShortcutsTitle": "Atajos de teclado (?)",
+      "showKeyboardShortcuts": "Mostrar atajos de teclado de tabla",
+      "copyHint": "Copiar celda: Ctrl/Cmd+C · Copiar fila: Ctrl/Cmd+Shift+C"
+    },
+    "detail": {
+      "authorBooks": {
+        "alsoByAuthor": "También de este autor",
+        "alsoByAuthors": "También por estos autores"
+      },
+      "header": {
+        "previousBook": "Libro anterior",
+        "nextBook": "próximo libro"
+      },
+      "tabs": {
+        "details": "Detalles",
+        "editMetadata": "Editar metadatos",
+        "files": "Archivos",
+        "readingLog": "Registro de lectura",
+        "highlights": "Lo más destacado"
+      },
+      "discover": {
+        "moreInSeries": "Más en la serie",
+        "byAuthor": "Por autor",
+        "similarBooks": "Libros similares"
+      },
+      "recommended": {
+        "moreLikeThis": "Más como esto"
+      },
+      "series": {
+        "moreInSeries": "Más en la serie {series}"
+      },
+      "writeRename": {
+        "written": "{count, plural, =0 {no hay campos escritos} one {Escrito (un campo)} other {escrito (# campos)} many {escrito (# campos)}}",
+        "writeFailed": "Error de escritura",
+        "skipped": "Saltado",
+        "renamedTo": "Renombrado a {name}",
+        "fileRenamed": "Archivo renombrado",
+        "renameFailed": "Error al cambiar el nombre",
+        "autoWriteAndRenameDisabled": "La escritura automática y el cambio de nombre están deshabilitados en la configuración de la biblioteca. Los cambios no se sincronizarán automáticamente en futuros guardados.",
+        "autoWriteDisabled": "La escritura automática está deshabilitada en la configuración de la biblioteca. Los cambios no se sincronizarán automáticamente en futuros guardados.",
+        "autoRenameDisabled": "El cambio de nombre automático está deshabilitado en la configuración de la biblioteca. Los cambios no se sincronizarán automáticamente en futuros guardados.",
+        "writeLabel": "Escribe:",
+        "renameLabel": "Cambiar nombre:"
+      },
+      "addFile": {
+        "uploading": "Subiendo...",
+        "uploadComplete": "Subida completa",
+        "title": "Agregar archivo",
+        "dropzone": {
+          "title": "Suelte los archivos aquí o haga clic para explorar",
+          "hint": "epub, pdf, mobi, cbz, m4b y más: hasta {size} MB cada uno"
+        },
+        "addMore": "Agregar más archivos",
+        "fileCount": "{count, plural, =0 {sin archivos} one {un archivo} other {# archivos} many {# archivos}}",
+        "clearAll": "Borrar todo",
+        "done": "Hecho",
+        "retry": "Reintentar",
+        "filesAdded": "{count, plural, =0 {no se agregaron archivos} one {un archivo agregado} other {# archivos agregados} many {# archivos agregados}}",
+        "uploadedFailed": "{done} subido, {failed} falló",
+        "uploadingProgress": "{done} de {total} subiendo...",
+        "renameAfter": "Cambiar el nombre de todos los archivos de libros después de cargarlos",
+        "uploadCount": "Subir ({count})",
+        "upload": "Subir"
+      },
+      "addSession": {
+        "errors": {
+          "invalidDate": "Elija una fecha y hora válidas.",
+          "future": "La sesión no puede comenzar en el futuro.",
+          "duration": "La duración debe estar entre 1 y 1440 minutos.",
+          "endProgress": "El progreso final debe estar entre 0 y 100."
+        },
+        "title": "Añadir sesión de lectura",
+        "startedAt": "Comenzó en",
+        "duration": "Duración (minutos)",
+        "endProgress": "% de progreso final",
+        "optional": "Opcional",
+        "format": "Formato",
+        "noFormat": "Sin formato específico",
+        "saving": "Guardando...",
+        "submit": "Agregar sesión"
+      },
+      "coverEditor": {
+        "unlockCover": "Desbloquear cubierta",
+        "lockCover": "Tapa de bloqueo",
+        "fileTab": "Archivo",
+        "urlTab": "URL",
+        "chooseImage": "Elige imagen...",
+        "findCoverOnline": "Encuentra portada en línea",
+        "saving": "Guardando...",
+        "saveCover": "Guardar portada",
+        "revertToOriginal": "Volver al original",
+        "regenerateCover": "Regenerar cubierta"
+      },
+      "coverSearch": {
+        "title": "Búsqueda en línea",
+        "subtitle": "Buscar portadas de libros",
+        "titleField": "Título",
+        "authorField": "Autor",
+        "sourceField": "Fuente",
+        "allSources": "Todas las fuentes",
+        "audiobookCovers": "Portadas de audiolibros",
+        "squareHint": "(cuadrado)",
+        "searching": "Buscando...",
+        "findCovers": "encontrar portadas",
+        "selectCover": "Seleccionar portada",
+        "noResultsTitle": "No se encontraron resultados",
+        "noResultsHint": "Intente ajustar sus términos de búsqueda",
+        "readyTitle": "Listo para buscar",
+        "readyHint": "Introduzca un título y autor arriba",
+        "resolutionTip": "Consejo: las portadas de alta resolución están marcadas en verde"
+      },
+      "details": {
+        "by": "por",
+        "narratedBy": "narrado por",
+        "ratingLocked": "La clasificación está bloqueada",
+        "rateStar": "Califica {star}",
+        "listen": "Escuchar",
+        "read": "Leído",
+        "chooseFormat": "Elige formato",
+        "audiobook": "Audiolibro",
+        "primary": "Principal",
+        "peek": "vistazo",
+        "sendViaEmail": "Enviar por correo electrónico",
+        "personalReview": {
+          "title": "Opinión personal",
+          "toggleAria": "Alternar revisión personal",
+          "editAria": "Editar reseña personal",
+          "placeholder": "Revisión privada",
+          "clearAria": "Borrar reseña personal",
+          "cancelEditAria": "Cancelar edición de reseña personal"
+        },
+        "editCover": "Editar portada",
+        "finished": "Terminado",
+        "resetFileProgress": "Restablecer el progreso del archivo",
+        "resetting": "Restableciendo...",
+        "resetProgressConfirm": "¿Restablecer el progreso de lectura almacenado para {label}?",
+        "moreCount": "+{count} más",
+        "untitled": "Sin título",
+        "metadataScore": "Puntuación de metadatos",
+        "primaryFormat": "formato primario",
+        "openIn": "Abrir en {provider}",
+        "showLess": "Mostrar menos",
+        "showMore": "Mostrar más",
+        "publisher": "Editor",
+        "published": "Publicado",
+        "language": "Idioma",
+        "pages": "paginas",
+        "duration": "Duración",
+        "edition": "Edición",
+        "abridged": "abreviado",
+        "unabridged": "íntegro",
+        "isbn": "ISBN",
+        "fileSize": "Tamaño de archivo",
+        "library": "Biblioteca",
+        "added": "Añadido",
+        "dateStarted": "Fecha de inicio",
+        "saving": "Guardando...",
+        "cancelDateStartedEdit": "Cancelar fecha de inicio editar",
+        "editDateStarted": "Editar fecha de inicio",
+        "dateFinished": "Fecha finalizada",
+        "cancelDateFinishedEdit": "Cancelar fecha de finalización de la edición",
+        "editDateFinished": "Editar fecha finalizada",
+        "customMetadata": "Metadatos personalizados",
+        "synopsis": "Sinopsis",
+        "noDescription": "No hay descripción disponible.",
+        "dateStartedFutureError": "La fecha de inicio no puede ser futura.",
+        "dateFinishedFutureError": "La fecha de finalización no puede ser futura.",
+        "dateFinishedBeforeStartedError": "La fecha de finalización debe ser igual o posterior a la fecha de inicio.",
+        "saveReadingDatesError": "No se pudieron guardar las fechas de lectura.",
+        "koboPendingDelete": "Pendiente de eliminar del dispositivo",
+        "koboPendingDeleteTooltip": "Kobo lo eliminará en la próxima sincronización.",
+        "koboRemovedByDevice": "Eliminado por dispositivo",
+        "koboRemovedByDeviceTooltip": "Kobo informó que este libro se eliminó.",
+        "koboNotSynced": "No sincronizado",
+        "koboNotSyncedTooltip": "En cola para la próxima sincronización Kobo.",
+        "filesNotFound": "Archivos no encontrados",
+        "filesNotFoundDescription": "Los archivos de este libro ya no se pueden encontrar en el disco. Los metadatos todavía están disponibles. Ejecute un escaneo de la biblioteca para confirmar o eliminar el registro."
+      },
+      "editMetadata": {
+        "fieldCount": "{count, plural, =0 {sin campos} one {un campo} other {# campos} many {# campos}}",
+        "bookFilesTarget": "archivos de libros",
+        "formatFilesTarget": "{formats} archivos",
+        "noPrimaryFile": "No hay ningún archivo principal disponible",
+        "formatNotSupported": "Este formato de archivo no admite reescritura",
+        "formatDisabled": "La reescritura está deshabilitada para este formato.",
+        "fileExceedsSizeLimit": "Este archivo excede el límite de tamaño de reescritura",
+        "writing": "Escribiendo...",
+        "saveInProgress": "Guardar en progreso",
+        "writeManualLibraryDisabled": "Escriba metadatos en un archivo y cambie el nombre en el disco; La reescritura automática está deshabilitada para esta biblioteca.",
+        "writeManualTooltip": "Escriba {fields} en {target} y cambie el nombre en el disco",
+        "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "{count, plural, =0 {No se omitió ningún campo bloqueado} one {Se saltó un campo bloqueado} other {Saltado # campos bloqueados} many {Saltado # campos bloqueados}}",
+        "updatedFields": "{count, plural, =0 {actualizado sin campos} one {actualizado un campo} other {actualizado # campos} many {actualizado # campos}}",
+        "wroteFieldsToFile": "Escribió {fields} para presentar",
+        "fileWriteFailedReason": "Error al escribir el archivo: {reason}",
+        "fileWriteFailed": "Error al escribir el archivo",
+        "fileWriteSkippedReason": "Escritura de archivo omitida: {reason}",
+        "fileWriteSkipped": "Escritura de archivo omitida",
+        "metadataSaved": "Metadatos guardados",
+        "metadataWrittenToFile": "Metadatos escritos en un archivo",
+        "savedButWriteFailedReason": "Metadatos guardados, pero error al escribir el archivo: {reason}",
+        "savedButWriteFailed": "Metadatos guardados, pero falla la escritura del archivo",
+        "savedWriteSkippedReason": "Metadatos guardados, escritura de archivo omitida: {reason}",
+        "savedWriteSkipped": "Metadatos guardados, escritura de archivo omitida",
+        "loadFromFileFailed": "No se pudieron cargar los metadatos del archivo",
+        "loadedFieldsFromFile": "{count, plural, =0 {No se cargaron campos del archivo} one {Cargó un campo del archivo} other {cargado # campos del archivo} many {cargado # campos del archivo}}",
+        "noMetadataInFile": "No se encontraron metadatos en el archivo",
+        "loadFromFile": "Cargar desde archivo",
+        "loadFromFileTooltip": "Cargar metadatos desde el archivo del libro principal",
+        "writeToFile": "escribir al archivo",
+        "autoFill": "Autocompletar",
+        "fetchingMetadata": "Obteniendo metadatos...",
+        "allFieldsLocked": "Todos los campos están bloqueados",
+        "autoFillTooltip": "Complete automáticamente los campos usando sus preferencias de metadatos",
+        "lockAll": "bloquear todo",
+        "lockAllTooltip": "Bloquear todos los campos",
+        "unlockAll": "Desbloquear todo",
+        "unlockAllTooltip": "Desbloquear todos los campos",
+        "saving": "Guardando...",
+        "fileWriteBackDetails": "Detalles de reescritura de archivos",
+        "fileWriteBack": "Reescritura de archivos",
+        "enabled": "Habilitado",
+        "saveWritesMetadata": "'Guardar' escribe metadatos en {target}",
+        "formats": "Formatos",
+        "bookFiles": "Archivos de libros",
+        "supportedFields": "Campos admitidos",
+        "titleLabel": "Título",
+        "subtitleLabel": "Subtítulo",
+        "authorsLabel": "Autores",
+        "narratorsLabel": "Narradores",
+        "genresLabel": "Géneros",
+        "tagsLabel": "Etiquetas",
+        "ratingLabel": "Calificación",
+        "rateStar": "Califica {star}",
+        "clear": "Borrar",
+        "communityRatingsLabel": "Calificaciones de la comunidad",
+        "noProviderRatings": "Sin calificaciones de proveedores",
+        "seriesLabel": "Serie",
+        "publisherLabel": "Editor",
+        "languageLabel": "Idioma",
+        "yearLabel": "Año",
+        "pageCountLabel": "Conteo de páginas",
+        "isbn13Label": "ISBN-13",
+        "isbn10Label": "ISBN-10",
+        "durationLabel": "Duración (es)",
+        "abridgedLabel": "abreviado",
+        "providerIds": "ID de proveedor",
+        "comicDetails": "Detalles del cómic",
+        "comicIssueNumberLabel": "Número de emisión",
+        "comicVolumeLabel": "Volumen",
+        "comicStoryArcsLabel": "Arcos de la historia",
+        "comicPencillersLabel": "dibujantes",
+        "comicInkersLabel": "entintadores",
+        "comicColoristsLabel": "Coloristas",
+        "comicLetterersLabel": "rotuladores",
+        "comicCoverArtistsLabel": "Artistas de portada",
+        "comicCharactersLabel": "Personajes",
+        "comicTeamsLabel": "equipos",
+        "comicLocationsLabel": "Ubicaciones",
+        "customMetadata": "Metadatos personalizados",
+        "descriptionLabel": "Descripción",
+        "unlockField": "Desbloquear {field}",
+        "lockField": "Bloquear {field}",
+        "diffPanel": {
+          "untitled": "Sin título",
+          "noFieldsSelected": "No hay campos seleccionados",
+          "fieldsSelected": "{count, plural, =0 {ningún campo seleccionado} one {un campo seleccionado} other {# campos seleccionados} many {# campos seleccionados}}",
+          "results": "Resultados",
+          "providerMatches": "{provider} coincidencias",
+          "selectedOf": "Seleccionado {selected} de {total}",
+          "yearUnknown": "Año desconocido",
+          "indexOf": "{index} de {total}",
+          "switchedResult": "Resultado cambiado. Se borraron las selecciones anteriores de este proveedor.",
+          "selectFieldsToApply": "Seleccione campos para aplicar",
+          "copyMissing": "Falta copia",
+          "copyAll": "Copiar todo",
+          "hideUnchanged": "Ocultar sin cambios",
+          "showUnchanged": "Mostrar sin cambios",
+          "current": "Actual",
+          "noMetadata": "No hay metadatos disponibles de esta fuente.",
+          "noChangedFields": "No hay campos modificados ni faltantes. Utilice Mostrar sin cambios para inspeccionar todo.",
+          "applyToForm": "Aplicar al formulario"
+        },
+        "diff": {
+          "locked": "bloqueado",
+          "previewAlt": "Vista previa",
+          "currentCoverAlt": "portada actual",
+          "newCoverAlt": "Nueva portada",
+          "pickCoverFromProvider": "Elija cobertura de otro proveedor",
+          "pickCoverSource": "Elija la fuente de la portada",
+          "pickFromProvider": "Elija de otro proveedor",
+          "pickSource": "Elegir fuente",
+          "empty": "vacío",
+          "showLess": "Mostrar menos",
+          "showMore": "Mostrar más",
+          "coverPreviewAlt": "Vista previa de la portada"
+        },
+        "searchDrawer": {
+          "searchTitle": "Metadatos de búsqueda",
+          "compareTitle": "Comparar metadatos",
+          "searchSubtitle": "Encuentre el mejor proveedor compatible con este libro.",
+          "compareSubtitle": "Revisa las diferencias y aplica solo lo que quieras."
+        },
+        "searchPanel": {
+          "untitledQuery": "Consulta sin título",
+          "titlePlaceholder": "Título",
+          "authorPlaceholder": "Autor",
+          "isbnPlaceholder": "ISBN",
+          "searching": "Buscando...",
+          "activeQuery": "consulta activa",
+          "searchScope": "Alcance de la búsqueda",
+          "allEnabled": "Todo habilitado",
+          "all": "Todos",
+          "fieldRules": "Reglas de campo",
+          "custom": "personalizado",
+          "providerNotInFieldRules": "{provider} está habilitado pero no en Reglas de campo",
+          "notInFieldRulesLabel": "No en las reglas de campo:",
+          "notInFieldRulesText": "{providers}. Incluido en la búsqueda manual con Todo habilitado, pero no utilizado por la recuperación automática de metadatos.",
+          "noResults": "No se encontraron resultados",
+          "noResultsHint": "Intenta ajustar el título o el autor.",
+          "searchPrompt": "Busque arriba y luego haga clic en un resultado para comenzar a comparar metadatos."
+        },
+        "writeAndRename": "Escribir en archivo y cambiar nombre",
+        "writeAndRenameShort": "Escribir y cambiar nombre"
+      },
+      "files": {
+        "title": "Archivos de libros",
+        "fileCount": "{count, plural, =0 {sin archivos} one {# archivo} other {# archivos} many {# archivos}}",
+        "synced": "Sincronizado {time}",
+        "sortAria": "ordenar archivos",
+        "syncHistory": "Historial de sincronización",
+        "metadataWriteBack": "Reescritura de metadatos",
+        "relative": {
+          "seconds": "Hace {value}s",
+          "minutes": "Hace {value}m",
+          "hours": "Hace {value}h",
+          "days": "Hace {value}d"
+        },
+        "renameFailed": "No se pudo cambiar el nombre del archivo",
+        "deleteFailed": "No se pudo eliminar el archivo",
+        "addFile": "Agregar archivo",
+        "lastSynced": "Última sincronización: {time}",
+        "sort": {
+          "label": "Ordenar:",
+          "name": "Nombre",
+          "format": "Formato",
+          "size": "Tamaño",
+          "date": "Fecha"
+        },
+        "hidePaths": "Ocultar caminos",
+        "showPaths": "Mostrar caminos",
+        "hideLog": "Ocultar registro",
+        "viewSyncLog": "Ver registro de sincronización",
+        "noWriteHistory": "Aún no hay historial de escritura.",
+        "fieldsWritten": "{count, plural, =0 {sin campos} one {un campo} other {# campos} many {# campos}}",
+        "track": "Seguimiento {number}",
+        "primary": "Principal",
+        "read": "Leído",
+        "play": "Jugar",
+        "peek": "vistazo",
+        "download": "Descargar",
+        "moreActions": "Más acciones",
+        "rename": "Cambiar nombre",
+        "empty": {
+          "title": "No hay archivos adjuntos",
+          "description": "Este libro no tiene archivos asociados."
+        },
+        "renameModal": {
+          "title": "Cambiar nombre de archivo",
+          "description": "Cambie el nombre del archivo físico en el disco.",
+          "placeholder": "Nuevo nombre de archivo"
+        },
+        "saving": "Guardando...",
+        "deleteModal": {
+          "title": "¿Eliminar archivo?",
+          "description": "¿Está seguro de que desea eliminar \"{filename}\"? Esta acción no se puede deshacer."
+        },
+        "deleting": "Eliminando..."
+      },
+      "highlights": {
+        "note": {
+          "placeholder": "Añade una nota...",
+          "saving": "Ahorro"
+        },
+        "export": {
+          "trigger": "Exportar",
+          "plainText": "Texto sin formato",
+          "page": "Exportar página",
+          "selected": "Exportar seleccionado"
+        },
+        "sort": {
+          "position": "Posición",
+          "newest": "Lo nuevo primero",
+          "oldest": "El más viejo primero"
+        },
+        "summary": {
+          "highlights": "{count, plural, =0 {sin reflejos} one {un punto culminante} other {# aspectos más destacados} many {# aspectos más destacados}}",
+          "notes": "{count, plural, =0 {sin notas} one {una nota} other {# notas} many {# notas}}",
+          "chapters": "{count, plural, =0 {sin capítulos} one {un capitulo} other {# capítulos} many {# capítulos}}"
+        },
+        "filterByChapter": "Filtrar por capítulo",
+        "allChapters": "Todos los capítulos",
+        "untitled": "Sin título",
+        "trash": "basura",
+        "empty": {
+          "noMatch": "Ningún resaltado coincide con tus filtros.",
+          "resetFilters": "Restablecer filtros",
+          "none": "Aún no hay destacados",
+          "hint": "Seleccione texto mientras lee para crear momentos destacados"
+        },
+        "uncategorized": "Sin categoría",
+        "paginationUnit": "aspectos más destacados"
+      },
+      "readingLog": {
+        "moreActionsAria": "Más acciones de registro de lectura",
+        "export": {
+          "button": "Exportar"
+        },
+        "weekdays": {
+          "sun": "sol",
+          "mon": "lun",
+          "tue": "mar",
+          "wed": "mié",
+          "thu": "jueves",
+          "fri": "viernes",
+          "sat": "sábado"
+        },
+        "months": {
+          "jan": "enero",
+          "feb": "febrero",
+          "mar": "mar",
+          "apr": "abril",
+          "may": "mayo",
+          "jun": "junio",
+          "jul": "julio",
+          "aug": "agosto",
+          "sep": "septiembre",
+          "oct": "octubre",
+          "nov": "noviembre",
+          "dec": "diciembre"
+        },
+        "heatmap": {
+          "minutesUnit": "mín.",
+          "title": "Actividad",
+          "empty": "No hay actividad de lectura en esta ventana.",
+          "emptyHint": "Las sesiones grabadas aquí construirán su vista de coherencia."
+        },
+        "hero": {
+          "summaryAria": "Resumen de lectura",
+          "notSet": "No establecido",
+          "relative": {
+            "seconds": "Hace {count}s",
+            "minutes": "Hace {count}m",
+            "hours": "Hace {count}h",
+            "days": "Hace {count}d",
+            "months": "{count, plural, =0 {# hace un mes} one {# hace un mes} other {# hace meses} many {# hace meses}}",
+            "years": "{count, plural, =0 {# hace un año} one {# hace un año} other {# hace años} many {# hace años}}"
+          },
+          "noSessions": "Sin sesiones",
+          "dateErrors": {
+            "startFuture": "La fecha de inicio no puede ser en el futuro.",
+            "finishFuture": "La fecha de finalización no puede ser en el futuro.",
+            "finishBeforeStart": "La fecha de finalización debe ser igual o posterior a la fecha de inicio.",
+            "saveFailed": "No se pudieron guardar las fechas de lectura."
+          },
+          "eta": {
+            "max": "99h+ para terminar",
+            "minutes": "~{m}m para finalizar",
+            "hours": "~{h}h para finalizar",
+            "hoursMinutes": "~{h}h {m}m para finalizar"
+          },
+          "momentum": {
+            "none": "Sin actividad en las últimas dos semanas.",
+            "new": "Nueva actividad esta semana",
+            "up": "+{pct}% frente a los 7 días anteriores",
+            "down": "{pct}% frente a los 7 días anteriores",
+            "flat": "Sin cambios frente a los 7 días anteriores"
+          },
+          "stats": {
+            "totalTime": "Tiempo Total",
+            "sessions": "Sesiones",
+            "avgSession": "Sesión promedio",
+            "lastRead": "Última lectura"
+          },
+          "firstRead": "Primera lectura",
+          "lastRead": "Última lectura",
+          "dateStarted": "Fecha de inicio",
+          "dateFinished": "Fecha finalizada",
+          "addSession": "Agregar sesión"
+        },
+        "journey": {
+          "tooltipProgress": "Progreso",
+          "tooltipReading": "leyendo",
+          "minutesUnit": "mín.",
+          "title": "Viaje de progreso",
+          "empty": "No hay datos de progreso en esta ventana.",
+          "emptyHint": "El progreso aparecerá después de que una sesión registre una posición de lectura."
+        },
+        "sourceSplit": {
+          "title": "fuentes de lectura",
+          "shortTitle": "Fuentes"
+        },
+        "untitled": "Sin título",
+        "addSessionFailed": "No se pudo agregar la sesión",
+        "filters": {
+          "show": "Mostrar",
+          "dateRangeAria": "Intervalo de fechas de la sesión de lectura",
+          "allTime": "Todo el tiempo",
+          "last30": "últimos 30 días",
+          "last90": "últimos 90 días",
+          "thisYear": "este año",
+          "allFormats": "Todos los formatos"
+        },
+        "table": {
+          "title": "Sesiones",
+          "sourceWeb": "Web",
+          "sourceManual": "Manual",
+          "colDate": "Fecha",
+          "colDateMobile": "Fecha",
+          "colDuration": "Duración",
+          "colDurationMobile": "Duración",
+          "colProgressChange": "Cambio de progreso",
+          "colProgressChangeMobile": "delta",
+          "colEndProgress": "Finalizar progreso",
+          "colEndProgressMobile": "Fin",
+          "empty": "Aún no se han registrado sesiones de lectura.",
+          "emptyHint": "Agregue una sesión para comenzar a construir el historial de lectura de este libro.",
+          "colPace": "ritmo",
+          "colSource": "Fuente",
+          "colFormatMobile": "fmt",
+          "colFormat": "Formato",
+          "cancelDelete": "Cancelar eliminar",
+          "cancelDeleteAria": "Cancelar eliminar sesión",
+          "confirmDeleteTitle": "Haga clic nuevamente para confirmar la eliminación.",
+          "confirmDeleteAria": "Confirmar eliminar sesión",
+          "deleteAria": "Eliminar sesión",
+          "loadMore": "Cargar más",
+          "showing": "Mostrando {shown} de {total} sesiones"
+        }
+      },
+      "richDescription": {
+        "linkProtocolError": "Utilice http, https o mailto.",
+        "bold": "Negrita",
+        "italic": "cursiva",
+        "underline": "subrayado",
+        "strikethrough": "Tachado",
+        "bulletList": "lista de viñetas",
+        "numberedList": "lista numerada",
+        "outdentAria": "Reducir la sangría del elemento de la lista",
+        "outdent": "Reducir sangría",
+        "indentAria": "Elemento de lista de sangría",
+        "indent": "sangría",
+        "quote": "Cotización",
+        "editLink": "Editar enlace",
+        "link": "Enlace",
+        "removeLink": "Quitar enlace",
+        "undo": "Deshacer",
+        "redo": "Rehacer",
+        "clearFormatting": "Borrar formato",
+        "previewDescription": "Descripción de vista previa",
+        "preview": "Vista previa",
+        "linkUrlLabel": "URL del enlace",
+        "applyLink": "Aplicar enlace",
+        "apply": "Aplicar",
+        "cancelLink": "Cancelar enlace",
+        "noDescription": "No hay descripción disponible."
+      },
+      "seriesMembership": {
+        "addSeries": "Agregar serie",
+        "seriesPlaceholder": "Serie",
+        "moveUp": "Subir",
+        "moveDown": "Bajar",
+        "removeSeries": "Quitar serie"
+      }
+    },
+    "table": {
+      "actions": {
+        "quickView": "Vista rápida",
+        "bookDetails": "Detalles del libro",
+        "editMetadata": "Editar metadatos",
+        "refreshMetadata": "Actualizar metadatos",
+        "addToCollection": "Añadir a la colección",
+        "sendToDevice": "Enviar al dispositivo"
+      },
+      "boolean": {
+        "ariaNotSet": "No establecido: haga clic para establecerlo como verdadero",
+        "ariaTrue": "Verdadero: haga clic para establecer falso",
+        "ariaFalse": "Falso: haga clic para borrar"
+      },
+      "chips": {
+        "addPlaceholder": "Añadir..."
+      },
+      "cover": {
+        "previewDescription": "Vista previa de la portada del libro",
+        "editDescription": "Editar portada del libro",
+        "editTitle": "Editar portada",
+        "editCover": "Editar portada",
+        "view": "Ver portada"
+      },
+      "date": {
+        "justNow": "justo ahora"
+      },
+      "format": {
+        "unknown": "desconocido"
+      },
+      "header": {
+        "sortAscending": "Orden ascendente",
+        "sortDescending": "Orden descendente",
+        "clearSort": "Borrar orden",
+        "hideColumn": "Ocultar columna",
+        "pinLeft": "Fijar a la izquierda",
+        "pinRight": "Fijar a la derecha",
+        "unpinColumn": "Desanclar columna",
+        "autoFitWidth": "Ancho de ajuste automático",
+        "autoFitAllColumns": "Ajustar automáticamente todas las columnas",
+        "selectAllBooks": "Seleccionar todos los libros",
+        "shiftClickSecondarySort": "Mayús+clic para agregar clasificación secundaria",
+        "clickToSort": "Haga clic para ordenar"
+      },
+      "locks": {
+        "lockAll": "Bloquear todos los campos",
+        "unlockAll": "Desbloquear todos los campos",
+        "lockField": "Bloquear campo",
+        "unlockField": "Desbloquear campo",
+        "clickToLock": "Haga clic para bloquear",
+        "clickToUnlock": "Haga clic para desbloquear"
+      },
+      "progress": {
+        "complete": "{percent} completo"
+      },
+      "rating": {
+        "label": "Calificación",
+        "remove": "Eliminar calificación",
+        "rate": "Califica {star} sobre 5"
+      },
+      "read": {
+        "play": "Jugar",
+        "read": "Leído",
+        "primary": "Principal",
+        "peekFormat": "Vistazo {format}",
+        "chooseFormat": "Elige el formato para leer o reproducir",
+        "fileFallback": "ARCHIVO"
+      },
+      "readStatus": {
+        "unread": "No leído"
+      },
+      "series": {
+        "bookCount": "{count, plural, =0 {(sin libros)} one {(# libro)} other {(# libros)} many {(# libros)}}",
+        "readOfCount": "{read} de {total} leído"
+      },
+      "text": {
+        "openDetails": "Abrir detalles"
+      }
+    }
+  },
+  "bookMetadataFetch": {
+    "book": {
+      "title": "Recuperación de metadatos"
+    },
+    "author": {
+      "title": "Enriquecimiento del autor"
+    },
+    "stats": {
+      "queued": "En cola",
+      "processing": "Procesamiento",
+      "rateLimited": "Tarifa limitada",
+      "failed": "Fallido"
+    },
+    "actions": {
+      "pause": "Pausa",
+      "resume": "Reanudar",
+      "cancelQueued": "Cancelar en cola",
+      "dismissBookStatus": "Descartar el estado de obtención de metadatos",
+      "dismissAuthorStatus": "Descartar el estado de enriquecimiento del autor"
+    },
+    "cancel": {
+      "processingWillFinish": "Los artículos actualmente procesados finalizarán.",
+      "confirm": "Confirmar cancelar",
+      "keepRunning": "sigue corriendo"
+    },
+    "viewFailed": "{count, plural, one {Ver uno fallido} other {Ver # falló} many {Ver # falló}}",
+    "card": {
+      "fetchingMetadata": "Obteniendo metadatos",
+      "enrichingAuthors": "Autores enriquecedores",
+      "metadataFetchFinished": "Recuperación de metadatos finalizada",
+      "authorEnrichmentFinished": "Enriquecimiento del autor finalizado."
+    },
+    "label": {
+      "paused": "En pausa",
+      "remaining": "{count} restantes",
+      "processing": "{count} procesamiento",
+      "failed": "{count} falló",
+      "rateLimited": "{count} tasa limitada"
+    },
+    "report": {
+      "bookTitle": "Recuperaciones de metadatos fallidas",
+      "authorTitle": "Enriquecimientos de autor fallidos",
+      "noFailedItems": "No hay elementos fallidos.",
+      "retryAllFailed": "Reintentar todo falló",
+      "bookFallback": "Libro #{id}",
+      "authorFallback": "Autor #{id}",
+      "columns": {
+        "title": "Título",
+        "library": "Biblioteca",
+        "author": "Autor",
+        "error": "error",
+        "http": "HTTP"
+      }
+    },
+    "toast": {
+      "failedToPause": "No se pudo pausar",
+      "failedToResume": "No se pudo reanudar",
+      "failedToCancel": "No se pudo cancelar",
+      "failedToRetry": "No se pudo volver a intentar",
+      "failedItemsRequeued": "Artículos fallidos puestos en cola",
+      "bookComplete": "Recuperación de metadatos completada: {done} libros actualizados",
+      "bookDoneWithFailures": "Recuperación de metadatos realizada: {done} procesada, {failed} fallida",
+      "authorComplete": "Enriquecimiento del autor completado: {done} autores actualizados",
+      "authorDoneWithFailures": "Enriquecimiento del autor realizado: {done} procesado, {failed} fallido"
+    }
+  },
+  "bookDock": {
+    "apply": "Aplicar",
+    "done": "Hecho",
+    "discard": "Descartar",
+    "finalize": "finalizar",
+    "rescan": "Volver a escanear",
+    "uploadAction": "Subir",
+    "uploading": "Subiendo...",
+    "searchPlaceholder": "Buscar archivos...",
+    "setDestinationAction": "Establecer destino",
+    "bulkEditAction": "Edición masiva",
+    "applyFetched": "Aplicar recuperado",
+    "retryErrors": "Errores de reintento",
+    "commaSeparated": "separados por comas",
+    "destinationLibrary": "Biblioteca de destino",
+    "destinationFolder": "Carpeta de destino",
+    "nFailed": "{count} falló",
+    "updatedOfFiles": "Actualizado {updated} de {total} archivos",
+    "errorStatus": "Error {status}",
+    "tab": {
+      "all": "Todos",
+      "pending": "Pendiente",
+      "ready": "Listo",
+      "error": "error"
+    },
+    "status": {
+      "pending": "Pendiente",
+      "extracting": "Extrayendo",
+      "fetching": "buscando",
+      "ready": "Listo",
+      "error": "error"
+    },
+    "field": {
+      "title": "Título",
+      "subtitle": "Subtítulo",
+      "authors": "Autores",
+      "authorsCommaSeparated": "Autores (separados por comas)",
+      "publisher": "Editor",
+      "publishedDate": "Fecha de publicación",
+      "year": "Año",
+      "language": "Idioma",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "series": "Serie",
+      "seriesIndex": "Serie #",
+      "genres": "Géneros",
+      "genresCommaSeparated": "Géneros (separados por comas)",
+      "description": "Descripción"
+    },
+    "upload": {
+      "nDone": "{count} hecho",
+      "nFailed": "{count} falló",
+      "nTotal": "{count} total"
+    },
+    "fileList": {
+      "emptyTitle": "No hay archivos en Book Dock",
+      "emptyMessageDefault": "Cargue archivos o suéltelos en la carpeta Book Dock",
+      "colCurrent": "Actual",
+      "colNew": "Nuevo",
+      "colFile": "Archivo",
+      "colSize": "Tamaño",
+      "colFormat": "Formato",
+      "colMatch": "Coincidencia",
+      "colApply": "Aplicar",
+      "colStatus": "Estado",
+      "applyFetchedMetadata": "Aplicar metadatos recuperados",
+      "coverPreview": "Vista previa de la portada",
+      "coverPreviewDescription": "Cuadro de diálogo de vista previa de la imagen de portada ampliada.",
+      "currentCoverAlt": "{title} cobertura actual",
+      "newCoverAlt": "{title} nueva portada",
+      "unknownLibrary": "Biblioteca desconocida",
+      "unassigned": "No asignado",
+      "targetPath": "Objetivo: {library} · {path}",
+      "targetUnassigned": "Objetivo: no asignado",
+      "targetUnknownPath": "Destino: {library} · Ruta de destino desconocida"
+    },
+    "sheet": {
+      "saved": "Guardado",
+      "providerMetadataFound": "Metadatos del proveedor encontrados",
+      "providerMetadataFoundEdited": "Se encontraron metadatos del proveedor: la aplicación masiva omitirá este archivo (tiene ediciones)",
+      "review": "Revisión",
+      "added": "Añadido {date}",
+      "searchMetadata": "Metadatos de búsqueda",
+      "results": "Resultados"
+    },
+    "bulkEdit": {
+      "title": "{count, plural, =0 {Edición masiva sin archivos} one {Edición masiva # archivo} other {Edición masiva # archivos} many {Edición masiva # archivos}}",
+      "resultTitle": "Resultados de edición masiva",
+      "instructions": "Alterna los campos que deseas actualizar. Sólo se aplicarán los campos habilitados.",
+      "mergeArrays": "Fusionar matrices (agregar a los valores existentes en lugar de reemplazar)",
+      "failed": "Error en la edición masiva"
+    },
+    "setDestination": {
+      "title": "{count, plural, =0 {Establecer destino sin archivos} one {Establecer destino para # archivo} other {Establecer destino para # archivos} many {Establecer destino para # archivos}}",
+      "resultTitle": "Destino actualizado",
+      "failed": "No se pudo establecer el destino"
+    },
+    "finalizeDialog": {
+      "title": "{count, plural, =0 {No finalizar ningún archivo} one {finalizar # archivo} other {finalizar # archivos} many {finalizar # archivos}}",
+      "resultTitle": "Finalizar resultados",
+      "needDestination": "{count, plural, =0 {Sin destino: {without} de # archivos seleccionados} one {Sin destino: {without} de # archivo seleccionado} other {Sin destino: {without} de # archivos seleccionados} many {Sin destino: {without} de # archivos seleccionados}}",
+      "allHaveDestination": "Todos los archivos seleccionados ya tienen el destino establecido",
+      "defaultDestinationLibrary": "Biblioteca de destino predeterminada",
+      "defaultDestinationFolder": "Carpeta de destino predeterminada",
+      "renamePreview": "Cambiar nombre de vista previa",
+      "moreFiles": "+{count} archivos más",
+      "start": "Empezar",
+      "filesFinalized": "{succeeded} de {total} archivos finalizados",
+      "checking": "Comprobando archivos seleccionados...",
+      "readyCount": "{count, plural, =0 {no hay archivos listos} one {# archivo listo} other {# archivos listos} many {# archivos listos}}",
+      "duplicateCount": "{count, plural, =0 {ninguno ya en la biblioteca} one {# ya en la biblioteca} other {# ya en la biblioteca} many {# ya en la biblioteca}}",
+      "conflictCount": "{count, plural, =0 {no hay conflictos de nombre de archivo} one {# conflicto de nombre de archivo} other {# conflictos de nombre de archivo} many {# conflictos de nombre de archivo}}",
+      "missingDestinationCount": "{count, plural, =0 {no faltan destinos} one {# destino perdido} other {# destinos faltantes} many {# destinos faltantes}}",
+      "blockedCount": "{count, plural, =0 {ningún archivo bloqueado} one {# archivo bloqueado} other {# archivos bloqueados} many {# archivos bloqueados}}",
+      "moreDuplicates": "+{count} más ya en la biblioteca",
+      "discardDuplicates": "Descartar duplicados",
+      "failedCount": "{count, plural, =0 {ningún archivo falló} one {# archivo fallido} other {# los archivos fallaron} many {# los archivos fallaron}}",
+      "failedWithDuplicates": "{count, plural, =0 {{failed} fallidos (# duplicados)} one {{failed} fallidos (# duplicado)} other {{failed} fallidos (# duplicados)} many {{failed} fallidos (# duplicados)}}",
+      "view": "Ver",
+      "viewExisting": "Ver existente",
+      "hide": "Ocultar",
+      "details": "Detalles",
+      "alreadyExistsSaveAs": "Ya existe - guardar como:",
+      "renamePlaceholder": "por ej. {name} (2)",
+      "import": "Importar"
+    }
+  },
+  "collection": {
+    "dialog": {
+      "name": "Nombre",
+      "icon": "Icono",
+      "iconPlaceholder": "Elige un icono...",
+      "nameRequired": "El nombre es obligatorio",
+      "iconRequired": "Elige un icono",
+      "creating": "Creando...",
+      "createFailed": "No se pudo crear la colección"
+    },
+    "createDialog": {
+      "title": "Nueva colección",
+      "namePlaceholder": "por ej. Favoritos"
+    },
+    "editDialog": {
+      "title": "Editar colección",
+      "syncToKobo": "Sincronizar con Kobo",
+      "syncToKoboHint": "Los libros de esta colección aparecerán en su dispositivo Kobo",
+      "deleteCollection": "Eliminar colección",
+      "confirmDelete": "¿Confirmar?",
+      "deleting": "Eliminando...",
+      "saving": "Guardando...",
+      "deleted": "\"{name}\" eliminado",
+      "updateFailed": "No se pudo actualizar la colección",
+      "deleteFailed": "No se pudo eliminar la colección"
+    },
+    "addToSheet": {
+      "title": "Administrar colecciones",
+      "selectedCount": "{count, plural, =0 {no hay libros seleccionados} one {un libro seleccionado} other {# libros seleccionados} many {# libros seleccionados}}",
+      "newCollection": "Nueva colección",
+      "namePlaceholder": "Nombre de la colección",
+      "create": "crear",
+      "collections": "Colecciones",
+      "empty": "Aún no hay colecciones. Crea uno arriba.",
+      "done": "Hecho",
+      "added": "Añadido",
+      "allAdded": "Todos los {total} agregados",
+      "inCollection": "En esta colección",
+      "allInCollection": "Todos los {total} de esta colección",
+      "partialInCollection": "{partial} de {total} en esta colección",
+      "bookCount": "{count, plural, =0 {sin libros} one {un libro} other {# libros} many {# libros}}",
+      "loadFailed": "No se pudieron cargar las colecciones",
+      "createdAndAdded": "{count, plural, =0 {Creado \"{name}\" y no agregó ningún libro} one {Creado \"{name}\" y agregó un libro} other {Creado \"{name}\" y agregó # libros} many {Creado \"{name}\" y agregó # libros}}",
+      "createdButAddFailed": "Creó \"{name}\" pero no pudo agregar libros",
+      "createFailed": "No se pudo crear la colección",
+      "addedNewWithExisting": "{count, plural, =0 {Se agregó un libro nuevo a \"{name}\" ({alreadyHad} ya ahí)} one {Se agregó un libro nuevo a \"{name}\" ({alreadyHad} ya ahí)} other {Añadido # nuevos libros para \"{name}\" ({alreadyHad} ya ahí)} many {Añadido # nuevos libros para \"{name}\" ({alreadyHad} ya ahí)}}",
+      "addedToCollection": "{count, plural, =0 {No se agregaron libros a \"{name}\"} one {Se agregó un libro a \"{name}\"} other {Añadido # libros a \"{name}\"} many {Añadido # libros a \"{name}\"}}",
+      "addFailed": "No se pudo agregar a la colección",
+      "removedFromCollection": "{count, plural, =0 {No se eliminó ningún libro de \"{name}\"} one {Se eliminó un libro de \"{name}\"} other {Eliminado # libros de \"{name}\"} many {Eliminado # libros de \"{name}\"}}",
+      "removeFailed": "No se pudo eliminar de la colección"
+    }
+  },
+  "components": {
+    "appHeader": {
+      "searchAllBooks": "Buscar todos los libros...",
+      "searching": "Buscando...",
+      "noResults": "Sin resultados",
+      "loadingMore": "Cargando más...",
+      "loadMore": "Cargar más ({loaded}/{total})",
+      "allMatchesShown": "{count, plural, =0 {Se muestra el 1 partido} one {Se muestra el 1 partido} other {Todos # coincidencias mostradas} many {Todos # coincidencias mostradas}}",
+      "bookCount": "{count, plural, =0 {sin libros} one {# libro} other {# libros} many {# libros}}",
+      "fileCount": "{count, plural, =0 {sin archivos} one {# archivo} other {# archivos} many {# archivos}}",
+      "uploadedToast": "Subido {uploaded}",
+      "uploadFailedToast": "La carga falló para {failed}",
+      "uploadPartialToast": "Subido {uploaded}, {failed} falló",
+      "bookDock": "Book Dock",
+      "statistics": "Estadísticas",
+      "achievements": "Logros",
+      "annotations": "Anotaciones",
+      "uploadBooks": "Subir libros",
+      "appearance": "Apariencia",
+      "theme": "Tema",
+      "accent": "acento",
+      "radius": "Radio",
+      "background": "Antecedentes",
+      "settings": "Configuración",
+      "whatsNew": "¿Qué hay de nuevo?",
+      "documentation": "Documentación",
+      "help": "Ayuda",
+      "starOnGithub": "Estrella en GitHub",
+      "new": "Nuevo",
+      "newReleaseNotes": "Nuevas notas de la versión disponibles",
+      "account": "cuenta",
+      "changePassword": "Cambiar contraseña",
+      "signOut": "Cerrar sesión",
+      "githubStar": {
+        "title": "¿Estás disfrutando de BookOrbit?",
+        "body": "Si BookOrbit está ayudando con su biblioteca, considere destacar el proyecto en GitHub. Ayuda a que más personas descubran la aplicación y respalda el desarrollo continuo.",
+        "cta": "Estrella BookOrbit en GitHub"
+      }
+    },
+    "sidebar": {
+      "tagline": "Tu espacio de lectura",
+      "dashboard": "Panel de control",
+      "authors": "Autores",
+      "series": "Serie",
+      "tools": "Herramientas",
+      "libraries": "Bibliotecas",
+      "newLibrary": "Nueva biblioteca",
+      "libraryScanning": "{name} - Escaneando {pct}%",
+      "scanProgress": "{processed} / {total} libros",
+      "smartScopes": "Visores inteligentes",
+      "newSmartScope": "Nuevo alcance inteligente",
+      "noSmartScopes": "Aún no hay osciloscopios inteligentes",
+      "collections": "Colecciones",
+      "newCollection": "Nueva colección",
+      "noCollections": "Aún no hay colecciones",
+      "latest": "Último {version}",
+      "newReleaseNotes": "Nuevas notas de la versión disponibles",
+      "support": "Soporte BookOrbit",
+      "supportShort": "Soporte",
+      "supportAria": "Soporte BookOrbit en Ko-fi",
+      "sectionHeader": {
+        "add": "Añadir",
+        "reorder": "Reordenar",
+        "doneReordering": "Hecho de reordenar"
+      }
+    },
+    "selectionActionBar": {
+      "setReadingStatus": "Establecer estado de lectura",
+      "setRating": "Establecer calificación",
+      "openMetadataEditor": "Abrir editor de metadatos",
+      "editIndividually": "Editar libros individualmente",
+      "addToCollection": "Añadir a la colección",
+      "removeFromCollection": "Quitar de la colección",
+      "sendViaEmail": "Enviar por correo electrónico",
+      "downloadFilesZip": "Descargar archivos como ZIP",
+      "moreActions": "Más acciones",
+      "setField": "Establecer campo",
+      "refreshMetadata": "Actualizar metadatos",
+      "reExtractCover": "Vuelva a extraer la cubierta",
+      "metadataLock": "Bloqueo de metadatos",
+      "lockAll": "bloquear todo",
+      "unlockAll": "Desbloquear todo",
+      "exportMetadata": "Exportar metadatos",
+      "deleteSelected": "Eliminar seleccionado",
+      "exitSelection": "Salir de la selección",
+      "downloadFilesZipLabel": "Descargar archivos como ZIP:",
+      "primaryOnly": "Solo principal",
+      "allFormats": "Todos los formatos",
+      "audioOnly": "Sólo audio",
+      "setRatingLabel": "Establecer calificación:",
+      "clear": "Borrar",
+      "setFieldLabel": "Establecer campo:",
+      "apply": "Aplicar",
+      "fieldPlaceholder": "Dejar en blanco para borrar",
+      "fieldPlaceholderArray": "Separados por comas (dejar en blanco para borrar)",
+      "deleteConfirm": "{count, plural, =0 {Eliminar # libro?} one {Eliminar # libro?} other {Eliminar # libros?} many {Eliminar # libros?}}",
+      "typeDelete": "Tipo BORRAR"
+    },
+    "viewHeader": {
+      "select": "Seleccionar",
+      "display": "Visualización",
+      "displayDescription": "Ajuste el tamaño de la portada, el espaciado de la cuadrícula y vea las opciones de visualización.",
+      "columnVisibilityHint": "Utilice el panel de visibilidad de columnas en el encabezado de la tabla para mostrar u ocultar columnas.",
+      "columnVisibilityMobileHint": "La visibilidad de las columnas se puede gestionar desde el encabezado de la tabla.",
+      "searchPlaceholder": "Buscar título, autor, serie, narrador...",
+      "mobileSearch": {
+        "description": "Busque artículos por título, autor, serie o narrador.",
+        "done": "Hecho"
+      },
+      "mobileMenu": {
+        "grid": "Cuadrícula",
+        "list": "Lista",
+        "select": "Seleccionar",
+        "exitSelect": "Salir Seleccionar"
+      },
+      "displayControls": {
+        "display": "Visualización",
+        "coverSize": "Tamaño de la cubierta",
+        "gridGap": "Espacio de red",
+        "showJumpRails": "Mostrar carriles de salto",
+        "columnsHint": "Utilice el panel de visibilidad de columnas en el encabezado de la tabla para mostrar u ocultar columnas.",
+        "coverShape": "Forma de la cubierta",
+        "circle": "circulo",
+        "square": "cuadrado"
+      }
+    },
+    "iconPicker": {
+      "clearSelectionAria": "Borrar icono seleccionado",
+      "searchLucide": "Buscar iconos de Lucide...",
+      "searchCustom": "Buscar iconos personalizados...",
+      "chooseIcon": "Elige un icono...",
+      "selectIcon": "Seleccionar icono",
+      "customTab": "personalizado",
+      "searching": "Buscando...",
+      "noIconsMatch": "Ningún icono coincide con \"{query}\"",
+      "typeToSearch": "Escriba para buscar todos los iconos",
+      "noCustomIcons": "No se han subido iconos personalizados",
+      "noIconsAvailable": "No hay iconos disponibles"
+    },
+    "entityNotFound": {
+      "title": "{entity} no encontrado",
+      "description": "Este {entity} no existe o ha sido eliminado.",
+      "goBack": "volver"
+    },
+    "themePicker": {
+      "light": "Luz",
+      "dark": "oscuro",
+      "system": "Sistema"
+    },
+    "userAvatar": {
+      "profilePicture": "Foto de perfil",
+      "profilePictureOf": "{name} foto de perfil"
+    },
+    "ui": {
+      "sidebar": {
+        "title": "Barra lateral",
+        "mobileDescription": "Muestra la barra lateral móvil.",
+        "toggle": "Alternar barra lateral"
+      },
+      "chipInput": {
+        "typeAndEnter": "Escribe y presiona Enter para agregar",
+        "pressEnter": "Presione Entrar para agregar"
+      }
+    }
+  },
+  "customIcons": {
+    "dialogTitle": "Subir iconos personalizados",
+    "dialogDescription": "Revise los nombres antes de agregarlos a su biblioteca.",
+    "readingFiles": "Leyendo archivos...",
+    "dropPrompt": "Suelte archivos SVG o haga clic para explorar",
+    "fileLimit": "Hasta {max} archivos, 128 KB cada uno",
+    "namePlaceholder": "Nombre",
+    "nameRequired": "El nombre es obligatorio",
+    "invalidSvg": "SVG no válido",
+    "invalidSvgFile": "Archivo SVG no válido",
+    "identicalTo": "Idéntico a \"{name}\"",
+    "uploadAnyway": "Subir de todos modos",
+    "skipThisOne": "Salta este",
+    "readyToUpload": "{count} listo para cargar",
+    "noIconsStaged": "Aún no hay íconos en escena",
+    "uploading": "Subiendo...",
+    "upload": "Subir",
+    "uploadCount": "Subir {count}",
+    "onlySvgSupported": "Sólo se admiten archivos SVG",
+    "maxStaged": "Puedes organizar como máximo {max} íconos a la vez",
+    "onlyMoreCanStage": "{count, plural, =0 {No se pueden montar más iconos} one {Sólo # Se pueden organizar más íconos.} other {Sólo # Se pueden organizar más íconos.} many {Sólo # Se pueden organizar más íconos.}}",
+    "readFailed": "No se pudieron leer los archivos SVG",
+    "uploadedCount": "{count, plural, =0 {No se han subido iconos} one {subido # icono} other {subido # iconos} many {subido # iconos}}",
+    "uploadedPartial": "Subido {created}, {failed} falló",
+    "noIconsUploaded": "No se han subido iconos",
+    "uploadFailed": "No se pudieron cargar los íconos",
+    "uploadFailedEntry": "Error al subir"
+  },
+  "dashboard": {
+    "common": {
+      "failedToLoad": "No se pudo cargar",
+      "retry": "Reintentar",
+      "untitled": "Sin título",
+      "cover": "Portada",
+      "bookCover": "portada del libro"
+    },
+    "scroller": {
+      "failedToLoad": "No se pudo cargar.",
+      "empty": {
+        "continueReading": "Aún no hay libros en progreso. Empieza a leer uno para verlo aquí.",
+        "continueListening": "Aún no hay audiolibros en progreso. Empieza a escuchar uno para verlo aquí.",
+        "wantToRead": "Ningún libro marcado quiere leer todavía.",
+        "upNextInSeries": "Aún no hay selecciones de la próxima serie. Termina un volumen para que salga a la superficie el siguiente.",
+        "recentlyAdded": "Aún no hay libros en tu biblioteca.",
+        "smartScope": "Ningún libro coincide con este smartScope.",
+        "default": "No se encontraron libros."
+      }
+    },
+    "settings": {
+      "title": "Personalizar el panel",
+      "tabs": {
+        "widgets": "widgets",
+        "shelves": "estantes"
+      },
+      "reorderHintWidget": "Arrastre para reordenar. Alternar para mostrar u ocultar un widget.",
+      "reorderHintShelf": "Arrastre para reordenar. Alternar para mostrar u ocultar un estante.",
+      "smartScope": "Alcance inteligente",
+      "noSmartScopes": "Aún no hay osciloscopios inteligentes. Crea uno desde la barra lateral.",
+      "addShelf": "Agregar estante",
+      "resetToDefaults": "Restablecer los valores predeterminados"
+    },
+    "welcome": {
+      "emptyTitle": "Tu biblioteca está vacía",
+      "noLibrariesTitle": "Aún no hay bibliotecas",
+      "emptyDescription": "Crea una biblioteca para empezar a organizar y leer tus libros. Apúntelo a una carpeta y él hará el resto.",
+      "noLibrariesDescription": "Su administrador aún no ha configurado ninguna biblioteca. Comuníquese con ellos para comenzar.",
+      "createFirstLibrary": "Crea tu primera biblioteca"
+    },
+    "widgets": {
+      "currentlyReading": {
+        "title": "Actualmente leyendo",
+        "empty": "No hay libros en progreso. Empieza a leer uno para verlo aquí.",
+        "continueReading": "Continuar leyendo"
+      },
+      "diversityScore": {
+        "title": "Puntuación de diversidad",
+        "notEnoughData": "Lea al menos 3 libros para ver su puntuación de diversidad",
+        "booksAnalyzed": "{count, plural, =0 {ningún libro analizado} one {# libro analizado} other {# libros analizados} many {# libros analizados}}",
+        "subScores": {
+          "genre": "Género",
+          "author": "Autor",
+          "era": "Época",
+          "language": "Lang"
+        }
+      },
+      "highlightOfTheDay": {
+        "title": "Lo más destacado del día",
+        "empty": "Resalte pasajes mientras lee para verlos aquí"
+      },
+      "libraryOverview": {
+        "title": "Descripción general de la biblioteca",
+        "empty": "Tu biblioteca está vacía. Agregue algunos libros para comenzar.",
+        "addedThisYear": "+{count} agregado este año",
+        "stats": {
+          "books": "Libros",
+          "authors": "Autores",
+          "series": "Serie",
+          "storage": "Almacenamiento"
+        }
+      },
+      "longWait": {
+        "title": "La larga espera",
+        "empty": "No hay libros esperando. ¡Has empezado todo!",
+        "daysWaiting": "días esperando",
+        "pages": "{count, plural, =0 {sin páginas} one {# página} other {# paginas} many {# paginas}}",
+        "startReading": "Empezar a leer"
+      },
+      "monthlyChallenge": {
+        "title": "Reto Mensual",
+        "complete": "¡Completo!"
+      },
+      "neglectedGems": {
+        "title": "Gemas olvidadas",
+        "empty": "¡Se han leído todos tus libros mejor valorados!",
+        "rating": "{rating}/5",
+        "daysWaiting": "{count}d esperando",
+        "queued": "En cola",
+        "addToQueue": "Añadir a la cola",
+        "shuffle": "barajar"
+      },
+      "readingDna": {
+        "title": "Lectura de ADN",
+        "notEnoughData": "Lee al menos 5 libros para desbloquear tu ADN de lectura",
+        "basedOn": "{count, plural, =0 {Basado en ningún libro} one {Basado en # libro} other {Basado en # libros} many {Basado en # libros}}",
+        "traits": {
+          "length": "Longitud",
+          "variety": "Variedad",
+          "rhythm": "ritmo",
+          "time": "tiempo",
+          "speed": "Velocidad"
+        }
+      },
+      "readingGoal": {
+        "title": "Objetivo de lectura {year}",
+        "setGoalPrompt": "Establece un objetivo de lectura para seguir tu progreso",
+        "setGoal": "Establecer objetivo",
+        "booksPerYear": "Libros por año",
+        "ofGoal": "de {goal}",
+        "percentComplete": "{percentage}% completado",
+        "editGoal": "Editar objetivo"
+      },
+      "readingRhythm": {
+        "title": "Ritmo de lectura",
+        "empty": "Empieza a leer para ver cómo tu ritmo toma forma",
+        "activeDays": "{count, plural, =0 {sin días activos} one {# dia activo} other {# dias activos} many {# dias activos}}",
+        "consistency": "{activeDays} · {percent}% de consistencia",
+        "avgPerDay": "promedio {time}/día"
+      },
+      "readingStreak": {
+        "title": "Racha de lectura",
+        "empty": "Lee hoy para comenzar tu racha",
+        "streakLabel": "{count, plural, =0 {racha de dias} one {racha de dias} other {racha de dias} many {racha de dias}}",
+        "best": "{count, plural, =0 {Mejor: # dia} one {Mejor: # dia} other {Mejor: # dias} many {Mejor: # dias}}",
+        "lastSevenDays": "últimos 7 días"
+      },
+      "yearProjection": {
+        "title": "Proyección del año",
+        "books": "libros",
+        "trendUp": "Tendencia ascendente",
+        "trendDown": "Tendencia a la baja",
+        "trendSteady": "ritmo constante",
+        "pages": "paginas",
+        "hours": "horas",
+        "readCount": "{count} leer",
+        "daysLeft": "{count}d queda"
+      }
+    }
+  },
+  "email": {
+    "title": "Correo electrónico",
+    "subtitle": "Envíe libros a su lector electrónico por correo electrónico.",
+    "loadFailed": "No se pudo cargar",
+    "saveFailed": "No se pudo guardar",
+    "deleteFailed": "No se pudo eliminar",
+    "setDefaultFailed": "No se pudo establecer el valor predeterminado",
+    "setAsDefault": "Establecer como predeterminado",
+    "saving": "Guardando...",
+    "update": "Actualizar",
+    "create": "crear",
+    "deleteConfirm": "Eliminar \"{name}\". Esta acción no se puede deshacer.",
+    "badge": {
+      "default": "Predeterminado",
+      "shared": "Compartido",
+      "system": "Sistema"
+    },
+    "tabs": {
+      "providers": "Proveedores",
+      "recipients": "Destinatarios",
+      "groups": "Grupos",
+      "templates": "Plantillas",
+      "preferences": "Preferencias",
+      "history": "Historia"
+    },
+    "providers": {
+      "heading": "Proveedores SMTP",
+      "add": "Agregar proveedor",
+      "newTitle": "Nuevo proveedor",
+      "editTitle": "Editar proveedor",
+      "name": "Nombre",
+      "namePlaceholder": "por ej. Gmail",
+      "host": "Anfitrión",
+      "port": "Puerto",
+      "username": "Nombre de usuario",
+      "password": "Contraseña",
+      "passwordEdit": "Contraseña (déjela en blanco para mantenerla actualizada)",
+      "fromName": "Del nombre",
+      "fromNamePlaceholder": "Mi biblioteca",
+      "fromAddress": "De la dirección",
+      "authentication": "Autenticación",
+      "verifyTls": "Verificar el certificado TLS",
+      "tlsWarning": "La verificación TLS está deshabilitada. El certificado del servidor no será validado; utilícelo solo para servidores internos confiables.",
+      "noFromAddress": "no de la dirección",
+      "emptyManage": "Aún no hay proveedores. Agregue un proveedor SMTP para comenzar a enviar correos electrónicos.",
+      "emptyReadonly": "No hay proveedores disponibles. Pídale a un administrador que agregue uno.",
+      "setSystemTooltip": "Establecer como proveedor de correo del sistema",
+      "removeSystemTooltip": "Eliminar como proveedor de correo del sistema",
+      "testTooltip": "Conexión de prueba",
+      "toggleSharing": "Alternar compartir",
+      "removeSystemBeforeDelete": "Elimine la designación del sistema antes de eliminar",
+      "notesHeading": "Notas del proveedor",
+      "notesBody": "El proveedor {system} (solo superusuario) se utiliza para los correos electrónicos de restablecimiento de contraseña. El proveedor {defaultProvider} se utiliza al enviar libros sin ningún proveedor explícito seleccionado. Los proveedores marcados {shared} están disponibles para todos los usuarios.",
+      "deleteTitle": "¿Eliminar proveedor?",
+      "nameHostRequired": "El nombre y el host son obligatorios",
+      "created": "Proveedor creado",
+      "updated": "Proveedor actualizado",
+      "deleted": "\"{name}\" eliminado",
+      "setDefaultSuccess": "\"{name}\" establecido como predeterminado",
+      "unshared": "Proveedor no compartido",
+      "sharedWithAll": "Proveedor compartido con todos los usuarios.",
+      "updateSharingFailed": "No se pudo actualizar el uso compartido",
+      "systemRemoved": "\"{name}\" eliminado como proveedor de correo del sistema",
+      "systemSet": "\"{name}\" configurado como proveedor de correo del sistema",
+      "updateSystemFailed": "No se pudo actualizar el proveedor del sistema",
+      "connectionSuccess": "Conexión exitosa",
+      "connectionFailed": "La conexión falló",
+      "testFailed": "Prueba fallida"
+    },
+    "recipients": {
+      "heading": "Destinatarios",
+      "add": "Agregar destinatario",
+      "newTitle": "Nuevo destinatario",
+      "editTitle": "Editar destinatario",
+      "name": "Nombre",
+      "namePlaceholder": "Mi Kindle",
+      "emailAddress": "Dirección de correo electrónico",
+      "deviceType": "Tipo de dispositivo",
+      "deviceNone": "Ninguno",
+      "deviceOther": "Otro",
+      "preferredFormat": "Formato preferido",
+      "formatAuto": "Automático",
+      "defaultTemplate": "Plantilla predeterminada",
+      "useAccountDefault": "Usar cuenta predeterminada",
+      "kindleNote": "Los destinatarios de Kindle reciben automáticamente correos electrónicos con el asunto \"convertir\" para activar la conversión de formato.",
+      "empty": "Aún no hay destinatarios.",
+      "prefersFormat": "prefiere {format}",
+      "deleteTitle": "¿Eliminar destinatario?",
+      "nameEmailRequired": "Nombre y correo electrónico son requeridos",
+      "created": "Destinatario creado",
+      "updated": "Destinatario actualizado",
+      "deleted": "\"{name}\" eliminado",
+      "setDefaultSuccess": "\"{name}\" establecido como predeterminado"
+    },
+    "groups": {
+      "heading": "Grupos de destinatarios",
+      "create": "Crear grupo",
+      "newTitle": "Nuevo grupo",
+      "name": "Nombre del grupo",
+      "namePlaceholder": "por ej. Club de lectura",
+      "creating": "Creando...",
+      "empty": "Aún no hay grupos. Crea un grupo para enviar a varios destinatarios a la vez.",
+      "memberCount": "{count, plural, =0 {ningún miembro} one {un miembro} other {# miembros} many {# miembros}}",
+      "deleteTooltip": "Eliminar grupo",
+      "noMembers": "Aún no hay miembros.",
+      "removeMember": "Quitar",
+      "selectRecipient": "Seleccionar destinatario...",
+      "add": "Añadir",
+      "addMember": "Agregar miembro",
+      "allRecipientsInGroup": "Todos los destinatarios ya están en este grupo.",
+      "deleteTitle": "¿Eliminar grupo?",
+      "created": "Grupo creado",
+      "createFailed": "No se pudo crear el grupo",
+      "deleted": "\"{name}\" eliminado",
+      "memberAdded": "Miembro agregado",
+      "addMemberFailed": "No se pudo agregar miembro",
+      "memberRemoved": "Miembro eliminado",
+      "removeMemberFailed": "No se pudo eliminar el miembro"
+    },
+    "templates": {
+      "heading": "Plantillas de correo electrónico",
+      "new": "Nueva plantilla",
+      "newTitle": "Nueva plantilla",
+      "editTitle": "Editar plantilla",
+      "name": "Nombre",
+      "namePlaceholder": "Predeterminado",
+      "subject": "Asunto",
+      "body": "cuerpo",
+      "availableVariables": "Variables disponibles",
+      "editTemplate": "Editar plantilla",
+      "empty": "Aún no hay plantillas.",
+      "notesHeading": "Notas de plantilla",
+      "notesBody": "Las plantillas del sistema no se pueden eliminar. Los administradores pueden editarlos. Utilice variables como {variable} en asuntos y cuerpos; se reemplazan con detalles del libro en el momento del envío.",
+      "deleteTitle": "¿Eliminar plantilla?",
+      "nameSubjectRequired": "El nombre y el asunto son obligatorios.",
+      "created": "Plantilla creada",
+      "updated": "Plantilla actualizada",
+      "deleted": "\"{name}\" eliminado",
+      "setDefaultSuccess": "\"{name}\" establecido como predeterminado"
+    },
+    "preferences": {
+      "heading": "Preferencias de correo electrónico",
+      "defaultProvider": "Proveedor predeterminado",
+      "defaultProviderHint": "Se utiliza cuando no se especifica ningún proveedor. Si está vacío, se utiliza la cuenta predeterminada.",
+      "noneAccountDefault": "Ninguno (usar cuenta predeterminada)",
+      "defaultRecipient": "Destinatario predeterminado",
+      "defaultRecipientHint": "Se utiliza para envío rápido. Debe estar configurado para utilizar la acción de envío rápido en tarjetas de libros.",
+      "none": "Ninguno",
+      "defaultTemplate": "Plantilla predeterminada",
+      "defaultTemplateHint": "Se utiliza cuando no se especifica ninguna plantilla. Vuelve al valor predeterminado del sistema si está vacío.",
+      "noneSystemDefault": "Ninguno (usar valor predeterminado del sistema)",
+      "save": "Guardar preferencias",
+      "saved": "Preferencias guardadas"
+    },
+    "history": {
+      "heading": "Enviar historial",
+      "empty": "Aún no se han enviado correos electrónicos.",
+      "noSubject": "(sin tema)",
+      "loadMore": "Cargar más",
+      "resend": "Reenviar",
+      "deleteTitle": "¿Eliminar entrada del historial?",
+      "entryDeleted": "Entrada eliminada",
+      "queuedForResend": "En cola para reenviar",
+      "resendFailed": "No se pudo reenviar",
+      "statusSent": "Enviado",
+      "statusFailed": "Fallido",
+      "statusQueued": "En cola",
+      "statusPending": "Pendiente"
+    },
+    "send": {
+      "title": "Enviar por correo electrónico",
+      "bookCount": "{count, plural, =0 {sin libros} one {un libro} other {# libros} many {# libros}}",
+      "recipients": "Destinatarios",
+      "noRecipients": "No hay destinatarios configurados. Agregue uno en la configuración de correo electrónico.",
+      "groups": "Grupos",
+      "options": "Opciones",
+      "fileFormat": "Formato de archivo",
+      "autoRecipientPreference": "Automático (usar preferencia de destinatario)",
+      "unknownFormat": "Desconocido",
+      "primarySuffix": "(principal)",
+      "provider": "Proveedor",
+      "template": "Plantilla",
+      "default": "Predeterminado",
+      "send": "enviar",
+      "sending": "Enviando...",
+      "queued": "{count, plural, =0 {no hay correos electrónicos en cola} one {un correo electrónico en cola} other {# correos electrónicos en cola} many {# correos electrónicos en cola}}",
+      "failed": "No se pudo enviar"
+    }
+  },
+  "hardcover": {
+    "settings": {
+      "subtitle": "Sincronice su progreso de lectura, estado y calificaciones con Hardcover."
+    },
+    "bookSync": {
+      "label": "Hardcover Sincronización",
+      "toggleAriaLabel": "Sincroniza este libro con Hardcover",
+      "syncNow": "Sincronizar ahora"
+    },
+    "connection": {
+      "title": "Conexión",
+      "description": "Conecte su cuenta Hardcover para sincronizar los datos de lectura.",
+      "connected": "Conectado",
+      "apiToken": "Token de API",
+      "tokenPlaceholder": "Pega tu token Hardcover API",
+      "show": "Mostrar",
+      "hide": "Ocultar",
+      "findTokenAt": "Encuentra tu token en",
+      "validateToken": "Validar token",
+      "valid": "Válido ({username})",
+      "invalidToken": "Token no válido",
+      "syncOptions": "Opciones de sincronización",
+      "syncInfo": "La sincronización se ejecuta solo para libros que no están sin leer. Esto se aplica a los activadores de estado, progreso y calificación. Estos interruptores controlan cuándo se ejecuta una sincronización.",
+      "syncScope": {
+        "title": "Alcance de la sincronización del libro",
+        "allEligible": {
+          "label": "Todos los libros elegibles",
+          "description": "Sincroniza todo a menos que excluyas un libro."
+        },
+        "selectedOnly": {
+          "label": "Solo libros seleccionados",
+          "description": "Sincroniza solo los libros que incluyas explícitamente."
+        }
+      },
+      "enableSync": {
+        "title": "Habilitar sincronización",
+        "description": "Pausa toda la sincronización de Hardcover sin desconectarte."
+      },
+      "syncOnStatus": {
+        "title": "Sincronización al cambiar de estado",
+        "description": "Actualizaciones automáticas cuando marcas un libro como leído, leído, etc."
+      },
+      "syncOnProgress": {
+        "title": "Sincronización en actualización de progreso",
+        "description": "Envíe el progreso de lectura y las fechas en las que cambia el progreso de BookOrbit o KOReader."
+      },
+      "syncOnRating": {
+        "title": "Sincronización al cambiar de calificación",
+        "description": "Sube tus calificaciones de estrellas a Hardcover."
+      },
+      "privacy": {
+        "title": "Privacidad",
+        "description": "Visibilidad predeterminada para libros sincronizados en Hardcover.",
+        "public": "Público",
+        "followersOnly": "Sólo seguidores",
+        "private": "Privado"
+      },
+      "disconnect": "Desconectar",
+      "toast": {
+        "enterToken": "Ingrese primero su token Hardcover API",
+        "saved": "Hardcover configuración guardada",
+        "saveFailed": "No se pudo guardar la configuración",
+        "disconnected": "Hardcover desconectado"
+      }
+    },
+    "sync": {
+      "title": "Sincronización manual",
+      "description": "Envía tu {scope} a Hardcover ahora.",
+      "scope": {
+        "selected": "libros seleccionados",
+        "eligible": "libros elegibles"
+      },
+      "checkingPending": "Comprobando elementos pendientes...",
+      "pendingOf": "{pending} pendiente de {total} libros.",
+      "noBooksInScope": "No hay libros en el ámbito de sincronización.",
+      "allSynced": "Todos los libros ya están sincronizados.",
+      "lastSyncedLabel": "Última sincronización",
+      "lastSuccessfulSync": "Última sincronización exitosa",
+      "syncing": "Sincronizando...",
+      "progressCount": "{synced} / {total} libros",
+      "unavailable": {
+        "permissionDenied": "No tienes permiso para utilizar la sincronización Hardcover.",
+        "userDisabled": "La sincronización está pausada en tu configuración de Hardcover."
+      },
+      "button": {
+        "unavailable": "Sincronización no disponible",
+        "syncNow": "Sincronizar ahora",
+        "syncNowCount": "Sincronizar ahora ({count})"
+      },
+      "lastSynced": {
+        "justNow": "Justo ahora",
+        "minutesAgo": "{count} hace minutos",
+        "hoursAgo": "{count, plural, =0 {# hace una hora} one {# hace una hora} other {# hace horas} many {# hace horas}}",
+        "daysAgo": "{count, plural, =0 {# hace un día} one {# hace un día} other {# hace dias} many {# hace dias}}"
+      }
+    },
+    "import": {
+      "title": "Extraer estado de lectura",
+      "description": "Obtenga una vista previa de las coincidencias de Hardcover antes de completar los estados de BookOrbit en blanco.",
+      "clear": "Borrar",
+      "preview": "Vista previa",
+      "importProgress": "Progreso de importación",
+      "reviewMatches": "Revisar partidos",
+      "importReady": "Importación lista",
+      "exactMatches": "{count, plural, =0 {no se pueden importar coincidencias exactas sin revisión} one {# la coincidencia exacta se puede importar sin revisión} other {# las coincidencias exactas se pueden importar sin revisión} many {# las coincidencias exactas se pueden importar sin revisión}}",
+      "progressAvailable": "{count, plural, =0 {no hay actualizaciones de progreso disponibles} one {# actualización de progreso disponible} other {# actualizaciones de progreso disponibles} many {# actualizaciones de progreso disponibles}}",
+      "progressConflicts": "{count, plural, =0 {sin conflictos} one {# conflicto} other {# conflictos} many {# conflictos}}",
+      "unavailable": {
+        "permissionDenied": "No tienes permiso para utilizar la sincronización Hardcover.",
+        "missingToken": "Conecte Hardcover antes de importar.",
+        "userDisabled": "La sincronización está pausada en tu configuración de Hardcover."
+      },
+      "summary": {
+        "ready": "Listo",
+        "review": "Revisión",
+        "conflicts": "Conflictos",
+        "unmatched": "Inigualable",
+        "skipped": "Saltado"
+      },
+      "result": {
+        "summary": "{applied} importado{progress}, {failed} falló",
+        "progressUpdated": "{count} progreso actualizado"
+      },
+      "toast": {
+        "importFailed": "No se pudo importar el estado de lectura Hardcover",
+        "imported": "{count, plural, =0 {no se importaron estados de lectura{progress}} one {# estado de lectura importado{progress}} other {# leer estados importados{progress}} many {# leer estados importados{progress}}}",
+        "progressUpdates": "{count, plural, =0 {sin actualizaciones de progreso} one {# actualización de progreso} other {# actualizaciones de progreso} many {# actualizaciones de progreso}}"
+      }
+    },
+    "review": {
+      "title": "Hardcover revisión de importación",
+      "subtitle": "{total} Hardcover libros, {matched} coincidentes.",
+      "closeAriaLabel": "Cerrar revisión de importación",
+      "searchPlaceholder": "Buscar título o autor",
+      "importProgress": "Progreso de importación",
+      "untitled": "Sin título",
+      "blank": "en blanco",
+      "noRows": "Ninguna fila coincide con los filtros actuales.",
+      "selectRowAriaLabel": "Seleccione {title}",
+      "selectionSummary": "{count} seleccionado: {ready} listo, {reviewed} revisado.",
+      "selectedProgress": "{count, plural, =0 {sin actualizaciones de progreso} one {# actualización de progreso} other {# actualizaciones de progreso} many {# actualizaciones de progreso}}",
+      "selectReady": "Seleccione listo",
+      "selectPage": "Seleccionar página",
+      "clearPage": "Borrar página",
+      "clearSelection": "Borrar selección",
+      "importSelected": "Importar seleccionado",
+      "previousPage": "Pagina anterior",
+      "nextPage": "Página siguiente",
+      "pageRange": "{start}-{end} de {total}",
+      "tabs": {
+        "all": "Todos",
+        "ready": "Listo",
+        "review": "Revisión",
+        "conflicts": "Conflictos",
+        "unmatched": "Inigualable",
+        "skipped": "Saltado"
+      },
+      "summary": {
+        "ready": "Listo",
+        "review": "Revisión",
+        "conflicts": "Conflictos",
+        "unmatched": "Inigualable",
+        "skipped": "Saltado"
+      },
+      "matchOptions": {
+        "all": "Todos los tipos de partidos"
+      },
+      "matchMethod": {
+        "hardcoverId": "Hardcover ID",
+        "isbn": "ISBN",
+        "titleAuthor": "Título + autor"
+      },
+      "outcome": {
+        "ready": "Listo",
+        "review": "Revisión",
+        "conflict": "Conflicto",
+        "unmatched": "Inigualable",
+        "skipped": "Saltado"
+      },
+      "column": {
+        "progress": "Progreso"
+      }
+    }
+  },
+  "library": {
+    "creator": {
+      "createTitle": "Crear biblioteca",
+      "editTitle": "Editar: {name}",
+      "stepOf": "Paso {current} de {total}",
+      "unsaved": "No guardado",
+      "required": "Requerido",
+      "closeAria": "Cerrar creador de biblioteca",
+      "progressAria": "Progreso de la configuración de la biblioteca",
+      "sectionsAria": "Secciones de configuración de la biblioteca",
+      "loadingAria": "Cargando la configuración de la biblioteca",
+      "sections": {
+        "details": "Detalles",
+        "folders": "Carpetas",
+        "scanner": "Escáner",
+        "metadata": "Metadatos",
+        "fileWrite": "Escritura de archivo",
+        "reading": "leyendo",
+        "schedule": "Horario",
+        "access": "Acceso"
+      },
+      "actions": {
+        "saving": "Guardando…",
+        "saveChanges": "Guardar cambios",
+        "creating": "Creando…",
+        "createLibrary": "Crear biblioteca"
+      },
+      "details": {
+        "libraryName": "Nombre de la biblioteca",
+        "namePlaceholder": "Mi biblioteca",
+        "coverStyle": {
+          "title": "Estilo de portada",
+          "portrait": "retrato",
+          "square": "cuadrado",
+          "hint": "Retrato para libros electrónicos o bibliotecas mixtas. Square para bibliotecas exclusivas de audiolibros."
+        },
+        "icon": {
+          "label": "Icono",
+          "placeholder": "Elige un icono...",
+          "selected": "Seleccionado"
+        }
+      },
+      "folders": {
+        "title": "Escanear carpetas",
+        "description": "Agregue uno o más directorios para buscar libros.",
+        "browseAdd": "Explorar y agregar una carpeta",
+        "browseTitle": "Explorar carpetas del servidor",
+        "browseDescription": "Seleccione una o más carpetas sin salir del navegador.",
+        "selectedTitle": "Carpetas seleccionadas",
+        "addFolders": "Agregar carpetas",
+        "manualEntry": "Ingrese una ruta manualmente",
+        "absolutePath": "Ruta absoluta del servidor",
+        "addFolder": "Agregar carpeta",
+        "removeFolder": "Eliminar {folder}",
+        "manualCheckHint": "Las rutas manuales se comprueban junto con el resto de carpetas seleccionadas.",
+        "pathPlaceholder": "/ruta/a/libros",
+        "test": "prueba",
+        "add": "Añadir",
+        "pathNotAccessible": "No se puede acceder a la ruta en el servidor.",
+        "pathAccessible": "El camino es accesible.",
+        "pathNotAccessibleShort": "El camino no es accesible",
+        "overlapsWith": "Se superpone con \"{library}\"",
+        "noneAdded": "Aún no se han agregado carpetas",
+        "runPrescanHint": "Ejecute un escaneo previo para validar las rutas antes de guardar.",
+        "scanning": "Escaneando…",
+        "prescan": "preescaneado"
+      },
+      "scanner": {
+        "scanMode": {
+          "title": "Modo de escaneo",
+          "lockedAria": "El modo de organización está bloqueado",
+          "lockTooltip": "El modo de organización se corrige después de la creación de la biblioteca porque cambiarlo puede crear entradas de libro duplicadas o faltantes. Para utilizar un modo diferente, cree una nueva biblioteca y vuelva a escanear.",
+          "recommended": "Recomendado",
+          "folderAsBook": {
+            "title": "Carpeta como libro",
+            "hint": "Todos los archivos de una carpeta se agrupan en un solo libro. Funciona bien cuando mantienes varios formatos, como EPUB y MOBI, juntos."
+          },
+          "fileAsBook": {
+            "title": "Archivar como libro",
+            "hint": "Trata cada archivo como un libro individual. Ideal para bibliotecas con un formato por título. Evítelo si sus audiolibros abarcan varios archivos."
+          }
+        },
+        "allowedFormats": {
+          "title": "Formatos permitidos",
+          "allowAll": "Permitir todo",
+          "allAllowed": "Todos los formatos están permitidos.",
+          "onlySelected": "Sólo se importarán los formatos seleccionados.",
+          "warning": "Los libros en otros formatos que ya estén en la biblioteca se marcarán como faltantes en el siguiente escaneo."
+        },
+        "excludePatterns": {
+          "title": "Excluir patrones",
+          "hintBefore": "Patrones globales que se deben omitir durante el escaneo (p. ej. ",
+          "hintAfter": ").",
+          "add": "Añadir",
+          "empty": "No se agregaron patrones."
+        }
+      },
+      "metadata": {
+        "sourcePrecedence": {
+          "title": "Prioridad de fuente",
+          "hint": "Se prefiere la fuente más alta de la lista cuando hay varias disponibles."
+        },
+        "formatPriority": {
+          "title": "Prioridad de formato",
+          "hint": "Cuando un libro tiene varios formatos, se prefiere el formato más alto de la lista."
+        }
+      },
+      "fileWrite": {
+        "maxFileSizeMb": "Tamaño máximo de archivo (MB)",
+        "formatLimits": "Límites de formato",
+        "rename": {
+          "title": "Cambiar el nombre de los archivos después de cambios de metadatos",
+          "hint": "Cambia el nombre de los archivos físicos cuando cambia el título, el autor, la serie o el año, utilizando el patrón de nomenclatura de la biblioteca."
+        },
+        "write": {
+          "title": "Escribir metadatos en archivos",
+          "hint": "Cuando está habilitado, guardar metadatos también escribirá los cambios nuevamente en el archivo físico en el disco."
+        },
+        "cover": {
+          "title": "Incluir imagen de portada",
+          "hint": "Vuelve a escribir la portada almacenada en formatos de archivo compatibles."
+        },
+        "epub": {
+          "title": "EPUB",
+          "hint": "Escribe metadatos en el archivo OPF dentro del archivo EPUB.",
+          "toggleAria": "Escribir metadatos EPUB"
+        },
+        "fb2": {
+          "title": "FictionBook (FB2)",
+          "hint": "Reescribe el bloque de descripción dentro de los archivos FB2, dejando intacto el texto del libro.",
+          "toggleAria": "Escribir metadatos FB2"
+        },
+        "pdf": {
+          "title": "PDF",
+          "hint": "Incorpora metadatos en PDF Diccionario de información y secuencia XMP.",
+          "toggleAria": "Escribir metadatos PDF"
+        },
+        "cbx": {
+          "title": "Archivos de cómics (CBX)",
+          "hint": "Escribe ComicInfo.xml en archivos CBZ y CB7.",
+          "toggleAria": "Escribir metadatos de archivo de cómics"
+        },
+        "kindle": {
+          "title": "Kindle (MOBI, AZW3)",
+          "hint": "Escribe metadatos en el encabezado EXTH de los archivos MOBI, AZW3 y AZW.",
+          "toggleAria": "Escribir metadatos de Kindle"
+        },
+        "audio": {
+          "title": "Audio",
+          "hint": "Incrusta la portada almacenada en archivos M4B, M4A, MP3 y FLAC.",
+          "toggleAria": "Escribir portadas de audio"
+        }
+      },
+      "reading": {
+        "readingStart": {
+          "title": "inicio de lectura",
+          "hint": "Un libro se marca como \"leyendo\" una vez que se alcanza este porcentaje de progreso."
+        },
+        "markAsFinished": {
+          "title": "Marcar como terminado",
+          "hint": "Un libro se marca automáticamente como \"leído\" cuando se alcanza este porcentaje de progreso."
+        }
+      },
+      "schedule": {
+        "fileWatching": "Observación de archivos",
+        "autoScanSchedule": "Programación de escaneo automático",
+        "cronExpression": "expresión cron",
+        "cronInvalid": "Expresión cron no válida.",
+        "cronFormat": "Formato: minuto hora día mes día laborable",
+        "watchFolders": {
+          "title": "Ver carpetas",
+          "hint": "Detecta automáticamente nuevos archivos agregados a las carpetas de la biblioteca."
+        },
+        "presets": {
+          "never": "nunca",
+          "hourly": "cada hora",
+          "every6Hours": "Cada 6 horas",
+          "every12Hours": "Cada 12 horas",
+          "daily": "Diariamente",
+          "weekly": "Semanal",
+          "custom": "personalizado"
+        },
+        "human": {
+          "disabled": "Escaneo automático deshabilitado",
+          "hourly": "cada hora",
+          "every6Hours": "Cada 6 horas",
+          "every12Hours": "Cada 12 horas",
+          "dailyMidnight": "Diariamente a medianoche",
+          "weeklyMonday": "Semanalmente el lunes a medianoche.",
+          "cron": "Cron: {cron}"
+        }
+      },
+      "access": {
+        "title": "control de acceso",
+        "description": "Los superusuarios siempre tienen acceso completo. Concede acceso a otros usuarios a continuación.",
+        "notYetCreated": "El acceso se puede configurar después de crear la biblioteca.",
+        "selectUser": "Seleccione un usuario…",
+        "grant": "Conceder",
+        "empty": "Aún no se ha concedido acceso a ningún usuario.",
+        "loading": "Cargando configuración de acceso...",
+        "userSelectAria": "Usuario para otorgar acceso",
+        "levelSelectAria": "Nivel de acceso a otorgar",
+        "levels": {
+          "viewer": "Visor",
+          "editor": "Redactor",
+          "owner": "propietario"
+        },
+        "columns": {
+          "user": "Usuario",
+          "accessLevel": "Nivel de acceso"
+        },
+        "errors": {
+          "grant": "No se pudo otorgar acceso",
+          "updateLevel": "No se pudo actualizar el nivel de acceso",
+          "revoke": "No se pudo revocar el acceso"
+        }
+      }
+    },
+    "folderPicker": {
+      "title": "Explorar carpetas del servidor",
+      "description": "Seleccione una o más carpetas para esta biblioteca.",
+      "closeAria": "Cerrar el navegador de carpetas",
+      "currentFolderAria": "Carpeta actual",
+      "parentFolder": "Ir a la carpeta principal",
+      "newFolder": "Nueva carpeta",
+      "goUp": "subir",
+      "filterPlaceholder": "Filtrar carpetas…",
+      "clearFilterAria": "Limpiar filtro de carpeta",
+      "newFolderNamePlaceholder": "Nuevo nombre de carpeta",
+      "create": "crear",
+      "loading": "Cargando carpetas...",
+      "selectCurrent": "Seleccionar carpeta actual",
+      "noMatches": "No hay carpetas coincidentes",
+      "noMatchesHint": "Pruebe con un filtro diferente.",
+      "empty": "Esta carpeta está vacía",
+      "emptyHint": "Puede seleccionar la carpeta actual o crear una nueva.",
+      "openFolderAria": "Abrir {name}",
+      "selectedCount": "{count, plural, =0 {no hay carpetas seleccionadas} one {# carpeta seleccionada} other {# carpetas seleccionadas} many {# carpetas seleccionadas}}",
+      "noFolders": "No se encontraron carpetas",
+      "selectFolder": "Seleccione esta carpeta",
+      "errors": {
+        "readDirectory": "No se pudo leer el directorio",
+        "connect": "No se pudo conectar",
+        "invalidName": "Ingrese un solo nombre de carpeta sin barras ni puntos iniciales",
+        "createFolder": "No se pudo crear la carpeta"
+      }
+    },
+    "upload": {
+      "library": "Biblioteca",
+      "selectLibrary": "Seleccione una biblioteca...",
+      "targetFolder": "Carpeta de destino",
+      "addMoreFiles": "Agregar más archivos",
+      "clearAll": "Borrar todo",
+      "done": "Hecho",
+      "retry": "Reintentar",
+      "upload": "Subir",
+      "uploadWithCount": "Subir ({count})",
+      "viewInLibrary": "Ver en la biblioteca",
+      "fileCount": "{count, plural, =0 {sin archivos} one {# archivo} other {# archivos} many {# archivos}}",
+      "booksAdded": "{count, plural, =0 {no se agregaron libros} one {# libro agregado} other {# libros añadidos} many {# libros añadidos}}",
+      "uploadedFailed": "{done} subido, {failed} falló",
+      "progress": "{done} de {total} subiendo...",
+      "header": {
+        "uploading": "Subiendo...",
+        "complete": "Subida completa",
+        "uploadTo": "Subir a {library}",
+        "uploadBooks": "Subir libros"
+      },
+      "dropzone": {
+        "title": "Suelte los archivos aquí o haga clic para explorar",
+        "hint": "{formats} - hasta {size} MB cada uno"
+      }
+    }
+  },
+  "metadataScore": {
+    "missingFields": "{count, plural, =0 {no faltan campos - editar metadatos} one {# falta campo - editar metadatos} other {# faltan campos - editar metadatos} many {# faltan campos - editar metadatos}}"
+  },
+  "migration": {
+    "sidebarTitle": "Importación de libros",
+    "status": {
+      "done": "Hecho",
+      "saved": "Guardado",
+      "running": "corriendo",
+      "failed": "Fallido"
+    },
+    "badge": {
+      "validated": "Validado",
+      "upToDate": "actualizado",
+      "completed": "Completado"
+    },
+    "steps": {
+      "source": {
+        "short": "Conexión de origen",
+        "title": "Conexión de origen",
+        "subtitle": "Configure la conexión de la base de datos a su instancia de Booklore de origen."
+      },
+      "mappings": {
+        "short": "Mapeo de usuarios y rutas",
+        "title": "Mapeo de usuarios y rutas",
+        "subtitle": "Asigne usuarios de origen a usuarios de destino y traduzca rutas de archivos."
+      },
+      "dryRun": {
+        "short": "Ejecución en seco",
+        "title": "Ejecución en seco",
+        "subtitle": "Obtenga una vista previa de lo que se importará antes de ejecutar la migración en vivo."
+      },
+      "migration": {
+        "short": "Ejecutar migración",
+        "title": "Ejecutar migración",
+        "subtitle": "Inicie la importación en vivo y supervise su progreso."
+      },
+      "report": {
+        "short": "Informe",
+        "title": "Informe de migración",
+        "subtitle": "Revise lo que se importó y exporte un informe detallado."
+      }
+    },
+    "footer": {
+      "continueToMappings": "Continuar a Asignaciones",
+      "continueToDryRun": "Continuar con el funcionamiento en seco",
+      "continueToMigration": "Continuar con la migración",
+      "viewReport": "Ver informe",
+      "resetSetup": "Restablecer configuración",
+      "stepOf": "Paso {current} de {total}",
+      "backToSetup": "Volver a la configuración"
+    },
+    "stages": {
+      "init": "Inicializando",
+      "sharedOverlays": "Importando metadatos",
+      "bookCovers": "Importación de portadas",
+      "userState": "Importar datos de usuario"
+    },
+    "source": {
+      "testConnection": "Conexión de prueba",
+      "saveAndValidate": "Guardar y validar",
+      "validatedWithWarnings": "Fuente validada con advertencias.",
+      "fields": {
+        "type": "Tipo de fuente",
+        "name": "Nombre de fuente",
+        "host": "Anfitrión",
+        "port": "Puerto",
+        "user": "Usuario",
+        "password": "Contraseña",
+        "passwordSaved": "Guardado - dejar sin cambios",
+        "passwordNotSet": "No se ha establecido ninguna contraseña",
+        "database": "Base de datos",
+        "mediaRootPath": "Ruta raíz de medios",
+        "ssl": "Usar TLS/SSL"
+      },
+      "mediaPath": {
+        "hintRequired": "Requerido para migrar portadas de libros.",
+        "hintAbsolute": "Utilice una ruta absoluta (por ejemplo: /libros). No se admiten rutas relativas.",
+        "hintConfigured": "Ruta de importación de portada configurada. Utilice Test Connection para verificar el acceso y la estructura de carpetas de imágenes de Booklore.",
+        "buttonOk": "Camino correcto",
+        "buttonIssue": "Problema de ruta",
+        "buttonTest": "Ruta de prueba"
+      },
+      "compatibility": {
+        "title": "Compatibilidad probada",
+        "verifiedAgainst": "Verificado contra:",
+        "note": "Es probable que las versiones posteriores sean compatibles, pero no han sido verificadas. Primero ejecute un ensayo para confirmar antes de confirmar los datos."
+      },
+      "snapshot": {
+        "title": "Última instantánea de validación",
+        "sourceVersion": "Versión fuente: {version}",
+        "unknown": "Desconocido",
+        "missingTables": "Faltan tablas requeridas: {tables}"
+      }
+    },
+    "mappings": {
+      "suggestionsAutoLoad": "Las sugerencias de los usuarios se cargan automáticamente después de la validación de la fuente.",
+      "refresh": "Actualizar",
+      "sourceUser": "Usuario fuente",
+      "targetUser": "Usuario objetivo",
+      "noSourceUsersLoaded": "Aún no se han cargado usuarios de origen.",
+      "noActiveTargetUsers": "No se encontraron usuarios objetivo activos. Cree o vuelva a habilitar un usuario BookOrbit antes de realizar la asignación.",
+      "pathPrefixMappings": "Asignaciones de prefijos de ruta",
+      "addMapping": "Agregar mapeo",
+      "pathMappingsExplanation": "Las asignaciones de rutas traducen las rutas de los archivos de origen en rutas de destino para que los libros puedan coincidir según la ubicación del archivo. Los libros también coinciden con ISBN, hash de archivo y título/autor, independientemente de las asignaciones de rutas.",
+      "noPrefixesFound": "No se encontraron prefijos: primero valide la fuente",
+      "selectSourcePrefix": "Seleccione el prefijo de origen...",
+      "selectTargetFolder": "Seleccione la carpeta de destino...",
+      "remove": "Quitar",
+      "saveMappings": "Guardar asignaciones",
+      "pathValidation": {
+        "title": "Validación de ruta",
+        "mappedSummary": "{mapped} de {total} libros fuente tienen una ruta asignada",
+        "unmatched": "{count} rutas asignadas no encontradas en el disco",
+        "allMatched": "Todas las {count} rutas asignadas encontradas en el disco"
+      }
+    },
+    "dryRun": {
+      "run": "Ejecutar funcionamiento en seco",
+      "matched": "Emparejado:",
+      "unresolved": "Sin resolver:",
+      "duplicates": "Duplicados:",
+      "unresolvedSummary": "Resumen no resuelto"
+    },
+    "duplicates": {
+      "title": "Resolver coincidencias de objetivos duplicados",
+      "explanation": "Para cada libro de destino, elija un libro de origen para conservar. Las opciones recomendadas se preseleccionan cuando hay una coincidencia más fuerte.",
+      "remainingGroups": "Grupos restantes:",
+      "ofCount": "de {total}",
+      "targetBookId": "Libro de destino #{id}",
+      "recommended": "Recomendado",
+      "resolveButton": "{count, plural, =0 {resolver # duplicar} one {resolver # duplicar} other {resolver # duplicados} many {resolver # duplicados}}",
+      "sourceRecordId": "ID de registro de origen n.º {id}",
+      "byAuthor": "por {author} (ID: {id})",
+      "byFilePath": "{filePath} (ID: {id})",
+      "bookloreSourceId": "ID de fuente del libro: {id}",
+      "libraryBookId": "Libro de la biblioteca #{id}"
+    },
+    "preflight": {
+      "title": "Comprobaciones previas al vuelo",
+      "allPassed": "Todas las comprobaciones pasaron: listo para migrar",
+      "sourceValidated": "Fuente validada",
+      "saveAndValidateSource": "Guardar y validar la conexión de origen",
+      "validateSourceConnection": "Validar conexión de origen",
+      "mappingsSaved": "Asignaciones guardadas",
+      "saveUserAndPathMappings": "Guardar asignaciones de usuarios y rutas",
+      "pathMappingsValidated": "Asignaciones de rutas validadas",
+      "savePathMappingsToValidate": "Guarde asignaciones de rutas para validarlas",
+      "dryRunUpToDate": "El ensayo está actualizado.",
+      "runFreshDryRun": "Realizar un nuevo ensayo",
+      "issues": {
+        "saveSource": "Guardar la configuración de conexión de origen",
+        "validateSource": "Validar conexión de origen",
+        "saveMappings": "Guardar asignaciones de usuarios y rutas",
+        "savePathMappings": "Guarde asignaciones de rutas para validarlas",
+        "freshDryRun": "Realizar un nuevo ensayo",
+        "resolveDuplicates": "Resolver coincidencias de libros de destino duplicados en el ensayo",
+        "waitForRun": "Espere a que finalice la ejecución activa"
+      }
+    },
+    "run": {
+      "confirmPrompt": "Esto iniciará la migración en vivo. ¿Está seguro?",
+      "confirmStart": "Confirmar inicio",
+      "startMigration": "Iniciar la migración",
+      "cancelRun": "Cancelar ejecución",
+      "refreshStatus": "Actualizar estado",
+      "pollingStopped": "El sondeo de estado se detuvo debido a un error.",
+      "retry": "Reintentar",
+      "stage": "Etapa: {stage}",
+      "initializing": "inicializando",
+      "ended": "Finalizado {time}"
+    },
+    "report": {
+      "noRunYet": "Aún no se ha realizado ninguna migración. Complete los pasos anteriores para comenzar.",
+      "runNumber": "Ejecute #{id}",
+      "notStarted": "No iniciado",
+      "reloadReport": "Recargar informe",
+      "loadFullReport": "Cargar informe completo",
+      "exportJson": "Exportar JSON",
+      "exportCsv": "Exportar CSV",
+      "migrationFailed": "La migración falló",
+      "retryFromLastStage": "Reintentar desde la última etapa completada",
+      "booksSection": "Libros",
+      "metadataOverlays": "Superposiciones de metadatos aplicadas",
+      "authorMappings": "Se reemplazaron las asignaciones de autor",
+      "narratorMappings": "Se reemplazaron las asignaciones del narrador",
+      "genreMappings": "Se reemplazaron las asignaciones de género",
+      "tagMappings": "Asignaciones de etiquetas reemplazadas",
+      "coversImported": "Cubiertas importadas",
+      "coverImportSkipped": "Se omitió la importación de portada: la ruta raíz del medio no está configurada",
+      "couldNotMatch": "No se pudo coincidir",
+      "userDataSection": "Datos de usuario",
+      "readingStatuses": "Estados de lectura",
+      "readingProgressEntries": "Lectura de entradas de progreso",
+      "audiobookProgressEntries": "Entradas de progreso del audiolibro",
+      "readingSessions": "Sesiones de lectura",
+      "bookmarks": "Marcadores",
+      "annotations": "Anotaciones",
+      "collectionEntries": "Entradas de colección",
+      "loadFullReportHint": "Haga clic en \"Cargar informe completo\" para incluir el resumen del partido de prueba en el informe exportado.",
+      "completedNoIssues": "La migración se completó sin libros ni fallas sin resolver.",
+      "matchedBooks": "Libros coincidentes ({count})",
+      "matchedBooksExplanation": "Estas coincidencias de prueba se utilizaron para decidir qué libros de la biblioteca recibieron datos importados.",
+      "sourceBook": "Libro de consulta {id}",
+      "libraryBook": "Libro de la biblioteca {id}",
+      "unresolvedBooks": "Libros sin resolver ({count})",
+      "unresolvedBooksExplanation": "Estos libros existen en la fuente, pero no se pueden relacionar con ningún libro de su biblioteca.",
+      "mappedUsers": "Usuarios asignados ({count})",
+      "mappedUsersExplanation": "Los totales por usuario provienen de la vista previa de prueba almacenada en caché con el plan de migración.",
+      "coverFailures": "{count} falló la importación de portada. Las filas de errores detalladas no se almacenan.",
+      "userPreviewCounts": "{statuses} estados, {progress} entradas de progreso, {sessions} sesiones de lectura, {bookmarks} marcadores, {annotations} anotaciones, {collections} entradas de colección"
+    },
+    "unresolvedReason": {
+      "noTitleAuthorMatch": "No se encontró ningún libro coincidente por título o autor",
+      "noFilePathMatch": "La ruta del archivo no coincide con ningún libro de esta biblioteca.",
+      "noFileHashMatch": "El hash del archivo no coincide con ningún libro de esta biblioteca",
+      "noIsbnMatch": "ISBN no coincide con ningún libro de esta biblioteca",
+      "insufficientSourceData": "No hay suficientes metadatos para intentar hacer coincidir",
+      "ambiguousIsbnMatch": "Varios libros coincidieron con el mismo ISBN",
+      "ambiguousFileHashMatch": "Varios libros coincidieron con el mismo hash de archivo",
+      "ambiguousFilePathMatch": "Varios libros coincidieron con la misma ruta de archivo",
+      "ambiguousTitleAuthorMatch": "Varios libros coincidían con el mismo título y autor",
+      "unknown": "No se pudo determinar el motivo"
+    },
+    "matchStrategy": {
+      "isbn": "Emparejado por ISBN",
+      "fileHash": "Coincidencia por hash de archivo",
+      "pathMapping": "Coincidencia por ruta de archivo asignada",
+      "titleAuthor": "Emparejado por título y autor",
+      "unavailable": "Estrategia de partido no disponible"
+    },
+    "connectionError": {
+      "unreachable": "No se pudo acceder al servidor de la base de datos. Verifique el host y el puerto.",
+      "authFailed": "La autenticación falló. Verifique el nombre de usuario y la contraseña.",
+      "databaseNotFound": "Base de datos no encontrada. Verifique el nombre de la base de datos.",
+      "timeout": "Se agotó el tiempo de conexión. Verifique la configuración del host y del firewall.",
+      "generic": "La prueba de conexión falló"
+    },
+    "userSelect": {
+      "placeholder": "Seleccionar usuario",
+      "noUsersFound": "No se encontraron usuarios"
+    },
+    "toast": {
+      "initFailed": "No se pudo inicializar la configuración de migración",
+      "loadSupportedTypesFailed": "No se pudieron cargar los tipos de origen de migración admitidos",
+      "loadTargetUsersFailed": "No se pudieron cargar los usuarios de destino",
+      "loadTargetFoldersFailed": "No se pudieron cargar las carpetas de la biblioteca de destino",
+      "noSourceUsers": "No se devolvieron usuarios de origen",
+      "suggestionsLoaded": "Sugerencias de mapeo de usuario cargadas",
+      "loadSuggestionsFailed": "No se pudieron cargar las sugerencias de mapeo del usuario",
+      "sourceFieldsRequired": "Se requieren host, usuario, base de datos y nombre de fuente",
+      "connectionPassedWithWarnings": "Prueba de conexión superada con advertencias.",
+      "connectionPassedWithWarningCount": "La prueba de conexión pasó con {count} advertencia(s). Primero: {warning}",
+      "connectionPassed": "Prueba de conexión superada",
+      "connectionMissingTables": "La conexión es correcta, pero faltan {count} tablas requeridas",
+      "cannotTestMediaWhileRunning": "No se puede probar la ruta del medio mientras hay una ejecución activa",
+      "mediaPathRequired": "Se requiere Media Root Path para importar la portada.",
+      "mediaPathAbsolute": "Utilice una ruta absoluta (por ejemplo: /libros).",
+      "mediaPathVerified": "Ruta de medios verificada.",
+      "mediaPathValid": "La ruta del medio es válida y legible.",
+      "mediaPathValidationFailed": "Error en la validación de la ruta del medio.",
+      "connectionFailedBeforeMedia": "La prueba de conexión falló antes de que se pudiera completar la validación de la ruta del medio.",
+      "cannotModifySourceWhileRunning": "No se puede modificar la fuente mientras una ejecución está activa",
+      "sourceSavedWithWarnings": "Fuente guardada y validada con {count} advertencia(s)",
+      "sourceSaved": "Fuente guardada y validada",
+      "saveSourceFailed": "No se pudo guardar o validar la fuente",
+      "cannotSaveMappingsWhileRunning": "No se pueden guardar asignaciones mientras una ejecución está activa",
+      "saveSourceFirst": "Guardar la fuente primero",
+      "mapAtLeastOneUser": "Asigne al menos un usuario de origen a un usuario de destino",
+      "mapEveryUser": "Asigne cada usuario de origen antes de guardar",
+      "pathValidationFailedButSaved": "La validación de la ruta falló, pero el perfil aún se guardará",
+      "mappingsSaved": "Asignaciones guardadas",
+      "saveMappingsFailed": "No se pudieron guardar las asignaciones",
+      "cannotDryRunWhileRunning": "No se puede realizar un ensayo en seco mientras hay una ejecución activa",
+      "saveMappingsFirst": "Guarde las asignaciones primero",
+      "dryRunCompleted": "Ejecución en seco completada: {matched} coincidente, {unresolved} sin resolver",
+      "dryRunFailed": "Error en el ensayo",
+      "selectSourceForDuplicates": "Seleccione un libro fuente para todos los {count} grupos duplicados",
+      "duplicatesResolved": "Coincidencias duplicadas resueltas",
+      "resolveDuplicatesFailed": "No se pudieron resolver duplicados",
+      "preflightNotReady": "La verificación previa a la migración no está lista",
+      "runDryRunFirst": "Ejecute primero el ensayo",
+      "runStarted": "Se inició la ejecución de migración",
+      "startFailed": "No se pudo iniciar la migración",
+      "runCancelled": "Ejecución de migración cancelada",
+      "cancelFailed": "No se pudo cancelar la migración",
+      "runRetried": "Se ha reintentado la ejecución de la migración: se reanuda desde la última etapa completada",
+      "retryFailed": "No se pudo volver a intentar la migración",
+      "loadProgressFailed": "No se pudo cargar el progreso de la ejecución",
+      "startMigrationFirst": "Iniciar la migración primero",
+      "reportRefreshed": "Ejecutar informe actualizado",
+      "loadReportFailed": "No se pudo cargar el informe de ejecución",
+      "reportExported": "Informe exportado como {format}",
+      "exportFailed": "No se pudo exportar el informe de migración"
+    }
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "markAllRead": "Marcar todo como leído",
+    "clear": "Borrar",
+    "empty": "Aún no hay notificaciones",
+    "loadMore": "Cargar más notificaciones",
+    "preferences": {
+      "title": "Notificaciones",
+      "subtitle": "Elija qué categorías de notificaciones desea recibir.",
+      "saving": "Guardando...",
+      "unsavedChanges": "Cambios no guardados",
+      "saved": "Preferencias de notificación guardadas",
+      "saveFailed": "No se pudieron guardar las preferencias",
+      "savePreferenceFailed": "No se pudo guardar la preferencia",
+      "whatsNewToggle": "Mostrar \"Novedades\" después de las actualizaciones",
+      "whatsNewToggleHint": "Una ventana emergente que destaca nuevas funciones después de las actualizaciones de la aplicación. El archivo permanece disponible de cualquier manera."
+    }
+  },
+  "reader": {
+    "retry": "Reintentar",
+    "pdf": {
+      "openError": "No se puede abrir este PDF",
+      "preparing": "Preparando el lector PDF",
+      "opening": "Abriendo PDF"
+    },
+    "loadingBook": "Cargando libro…",
+    "failedToLoadBook": "No se pudo cargar el libro",
+    "chapterNumber": "Capítulo {number}",
+    "peek": {
+      "badge": "Mirando a escondidas",
+      "startReading": "Empezar a leer"
+    },
+    "toast": {
+      "linkedHighlightError": "No se pudo abrir la posición destacada vinculada",
+      "resumed": "Reanudado en {pct}% - {label}"
+    },
+    "header": {
+      "goBack": "volver",
+      "tableOfContents": "Tabla de contenidos",
+      "toggleBookmark": "Alternar marcador",
+      "cycleFooterMode": "Modo de información de pie de página de ciclo",
+      "keyboardShortcutsHint": "Atajos de teclado (?)",
+      "enterFullscreen": "Entrar en pantalla completa",
+      "exitFullscreen": "Salir de pantalla completa",
+      "footerMode": {
+        "pageProgress": "Información del pie de página: página + progreso",
+        "sessionTimeLeft": "Información del pie de página: sesión de lectura + tiempo restante",
+        "chapterTimeLeft": "Información al pie de página: capítulo + tiempo restante del capítulo"
+      }
+    },
+    "footer": {
+      "previousSection": "Sección anterior",
+      "nextSection": "Siguiente sección",
+      "goToPlaceholder": "45 o p123",
+      "jumpToLocation": "Saltar a ubicación",
+      "jumpTooltip": "Saltar a % o página (por ejemplo, 45 o p123)",
+      "go": "ir"
+    },
+    "settings": {
+      "title": "Configuración",
+      "ariaLabel": "Configuración del lector",
+      "tabs": {
+        "appearance": "Apariencia",
+        "text": "Texto",
+        "layout": "Diseño"
+      },
+      "appearance": {
+        "mode": "Modo",
+        "light": "Luz",
+        "dark": "oscuro",
+        "colorTheme": "Tema de color"
+      },
+      "text": {
+        "fontSize": "Tamaño de fuente",
+        "fontSizeRange": "Rango: 10-32px",
+        "lineHeight": "altura de la línea",
+        "lineHeightRange": "Rango: 0,8-3,0",
+        "fontFamily": "Familia de fuentes",
+        "fontFamilyDescription": "Elija fuentes integradas o cargadas para el cuerpo del texto.",
+        "builtIn": "Incorporado",
+        "yourFonts": "Tus fuentes"
+      },
+      "layout": {
+        "pageSpreads": "Extensiones de página",
+        "pageSpreadsDescription": "Elija cómo este EPUB basado en imágenes empareja páginas.",
+        "bookDefault": "Reservar por defecto",
+        "singlePage": "Una sola página",
+        "readingFlow": "Flujo de lectura",
+        "readingFlowDescription": "Cambie entre desplazamiento paginado y continuo.",
+        "paginated": "paginado",
+        "scrolled": "Desplazado",
+        "textColumns": "Columnas de texto",
+        "textColumnsRange": "Rango: 1-10",
+        "columnGap": "Espacio de columna",
+        "columnGapRange": "Rango: 0-50%",
+        "maxWidth": "Ancho máximo",
+        "maxWidthRange": "Rango: 400-1600",
+        "justifyText": "Justificar texto",
+        "justifyTextDescription": "Habilite la alineación de párrafos de ancho completo.",
+        "hyphenation": "Separación de sílabas",
+        "hyphenationDescription": "Habilite la separación de palabras automática."
+      }
+    },
+    "search": {
+      "placeholder": "Buscar en el libro (min {min} caracteres)...",
+      "searching": "Buscando…",
+      "tooShort": "Escriba al menos {min} caracteres",
+      "noResults": "No se encontraron resultados",
+      "prompt": "Escribe para buscar",
+      "resultCount": "{count, plural, =0 {sin resultados} one {# resultado} other {# resultados} many {# resultados}}"
+    },
+    "sidebar": {
+      "tabs": {
+        "chapters": "Capítulos",
+        "bookmarks": "Marcadores",
+        "highlights": "Lo más destacado",
+        "toc": "Tabla de contenidos",
+        "tocShort": "TOC",
+        "marksShort": "marcas",
+        "notesShort": "Notas"
+      },
+      "pin": "Fijar barra lateral",
+      "unpin": "Desanclar barra lateral",
+      "close": "Cerrar barra lateral",
+      "noChapters": "No se encontraron capítulos",
+      "noBookmarks": "Aún no hay marcadores",
+      "noBookmarksMatch": "Ningún marcador coincide con tus filtros",
+      "noHighlights": "Aún no hay destacados",
+      "noHighlightsMatch": "Ningún resaltado coincide con tus filtros",
+      "searchBookmarks": "Buscar marcadores...",
+      "searchHighlights": "Buscar aspectos destacados...",
+      "bookmarkFallback": "Marcador",
+      "locationUnavailable": "Ubicación no disponible",
+      "customColor": "Personalizado ({color})",
+      "allColors": "Todos los colores",
+      "allChapters": "Todos los capítulos",
+      "notesOnly": "Sólo notas",
+      "deleteBookmark": "Eliminar marcador",
+      "deleteHighlight": "Eliminar resaltado",
+      "approximatePosition": "Sincronizado desde el dispositivo; posición exacta no disponible, salta al capítulo",
+      "sort": {
+        "readingOrder": "Orden de lectura",
+        "newest": "Lo nuevo primero",
+        "oldest": "El más viejo primero"
+      }
+    },
+    "selection": {
+      "copy": "Copiar",
+      "copied": "¡Copiado!",
+      "highlight": "Resaltar",
+      "translate": "Traducir",
+      "define": "Definir",
+      "deleteAnnotation": "Eliminar anotación",
+      "apply": "Aplicar"
+    },
+    "note": {
+      "title": "Agregar nota",
+      "placeholder": "Escribe tu nota..."
+    },
+    "dictionary": {
+      "noDefinition": "No se encontró ninguna definición",
+      "loadError": "No se pudo cargar la definición"
+    },
+    "translation": {
+      "original": "Originales",
+      "translation": "Traducción",
+      "translating": "Traduciendo...",
+      "noTranslation": "Aún no hay traducción",
+      "viaProvider": "vía {provider}",
+      "copyTranslation": "Copiar traducción"
+    },
+    "shortcuts": {
+      "title": "Atajos de teclado",
+      "groups": {
+        "panels": "Paneles",
+        "reading": "leyendo",
+        "actions": "Acciones"
+      },
+      "toggleToc": "Alternar tabla de contenidos",
+      "toggleSearch": "Alternar búsqueda",
+      "toggleHelp": "Mostrar/ocultar esta ayuda",
+      "closePanel": "Cerrar panel",
+      "prevNextPage": "Página anterior/siguiente",
+      "goToStart": "Ir al inicio del libro",
+      "goToEnd": "Ir al final del libro",
+      "toggleBookmark": "Alternar marcador",
+      "toggleFullscreen": "Alternar pantalla completa",
+      "cycleFooterMode": "Modo de información de pie de página de ciclo"
+    },
+    "cbz": {
+      "tabs": {
+        "view": "Ver",
+        "reading": "leyendo",
+        "layout": "Diseño"
+      },
+      "fitMode": "Modo de ajuste",
+      "background": "Antecedentes",
+      "scrollMode": "Modo de desplazamiento",
+      "scrollModeHint": "Utilice \"Sin espacios\" para webtoons y tiras verticales.",
+      "readingDirection": "dirección de lectura",
+      "pageView": "Vista de página",
+      "autoFallback": "Respaldo automático",
+      "spreadAlignmentLabel": "Alineación extendida",
+      "spreadAlignmentHint": "La alineación de propagación no está disponible en el modo de reserva automática.",
+      "spreadGap": "Brecha de propagación",
+      "spreadGapValue": "{value}px",
+      "focusTwoPageToggle": "Alternar enfoque de dos páginas",
+      "forceTwoPage": "Forzar dos páginas",
+      "off": "Apagado",
+      "on": "encendido",
+      "widePages": "paginas anchas",
+      "resetBookViewSettings": "Restablecer la configuración de vista de libro",
+      "resetConfirm": "¿Restablecer la configuración de visualización de este libro a sus valores predeterminados globales?",
+      "firstPage": "Primera pagina",
+      "lastPage": "Última página",
+      "fit": {
+        "page": "Ajuste de página",
+        "width": "Ancho de página",
+        "height": "Alto de página",
+        "actual": "Tamaño real"
+      },
+      "view": {
+        "single": "soltero",
+        "twoPage": "dos páginas"
+      },
+      "scroll": {
+        "paged": "paginado",
+        "infinite": "infinito",
+        "noGaps": "Sin espacios"
+      },
+      "direction": {
+        "ltr": "De izquierda a derecha",
+        "rtl": "De derecha a izquierda"
+      },
+      "spreadAlignment": {
+        "normal": "normales",
+        "shifted": "desplazado"
+      },
+      "widePage": {
+        "auto": "Automático",
+        "inSpreads": "en diferenciales"
+      },
+      "bg": {
+        "black": "negro",
+        "gray": "gris",
+        "white": "blanco"
+      }
+    },
+    "audiobook": {
+      "untitled": "Sin título",
+      "loading": "Cargando audiolibro...",
+      "loadError": "No se pudo cargar el audiolibro",
+      "noAudioFiles": "No se encontraron archivos de audio para este libro.",
+      "speed": "Velocidad",
+      "chapters": "Capítulos",
+      "bookmarks": "Marcadores",
+      "volume": "Volumen",
+      "muted": "silenciado",
+      "sleep": "Dormir",
+      "chapterAbbrev": "Cap.",
+      "sleepTimer": "Temporizador de sueño",
+      "minutes": "{count} minutos",
+      "endOfChapter": "Fin del capítulo",
+      "noChaptersAvailable": "No hay capítulos disponibles",
+      "extend15": "+ 15 minutos",
+      "timeLeft": "({time} izquierda)",
+      "playbackSpeed": "Velocidad de reproducción",
+      "noChapters": "No hay capítulos disponibles.",
+      "noBookmarks": "Aún no hay marcadores.",
+      "noBookmarksHint": "Toque el ícono de marcador en la parte superior para guardar su posición actual.",
+      "playerSettings": "Configuración del reproductor",
+      "skipBack": "saltar hacia atrás",
+      "skipForward": "Saltar adelante"
+    }
+  },
+  "scanner": {
+    "filesProgress": "Archivos {processed}/{total}",
+    "booksFound": "{count, plural, =0 {no se encontraron libros} one {# libro encontrado} other {# libros encontrados} many {# libros encontrados}}"
+  },
+  "series": {
+    "completion": {
+      "readOfTotal": "{read} de {total} leído ({percentage}%)"
+    },
+    "gaps": {
+      "label": "Posibles lagunas:"
+    },
+    "filters": {
+      "title": "Filtros de serie",
+      "clearAll": "Borrar todo",
+      "allLibraries": "Todas las bibliotecas",
+      "allCompletion": "Todo completado",
+      "notStarted": "No iniciado",
+      "inProgress": "En progreso",
+      "complete": "completo"
+    },
+    "list": {
+      "title": "Serie",
+      "showControlsAria": "Mostrar controles de serie",
+      "searchPlaceholder": "Buscar serie o autor",
+      "sortButton": "Ordenar",
+      "sortBy": "Ordenar por",
+      "ascending": "Ascendente",
+      "descending": "Descendente",
+      "ascShort": "asc",
+      "descShort": "Descripción",
+      "filters": "Filtros",
+      "clear": "Borrar",
+      "noMatch": "Ninguna serie coincide con tus filtros.",
+      "empty": "No se encontraron series en sus bibliotecas.",
+      "sort": {
+        "name": "Nombre",
+        "bookCount": "Conteo de libros",
+        "recentAdditions": "Adiciones recientes",
+        "readingProgress": "Progreso de lectura"
+      }
+    },
+    "detail": {
+      "pageTitle": "Serie",
+      "pageTitleNamed": "Serie · {name}",
+      "pageTitleWithId": "Serie #{id}",
+      "entityName": "Serie",
+      "bookCount": "{count, plural, =0 {sin libros} one {# libro} other {# libros} many {# libros}}",
+      "byAuthors": "por {authors}",
+      "moreAuthors": "+{count} más",
+      "preparingEditor": "Preparando editor...",
+      "editMetadata": "Editar metadatos",
+      "firstInSeries": "Primero en la serie",
+      "untitled": "Sin título",
+      "loadingFirstBook": "Cargando vista previa del primer libro...",
+      "showLess": "Mostrar menos",
+      "showMore": "Mostrar más",
+      "moreGenres": "+{count} más",
+      "synopsis": "Sinopsis",
+      "noDescription": "No hay descripción disponible.",
+      "updatingPreview": "Actualizando vista previa...",
+      "noBooksToPreview": "No hay libros disponibles para obtener una vista previa.",
+      "loadingSeries": "Cargando serie...",
+      "booksHeading": "Libros",
+      "allLibraries": "Todas las bibliotecas",
+      "groupByMedia": "Agrupar por medios",
+      "noBooksFound": "No se encontraron libros en esta serie.",
+      "trySelectingLibrary": "Intente seleccionar otra biblioteca.",
+      "allBooksLoaded": "Todos los {count} libros cargados",
+      "leadBookLoadError": "No se pudieron cargar los detalles del libro principal",
+      "noBooksToEdit": "Esta serie no tiene libros para editar.",
+      "loadFullSeriesError": "No se pudo cargar la serie completa para editarla.",
+      "sort": {
+        "seriesOrder": "Orden de serie",
+        "title": "Título",
+        "recentlyAdded": "Agregado recientemente"
+      },
+      "order": {
+        "ascending": "Ascendente",
+        "descending": "Descendente"
+      }
+    }
+  },
+  "smartScope": {
+    "syncToKobo": "Sincronizar con Kobo",
+    "syncToKoboHint": "Los libros que coincidan con este alcance aparecerán en su dispositivo Kobo",
+    "dialog": {
+      "name": "Nombre",
+      "namePlaceholder": "por ej. Ciencia ficción no leída",
+      "icon": "Icono",
+      "iconPlaceholder": "Elige un icono...",
+      "nameRequired": "El nombre es obligatorio",
+      "iconRequired": "Elige un icono",
+      "create": "crear",
+      "creating": "Creando...",
+      "saving": "Guardando..."
+    },
+    "createDialog": {
+      "title": "Nuevo alcance inteligente",
+      "visibleToAll": "Visible para todos los usuarios",
+      "createFailed": "No se pudo crear Smart Scope"
+    },
+    "saveAsDialog": {
+      "title": "Guardar como SmartScope",
+      "save": "Guardar SmartScope",
+      "saveFailed": "No se pudo guardar el alcance inteligente"
+    },
+    "editorPanel": {
+      "untitled": "SmartScope sin título",
+      "subtitle": "Configurar los ajustes del alcance inteligente",
+      "counting": "contando...",
+      "bookCount": "{count, plural, =0 {sin libros} one {un libro} other {# libros} many {# libros}}",
+      "identity": "Identidad",
+      "filters": "Filtros",
+      "noFilters": "No hay filtros establecidos. Todos los libros accesibles se incluirán en este alcance inteligente.",
+      "buildFromScratch": "Construir desde cero",
+      "replaceWithTemplate": "Reemplazar con plantilla:",
+      "defaultSort": "Orden predeterminado",
+      "saveChanges": "Guardar cambios",
+      "saveFailed": "No se pudo guardar",
+      "templates": {
+        "hasSeries": "Tiene serie",
+        "addedRecently": "Agregado recientemente",
+        "pdfOnly": "PDF Solamente",
+        "noGenres": "Sin géneros",
+        "epubOnly": "EPUB Solamente"
+      }
+    }
+  },
+  "statistics": {
+    "tabs": {
+      "library": "Estadísticas de la biblioteca",
+      "user": "mi lectura"
+    },
+    "filter": {
+      "allLibraries": "Todas las bibliotecas",
+      "librarySelection": "{count} de {total} Bibliotecas"
+    },
+    "config": {
+      "button": "Configurar",
+      "title": "Configurar gráficos",
+      "description": "Arrastra para reordenar, alterna para mostrar u ocultar.",
+      "reset": "Restablecer los valores predeterminados"
+    },
+    "summary": {
+      "books": "Libros",
+      "authors": "Autores",
+      "series": "Serie",
+      "publishers": "Editores",
+      "storage": "Almacenamiento",
+      "genres": "Géneros",
+      "languages": "Idiomas",
+      "published": "Publicado",
+      "thisYear": "este año",
+      "started": "iniciado",
+      "inProgress": "En progreso",
+      "completed": "Completado",
+      "avgProgress": "Progreso promedio"
+    },
+    "card": {
+      "loadError": "No se pudieron cargar los datos",
+      "emptyTitle": "Aún no hay datos",
+      "emptyDescription": "No hay datos disponibles para este gráfico",
+      "unknownField": "{count, plural, =0 {no hay datos para este campo} one {# El libro no tiene datos para este campo.} other {# Los libros no tienen datos para este campo.} many {# Los libros no tienen datos para este campo.}}"
+    },
+    "breakdown": {
+      "ariaLabel": "Desglosar por fuente o formato"
+    },
+    "empty": {
+      "notEnoughData": "Aún no hay suficientes datos"
+    },
+    "charts": {
+      "acquisitionLag": {
+        "title": "Retraso de adquisición"
+      },
+      "booksAddedOverTime": {
+        "title": "Libros agregados con el tiempo",
+        "monthly": "Mensual",
+        "yearly": "Anual",
+        "allTime": "Todo el tiempo",
+        "last5Years": "Últimos 5 años",
+        "lastYear": "El año pasado"
+      },
+      "formatDistribution": {
+        "title": "Distribución de formato"
+      },
+      "formatShareOverTime": {
+        "title": "Compartir formato a lo largo del tiempo"
+      },
+      "genreCooccurrence": {
+        "title": "Coocurrencia de género"
+      },
+      "genreDistribution": {
+        "title": "Distribución de género"
+      },
+      "languageDistribution": {
+        "title": "Distribución de idiomas"
+      },
+      "largestBooks": {
+        "title": "Los 50 libros más importantes"
+      },
+      "libraryIntegrity": {
+        "title": "Integridad de la biblioteca"
+      },
+      "libraryMetadataCompleteness": {
+        "title": "Integridad de los metadatos de la biblioteca"
+      },
+      "metadataCompleteness": {
+        "title": "Integridad de los metadatos"
+      },
+      "metadataFreshness": {
+        "title": "Actualización de metadatos"
+      },
+      "metadataScoreDistribution": {
+        "title": "Distribución de puntuación de metadatos"
+      },
+      "pageCountDistribution": {
+        "title": "Distribución del recuento de páginas"
+      },
+      "publicationDecade": {
+        "title": "Década de Publicaciones"
+      },
+      "publicationYearTimeline": {
+        "title": "Cronología del año de publicación"
+      },
+      "storageByFormat": {
+        "title": "Almacenamiento por formato"
+      },
+      "topAuthors": {
+        "title": "25 autores principales"
+      },
+      "topSeries": {
+        "title": "Las 50 mejores series"
+      },
+      "booksCompleted": {
+        "title": "Libros completados",
+        "notEnoughData": "Necesita al menos {count} libros completos para este gráfico."
+      },
+      "completionLatency": {
+        "title": "Latencia de finalización",
+        "notEnoughData": "Necesita al menos {count} libros completos para este gráfico."
+      },
+      "completionTimeline": {
+        "title": "Cronograma de finalización",
+        "notEnoughData": "Necesita al menos {count} libros completos para este gráfico."
+      },
+      "favoriteReadingDays": {
+        "title": "Días de lectura favoritos",
+        "notEnoughData": "Necesita al menos {count} eventos de lectura para este gráfico."
+      },
+      "genreReadingTime": {
+        "title": "Género Tiempo de lectura",
+        "notEnoughData": "Necesita al menos {count} géneros con tiempo de lectura para este gráfico."
+      },
+      "goalTrajectory": {
+        "title": "Ritmo vs Objetivo",
+        "noCompletedTitle": "Aún no hay libros completos",
+        "noCompletedDescription": "Complete un libro en este período para comparar su ritmo con su objetivo anual.",
+        "notEnoughData": "Necesita al menos {count} libros completos para este gráfico."
+      },
+      "peakReadingHours": {
+        "title": "Horas pico de lectura",
+        "notEnoughData": "Necesita al menos {count} eventos de lectura para este gráfico."
+      },
+      "progressFunnel": {
+        "title": "Embudo de progreso",
+        "modePercent": "Porcentaje",
+        "modeCounts": "Cuenta",
+        "modeDropoff": "Devolución",
+        "started": "Iniciado {count}",
+        "notEnoughData": "Necesita al menos {count} libros iniciados para este gráfico.",
+        "noDropOffTitle": "No se observó caída",
+        "noDropOffDescription": "Cada libro iniciado avanzó a través de todas las etapas del embudo en este período."
+      },
+      "readingClock": {
+        "title": "Reloj de lectura",
+        "notEnoughData": "Necesita al menos {count} sesiones de lectura para este gráfico."
+      },
+      "readingHeatmap": {
+        "title": "Leer mapa de calor",
+        "notEnoughData": "Necesita actividad al menos {count} días para este gráfico."
+      },
+      "readingPace": {
+        "title": "Ritmo de lectura",
+        "notEnoughData": "Necesita al menos {count} sesiones con datos de progreso para este gráfico."
+      },
+      "readingSessionTimeline": {
+        "title": "Cronología de la sesión de lectura",
+        "dragOn": "Arrastrar: activado",
+        "dragOff": "Arrastrar: Desactivado",
+        "prev": "Anterior",
+        "next": "Siguiente",
+        "week": "Semana {week}",
+        "dragHint": "Arrastre barras para mover sesiones. La duración está bloqueada y se rechazan las sesiones superpuestas.",
+        "noSessionsTitle": "No hay sesiones esta semana",
+        "noSessionsDescription": "Utilice Anterior/Siguiente o el selector de semana para ver una semana diferente.",
+        "overlapError": "La sesión se superpone a otra sesión en esta ventana",
+        "moveError": "No se pudo mover la sesión"
+      },
+      "sessionArchetypes": {
+        "title": "Arquetipos de sesión"
+      },
+      "sourceDistribution": {
+        "title": "donde lees",
+        "emptyTitle": "Aún no hay actividad de lectura",
+        "emptyDescription": "Lea en la web, KOReader o Kobo para ver su fuente dividida."
+      }
+    }
+  },
+  "tools": {
+    "header": {
+      "entityManager": "Gerente de entidad",
+      "bulkRename": "Cambio de nombre masivo",
+      "duplicateBooks": "Libros duplicados"
+    },
+    "entityTypes": {
+      "authors": "Autores",
+      "genres": "Géneros",
+      "tags": "Etiquetas",
+      "narrators": "Narradores",
+      "publishers": "Editores",
+      "languages": "Idiomas",
+      "series": "Serie"
+    },
+    "bulkRename": {
+      "previewToolbar": "Cambiar nombre de vista previa",
+      "renameSettings": "Cambiar nombre de configuración",
+      "library": "Biblioteca",
+      "selectLibraryPlaceholder": "Seleccione una biblioteca...",
+      "noEligibleLibraries": "Ninguna biblioteca tiene habilitado el cambio de nombre de archivo. Habilítelo en la configuración de la biblioteca.",
+      "refresh": "Actualizar",
+      "applyRename": "Aplicar cambiar nombre",
+      "showFullPaths": "Mostrar rutas completas",
+      "columnsMenu": "columnas",
+      "renamingInProgress": "Cambiar el nombre de los archivos: puede cancelar en cualquier momento.",
+      "executionFailed": "Error al cambiar el nombre en masa",
+      "previewFailed": "No se pudo cargar la vista previa",
+      "noBooksMatch": "No se encontraron libros que coincidan con el filtro actual.",
+      "openBookDetails": "Detalles del libro abierto",
+      "columns": {
+        "title": "Título",
+        "currentPath": "Ruta actual",
+        "newPath": "Nuevo camino",
+        "status": "Estado"
+      },
+      "status": {
+        "willRename": "Cambiará el nombre",
+        "unchanged": "Sin cambios",
+        "collision": "colisión",
+        "noPattern": "Sin patrón",
+        "error": "error"
+      },
+      "filter": {
+        "all": "Todos"
+      },
+      "summary": {
+        "label": "Resumen",
+        "toRename": "{count} para cambiar el nombre",
+        "unchanged": "{count} sin cambios",
+        "collisions": "{count, plural, =0 {# colisión} one {# colisión} other {# colisiones} many {# colisiones}}",
+        "errors": "{count, plural, =0 {# error} one {# error} other {# errores} many {# errores}}"
+      },
+      "empty": {
+        "title": "Elija una biblioteca para comenzar",
+        "description": "Seleccione una de las bibliotecas anteriores para obtener una vista previa de los cambios de nombre, filtrar por estado y aplicar la ejecución de cambio de nombre masivo.",
+        "chooseLibrary": "Elija biblioteca"
+      },
+      "completed": {
+        "title": "Cambio de nombre masivo completado",
+        "stats": "{succeeded} renombrado, {failed} falló, {skipped} omitido ({processed} en total)"
+      },
+      "pagination": {
+        "showing": "Mostrando {from}-{to} de {total}"
+      },
+      "confirmDialog": {
+        "title": "Confirmar cambio de nombre masivo",
+        "body": "{count, plural, =0 {Esto cambiará el nombre # libro en disco. Se omitirán los archivos con colisiones o errores. Esta acción no se puede deshacer.} one {Esto cambiará el nombre # libro en disco. Se omitirán los archivos con colisiones o errores. Esta acción no se puede deshacer.} other {Esto cambiará el nombre # libros en disco. Se omitirán los archivos con colisiones o errores. Esta acción no se puede deshacer.} many {Esto cambiará el nombre # libros en disco. Se omitirán los archivos con colisiones o errores. Esta acción no se puede deshacer.}}",
+        "renameButton": "{count, plural, =0 {Cambiar nombre # libro} one {Cambiar nombre # libro} other {Cambiar nombre # libros} many {Cambiar nombre # libros}}"
+      }
+    },
+    "bookDuplicates": {
+      "scanSettings": "Configuración de escaneo",
+      "title": "Libros duplicados",
+      "description": "Escanee archivos y metadatos en busca de posibles registros duplicados. No se elimina nada durante un escaneo.",
+      "scope": "Alcance de la biblioteca",
+      "allLibraries": "Todas las bibliotecas accesibles",
+      "similarity": "Umbral de títulos similares",
+      "explainSimilarity": "Explique el umbral de títulos similares",
+      "similarityHelp": "Sólo para coincidencias de título y autor similares. También deben coincidir al menos un autor y el tipo de libro. Lower encuentra más posibles duplicados; más alto requiere títulos más cercanos. Los archivos idénticos, ISBN y los metadatos exactos se verifican por separado.",
+      "runScan": "Ejecutar escaneo",
+      "rescan": "Volver a escanear",
+      "status": {
+        "queued": "Escaneo en cola",
+        "running": "Escaneando libros"
+      },
+      "groupsFound": "{count, plural, =0 {No hay grupos duplicados} one {Un grupo duplicado} other {# grupos duplicados} many {# grupos duplicados}}",
+      "filter": "Tipo de coincidencia",
+      "allReasons": "Todos los tipos de partidos",
+      "reasons": {
+        "file_hash": "Conjunto de archivos idéntico",
+        "isbn": "Mismo ISBN",
+        "exact_metadata": "Título exacto y autores.",
+        "fuzzy_metadata": "Título y autor similares"
+      },
+      "similarityValue": "{percent}% similitud del título",
+      "notDuplicates": "No duplicados",
+      "keepThis": "Guarde este libro",
+      "discardThis": "Descartar este libro",
+      "selectKeeperFirst": "Seleccione un portero primero",
+      "noDirectMatch": "No hay partido directo con el portero",
+      "moreFiles": "+{count} más",
+      "showDetails": "Mostrar detalles",
+      "hideDetails": "Ocultar detalles",
+      "deleteSelected": "Eliminar {count} seleccionado",
+      "openBook": "Abrir detalles para {title}",
+      "unknownAuthor": "Autor desconocido",
+      "unknown": "Desconocido",
+      "none": "Ninguno",
+      "accessDenied": "No tienes permiso para utilizar la herramienta de duplicar libros.",
+      "pairDetails": "Detalles del partido",
+      "pairLabel": "{first} y {second}",
+      "fields": {
+        "library": "Biblioteca",
+        "isbn": "ISBN",
+        "formats": "Formatos",
+        "fileLocation": "Archivo",
+        "files": "Archivos",
+        "readingStatus": "Estado de lectura",
+        "progress": "Progreso",
+        "path": "Ruta de la biblioteca",
+        "collections": "Colecciones",
+        "added": "Añadido",
+        "updated": "Actualizado"
+      },
+      "initial": {
+        "title": "Encuentra libros duplicados",
+        "description": "Elija un alcance de biblioteca y un nivel de similitud, luego ejecute un análisis. No se modifica ningún libro hasta que usted confirme explícitamente una eliminación."
+      },
+      "empty": {
+        "title": "No se encontraron grupos duplicados",
+        "description": "Ningún libro coincidió con el alcance, el nivel de similitud y el filtro de coincidencia actuales."
+      },
+      "deleteDialog": {
+        "title": "¿Eliminar permanentemente libros duplicados?",
+        "description": "{count, plural, =0 {Esto eliminará permanentemente # libro seleccionado y sus archivos.} one {Esto eliminará permanentemente # libro seleccionado y sus archivos.} other {Esto eliminará permanentemente # libros seleccionados y sus archivos.} many {Esto eliminará permanentemente # libros seleccionados y sus archivos.}}",
+        "warning": "Los metadatos, las colecciones, los datos de lectura y el estado del dispositivo no se transfieren al libro llevado. También se eliminan los datos asociados de otros usuarios.",
+        "confirm": "{count, plural, =0 {Eliminar # libro} one {Eliminar # libro} other {Eliminar # libros} many {Eliminar # libros}}",
+        "success": "{count, plural, =0 {No se eliminaron libros} one {Se ha eliminado un libro duplicado.} other {# libros duplicados eliminados} many {# libros duplicados eliminados}}"
+      },
+      "errors": {
+        "start": "No se pudo iniciar el análisis de duplicados.",
+        "status": "No se pudo cargar el progreso del escaneo.",
+        "scan": "El escaneo duplicado falló. Intente ejecutarlo nuevamente.",
+        "results": "No se pudieron cargar grupos duplicados.",
+        "delete": "No se pudieron eliminar los libros duplicados seleccionados."
+      },
+      "pagination": {
+        "label": "Páginas de grupos duplicadas",
+        "page": "Página {page} de {total}"
+      }
+    },
+    "entityManager": {
+      "unknown": "Desconocido",
+      "bookCount": "{count, plural, =0 {sin libros} one {# libro} other {# libros} many {# libros}}",
+      "sortPrefix": "· ordenar: {sortName}",
+      "selectTargetToKeep": "Seleccionar objetivo para mantener",
+      "writeToFiles": "Escribir en archivos",
+      "writeChangesToFiles": "Escribir cambios en archivos",
+      "mergeIntoTarget": "Fusionar {count} con el objetivo",
+      "modes": {
+        "browse": "Explorar y administrar",
+        "duplicates": "Buscar duplicados"
+      },
+      "actions": {
+        "rename": "Cambiar nombre",
+        "split": "dividir"
+      },
+      "duplicates": {
+        "similarity": "Similitud:",
+        "scan": "Escanear",
+        "scanning": "Escaneando...",
+        "computing": "Candidatos informáticos...",
+        "computedAt": "Los candidatos calcularon {date}",
+        "recompute": "Recalcular",
+        "noneComputed": "Aún no se han computado candidatos.",
+        "computeNow": "Calcular ahora",
+        "emptyTitle": "Encuentra entidades duplicadas",
+        "emptyDescription": "Ajuste el umbral de similitud y haga clic en Escanear para detectar posibles duplicados.",
+        "noneFoundTitle": "No se encontraron duplicados",
+        "noneFoundDescription": "No se detectaron posibles duplicados con la configuración actual.",
+        "clustersFound": "{count, plural, =0 {no se encontraron grupos} one {# grupo encontrado} other {# grupos encontrados} many {# grupos encontrados}}",
+        "plusOthers": "{count, plural, =0 {+ # otro} one {+ # otro} other {+ # otros} many {+ # otros}}",
+        "percentSimilar": "{percent}% de similitud",
+        "pairDetails": "Detalles del par",
+        "dismissEntityTitle": "Descartar todos los pares para esta entidad",
+        "dismissPairTitle": "Descartar este par"
+      },
+      "dismissed": {
+        "loading": "Cargando pares descartados...",
+        "empty": "No hay parejas descartadas",
+        "restore": "Restaurar",
+        "restoreTitle": "Restaurar este par",
+        "hidePairs": "Ocultar pares descartados",
+        "showPairs": "Mostrar pares descartados"
+      },
+      "browse": {
+        "searchPlaceholder": "Buscar...",
+        "emptyOnly": "Sólo vacío",
+        "clear": "Borrar",
+        "noEntities": "No se encontraron entidades",
+        "mergeCount": "Fusionar ({count})",
+        "deleteCount": "Eliminar ({count})",
+        "totalCount": "{count} total",
+        "sortLabel": "ordenar: {sortName}",
+        "sort": {
+          "nameAsc": "Nombre A-Z",
+          "nameDesc": "Nombre Z-A",
+          "fewestBooks": "Menos libros",
+          "mostBooks": "La mayoría de los libros"
+        }
+      },
+      "deleteMode": {
+        "label": "Modo eliminar",
+        "softTitle": "eliminación suave",
+        "softDescription": "Desvincularse de todos los libros pero mantener el registro de la entidad",
+        "softDescriptionPlural": "Desvincularse de todos los libros pero conservar los registros de la entidad",
+        "hardTitle": "Eliminación definitiva",
+        "hardDescription": "Eliminar entidad y todas las asociaciones de forma permanente",
+        "hardDescriptionPlural": "Eliminar entidades y todas las asociaciones de forma permanente"
+      },
+      "renameModal": {
+        "title": "Cambiar nombre de entidad",
+        "currentName": "Nombre actual",
+        "newName": "Nuevo nombre"
+      },
+      "deleteModal": {
+        "title": "Eliminar entidad",
+        "confirm": "¿Estás seguro de que deseas eliminar {name}?"
+      },
+      "splitModal": {
+        "title": "Entidad dividida",
+        "splitting": "Dividiendo",
+        "newNames": "Nuevos nombres (min 2)",
+        "namePlaceholder": "Introduce el nombre...",
+        "addAnother": "agregar otro"
+      },
+      "bulkDeleteModal": {
+        "title": "Eliminación masiva",
+        "confirm": "{count, plural, =0 {¿Estás seguro de que quieres eliminar? # entidad seleccionada?} one {¿Estás seguro de que quieres eliminar? # entidad seleccionada?} other {¿Estás seguro de que quieres eliminar? # entidades seleccionadas?} many {¿Estás seguro de que quieres eliminar? # entidades seleccionadas?}}",
+        "deleteButton": "Eliminar {count}"
+      },
+      "mergeModal": {
+        "title": "Fusionar entidades",
+        "description": "Seleccione qué entidad conservar. Los demás se fusionarán con él y se eliminarán."
+      }
+    }
+  },
+  "views": {
+    "entity": {
+      "book": "Libro",
+      "collection": "Colección",
+      "library": "Biblioteca",
+      "smartScope": "alcance inteligente"
+    },
+    "common": {
+      "retry": "Reintentar"
+    },
+    "bookView": {
+      "sort": "Ordenar",
+      "sortOn": "encendido",
+      "resetSort": "Restablecer la clasificación a la predeterminada",
+      "filters": "Filtros",
+      "clear": "Borrar",
+      "clearAllFilters": "Limpiar todos los filtros",
+      "expandSeries": "Ampliar serie",
+      "collapseSeries": "Contraer serie",
+      "expanded": "Ampliado",
+      "exportMetadata": "Exportar metadatos",
+      "showControlsAria": "Mostrar controles de biblioteca",
+      "export": "Exportar",
+      "searchPlaceholder": "Buscar título, autor, serie, narrador...",
+      "allBooksLoaded": "Todos los {count} libros cargados"
+    },
+    "notFound": {
+      "title": "Página no encontrada",
+      "description": "La página que estás buscando no existe.",
+      "goHome": "Vete a casa"
+    },
+    "dashboard": {
+      "customize": "Personalizar el panel",
+      "allShelvesHidden": "Todos los estantes están ocultos.",
+      "greeting": {
+        "night": "Buenas noches,",
+        "morning": "Buenos días,",
+        "afternoon": "Buenas tardes,",
+        "evening": "Buenas noches,",
+        "fallbackName": "allí"
+      }
+    },
+    "bookDetail": {
+      "title": "Libro",
+      "titleWithId": "Libro #{id}",
+      "pageTitle": {
+        "book": "Libro · {base}",
+        "editMetadata": "Editar metadatos · {base}",
+        "edit": "Editar · {base}",
+        "files": "Archivos · {base}",
+        "readingLog": "Registro de lectura · {base}",
+        "highlights": "Destacados · {base}"
+      }
+    },
+    "bookDock": {
+      "title": "Book Dock",
+      "newFilesDetected": "Nuevos archivos detectados",
+      "reconnecting": "Reconectando",
+      "rescanFailed": "Error al volver a escanear",
+      "totalInDock": "{size} en Book Dock",
+      "dropFiles": "Colocar archivos en Book Dock",
+      "supportedFormats": "Soportado: {formats}",
+      "empty": {
+        "noSearchMatch": "Ningún archivo coincide con \"{query}\"",
+        "noStatusFiles": "No hay archivos {status}",
+        "uploadPrompt": "Cargue archivos o suéltelos en la carpeta Book Dock"
+      },
+      "retry": {
+        "noneToRetry": "No hay archivos de error para volver a intentar",
+        "retrying": "{count, plural, =0 {Reintentando un archivo} one {Reintentando un archivo} other {Reintentando # archivos} many {Reintentando # archivos}}"
+      },
+      "applyFetched": {
+        "applied": "{count, plural, =0 {Aplicado a ningún archivo} one {Aplicado a un archivo} other {Aplicado a # archivos} many {Aplicado a # archivos}}",
+        "skippedEdited": "{count, plural, =0 {omitió un archivo porque tienen ediciones manuales} one {omití un archivo porque tiene ediciones manuales} other {saltado # archivos porque tienen ediciones manuales} many {saltado # archivos porque tienen ediciones manuales}}",
+        "skippedNoMetadata": "{count, plural, =0 {omitió un archivo porque no han obtenido metadatos} one {omitió un archivo porque no tiene metadatos recuperados} other {saltado # archivos porque no tienen metadatos recuperados} many {saltado # archivos porque no tienen metadatos recuperados}}",
+        "noneApplied": "No se aplicaron archivos; {reasons}",
+        "noneSelected": "No hay archivos seleccionados"
+      }
+    },
+    "collection": {
+      "title": "Colección",
+      "pageTitle": "Colección · {name}",
+      "pageTitleWithId": "Colección #{id}",
+      "editCollection": "Editar colección",
+      "showControlsAria": "Mostrar controles de colección",
+      "loadError": "No se pudo cargar esta colección",
+      "toast": {
+        "removed": "{count, plural, =0 {No se eliminó ningún libro de la colección.} one {Se eliminó un libro de la colección.} other {Eliminado # libros de la colección} many {Eliminado # libros de la colección}}",
+        "removeFailed": "No se pudieron eliminar los libros de la colección"
+      },
+      "empty": {
+        "noSearchMatch": "Ningún libro coincide con esta búsqueda",
+        "noSearchMatchHint": "Pruebe con un término de búsqueda diferente o borre la búsqueda.",
+        "noBooks": "No hay libros en esta colección.",
+        "noBooksHint": "Seleccione libros de su biblioteca y agréguelos aquí."
+      }
+    },
+    "library": {
+      "title": "Biblioteca",
+      "pageTitle": "Biblioteca · {name}",
+      "pageTitleWithId": "Biblioteca #{id}",
+      "filterRules": "Reglas de filtrado",
+      "saveAsSmartScope": "Guardar como alcance inteligente",
+      "saveScope": "Guardar alcance",
+      "saveAsSmartScopeTooltip": "Guarde este filtro como un Smart Scope con nombre",
+      "saved": "Guardado",
+      "saveFilter": "Guardar filtro",
+      "filterSaved": "Filtro guardado",
+      "saveFilterTooltip": "Guardar filtro para esta biblioteca",
+      "removeSavedFilter": "Eliminar filtro guardado",
+      "empty": {
+        "noFilterMatch": "Ningún libro coincide con tus filtros",
+        "noFilterMatchHint": "Intente ajustar o borrar sus filtros para ver más libros.",
+        "clearFilters": "Limpiar filtros",
+        "scanning": "Escaneando tu biblioteca...",
+        "scanningHint": "Los libros aparecerán aquí a medida que se descubran.",
+        "emptyLibrary": "Tu biblioteca está vacía",
+        "emptyLibraryHint": "Una vez que agregue libros a esta biblioteca, aparecerán aquí."
+      },
+      "querySelection": {
+        "loadedSelected": "{selected} de {total} libros cargados seleccionados.",
+        "selectAllMatching": "Seleccione todos los {total} libros coincidentes"
+      }
+    },
+    "smartScope": {
+      "title": "alcance inteligente",
+      "pageTitle": "SmartScope · {name}",
+      "pageTitleWithId": "SmartScope #{id}",
+      "defaultName": "Alcance inteligente",
+      "filter": "Filtrar",
+      "edit": "Editar alcance inteligente",
+      "showControlsAria": "Mostrar controles de alcance inteligente",
+      "hideFilter": "Ocultar filtro",
+      "showFilter": "Mostrar filtro",
+      "confirmDelete": "¿Confirmar?",
+      "loadError": "No se pudo cargar este SmartScope",
+      "toast": {
+        "deleted": "\"{name}\" eliminado",
+        "deleteFailed": "No se pudo eliminar \"{name}\""
+      },
+      "empty": {
+        "noRules": "No hay reglas configuradas",
+        "noRulesHint": "Abra el editor para definir qué libros aparecen en este smartScope usando filtros y reglas de clasificación.",
+        "configure": "Configurar SmartScope",
+        "noMatch": "Ningún libro coincide con este smartScope",
+        "noMatchHint": "Intente ajustar las reglas de filtrado.",
+        "edit": "Editar SmartScope"
+      }
+    }
+  },
+  "whatsNew": {
+    "title": "¿Qué hay de nuevo?",
+    "subtitle": "Todo lo que se envía, lo más nuevo primero.",
+    "versionPrefix": "Versión {version}",
+    "newUpdates": "{count, plural, =0 {no hay nuevas actualizaciones} one {una nueva actualización} other {# nuevas actualizaciones} many {# nuevas actualizaciones}}",
+    "remindLater": "Recuérdamelo más tarde",
+    "gotIt": "Lo tengo",
+    "latest": "Lo último",
+    "fullChangelog": "Registro de cambios completo",
+    "seeAllReleases": "Ver todos los lanzamientos",
+    "versions": "Versiones",
+    "currentVersion": "Versión actual",
+    "youreHere": "estas aqui",
+    "searchPlaceholder": "Buscar lanzamientos…",
+    "noReleasesFound": "No se encontraron lanzamientos.",
+    "noHighlights": "No hay aspectos destacados de esta versión.",
+    "showChangelog": "Mostrar registro de cambios completo",
+    "hideChangelog": "Ocultar registro de cambios completo",
+    "openOnGitHub": "Abrir en GitHub",
+    "loadMore": "Cargar más",
+    "loadingMore": "Cargando…",
+    "loadFailed": "No se pudieron cargar las versiones",
+    "loadMoreFailed": "No se pudieron cargar más lanzamientos. Por favor inténtalo de nuevo.",
+    "loadErrorHint": "No se pudieron cargar las versiones. Comprueba tu conexión y vuelve a intentarlo.",
+    "retry": "Reintentar",
+    "imageViewer": "Visor de imágenes",
+    "closeImage": "Cerrar imagen",
+    "previousImage": "Imagen anterior",
+    "nextImage": "Siguiente imagen"
+  },
+  "titles": {
+    "dashboard": "Panel de control",
+    "libraries": "Bibliotecas",
+    "opds": "OPDS",
+    "koboSync": "Kobo Sincronización",
+    "koreaderSync": "KOReader Sincronización",
+    "bookDock": "Book Dock",
+    "whatsNew": "¿Qué hay de nuevo?",
+    "annotations": "Anotaciones",
+    "achievements": "Logros",
+    "statistics": "Estadísticas",
+    "authors": "Autores",
+    "series": "Serie",
+    "entityManager": "Gerente de entidad",
+    "bulkRename": "Cambio de nombre masivo",
+    "duplicateBooks": "Libros duplicados",
+    "notFound": "No encontrado",
+    "signIn": "Iniciar sesión",
+    "initialSetup": "Configuración inicial",
+    "forgotPassword": "Olvidé mi contraseña",
+    "resetPassword": "Restablecer contraseña",
+    "completingSignIn": "Completando el inicio de sesión",
+    "magicLinkLogin": "Iniciar sesión con enlace mágico",
+    "readPrefix": "Leer",
+    "emailSuffix": "Correo electrónico",
+    "library": "Biblioteca",
+    "smartScope": "alcance inteligente",
+    "collection": "Colección",
+    "author": "Autor",
+    "book": "Libro",
+    "seriesItem": "Serie",
+    "appearance": {
+      "theme": "Visualización",
+      "book-covers": "Portadas de libros",
+      "icons": "Iconos",
+      "layout": "Diseño de pantalla",
+      "behavior": "Comportamiento de la biblioteca"
+    },
+    "reader": {
+      "general": "Configuración del lector",
+      "ebook": "Lector de libros electrónicos",
+      "pdf": "PDF Lector",
+      "comics": "Lector de cómics",
+      "audio": "Reproductor de audiolibros",
+      "fonts": "Fuentes del lector"
+    },
+    "email": {
+      "providers": "Proveedores",
+      "recipients": "Destinatarios",
+      "groups": "Grupos",
+      "templates": "Plantillas",
+      "preferences": "Preferencias",
+      "history": "Historia"
+    },
+    "metadata": {
+      "providers": "Proveedores",
+      "field-rules": "Reglas a nivel de campo",
+      "custom-fields": "Metadatos personalizados",
+      "genre-blocklist": "Lista de bloqueo de género",
+      "score": "Puntuación de confianza",
+      "auto-fetch": "Búsqueda automática de libros",
+      "authors": "Recuperación automática del autor"
+    },
+    "admin": {
+      "users": "Usuarios",
+      "account-activity": "Actividad de la cuenta",
+      "magic-links": "Enlaces mágicos",
+      "oidc": "OIDC/SSO"
+    },
+    "system": {
+      "file-naming": "Nomenclatura de archivos",
+      "book-dock": "Book Dock",
+      "maintenance": "Mantenimiento",
+      "audit-log": "Registro de auditoría"
+    },
+    "account": {
+      "profile": "cuenta",
+      "privacy": "Privacidad y uso compartido",
+      "notifications": "Notificaciones",
+      "restrictions": "Restricciones de contenido"
+    }
+  }
+}

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -1,0 +1,6633 @@
+{
+  "common": {
+    "resetSortAria": "Réinitialiser le tri par défaut",
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "close": "Fermer",
+    "confirm": "Confirmer",
+    "loading": "Chargement...",
+    "search": "Rechercher",
+    "back": "Retour",
+    "next": "Suivant",
+    "previous": "Précédent",
+    "retry": "Réessayer",
+    "yes": "Oui",
+    "no": "Non"
+  },
+  "settings": {
+    "privacySharing": {
+      "title": "Confidentialité et partage",
+      "subtitle": "Contrôlez si les administrateurs peuvent voir un résumé identifiable de votre activité de lecture.",
+      "levelLegend": "Niveau de partage des insights sur la lecture",
+      "current": "Paramètre actuel",
+      "levels": {
+        "private": {
+          "title": "Privé",
+          "description": "Vous seul pouvez voir vos statistiques de lecture."
+        },
+        "summary": {
+          "title": "Partager le résumé",
+          "description": "Partagez vos habitudes globales sans titres de livres, auteurs, séries ou narrateurs."
+        },
+        "detailed": {
+          "title": "Partagez des informations détaillées",
+          "description": "Partagez également des livres, auteurs, séries, genres et narrateurs récents et de premier ordre."
+        }
+      },
+      "fields": {
+        "frequency": "Fréquence de lecture et jours actifs",
+        "completion": "Livres agrégés commencés et terminés",
+        "formats": "Distribution des formats",
+        "genres": "Large répartition des genres",
+        "trend": "Tendance globale de lecture",
+        "books": "Titres de livres actuels, récents et les plus lus",
+        "authors": "Meilleurs auteurs",
+        "series": "Meilleures séries",
+        "narrators": "Meilleurs narrateurs"
+      },
+      "confirm": {
+        "shareTitle": "Activer {level} ?",
+        "shareDescription": "Les administrateurs autorisés pourront voir les informations suivantes.",
+        "stopTitle": "Arrêter de partager des informations sur la lecture ?",
+        "stopDescription": "L'accès administrateur sera immédiatement bloqué. Les enregistrements d'accès existants restent dans votre historique.",
+        "recordedNotice": "Chaque vue de profil d'administrateur est enregistrée et apparaît dans votre historique d'accès."
+      },
+      "preview": {
+        "title": "Prévisualisez votre profil partagé",
+        "description": "Consultez les informations actuellement disponibles pour les administrateurs autorisés.",
+        "action": "Charger l'aperçu",
+        "readingTime": "Temps de lecture",
+        "activeDays": "Journées actives",
+        "started": "Livres commencés",
+        "completed": "Livres terminés",
+        "topBooks": "Meilleurs livres"
+      },
+      "history": {
+        "title": "Historique d'accès au profil",
+        "description": "Vues récentes de l'administrateur de votre profil de lecture partagé.",
+        "empty": "Aucun administrateur n'a consulté votre profil de lecture partagé.",
+        "paginationLabel": "Pages d'historique d'accès au profil"
+      },
+      "durationMinutes": "{count, plural, one {# minute} other {# minutes} many {# minutes}}",
+      "durationHours": "{count} heures",
+      "unknownTitle": "Livre sans titre",
+      "errors": {
+        "load": "Échec du chargement des paramètres de partage.",
+        "save": "Échec de la mise à jour des paramètres de partage.",
+        "preview": "Échec du chargement de l'aperçu du profil partagé."
+      }
+    },
+    "appearance": {
+      "language": {
+        "title": "Langue",
+        "description": "Choisissez la langue utilisée dans l'interface.",
+        "label": "Langue de l'interface",
+        "loadError": "Échec du chargement de la langue sélectionnée",
+        "saveError": "Échec de l'enregistrement des préférences de langue"
+      },
+      "pageTitle": "Affichage",
+      "pageSubtitle": "Contrôlez les thèmes, les couvertures, la mise en page et la présentation de votre bibliothèque.",
+      "mobileSummary": "Thème : {theme} • Accent : {accent} • Contexte : {background}",
+      "themeMode": {
+        "light": "Lumière",
+        "dark": "Sombre",
+        "system": "Système"
+      },
+      "theme": {
+        "title": "Thème",
+        "colorScheme": {
+          "label": "Jeu de couleurs",
+          "hint": "Interface claire ou sombre"
+        },
+        "accents": {
+          "grey": "Gris",
+          "scarlet": "Écarlate",
+          "vermilion": "Vermillon",
+          "rose": "Rose",
+          "copper": "Cuivre",
+          "orange": "Orange",
+          "chartreuse": "Chartreuse",
+          "marigold": "Souci",
+          "wasabi": "Wasabi",
+          "amber": "Ambre",
+          "malachite": "Malachite",
+          "yellow": "Jaune",
+          "viridian": "Viridien",
+          "turquoise": "Turquoises",
+          "lime": "Chaux",
+          "green": "Vert",
+          "acid-green": "Vert acide",
+          "emerald": "Émeraude",
+          "teal": "Sarcelle",
+          "electric-blue": "Bleu électrique",
+          "cyan": "Cyan",
+          "jade": "Jade",
+          "ultramarine": "Outremer",
+          "iris": "Iris",
+          "purple": "Violet",
+          "blue": "Bleu",
+          "indigo": "Indigo",
+          "violet": "Violette",
+          "amethyst": "Améthyste",
+          "fuchsia": "Fushia",
+          "raspberry": "Framboise",
+          "pink": "Rose",
+          "white": "Blanc",
+          "rosewater": "Eau de rose",
+          "salmon": "Saumon",
+          "coral": "Corail",
+          "sand": "Sable",
+          "peach": "Pêche",
+          "pear": "Poire",
+          "flax": "Lin",
+          "sprout": "Germer",
+          "butter": "Beurre",
+          "aloe": "Aloès",
+          "lemon": "Citron",
+          "foam": "Mousse",
+          "aqua": "Aqua",
+          "celadon": "Céladon",
+          "sage": "Sauge",
+          "pistachio": "Pistache",
+          "mint": "Menthe",
+          "seafoam": "Écume de mer",
+          "baby-blue": "Bleu bébé",
+          "powder": "Poudre",
+          "sea-glass": "Verre de mer",
+          "bluebell": "Jacinthe des bois",
+          "cornflower": "Bleuet",
+          "thistle": "Chardon",
+          "periwinkle": "Pervenche",
+          "wisteria": "Glycine",
+          "lavender": "Lavande",
+          "mauve": "Mauve",
+          "orchid": "Orchidée",
+          "rose-quartz": "Quartz Rose",
+          "blush": "Fard à joues"
+        },
+        "accentColor": {
+          "label": "Couleur d'accentuation",
+          "hint": "Contrôle les points forts et les éléments interactifs"
+        },
+        "cornerRadius": {
+          "label": "Rayon d'angle",
+          "hint": "Rondeur des cartes et des éléments de l'interface utilisateur"
+        },
+        "surfaceBrightness": {
+          "label": "Luminosité des surfaces",
+          "hint": "Éclaircir les surfaces en mode sombre",
+          "reset": "Réinitialiser"
+        },
+        "libraryBackground": {
+          "title": "Contexte de la bibliothèque",
+          "pattern": {
+            "label": "Motif de fond",
+            "hint": "Motif affiché derrière la grille du livre"
+          }
+        },
+        "backgroundGroups": {
+          "fundamental": "Fondamental",
+          "structural": "Structurel",
+          "ambient": "Ambiante",
+          "refractive": "Réfractif"
+        }
+      },
+      "storage": {
+        "title": "Où enregistrer les préférences d'apparence",
+        "active": "Actif",
+        "notAvailable": "Non disponible",
+        "device": {
+          "title": "Cet appareil uniquement",
+          "description": "Les préférences restent dans votre navigateur. Idéal si vous souhaitez un look différent sur différents appareils."
+        },
+        "account": {
+          "title": "Mon compte",
+          "description": "Les préférences sont enregistrées sur votre compte. Idéal si vous souhaitez la même apparence sur chaque appareil."
+        },
+        "toasts": {
+          "synced": "Les préférences seront désormais synchronisées",
+          "local": "Les préférences resteront sur cet appareil"
+        },
+        "errors": {
+          "demoRestricted": "Le compte restreint à la démo ne peut pas changer le mode de stockage du thème",
+          "update": "Échec de la mise à jour du mode de stockage",
+          "generic": "Une erreur s'est produite lors de la mise à jour du mode de stockage"
+        }
+      },
+      "bookCovers": {
+        "title": "Couvertures de livres",
+        "displayMode": {
+          "title": "Mode d'affichage de la couverture",
+          "hint": "Contrôle la manière dont les couvertures réelles s'insèrent dans les emplacements des livres lorsque les proportions diffèrent",
+          "blurredFit": {
+            "label": "Ajustement flou",
+            "hint": "Afficher la couverture complète avec un remplissage flou derrière"
+          },
+          "fillCrop": {
+            "label": "Remplir la carte",
+            "hint": "Remplissez tout l'emplacement en coupant les bords lorsque les proportions diffèrent"
+          },
+          "naturalBottom": {
+            "label": "Fond naturel",
+            "hint": "Conservez le rapport de couverture d'origine et ancrez la couverture au fond."
+          }
+        },
+        "spine": {
+          "title": "Superposition du dos du livre",
+          "hint": "Ajoute un dos stylisé et un effet brillant aux cartes de couverture.",
+          "off": {
+            "label": "Désactivé",
+            "hint": "Pas d'effet dos/brillant sur les couvertures"
+          },
+          "subtle": {
+            "label": "Subtil",
+            "hint": "Dos et brillance légers, plus proches de l'aspect par défaut"
+          },
+          "strong": {
+            "label": "Fort",
+            "hint": "Traitement du dos et du brillant plus prononcé"
+          }
+        },
+        "showSpineOnComics": {
+          "label": "Montrer le dos des bandes dessinées",
+          "hint": "Appliquer l'effet dos et brillant aux couvertures de bandes dessinées (cbz, cbr, cb7)"
+        },
+        "shadow": {
+          "title": "Couvrir la force de l'ombre",
+          "hint": "Contrôle la profondeur sous les couvertures dans les vignettes de la grille, de la liste, du tableau et du tableau de bord",
+          "default": {
+            "label": "Par défaut",
+            "hint": "Altitude et profondeur actuelles"
+          },
+          "strong": {
+            "label": "Fort",
+            "hint": "Ombre portée plus lourde, semblable à une étagère, sous les couvertures"
+          }
+        },
+        "overlays": {
+          "title": "Superpositions de cartes",
+          "hint": "Choisissez les métadonnées affichées directement sur les cartes de couverture du livre",
+          "progressBar": {
+            "label": "Barre de progression",
+            "hint": "Fine ligne colorée le long du bord inférieur"
+          },
+          "format": {
+            "label": "Format de fichier",
+            "hint": "Badge à code couleur EPUB, PDF, CBZ en bas à droite"
+          },
+          "rating": {
+            "label": "Note",
+            "hint": "Indicateur de nombre d'étoiles en bas à gauche"
+          },
+          "readStatus": {
+            "label": "Lire l'état",
+            "hint": "Icône de couleur affichant l'état de lecture actuel en haut à gauche"
+          },
+          "seriesPosition": {
+            "label": "Numéro de série",
+            "hint": "Badge indiquant la position du livre dans sa série en haut à droite (par exemple #3, #1.5)"
+          },
+          "lockStatus": {
+            "label": "Statut de verrouillage",
+            "hint": "Icône de verrouillage des métadonnées en haut à droite : orange lorsqu'elle est verrouillée, verte lorsqu'elle est déverrouillée"
+          }
+        }
+      },
+      "layout": {
+        "coverSize": "Taille de la couverture",
+        "gridSpacing": "Espacement des grilles",
+        "gridLayout": {
+          "title": "Disposition de la grille de la bibliothèque"
+        },
+        "coverSizeBehavior": {
+          "label": "Comportement de la taille de la couverture",
+          "hint": "Contrôlez si les tailles portrait/carré et l'espacement de la grille sont partagés dans toutes les vues ou conservés par vue.",
+          "perViewHint": "Mode par vue : ajustez la taille de la couverture et l'espacement à partir du panneau d'affichage de chaque vue.",
+          "syncAll": "Synchroniser toutes les vues",
+          "perView": "Tailles par vue"
+        },
+        "portraitCoverSize": {
+          "label": "Taille de la couverture en mode portrait",
+          "hint": "Utilisé pour les bibliothèques de portraits et les vues"
+        },
+        "squareCoverSize": {
+          "label": "Taille du couvercle carré",
+          "hint": "Utilisé pour les bibliothèques et les vues carrées"
+        },
+        "portraitGridSpacing": {
+          "label": "Espacement de la grille portrait",
+          "hint": "Écart entre les couvertures de portrait"
+        },
+        "squareGridSpacing": {
+          "label": "Espacement des grilles carrées",
+          "hint": "Espace entre les couvercles carrés"
+        },
+        "cardInfoMode": {
+          "label": "Mode informations sur la carte",
+          "hint": "Où afficher le titre du livre et l'auteur sur les cartes quadrillées",
+          "onHover": "En survol",
+          "belowCover": "Sous la couverture",
+          "off": "Désactivé"
+        },
+        "primaryCardLabel": {
+          "label": "Etiquette de la carte principale",
+          "hint": "Texte affiché sous chaque couverture de livre (première ligne)"
+        },
+        "secondaryCardLabel": {
+          "label": "Étiquette de carte secondaire",
+          "hint": "Texte supplémentaire sous l'étiquette principale (deuxième ligne)"
+        },
+        "labelField": {
+          "hidden": "Caché",
+          "bookTitle": "Titre du livre",
+          "seriesTitle": "Titre de la série",
+          "seriesTitlePosition": "Titre de la série + position",
+          "author": "Auteur"
+        },
+        "seriesDisplay": {
+          "title": "Affichage de la série",
+          "collapsedCover": {
+            "label": "Couverture de la série réduite",
+            "hint": "Choisissez la couverture à afficher lorsque les séries sont réduites dans la grille du livre"
+          },
+          "stack": "Pile",
+          "mosaic": "Mosaïque",
+          "first": "D'abord",
+          "latest": "Dernier",
+          "firstUnread": "Premier non lu"
+        },
+        "authorGrid": {
+          "title": "Grille des auteurs",
+          "coverSize": {
+            "label": "Taille de la couverture",
+            "hint": "Largeur des couvertures d'auteur dans la grille"
+          },
+          "coverShape": {
+            "label": "Forme de la couverture",
+            "hint": "Forme des couvertures d'auteur dans la grille"
+          },
+          "circle": "Cercle",
+          "square": "Carré"
+        },
+        "listTableViews": {
+          "title": "Vues de liste et de tableau"
+        },
+        "zebraStriping": {
+          "label": "Rayure zébrée",
+          "hint": "Couleurs d'arrière-plan des lignes alternatives pour une numérisation plus facile"
+        }
+      },
+      "behavior": {
+        "title": "Comportement de la bibliothèque",
+        "thumbnailClicks": {
+          "label": "Clics sur les vignettes",
+          "hint": "Choisissez ce qui se passe lors de l'ouverture d'un livre à partir des vues grille et liste",
+          "readFirst": "Lire d'abord",
+          "readFirstHint": "Ouvrir le lecteur lorsqu'un fichier lisible existe",
+          "openDetails": "Ouvrir les détails",
+          "openDetailsHint": "Accédez à la page de détails du livre à partir des vignettes de la grille et de la liste."
+        },
+        "filterPreview": {
+          "label": "Afficher l'aperçu du filtre par défaut",
+          "hint": "Développez le filtre actif et triez le résumé lors de l'ouverture d'un smartScope"
+        },
+        "collapseSeries": {
+          "label": "Réduire la série par défaut",
+          "hint": "Regroupez les livres de la même série sur une seule carte dans les vues de bibliothèque et de collection."
+        }
+      },
+      "icons": {
+        "title": "Icônes personnalisées",
+        "uploadIcons": "Télécharger des icônes",
+        "uploadedCount": "{count, plural, =0 {aucune icône téléchargée} one {# icône téléchargée} other {# icônes téléchargées} many {# icônes téléchargées}}",
+        "searchPlaceholder": "Icônes de recherche",
+        "sort": {
+          "newest": "Le plus récent",
+          "name": "Nom"
+        },
+        "selectedCount": "{count} sélectionné",
+        "clear": "Effacer",
+        "deleteSelected": "Supprimer la sélection",
+        "loading": "Chargement des icônes...",
+        "emptySearch": "Aucune icône ne correspond à votre recherche.",
+        "emptyNoIcons": "Aucune icône personnalisée n'a encore été téléchargée.",
+        "namePlaceholder": "Nom",
+        "checkingUsage": "Vérification de l'utilisation...",
+        "usedBy": "Utilisé par {count}",
+        "notUsedYet": "Pas encore utilisé",
+        "rename": "Renommer",
+        "replace": "Remplacer",
+        "usage": {
+          "libraries": "{count, plural, =0 {pas de bibliothèques} one {# bibliothèque} other {# bibliothèques} many {# bibliothèques}}",
+          "collections": "{count, plural, =0 {pas de collecte} one {# collecte} other {# collections} many {# collections}}",
+          "smartScopes": "{count, plural, =0 {pas de lunettes intelligentes} one {# portée intelligente} other {# lunettes intelligentes} many {# lunettes intelligentes}}"
+        },
+        "confirm": {
+          "deleteOne": "Supprimer \"{name}\" ? Les utilisations existantes reviendront à leur icône par défaut.",
+          "deleteMany": "{count, plural, =0 {Supprimer aucune icône ?} one {Supprimer # icône ? Les utilisations existantes reviendront à leur icône par défaut.} other {Supprimer # des icônes ? Les utilisations existantes reviendront à leur icône par défaut.} many {Supprimer # des icônes ? Les utilisations existantes reviendront à leur icône par défaut.}}"
+        },
+        "toasts": {
+          "saved": "Icône enregistrée",
+          "updated": "Icône mise à jour",
+          "deleted": "Icône supprimée",
+          "bulkDeleted": "{count, plural, =0 {Aucune icône supprimée} one {Supprimé # icône} other {Supprimé # icônes} many {Supprimé # icônes}}",
+          "bulkDeletePartial": "{deleted} supprimé, {failed} a échoué"
+        },
+        "errors": {
+          "load": "Échec du chargement des icônes",
+          "save": "Échec de l'enregistrement de l'icône",
+          "replace": "Échec du remplacement de l'icône",
+          "delete": "Échec de la suppression de l'icône",
+          "bulkDelete": "Échec de la suppression des icônes"
+        }
+      },
+      "tabs": {
+        "theme": "Thème",
+        "book-covers": "Couvertures de livres",
+        "icons": "Icônes",
+        "layout": "Disposition",
+        "behavior": "Comportement"
+      }
+    },
+    "account": {
+      "title": "Compte",
+      "subtitle": "Gérez les paramètres de votre profil personnel.",
+      "subtitleAll": "Gérez votre profil et vos préférences de notification.",
+      "tabs": {
+        "profile": "Profil",
+        "privacy": "Confidentialité et partage",
+        "notifications": "Notifications",
+        "restrictions": "Restrictions"
+      },
+      "demoRestricted": {
+        "cannotEdit": "Le compte restreint à la démo ne peut pas modifier les paramètres du compte",
+        "notice": "Compte restreint à la démo : la modification du profil, du mot de passe, de l'avatar et des identités liées est désactivée."
+      },
+      "feedback": {
+        "unsavedChanges": "Modifications non enregistrées",
+        "allSaved": "Toutes les modifications enregistrées"
+      },
+      "profile": {
+        "securityHeading": "Profil et sécurité",
+        "username": "Nom d'utilisateur",
+        "fullName": "Nom complet",
+        "email": "Courriel",
+        "emailHint": "Contactez un administrateur pour modifier votre adresse e-mail.",
+        "save": "Enregistrer le profil",
+        "saving": "Sauvegarde...",
+        "changePassword": "Changer le mot de passe",
+        "accountType": "Type de compte :",
+        "accountTypeOidc": "OIDC / SSO",
+        "accountTypeShared": "Partagé",
+        "accountTypeLocal": "Local",
+        "nameRequired": "Le nom est requis",
+        "updateFailed": "Échec de la mise à jour du profil",
+        "updated": "Profil mis à jour"
+      },
+      "readingPreferences": {
+        "title": "Préférences de lecture",
+        "timezoneHint": "Le fuseau horaire est utilisé pour les réalisations urgentes comme Early Bird et All-nighter.",
+        "timezone": "Fuseau horaire",
+        "save": "Enregistrer les préférences",
+        "enableAchievements": "Activer les réalisations",
+        "enableAchievementsHint": "Suivez la progression des réalisations et affichez l’interface liée aux réalisations. Gérez les notifications de réussite séparément dans Notifications."
+      },
+      "preferences": {
+        "saveFailed": "Échec de l'enregistrement des préférences",
+        "saved": "Préférences enregistrées"
+      },
+      "avatar": {
+        "title": "Photo de profil",
+        "unknownUser": "Utilisateur inconnu",
+        "formatHint": "PNG/JPEG/WEBP jusqu'à {size} Mo",
+        "upload": "Télécharger une photo",
+        "replace": "Remplacer l'image",
+        "uploading": "Téléchargement...",
+        "remove": "Supprimer l'image",
+        "removing": "Suppression...",
+        "updated": "Photo de profil mise à jour",
+        "uploadFailed": "Échec du téléchargement de la photo de profil",
+        "removed": "Photo de profil supprimée",
+        "removeFailed": "Échec de la suppression de la photo de profil",
+        "removeConfirm": {
+          "title": "Supprimer la photo de profil ?",
+          "description": "Votre avatar sera supprimé et remplacé par vos initiales.",
+          "confirm": "Supprimer"
+        }
+      },
+      "connectedAccounts": {
+        "title": "Comptes connectés",
+        "unlink": "Dissocier",
+        "unlinking": "Dissociation...",
+        "linkAdditional": "Associez des fournisseurs supplémentaires :",
+        "linkProvider": "Lier {provider}",
+        "redirecting": "Redirection...",
+        "noneConfigured": "Aucun fournisseur OIDC n'est configuré. Demandez à un administrateur de configurer le SSO.",
+        "linkStateFailed": "Échec de la génération de l'état du lien",
+        "startLinkFailed": "Échec du démarrage du lien OIDC",
+        "unlinkFailed": "Échec de la dissociation",
+        "unlinked": "Identité non liée",
+        "unlinkIdentityFailed": "Échec de la dissociation de l'identité",
+        "unlinkDialog": {
+          "title": "Dissocier l'identité {provider} ?",
+          "description": "Entrez votre mot de passe pour confirmer. Vous ne pourrez plus vous connecter avec ce fournisseur.",
+          "currentPassword": "Mot de passe actuel"
+        }
+      },
+      "tour": {
+        "title": "Visite guidée",
+        "description": "Rejouez la procédure pas à pas qui met en évidence les principales fonctionnalités de l'application.",
+        "action": "Refaire le tour"
+      },
+      "restrictions": {
+        "none": {
+          "title": "Aucune restriction de contenu",
+          "description": "Votre compte a un accès complet à tout le contenu de vos bibliothèques attribuées."
+        },
+        "banner": "Votre compte est soumis à des restrictions de contenu appliquées par un administrateur. Certains livres peuvent ne pas vous être visibles.",
+        "allowedTags": {
+          "title": "Balises autorisées",
+          "description": "Seuls les livres comportant au moins une de ces balises vous sont présentés."
+        },
+        "blockedTags": {
+          "title": "Balises bloquées",
+          "description": "Les livres comportant l’une de ces balises vous sont masqués."
+        },
+        "allowedGenres": {
+          "title": "Genres autorisés",
+          "description": "Seuls les livres appartenant à au moins un de ces genres vous sont présentés."
+        },
+        "blockedGenres": {
+          "title": "Genres bloqués",
+          "description": "Les livres appartenant à l’un de ces genres vous sont cachés."
+        }
+      }
+    },
+    "magicLinks": {
+      "title": "Liens magiques",
+      "subtitle": "Créez des liens de connexion partageables pour les comptes partagés.",
+      "createLink": "Créer un lien",
+      "noSharedAccounts": "Aucun compte partagé trouvé",
+      "noSharedAccountsHint": "Créez d'abord un compte partagé à partir du {usersPage} pour générer des liens magiques.",
+      "activeLinks": "Liens actifs",
+      "inactiveLinks": "Liens inactifs",
+      "paused": "En pause",
+      "deletedUser": "Utilisateur supprimé",
+      "expiredPrefix": "Expiré ",
+      "never": "Aucune activité enregistrée",
+      "noExpiry": "Pas d'expiration",
+      "expired": "Expiré",
+      "expiresOn": "Expire {date}",
+      "revokedOn": "Révoqué {date}",
+      "expiredOn": "{date} expiré",
+      "usesCount": "{count, plural, =0 {aucune utilisation} one {une utilisation} other {# utilise} many {# utilise}}",
+      "copied": "Copié!",
+      "copyLink": "Copier le lien",
+      "pause": "Pause",
+      "resume": "Reprendre",
+      "revoke": "Révoquer",
+      "revoking": "Révoquer...",
+      "emptyState": "Aucun lien magique n'a encore été créé. Cliquez sur \"{action}\" pour générer une connexion partageable URL.",
+      "columns": {
+        "label": "Étiquette",
+        "account": "Compte",
+        "createdBy": "Créé par",
+        "expires": "Expire",
+        "uses": "Utilisations",
+        "lastUsed": "Dernière utilisation",
+        "created": "Créé",
+        "status": "Statut",
+        "totalUses": "Utilisations totales"
+      },
+      "createDialog": {
+        "title": "Créer un lien magique",
+        "description": "Générez une connexion partageable URL pour un compte partagé.",
+        "sharedAccount": "Compte partagé",
+        "selectAccount": "Sélectionnez un compte partagé",
+        "label": "Étiquette",
+        "labelPlaceholder": "par ex. Lien de démonstration pour la conférence",
+        "expiresAt": "Expire à",
+        "optional": "(facultatif)",
+        "create": "Créer",
+        "creating": "Création..."
+      },
+      "revokeDialog": {
+        "title": "Révoquer le lien magique ?",
+        "description": "Cela invalidera immédiatement le lien et mettra fin à toutes les sessions actives pour le compte lié."
+      },
+      "errors": {
+        "create": "Échec de la création",
+        "copy": "Échec de la copie du lien magique",
+        "update": "Échec de la mise à jour du lien magique",
+        "revoke": "Échec de la révocation"
+      },
+      "usersPage": "Page des utilisateurs",
+      "emptyTitle": "Aucun lien magique n'a encore été créé",
+      "emptyHint": "Cliquez sur \"{action}\" pour générer une connexion partageable URL.",
+      "noActiveTitle": "Aucun lien magique actif",
+      "noActiveHint": "Tous les liens magiques générés pour cette page ont expiré ou ont été révoqués."
+    },
+    "oidc": {
+      "title": "OIDC / SSO",
+      "subtitle": "Gérez les fournisseurs OpenID Connect pour l’authentification unique.",
+      "providers": "Fournisseurs",
+      "addProvider": "Ajouter un fournisseur",
+      "editProvider": "Modifier le fournisseur",
+      "configureNew": "Configurez un nouveau fournisseur OIDC.",
+      "editing": "Modification de {slug}",
+      "enabled": "Activé",
+      "disabled": "Désactivé",
+      "empty": {
+        "title": "Aucun fournisseur pour l'instant",
+        "description": "Ajoutez un fournisseur OIDC pour activer l'authentification unique pour vos utilisateurs."
+      },
+      "form": {
+        "status": "Statut",
+        "enableProvider": "Activer le fournisseur",
+        "enableProviderHint": "Affichez ce fournisseur sur la page de connexion.",
+        "identity": "Identité du fournisseur",
+        "slug": "Limace",
+        "slugHint": "Identifiant unique (minuscules, tirets). Ne peut pas être modifié ultérieurement.",
+        "displayName": "Nom d'affichage",
+        "displayNameHint": "Affiché sur le bouton de connexion.",
+        "iconUrl": "Icône URL",
+        "iconUrlHint": "Logo facultatif affiché à côté du bouton de connexion.",
+        "iconPreviewAlt": "aperçu de l'icône",
+        "connection": "Connexion",
+        "issuerUri": "URI de l'émetteur",
+        "issuerUriHint": "La base du fournisseur URL.",
+        "test": "Tester",
+        "testing": "Test...",
+        "clientId": "Identifiant client",
+        "clientSecret": "Secret client",
+        "clientSecretPlaceholder": "Laisser vide pour conserver l'existant",
+        "scopes": "Portées",
+        "claimMapping": "Cartographie des revendications",
+        "previewClaims": "Aperçu des revendications",
+        "redirecting": "Redirection...",
+        "mappedClaims": "Revendications cartographiées",
+        "rawClaims": "Allégations brutes",
+        "usernameClaim": "Réclamation du nom d'utilisateur",
+        "nameClaim": "Revendication de nom",
+        "emailClaim": "Réclamation par courrier électronique",
+        "groupsClaim": "Réclamation des groupes",
+        "autoProvisioning": "Provisionnement automatique",
+        "autoProvisionUsers": "Provisionner automatiquement les utilisateurs",
+        "autoProvisionUsersHint": "Créez des comptes lors de la première connexion OIDC si l'utilisateur n'existe pas.",
+        "allowLocalLinking": "Autoriser l'association de comptes locaux",
+        "allowLocalLinkingHint": "Liez l'identité OIDC à un compte local existant par correspondance de nom d'utilisateur.",
+        "defaultPermissions": "Autorisations par défaut",
+        "defaultPermissionsHint": "Autorisations accordées aux nouveaux utilisateurs lors de la première connexion OIDC.",
+        "createProvider": "Créer un fournisseur",
+        "saveChanges": "Enregistrer les modifications",
+        "saving": "Sauvegarde...",
+        "deleteProvider": "Supprimer le fournisseur",
+        "deleting": "Suppression..."
+      },
+      "test": {
+        "connected": "Connecté - {issuer}",
+        "connectionFailed": "La connexion a échoué",
+        "hide": "Masquer",
+        "details": "Détails",
+        "supported": "pris en charge",
+        "notSupported": "non pris en charge"
+      },
+      "groupMappings": {
+        "title": "Mappages de groupes",
+        "description": "Mapper les revendications du groupe OIDC aux autorisations BookOrbit. Synchronisé à chaque connexion.",
+        "noPermission": "Aucune autorisation",
+        "empty": "Aucun mappage de groupe configuré.",
+        "addMapping": "Ajouter un mappage",
+        "claimPlaceholder": "Revendication de groupe OIDC (par exemple, administrateurs)",
+        "add": "Ajouter",
+        "adding": "Ajout..."
+      },
+      "toasts": {
+        "providerCreated": "Fournisseur créé",
+        "providerSaved": "Fournisseur enregistré",
+        "providerDeleted": "Fournisseur supprimé",
+        "mappingAdded": "Mappage de groupe ajouté",
+        "mappingRemoved": "Mappage de groupe supprimé"
+      },
+      "errors": {
+        "loadProvider": "Échec du chargement du fournisseur",
+        "createProvider": "Échec de la création du fournisseur",
+        "save": "Échec de l'enregistrement",
+        "delete": "Échec de la suppression",
+        "deleteProvider": "Échec de la suppression du fournisseur",
+        "requestFailed": "La demande a échoué",
+        "previewState": "Échec de la génération de l'état d'aperçu",
+        "startPreview": "Échec du démarrage de l'aperçu",
+        "addMapping": "Échec de l'ajout du mappage",
+        "removeMapping": "Échec de la suppression du mappage de groupe"
+      }
+    },
+    "admin": {
+      "title": "Administrateur",
+      "subtitle": "Gérez les utilisateurs et les paramètres d'authentification.",
+      "system": {
+        "title": "Système",
+        "subtitle": "Paramètres d’organisation, d’ingestion et de maintenance des fichiers."
+      },
+      "maintenance": {
+        "title": "Entretien",
+        "subtitle": "Gérez les tâches en arrière-plan, les index système et les opérations de maintenance.",
+        "importGroup": "Importer",
+        "recommendationsGroup": "Recommandations",
+        "achievementsGroup": "Réalisations",
+        "updatesGroup": "Mises à jour",
+        "importFromBooklore": "Importer depuis Booklore",
+        "bookloreImportConfigured": "Importation de livres configurée",
+        "migrationRunning": "Migration en cours",
+        "migrationCompleted": "Migration terminée",
+        "migrationFailed": "Échec de la migration",
+        "importDescription": "Importation unique de livres, de métadonnées et de progrès de lecture à partir d'une installation précédente de Booklore.",
+        "configuredDescription": "Source : {name}. Aucune migration n'a encore été effectuée : poursuivez l'installation pour exécuter l'importation.",
+        "runningDescription": "Étape : {stage} - commencée {started}",
+        "completedDescription": "De {name} à {date} terminé",
+        "migrationErrorGeneric": "Une erreur s'est produite lors de la migration.",
+        "stageInitializing": "initialisation",
+        "recently": "récemment",
+        "getStarted": "Commencer",
+        "continueSetup": "Continuer la configuration",
+        "viewDetails": "Afficher les détails",
+        "refreshRecommendationIndex": "Actualiser l'index des recommandations",
+        "refreshRecommendationHint": "Mettez à jour le moteur de recommandations avec les dernières modifications de votre bibliothèque. Ce processus s'exécute en arrière-plan.",
+        "booksQueuedForProcessing": "{count, plural, =0 {aucun livre en attente de traitement} one {# livre en attente de traitement} other {# livres en attente de traitement} many {# livres en attente de traitement}}",
+        "run": "Courir",
+        "running": "Courir...",
+        "backfillAchievements": "Réalisations de remplissage",
+        "backfillAchievementsHint": "Réévaluez les réalisations de tous les utilisateurs.",
+        "backfillResult": "Utilisateurs {users} traités ; a reçu {awards} récompenses.",
+        "runBackfill": "Exécuter le remplissage",
+        "checkForUpdates": "Vérifier les mises à jour",
+        "checkForUpdatesHint": "Recherchez automatiquement une nouvelle version sur GitHub au démarrage et affichez un indicateur dans la barre latérale lorsqu'elle est disponible.",
+        "updateChecksEnabled": "Vérifications de mise à jour activées",
+        "updateChecksDisabled": "Vérifications de mise à jour désactivées",
+        "updateSettingFailed": "Échec de la mise à jour du paramètre",
+        "booksQueuedForEmbedding": "{count, plural, =0 {aucun livre en attente d'intégration} one {# livre en attente d'intégration} other {# livres en attente d'intégration} many {# livres en attente d'intégration}}",
+        "failed": "Échec",
+        "unknownError": "Erreur inconnue",
+        "rebuildEmbeddingsFailed": "Échec de la reconstruction des intégrations : {error}",
+        "achievementBackfillConfirm": "Exécuter le remplissage des réussites pour toutes les réussites de tous les utilisateurs ? Cela peut prendre un certain temps.",
+        "achievementBackfillComplete": "Remplissage des réalisations terminé : {count} récompenses accordées",
+        "backfillRunFailed": "Échec de l'exécution du remplissage",
+        "achievementBackfillFailed": "Échec de l'exécution du remplissage des réussites : {error}",
+        "uploadsGroup": "Téléchargements",
+        "maxUploadSize": "Limite maximale de taille de fichier de téléchargement",
+        "maxUploadSizeHint": "Configurez la limite de taille maximale pour les téléchargements de fichiers sur l'ensemble du système.",
+        "save": "Enregistrer",
+        "uploadSizeInvalid": "La limite de taille de téléchargement doit être supérieure à 0",
+        "uploadSizeUpdated": "Limite de taille de téléchargement mise à jour"
+      },
+      "migration": {
+        "title": "Migrations",
+        "subtitle": "Importation unique de Booklore : connectez la source, cartographiez les utilisateurs, effectuez une exécution à sec, démarrez la migration et exportez un rapport.",
+        "progress": "Progrès",
+        "stepSourceConnection": "Connexion source",
+        "stepUserPathMapping": "Cartographie des utilisateurs et des chemins",
+        "stepDryRun": "Essai à sec",
+        "stepDryRunTitle": "Essai à sec",
+        "stepRunMigration": "Exécuter la migration",
+        "stepReport": "Rapport",
+        "stepReportTitle": "Rapport de migration",
+        "subtitleSource": "Configurez la connexion à la base de données à votre instance Booklore source.",
+        "subtitleMappings": "Mappez les utilisateurs source avec les utilisateurs cibles et traduisez les chemins de fichiers.",
+        "subtitleDryRun": "Prévisualisez ce qui sera importé avant d’exécuter la migration en direct.",
+        "subtitleRun": "Démarrez l’importation en direct et suivez sa progression.",
+        "subtitleReport": "Vérifiez ce qui a été importé et exportez un rapport détaillé.",
+        "continueToMappings": "Continuer vers les mappages",
+        "continueToDryRun": "Continuer à faire un essai à sec",
+        "continueToMigration": "Continuer vers la migration",
+        "viewReport": "Afficher le rapport",
+        "badgeValidated": "Validé",
+        "badgeSaved": "Enregistré",
+        "badgeUpToDate": "À jour",
+        "badgeCompleted": "Terminé",
+        "badgeRunning": "Courir",
+        "badgeFailed": "Échec",
+        "mediaPathRequired": "Obligatoire pour la migration des couvertures de livres.",
+        "mediaPathAbsolute": "Utilisez un chemin absolu (par exemple : /books). Les chemins relatifs ne sont pas pris en charge.",
+        "mediaPathConfigured": "Chemin d’importation de couverture configuré. Utilisez Test Connection pour vérifier l’accès et la structure des dossiers d’images Booklore.",
+        "issueSaveSource": "Enregistrer les paramètres de connexion source",
+        "issueValidateSource": "Valider la connexion source",
+        "issueSaveMappings": "Enregistrer les mappages d'utilisateurs et de chemins",
+        "issueSavePathMappings": "Enregistrez les mappages de chemin pour les valider",
+        "issueFreshDryRun": "Exécutez un nouvel essai à sec",
+        "issueResolveDuplicates": "Résoudre les correspondances de livres cibles en double lors de l'essai à sec",
+        "issueWaitActiveRun": "Attendez la fin de l'exécution active",
+        "sourceRecordId": "ID de l'enregistrement source #{id}",
+        "byAuthorWithId": "par {author} (ID : {id})",
+        "filePathWithId": "{path} (ID : {id})",
+        "bookloreSourceId": "ID de la source du livre : {id}",
+        "libraryBookNum": "Livre de bibliothèque #{id}",
+        "errorInitialize": "Échec de l'initialisation des paramètres de migration",
+        "errorLoadSourceTypes": "Échec du chargement des types de sources de migration pris en charge",
+        "errorLoadTargetUsers": "Échec du chargement des utilisateurs cibles",
+        "errorLoadLibraryFolders": "Échec du chargement des dossiers de la bibliothèque cible",
+        "noSourceUsersReturned": "Aucun utilisateur source n'a été renvoyé",
+        "userMappingSuggestionsLoaded": "Suggestions de mappage utilisateur chargées",
+        "errorLoadSuggestions": "Échec du chargement des suggestions de mappage utilisateur",
+        "requiredFields": "L'hôte, l'utilisateur, la base de données et le nom de la source sont requis",
+        "connectionTestPassedWithWarnings": "Test de connexion réussi avec avertissements",
+        "connectionTestPassedWithCount": "Test de connexion réussi avec {count} avertissement(s). Premier : {first}",
+        "connectionTestPassed": "Test de connexion réussi",
+        "connectionOkMissingTables": "Connexion correcte, mais {count} table(s) requise(s) sont manquantes",
+        "cannotTestMediaPathActiveRun": "Impossible de tester le chemin du support lorsqu'une exécution est active",
+        "mediaRootPathRequiredCover": "Le chemin racine du média est requis pour l’importation de la couverture.",
+        "useAbsolutePath": "Utilisez un chemin absolu (par exemple : /books).",
+        "mediaPathVerified": "Chemin du média vérifié.",
+        "mediaPathValidReadable": "Le chemin du média est valide et lisible",
+        "mediaPathValidationFailed": "La validation du chemin du média a échoué.",
+        "connectionFailedBeforeMediaPath": "Le test de connexion a échoué avant que la validation du chemin du support ne puisse être terminée.",
+        "cannotModifySourceActiveRun": "Impossible de modifier la source lorsqu'une exécution est active",
+        "sourceSavedValidatedWarnings": "Source enregistrée et validée avec {count} avertissement(s)",
+        "sourceSavedValidated": "Source enregistrée et validée",
+        "errorSaveValidateSource": "Échec de l'enregistrement ou de la validation de la source",
+        "cannotSaveMappingsActiveRun": "Impossible d'enregistrer les mappages lorsqu'une exécution est active",
+        "saveSourceFirst": "Enregistrez d'abord la source",
+        "mapAtLeastOneUser": "Mapper au moins un utilisateur source à un utilisateur cible",
+        "mapEveryUser": "Mappez chaque utilisateur source avant de l'enregistrer",
+        "pathValidationFailedProfileSaved": "La validation du chemin a échoué, mais le profil sera toujours enregistré",
+        "mappingsSaved": "Mappages enregistrés",
+        "errorSaveMappings": "Échec de l'enregistrement des mappages",
+        "cannotRunDryRunActiveRun": "Impossible d'exécuter un essai à blanc lorsqu'une exécution est active",
+        "saveMappingsFirst": "Enregistrez d'abord les mappages",
+        "dryRunCompleted": "Essai à sec terminé : {matched} correspondant, {unresolved} non résolu",
+        "dryRunFailed": "Échec de l'essai à sec",
+        "selectSourceForAllGroups": "Sélectionnez un livre source pour tous les {count} groupes en double",
+        "duplicatesResolved": "Correspondances en double résolues",
+        "errorResolveDuplicates": "Échec de la résolution des doublons",
+        "preflightNotReady": "Le contrôle en amont de la migration n'est pas prêt",
+        "runDryRunFirst": "Exécutez d'abord un essai à sec",
+        "runStarted": "La migration a démarré",
+        "errorStartMigration": "Échec du démarrage de la migration",
+        "runCancelled": "Exécution de migration annulée",
+        "errorCancelMigration": "Échec de l'annulation de la migration",
+        "runRetried": "Nouvelle tentative d'exécution de migration – reprise à partir de la dernière étape terminée",
+        "errorRetryMigration": "Échec de la nouvelle tentative de migration",
+        "errorLoadRunProgress": "Échec du chargement de la progression de l'exécution",
+        "startMigrationFirst": "Commencer la migration en premier",
+        "reportRefreshed": "Exécuter le rapport actualisé",
+        "errorLoadReport": "Échec du chargement du rapport d'exécution",
+        "reportExported": "Rapport exporté sous {format}",
+        "errorExportReport": "Échec de l'exportation du rapport de migration",
+        "reasonNoTitleAuthorMatch": "Aucun livre correspondant trouvé par titre ou par auteur",
+        "reasonNoFilePathMatch": "Le chemin du fichier ne correspond à aucun livre de cette bibliothèque",
+        "reasonNoFileHashMatch": "Le hachage du fichier ne correspond à aucun livre de cette bibliothèque",
+        "reasonNoIsbnMatch": "ISBN ne correspond à aucun livre de cette bibliothèque",
+        "reasonInsufficientSourceData": "Pas assez de métadonnées pour tenter une correspondance",
+        "reasonAmbiguousIsbnMatch": "Plusieurs livres correspondent au même ISBN",
+        "reasonAmbiguousFileHashMatch": "Plusieurs livres correspondaient au même hachage de fichier",
+        "reasonAmbiguousFilePathMatch": "Plusieurs livres correspondaient au même chemin de fichier",
+        "reasonAmbiguousTitleAuthorMatch": "Plusieurs livres correspondaient au même titre et au même auteur",
+        "reasonUnknown": "Impossible de déterminer la raison",
+        "strategyIsbn": "Correspondant à ISBN",
+        "strategyFileHash": "Correspondance par hachage de fichier",
+        "strategyPathMapping": "Correspondant au chemin du fichier mappé",
+        "strategyTitleAuthor": "Assorti par titre et auteur",
+        "strategyUnavailable": "Stratégie de correspondance indisponible",
+        "userPreviewCounts": "Statuts {statuses}, entrées de progression {progress}, signets {bookmarks}, annotations {annotations}, entrées de collection {collections}",
+        "connErrorUnreachable": "Impossible d'atteindre le serveur de base de données. Vérifiez l'hôte et le port.",
+        "connErrorAuth": "L'authentification a échoué. Vérifiez le nom d'utilisateur et le mot de passe.",
+        "connErrorUnknownDatabase": "Base de données introuvable. Vérifiez le nom de la base de données.",
+        "connErrorTimeout": "La connexion a expiré. Vérifiez les paramètres de l'hôte et du pare-feu.",
+        "connErrorGeneric": "Le test de connexion a échoué",
+        "sourceType": "Type de source",
+        "sourceName": "Nom de la source",
+        "host": "Hôte",
+        "port": "Port",
+        "user": "Utilisateur",
+        "password": "Mot de passe",
+        "passwordSavedPlaceholder": "Enregistré - laisser inchangé",
+        "passwordEmptyPlaceholder": "Aucun mot de passe défini",
+        "database": "Base de données",
+        "mediaRootPath": "Chemin racine du média",
+        "pathOk": "Chemin OK",
+        "pathIssue": "Problème de chemin",
+        "testPath": "Chemin de test",
+        "useTls": "Utiliser TLS/SSL",
+        "testConnection": "Tester la connexion",
+        "saveAndValidate": "Enregistrer et valider",
+        "sourceValidatedWithWarnings": "Source validée avec avertissements",
+        "lastValidationSnapshot": "Dernier instantané de validation",
+        "sourceVersion": "Version source : {version}",
+        "unknown": "Inconnu",
+        "missingRequiredTables": "Tables obligatoires manquantes : {tables}",
+        "suggestionsAutoLoad": "Les suggestions des utilisateurs se chargent automatiquement après validation de la source.",
+        "refresh": "Actualiser",
+        "sourceUser": "Utilisateur source",
+        "targetUser": "Utilisateur cible",
+        "noSourceUsersLoaded": "Aucun utilisateur source n'a encore été chargé.",
+        "noActiveTargetUsers": "Aucun utilisateur cible actif trouvé. Créez ou réactivez un utilisateur BookOrbit avant le mappage.",
+        "pathPrefixMappings": "Mappages de préfixes de chemin",
+        "addMapping": "Ajouter un mappage",
+        "pathMappingsHelp1": "Les mappages de chemin traduisent les chemins des fichiers source en chemins cibles afin que les livres puissent être mis en correspondance par emplacement de fichier. Par exemple, si votre bibliothèque Booklore stockait des fichiers sous",
+        "pathMappingsHelp2": "et les mêmes fichiers vivent maintenant sous",
+        "pathMappingsHelp3": ", ajoutez ce mappage ici. Les livres correspondent également à ISBN, au hachage de fichier et au titre/auteur, quels que soient les mappages de chemin. Le mappage de chemin n'est qu'une des quatre stratégies et ne limite pas les livres sources inclus dans la migration.",
+        "noPrefixesFound": "Aucun préfixe trouvé - validez d'abord la source",
+        "selectSourcePrefix": "Sélectionnez le préfixe source...",
+        "selectTargetFolder": "Sélectionnez le dossier cible...",
+        "remove": "Supprimer",
+        "pathValidation": "Validation du chemin",
+        "pathValidationMapped": "{mapped} des {total} livres sources ont un chemin cartographié",
+        "pathValidationUnmatched": "{count} chemins mappés introuvables sur le disque - ces livres reviendront à ISBN / correspondance de titre",
+        "pathValidationAllMatched": "Tous les chemins mappés {count} trouvés sur le disque",
+        "saveMappings": "Enregistrer les mappages",
+        "runDryRun": "Exécuter un essai à sec",
+        "matched": "Correspondances :",
+        "unresolved": "Non résolu :",
+        "duplicateMatches": "Correspondances en double :",
+        "unresolvedSummary": "Résumé non résolu",
+        "resolveDuplicateMatches": "Résoudre les correspondances de cibles en double",
+        "resolveDuplicateHint": "Pour chaque livre cible, choisissez un livre source à conserver. Les choix recommandés sont présélectionnés lorsqu’il existe une seule correspondance la plus forte.",
+        "remainingGroups": "Groupes restants :",
+        "ofCount": "de {count}",
+        "targetBookNum": "Livre cible #{id}",
+        "recommended": "Recommandé",
+        "resolveDuplicatesButton": "{count, plural, =0 {Résoudre # dupliquer} one {Résoudre # dupliquer} other {Résoudre # doublons} many {Résoudre # doublons}}",
+        "preflightChecks": "Vérifications avant vol",
+        "allChecksPassed": "Tous les contrôles ont été réussis - prêt à migrer",
+        "checkSourceValidated": "Source validée",
+        "checkSaveValidateSource": "Enregistrer et valider la connexion source",
+        "checkValidateSource": "Valider la connexion source",
+        "checkMappingsSaved": "Mappages enregistrés",
+        "checkSaveMappings": "Enregistrer les mappages d'utilisateurs et de chemins",
+        "checkPathMappingsValidated": "Mappages de chemins validés",
+        "checkSavePathMappings": "Enregistrez les mappages de chemin pour les valider",
+        "checkDryRunUpToDate": "Le test à sec est à jour",
+        "checkFreshDryRun": "Exécutez un nouvel essai à sec",
+        "startConfirmPrompt": "Cela lancera la migration en direct. Es-tu sûr?",
+        "confirmStart": "Confirmer le démarrage",
+        "startMigration": "Démarrer la migration",
+        "cancelRun": "Annuler l'exécution",
+        "refreshStatus": "Actualiser le statut",
+        "statusPollingStopped": "L'interrogation d'état s'est arrêtée en raison d'une erreur.",
+        "retry": "Réessayer",
+        "stageLabel": "Étape : {stage}",
+        "stageInitializing": "initialisation",
+        "endedLabel": "Terminé {date}",
+        "stageCompleted": "Terminé",
+        "stageInit": "Initialisation",
+        "stageSharedOverlays": "Importer des métadonnées",
+        "stageBookCovers": "Importer des couvertures",
+        "stageUserState": "Importer des données utilisateur",
+        "noRunYet": "Aucune migration n'a encore été exécutée. Suivez les étapes ci-dessus pour commencer.",
+        "runNum": "Exécutez #{id}",
+        "notStarted": "Pas démarré",
+        "reloadReport": "Recharger le rapport",
+        "loadFullReport": "Charger le rapport complet",
+        "exportJson": "Exporter JSON",
+        "exportCsv": "Exporter CSV",
+        "migrationFailed": "Échec de la migration",
+        "retryFromLastStage": "Réessayer depuis la dernière étape terminée",
+        "booksCard": "Livres",
+        "metadataOverlaysApplied": "Superpositions de métadonnées appliquées",
+        "authorMappingsReplaced": "Mappages d'auteur remplacés",
+        "narratorMappingsReplaced": "Mappages du narrateur remplacés",
+        "genreMappingsReplaced": "Les mappages de genre remplacés",
+        "tagMappingsReplaced": "Mappages de balises remplacés",
+        "coversImported": "Couvertures importées",
+        "coverImportSkipped": "L'importation de la couverture a été ignorée : le chemin racine du média n'est pas configuré sur la source",
+        "couldNotMatch": "Impossible de correspondre",
+        "userDataCard": "Données utilisateur",
+        "readingStatuses": "Statuts de lecture",
+        "readingProgressEntries": "Lecture des entrées de progression",
+        "audiobookProgressEntries": "Entrées de progression du livre audio",
+        "bookmarksLabel": "Signets",
+        "annotationsLabel": "Annotations",
+        "collectionEntries": "Entrées de collection",
+        "loadFullReportHint": "Cliquez sur « Charger le rapport complet » pour inclure le résumé des correspondances à sec dans le rapport exporté.",
+        "completedNoIssues": "Migration terminée sans livres ni échecs non résolus.",
+        "matchedBooksHeading": "Livres correspondants ({count})",
+        "matchedBooksHint": "Ces correspondances à sec ont été utilisées pour décider quels livres de bibliothèque recevaient des données importées.",
+        "sourceBookFallback": "Livre source {id}",
+        "libraryBookFallback": "Livre de bibliothèque {id}",
+        "unresolvedBooksHeading": "Livres non résolus ({count})",
+        "unresolvedBooksHint": "Ces livres existent dans la source mais n'ont pu être associés à aucun livre de votre bibliothèque.",
+        "mappedUsersHeading": "Utilisateurs mappés ({count})",
+        "mappedUsersHint": "Les totaux par utilisateur proviennent de l'aperçu d'exécution à sec mis en cache avec le plan de migration.",
+        "coverImportsFailed": "{count} a échoué dans les importations de couverture. Les lignes de défaillance détaillées ne sont pas stockées.",
+        "backToSetup": "Retour à la configuration"
+      },
+      "libraries": {
+        "title": "Bibliothèques",
+        "subtitle": "Gérez vos bibliothèques multimédias et déclenchez des analyses de contenu.",
+        "scanAll": "Scanner tout",
+        "scanning": "Numérisation...",
+        "addLibrary": "Ajouter une bibliothèque",
+        "scan": "Analyser",
+        "editLibrary": "Modifier la bibliothèque",
+        "refreshCovers": "Actualiser les couvertures",
+        "syncMetadataToFiles": "Synchroniser les métadonnées avec les fichiers",
+        "deleteLibrary": "Supprimer la bibliothèque",
+        "bookCount": "{count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+        "addedDate": "Ajout de {date}",
+        "fileMode": "Mode fichier",
+        "folderMode": "Mode dossier",
+        "folderCount": "{count, plural, =0 {pas de dossiers} one {# dossier} other {# dossiers} many {# dossiers}}",
+        "watching": "Regarder",
+        "fileWrite": "Écriture de fichier",
+        "fileRename": "Renommer le fichier",
+        "emptyTitle": "Pas encore de bibliothèques",
+        "emptyHint": "Ajoutez une bibliothèque pour commencer à organiser vos livres.",
+        "addFirstLibrary": "Ajoutez votre première bibliothèque",
+        "deleteConfirmTitle": "Supprimer \"{name}\" ?",
+        "deleteConfirmBody": "Cela supprimera définitivement tous les livres, métadonnées, progression de la lecture, signets et annotations de cette bibliothèque. Cela ne peut pas être annulé.",
+        "deleteConfirmTypeName": "Tapez le nom de la bibliothèque pour confirmer :",
+        "deleting": "Suppression...",
+        "deleteLibraryButton": "Supprimer la bibliothèque",
+        "syncConfirmTitle": "Synchroniser les métadonnées avec les fichiers ?",
+        "syncConfirmBodyPrefix": "Cela écrasera les métadonnées dans chaque fichier pris en charge dans",
+        "syncConfirmBodySuffix": "directement sur le disque. Cela ne peut pas être annulé.",
+        "syncFiles": "Synchroniser les fichiers",
+        "metadataSynced": "Métadonnées synchronisées avec les fichiers pour \"{name}\"",
+        "fileWriteNotEnabled": "L'écriture du fichier de métadonnées n'est pas activée pour cette bibliothèque. Activez-le dans les paramètres de la bibliothèque.",
+        "fileSyncFailed": "Échec de la synchronisation du fichier pour \"{name}\"",
+        "scanStarted": "Analyse lancée pour \"{name}\"",
+        "scanStartFailed": "Échec du démarrage de la recherche de \"{name}\"",
+        "refreshCoversFailed": "Échec de l'actualisation des couvertures pour \"{name}\"",
+        "scanStartedAll": "Analyse lancée pour toutes les bibliothèques",
+        "librariesFailedToStart": "{count, plural, =0 {aucune bibliothèque n'a échoué à démarrer} one {# la bibliothèque n'a pas pu démarrer} other {# les bibliothèques n'ont pas pu démarrer} many {# les bibliothèques n'ont pas pu démarrer}}",
+        "scansStartFailed": "Échec du démarrage des analyses",
+        "libraryCreated": "Bibliothèque \"{name}\" créée",
+        "libraryUpdated": "Bibliothèque \"{name}\" mise à jour",
+        "libraryDeleted": "\"{name}\" supprimé",
+        "deleteFailed": "Échec de la suppression de la bibliothèque",
+        "scanningProgress": "Numérisation de {pct} % ({processed}/{total})",
+        "scanDone": "Terminé - {added} ajouté, {updated} mis à jour",
+        "scanFailedWithError": "Échec : {error}",
+        "scanFailed": "Échec de l'analyse",
+        "refreshingCovers": "Couvertures rafraîchissantes {pct}% ({processed}/{total})",
+        "coversRefreshed": "Couvertures actualisées ({count} traitées)"
+      },
+      "authorEnrichment": {
+        "configuration": "Configuration",
+        "saving": "Sauvegarde...",
+        "running": "Courir...",
+        "runEligibleShort": "Courez éligible",
+        "runAllShort": "Exécutez tout",
+        "enableTitle": "Activer l'enrichissement automatique des auteurs",
+        "enableHint": "Récupérez automatiquement les biographies des auteurs et les photos de profil lorsque des livres sont ajoutés ou mis à jour.",
+        "updateStrategyTitle": "Stratégie de mise à jour",
+        "updateStrategyHint": "Que faire lorsqu'un auteur possède déjà une biographie ou une photo.",
+        "writeModeMissingOnly": "Ne remplir que les données manquantes (recommandé)",
+        "writeModeAlwaysRefetch": "Actualisez toujours les données existantes",
+        "triggerOnImportTitle": "Déclencheur à l'importation",
+        "triggerOnImportHint": "Mettez les auteurs en file d'attente pour les enrichir lorsque les livres sont ajoutés pour la première fois à une bibliothèque.",
+        "eligibilityTitle": "Conditions d'éligibilité",
+        "eligibilityHint": "Un auteur est éligible s’il répond à l’une des conditions activées.",
+        "neverEnrichedTitle": "Jamais enrichi",
+        "neverEnrichedHint": "Enrichissez les auteurs qui n’ont jamais eu d’enrichissement réussi.",
+        "missingBioTitle": "Biographie manquante",
+        "missingBioHint": "Enrichir si l'auteur n'a pas de biographie.",
+        "missingPhotoTitle": "Photo manquante",
+        "missingPhotoHint": "Enrichissez si l'auteur n'a pas de photo de profil.",
+        "runForEligibleAuthors": "Courir pour les auteurs éligibles",
+        "eligibleCount": "~{count} éligible",
+        "runForAllAuthors": "Courir pour tous les auteurs",
+        "saved": "Paramètres d'enrichissement de l'auteur enregistrés",
+        "saveFailed": "Échec de l'enregistrement des paramètres d'enrichissement de l'auteur",
+        "noEligibleAuthors": "Aucun auteur éligible trouvé",
+        "noAuthorsToEnrich": "Aucun auteur à enrichir",
+        "queueFailed": "Échec du remplissage de la file d'attente de l'auteur"
+      },
+      "scoreWeights": {
+        "groupLabel": "Pondérations des scores",
+        "assignHintPrefix": "Attribuez un poids à chaque champ. Poids total :",
+        "areYouSure": "Êtes-vous sûr?",
+        "resetToDefaultsButton": "Réinitialiser aux valeurs par défaut",
+        "recalculateAll": "Tout recalculer",
+        "confirmReset": "Confirmer la réinitialisation",
+        "reset": "Réinitialiser",
+        "recalculate": "Recalculer",
+        "subtotal": "sous-total : {count}",
+        "savedRecalculating": "Score des poids enregistrés. Recalcul des scores de la bibliothèque...",
+        "saveFailed": "Échec de l'enregistrement des pondérations des scores",
+        "recalcStarted": "Le recalcul du score a démarré en arrière-plan",
+        "recalcFailed": "Le recalcul a échoué",
+        "resetToDefaults": "Les poids sont réinitialisés aux valeurs par défaut. Enregistrez pour postuler."
+      },
+      "tabs": {
+        "users": "Utilisateurs",
+        "account-activity": "Activité du compte",
+        "magic-links": "Liens magiques",
+        "oidc": "OIDC / SSO"
+      }
+    },
+    "common": {
+      "nav": {
+        "libraries": "Bibliothèques",
+        "display": "Affichage",
+        "reader": "Lecteur",
+        "metadata": "Métadonnées",
+        "email": "Courriel",
+        "opds": "OPDS",
+        "kobo": "Kobo",
+        "koreader": "KOReader",
+        "hardcover": "Hardcover",
+        "admin": "Administrateur",
+        "system": "Système",
+        "account": "Compte"
+      }
+    },
+    "metadata": {
+      "title": "Métadonnées",
+      "noPermission": "Vous n'êtes pas autorisé à gérer les paramètres de métadonnées.",
+      "fields": {
+        "title": "Titre",
+        "subtitle": "Sous-titre",
+        "description": "Descriptif",
+        "cover": "Couverture",
+        "authors": "Auteurs",
+        "publisher": "Éditeur",
+        "publishedYear": "Année de publication",
+        "language": "Langue",
+        "pageCount": "Nombre de pages",
+        "communityRating": "Évaluation de la communauté",
+        "seriesName": "Nom de la série",
+        "seriesIndex": "Indice de série",
+        "genres": "Genre",
+        "narrators": "Narrateurs",
+        "duration": "Durée",
+        "abridged": "Abrégé"
+      },
+      "mergeStrategy": {
+        "fillMissing": {
+          "label": "Remplissage manquant",
+          "description": "N'écrire que si le champ est actuellement vide"
+        },
+        "overwriteIfProvided": {
+          "label": "Écraser si fourni",
+          "description": "Écrire si le fournisseur a renvoyé une valeur"
+        },
+        "overwrite": {
+          "label": "Toujours écraser",
+          "description": "Remplacez toujours la valeur existante"
+        }
+      },
+      "autoFetch": {
+        "globalSettings": "Paramètres globaux",
+        "perLibraryOverrides": "Exceptions par bibliothèque",
+        "saving": "Sauvegarde...",
+        "running": "Courir...",
+        "runNow": "Courez maintenant",
+        "runForEligible": "Courez pour les livres éligibles",
+        "enable": {
+          "label": "Activer la récupération automatique",
+          "hint": "Récupérez automatiquement les métadonnées des livres éligibles."
+        },
+        "triggerOnImport": {
+          "label": "Déclencheur à l'importation",
+          "hint": "Mettez en file d'attente les livres éligibles lorsqu'ils sont ajoutés pour la première fois à une bibliothèque."
+        },
+        "status": {
+          "inQueuePaused": "{count} dans la file d'attente – en pause",
+          "remaining": "{count} restants",
+          "eligible": "~{count} éligible"
+        },
+        "trigger": {
+          "queued": "{count, plural, one {En file d'attente # livre} other {En file d'attente # livres} many {En file d'attente # livres}}",
+          "noneFound": "Aucun livre éligible trouvé"
+        },
+        "lastRun": {
+          "justNow": "juste maintenant",
+          "minutesAgo": "il y a {count} m",
+          "hoursAgo": "il y a {count}h",
+          "yesterday": "hier",
+          "daysAgo": "Il y a {count} jours",
+          "label": "Dernière exécution : {when}",
+          "labelQueued": "Dernière exécution : {when} - livres {count} mis en file d'attente",
+          "labelNoneEligible": "Dernière exécution : {when} - aucun livre éligible"
+        },
+        "conditions": {
+          "title": "Conditions d'éligibilité",
+          "hint": "Un livre est éligible s’il répond à l’une des conditions activées.",
+          "noneEnabled": "Aucune condition activée",
+          "neverFetched": {
+            "label": "Jamais récupéré",
+            "hint": "Récupérez des livres qui n'ont jamais fait l'objet d'une tentative de récupération de métadonnées.",
+            "summary": "Jamais récupéré"
+          },
+          "scoreThreshold": {
+            "label": "Faible score de métadonnées",
+            "hint": "Récupère si le score des métadonnées est inférieur à un seuil.",
+            "scoreBelow": "Score ci-dessous",
+            "summary": "Score < {threshold}"
+          },
+          "missingFields": {
+            "label": "Champs manquants",
+            "hint": "Récupère si l'un des champs sélectionnés est vide.",
+            "summary": "{count, plural, one {Manquant # champ} other {Manquant # champs} many {Manquant # champs}}"
+          }
+        },
+        "library": {
+          "inheritingGlobal": "Héritage des valeurs par défaut globales",
+          "inheritFromGlobal": "Hériter du global",
+          "usingGlobalDefaults": "Utilisation des valeurs par défaut globales.",
+          "saveOverride": "Enregistrer le remplacement"
+        }
+      },
+      "providers": {
+        "availableSources": "Sources disponibles",
+        "saveChanges": "Enregistrer les modifications",
+        "test": "Tester",
+        "testing": "Test...",
+        "enabled": "Activé",
+        "retryIn": "Réessayez dans {duration}",
+        "runTestBeforeEnabling": "Exécutez le test avant d'activer",
+        "hardcoverEnableHint": "Exécutez le test avec le jeton actuel pour déverrouiller le commutateur d'activation.",
+        "badge": {
+          "setupRequired": "Configuration requise",
+          "throttled": "Étranglé",
+          "ready": "Prêt"
+        },
+        "fields": {
+          "apiKey": "Clé API",
+          "region": "Région",
+          "cookie": "Biscuit",
+          "coverResolution": "Résolution de la couverture",
+          "country": "Pays",
+          "language": "Langue",
+          "ttbKey": "Clé TTB"
+        },
+        "helpers": {
+          "googleApiKey": "Clé Google Books API de Google Cloud."
+        },
+        "hints": {
+          "google": "Large couverture de l'index des livres de Google. Google Books nécessite désormais une clé API avant que ce fournisseur puisse être activé.",
+          "amazon": "Le cookie de session est recommandé. Collez uniquement la valeur du cookie (pas de « Cookie : »).",
+          "goodreads": "La plus grande communauté de lecture sur le Web. Aucune configuration requise.",
+          "hardcover": "Une alternative moderne à Goodreads. Jeton de hardcover.app/account/api. Le préfixe \"Bearer\" est facultatif.",
+          "openLibrary": "Le catalogue de livres gratuit d'Internet Archive. Aucune configuration requise.",
+          "itunes": "Le catalogue de livres numériques d'Apple. Choisissez si vous souhaitez récupérer des couvertures haute résolution ou standard.",
+          "kobo": "Gratte les pages du livre public de Kobo. Le pays et la langue doivent correspondre aux chemins Kobo URL ; la protection contre les robots peut bloquer les demandes.",
+          "audible": "Extrait les métadonnées du livre audio de Audible. Aucune configuration supplémentaire n’est requise.",
+          "audnexus": "Métadonnées de livres audio gérées par la communauté. Aucune configuration requise.",
+          "comicvine": "Métadonnées de bande dessinée de ComicVine. Une clé API gratuite est requise sur comicvine.gamespot.com.",
+          "ranobedb": "Métadonnées du light novel japonais de RanobeDB. Aucune configuration requise.",
+          "lubimyczytac": "Catalogue de livres polonais (lubimyczytac.pl). Gratte les pages des livres publics. Aucune configuration requise.",
+          "aladin": "Métadonnées du livre coréen d'Aladin (알라딘). Une clé TTB d'aladin.co.kr est requise."
+        },
+        "blocked": {
+          "google": "Google Books nécessite une clé API avant de pouvoir être activé",
+          "hardcover": "Hardcover nécessite une clé API avant de pouvoir être activé",
+          "hardcoverTest": "Le jeton Hardcover doit réussir le test avant de pouvoir être activé",
+          "comicvine": "ComicVine nécessite une clé API avant de pouvoir être activé",
+          "aladin": "Aladin nécessite une clé TTB avant de pouvoir être activé"
+        }
+      },
+      "fieldRules": {
+        "clearAllProviders": "Effacer tous les fournisseurs",
+        "clearAll": "Tout effacer",
+        "resetToDefault": "Réinitialiser aux valeurs par défaut",
+        "reset": "Réinitialiser",
+        "dragProvidersHint": "Faites glisser les fournisseurs d'ici vers n'importe quel champ pour les ajouter",
+        "dragProviderHere": "faites glisser un fournisseur ici",
+        "howItWorks": {
+          "title": "Comment fonctionnent les règles de champ",
+          "priorityOrder": {
+            "title": "Ordre prioritaire",
+            "body": "Faites glisser les fournisseurs dans la liste pour les réorganiser. Le principal fournisseur qui renvoie un résultat sera la source principale de ce champ."
+          },
+          "mergeStrategy": {
+            "title": "Stratégie de fusion",
+            "fillMissingTerm": "Remplissez manquant :",
+            "fillMissingBody": "N'écrivez que si la valeur actuelle est vide.",
+            "overwriteTerm": "Écraser :",
+            "overwriteBody": "Remplacez chaque fois qu'un fournisseur dispose de données."
+          }
+        },
+        "libraryOverrides": {
+          "title": "Remplacements de bibliothèque",
+          "hint": "Développez une bibliothèque pour personnaliser des champs individuels. Les champs non remplacés héritent des valeurs par défaut globales."
+        },
+        "global": {
+          "title": "Valeurs par défaut globales",
+          "hint": "Règles par défaut appliquées à chaque bibliothèque. Remplacez par bibliothèque ci-dessous.",
+          "saveDefaults": "Enregistrer les paramètres par défaut",
+          "clearAllConfirm": "Supprimer tous les fournisseurs actifs de chaque domaine ? Ceci sera enregistré immédiatement et ne pourra pas être annulé.",
+          "resetConfirm": "Réinitialiser toutes les règles de champ globales aux valeurs par défaut du système ? Cela écrasera votre configuration actuelle."
+        },
+        "advanced": {
+          "title": "Comportement de récupération avancé",
+          "combineGenres": {
+            "label": "Combinez les genres de tous les fournisseurs sélectionnés",
+            "hint": "Collectez et dédupliquez les genres de chaque fournisseur attribué au champ Genres, plutôt que de vous arrêter au premier résultat."
+          },
+          "storeProviderIds": {
+            "label": "Stocker les identifiants des fournisseurs sur les livres",
+            "hint": "Lors de la récupération des métadonnées, enregistrez les identifiants de fournisseur renvoyés (ISBN, ASIN, Goodreads ID, etc.) dans l'enregistrement du livre pour des recherches futures plus précises."
+          }
+        },
+        "library": {
+          "primary": "Principal :",
+          "overrideCount": "{count, plural, one {# Remplacer} other {# Remplacements} many {# Remplacements}}",
+          "unsavedSuffix": "(non enregistré)",
+          "unsavedChanges": "Modifications non enregistrées",
+          "globalDefaults": "Valeurs par défaut globales",
+          "overriding": "Remplacement : {fields}",
+          "inheritingAll": "Héritage de toutes les règles globales de métadonnées",
+          "subHint": "Les champs non remplacés héritent des valeurs par défaut globales.",
+          "resetTooltip": "Supprimez tous les remplacements et héritez des valeurs par défaut globales",
+          "clearAllConfirm": "Supprimer tous les fournisseurs actifs de chaque champ dans « {library} » ?",
+          "resetConfirm": "Réinitialiser \"{library}\" aux valeurs par défaut globales ? Tous les remplacements de bibliothèque seront supprimés."
+        },
+        "groups": {
+          "core": "Noyau",
+          "contributors": "Contributeurs",
+          "publication": "Publication",
+          "series": "Série",
+          "classification": "Classement",
+          "audiobook": "Livre audio"
+        },
+        "groupSummary": {
+          "base": "Champs {fields} · {enabled} activé",
+          "withOverrides": "{base} · {overrides} remplace"
+        },
+        "table": {
+          "field": "Champ",
+          "activeProviders": "Fournisseurs actifs (classés par priorité)",
+          "mergeStrategy": "Stratégie de fusion",
+          "status": "Statut"
+        },
+        "field": {
+          "noProviders": "Activé mais n'a aucun fournisseur",
+          "empty": "Vide",
+          "config": "Configuration",
+          "custom": "Personnalisé",
+          "default": "Par défaut",
+          "resetToDefault": "Réinitialiser aux valeurs par défaut"
+        },
+        "reservoir": {
+          "disabled": "{provider} - désactivé",
+          "notConfigured": "{provider} - non configuré",
+          "dragToAssign": "Faites glisser pour attribuer {provider} à un champ"
+        },
+        "sheet": {
+          "subtitle": "Appuyez sur les fournisseurs à attribuer, utilisez les flèches pour réorganiser",
+          "enableField": "Activer ce champ lors de l'actualisation",
+          "providers": "Fournisseurs",
+          "statusDisabled": "désactivé",
+          "statusNotConfigured": "non configuré",
+          "done": "Terminé"
+        }
+      },
+      "genreBlocklist": {
+        "heading": "Exclusions de genres mondiaux",
+        "hint": "Les valeurs exactes de genre dans cette liste sont supprimées des résultats du fournisseur avant l'écriture des métadonnées.",
+        "saving": "Économiser",
+        "genreValueLabel": "Valeur du genre",
+        "addPlaceholder": "Ajoutez une valeur de genre, par exemple Livre audio",
+        "duplicate": "Ce genre est déjà bloqué.",
+        "add": "Ajouter",
+        "filterPlaceholder": "Filtrer la liste de blocage",
+        "entryCount": "{count, plural, one {# entrée} other {# entrées} many {# entrées}}",
+        "filteredCount": "{shown} sur {total}",
+        "noFilterMatch": "Aucun genre bloqué ne correspond au filtre actuel.",
+        "emptyTitle": "Aucun genre bloqué",
+        "emptyHint": "Ajoutez des valeurs exactes telles que Livre audio ou Adulte pour les empêcher d'apparaître dans les métadonnées récupérées.",
+        "removeLabel": "Supprimer {genre}"
+      },
+      "customFields": {
+        "label": "Étiquette",
+        "labelPlaceholder": "par ex. Titre original",
+        "labelTooLong": "L'étiquette doit comporter 255 caractères maximum",
+        "labelDuplicate": "Un champ avec ce libellé existe déjà",
+        "type": "Tapez",
+        "usage": "{count, plural, one {Utilisé par # livre} other {Utilisé par # livres} many {Utilisé par # livres}}",
+        "newField": {
+          "title": "Nouveau champ",
+          "hint": "Définissez un champ de métadonnées personnalisé et choisissez les bibliothèques qui l'utilisent."
+        },
+        "previewToggle": "Aperçu de l'apparence de ce champ lors de la modification d'un livre",
+        "untitledField": "Champ sans titre",
+        "addField": "Ajouter un champ",
+        "fields": "Champs",
+        "fieldsHint": "Faites glisser pour réorganiser, modifier les étiquettes, basculer entre les bibliothèques ou archiver les champs dont vous n'avez plus besoin.",
+        "searchPlaceholder": "Champs de recherche",
+        "searchAriaLabel": "Rechercher des champs personnalisés",
+        "emptyTitle": "Pas encore de champs personnalisés",
+        "emptyHint": "Utilisez le formulaire ci-dessus pour définir votre premier champ de métadonnées personnalisé.",
+        "noMatchTitle": "Aucun champ ne correspond à \"{query}\"",
+        "noMatchHint": "Essayez une autre étiquette, clé ou type.",
+        "clearSearchToReorder": "Effacer la recherche pour réorganiser",
+        "dragToReorder": "Faites glisser pour réorganiser",
+        "dragToReorderField": "Faites glisser pour réorganiser le champ",
+        "unsaved": "Non enregistré",
+        "archive": "Archiver",
+        "archivedFields": "Champs archivés",
+        "archivedSummary": "{count, plural, one {# champ archivé - restaurer ou supprimer définitivement.} other {# champs archivés - restaurer ou supprimer définitivement.} many {# champs archivés - restaurer ou supprimer définitivement.}}",
+        "archivedAt": "Archivé {when}",
+        "restore": "Restaurer",
+        "deleteForever": "Supprimer pour toujours",
+        "deleteDialog": {
+          "title": "Supprimer définitivement le champ",
+          "bodyBefore": "Cela supprimera définitivement",
+          "bodyMiddle": "et supprimez ses valeurs stockées de",
+          "bodyAfter": ". Cela ne peut pas être annulé.",
+          "confirmBefore": "Tapez",
+          "confirmAfter": "pour confirmer",
+          "confirmPlaceholder": "Tapez le libellé du champ pour confirmer"
+        },
+        "preview": "Aperçu",
+        "sampleValue": "Exemple de valeur",
+        "enabledLibraries": "Bibliothèques activées",
+        "countOf": "{selected} sur {total}",
+        "selectAll": "Tout sélectionner",
+        "clear": "Effacer",
+        "noLibraries": "Aucune bibliothèque disponible pour l'instant.",
+        "allLibraries": "Toutes les bibliothèques"
+      },
+      "tabs": {
+        "providers": "Fournisseurs",
+        "field-rules": "Règles de terrain",
+        "custom-fields": "Champs personnalisés",
+        "genre-blocklist": "Liste de blocage des genres",
+        "score": "Score",
+        "auto-fetch": "Livres",
+        "authors": "Auteurs"
+      },
+      "tabTitles": {
+        "providers": "Fournisseurs",
+        "field-rules": "Règles au niveau du champ",
+        "custom-fields": "Métadonnées personnalisées",
+        "genre-blocklist": "Liste de blocage des genres",
+        "score": "Score de confiance",
+        "auto-fetch": "Récupération automatique du livre",
+        "authors": "Récupération automatique de l'auteur"
+      },
+      "tabSubtitles": {
+        "providers": "Activez les sources de métadonnées externes et configurez leurs informations d'identification.",
+        "field-rules": "Contrôlez quel fournisseur fournit chaque champ de métadonnées et comment les valeurs sont fusionnées dans vos bibliothèques.",
+        "custom-fields": "Définissez des champs de métadonnées personnalisés et choisissez les bibliothèques qui les utilisent.",
+        "genre-blocklist": "Empêchez que les valeurs de genre indésirables du fournisseur soient écrites dans les livres.",
+        "score": "Attribuez des pondérations aux champs de métadonnées pour calculer le degré de confiance dans les résultats récupérés.",
+        "auto-fetch": "Récupérez automatiquement des couvertures, des descriptions et d'autres détails lorsque de nouveaux livres sont ajoutés à votre bibliothèque.",
+        "authors": "Récupérez automatiquement des biographies et des photos de profil lorsque de nouveaux auteurs apparaissent dans votre bibliothèque."
+      }
+    },
+    "reader": {
+      "resetToDefaults": "Réinitialiser aux valeurs par défaut",
+      "all": {
+        "title": "Lecteur",
+        "subtitle": "Configurez les valeurs par défaut pour tous les modes de lecture en un seul endroit."
+      },
+      "general": {
+        "title": "Lecture",
+        "subtitle": "Comportement général qui s’applique à tous les types de lecteurs.",
+        "storageLabel": "Où enregistrer les préférences du lecteur",
+        "deviceOnly": "Cet appareil uniquement",
+        "deviceOnlyHint": "Les préférences restent dans votre navigateur. Idéal si vous lisez toujours sur cet appareil ou si vous souhaitez des paramètres différents par appareil.",
+        "myAccount": "Mon compte",
+        "myAccountHint": "Les préférences sont enregistrées sur votre compte. Idéal si vous vous connectez à partir de plusieurs appareils et souhaitez une expérience cohérente partout.",
+        "active": "Actif",
+        "notAvailable": "Non disponible",
+        "demoCannotChangeStorage": "Le compte restreint à la démo ne peut pas modifier le mode de stockage du lecteur",
+        "preferencesSynced": "Les préférences seront désormais synchronisées",
+        "preferencesLocal": "Les préférences resteront sur cet appareil",
+        "storageUpdateFailed": "Échec de la mise à jour du mode de stockage",
+        "storageUpdateError": "Une erreur s'est produite lors de la mise à jour du mode de stockage"
+      },
+      "ebook": {
+        "title": "Lecteur de livres électroniques",
+        "subtitle": "Paramètres par défaut appliqués lors de l'ouverture des fichiers EPUB, MOBI, FB2 et TXT.",
+        "newBooks": "Nouveaux livres",
+        "applySettings": "Appliquer mes paramètres aux nouveaux livres",
+        "applySettingsHint": "Lorsqu'elle est désactivée, les nouveaux livres s'ouvrent avec les polices et la mise en page propres à l'éditeur. Vos paramètres ne s'appliquent qu'une fois que vous modifiez quelque chose dans le lecteur.",
+        "layout": "Disposition",
+        "readingFlow": "Flux de lecture",
+        "readingFlowHint": "Pages flip paginées ; flux défilés en continu",
+        "paginated": "Paginé",
+        "scrolled": "Défilé",
+        "fixedLayoutSpread": "Pages doubles à mise en page fixe",
+        "fixedLayoutSpreadHint": "Valeur par défaut pour les mangas, les bandes dessinées et les EPUB basés sur des images",
+        "bookDefault": "Livre par défaut",
+        "singlePage": "Page unique",
+        "columns": "Colonnes",
+        "columnsHint": "Nombre de colonnes de texte par page",
+        "theme": "Thème",
+        "darkMode": "Mode sombre",
+        "darkModeHint": "Utiliser la variante sombre du thème sélectionné",
+        "typography": "Typographie",
+        "font": "Police",
+        "fontHint": "Police utilisée pour le corps du texte",
+        "builtInFonts": "Polices intégrées",
+        "yourFonts": "Vos polices",
+        "fontSize": "Taille de la police",
+        "fontSizeHint": "Taille du texte de base en pixels",
+        "lineHeight": "Hauteur de ligne",
+        "lineHeightHint": "Espacement vertical entre les lignes",
+        "justify": "Justifier le texte",
+        "justifyHint": "Aligner le texte sur les deux marges",
+        "hyphenation": "Césure",
+        "hyphenationHint": "Coupez automatiquement les mots longs avec des traits d'union",
+        "advanced": "Avancé",
+        "maxContentWidth": "Largeur maximale du contenu",
+        "maxContentWidthHint": "Largeur maximale de la zone de texte en pixels",
+        "columnGap": "Écart de colonne",
+        "columnGapHint": "Remplissage horizontal de chaque côté de la zone de texte"
+      },
+      "pdf": {
+        "title": "PDF Lecteur",
+        "subtitle": "Paramètres par défaut appliqués lors de l'ouverture des fichiers PDF.",
+        "layout": "Disposition",
+        "scrollMode": "Mode défilement",
+        "scrollModeHint": "Les pages se retournent une à la fois ; défile en continu à travers toutes les pages",
+        "page": "Pages",
+        "scrolled": "Défilé",
+        "pageSpread": "Page étendue",
+        "pageSpreadHint": "Quel numéro de page commence à droite en affichage sur deux pages",
+        "spreadNone": "Aucun",
+        "spreadOdd": "Bizarre",
+        "spreadEven": "Paires",
+        "zoom": "Zoomer",
+        "defaultFit": "Ajustement par défaut",
+        "defaultFitHint": "Comment les pages sont mises à l'échelle lorsqu'un PDF est ouvert",
+        "fitPage": "Ajuster la page",
+        "fitWidth": "Ajuster la largeur",
+        "custom": "Personnalisé",
+        "zoomLevel": "Niveau de zoom",
+        "zoomLevelHint": "Facteur d'échelle pour le mode de zoom personnalisé"
+      },
+      "comics": {
+        "title": "Lecteur de bandes dessinées",
+        "subtitle": "Paramètres par défaut appliqués lors de l'ouverture des fichiers CBZ, CBR et CB7.",
+        "view": "Voir",
+        "readingMode": "Mode lecture",
+        "readingModeHint": "Comment les pages sont parcourues - utilisez \"Infini (pas d'espaces)\" pour les webtoons",
+        "paginated": "Paginé",
+        "infiniteSpaced": "Infini (espacé)",
+        "infiniteNoGaps": "Infini (pas de lacunes)",
+        "pageView": "Affichage des pages",
+        "pageViewHint": "Afficher une ou deux pages côte à côte",
+        "single": "Célibataire",
+        "twoPage": "Deux pages",
+        "fitMode": "Mode d'ajustement",
+        "fitModeHint": "Comment les pages sont mises à l'échelle pour s'adapter à l'écran",
+        "fitPage": "Pages",
+        "fitWidth": "Largeur",
+        "fitHeight": "Hauteur",
+        "fitActual": "Réel",
+        "readingDirection": "Sens de lecture",
+        "readingDirectionHint": "De gauche à droite pour les bandes dessinées occidentales ; de droite à gauche pour les mangas",
+        "ltr": "De gauche à droite",
+        "rtl": "R à L",
+        "spreadAlignment": "Alignement de la propagation",
+        "spreadAlignmentHint": "Décaler l'appariement d'une page après la couverture pour les numérisations une par une",
+        "alignmentNormal": "Normale",
+        "alignmentShifted": "Décalé",
+        "spreadGap": "Écart de propagation",
+        "spreadGapHint": "Espace entre les pages en affichage sur deux pages",
+        "spreadGapValue": "{value}px",
+        "widePageHandling": "Gestion des pages larges",
+        "widePageHandlingHint": "Affiche automatiquement les numérisations larges uniquement en mode paginé sur deux pages",
+        "widePageAuto": "Automatique",
+        "widePageDisable": "Désactiver",
+        "forceTwoPage": "Forcer deux pages sur les petits écrans",
+        "forceTwoPageHint": "Contourner le repli automatique mobile lorsque le mode paginé sur deux pages est sélectionné",
+        "off": "Désactivé",
+        "on": "Sur",
+        "display": "Affichage",
+        "backgroundColor": "Couleur de fond",
+        "backgroundColorHint": "Couleur de la toile derrière les pages",
+        "bgBlack": "Noir",
+        "bgGray": "Gris",
+        "bgWhite": "Blanc"
+      },
+      "audio": {
+        "title": "Lecteur de livres audio",
+        "subtitle": "Paramètres par défaut appliqués lors de la lecture de M4B, MP3 et d'autres formats audio.",
+        "playback": "Lecture",
+        "playbackSpeed": "Vitesse de lecture par défaut",
+        "playbackSpeedHint": "Multiplicateur de vitesse appliqué lors de l'ouverture d'un nouveau livre audio",
+        "volume": "Volume par défaut",
+        "volumeHint": "Niveau de volume initial (0 à 100%)",
+        "skipControls": "Ignorer les contrôles",
+        "skipBack": "Revenir en arrière sur la durée",
+        "skipBackHint": "Secondes rembobinées lors d'une pression en arrière",
+        "skipForward": "Avancer la durée",
+        "skipForwardHint": "Secondes avancées en appuyant sur le saut en avant"
+      },
+      "fonts": {
+        "title": "Polices",
+        "subtitle": "Téléchargez des polices personnalisées à utiliser dans le lecteur de livres électroniques.",
+        "uploadFonts": "Télécharger des polices",
+        "notAvailableDemo": "Non disponible pour les comptes démo",
+        "uploading": "Téléchargement...",
+        "dropFilesHere": "Déposez les fichiers ici",
+        "dragFontsPrefix": "Faites glisser les fichiers de polices ici, ou",
+        "browse": "parcourir",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - maximum 10 Mo chacun",
+        "yourFonts": "Vos polices",
+        "fontsUsed": "{count} / {max} utilisé",
+        "noFontsYet": "Aucune police téléchargée pour le moment",
+        "noFontsHint": "Faites glisser un fichier de police ci-dessus pour commencer.",
+        "fileCount": "{count, plural, =0 {pas de fichiers} one {# fichier} other {# fichiers} many {# fichiers}}",
+        "pangram": "Le renard brun rapide saute par-dessus le chien paresseux",
+        "renameFamily": "Renommer la famille",
+        "deleteFamily": "Supprimer la famille",
+        "editVariant": "Modifier le poids/le style",
+        "deleteVariant": "Supprimer la variante",
+        "styleNormal": "Normale",
+        "styleItalic": "Italique",
+        "weightThin": "Mince",
+        "weightExtraLight": "Lumière supplémentaire",
+        "weightLight": "Lumière",
+        "weightRegular": "Régulier",
+        "weightMedium": "Moyen",
+        "weightSemiBold": "Semi-gras",
+        "weightBold": "Audacieux",
+        "weightExtraBold": "Extra audacieux",
+        "weightBlack": "Noir",
+        "renameFamilyFailed": "Échec du renommage de la famille de polices",
+        "renamedTo": "Renommé en \"{name}\"",
+        "updateVariantFailed": "Échec de la mise à jour de la variante de police",
+        "deleteFontFailed": "Échec de la suppression de la police",
+        "deleteFamilyFailed": "Échec de la suppression de la famille de polices",
+        "demoCannotManage": "Le compte restreint à la démo ne peut pas gérer les polices",
+        "fileAdded": "\"{name}\" ajouté",
+        "uploadFailed": "Échec du téléchargement"
+      },
+      "bookDock": {
+        "title": "Book Dock",
+        "subtitle": "Configurez la manière dont les fichiers sont traités lorsqu'ils entrent dans Book Dock.",
+        "dropFolder": "Déposer le dossier",
+        "containerPath": "Chemin du conteneur",
+        "containerPathHint": "Copiez ou déplacez les fichiers du livre dans ce dossier et ils seront automatiquement récupérés et traités par Book Dock. Les sous-répertoires sont pris en charge.",
+        "changePathPrefix": "Pour modifier ce chemin, définissez",
+        "changePathMiddle": "dans votre",
+        "changePathSuffix": "fichier.",
+        "metadata": "Métadonnées",
+        "autoFetch": "Récupérer automatiquement les métadonnées des fournisseurs",
+        "autoFetchHint": "Récupérez automatiquement les métadonnées des fournisseurs configurés (Google Books, iTunes, Open Library, etc.) après l'ajout d'un fichier à Book Dock.",
+        "autoFinalize": "Finalisation automatique",
+        "enableAutoFinalize": "Activer la finalisation automatique",
+        "enableAutoFinalizeHint": "Les fichiers dont le score de confiance des métadonnées est égal ou supérieur au seuil seront finalisés automatiquement.",
+        "confidenceThreshold": "Seuil de confiance : {value} %",
+        "thresholdIgnored": "(ignoré en mode intégré uniquement)",
+        "destinationLibrary": "Bibliothèque de destinations",
+        "selectLibrary": "Sélectionnez une bibliothèque...",
+        "metadataMode": "Mode métadonnées",
+        "metadataModeSafeMerge": "Fusion sécurisée (recommandé)",
+        "metadataModeFetchedOnly": "Récupéré uniquement",
+        "metadataModeEmbeddedOnly": "Intégré uniquement",
+        "destinationFolder": "Dossier de destination",
+        "selectFolder": "Sélectionnez un dossier...",
+        "saveSettingFailed": "Échec de l'enregistrement du paramètre",
+        "updateSettingFailed": "Échec de la mise à jour du paramètre",
+        "autoFetchEnabled": "Récupération automatique activée",
+        "autoFetchDisabled": "Récupération automatique désactivée",
+        "autoFinalizeEnabled": "Finalisation automatique activée",
+        "autoFinalizeDisabled": "Finalisation automatique désactivée",
+        "destinationLibraryUpdated": "Bibliothèque de destinations mise à jour",
+        "destinationFolderUpdated": "Dossier de destination mis à jour",
+        "confidenceThresholdUpdated": "Seuil de confiance mis à jour",
+        "metadataModeUpdated": "Mode métadonnées mis à jour"
+      },
+      "fileNaming": {
+        "title": "Nom du fichier",
+        "subtitle": "Contrôlez la manière dont les fichiers sont organisés sur le disque lorsqu'ils sont téléchargés et comment ils sont nommés lors du téléchargement à l'aide de jetons d'espace réservé.",
+        "copy": "Copier",
+        "previewLabel": "Aperçu :",
+        "fileAsBookPreview": "Fichier en tant qu'aperçu du livre",
+        "folderAsBookPreview": "Dossier en tant qu'aperçu du livre",
+        "downloadPreview": "Télécharger l'aperçu",
+        "globalDefaults": "Valeurs par défaut globales",
+        "crossPlatform": "Désinfection des chemins multiplateformes",
+        "crossPlatformHint": "Sécurisez les noms de fichiers et de dossiers générés sous Windows en remplaçant les caractères non valides et les noms réservés, et en supprimant les points et les espaces de fin. Désactivez uniquement pour les configurations Linux uniquement qui conservent intentionnellement ces caractères.",
+        "fileAsBookDefault": "Fichier comme livre par défaut",
+        "fileAsBookDefaultHint": "Téléchargez un modèle pour les bibliothèques en utilisant le mode Fichier comme livre. Chaque fichier est un livre.",
+        "folderAsBookDefault": "Dossier par défaut du livre",
+        "folderAsBookDefaultHint": "Téléchargez un modèle pour les bibliothèques en utilisant le mode Dossier comme livre. Chaque livre doit être dans son propre dossier.",
+        "downloadPattern": "Télécharger le modèle",
+        "downloadPatternHint": "Noms de fichiers suggérés pour les téléchargements de fichiers uniques et les fichiers dans les ZIP d'exportation.",
+        "libraryOverrides": "Remplacements de bibliothèque",
+        "noLibraries": "Aucune bibliothèque configurée. Créez-en un dans les paramètres de la bibliothèque pour définir des modèles de dénomination personnalisés.",
+        "badgeCustom": "Personnalisé",
+        "badgeDefault": "Par défaut",
+        "orgFolderAsBook": "Dossier en tant que livre",
+        "orgFileAsBook": "Classer en tant que livre",
+        "resetToDefault": "Réinitialiser aux valeurs par défaut",
+        "patternReference": "Référence du modèle",
+        "placeholderReference": "Référence d'espace réservé",
+        "placeholderReferenceHint": "- guide pour créer des modèles de dénomination personnalisés",
+        "tokens": "Jetons",
+        "tokensHint": "Copiez rapidement les espaces réservés",
+        "clickTokenHint": "Cliquez sur n'importe quel jeton pour le copier dans votre presse-papiers.",
+        "copyValue": "Copier {value}",
+        "modifiers": "Modificateurs",
+        "modifiersHint": "Transformer les valeurs des jetons",
+        "modifiersExplain": "Ajoutez un modificateur à l'intérieur d'un jeton pour transformer sa valeur :",
+        "modFirst": "Première valeur uniquement",
+        "modSort": "Format Dernier, Premier",
+        "modInitial": "Première lettre seulement",
+        "modFixed2": "Deux décimales",
+        "folderOnlyPrefix": "Terminez un motif avec",
+        "folderOnlySuffix": "pour spécifier un dossier uniquement. Le nom du fichier original sera conservé à l'intérieur.",
+        "conditionalLogic": "Logique conditionnelle",
+        "conditionalLogicHint": "Segments facultatifs et solutions de secours",
+        "conditionalPart1": "Enveloppez-vous",
+        "conditionalPart2": "pour sauter un segment lorsque son jeton est vide. Utiliser",
+        "conditionalPart3": "pour une valeur par défaut.",
+        "examples": "Exemples",
+        "patternExamples": "Exemples de modèles",
+        "patternExamplesHint": "Modèles prêts à l'emploi pour les styles de bibliothèque courants",
+        "copyPatternTooltip": "Copier le motif dans le presse-papiers",
+        "exCalibre": "Style Calibre par défaut",
+        "exSeriesReader": "Lecteur de série",
+        "exCleanDownload": "Nettoyer le nom du fichier de téléchargement",
+        "exAlphabetical": "Regroupement alphabétique avec séries",
+        "exSeriesFallback": "Série ou solution de secours autonome",
+        "exOptionalSubtitle": "Télécharger avec sous-titre facultatif",
+        "exMultilingual": "Bibliothèque multilingue",
+        "exPublisher": "Organisé par l'éditeur",
+        "exStacked": "Dossiers facultatifs empilés",
+        "exFolderDrop": "Dossier déposé avec le nom du tri",
+        "caseWithYear": "avec année",
+        "caseNoYear": "pas d'année",
+        "caseInSeries": "en série",
+        "caseStandalone": "autonome",
+        "caseNoSeries": "pas de série",
+        "caseFull": "plein",
+        "caseMinimal": "minime",
+        "caseWithLanguage": "avec la langue",
+        "caseNoLanguage": "pas de langue",
+        "caseWithPublisher": "avec l'éditeur",
+        "caseNoPublisher": "pas d'éditeur",
+        "caseAllSet": "tout est prêt",
+        "copiedToClipboard": "{value} copié dans le presse-papiers",
+        "copyTokenFailed": "Échec de la copie du jeton",
+        "patternCopied": "Motif copié dans le presse-papiers",
+        "copyPatternFailed": "Échec de la copie du modèle",
+        "labelCopied": "{label} copié dans le presse-papiers",
+        "copyLabelFailed": "Échec de la copie de {label}"
+      },
+      "kobo": {
+        "title": "Kobo Synchronisation",
+        "subtitle": "Associez votre appareil Kobo pour synchroniser votre bibliothèque.",
+        "copy": "Copier",
+        "never": "Jamais",
+        "justNow": "Juste maintenant",
+        "minutesAgo": "il y a {count} m",
+        "hoursAgo": "il y a {count}h",
+        "daysAgo": "Il y a {count}j",
+        "loadFailed": "Échec du chargement",
+        "devicePaired": "Appareil couplé avec succès",
+        "devicePairedHint": "Vous êtes prêt à configurer votre Kobo. Suivez les instructions ci-dessous.",
+        "syncUrl": "Synchroniser URL",
+        "urlNotShownAgain": "Ce URL ne sera plus affiché. Gardez-le privé.",
+        "registeredDevices": "Appareils enregistrés",
+        "addDevice": "Ajouter un appareil",
+        "deviceName": "Nom de l'appareil",
+        "deviceNamePlaceholder": "par ex. Ma Kobo Balance",
+        "creating": "Création...",
+        "createDevice": "Créer un appareil",
+        "createDeviceFailed": "Échec de la création de l'appareil",
+        "deviceRegistered": "Appareil \"{name}\" enregistré",
+        "noDevicesYet": "Aucun appareil pour l'instant",
+        "noDevicesHint": "Ajoutez un appareil pour commencer à synchroniser vos livres avec votre Kobo.",
+        "lastSync": "Dernière synchronisation : {time}",
+        "renameDevice": "Renommer l'appareil",
+        "revokeAccess": "Révoquer l'accès",
+        "deviceRenamed": "Appareil renommé",
+        "renameDeviceFailed": "Échec du renommage de l'appareil",
+        "revokeConfirm": "Révoquer l'accès pour \"{name}\" ? L'appareil ne pourra pas se synchroniser tant qu'il n'aura pas été réappairé.",
+        "accessRevoked": "Accès révoqué pour \"{name}\"",
+        "revokeFailed": "Échec de la révocation de l'accès",
+        "syncUrlCopied": "Synchroniser URL copié dans le presse-papiers",
+        "syncUrlCopyFailed": "Échec de la copie de la synchronisation URL",
+        "syncPreferences": "Préférences de synchronisation",
+        "twoWaySync": "Synchronisation de progression bidirectionnelle",
+        "twoWaySyncHint": "Synchronisez la position de lecture entre BookOrbit et Kobo. Nécessite la livraison KEPUB pour des emplacements précis et une restauration de page fiable.",
+        "syncHighlights": "Synchronisez les faits saillants de BookOrbit avec Kobo",
+        "syncHighlightsHint": "Envoyez les faits saillants réalisés en BookOrbit ou KOReader à votre Kobo. Les surbrillances Kobo sont importées dans BookOrbit même lorsque cette option est désactivée. Les annotations liées synchronisent les modifications et les suppressions dans les deux sens. Nécessite la livraison KEPUB ; le livre sur Kobo doit être le KEPUB téléchargé depuis BookOrbit.",
+        "convertKepub": "Convertir en KEPUB",
+        "convertKepubHint": "Envoyez des EPUB éligibles en tant que KEPUB. Cela reste activé lorsque la synchronisation de la progression ou les surbrillance BookOrbit-to-Kobo sont activées. Lors de la prochaine synchronisation Kobo, les livres concernés sont à nouveau proposés en téléchargement KEPUB ; supprimez toute ancienne copie de EPUB si Kobo continue de l'ouvrir.",
+        "forceHyphenation": "Forcer la césure",
+        "forceHyphenationHint": "Garantit une justification cohérente du texte. Cela régénérera les KEPUB mis en cache.",
+        "progressThresholds": "Seuils de progression",
+        "progressThresholdsHint": "Définissez quand la progression de la lecture Kobo met à jour le statut de votre bibliothèque.",
+        "markAsReading": "Marquer comme lecture",
+        "markAsReadingHint": "Pourcentage minimum pour déplacer un livre vers « Lecture ».",
+        "markAsFinished": "Marquer comme terminé",
+        "markAsFinishedHint": "Seuil de pourcentage pour marquer un livre comme « Terminé ».",
+        "kepubLimit": "Limite de conversion KEPUB",
+        "kepubLimitHint": "Les livres dépassant cette limite sont envoyés sous forme d'EPUB standards, donc BookOrbit ne synchronisera pas sa position de lecteur avec Kobo.",
+        "changesMustBeSaved": "Les modifications doivent être enregistrées pour prendre effet.",
+        "saving": "Sauvegarde...",
+        "saveSyncSettings": "Enregistrer les paramètres de synchronisation",
+        "thresholdOrderError": "Le seuil de lecture doit être inférieur au seuil de fin",
+        "saveSettingsFailed": "Échec de l'enregistrement des paramètres",
+        "settingsSaved": "Kobo paramètres de synchronisation enregistrés",
+        "saveFailed": "Échec de l'enregistrement",
+        "activity": {
+          "waitingForActivity": "En attente d'activité",
+          "needsAttention": "A besoin d'attention",
+          "syncHealthy": "Synchronisation saine",
+          "never": "Jamais",
+          "none": "Aucun",
+          "unknown": "Inconnu",
+          "failureCount": "{count, plural, one {# échec} other {# échecs} many {# échecs}}",
+          "noActivityRecorded": "Aucune activité de synchronisation Kobo n'a été enregistrée.",
+          "lastSuccess": "Dernier succès {time}",
+          "lastFailure": "Dernier échec {time}",
+          "noFailedActivity": "Aucune activité Kobo ayant échoué dans l'historique récent.",
+          "noActivityYet": "Aucune activité Kobo pour l'instant.",
+          "event": {
+            "librarySync": "Bibliothèque vérifiée pour les mises à jour",
+            "bookDownload": "Livre téléchargé",
+            "progressUpdate": "Position de lecture mise à jour",
+            "annotationsPull": "Points forts envoyés à Kobo",
+            "annotationsPush": "Faits saillants reçus de Kobo"
+          },
+          "outcome": {
+            "failed": "Échec",
+            "noUpdates": "Aucune mise à jour",
+            "noChanges": "Aucun changement",
+            "pending": "En attente",
+            "completed": "Terminé",
+            "downloaded": "Téléchargé",
+            "updated": "Mis à jour",
+            "sent": "Envoyé",
+            "imported": "Importé"
+          },
+          "failure": {
+            "librarySync": "La vérification de la bibliothèque n'a pas été terminée",
+            "bookDownload": "Le téléchargement n'a pas été terminé",
+            "progressUpdate": "La position de lecture n'a pas été mise à jour",
+            "annotationsPull": "Les faits saillants n'ont pas été envoyés",
+            "annotationsPush": "Les faits saillants n'ont pas été importés"
+          },
+          "chip": {
+            "morePending": "Plus en attente",
+            "noUpdatesPending": "Aucune mise à jour en attente",
+            "bookCount": "{count, plural, one {# livre} other {# livres} many {# livres}}",
+            "deletedAnnotations": "{count} annotations supprimées",
+            "deviceAlreadyCurrent": "Appareil déjà actuel",
+            "freshHighlightData": "Données récentes sur les faits saillants",
+            "created": "{count} créé",
+            "updated": "{count} mis à jour",
+            "deleted": "{count} supprimé",
+            "unchanged": "{count} inchangé"
+          },
+          "readingPositionSyncedTitle": "Position de lecture synchronisée : {title}",
+          "readingPositionSynced": "Position de lecture synchronisée",
+          "labelWithTitle": "{label} : {title}",
+          "updateCount": "{count, plural, one {# mettre à jour} other {# mises à jour} many {# mises à jour}}",
+          "directionToKobo": "BookOrbit -> Kobo",
+          "directionToBookOrbit": "Kobo -> BookOrbit",
+          "twoWaySyncEnabled": "Synchronisation bidirectionnelle activée",
+          "deviceProgressSaved": "Progression de l'appareil enregistrée",
+          "summary": {
+            "noLibraryUpdatesPending": "Aucune mise à jour de bibliothèque n'est en attente pour cet appareil",
+            "libraryUpdatesPrepared": "{count, plural, one {# mise à jour de la bibliothèque préparée pour l'appareil} other {# mises à jour de bibliothèque préparées pour l'appareil} many {# mises à jour de bibliothèque préparées pour l'appareil}}",
+            "bookDownloadedBy": "{title} a été téléchargé par {device}",
+            "booksDownloaded": "{count, plural, one {# livre téléchargé} other {# livres téléchargés} many {# livres téléchargés}}",
+            "progressUpdatesSyncedFor": "{count, plural, one {# mise à jour de progression synchronisée pour {title}} other {# mises à jour de progression synchronisées pour {title}} many {# mises à jour de progression synchronisées pour {title}}}",
+            "progressUpdatesSynced": "{count, plural, one {# mise à jour de progression synchronisée} other {# mises à jour de progression synchronisées} many {# mises à jour de progression synchronisées}}",
+            "newReadingPositionFor": "Kobo a signalé une nouvelle position de lecture pour {title}",
+            "newReadingPosition": "Kobo a signalé une nouvelle position de lecture",
+            "noHighlightChangesNeededFor": "Aucune modification de surbrillance n'est nécessaire pour {title}",
+            "noHighlightChangesNeeded": "Aucun changement de surbrillance n'est nécessaire",
+            "highlightsSentToKoboFor": "{count, plural, one {# surbrillance envoyé à Kobo pour {title}} other {# faits saillants envoyés à Kobo pour {title}} many {# faits saillants envoyés à Kobo pour {title}}}",
+            "highlightsSentToKobo": "{count, plural, one {# surbrillance envoyée à Kobo} other {# faits saillants envoyés à Kobo} many {# faits saillants envoyés à Kobo}}",
+            "noKoboHighlightChangesFor": "Aucun changement de mise en évidence de Kobo pour {title}",
+            "noKoboHighlightChanges": "Aucun changement de mise en évidence de Kobo",
+            "highlightsImportedFromKoboFor": "{count, plural, one {# surbrillance importée de Kobo pour {title}} other {# faits saillants importés de Kobo pour {title}} many {# faits saillants importés de Kobo pour {title}}}",
+            "highlightsImportedFromKobo": "{count, plural, one {# surbrillance importée de Kobo} other {# faits saillants importés de Kobo} many {# faits saillants importés de Kobo}}"
+          },
+          "timeRange": "{from} à {to}",
+          "eventsGrouped": "{count, plural, one {# événement groupé} other {# événements regroupés} many {# événements regroupés}}",
+          "removedDevice": "Appareil supprimé",
+          "loadMoreFailed": "Échec du chargement de plus d'historique",
+          "historyRefreshed": "Kobo historique de synchronisation actualisé",
+          "refreshFailed": "Échec de l'actualisation de l'historique",
+          "recentActivity": "Activité récente de Kobo",
+          "filterAll": "Tout",
+          "filterFailures": "Échecs",
+          "refresh": "Actualiser",
+          "loadingActivity": "Chargement de l'activité Kobo...",
+          "noActivityHint": "L'activité de synchronisation récente apparaîtra après un Kobo contacts BookOrbit couplés.",
+          "error": "Erreur",
+          "loading": "Chargement...",
+          "loadMore": "Charger plus d'activité"
+        },
+        "howBooksSynced": {
+          "title": "Comment les livres sont synchronisés",
+          "body": "Pour envoyer des livres vers votre appareil Kobo, vous devez activer {syncToKobo} sur les collections contenant ces livres. Ouvrez n'importe quelle collection dans la barre latérale, cliquez sur l'icône Modifier et activez {syncToKobo}. Les livres qui ne font pas partie d'une collection activée ne seront pas synchronisés."
+        },
+        "nextSteps": {
+          "title": "Prochaines étapes",
+          "step1": "1. Configurez votre appareil Kobo pour qu'il se synchronise avec le Sync URL ci-dessus.",
+          "step2": "2. Dans BookOrbit, accédez à n'importe quelle collection dans la barre latérale, cliquez sur l'icône Modifier et activez {syncToKobo}. Seuls les livres appartenant à des collections compatibles avec la synchronisation seront téléchargés sur votre appareil."
+        },
+        "syncToKobo": "Synchroniser avec Kobo",
+        "tabs": {
+          "syncSettings": "Paramètres de synchronisation",
+          "activityLog": "Journal d'activité"
+        }
+      },
+      "koreader": {
+        "title": "KOReader Synchronisation",
+        "subtitle": "Parcourez votre catalogue BookOrbit dans KOReader et synchronisez la progression, l'activité de lecture, les faits saillants et les modifications d'annotations.",
+        "tabs": {
+          "sync": "Paramètres de synchronisation",
+          "fileNaming": "Nom du fichier"
+        },
+        "fileNaming": {
+          "accountTitle": "Modèle KOReader par défaut du compte",
+          "accountDescription": "Définit le dossier relatif et le nom de fichier par défaut utilisés par les téléchargements du plugin BookOrbit pour votre compte KOReader. Les règles spécifiques à l'appareil peuvent le remplacer ci-dessous.",
+          "defaultPattern": "Modèle de chemin de livre par défaut",
+          "accountHelp": "Votre compte est par défaut pour les téléchargements du plug-in KOReader, sauf si un appareil dispose d'une règle personnalisée.",
+          "accountHint": "Utilisé par vos appareils KOReader qui ne disposent pas de remplacement personnalisé.",
+          "preview": "Aperçu",
+          "saveAccount": "Enregistrer le compte par défaut",
+          "deviceTitle": "Remplacements de périphérique KOReader",
+          "deviceDescription": "Personnalisez n'importe quelle combinaison de chemins par défaut, en série et autonomes. Les lignes vides spécifiques à l'appareil héritent de la valeur par défaut de l'appareil, qui elle-même peut hériter du modèle KOReader par défaut du compte.",
+          "noDevices": "Les appareils apparaissent ici après avoir été synchronisés avec BookOrbit.",
+          "customOrganization": "Organisation personnalisée",
+          "usingAccountDefault": "Utiliser le compte par défaut",
+          "deviceDefaultHelp": "Solution de repli pour cet appareil. Laissez-le égal à la valeur par défaut du compte pour hériter automatiquement des modifications futures.",
+          "seriesBooks": "Livres en série",
+          "seriesHelp": "Chemin facultatif utilisé uniquement pour les livres avec des métadonnées de série. Laissez vide pour utiliser le modèle de chemin par défaut de cet appareil.",
+          "standaloneBooks": "Livres sans série",
+          "standaloneHelp": "Chemin facultatif utilisé uniquement pour les livres sans métadonnées de série. Laissez vide pour utiliser le modèle de chemin par défaut de cet appareil.",
+          "inheritPlaceholder": "Laissez vide pour utiliser le modèle par défaut de cet appareil",
+          "useAccount": "Utiliser le compte par défaut",
+          "saveOverride": "Enregistrer le remplacement",
+          "loadFailed": "Échec du chargement des paramètres d'organisation des fichiers",
+          "accountRequired": "Entrez un modèle de chemin de livre par défaut avant d'enregistrer.",
+          "accountSaved": "Modèle KOReader par défaut du compte enregistré",
+          "accountSaveFailed": "Échec de l'enregistrement des paramètres d'organisation des fichiers",
+          "deviceUsesAccount": "L'appareil utilise désormais le modèle KOReader par défaut du compte",
+          "deviceSaved": "Remplacement de l'organisation des appareils enregistré",
+          "deviceSaveFailed": "Échec de l'enregistrement du remplacement du périphérique",
+          "deviceResetFailed": "Échec de la réinitialisation du remplacement du périphérique"
+        },
+        "loadingSettings": "Chargement des paramètres KOReader...",
+        "loadFailed": "Échec du chargement des paramètres KOReader",
+        "never": "Jamais",
+        "justNow": "Juste maintenant",
+        "minutesAgo": "il y a {count} m",
+        "hoursAgo": "il y a {count}h",
+        "daysAgo": "Il y a {count}j",
+        "unknown": "Inconnu",
+        "updateAvailable": "Mise à jour disponible",
+        "upToDate": "À jour",
+        "versionUnknown": "Version inconnue",
+        "latestPlugin": "Dernier plugin : v{version}",
+        "latestPluginUnavailable": "Dernier plugin indisponible",
+        "notConfigured": "La synchronisation KOReader n'est pas configurée",
+        "notConfiguredHint": "Créez un ensemble d'informations d'identification de synchronisation, puis utilisez-les avec le plugin BookOrbit KOReader pour la navigation, les téléchargements, la progression, la lecture des événements, les surlignages et les suppressions.",
+        "createCredentials": "Créer des identifiants",
+        "createFormTitle": "Créer des informations d'identification de synchronisation KOReader",
+        "createFormHint": "Ces informations d'identification authentifient vos appareils KOReader avec BookOrbit.",
+        "username": "Nom d'utilisateur",
+        "usernamePlaceholder": "par ex. mon lecteur",
+        "password": "Mot de passe",
+        "passwordPlaceholder": "Minimum 6 caractères",
+        "creating": "Création...",
+        "create": "Créer",
+        "credentialsCreated": "KOReader identifiants de synchronisation créés",
+        "createCredentialsFailed": "Échec de la création des informations d'identification",
+        "status": "KOReader Statut",
+        "refresh": "Actualiser",
+        "progressSync": "Synchronisation de la progression",
+        "progressSyncHint": "Autorisez les appareils KOReader à synchroniser la progression, l'activité de lecture, les surlignages et les suppressions d'annotations avec BookOrbit.",
+        "lastSync": "Dernière synchronisation",
+        "syncedBooks": "Livres synchronisés",
+        "bookCount": "{count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+        "devices": "Appareils",
+        "deviceCount": "{count, plural, =0 {aucun appareil} one {# appareil} other {# appareils} many {# appareils}}",
+        "credentialsCreatedLabel": "Identifiants créés",
+        "setup": "Configuration",
+        "pluginServerUrl": "Serveur de plugins URL",
+        "copied": "Copié",
+        "copyUrl": "Copier URL",
+        "preconfiguredPlugin": "Plugin BookOrbit préconfiguré",
+        "preconfiguredPluginHintPrefix": "Téléchargez un zip avec le serveur URL et votre connexion de synchronisation déjà configurée. Le plugin inclut la navigation et la synchronisation du catalogue. Copiez le dossier dans",
+        "preconfiguredPluginHintSuffix": "et redémarrez KOReader.",
+        "latestPluginNote": "{label}. Les mises à jour des appareils s'exécutent à partir du menu BookOrbit dans KOReader.",
+        "preparing": "Préparation...",
+        "downloadPlugin": "Télécharger le plugin",
+        "noDevicesSynced": "Aucun appareil n'a encore été synchronisé",
+        "noDevicesSyncedHint": "Installez le plugin BookOrbit pour une synchronisation complète ou configurez la synchronisation de la progression des stocks de KOReader pour les mises à jour uniquement sur la progression.",
+        "lastSyncLabel": "Dernière synchronisation :",
+        "lastBookLabel": "Dernier livre :",
+        "noneYet": "Aucun pour l'instant",
+        "pluginActivity": "Activité du plugin",
+        "noPluginActivity": "Aucune activité du plugin n'a encore été signalée.",
+        "lastFullSync": "Dernière synchronisation complète : {time}",
+        "latestPluginSuffix": "- dernier plugin v{version}",
+        "matchedBooks": "Livres assortis",
+        "readingEvents": "Événements de lecture",
+        "highlights": "Points forts",
+        "syncedTotals": "Totaux synchronisés",
+        "trashedHighlights": "Faits saillants saccagés",
+        "pendingDeletes": "{count, plural, =0 {aucun surlignage supprimé en attente de reconnaissance du plugin KOReader.} one {# surbrillance supprimée en attente de confirmation du plugin KOReader.} other {# faits saillants supprimés en attente de reconnaissance du plugin KOReader.} many {# faits saillants supprimés en attente de reconnaissance du plugin KOReader.}}",
+        "failedPositions": "{count, plural, =0 {aucune position de surbrillance ne nécessite d’attention.} one {# La position en surbrillance nécessite une attention particulière.} other {# les positions mises en évidence nécessitent une attention particulière.} many {# les positions mises en évidence nécessitent une attention particulière.}}",
+        "setupGuide": "Guide de configuration",
+        "setupSteps": "KOReader étapes de configuration",
+        "setupStepsHint": "Utilisez le plugin BookOrbit pour la navigation dans le catalogue, les téléchargements, la progression, la lecture des événements et les faits saillants. Utilisez le plugin stock pour progresser uniquement.",
+        "pluginGuideTitle": "Plugin BookOrbit",
+        "pluginStep1": "Téléchargez le plugin préconfiguré ci-dessus.",
+        "pluginStep2Prefix": "Décompressez-le et copiez",
+        "pluginStep2Middle": "à",
+        "pluginStep2Suffix": "sur votre appareil.",
+        "pluginStep3": "Redémarrez KOReader. Le serveur et la connexion sont configurés automatiquement.",
+        "pluginStep4Prefix": "Ouvert",
+        "pluginStep4Suffix": "pour rechercher, télécharger et lier des livres à synchroniser.",
+        "stockGuideTitle": "Plugin de synchronisation de la progression des stocks",
+        "stockStep1Prefix": "Sur votre appareil KOReader, accédez à",
+        "stockStep1Suffix": ".",
+        "stockStep2": "Définissez le serveur de synchronisation personnalisé sur URL indiqué ci-dessus.",
+        "stockStep3": "Saisissez le nom d'utilisateur et le mot de passe que vous avez créés, puis appuyez sur Connexion.",
+        "locationNote": "BookOrbit enregistre les emplacements EPUB compatibles KOReader à partir du lecteur Web. La restauration doit atterrir à proximité de la même position, bien que l'emplacement exact de la ligne puisse varier selon le lecteur et la disposition EPUB.",
+        "dangerZone": "Zone dangereuse",
+        "deleteCredentials": "Supprimer les identifiants KOReader",
+        "deleteCredentialsHint": "Supprimez les informations d'identification de synchronisation et déconnectez tous les appareils. Les données de progression seront conservées.",
+        "credentialsDeleted": "KOReader identifiants supprimés",
+        "deleteCredentialsFailed": "Échec de la suppression des informations d'identification",
+        "deleteConfirmTitle": "Supprimer les identifiants KOReader ?",
+        "deleteConfirmBody": "Cela supprimera vos informations d'identification de synchronisation et déconnectera tous les appareils KOReader. Les données de progression existantes seront conservées.",
+        "syncEnabled": "Synchronisation KOReader activée",
+        "syncDisabled": "Synchronisation KOReader désactivée",
+        "toggleSyncFailed": "Échec de la synchronisation",
+        "syncUrlCopied": "Synchroniser URL copié dans le presse-papiers",
+        "syncUrlCopyFailed": "Échec de la copie de la synchronisation URL",
+        "statusRefreshed": "Statut de synchronisation actualisé",
+        "refreshFailed": "Échec de l'actualisation",
+        "pluginDownloaded": "Plugin téléchargé. Copiez bookorbit.koplugin du zip vers koreader/plugins/ sur votre appareil.",
+        "pluginDownloadFailed": "Échec du téléchargement du plugin",
+        "hashLinks": {
+          "unmatchedTitle": "Livres KOReader inégalés",
+          "unmatchedBooks": "Des livres inégalés",
+          "manualTitle": "Liens manuels KOReader",
+          "refresh": "Actualiser",
+          "link": "Lien",
+          "change": "Changement",
+          "unlink": "Dissocier",
+          "hash": "Hachage :",
+          "lastOpened": "Dernière ouverture :",
+          "firstSeen": "Vu pour la première fois :",
+          "lastSeen": "Vu pour la dernière fois :",
+          "linked": "En lien :",
+          "updated": "Mis à jour :",
+          "linkedTo": "Lié à {title}",
+          "loadingUnmatched": "Chargement de livres inégalés...",
+          "loadingManual": "Chargement des liens de hachage manuels...",
+          "noUnmatched": "Aucun livre KOReader inégalé.",
+          "noManual": "Aucun lien manuel KOReader.",
+          "pageOf": "Page {page} sur {total}",
+          "showingRange": "Affichage de {start}-{end} sur {total}",
+          "unknownFile": "Fichier KOReader inconnu {hash}",
+          "unknownAuthor": "Auteur inconnu",
+          "noTitleOrAuthor": "Aucun titre ni auteur signalé",
+          "bookNumber": "BookOrbit livre n°{id}",
+          "toast": {
+            "unmatchedRefreshed": "Des livres inégalés rafraîchis",
+            "unmatchedRefreshFailed": "Échec de l'actualisation des livres sans correspondance",
+            "manualRefreshed": "Liens de hachage manuels actualisés",
+            "manualRefreshFailed": "Échec de l'actualisation des liens de hachage manuels",
+            "bookLinked": "Livre lié",
+            "linkUpdated": "Lien mis à jour",
+            "linkFailed": "Échec de l'association du livre",
+            "linkRemoved": "Lien supprimé",
+            "unlinkFailed": "Échec de la dissociation du livre",
+            "unmatchedDismissed": "Un livre inégalé rejeté",
+            "dismissFailed": "Échec de la suppression du livre sans correspondance",
+            "allDismissed": "{count, plural, =0 {Rejeté aucun livre inégalé} one {Rejeté # livre inégalé} other {Rejeté # livres inégalés} many {Rejeté # livres inégalés}}",
+            "dismissAllFailed": "Échec de la suppression de tous les livres sans correspondance"
+          },
+          "modal": {
+            "linkTitle": "Lien vers le livre KOReader",
+            "changeTitle": "Modifier le lien KOReader",
+            "bookOrbitBook": "Livre BookOrbit",
+            "searchPlaceholder": "Recherchez dans votre bibliothèque BookOrbit",
+            "minChars": "Saisissez au moins 2 caractères.",
+            "searching": "Recherche...",
+            "noBooksFound": "Aucun livre trouvé.",
+            "untitledBook": "Livre sans titre",
+            "selected": "Sélectionné",
+            "select": "Sélectionnez",
+            "loadMore": "Charger plus",
+            "confirmTitle": "Confirmer le lien KOReader",
+            "koreader": "KOReader",
+            "bookOrbit": "BookOrbit",
+            "bookId": "Identifiant du livre : {id}",
+            "syncedStatsNote": "Les statistiques déjà synchronisées resteront sur leur livre BookOrbit actuel.",
+            "chooseDifferent": "Choisissez différent",
+            "saving": "Sauvegarde...",
+            "confirmLink": "Confirmer le lien",
+            "unlinkTitle": "Dissocier le livre KOReader ?",
+            "unlinkBody": "Les synchronisations futures pour ce hachage cesseront de se résoudre en {title} jusqu'à ce qu'il soit à nouveau lié. Les statistiques déjà synchronisées resteront sur leur livre BookOrbit actuel.",
+            "unlinking": "Dissociation..."
+          },
+          "dismiss": "Ignorer",
+          "dismissAll": "Tout rejeter",
+          "dismissing": "Rejeter...",
+          "unlinking": "Dissociation...",
+          "unlinkConfirmTitle": "Dissocier le livre KOReader ?",
+          "unlinkConfirmBody": "Les synchronisations futures pour ce hachage cesseront de se résoudre en {title} jusqu'à ce qu'il soit à nouveau lié. Les statistiques déjà synchronisées resteront sur leur livre BookOrbit actuel.",
+          "dismissConfirmTitle": "Ignorer {title} ?",
+          "dismissConfirmBody": "Cela le supprime de votre liste de livres sans correspondance. Si un appareil signale à nouveau ce hachage, il réapparaîtra en tant que nouvelle entrée.",
+          "dismissAllConfirmTitle": "{count, plural, =0 {pas de livres inégalés} one {Tout rejeter # un livre inégalé ?} other {Tout rejeter # des livres inégalés ?} many {Tout rejeter # des livres inégalés ?}}",
+          "dismissAllConfirmBody": "Cela efface toute votre liste de livres sans correspondance, pas seulement la page actuelle. Si un appareil signale à nouveau l'un de ces hachages, il réapparaîtra sous la forme d'une nouvelle entrée.",
+          "changeLinkTitle": "Modifier le lien KOReader",
+          "linkBookTitle": "Lien vers le livre KOReader",
+          "bookOrbitBook": "Livre BookOrbit",
+          "searchLibraryPlaceholder": "Recherchez dans votre bibliothèque BookOrbit",
+          "enterMinChars": "Saisissez au moins 2 caractères.",
+          "searching": "Recherche...",
+          "noBooksFound": "Aucun livre trouvé.",
+          "untitledBook": "Livre sans titre",
+          "selected": "Sélectionné",
+          "select": "Sélectionnez",
+          "loadMore": "Charger plus",
+          "loadingMore": "Chargement...",
+          "confirmLinkTitle": "Confirmer le lien KOReader",
+          "bookId": "Identifiant du livre : {id}",
+          "syncedStatsNote": "Les statistiques déjà synchronisées resteront sur leur livre BookOrbit actuel.",
+          "chooseDifferent": "Choisissez différent",
+          "saving": "Sauvegarde...",
+          "confirmLink": "Confirmer le lien"
+        },
+        "remove": "Supprimer",
+        "removing": "Suppression...",
+        "unmatchedBooks": "Des livres inégalés",
+        "deviceRemoved": "Appareil supprimé",
+        "removeDeviceFailed": "Échec de la suppression de l'appareil",
+        "removeDeviceConfirmTitle": "Supprimer {device} ?",
+        "removeDeviceConfirmBody": "Cela supprime définitivement la progression synchronisée de cet appareil, l'activité de lecture et toutes les entrées de livre sans correspondance qui ne sont plus signalées par un autre appareil. Si l'appareil se synchronise à nouveau plus tard, il réapparaîtra en tant que nouvelle entrée."
+      },
+      "opds": {
+        "title": "OPDS",
+        "subtitle": "Connectez des applications de lecture compatibles OPDS comme KOReader ou Thorium Reader à votre bibliothèque.",
+        "copy": "Copier",
+        "loadFailed": "Échec du chargement",
+        "server": "Serveur",
+        "catalogServer": "OPDS Serveur de catalogue",
+        "catalogServerHint": "Autoriser les clients OPDS à parcourir et télécharger des livres",
+        "endpoint": "Point de terminaison",
+        "accounts": "OPDS Comptes",
+        "add": "Ajouter",
+        "addAccount": "Ajouter un compte",
+        "username": "Nom d'utilisateur",
+        "usernameLabel": "Nom d'utilisateur",
+        "usernamePlaceholder": "par ex. coréen",
+        "password": "Mot de passe",
+        "passwordPlaceholder": "Minimum 8 caractères",
+        "defaultSort": "Tri par défaut",
+        "sortLabel": "Trier",
+        "creating": "Création...",
+        "create": "Créer",
+        "noAccounts": "Aucun compte OPDS pour l'instant. Créez-en un pour commencer à utiliser les clients OPDS.",
+        "hideDetails": "Masquer les détails",
+        "showDetails": "Afficher les détails",
+        "copyUsername": "Copier le nom d'utilisateur",
+        "notes": "OPDS Remarques",
+        "notesBody": "Utilisez les comptes OPDS dans les applications de lecture. Gardez les informations d'identification privées et alternez les mots de passe s'ils sont partagés accidentellement.",
+        "deleteConfirmTitle": "Supprimer le compte OPDS ?",
+        "deleteConfirmBody": "Supprimez \"{username}\". Cette action ne peut pas être annulée.",
+        "sortRecent": "Récemment ajouté",
+        "sortTitleAsc": "Titre (A-Z)",
+        "sortTitleDesc": "Titre (Z-A)",
+        "sortAuthorAsc": "Auteur (A-Z)",
+        "sortAuthorDesc": "Auteur (Z-A)",
+        "sortSeriesAsc": "Série (A-Z)",
+        "sortSeriesDesc": "Série (ZA)",
+        "serverEnabled": "Serveur OPDS activé",
+        "serverDisabled": "Serveur OPDS désactivé",
+        "updateSettingsFailed": "Échec de la mise à jour des paramètres OPDS",
+        "urlCopied": "OPDS URL copié dans le presse-papiers",
+        "urlCopyFailed": "Échec de la copie de OPDS URL",
+        "createUserFailed": "Échec de la création de l'utilisateur OPDS",
+        "userCreated": "OPDS utilisateur \"{username}\" créé",
+        "sortOrderUpdated": "Ordre de tri mis à jour pour \"{username}\"",
+        "updateSortFailed": "Échec de la mise à jour de l'ordre de tri",
+        "userDeleted": "OPDS utilisateur \"{username}\" supprimé",
+        "deleteUserFailed": "Échec de la suppression de l'utilisateur OPDS",
+        "labelCopied": "{label} copié",
+        "copyLabelFailed": "Échec de la copie de {label}"
+      },
+      "tabs": {
+        "general": "Général",
+        "ebook": "eBook",
+        "pdf": "PDF",
+        "comics": "Bandes dessinées",
+        "audio": "Livre audio",
+        "fonts": "Polices"
+      }
+    },
+    "system": {
+      "tabs": {
+        "file-naming": "Nom du fichier",
+        "book-dock": "Book Dock",
+        "maintenance": "Entretien",
+        "audit-log": "Journal d'audit"
+      }
+    }
+  },
+  "achievements": {
+    "title": "Réalisations",
+    "tiersCount": "Niveaux {earned} / {total}",
+    "loadFailed": "Échec du chargement des réalisations",
+    "tryAgain": "Réessayez",
+    "noMatchFilter": "Aucune réalisation ne correspond à ce filtre",
+    "secretAchievement": "Réalisation secrète",
+    "earnedOn": "Vous avez gagné {date}",
+    "whileReading": "En lisant « {title} »",
+    "tierProgress": "Niveau {earned} sur {total}",
+    "progressToNext": "{current} / {threshold} à {name}",
+    "rarity": {
+      "common": "Commun",
+      "rare": "Rare",
+      "epic": "Épique",
+      "legendary": "Légendaire"
+    },
+    "filter": {
+      "all": "Tout",
+      "earned": "Gagné ({count})",
+      "inProgress": "En cours ({count})",
+      "locked": "Verrouillé ({count})"
+    }
+  },
+  "adminFeature": {
+    "accountActivity": {
+      "title": "Activité du compte",
+      "subtitle": "Examinez l’activité d’authentification du compte sans exposer l’historique de lecture.",
+      "privacyNotice": "Cette page signale uniquement les connexions et les actualisations d’authentification. Il n'utilise pas l'historique de lecture, la progression du livre ou l'activité de la bibliothèque.",
+      "privacyLabel": "À propos de la confidentialité des activités du compte",
+      "never": "Jamais",
+      "openInsightsFor": "Ouvrir les informations de lecture partagées pour {name}",
+      "permissionLabel": "Afficher l'activité des utilisateurs",
+      "states": {
+        "recent": "Récemment actif",
+        "dormant": "Dormant",
+        "never": "Aucune activité enregistrée",
+        "disabled": "Désactivé"
+      },
+      "filters": {
+        "search": "Rechercher des comptes",
+        "searchPlaceholder": "Rechercher un nom ou un nom d'utilisateur",
+        "state": "État d'activité",
+        "allStates": "Tous les états d'activité",
+        "provisioning": "Méthode d'authentification",
+        "allMethods": "Toutes les méthodes d'authentification",
+        "sort": "Trier les comptes",
+        "mostRecent": "Actif le plus récemment",
+        "leastRecent": "Actif le moins récemment",
+        "lastLogin": "Connexion la plus récente",
+        "newest": "Comptes les plus récents",
+        "oldest": "Comptes les plus anciens",
+        "name": "Nom",
+        "apply": "Appliquer",
+        "clear": "Effacer"
+      },
+      "methods": {
+        "local": "Local",
+        "manual": "Créé par l'administrateur",
+        "oidc": "OIDC / SSO",
+        "shared": "Lien magique partagé"
+      },
+      "columns": {
+        "user": "Utilisateur",
+        "state": "État du compte",
+        "lastLogin": "Dernière connexion",
+        "lastAuthenticated": "Dernière authentification",
+        "created": "Créé",
+        "readingInsights": "Aperçus de lecture"
+      },
+      "sharing": {
+        "private": "Non partagé",
+        "summary": "Résumé partagé",
+        "detailed": "Partagé détaillé"
+      },
+      "empty": {
+        "title": "Aucun compte trouvé",
+        "description": "Essayez de modifier ou d'effacer les filtres actuels."
+      },
+      "pagination": {
+        "label": "Pages d'activité du compte",
+        "page": "Page {page} sur {totalPages}"
+      },
+      "errors": {
+        "load": "Échec du chargement de l'activité du compte."
+      }
+    },
+    "sharedInsights": {
+      "title": "Informations de lecture partagées",
+      "subtitle": "Lecture des informations que cet utilisateur a volontairement choisi de partager.",
+      "auditNotice": "L'accès à ce profil est enregistré et visible par l'utilisateur.",
+      "period": "Période de déclaration",
+      "periodDays": "{count} derniers jours",
+      "durationMinutes": "{count, plural, one {# minute} other {# minutes} many {# minutes}}",
+      "durationHours": "{count} heures",
+      "metrics": {
+        "sessions": "Séances",
+        "readingTime": "Temps de lecture",
+        "activeDays": "Journées actives",
+        "started": "Livres commencés",
+        "completed": "Livres terminés"
+      },
+      "trend": "Tendance de lecture quotidienne",
+      "emptyTitle": "Aucune activité de lecture pendant cette période",
+      "noData": "Aucune donnée de lecture enregistrée pour cette période.",
+      "sourceNames": {
+        "web": "Lecteur Web",
+        "koreader": "KOReader",
+        "manual": "Manuel",
+        "kobo": "Kobo",
+        "unknown": "Inconnu"
+      },
+      "formats": "Formats",
+      "genres": "Genre",
+      "broadGenres": {
+        "science_fiction": "Science-fiction",
+        "fantasy": "Fantaisie",
+        "mystery_thriller": "Mystère et thriller",
+        "romance": "Romance",
+        "horror": "Horreur",
+        "history_biography": "Histoire et biographie",
+        "science_technology": "Sciences et technologies",
+        "business_economics": "Affaires et économie",
+        "self_development": "Développement personnel",
+        "society_culture": "Société et culture",
+        "children_young_adult": "Enfants et jeunes adultes",
+        "comics_graphic_novels": "Bandes dessinées et romans graphiques",
+        "poetry": "Poésie",
+        "other": "Autre"
+      },
+      "sources": "Sources de données",
+      "topBooks": "Livres les plus lus",
+      "recentBooks": "Lu récemment",
+      "unknownTitle": "Livre sans titre",
+      "top": {
+        "authors": "Meilleurs auteurs",
+        "genres": "Genres populaires",
+        "series": "Meilleures séries",
+        "narrators": "Meilleurs narrateurs"
+      },
+      "errors": {
+        "READING_INSIGHTS_PRIVATE": "Cet utilisateur ne partage pas d'informations sur la lecture.",
+        "READING_INSIGHTS_SUMMARY_ONLY": "Cet utilisateur partage uniquement des informations récapitulatives.",
+        "READING_INSIGHTS_VIEW_SESSION_REQUIRED": "Une session de visualisation de profil est requise.",
+        "READING_INSIGHTS_VIEW_SESSION_INVALID": "Cette vue de profil a expiré ou n'est plus valide.",
+        "LOAD_FAILED": "Les informations de lecture partagées n'ont pas pu être chargées.",
+        "cleared": "Aucune information de profil précédemment chargée n'est affichée."
+      }
+    },
+    "resetLink": {
+      "title": "Lien de réinitialisation du mot de passe",
+      "description": "Partagez ce lien avec l'utilisateur. Il expire dans 15 minutes.",
+      "copy": "Copier",
+      "copied": "Copié!",
+      "copyFailed": "Échec de la copie",
+      "notShownAgain": "Ce lien ne sera plus affiché."
+    },
+    "userForm": {
+      "editUser": "Modifier l'utilisateur",
+      "createUser": "Créer un utilisateur",
+      "createSharedAccount": "Créer un compte partagé",
+      "sharedBadge": "Partagé",
+      "active": "Actif",
+      "suspended": "Suspendu",
+      "tabs": {
+        "general": "général",
+        "access": "accès",
+        "restrictions": "restrictions"
+      },
+      "sharedAccount": "Compte partagé",
+      "sharedAccountHint": "Pas de mot de passe. L'accès est accordé uniquement via des liens magiques.",
+      "sharedAccountManageHint": "Gérez les liens de connexion depuis Paramètres - Magic Links.",
+      "username": "Nom d'utilisateur",
+      "fullName": "Nom complet",
+      "email": "Courriel",
+      "optional": "(facultatif)",
+      "libraryAccess": "Accès à la bibliothèque",
+      "noLibrariesSelected": "Aucune bibliothèque sélectionnée. L'utilisateur ne peut afficher aucun livre.",
+      "permissions": "Autorisations",
+      "presetStandard": "Norme",
+      "presetAdmin": "Administrateur",
+      "presetClearAll": "Tout effacer",
+      "permissionGroups": {
+        "content": "Contenu",
+        "devicesAccess": "Appareils et accès",
+        "email": "Courriel",
+        "administration": "Administration",
+        "notifications": "Notifications",
+        "restrictions": "Restrictions"
+      },
+      "superuserTarget": "Cible du superutilisateur",
+      "superuserTargetHint": "Les restrictions de contenu ne peuvent pas être appliquées aux superutilisateurs.",
+      "noRestrictions": "Aucune restriction de contenu",
+      "noRestrictionsHint": "Cet utilisateur a un accès complet à tous les livres de ses bibliothèques assignées.",
+      "addRestrictions": "+ Ajouter des restrictions de contenu",
+      "contentRestrictions": "Restrictions de contenu",
+      "remove": "Supprimer",
+      "includeTags": "Inclure des balises",
+      "includeTagsHint": "(afficher uniquement les livres avec ces balises)",
+      "excludeTags": "Exclure les balises",
+      "excludeTagsHint": "(masquer les livres avec ces balises)",
+      "includeGenres": "Inclure les genres",
+      "includeGenresHint": "(afficher uniquement les livres avec ces genres)",
+      "excludeGenres": "Exclure les genres",
+      "excludeGenresHint": "(masquer les livres avec ces genres)",
+      "searchTagsPlaceholder": "Rechercher des balises...",
+      "searchGenresPlaceholder": "Rechercher des genres...",
+      "saving": "Sauvegarde...",
+      "errors": {
+        "updateUser": "Échec de la mise à jour de l'utilisateur",
+        "updatePermissions": "Échec de la mise à jour des autorisations",
+        "updateLibraryAccess": "Échec de la mise à jour de l'accès à la bibliothèque",
+        "updateContentFilters": "Échec de la mise à jour des filtres de contenu",
+        "emailRequired": "L'e-mail est requis",
+        "createSharedAccount": "Échec de la création d'un compte partagé",
+        "createUser": "Échec de la création de l'utilisateur"
+      }
+    },
+    "usersPage": {
+      "usersTitle": "Utilisateurs",
+      "magicLinksTitle": "Liens magiques",
+      "usersSubtitle": "Gérez les comptes d'utilisateurs et les attributions d'autorisations.",
+      "magicLinksSubtitle": "Créez des liens de connexion partageables pour les comptes partagés.",
+      "createUser": "Créer un utilisateur",
+      "createLink": "Créer un lien",
+      "usersTab": "Utilisateurs",
+      "magicLinksTab": "Liens magiques",
+      "columns": {
+        "name": "Nom",
+        "username": "Nom d'utilisateur",
+        "email": "Courriel",
+        "access": "Accès",
+        "status": "Statut"
+      },
+      "adminBadge": "Administrateur",
+      "permissionCount": "{count, plural, =0 {aucune autorisation} one {une autorisation} other {# autorisations} many {# autorisations}}",
+      "filteredBadge": "Filtré",
+      "contentRestrictionsActive": "Restrictions de contenu actives",
+      "statusActive": "Actif",
+      "statusInactive": "Inactif",
+      "resetPassword": "Réinitialiser le mot de passe",
+      "resetPasswordOidcHint": "OIDC utilisateurs réinitialisent les mots de passe dans leur fournisseur d'identité",
+      "resetPasswordSharedHint": "Les comptes partagés n'ont pas de mot de passe",
+      "resetPasswordOidcHintFull": "Les utilisateurs OIDC réinitialisent les mots de passe dans leur fournisseur d'identité.",
+      "resetPasswordSharedHintFull": "Les comptes partagés n'ont pas de mot de passe.",
+      "deleteUserAction": "Supprimer un utilisateur",
+      "deleteDialogTitle": "Supprimer l'utilisateur ?",
+      "deleteDialogBody": "Supprimez l'utilisateur \"{username}\". Cette action ne peut pas être annulée.",
+      "deleting": "Suppression...",
+      "errors": {
+        "loadData": "Échec du chargement des données",
+        "load": "Échec du chargement",
+        "deleteUser": "Échec de la suppression de l'utilisateur"
+      },
+      "currentUsers": "Utilisateurs actuels",
+      "defaultLibraryAccess": {
+        "title": "Accès à la bibliothèque par défaut",
+        "subtitle": "Accès de visualisation accordé aux utilisateurs auto-enregistrés et dotés de OIDC.",
+        "description": "Sélectionnez les bibliothèques attribuées automatiquement aux nouveaux utilisateurs.",
+        "noLibraries": "Aucune bibliothèque disponible.",
+        "save": "Enregistrer les valeurs par défaut",
+        "saving": "Sauvegarde...",
+        "saved": "Accès à la bibliothèque par défaut enregistré.",
+        "saveError": "Échec de l'enregistrement de l'accès par défaut à la bibliothèque"
+      }
+    }
+  },
+  "annotations": {
+    "unknownBook": "Livre inconnu",
+    "styles": {
+      "highlight": "Mettre en surbrillance",
+      "underline": "Souligner",
+      "strike": "Barré",
+      "squiggle": "Ondulé",
+      "invert": "Inverser"
+    },
+    "combobox": {
+      "filterByBook": "Filtrer par livre",
+      "allBooks": "Tous les livres",
+      "clearBookFilter": "Effacer le filtre de livre",
+      "searching": "Recherche...",
+      "noBooksFound": "Aucun livre trouvé"
+    },
+    "bulk": {
+      "countSelected": "{count} sélectionné",
+      "pageSelected": "Page sélectionnée",
+      "selectPage": "Sélectionner une page",
+      "clear": "Effacer",
+      "recolorTo": "Recolorer en {color}",
+      "restyleTo": "Relooker en {style}"
+    },
+    "chips": {
+      "active": "Actif :",
+      "removeFilter": "Supprimer le filtre {label}",
+      "clearAll": "Tout effacer"
+    },
+    "filters": {
+      "colors": "Couleurs",
+      "dateRange": "Plage de dates",
+      "fromDate": "À partir du jour",
+      "toDate": "À ce jour",
+      "to": "à",
+      "clearDateRange": "Effacer la plage de dates",
+      "clearAll": "Tout effacer"
+    },
+    "pagination": {
+      "showing": "Affichage de {start}-{end} sur {total}",
+      "pageOf": "Page {page} sur {totalPages}",
+      "firstPage": "Première page",
+      "previousPage": "Page précédente",
+      "nextPage": "Page suivante",
+      "lastPage": "Dernière page"
+    },
+    "sync": {
+      "loading": "Chargement des détails de synchronisation",
+      "positions": "Postes",
+      "devices": "Appareils",
+      "retryConversion": "Réessayer la conversion",
+      "noStoredPositions": "Aucune position enregistrée.",
+      "notSynced": "Pas encore synchronisé avec aucun appareil.",
+      "upToDate": "À jour",
+      "pendingVersion": "En attente de v{version}",
+      "syncedAt": "synchronisé {date}",
+      "format": {
+        "webReader": "Lecteur Web",
+        "koreader": "KOReader",
+        "pdf": "PDF",
+        "kobo": "Kobo"
+      },
+      "status": {
+        "exact": "Exact",
+        "repaired": "Réparé",
+        "failed": "Échec",
+        "pending": "En attente"
+      }
+    },
+    "toolbar": {
+      "searchPlaceholder": "Rechercher du texte et des notes",
+      "filters": "Filtres",
+      "sortOrder": "Ordre de tri",
+      "switchToCompact": "Passer à la vue compacte",
+      "switchToComfortable": "Passer à une vue confortable",
+      "compactView": "Vue compacte",
+      "comfortableView": "Vue confortable"
+    },
+    "listItem": {
+      "pageNumber": "p. {page}",
+      "chapterNumber": "chapitre {chapter}",
+      "selectAnnotation": "Sélectionner une annotation",
+      "collapse": "Réduire",
+      "expand": "Développer",
+      "hideSyncDetail": "Masquer les détails de synchronisation",
+      "showSyncDetail": "Afficher les détails de la synchronisation",
+      "exactPositionUnavailable": "Position exacte du lecteur indisponible",
+      "saving": "Économiser",
+      "bookDetails": "Détails du livre",
+      "openInReader": "Ouvrir dans le lecteur",
+      "restore": "Restaurer",
+      "deleteForever": "Supprimer pour toujours",
+      "editNote": "Modifier la note",
+      "addNote": "Ajouter une note",
+      "colorAndStyle": "Couleur et style",
+      "copied": "Copié",
+      "copyText": "Copier le texte",
+      "trash": "Corbeille",
+      "moveToTrash": "Déplacer vers la corbeille"
+    },
+    "hub": {
+      "title": "Annotations",
+      "totalCount": "{count} total",
+      "bookCount": "{count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+      "noteCount": "{count, plural, =0 {pas de notes} one {# remarque} other {# remarques} many {# remarques}}",
+      "export": "Exporter",
+      "exportMarkdown": "Démarquage",
+      "exportCsv": "CSV",
+      "exportJson": "JSON",
+      "notesOnly": "Remarques uniquement",
+      "style": "Style",
+      "source": "Source",
+      "bulkTrash": "Corbeille",
+      "bulkRestore": "Restaurer",
+      "tabs": {
+        "highlights": "Points forts",
+        "trash": "Corbeille"
+      },
+      "empty": {
+        "noMatch": "Aucun surlignage ne correspond à vos filtres.",
+        "resetFilters": "Réinitialiser les filtres",
+        "trashEmpty": "La corbeille est vide",
+        "noAnnotations": "Aucune annotation pour l'instant. Les faits saillants que vous créez sur le Web ou sur votre liseuse apparaissent ici."
+      },
+      "toast": {
+        "movedToTrash": "Déplacé vers la corbeille",
+        "annotationRestored": "Annotation restaurée",
+        "annotationDeletedForever": "Annotation supprimée définitivement",
+        "failedToDelete": "Échec de la suppression",
+        "bulkTrashed": "{count, plural, =0 {Aucune annotation déplacée vers la corbeille} one {Déplacé # annotation à la corbeille} other {Déplacé # annotations à la corbeille} many {Déplacé # annotations à la corbeille}}",
+        "bulkRestored": "{count, plural, =0 {Restauré sans annotations} one {Restauré # annotation} other {Restauré # annotations} many {Restauré # annotations}}",
+        "bulkRecolored": "{count, plural, =0 {Recoloré sans annotations} one {Recoloré # annotation} other {Recoloré # annotations} many {Recoloré # annotations}}",
+        "bulkRestyled": "{count, plural, =0 {Restylé sans annotations} one {Restylé # annotation} other {Restylé # annotations} many {Restylé # annotations}}"
+      }
+    }
+  },
+  "audit": {
+    "pageTitle": "Journal d'audit",
+    "pageSubtitle": "Un enregistrement des actions importantes pour l'administration effectuées dans l'ensemble du système.",
+    "filters": "Filtres",
+    "noActiveFilters": "Aucun filtre actif",
+    "clear": "Effacer",
+    "empty": "Aucun journal d'audit trouvé",
+    "showMore": "Afficher plus",
+    "showLess": "Afficher moins",
+    "details": "Détails",
+    "hideDetails": "Masquer les détails",
+    "refresh": "Actualiser le journal d'audit",
+    "loadError": "Impossible de charger les événements d'audit.",
+    "removeFilter": "Supprimer le filtre : {value}",
+    "allActions": "Toutes les actions",
+    "allEventTypes": "Tous types d'événements",
+    "allActors": "Tous les acteurs",
+    "noActionsFound": "Aucune action correspondante",
+    "noActorsFound": "Aucun acteur correspondant",
+    "noResourcesFound": "Aucun type de cible correspondant",
+    "unknownAction": "Action inconnue",
+    "unknownResource": "Autre type de cible",
+    "allResources": "Toutes les ressources",
+    "allTargetTypes": "Tous types de cibles",
+    "quickDates": "Rendez-vous rapides",
+    "today": "Aujourd'hui",
+    "sevenDays": "7 jours",
+    "thirtyDays": "30 jours",
+    "userId": "Utilisateur #{id}",
+    "userIdCompact": "#{id}",
+    "targetAdditional": "et {count, plural, one {# plus de cible} other {# plus de cibles} many {# plus de cibles}}",
+    "bookImpact": "{count, plural, one {# livre} other {# livres} many {# livres}}",
+    "entryDetailsLabel": "Détails de l'événement d'audit n°{id}",
+    "detailEventId": "ID d'événement",
+    "detailOccurredAt": "Survenu",
+    "detailActor": "Acteur",
+    "detailCategory": "Catégorie",
+    "detailActionLabel": "Action",
+    "detailEventTypeLabel": "Type d'événement",
+    "detailIpLabel": "Adresse IP",
+    "detailResourceLabel": "Ressource",
+    "detailResourceIdLabel": "ID de ressource",
+    "detailTargetTypeLabel": "Type de cible",
+    "detailTargetIdLabel": "ID cible",
+    "detailAction": "Action : {value}",
+    "detailIp": "IP : {value}",
+    "detailResource": "Ressource : {value}",
+    "detailResourceId": "ID de ressource : {value}",
+    "deletedBooks": "Livres supprimés",
+    "deletedBookDetail": "{title} (livre n°{id})",
+    "untitledBook": "Sans titre",
+    "deletedBooksOmitted": "{count, plural, one {# livre supplémentaire omis} other {# livres supplémentaires omis} many {# livres supplémentaires omis}}",
+    "showing": "Affichage de {from}-{to} sur {total}",
+    "prev": "Précédent",
+    "chips": {
+      "search": "Rechercher : {value}",
+      "action": "Action : {value}",
+      "eventType": "Type d'événement : {value}",
+      "actor": "Acteur : {value}",
+      "resource": "Ressource : {value}",
+      "targetType": "Type de cible : {value}",
+      "user": "Utilisateur : {value}",
+      "from": "De : {value}",
+      "to": "À : {value}"
+    },
+    "filterLabels": {
+      "search": "Rechercher des événements",
+      "action": "Action",
+      "eventType": "Type d'événement (ce qui s'est passé)",
+      "actor": "Acteur",
+      "resource": "Ressource",
+      "targetType": "Type de cible (ce qui a été affecté)",
+      "userId": "Identifiant utilisateur",
+      "from": "De",
+      "to": "À"
+    },
+    "filterPlaceholders": {
+      "search": "Description, acteur, cible ou identifiant",
+      "actor": "Nom d'utilisateur",
+      "action": "par ex. connexion auth.",
+      "userId": "par ex. 1"
+    },
+    "columns": {
+      "when": "Quand",
+      "actor": "Acteur",
+      "event": "Événement",
+      "target": "Cible",
+      "impact": "Impact",
+      "user": "Utilisateur",
+      "action": "Action",
+      "description": "Descriptif",
+      "ip": "PI"
+    },
+    "categories": {
+      "authentication": "Authentification",
+      "books": "Livres",
+      "users": "Utilisateurs",
+      "libraries": "Bibliothèques",
+      "collections": "Collections",
+      "integrations": "Intégrations",
+      "settings": "Paramètres",
+      "other": "Autre"
+    },
+    "resourceLabels": {
+      "User": "Utilisateur",
+      "Library": "Bibliothèque",
+      "Book": "Livre",
+      "Collection": "Collecte",
+      "SmartScope": "Portée intelligente",
+      "BookDockFile": "Fichier Book Dock",
+      "Author": "Auteur",
+      "AppSettings": "Paramètres de l'application",
+      "Genre": "Genre",
+      "Tag": "Étiquette",
+      "KoboDevice": "Appareil Kobo",
+      "EmailProvider": "Fournisseur de messagerie",
+      "EmailTemplate": "Modèle d'e-mail",
+      "EmailRecipient": "Destinataire de l'e-mail",
+      "EmailRecipientGroup": "Groupe de destinataires d'e-mails",
+      "Narrator": "Narrateur",
+      "Publisher": "Éditeur",
+      "Language": "Langue",
+      "Series": "Série",
+      "OidcIdentity": "Identité OIDC",
+      "MagicLinkToken": "Lien magique",
+      "ReadingInsightsProfile": "Profil d'informations sur la lecture"
+    },
+    "actionLabels": {
+      "AuthRegister": "Créer un compte",
+      "AuthLogin": "Connectez-vous",
+      "AuthLoginFailed": "Échec de la connexion",
+      "AuthLogout": "Se déconnecter",
+      "AuthPasswordChange": "Changer le mot de passe",
+      "AuthPasswordResetRequest": "Demander la réinitialisation du mot de passe",
+      "AuthPasswordReset": "Réinitialiser le mot de passe",
+      "AuthPasswordAdminReset": "Réinitialiser le mot de passe utilisateur",
+      "AuthSessionRevoke": "Révoquer la session",
+      "MagicLinkCreate": "Créer un lien magique",
+      "MagicLinkLogin": "Connectez-vous avec le lien magique",
+      "MagicLinkRevoke": "Révoquer le lien magique",
+      "MagicLinkActivate": "Activer le lien magique",
+      "MagicLinkDeactivate": "Désactiver le lien magique",
+      "OidcLogin": "Connectez-vous avec OIDC",
+      "OidcUserProvisioned": "Provisionner l'utilisateur OIDC",
+      "OidcIdentityLinked": "Lier l'identité OIDC",
+      "OidcIdentityUnlinked": "Dissocier l'identité OIDC",
+      "UserCreate": "Créer un utilisateur",
+      "UserUpdate": "Mettre à jour l'utilisateur",
+      "UserSelfUpdate": "Mettre à jour son propre profil",
+      "UserDelete": "Supprimer un utilisateur",
+      "UserPermissionSet": "Mettre à jour les autorisations des utilisateurs",
+      "UserSuperuserEnable": "Activer l'accès superutilisateur",
+      "UserSuperuserDisable": "Désactiver l'accès superutilisateur",
+      "UserContentFiltersSet": "Mettre à jour les filtres de contenu",
+      "ReadingInsightsSharingUpdate": "Mettre à jour le partage d'informations",
+      "ReadingInsightsProfileView": "Afficher les informations partagées",
+      "LibraryCreate": "Créer une bibliothèque",
+      "LibraryUpdate": "Mettre à jour la bibliothèque",
+      "LibraryDelete": "Supprimer la bibliothèque",
+      "LibraryFolderAdd": "Ajouter un dossier de bibliothèque",
+      "LibraryFolderRemove": "Supprimer le dossier de la bibliothèque",
+      "LibraryAccessGrant": "Accorder l'accès à la bibliothèque",
+      "LibraryAccessUpdate": "Mettre à jour l'accès à la bibliothèque",
+      "LibraryAccessRevoke": "Révoquer l'accès à la bibliothèque",
+      "LibraryWriteMetadataToFiles": "Écrire des métadonnées dans des fichiers",
+      "LibraryBulkRename": "Renommer les fichiers de la bibliothèque",
+      "BookUpload": "Télécharger le livre",
+      "BookMetadataUpdate": "Mettre à jour les métadonnées du livre",
+      "BookMetadataLocksUpdate": "Mettre à jour les verrous des métadonnées",
+      "BookDelete": "Supprimer le livre",
+      "BookBulkMetadataRefresh": "Actualiser les métadonnées du livre",
+      "BookBulkDelete": "Supprimer des livres",
+      "BookBulkCoverReextract": "Réextraire les couvertures de livres",
+      "BookBulkSetStatus": "Définir le statut du livre",
+      "BookBulkSetRating": "Définir la note du livre",
+      "BookBulkSetMetadata": "Définir les métadonnées du livre",
+      "BookBulkUpdateTags": "Mettre à jour les balises du livre",
+      "BookBulkSetMetadataLock": "Définir des verrous de métadonnées",
+      "BookBulkEditMetadata": "Modifier les métadonnées du livre",
+      "BookReadingStateReset": "Réinitialiser l'état de lecture",
+      "BookWriteAndRename": "Écrire les métadonnées et renommer le fichier",
+      "CollectionCreate": "Créer une collection",
+      "CollectionUpdate": "Mettre à jour la collection",
+      "CollectionDelete": "Supprimer la collection",
+      "CollectionBooksAdd": "Ajouter des livres à la collection",
+      "CollectionBooksRemove": "Supprimer des livres de la collection",
+      "SmartScopeCreate": "Créer une portée intelligente",
+      "SmartScopeUpdate": "Mettre à jour la portée intelligente",
+      "SmartScopeDelete": "Supprimer la portée intelligente",
+      "BookDockFinalize": "Finaliser le fichier Book Dock",
+      "AuthorUpdate": "Mettre à jour l'auteur",
+      "AuthorDelete": "Supprimer l'auteur",
+      "AuthorMerge": "Fusionner les auteurs",
+      "AuthorEnrichmentConfigUpdate": "Mettre à jour l'enrichissement de l'auteur",
+      "AuthorEnrichmentPause": "Suspendre l'enrichissement de l'auteur",
+      "AuthorEnrichmentResume": "Reprendre l'enrichissement de l'auteur",
+      "AuthorEnrichmentCancel": "Annuler l'enrichissement de l'auteur",
+      "EntityManagerMerge": "Fusionner des entités",
+      "EntityManagerRename": "Renommer l'entité",
+      "EntityManagerDelete": "Supprimer l'entité",
+      "EntityManagerSplit": "Diviser l'entité",
+      "EntityManagerDismiss": "Ignorer le doublon",
+      "EntityManagerUndismiss": "Restaurer le doublon rejeté",
+      "AppSettingsUpdate": "Mettre à jour les paramètres de l'application",
+      "KoboDeviceRegister": "Enregistrer l'appareil Kobo",
+      "KoboDeviceRename": "Renommer l'appareil Kobo",
+      "KoboDeviceRemove": "Supprimer l'appareil Kobo",
+      "EmailProviderCreate": "Créer un fournisseur de messagerie",
+      "EmailProviderUpdate": "Mettre à jour le fournisseur de messagerie",
+      "EmailProviderDelete": "Supprimer le fournisseur de messagerie",
+      "EmailProviderSetDefault": "Définir le fournisseur de messagerie par défaut",
+      "EmailProviderSetSystem": "Définir le fournisseur de messagerie du système",
+      "EmailProviderClearSystem": "Fournisseur de messagerie système clair",
+      "EmailTemplateCreate": "Créer un modèle d'e-mail",
+      "EmailTemplateUpdate": "Mettre à jour le modèle d'e-mail",
+      "EmailTemplateDelete": "Supprimer le modèle d'e-mail",
+      "EmailTemplateSetDefault": "Définir le modèle d'e-mail par défaut",
+      "EmailRecipientCreate": "Créer un destinataire de courrier électronique",
+      "EmailRecipientUpdate": "Mettre à jour le destinataire de l'e-mail",
+      "EmailRecipientDelete": "Supprimer le destinataire de l'e-mail",
+      "EmailRecipientGroupCreate": "Créer un groupe de destinataires",
+      "EmailRecipientGroupUpdate": "Mettre à jour le groupe de destinataires",
+      "EmailRecipientGroupDelete": "Supprimer le groupe de destinataires",
+      "EmailRecipientGroupMemberAdd": "Ajouter un destinataire au groupe",
+      "EmailRecipientGroupMemberRemove": "Supprimer le destinataire du groupe"
+    }
+  },
+  "auth": {
+    "backToSignIn": "Retour pour vous connecter",
+    "themePicker": {
+      "switchToLight": "Passer à la lumière",
+      "switchToDark": "Passer au noir",
+      "changeRadius": "Changer le rayon du coin",
+      "changeBackground": "Changer l'arrière-plan",
+      "changeAccent": "Changer la couleur des accents"
+    },
+    "fields": {
+      "username": "Nom d'utilisateur",
+      "password": "Mot de passe",
+      "email": "Courriel",
+      "emailAddress": "Adresse e-mail",
+      "fullName": "Nom complet",
+      "newPassword": "Nouveau mot de passe",
+      "confirmPassword": "Confirmer le mot de passe",
+      "confirmNewPassword": "Confirmer le nouveau mot de passe",
+      "currentPassword": "Mot de passe actuel",
+      "passwordHint": "Min. 8 caractères avec majuscules, minuscules et un chiffre"
+    },
+    "errors": {
+      "generic": "Quelque chose s'est mal passé. Veuillez réessayer.",
+      "passwordsDoNotMatch": "Les mots de passe ne correspondent pas"
+    },
+    "login": {
+      "subtitle": "Connectez-vous à votre compte",
+      "signIn": "Connectez-vous",
+      "signingIn": "Connexion...",
+      "orDivider": "ou",
+      "forgotPassword": "Mot de passe oublié ?",
+      "errors": {
+        "invalidCredentials": "Nom d'utilisateur ou mot de passe invalide",
+        "tooManyAttempts": "Trop de tentatives de connexion. Veuillez patienter une minute et réessayer."
+      }
+    },
+    "oidc": {
+      "loginFailed": "Échec de la connexion à OIDC",
+      "redirecting": "Redirection...",
+      "signInWith": "Connectez-vous avec {provider}",
+      "completingSignIn": "Connexion terminée...",
+      "tryAgain": "Réessayez",
+      "errors": {
+        "stateExpired": "Votre session de connexion a expiré. Veuillez réessayer de vous connecter.",
+        "tokenExchangeFailed": "Impossible de terminer la connexion avec votre fournisseur. Veuillez réessayer ou contacter votre administrateur.",
+        "userNotProvisioned": "Votre compte n'a pas été créé. Contactez votre administrateur pour y accéder.",
+        "userInactive": "Votre compte a été désactivé. Contactez votre administrateur.",
+        "providerError": "Votre fournisseur d'identité a renvoyé une erreur. Veuillez réessayer.",
+        "missingCodeOrState": "Code ou paramètre d'état manquant"
+      },
+      "providerErrors": {
+        "accessDenied": "L'accès a été refusé par le fournisseur d'identité.",
+        "loginRequired": "L'authentification est requise. Veuillez vous reconnecter.",
+        "interactionRequired": "Une interaction utilisateur supplémentaire est requise."
+      }
+    },
+    "forgotPassword": {
+      "subtitle": "Réinitialisez votre mot de passe",
+      "submitted": "Si un compte avec cette adresse e-mail existe, un lien de réinitialisation a été envoyé. Vérifiez votre boîte de réception.",
+      "sending": "Envoi...",
+      "sendResetLink": "Envoyer le lien de réinitialisation",
+      "errors": {
+        "emailUnavailable": "La réinitialisation du mot de passe par e-mail n'est pas disponible. Contactez votre administrateur."
+      }
+    },
+    "resetPassword": {
+      "subtitle": "Définir un nouveau mot de passe",
+      "saving": "Sauvegarde...",
+      "setNewPassword": "Définir un nouveau mot de passe",
+      "errors": {
+        "invalidLink": "Lien de réinitialisation invalide. Veuillez en demander un nouveau.",
+        "invalidOrExpired": "Lien de réinitialisation invalide ou expiré. Veuillez en demander un nouveau."
+      }
+    },
+    "setup": {
+      "title": "Configuration initiale",
+      "subtitle": "Créez le premier compte administrateur.",
+      "setupToken": "Jeton de configuration",
+      "setupTokenHint": "(obligatoire en production)",
+      "creatingAccount": "Création d'un compte...",
+      "createAccount": "Créer un compte administrateur",
+      "errors": {
+        "failed": "Échec de la configuration"
+      }
+    },
+    "changePassword": {
+      "title": "Changer le mot de passe",
+      "saving": "Sauvegarde…",
+      "forcedNotice": "Vous devez définir un nouveau mot de passe avant de continuer.",
+      "errors": {
+        "failed": "Échec de la modification du mot de passe"
+      }
+    },
+    "magicLink": {
+      "signingIn": "Vous connecter...",
+      "loginFailed": "La connexion a échoué",
+      "goToLogin": "Allez vous connecter",
+      "errors": {
+        "noToken": "Aucun jeton fourni"
+      }
+    }
+  },
+  "author": {
+    "card": {
+      "portraitAlt": "{name}portrait",
+      "viewDetails": "Afficher les détails de l'auteur",
+      "refreshMetadata": "Actualiser les métadonnées",
+      "deleteAuthor": "Supprimer l'auteur"
+    },
+    "listRow": {
+      "noRecentAdditions": "Aucun ajout récent",
+      "portraitAlt": "{name}portrait"
+    },
+    "filters": {
+      "title": "Filtres d'auteur",
+      "clearAll": "Tout effacer",
+      "allLibraries": "Toutes les bibliothèques",
+      "allAuthors": "Tous les auteurs",
+      "hasPhoto": "A une photo",
+      "missingPhoto": "Photo manquante",
+      "minBooks": "Min. livres",
+      "anyPlaceholder": "N'importe lequel"
+    },
+    "header": {
+      "never": "Jamais",
+      "portraitAlt": "{name}portrait",
+      "actions": "Actions",
+      "editAuthor": "Modifier l'auteur",
+      "mergeAuthors": "Fusionner les auteurs",
+      "refreshing": "Rafraîchissant...",
+      "refreshMetadata": "Actualiser les métadonnées",
+      "deleteAuthor": "Supprimer l'auteur",
+      "showLess": "Afficher moins",
+      "showMore": "Afficher plus",
+      "lookingUpMetadata": "Recherche des métadonnées de l'auteur...",
+      "noBiography": "Aucune biographie disponible. Utilisez le menu pour actualiser les métadonnées.",
+      "previewFrom": "Aperçu à partir de {provider}. Enregistrez les métadonnées pour les conserver.",
+      "booksLabel": "Livres",
+      "lastAdded": "Dernier ajout"
+    },
+    "list": {
+      "title": "Auteurs",
+      "showControlsAria": "Afficher les contrôles d'auteur",
+      "searchPlaceholder": "Rechercher des auteurs",
+      "sortButton": "Trier",
+      "sortBy": "Trier par",
+      "ascending": "Ascendant",
+      "descending": "Décroissant",
+      "asc": "Asc.",
+      "desc": "Description",
+      "filters": "Filtres",
+      "clear": "Effacer",
+      "allLoaded": "Tous les auteurs {total} chargés",
+      "sort": {
+        "name": "Nom",
+        "sortName": "Nom du tri",
+        "bookCount": "Nombre de livres",
+        "recentAdditions": "Ajouts récents",
+        "lastEnriched": "Dernier enrichi"
+      },
+      "empty": {
+        "title": "Aucun auteur trouvé",
+        "hint": "Essayez de modifier le texte de recherche, le tri ou le filtre de bibliothèque."
+      },
+      "deleteDialog": {
+        "titleOne": "Supprimer l'auteur ?",
+        "titleMany": "Supprimer {count} auteurs ?",
+        "descriptionOne": "Cela supprime l'auteur du catalogue et le dissocie des livres associés. Cette action ne peut pas être annulée.",
+        "descriptionMany": "Cela supprime les auteurs sélectionnés du catalogue et les dissocie des livres associés. Cette action ne peut pas être annulée."
+      },
+      "selection": {
+        "selectVisible": "Sélectionnez visible",
+        "refreshMetadata": "Actualiser les métadonnées",
+        "refreshingMetadata": "Actualisation des métadonnées...",
+        "deleteSelected": "Supprimer la sélection",
+        "deleting": "Suppression...",
+        "exitSelection": "Quitter la sélection",
+        "confirmDeleteCount": "{count, plural, =0 {Supprimer # auteur ?} one {Supprimer # auteur ?} other {Supprimer # des auteurs ?} many {Supprimer # des auteurs ?}}"
+      },
+      "toast": {
+        "refreshed": "Métadonnées de l'auteur actualisées",
+        "refreshedNoImage": "Métadonnées actualisées, mais aucune image d'auteur n'a été trouvée.",
+        "refreshFailed": "Échec de l'actualisation des métadonnées de l'auteur",
+        "bulkRefreshPartial": "Auteur(s) {updated} actualisé(s), {failed} a échoué",
+        "bulkRefreshSuccess": "Métadonnées actualisées pour {updated} auteur(s)",
+        "bulkRefreshFailed": "Échec de l'actualisation des auteurs sélectionnés",
+        "deleteSuccess": "{count, plural, =0 {# auteurs supprimés ; {books} livres concernés} one {# auteur supprimé ; {books} livres concernés} other {# auteurs supprimés ; {books} livres concernés} many {# auteurs supprimés ; {books} livres concernés}}",
+        "deleteFailed": "Échec de la suppression des auteurs"
+      }
+    },
+    "detail": {
+      "pageTitle": "Auteur",
+      "pageTitleNamed": "Auteur · {name}",
+      "pageTitleId": "Auteur #{id}",
+      "entityName": "Auteur",
+      "loadingAuthor": "Chargement de l'auteur...",
+      "previewError": "Impossible de charger les métadonnées d'aperçu de l'auteur externe pour le moment.",
+      "edit": {
+        "name": "Nom",
+        "sortName": "Nom du tri",
+        "description": "Descriptif",
+        "image": "Images",
+        "uploading": "Téléchargement...",
+        "replaceImage": "Remplacer l'image",
+        "uploadImage": "Télécharger une image",
+        "removing": "Suppression...",
+        "removeImage": "Supprimer l'image",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP jusqu'à {size} Mo",
+        "saving": "Sauvegarde..."
+      },
+      "merge": {
+        "searchPlaceholder": "Rechercher des auteurs pour fusionner avec cet auteur",
+        "searching": "Recherche...",
+        "bookCount": "{count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+        "selectedSummary": "Auteur(s) {count} sélectionné(s), env. {books} livres concernés.",
+        "merging": "Fusion...",
+        "mergeSelected": "Fusionner la sélection",
+        "confirmLabel": "Fusionner"
+      },
+      "mergeDialog": {
+        "title": "Fusionner {count} auteur(s) dans \"{name}\" ?",
+        "titleFallback": "Fusionner les auteurs sélectionnés ?",
+        "description": "Cela fusionnera les auteurs sélectionnés avec l'auteur actuel et reliera à nouveau les livres associés. Cette action ne peut pas être annulée.",
+        "descriptionEmpty": "Cette action ne peut pas être annulée."
+      },
+      "deleteDialog": {
+        "title": "Supprimer l'auteur ?",
+        "description": "Cela supprime l'auteur du catalogue et le dissocie des livres associés. Cette action ne peut pas être annulée."
+      },
+      "books": {
+        "heading": "Livres",
+        "allLibraries": "Toutes les bibliothèques",
+        "asc": "Asc.",
+        "desc": "Description",
+        "ascending": "Ascendant",
+        "descending": "Décroissant",
+        "allLoaded": "Tous les {total} livres chargés",
+        "sort": {
+          "recentlyAdded": "Récemment ajouté",
+          "title": "Titre",
+          "publishedYear": "Année de publication"
+        },
+        "empty": {
+          "title": "Aucun livre trouvé pour cet auteur",
+          "hint": "Essayez de modifier le tri/l'ordre ou de sélectionner une autre bibliothèque."
+        }
+      },
+      "toast": {
+        "refreshed": "Métadonnées de l'auteur actualisées",
+        "refreshedNoImage": "Métadonnées actualisées, mais aucune image d'auteur n'a été trouvée.",
+        "refreshFailed": "Échec de l'actualisation des métadonnées de l'auteur",
+        "nameRequired": "Le nom de l'auteur est obligatoire",
+        "updated": "Auteur mis à jour",
+        "updateFailed": "Échec de la mise à jour de l'auteur",
+        "imageUpdated": "Image de l'auteur mise à jour",
+        "imageUploadFailed": "Échec du téléchargement de l'image de l'auteur",
+        "imageRemoved": "Image de l'auteur supprimée",
+        "imageRemoveFailed": "Échec de la suppression de l'image de l'auteur",
+        "mergeSuccess": "Auteur(s) {count} fusionné ; {books} livres concernés",
+        "mergeFailed": "Échec de la fusion des auteurs",
+        "deleteSuccess": "Auteur supprimé ; {books} livres concernés",
+        "deleteFailed": "Échec de la suppression de l'auteur"
+      }
+    }
+  },
+  "book": {
+    "untitled": "Sans titre",
+    "unknownFormat": "inconnu",
+    "collapsedSeries": {
+      "label": "Série",
+      "bookCount": "{count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+      "readCount": "{count} lire"
+    },
+    "card": {
+      "missing": "Manquant"
+    },
+    "file": {
+      "primary": "Principal",
+      "audiobook": "Livre audio"
+    },
+    "actions": {
+      "read": "Marquer comme lu",
+      "listen": "Ecoute",
+      "peek": "Coup d'oeil",
+      "quickView": "Aperçu rapide",
+      "details": "Détails",
+      "bookDetails": "Détails du livre",
+      "download": "Télécharger",
+      "metadata": "Métadonnées",
+      "editMetadata": "Modifier les métadonnées",
+      "refreshMetadata": "Actualiser les métadonnées",
+      "regenerateCover": "Régénérer la couverture",
+      "addToCollection": "Ajouter à la collection",
+      "setStatus": "Définir le statut",
+      "sendViaEmail": "Envoyer par e-mail",
+      "rate": "Notez {star}",
+      "openAs": "Ouvrir en tant que {format}"
+    },
+    "readStatus": {
+      "unread": "Non lu",
+      "wantToRead": "Envie de lire",
+      "reading": "Lecture",
+      "onHold": "En attente",
+      "rereading": "Relecture",
+      "read": "Lu",
+      "skimmed": "Écrémé",
+      "abandoned": "Abandonné"
+    },
+    "download": {
+      "action": "Télécharger",
+      "audiobookZip": "Livre audio (ZIP)",
+      "allFormatsZip": "Tous formats (ZIP)",
+      "primaryOnlyZip": "Principal uniquement (ZIP)"
+    },
+    "sort": {
+      "moveUp": "Monter",
+      "moveDown": "Descendre",
+      "ascending": "Ascendant",
+      "descending": "Décroissant",
+      "remove": "Supprimer",
+      "emptyState": "Aucun tri configuré. Le titre ascendant sera utilisé.",
+      "addLevel": "Ajouter un niveau de tri"
+    },
+    "filter": {
+      "match": "Correspondance",
+      "all": "TOUS",
+      "any": "TOUT",
+      "ofFollowingRules": "des règles suivantes",
+      "anyProvider": "N'importe quel fournisseur",
+      "communityRatingProvider": "Fournisseur de notation communautaire",
+      "loadingLibraries": "Chargement des bibliothèques...",
+      "noLibrariesAvailable": "Aucune bibliothèque disponible",
+      "selectLibrary": "Sélectionnez la bibliothèque...",
+      "selectStatus": "Sélectionnez le statut...",
+      "withinLastPlaceholder": "par ex. 7",
+      "unit": {
+        "days": "jours",
+        "weeks": "semaines",
+        "months": "mois"
+      },
+      "scorePreset": {
+        "outstanding": "Excellent",
+        "good": "Bon",
+        "fair": "Moyen",
+        "poor": "Faible"
+      },
+      "scoreRangePlaceholder": "0-100",
+      "valuePlaceholder": "valeur",
+      "maxPlaceholder": "maximum",
+      "to": "à",
+      "group": "Groupe",
+      "addRule": "Ajouter une règle",
+      "addGroup": "Ajouter un groupe",
+      "typeToSearch": "Tapez pour rechercher..."
+    },
+    "deleteDialog": {
+      "title": "Supprimer le livre ?",
+      "description": "Cela supprimera définitivement le livre et toutes ses métadonnées, fichiers, progression de la lecture et signets. Cela ne peut pas être annulé."
+    },
+    "bulkEdit": {
+      "title": "{count, plural, =0 {Modifier les métadonnées - # livre} one {Modifier les métadonnées - # livre} other {Modifier les métadonnées - # livres} many {Modifier les métadonnées - # livres}}",
+      "instructions": "Basculez les champs à modifier, puis configurez les valeurs. Seuls les champs basculés seront modifiés.",
+      "invalidYear": "Entrez une année valide (chiffres uniquement)",
+      "clearWarning": "Cela supprimera tous les {field} des livres sélectionnés.",
+      "searchPlaceholder": "Rechercher {field}...",
+      "enterPlaceholder": "Saisissez {field}",
+      "yearPlaceholder": "par ex. 2024",
+      "leaveEmptyHint": "Laissez vide pour effacer ce champ sur tous les livres sélectionnés.",
+      "applying": "Candidature...",
+      "apply": "Appliquer",
+      "mode": {
+        "add": "Ajouter",
+        "remove": "Supprimer",
+        "replace": "Remplacer",
+        "clear": "Effacer"
+      }
+    },
+    "export": {
+      "title": "Exporter les métadonnées",
+      "scope": "Portée",
+      "selectedRows": "Lignes sélectionnées",
+      "currentlySelected": "{count} actuellement sélectionné",
+      "allMatchingRows": "Toutes les lignes correspondantes",
+      "rowsInResult": "{count} lignes dans le résultat actuel",
+      "format": "Formater",
+      "csvDescription": "Compatible avec les feuilles de calcul, nomenclature UTF-8 incluse",
+      "jsonDescription": "Exportation structurée avec contexte de métadonnées",
+      "columns": "Colonnes",
+      "canonicalSchema": "Schéma canonique stable",
+      "visibleColumns": "Colonnes actuellement visibles",
+      "options": "Possibilités",
+      "includePersonalData": "Inclure les données de lecture personnelles",
+      "includeFilePaths": "Inclure les chemins de fichiers (avancé)",
+      "includeContextMeta": "Inclure les métadonnées contextuelles",
+      "preflight": "Contrôle en amont",
+      "scopeLabel": "Portée : {summary}",
+      "calculatingSize": "Calcul de la taille des exportations...",
+      "estimatedSize": "Taille estimée :",
+      "fileLabel": "Fichier : {fileName}",
+      "exportAction": "Exporter",
+      "selectedRowsSummary": "{count, plural, =0 {# ligne sélectionnée} one {# ligne sélectionnée} other {# lignes sélectionnées} many {# lignes sélectionnées}}",
+      "matchingRowsSummary": "{count, plural, =0 {# ligne correspondante} one {# ligne correspondante} other {# lignes correspondantes} many {# lignes correspondantes}}",
+      "prepareFailed": "Échec de la préparation de l'exportation",
+      "exportStarted": "L'exportation des métadonnées a démarré : {fileName}",
+      "exportFailed": "Échec de l'exportation des métadonnées"
+    },
+    "columnPanel": {
+      "columnsHeading": "Colonnes",
+      "reset": "Réinitialiser",
+      "tableDensity": "Densité du tableau",
+      "density": {
+        "compact": "Compacte",
+        "comfortable": "Confortable",
+        "roomy": "Spacieux"
+      },
+      "presets": "Préréglages",
+      "exportBackup": "Exporter les préréglages et les vues enregistrées",
+      "importBackup": "Importer des préréglages et des vues enregistrées",
+      "rename": "Renommer",
+      "renamePrompt": "Entrez un nouveau nom",
+      "builtIn": "Intégré",
+      "saveCurrentPreset": "Enregistrer le préréglage actuel",
+      "savedViews": "Vues enregistrées",
+      "savedViewsEmpty": "Enregistrez les filtres de tri, de mise en page et spécifiques à la vue pour une réutilisation rapide.",
+      "saveCurrentView": "Enregistrer la vue actuelle",
+      "pinnedLeft": "Épinglé à gauche",
+      "pinnedRight": "Épinglé à droite",
+      "columns": {
+        "cover": "Couverture",
+        "read": "Lu",
+        "actions": "Actions"
+      }
+    },
+    "shortcuts": {
+      "title": "Raccourcis clavier",
+      "navigation": {
+        "title": "Navigation",
+        "moveFocusVertical": "Déplacer la mise au point vers le haut/bas",
+        "moveFocusHorizontal": "Déplacer le focus vers la gauche/droite",
+        "jumpFirstColumn": "Aller à la première colonne",
+        "jumpLastColumn": "Aller à la dernière colonne",
+        "jumpFirstRow": "Passer à la première ligne",
+        "jumpLastRow": "Aller à la dernière ligne"
+      },
+      "actions": {
+        "title": "Actions",
+        "editCell": "Modifier la cellule ciblée",
+        "cancelEditing": "Annuler l'édition / Fermer la superposition",
+        "toggleRowSelection": "Basculer la sélection de ligne",
+        "copyCell": "Copier la valeur de la cellule",
+        "copyRow": "Copier la ligne ciblée"
+      },
+      "general": {
+        "title": "Général",
+        "toggleHelp": "Activer cette superposition d'aide"
+      }
+    },
+    "jumpRail": {
+      "jumpToSection": "Aller à la section",
+      "jumpTo": "Aller à {label}",
+      "unknownDate": "Date inconnue",
+      "unknownValue": "Valeur inconnue"
+    },
+    "quickView": {
+      "title": "Aperçu rapide du livre",
+      "titleFor": "Aperçu rapide de {title}",
+      "description": "Prévisualisez les détails du livre et exécutez des actions rapides.",
+      "openIn": "Ouvrir dans {provider}",
+      "pages": "{count, plural, =0 {# page} one {# page} other {# pages} many {# pages}}",
+      "primaryFile": "Fichier principal",
+      "fileNumber": "Fichier n°{id}",
+      "showLess": "Afficher moins",
+      "showMore": "Afficher plus",
+      "collections": "Collections",
+      "noDescription": "Aucune description disponible.",
+      "openMetadataEditor": "Ouvrir l'éditeur de métadonnées",
+      "coverPreview": "Aperçu de la couverture du livre",
+      "coverPreviewFor": "Aperçu de la couverture {title}",
+      "coverPreviewDescription": "Boîte de dialogue d’aperçu de l’image de couverture agrandie."
+    },
+    "tableView": {
+      "openBookDetails": "Détails du livre ouvert",
+      "openSeries": "Série ouverte",
+      "metadataRefreshFailed": "Échec de l'actualisation des métadonnées",
+      "booksSelected": "{count, plural, =0 {# livre sélectionné} one {# livre sélectionné} other {# livres sélectionnés} many {# livres sélectionnés}}",
+      "loadingMoreBooks": "Charger plus de livres",
+      "sort": "Trier",
+      "refreshingMetadata": "Actualisation des métadonnées {processed} / {total}",
+      "failedCount": "{count} a échoué",
+      "remainingCount": "{count} restants",
+      "readOnlyNotice": "L'édition des tableaux est désactivée sur les écrans plus petits. Passez à la liste ou à la grille pour des actions plus rapides.",
+      "fetching": "Récupération...",
+      "updated": "Mis à jour",
+      "failed": "Échec",
+      "noBooks": "Aucun livre à afficher",
+      "scrollToTop": "Faire défiler vers le haut",
+      "selectedStatus": "{count} sélectionné",
+      "filtered": "Filtré",
+      "loadedStatus": "{loaded} sur {total} chargé",
+      "bookCount": "{count, plural, =0 {# livre} one {# livre} other {# livres} many {# livres}}",
+      "keyboardShortcutsTitle": "Raccourcis clavier (?)",
+      "showKeyboardShortcuts": "Afficher les raccourcis clavier du tableau",
+      "copyHint": "Copier la cellule : Ctrl/Cmd+C · Copier la ligne : Ctrl/Cmd+Shift+C"
+    },
+    "detail": {
+      "authorBooks": {
+        "alsoByAuthor": "Également de cet auteur",
+        "alsoByAuthors": "Également par ces auteurs"
+      },
+      "header": {
+        "previousBook": "Livre précédent",
+        "nextBook": "Livre suivant"
+      },
+      "tabs": {
+        "details": "Détails",
+        "editMetadata": "Modifier les métadonnées",
+        "files": "Fichiers",
+        "readingLog": "Journal de lecture",
+        "highlights": "Points forts"
+      },
+      "discover": {
+        "moreInSeries": "Plus en série",
+        "byAuthor": "Par auteur",
+        "similarBooks": "Livres similaires"
+      },
+      "recommended": {
+        "moreLikeThis": "Plus comme ça"
+      },
+      "series": {
+        "moreInSeries": "Plus dans la série {series}"
+      },
+      "writeRename": {
+        "written": "{count, plural, =0 {aucun champ n'est écrit} one {Écrit (un champ)} other {Écrit (# champs)} many {Écrit (# champs)}}",
+        "writeFailed": "Échec de l'écriture",
+        "skipped": "Sauté",
+        "renamedTo": "Renommé en {name}",
+        "fileRenamed": "Fichier renommé",
+        "renameFailed": "Échec du changement de nom",
+        "autoWriteAndRenameDisabled": "L'écriture automatique et le renommage sont désactivés dans les paramètres de la bibliothèque. Les modifications ne seront pas automatiquement synchronisées lors des prochaines sauvegardes.",
+        "autoWriteDisabled": "L'écriture automatique est désactivée dans les paramètres de la bibliothèque. Les modifications ne seront pas automatiquement synchronisées lors des prochaines sauvegardes.",
+        "autoRenameDisabled": "Le renommage automatique est désactivé dans les paramètres de la bibliothèque. Les modifications ne seront pas automatiquement synchronisées lors des prochaines sauvegardes.",
+        "writeLabel": "Écrivez :",
+        "renameLabel": "Renommer :"
+      },
+      "addFile": {
+        "uploading": "Téléchargement...",
+        "uploadComplete": "Téléchargement terminé",
+        "title": "Ajouter un fichier",
+        "dropzone": {
+          "title": "Déposez les fichiers ici ou cliquez pour parcourir",
+          "hint": "epub, pdf, mobi, cbz, m4b et plus - jusqu'à {size} Mo chacun"
+        },
+        "addMore": "Ajouter plus de fichiers",
+        "fileCount": "{count, plural, =0 {pas de fichiers} one {un fichier} other {# fichiers} many {# fichiers}}",
+        "clearAll": "Tout effacer",
+        "done": "Terminé",
+        "retry": "Réessayer",
+        "filesAdded": "{count, plural, =0 {aucun fichier ajouté} one {un fichier ajouté} other {# fichiers ajoutés} many {# fichiers ajoutés}}",
+        "uploadedFailed": "{done} téléchargé, {failed} a échoué",
+        "uploadingProgress": "{done} sur {total} en cours de téléchargement...",
+        "renameAfter": "Renommer tous les fichiers du livre après le téléchargement",
+        "uploadCount": "Télécharger ({count})",
+        "upload": "Télécharger"
+      },
+      "addSession": {
+        "errors": {
+          "invalidDate": "Choisissez une date et une heure valides.",
+          "future": "La session ne pourra pas démarrer dans le futur.",
+          "duration": "La durée doit être comprise entre 1 et 1 440 minutes.",
+          "endProgress": "La progression finale doit être comprise entre 0 et 100."
+        },
+        "title": "Ajouter une séance de lecture",
+        "startedAt": "Commencé à",
+        "duration": "Durée (minutes)",
+        "endProgress": "Fin de la progression %",
+        "optional": "Facultatif",
+        "format": "Formater",
+        "noFormat": "Pas de format spécifique",
+        "saving": "Sauvegarde...",
+        "submit": "Ajouter une séance"
+      },
+      "coverEditor": {
+        "unlockCover": "Déverrouiller le couvercle",
+        "lockCover": "Couvercle de serrure",
+        "fileTab": "Fichier",
+        "urlTab": "URL",
+        "chooseImage": "Choisissez une image...",
+        "findCoverOnline": "Trouver une couverture en ligne",
+        "saving": "Sauvegarde...",
+        "saveCover": "Enregistrer la couverture",
+        "revertToOriginal": "Revenir à l'original",
+        "regenerateCover": "Régénérer la couverture"
+      },
+      "coverSearch": {
+        "title": "Recherche en ligne",
+        "subtitle": "Rechercher des couvertures de livres",
+        "titleField": "Titre",
+        "authorField": "Auteur",
+        "sourceField": "Source",
+        "allSources": "Toutes les sources",
+        "audiobookCovers": "Couvertures de livres audio",
+        "squareHint": "(carré)",
+        "searching": "Recherche...",
+        "findCovers": "Trouver des couvertures",
+        "selectCover": "Sélectionnez la couverture",
+        "noResultsTitle": "Aucun résultat trouvé",
+        "noResultsHint": "Essayez d'ajuster vos termes de recherche",
+        "readyTitle": "Prêt à rechercher",
+        "readyHint": "Entrez un titre et un auteur ci-dessus",
+        "resolutionTip": "Astuce : les couvertures haute résolution sont marquées en vert"
+      },
+      "details": {
+        "by": "par",
+        "narratedBy": "raconté par",
+        "ratingLocked": "La note est verrouillée",
+        "rateStar": "Notez {star}",
+        "listen": "Ecoute",
+        "read": "Lu",
+        "chooseFormat": "Choisir le format",
+        "audiobook": "Livre audio",
+        "primary": "Principal",
+        "peek": "Coup d'oeil",
+        "sendViaEmail": "Envoyer par e-mail",
+        "personalReview": {
+          "title": "Examen personnel",
+          "toggleAria": "Activer l'avis personnel",
+          "editAria": "Modifier l'avis personnel",
+          "placeholder": "Revue privée",
+          "clearAria": "Avis personnel clair",
+          "cancelEditAria": "Annuler la modification de l'avis personnel"
+        },
+        "editCover": "Modifier la couverture",
+        "finished": "Terminé",
+        "resetFileProgress": "Réinitialiser la progression du fichier",
+        "resetting": "Réinitialisation...",
+        "resetProgressConfirm": "Réinitialiser la progression de lecture stockée pour {label} ?",
+        "moreCount": "+{count} plus",
+        "untitled": "Sans titre",
+        "metadataScore": "Score des métadonnées",
+        "primaryFormat": "Format principal",
+        "openIn": "Ouvrir dans {provider}",
+        "showLess": "Afficher moins",
+        "showMore": "Afficher plus",
+        "publisher": "Éditeur",
+        "published": "Publié",
+        "language": "Langue",
+        "pages": "Pages",
+        "duration": "Durée",
+        "edition": "Édition",
+        "abridged": "Abrégé",
+        "unabridged": "Version intégrale",
+        "isbn": "ISBN",
+        "fileSize": "Taille du fichier",
+        "library": "Bibliothèque",
+        "added": "Ajouté",
+        "dateStarted": "Date de début",
+        "saving": "Sauvegarde...",
+        "cancelDateStartedEdit": "Annuler la date de début de la modification",
+        "editDateStarted": "Date de début de modification",
+        "dateFinished": "Date de fin",
+        "cancelDateFinishedEdit": "Annuler la date de fin de la modification",
+        "editDateFinished": "Date de fin de modification",
+        "customMetadata": "Métadonnées personnalisées",
+        "synopsis": "Résumé",
+        "noDescription": "Aucune description disponible.",
+        "dateStartedFutureError": "La date de début ne peut pas être postérieure.",
+        "dateFinishedFutureError": "La date de fin ne peut pas être postérieure.",
+        "dateFinishedBeforeStartedError": "La date de fin doit être identique ou postérieure à la date de début.",
+        "saveReadingDatesError": "Échec de l'enregistrement des dates de lecture.",
+        "koboPendingDelete": "En attente de suppression de l'appareil",
+        "koboPendingDeleteTooltip": "Kobo le supprimera lors de la prochaine synchronisation.",
+        "koboRemovedByDevice": "Supprimé par appareil",
+        "koboRemovedByDeviceTooltip": "Kobo a signalé la suppression de ce livre.",
+        "koboNotSynced": "Non synchronisé",
+        "koboNotSyncedTooltip": "En file d'attente pour la prochaine synchronisation Kobo.",
+        "filesNotFound": "Fichiers introuvables",
+        "filesNotFoundDescription": "Le(s) fichier(s) de ce livre sont introuvables sur le disque. Les métadonnées sont toujours disponibles. Exécutez une analyse de la bibliothèque pour confirmer ou supprimer l'enregistrement."
+      },
+      "editMetadata": {
+        "fieldCount": "{count, plural, =0 {pas de champs} one {un champ} other {# champs} many {# champs}}",
+        "bookFilesTarget": "dossiers de livres",
+        "formatFilesTarget": "{formats} fichiers",
+        "noPrimaryFile": "Aucun fichier principal disponible",
+        "formatNotSupported": "Ce format de fichier ne prend pas en charge la réécriture",
+        "formatDisabled": "La réécriture est désactivée pour ce format",
+        "fileExceedsSizeLimit": "Ce fichier dépasse la taille limite de réécriture",
+        "writing": "Écrire...",
+        "saveInProgress": "Sauvegarde en cours",
+        "writeManualLibraryDisabled": "Écrivez les métadonnées dans un fichier et renommez-les sur le disque ; la réécriture automatique est désactivée pour cette bibliothèque",
+        "writeManualTooltip": "Écrivez {fields} dans {target} et renommez-le sur le disque",
+        "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "{count, plural, =0 {Aucun champ verrouillé ignoré} one {J'ai ignoré un champ verrouillé} other {Sauté # champs verrouillés} many {Sauté # champs verrouillés}}",
+        "updatedFields": "{count, plural, =0 {mis à jour aucun champ} one {mis à jour un champ} other {mis à jour # champs} many {mis à jour # champs}}",
+        "wroteFieldsToFile": "J'ai écrit {fields} dans le fichier",
+        "fileWriteFailedReason": "Échec de l'écriture du fichier : {reason}",
+        "fileWriteFailed": "Échec de l'écriture du fichier",
+        "fileWriteSkippedReason": "Écriture du fichier ignorée : {reason}",
+        "fileWriteSkipped": "Écriture du fichier ignorée",
+        "metadataSaved": "Métadonnées enregistrées",
+        "metadataWrittenToFile": "Métadonnées écrites dans un fichier",
+        "savedButWriteFailedReason": "Métadonnées enregistrées, mais l'écriture du fichier a échoué : {reason}",
+        "savedButWriteFailed": "Métadonnées enregistrées, mais l'écriture du fichier a échoué",
+        "savedWriteSkippedReason": "Métadonnées enregistrées, écriture du fichier ignorée : {reason}",
+        "savedWriteSkipped": "Métadonnées enregistrées, écriture du fichier ignorée",
+        "loadFromFileFailed": "Échec du chargement des métadonnées du fichier",
+        "loadedFieldsFromFile": "{count, plural, =0 {Aucun champ chargé à partir du fichier} one {Chargé un champ du fichier} other {Chargé # champs du fichier} many {Chargé # champs du fichier}}",
+        "noMetadataInFile": "Aucune métadonnée trouvée dans le fichier",
+        "loadFromFile": "Charger à partir d'un fichier",
+        "loadFromFileTooltip": "Charger les métadonnées du fichier de livre principal",
+        "writeToFile": "Écrire dans un fichier",
+        "autoFill": "Remplissage automatique",
+        "fetchingMetadata": "Récupération des métadonnées...",
+        "allFieldsLocked": "Tous les champs sont verrouillés",
+        "autoFillTooltip": "Remplissez automatiquement les champs en utilisant vos préférences de métadonnées",
+        "lockAll": "Verrouiller tout",
+        "lockAllTooltip": "Verrouiller tous les champs",
+        "unlockAll": "Débloquez tout",
+        "unlockAllTooltip": "Débloquez tous les champs",
+        "saving": "Sauvegarde...",
+        "fileWriteBackDetails": "Détails de réécriture du fichier",
+        "fileWriteBack": "Réécriture de fichier",
+        "enabled": "Activé",
+        "saveWritesMetadata": "\"Enregistrer\" écrit les métadonnées dans {target}",
+        "formats": "Formats",
+        "bookFiles": "Fichiers de livres",
+        "supportedFields": "Champs pris en charge",
+        "titleLabel": "Titre",
+        "subtitleLabel": "Sous-titre",
+        "authorsLabel": "Auteurs",
+        "narratorsLabel": "Narrateurs",
+        "genresLabel": "Genre",
+        "tagsLabel": "Balises",
+        "ratingLabel": "Note",
+        "rateStar": "Notez {star}",
+        "clear": "Effacer",
+        "communityRatingsLabel": "Évaluations de la communauté",
+        "noProviderRatings": "Aucune évaluation du fournisseur",
+        "seriesLabel": "Série",
+        "publisherLabel": "Éditeur",
+        "languageLabel": "Langue",
+        "yearLabel": "Année",
+        "pageCountLabel": "Nombre de pages",
+        "isbn13Label": "ISBN-13",
+        "isbn10Label": "ISBN-10",
+        "durationLabel": "Durée(s)",
+        "abridgedLabel": "Abrégé",
+        "providerIds": "ID de fournisseur",
+        "comicDetails": "Détails de la bande dessinée",
+        "comicIssueNumberLabel": "Numéro de problème",
+        "comicVolumeLabel": "Volume",
+        "comicStoryArcsLabel": "Arcs d'histoire",
+        "comicPencillersLabel": "Crayonneurs",
+        "comicInkersLabel": "Encreurs",
+        "comicColoristsLabel": "Coloristes",
+        "comicLetterersLabel": "Lettreurs",
+        "comicCoverArtistsLabel": "Artistes de couverture",
+        "comicCharactersLabel": "Personnages",
+        "comicTeamsLabel": "Équipes",
+        "comicLocationsLabel": "Emplacements",
+        "customMetadata": "Métadonnées personnalisées",
+        "descriptionLabel": "Descriptif",
+        "unlockField": "Débloquez {field}",
+        "lockField": "Verrouiller {field}",
+        "diffPanel": {
+          "untitled": "Sans titre",
+          "noFieldsSelected": "Aucun champ sélectionné",
+          "fieldsSelected": "{count, plural, =0 {aucun champ sélectionné} one {un champ sélectionné} other {# champs sélectionnés} many {# champs sélectionnés}}",
+          "results": "Résultats",
+          "providerMatches": "{provider} correspondances",
+          "selectedOf": "{selected} sélectionné sur {total}",
+          "yearUnknown": "Année inconnue",
+          "indexOf": "{index} sur {total}",
+          "switchedResult": "Résultat commuté. Les sélections précédentes de ce fournisseur ont été effacées.",
+          "selectFieldsToApply": "Sélectionnez les champs à appliquer",
+          "copyMissing": "Copie manquante",
+          "copyAll": "Copier tout",
+          "hideUnchanged": "Masquer inchangé",
+          "showUnchanged": "Afficher inchangé",
+          "current": "Actuel",
+          "noMetadata": "Aucune métadonnée disponible à partir de cette source.",
+          "noChangedFields": "Aucun champ modifié ou manquant. Utilisez Show inchangé pour tout inspecter.",
+          "applyToForm": "Postuler au formulaire"
+        },
+        "diff": {
+          "locked": "Verrouillé",
+          "previewAlt": "Aperçu",
+          "currentCoverAlt": "Couverture actuelle",
+          "newCoverAlt": "Nouvelle couverture",
+          "pickCoverFromProvider": "Choisir une couverture auprès d'un autre fournisseur",
+          "pickCoverSource": "Choisir la source de couverture",
+          "pickFromProvider": "Choisissez auprès d'un autre fournisseur",
+          "pickSource": "Choisir la source",
+          "empty": "vide",
+          "showLess": "Afficher moins",
+          "showMore": "Afficher plus",
+          "coverPreviewAlt": "Aperçu de la couverture"
+        },
+        "searchDrawer": {
+          "searchTitle": "Rechercher des métadonnées",
+          "compareTitle": "Comparer les métadonnées",
+          "searchSubtitle": "Trouvez le meilleur fournisseur pour ce livre.",
+          "compareSubtitle": "Examinez les différences et appliquez uniquement ce que vous voulez."
+        },
+        "searchPanel": {
+          "untitledQuery": "Requête sans titre",
+          "titlePlaceholder": "Titre",
+          "authorPlaceholder": "Auteur",
+          "isbnPlaceholder": "ISBN",
+          "searching": "Recherche...",
+          "activeQuery": "Requête active",
+          "searchScope": "Portée de la recherche",
+          "allEnabled": "Tout activé",
+          "all": "Tout",
+          "fieldRules": "Règles de terrain",
+          "custom": "Personnalisé",
+          "providerNotInFieldRules": "{provider} est activé mais pas dans les règles de champ",
+          "notInFieldRulesLabel": "Pas dans les règles de terrain :",
+          "notInFieldRulesText": "{providers}. Inclus dans la recherche manuelle avec Tous activés, mais non utilisé par la récupération automatique des métadonnées.",
+          "noResults": "Aucun résultat trouvé",
+          "noResultsHint": "Essayez d'ajuster le titre ou l'auteur",
+          "searchPrompt": "Recherchez ci-dessus, puis cliquez sur un résultat pour commencer à comparer les métadonnées."
+        },
+        "writeAndRename": "Écrire dans un fichier et renommer",
+        "writeAndRenameShort": "Écrire et renommer"
+      },
+      "files": {
+        "title": "Fichiers de livres",
+        "fileCount": "{count, plural, =0 {pas de fichiers} one {# fichier} other {# fichiers} many {# fichiers}}",
+        "synced": "Synchronisé {time}",
+        "sortAria": "Trier les fichiers",
+        "syncHistory": "Historique de synchronisation",
+        "metadataWriteBack": "Réécriture des métadonnées",
+        "relative": {
+          "seconds": "Il y a {value}s",
+          "minutes": "il y a {value} m",
+          "hours": "il y a {value}h",
+          "days": "Il y a {value}j"
+        },
+        "renameFailed": "Échec du renommage du fichier",
+        "deleteFailed": "Échec de la suppression du fichier",
+        "addFile": "Ajouter un fichier",
+        "lastSynced": "Dernière synchronisation : {time}",
+        "sort": {
+          "label": "Trier :",
+          "name": "Nom",
+          "format": "Formater",
+          "size": "Taille",
+          "date": "Date"
+        },
+        "hidePaths": "Masquer les chemins",
+        "showPaths": "Afficher les chemins",
+        "hideLog": "Masquer le journal",
+        "viewSyncLog": "Afficher le journal de synchronisation",
+        "noWriteHistory": "Pas encore d'écriture d'historique.",
+        "fieldsWritten": "{count, plural, =0 {pas de champs} one {un champ} other {# champs} many {# champs}}",
+        "track": "Suivre {number}",
+        "primary": "Principal",
+        "read": "Lu",
+        "play": "Jouer",
+        "peek": "Coup d'oeil",
+        "download": "Télécharger",
+        "moreActions": "Plus de propositions",
+        "rename": "Renommer",
+        "empty": {
+          "title": "Aucun fichier joint",
+          "description": "Ce livre n'a aucun fichier associé."
+        },
+        "renameModal": {
+          "title": "Renommer le fichier",
+          "description": "Renommez le fichier physique sur le disque.",
+          "placeholder": "Nouveau nom de fichier"
+        },
+        "saving": "Sauvegarde...",
+        "deleteModal": {
+          "title": "Supprimer le fichier ?",
+          "description": "Êtes-vous sûr de vouloir supprimer « {filename} » ? Cette action ne peut pas être annulée."
+        },
+        "deleting": "Suppression..."
+      },
+      "highlights": {
+        "note": {
+          "placeholder": "Ajouter une note...",
+          "saving": "Économiser"
+        },
+        "export": {
+          "trigger": "Exporter",
+          "plainText": "Texte brut",
+          "page": "Page d'exportation",
+          "selected": "Exporter la sélection"
+        },
+        "sort": {
+          "position": "Poste",
+          "newest": "Le plus récent en premier",
+          "oldest": "Le plus ancien en premier"
+        },
+        "summary": {
+          "highlights": "{count, plural, =0 {pas de faits saillants} one {un point culminant} other {# faits saillants} many {# faits saillants}}",
+          "notes": "{count, plural, =0 {pas de notes} one {une note} other {# remarques} many {# remarques}}",
+          "chapters": "{count, plural, =0 {pas de chapitres} one {un chapitre} other {# chapitres} many {# chapitres}}"
+        },
+        "filterByChapter": "Filtrer par chapitre",
+        "allChapters": "Tous les chapitres",
+        "untitled": "Sans titre",
+        "trash": "Corbeille",
+        "empty": {
+          "noMatch": "Aucun surlignage ne correspond à vos filtres.",
+          "resetFilters": "Réinitialiser les filtres",
+          "none": "Pas encore de faits saillants",
+          "hint": "Sélectionnez du texte pendant la lecture pour créer des surbrillances"
+        },
+        "uncategorized": "Non classé",
+        "paginationUnit": "faits saillants"
+      },
+      "readingLog": {
+        "moreActionsAria": "Plus d'actions de journal de lecture",
+        "export": {
+          "button": "Exporter"
+        },
+        "weekdays": {
+          "sun": "Soleil",
+          "mon": "lundi",
+          "tue": "mar.",
+          "wed": "mer",
+          "thu": "jeu.",
+          "fri": "vendredi",
+          "sat": "Samedi"
+        },
+        "months": {
+          "jan": "janvier",
+          "feb": "Février",
+          "mar": "mars",
+          "apr": "avril",
+          "may": "mai",
+          "jun": "juin",
+          "jul": "juillet",
+          "aug": "Août",
+          "sep": "septembre",
+          "oct": "octobre",
+          "nov": "novembre",
+          "dec": "décembre"
+        },
+        "heatmap": {
+          "minutesUnit": "min",
+          "title": "Activité",
+          "empty": "Aucune activité de lecture dans cette fenêtre.",
+          "emptyHint": "Les sessions enregistrées ici construiront votre vue de cohérence."
+        },
+        "hero": {
+          "summaryAria": "Résumé de lecture",
+          "notSet": "Non défini",
+          "relative": {
+            "seconds": "Il y a {count}s",
+            "minutes": "il y a {count} m",
+            "hours": "il y a {count}h",
+            "days": "Il y a {count}j",
+            "months": "{count, plural, =0 {# il y a un mois} one {# il y a un mois} other {# il y a des mois} many {# il y a des mois}}",
+            "years": "{count, plural, =0 {# il y a un an} one {# il y a un an} other {# il y a des années} many {# il y a des années}}"
+          },
+          "noSessions": "Aucune séance",
+          "dateErrors": {
+            "startFuture": "La date de début ne peut pas être postérieure.",
+            "finishFuture": "La date de fin ne peut pas être postérieure.",
+            "finishBeforeStart": "La date de fin doit être identique ou postérieure à la date de début.",
+            "saveFailed": "Échec de l'enregistrement des dates de lecture."
+          },
+          "eta": {
+            "max": "99h+ pour terminer",
+            "minutes": "~{m}m pour terminer",
+            "hours": "~{h}h pour terminer",
+            "hoursMinutes": "~{h}h {m}m pour terminer"
+          },
+          "momentum": {
+            "none": "Aucune activité au cours des deux dernières semaines",
+            "new": "Nouvelle activité cette semaine",
+            "up": "+{pct}% par rapport aux 7 jours précédents",
+            "down": "{pct}% par rapport aux 7 jours précédents",
+            "flat": "Inchangé par rapport aux 7 jours précédents"
+          },
+          "stats": {
+            "totalTime": "Durée totale",
+            "sessions": "Séances",
+            "avgSession": "Session moyenne",
+            "lastRead": "Dernière lecture"
+          },
+          "firstRead": "Première lecture",
+          "lastRead": "Dernière lecture",
+          "dateStarted": "Date de début",
+          "dateFinished": "Date de fin",
+          "addSession": "Ajouter une séance"
+        },
+        "journey": {
+          "tooltipProgress": "Progrès",
+          "tooltipReading": "Lecture",
+          "minutesUnit": "min",
+          "title": "Parcours de progrès",
+          "empty": "Aucune donnée de progression dans cette fenêtre.",
+          "emptyHint": "La progression apparaîtra après qu’une session ait enregistré une position de lecture."
+        },
+        "sourceSplit": {
+          "title": "Sources de lecture",
+          "shortTitle": "Sources"
+        },
+        "untitled": "Sans titre",
+        "addSessionFailed": "Échec de l'ajout d'une session",
+        "filters": {
+          "show": "Afficher",
+          "dateRangeAria": "Plage de dates de la session de lecture",
+          "allTime": "Tout le temps",
+          "last30": "30 derniers jours",
+          "last90": "90 derniers jours",
+          "thisYear": "Cette année",
+          "allFormats": "Tous les formats"
+        },
+        "table": {
+          "title": "Séances",
+          "sourceWeb": "Internet",
+          "sourceManual": "Manuel",
+          "colDate": "Date",
+          "colDateMobile": "Date",
+          "colDuration": "Durée",
+          "colDurationMobile": "Durée",
+          "colProgressChange": "Changement de progrès",
+          "colProgressChangeMobile": "Delta",
+          "colEndProgress": "Fin de la progression",
+          "colEndProgressMobile": "Fin",
+          "empty": "Aucune séance de lecture enregistrée pour le moment.",
+          "emptyHint": "Ajoutez une session pour commencer à créer l'historique de lecture de ce livre.",
+          "colPace": "Rythme",
+          "colSource": "Source",
+          "colFormatMobile": "Fmt",
+          "colFormat": "Formater",
+          "cancelDelete": "Annuler la suppression",
+          "cancelDeleteAria": "Annuler la suppression de la session",
+          "confirmDeleteTitle": "Cliquez à nouveau pour confirmer la suppression",
+          "confirmDeleteAria": "Confirmer la suppression de la session",
+          "deleteAria": "Supprimer la séance",
+          "loadMore": "Charger plus",
+          "showing": "Affichage de {shown} sessions sur {total}"
+        }
+      },
+      "richDescription": {
+        "linkProtocolError": "Utilisez http, https ou mailto.",
+        "bold": "Audacieux",
+        "italic": "Italique",
+        "underline": "Souligner",
+        "strikethrough": "Barré",
+        "bulletList": "Liste à puces",
+        "numberedList": "Liste numérotée",
+        "outdentAria": "Réduire le retrait de l'élément de liste",
+        "outdent": "Réduire le retrait",
+        "indentAria": "Élément de liste de retrait",
+        "indent": "Retrait",
+        "quote": "Citation",
+        "editLink": "Modifier le lien",
+        "link": "Lien",
+        "removeLink": "Supprimer le lien",
+        "undo": "Annuler",
+        "redo": "Refaire",
+        "clearFormatting": "Formatage clair",
+        "previewDescription": "Description de l'aperçu",
+        "preview": "Aperçu",
+        "linkUrlLabel": "URL du lien",
+        "applyLink": "Appliquer le lien",
+        "apply": "Appliquer",
+        "cancelLink": "Annuler le lien",
+        "noDescription": "Aucune description disponible."
+      },
+      "seriesMembership": {
+        "addSeries": "Ajouter une série",
+        "seriesPlaceholder": "Série",
+        "moveUp": "Monter",
+        "moveDown": "Descendre",
+        "removeSeries": "Supprimer la série"
+      }
+    },
+    "table": {
+      "actions": {
+        "quickView": "Aperçu rapide",
+        "bookDetails": "Détails du livre",
+        "editMetadata": "Modifier les métadonnées",
+        "refreshMetadata": "Actualiser les métadonnées",
+        "addToCollection": "Ajouter à la collection",
+        "sendToDevice": "Envoyer à l'appareil"
+      },
+      "boolean": {
+        "ariaNotSet": "Non défini - cliquez pour définir vrai",
+        "ariaTrue": "Vrai - cliquez pour définir faux",
+        "ariaFalse": "Faux - cliquez pour effacer"
+      },
+      "chips": {
+        "addPlaceholder": "Ajouter..."
+      },
+      "cover": {
+        "previewDescription": "Aperçu de la couverture du livre",
+        "editDescription": "Modifier la couverture du livre",
+        "editTitle": "Modifier la couverture",
+        "editCover": "Modifier la couverture",
+        "view": "Voir la couverture"
+      },
+      "date": {
+        "justNow": "juste maintenant"
+      },
+      "format": {
+        "unknown": "inconnu"
+      },
+      "header": {
+        "sortAscending": "Trier par ordre croissant",
+        "sortDescending": "Trier par ordre décroissant",
+        "clearSort": "Effacer le tri",
+        "hideColumn": "Masquer la colonne",
+        "pinLeft": "Épingle à gauche",
+        "pinRight": "Épingler à droite",
+        "unpinColumn": "Désépingler la colonne",
+        "autoFitWidth": "Largeur d'ajustement automatique",
+        "autoFitAllColumns": "Ajuster automatiquement toutes les colonnes",
+        "selectAllBooks": "Sélectionnez tous les livres",
+        "shiftClickSecondarySort": "Maj+clic pour ajouter un tri secondaire",
+        "clickToSort": "Cliquez pour trier"
+      },
+      "locks": {
+        "lockAll": "Verrouiller tous les champs",
+        "unlockAll": "Débloquez tous les champs",
+        "lockField": "Champ de verrouillage",
+        "unlockField": "Champ de déverrouillage",
+        "clickToLock": "Cliquez pour verrouiller",
+        "clickToUnlock": "Cliquez pour déverrouiller"
+      },
+      "progress": {
+        "complete": "{percent} terminé"
+      },
+      "rating": {
+        "label": "Note",
+        "remove": "Supprimer la note",
+        "rate": "Notez {star} sur 5"
+      },
+      "read": {
+        "play": "Jouer",
+        "read": "Lu",
+        "primary": "Principal",
+        "peekFormat": "Jetez un œil à {format}",
+        "chooseFormat": "Choisissez le format à lire ou à jouer",
+        "fileFallback": "FICHIER"
+      },
+      "readStatus": {
+        "unread": "Non lu"
+      },
+      "series": {
+        "bookCount": "{count, plural, =0 {(pas de livres)} one {(# livre)} other {(# livres)} many {(# livres)}}",
+        "readOfCount": "{read} sur {total} lu"
+      },
+      "text": {
+        "openDetails": "Ouvrir les détails"
+      }
+    }
+  },
+  "bookMetadataFetch": {
+    "book": {
+      "title": "Récupération de métadonnées"
+    },
+    "author": {
+      "title": "Enrichissement de l'auteur"
+    },
+    "stats": {
+      "queued": "En file d'attente",
+      "processing": "Traitement",
+      "rateLimited": "Tarif limité",
+      "failed": "Échec"
+    },
+    "actions": {
+      "pause": "Pause",
+      "resume": "Reprendre",
+      "cancelQueued": "Annuler la file d'attente",
+      "dismissBookStatus": "Ignorer l'état de récupération des métadonnées",
+      "dismissAuthorStatus": "Ignorer le statut d'enrichissement de l'auteur"
+    },
+    "cancel": {
+      "processingWillFinish": "Le traitement des éléments en cours sera terminé.",
+      "confirm": "Confirmer l'annulation",
+      "keepRunning": "Continuez à courir"
+    },
+    "viewFailed": "{count, plural, one {Afficher un échec} other {Voir # échoué} many {Voir # échoué}}",
+    "card": {
+      "fetchingMetadata": "Récupérer des métadonnées",
+      "enrichingAuthors": "Enrichir les auteurs",
+      "metadataFetchFinished": "Récupération des métadonnées terminée",
+      "authorEnrichmentFinished": "Enrichissement de l'auteur terminé"
+    },
+    "label": {
+      "paused": "En pause",
+      "remaining": "{count} restants",
+      "processing": "Traitement {count}",
+      "failed": "{count} a échoué",
+      "rateLimited": "{count} tarif limité"
+    },
+    "report": {
+      "bookTitle": "Échec de la récupération des métadonnées",
+      "authorTitle": "Enrichissements d'auteurs ayant échoué",
+      "noFailedItems": "Aucun élément échoué.",
+      "retryAllFailed": "Réessayer, tout a échoué",
+      "bookFallback": "Livre n°{id}",
+      "authorFallback": "Auteur #{id}",
+      "columns": {
+        "title": "Titre",
+        "library": "Bibliothèque",
+        "author": "Auteur",
+        "error": "Erreur",
+        "http": "HTTP"
+      }
+    },
+    "toast": {
+      "failedToPause": "Échec de la mise en pause",
+      "failedToResume": "Échec de la reprise",
+      "failedToCancel": "Échec de l'annulation",
+      "failedToRetry": "Échec de la nouvelle tentative",
+      "failedItemsRequeued": "Éléments en échec remis en file d'attente",
+      "bookComplete": "Récupération des métadonnées terminée – {done} livres mis à jour",
+      "bookDoneWithFailures": "Récupération des métadonnées terminée – {done} traité, {failed} a échoué",
+      "authorComplete": "Enrichissement des auteurs terminé – {done} auteurs mis à jour",
+      "authorDoneWithFailures": "Enrichissement de l'auteur effectué - {done} traité, {failed} a échoué"
+    }
+  },
+  "bookDock": {
+    "apply": "Appliquer",
+    "done": "Terminé",
+    "discard": "Jeter",
+    "finalize": "Finaliser",
+    "rescan": "Nouvelle analyse",
+    "uploadAction": "Télécharger",
+    "uploading": "Téléchargement...",
+    "searchPlaceholder": "Rechercher des fichiers...",
+    "setDestinationAction": "Définir la destination",
+    "bulkEditAction": "Modification groupée",
+    "applyFetched": "Appliquer récupéré",
+    "retryErrors": "Erreurs de nouvelle tentative",
+    "commaSeparated": "séparés par des virgules",
+    "destinationLibrary": "Bibliothèque de destinations",
+    "destinationFolder": "Dossier de destination",
+    "nFailed": "{count} a échoué",
+    "updatedOfFiles": "Mise à jour de {updated} sur {total} fichiers",
+    "errorStatus": "Erreur {status}",
+    "tab": {
+      "all": "Tout",
+      "pending": "En attente",
+      "ready": "Prêt",
+      "error": "Erreur"
+    },
+    "status": {
+      "pending": "En attente",
+      "extracting": "Extraction",
+      "fetching": "Récupération",
+      "ready": "Prêt",
+      "error": "Erreur"
+    },
+    "field": {
+      "title": "Titre",
+      "subtitle": "Sous-titre",
+      "authors": "Auteurs",
+      "authorsCommaSeparated": "Auteurs (séparés par des virgules)",
+      "publisher": "Éditeur",
+      "publishedDate": "Date de publication",
+      "year": "Année",
+      "language": "Langue",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "series": "Série",
+      "seriesIndex": "Numéro de série",
+      "genres": "Genre",
+      "genresCommaSeparated": "Genres (séparés par des virgules)",
+      "description": "Descriptif"
+    },
+    "upload": {
+      "nDone": "{count} terminé",
+      "nFailed": "{count} a échoué",
+      "nTotal": "{count} total"
+    },
+    "fileList": {
+      "emptyTitle": "Aucun fichier dans Book Dock",
+      "emptyMessageDefault": "Téléchargez des fichiers ou déposez-les dans le dossier Book Dock",
+      "colCurrent": "Actuel",
+      "colNew": "Nouveau",
+      "colFile": "Fichier",
+      "colSize": "Taille",
+      "colFormat": "Formater",
+      "colMatch": "Correspondance",
+      "colApply": "Appliquer",
+      "colStatus": "Statut",
+      "applyFetchedMetadata": "Appliquer les métadonnées récupérées",
+      "coverPreview": "Aperçu de la couverture",
+      "coverPreviewDescription": "Boîte de dialogue d’aperçu de l’image de couverture agrandie.",
+      "currentCoverAlt": "{title} couverture actuelle",
+      "newCoverAlt": "{title} nouvelle couverture",
+      "unknownLibrary": "Bibliothèque inconnue",
+      "unassigned": "Non attribué",
+      "targetPath": "Cible : {library} · {path}",
+      "targetUnassigned": "Cible : non attribué",
+      "targetUnknownPath": "Cible : {library} · Chemin de destination inconnu"
+    },
+    "sheet": {
+      "saved": "Enregistré",
+      "providerMetadataFound": "Métadonnées du fournisseur trouvées",
+      "providerMetadataFoundEdited": "Métadonnées du fournisseur trouvées : l'application groupée ignorera ce fichier (vous avez des modifications)",
+      "review": "Examen",
+      "added": "Ajout de {date}",
+      "searchMetadata": "Rechercher des métadonnées",
+      "results": "Résultats"
+    },
+    "bulkEdit": {
+      "title": "{count, plural, =0 {Modification groupée d'aucun fichier} one {Modification groupée # fichier} other {Modification groupée # fichiers} many {Modification groupée # fichiers}}",
+      "resultTitle": "Modification groupée des résultats",
+      "instructions": "Basculez les champs que vous souhaitez mettre à jour. Seuls les champs activés seront appliqués.",
+      "mergeArrays": "Fusionner les tableaux (ajouter aux valeurs existantes au lieu de remplacer)",
+      "failed": "Échec de la modification groupée"
+    },
+    "setDestination": {
+      "title": "{count, plural, =0 {Définir la destination pour aucun fichier} one {Définir la destination pour # fichier} other {Définir la destination pour # fichiers} many {Définir la destination pour # fichiers}}",
+      "resultTitle": "Destination mise à jour",
+      "failed": "Échec de la définition de la destination"
+    },
+    "finalizeDialog": {
+      "title": "{count, plural, =0 {Ne finaliser aucun fichier} one {Finaliser # fichier} other {Finaliser # fichiers} many {Finaliser # fichiers}}",
+      "resultTitle": "Finaliser les résultats",
+      "needDestination": "{count, plural, =0 {Sans destination : {without} sur # fichiers sélectionnés} one {Sans destination : {without} sur # fichier sélectionné} other {Sans destination : {without} sur # fichiers sélectionnés} many {Sans destination : {without} sur # fichiers sélectionnés}}",
+      "allHaveDestination": "Tous les fichiers sélectionnés ont déjà une destination définie",
+      "defaultDestinationLibrary": "Bibliothèque de destination par défaut",
+      "defaultDestinationFolder": "Dossier de destination par défaut",
+      "renamePreview": "Renommer l'aperçu",
+      "moreFiles": "+{count} fichiers supplémentaires",
+      "start": "Commencer",
+      "filesFinalized": "{succeeded} fichiers sur {total} finalisés",
+      "checking": "Vérification des fichiers sélectionnés...",
+      "readyCount": "{count, plural, =0 {aucun fichier n'est prêt} one {# fichier prêt} other {# fichiers prêts} many {# fichiers prêts}}",
+      "duplicateCount": "{count, plural, =0 {aucun déjà dans la bibliothèque} one {# déjà en bibliothèque} other {# déjà en bibliothèque} many {# déjà en bibliothèque}}",
+      "conflictCount": "{count, plural, =0 {aucun conflit de nom de fichier} one {# conflit de nom de fichier} other {# conflits de noms de fichiers} many {# conflits de noms de fichiers}}",
+      "missingDestinationCount": "{count, plural, =0 {aucune destination manquante} one {# destination manquante} other {# destinations manquantes} many {# destinations manquantes}}",
+      "blockedCount": "{count, plural, =0 {aucun fichier bloqué} one {# fichier bloqué} other {# fichiers bloqués} many {# fichiers bloqués}}",
+      "moreDuplicates": "+{count} plus déjà dans la bibliothèque",
+      "discardDuplicates": "Supprimer les doublons",
+      "failedCount": "{count, plural, =0 {aucun fichier n'a échoué} one {# le fichier a échoué} other {# les fichiers ont échoué} many {# les fichiers ont échoué}}",
+      "failedWithDuplicates": "{count, plural, =0 {{failed} échecs (# doublons)} one {{failed} échecs (# doublon)} other {{failed} échecs (# doublons)} many {{failed} échecs (# doublons)}}",
+      "view": "Voir",
+      "viewExisting": "Voir existant",
+      "hide": "Masquer",
+      "details": "Détails",
+      "alreadyExistsSaveAs": "Existe déjà - enregistrer sous :",
+      "renamePlaceholder": "par ex. {name} (2)",
+      "import": "Importer"
+    }
+  },
+  "collection": {
+    "dialog": {
+      "name": "Nom",
+      "icon": "Icône",
+      "iconPlaceholder": "Choisissez une icône...",
+      "nameRequired": "Le nom est requis",
+      "iconRequired": "Choisissez une icône",
+      "creating": "Création...",
+      "createFailed": "Échec de la création de la collection"
+    },
+    "createDialog": {
+      "title": "Nouvelle collection",
+      "namePlaceholder": "par ex. Favoris"
+    },
+    "editDialog": {
+      "title": "Modifier la collection",
+      "syncToKobo": "Synchroniser avec Kobo",
+      "syncToKoboHint": "Les livres de cette collection apparaîtront sur votre appareil Kobo",
+      "deleteCollection": "Supprimer la collection",
+      "confirmDelete": "Confirmer ?",
+      "deleting": "Suppression...",
+      "saving": "Sauvegarde...",
+      "deleted": "\"{name}\" supprimé",
+      "updateFailed": "Échec de la mise à jour de la collection",
+      "deleteFailed": "Échec de la suppression de la collection"
+    },
+    "addToSheet": {
+      "title": "Gérer les collections",
+      "selectedCount": "{count, plural, =0 {aucun livre sélectionné} one {un livre sélectionné} other {# livres sélectionnés} many {# livres sélectionnés}}",
+      "newCollection": "Nouvelle collection",
+      "namePlaceholder": "Nom de la collection",
+      "create": "Créer",
+      "collections": "Collections",
+      "empty": "Aucune collection pour l'instant. Créez-en un ci-dessus.",
+      "done": "Terminé",
+      "added": "Ajouté",
+      "allAdded": "Tous les {total} ajoutés",
+      "inCollection": "Dans cette collection",
+      "allInCollection": "Tous les {total} de cette collection",
+      "partialInCollection": "{partial} sur {total} dans cette collection",
+      "bookCount": "{count, plural, =0 {pas de livres} one {un livre} other {# livres} many {# livres}}",
+      "loadFailed": "Échec du chargement des collections",
+      "createdAndAdded": "{count, plural, =0 {Créé \"{name}\" et n'a ajouté aucun livre} one {Créé \"{name}\" et j'ai ajouté un livre} other {Créé \"{name}\" et ajouté # livres} many {Créé \"{name}\" et ajouté # livres}}",
+      "createdButAddFailed": "\"{name}\" a été créé, mais n'a pas réussi à ajouter des livres.",
+      "createFailed": "Échec de la création de la collection",
+      "addedNewWithExisting": "{count, plural, =0 {Ajout d'un nouveau livre à \"{name}\" ({alreadyHad} déjà là)} one {Ajout d'un nouveau livre à \"{name}\" ({alreadyHad} déjà là)} other {Ajouté # de nouveaux livres à \"{name}\" ({alreadyHad} déjà là)} many {Ajouté # de nouveaux livres à \"{name}\" ({alreadyHad} déjà là)}}",
+      "addedToCollection": "{count, plural, =0 {Aucun livre ajouté à \"{name}\"} one {Ajout d'un livre à \"{name}\"} other {Ajouté # des livres à \"{name}\"} many {Ajouté # des livres à \"{name}\"}}",
+      "addFailed": "Échec de l'ajout à la collection",
+      "removedFromCollection": "{count, plural, =0 {Aucun livre n'a été supprimé de \"{name}\"} one {Suppression d'un livre de \"{name}\"} other {Supprimé # livres de \"{name}\"} many {Supprimé # livres de \"{name}\"}}",
+      "removeFailed": "Échec de la suppression de la collection"
+    }
+  },
+  "components": {
+    "appHeader": {
+      "searchAllBooks": "Rechercher tous les livres...",
+      "searching": "Recherche...",
+      "noResults": "Aucun résultat",
+      "loadingMore": "Chargement plus...",
+      "loadMore": "Charger plus ({loaded}/{total})",
+      "allMatchesShown": "{count, plural, =0 {Tous les 1 matchs affichés} one {Tous les 1 matchs affichés} other {Tout # matchs montrés} many {Tout # matchs montrés}}",
+      "bookCount": "{count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+      "fileCount": "{count, plural, =0 {pas de fichiers} one {# fichier} other {# fichiers} many {# fichiers}}",
+      "uploadedToast": "{uploaded} téléchargé",
+      "uploadFailedToast": "Échec du téléchargement pour {failed}",
+      "uploadPartialToast": "{uploaded} téléchargé, {failed} a échoué",
+      "bookDock": "Book Dock",
+      "statistics": "Statistiques",
+      "achievements": "Réalisations",
+      "annotations": "Annotations",
+      "uploadBooks": "Télécharger des livres",
+      "appearance": "Apparence",
+      "theme": "Thème",
+      "accent": "Accent",
+      "radius": "Rayon",
+      "background": "Contexte",
+      "settings": "Paramètres",
+      "whatsNew": "Quoi de neuf",
+      "documentation": "Documentation",
+      "help": "Aide",
+      "starOnGithub": "Étoile sur GitHub",
+      "new": "Nouveau",
+      "newReleaseNotes": "Nouvelles notes de version disponibles",
+      "account": "Compte",
+      "changePassword": "Changer le mot de passe",
+      "signOut": "Se déconnecter",
+      "githubStar": {
+        "title": "Vous appréciez BookOrbit ?",
+        "body": "Si BookOrbit vous aide avec votre bibliothèque, pensez à mettre le projet en vedette sur GitHub. Cela aide davantage de personnes à découvrir l’application et prend en charge le développement continu.",
+        "cta": "Étoile BookOrbit sur GitHub"
+      }
+    },
+    "sidebar": {
+      "tagline": "Votre espace de lecture",
+      "dashboard": "Tableau de bord",
+      "authors": "Auteurs",
+      "series": "Série",
+      "tools": "Outils",
+      "libraries": "Bibliothèques",
+      "newLibrary": "Nouvelle bibliothèque",
+      "libraryScanning": "{name} - Numérisation {pct}%",
+      "scanProgress": "Livres {processed} / {total}",
+      "smartScopes": "Portées intelligentes",
+      "newSmartScope": "Nouvelle lunette intelligente",
+      "noSmartScopes": "Pas encore de lunettes intelligentes",
+      "collections": "Collections",
+      "newCollection": "Nouvelle collection",
+      "noCollections": "Aucune collection pour l'instant",
+      "latest": "Dernier {version}",
+      "newReleaseNotes": "Nouvelles notes de version disponibles",
+      "support": "Prise en charge de BookOrbit",
+      "supportShort": "Assistance",
+      "supportAria": "Soutenez BookOrbit sur Ko-fi",
+      "sectionHeader": {
+        "add": "Ajouter",
+        "reorder": "Réorganiser",
+        "doneReordering": "Réorganisation terminée"
+      }
+    },
+    "selectionActionBar": {
+      "setReadingStatus": "Définir le statut de lecture",
+      "setRating": "Définir la note",
+      "openMetadataEditor": "Ouvrir l'éditeur de métadonnées",
+      "editIndividually": "Modifier des livres individuellement",
+      "addToCollection": "Ajouter à la collection",
+      "removeFromCollection": "Supprimer de la collection",
+      "sendViaEmail": "Envoyer par email",
+      "downloadFilesZip": "Télécharger des fichiers au format ZIP",
+      "moreActions": "Plus de propositions",
+      "setField": "Définir le champ",
+      "refreshMetadata": "Actualiser les métadonnées",
+      "reExtractCover": "Réextraire la couverture",
+      "metadataLock": "Verrouillage des métadonnées",
+      "lockAll": "Verrouiller tout",
+      "unlockAll": "Débloquez tout",
+      "exportMetadata": "Exporter les métadonnées",
+      "deleteSelected": "Supprimer la sélection",
+      "exitSelection": "Quitter la sélection",
+      "downloadFilesZipLabel": "Téléchargez des fichiers au format ZIP :",
+      "primaryOnly": "Principal uniquement",
+      "allFormats": "Tous les formats",
+      "audioOnly": "Audio uniquement",
+      "setRatingLabel": "Définir la note :",
+      "clear": "Effacer",
+      "setFieldLabel": "Définir le champ :",
+      "apply": "Appliquer",
+      "fieldPlaceholder": "Laisser vide pour effacer",
+      "fieldPlaceholderArray": "Séparés par des virgules (laisser vide pour effacer)",
+      "deleteConfirm": "{count, plural, =0 {Supprimer # livre ?} one {Supprimer # livre ?} other {Supprimer # des livres ?} many {Supprimer # des livres ?}}",
+      "typeDelete": "Tapez SUPPRIMER"
+    },
+    "viewHeader": {
+      "select": "Sélectionnez",
+      "display": "Affichage",
+      "displayDescription": "Ajustez la taille de la couverture, l’espacement de la grille et affichez les options d’affichage.",
+      "columnVisibilityHint": "Utilisez le panneau de visibilité des colonnes dans l'en-tête du tableau pour afficher ou masquer les colonnes.",
+      "columnVisibilityMobileHint": "La visibilité des colonnes peut être gérée depuis l'en-tête du tableau.",
+      "searchPlaceholder": "Rechercher un titre, un auteur, une série, un narrateur...",
+      "mobileSearch": {
+        "description": "Recherchez des éléments par titre, auteur, série ou narrateur.",
+        "done": "Terminé"
+      },
+      "mobileMenu": {
+        "grid": "Grille",
+        "list": "Liste",
+        "select": "Sélectionnez",
+        "exitSelect": "Quitter Sélectionner"
+      },
+      "displayControls": {
+        "display": "Affichage",
+        "coverSize": "Taille de la couverture",
+        "gridGap": "Écart de grille",
+        "showJumpRails": "Afficher les rails de saut",
+        "columnsHint": "Utilisez le panneau de visibilité des colonnes dans l'en-tête du tableau pour afficher ou masquer les colonnes.",
+        "coverShape": "Forme de la couverture",
+        "circle": "Cercle",
+        "square": "Carré"
+      }
+    },
+    "iconPicker": {
+      "clearSelectionAria": "Effacer l'icône sélectionnée",
+      "searchLucide": "Rechercher des icônes Lucide...",
+      "searchCustom": "Rechercher des icônes personnalisées...",
+      "chooseIcon": "Choisissez une icône...",
+      "selectIcon": "Sélectionner l'icône",
+      "customTab": "Personnalisé",
+      "searching": "Recherche...",
+      "noIconsMatch": "Aucune icône ne correspond à \"{query}\"",
+      "typeToSearch": "Tapez pour rechercher toutes les icônes",
+      "noCustomIcons": "Aucune icône personnalisée téléchargée",
+      "noIconsAvailable": "Aucune icône disponible"
+    },
+    "entityNotFound": {
+      "title": "{entity} introuvable",
+      "description": "Ce {entity} n'existe pas ou a été supprimé.",
+      "goBack": "Retourner"
+    },
+    "themePicker": {
+      "light": "Lumière",
+      "dark": "Sombre",
+      "system": "Système"
+    },
+    "userAvatar": {
+      "profilePicture": "Photo de profil",
+      "profilePictureOf": "photo de profil {name}"
+    },
+    "ui": {
+      "sidebar": {
+        "title": "Barre latérale",
+        "mobileDescription": "Affiche la barre latérale mobile.",
+        "toggle": "Basculer la barre latérale"
+      },
+      "chipInput": {
+        "typeAndEnter": "Tapez et appuyez sur Entrée pour ajouter",
+        "pressEnter": "Appuyez sur Entrée pour ajouter"
+      }
+    }
+  },
+  "customIcons": {
+    "dialogTitle": "Télécharger des icônes personnalisées",
+    "dialogDescription": "Vérifiez les noms avant de les ajouter à votre bibliothèque.",
+    "readingFiles": "Lecture de fichiers...",
+    "dropPrompt": "Déposez les fichiers SVG ou cliquez pour parcourir",
+    "fileLimit": "Jusqu'à {max} fichiers, 128 Ko chacun",
+    "namePlaceholder": "Nom",
+    "nameRequired": "Le nom est requis",
+    "invalidSvg": "SVG invalide",
+    "invalidSvgFile": "Fichier SVG invalide",
+    "identicalTo": "Identique à \"{name}\"",
+    "uploadAnyway": "Télécharger quand même",
+    "skipThisOne": "Passer celui-ci",
+    "readyToUpload": "{count} prêt à être téléchargé",
+    "noIconsStaged": "Aucune icône n'a encore été mise en scène",
+    "uploading": "Téléchargement...",
+    "upload": "Télécharger",
+    "uploadCount": "Téléchargez {count}",
+    "onlySvgSupported": "Seuls les fichiers SVG sont pris en charge",
+    "maxStaged": "Vous pouvez créer jusqu'à {max} icônes à la fois.",
+    "onlyMoreCanStage": "{count, plural, =0 {Aucune autre icône ne peut être mise en scène} one {Seulement # plus d'icônes peuvent être mises en scène} other {Seulement # plus d'icônes peuvent être mises en scène} many {Seulement # plus d'icônes peuvent être mises en scène}}",
+    "readFailed": "Échec de la lecture des fichiers SVG",
+    "uploadedCount": "{count, plural, =0 {Aucune icône téléchargée} one {Téléchargé # icône} other {Téléchargé # icônes} many {Téléchargé # icônes}}",
+    "uploadedPartial": "{created} téléchargé, {failed} a échoué",
+    "noIconsUploaded": "Aucune icône téléchargée",
+    "uploadFailed": "Échec du téléchargement des icônes",
+    "uploadFailedEntry": "Échec du téléchargement"
+  },
+  "dashboard": {
+    "common": {
+      "failedToLoad": "Échec du chargement",
+      "retry": "Réessayer",
+      "untitled": "Sans titre",
+      "cover": "Couverture",
+      "bookCover": "Couverture du livre"
+    },
+    "scroller": {
+      "failedToLoad": "Échec du chargement.",
+      "empty": {
+        "continueReading": "Aucun livre en cours pour le moment. Commencez à en lire un pour le voir ici.",
+        "continueListening": "Aucun livre audio en cours pour le moment. Commencez à en écouter un pour le voir ici.",
+        "wantToRead": "Aucun livre marqué « Je veux lire » pour l'instant.",
+        "upNextInSeries": "Pas encore de choix pour la prochaine série. Terminez un volume pour faire surface le suivant.",
+        "recentlyAdded": "Aucun livre dans votre bibliothèque pour l'instant.",
+        "smartScope": "Aucun livre ne correspond à ce smartScope.",
+        "default": "Aucun livre trouvé."
+      }
+    },
+    "settings": {
+      "title": "Personnaliser le tableau de bord",
+      "tabs": {
+        "widgets": "Widgets",
+        "shelves": "Étagères"
+      },
+      "reorderHintWidget": "Faites glisser pour réorganiser. Basculez pour afficher ou masquer un widget.",
+      "reorderHintShelf": "Faites glisser pour réorganiser. Basculez pour afficher ou masquer une étagère.",
+      "smartScope": "Portée intelligente",
+      "noSmartScopes": "Pas encore de lunettes intelligentes. Créez-en un à partir de la barre latérale.",
+      "addShelf": "Ajouter une étagère",
+      "resetToDefaults": "Réinitialiser aux valeurs par défaut"
+    },
+    "welcome": {
+      "emptyTitle": "Votre bibliothèque est vide",
+      "noLibrariesTitle": "Pas encore de bibliothèques",
+      "emptyDescription": "Créez une bibliothèque pour commencer à organiser et à lire vos livres. Pointez-le vers un dossier et il fera le reste.",
+      "noLibrariesDescription": "Votre administrateur n'a pas encore configuré de bibliothèques. Contactez-les pour commencer.",
+      "createFirstLibrary": "Créez votre première bibliothèque"
+    },
+    "widgets": {
+      "currentlyReading": {
+        "title": "Lecture en cours",
+        "empty": "Aucun livre en cours. Commencez à en lire un pour le voir ici.",
+        "continueReading": "Continuer la lecture"
+      },
+      "diversityScore": {
+        "title": "Score de diversité",
+        "notEnoughData": "Lisez au moins 3 livres pour voir votre score de diversité",
+        "booksAnalyzed": "{count, plural, =0 {aucun livre analysé} one {# livre analysé} other {# livres analysés} many {# livres analysés}}",
+        "subScores": {
+          "genre": "Genre",
+          "author": "Auteur",
+          "era": "Ère",
+          "language": "Lang"
+        }
+      },
+      "highlightOfTheDay": {
+        "title": "Le moment fort de la journée",
+        "empty": "Surlignez des passages pendant la lecture pour les voir ici"
+      },
+      "libraryOverview": {
+        "title": "Présentation de la bibliothèque",
+        "empty": "Votre bibliothèque est vide. Ajoutez quelques livres pour commencer.",
+        "addedThisYear": "+{count} ajouté cette année",
+        "stats": {
+          "books": "Livres",
+          "authors": "Auteurs",
+          "series": "Série",
+          "storage": "Stockage"
+        }
+      },
+      "longWait": {
+        "title": "La longue attente",
+        "empty": "Pas de livres en attente. Vous avez tout commencé !",
+        "daysWaiting": "jours d'attente",
+        "pages": "{count, plural, =0 {pas de page} one {# page} other {# pages} many {# pages}}",
+        "startReading": "Commencer la lecture"
+      },
+      "monthlyChallenge": {
+        "title": "Défi mensuel",
+        "complete": "Terminé !"
+      },
+      "neglectedGems": {
+        "title": "Joyaux négligés",
+        "empty": "Tous vos livres les mieux notés ont été lus !",
+        "rating": "{rating}/5",
+        "daysWaiting": "{count}d en attente",
+        "queued": "En file d'attente",
+        "addToQueue": "Ajouter à la file d'attente",
+        "shuffle": "Mélanger"
+      },
+      "readingDna": {
+        "title": "Lire l'ADN",
+        "notEnoughData": "Lisez au moins 5 livres pour débloquer votre ADN de lecture",
+        "basedOn": "{count, plural, =0 {Basé sur aucun livre} one {Basé sur # livre} other {Basé sur # livres} many {Basé sur # livres}}",
+        "traits": {
+          "length": "Longueur",
+          "variety": "Variété",
+          "rhythm": "Rythme",
+          "time": "Temps",
+          "speed": "Vitesse"
+        }
+      },
+      "readingGoal": {
+        "title": "Objectif de lecture {year}",
+        "setGoalPrompt": "Fixez-vous un objectif de lecture pour suivre vos progrès",
+        "setGoal": "Fixer un objectif",
+        "booksPerYear": "Livres par an",
+        "ofGoal": "de {goal}",
+        "percentComplete": "{percentage}% terminé",
+        "editGoal": "Modifier l'objectif"
+      },
+      "readingRhythm": {
+        "title": "Rythme de lecture",
+        "empty": "Commencez à lire pour voir votre rythme prendre forme",
+        "activeDays": "{count, plural, =0 {pas de jours actifs} one {# journée active} other {# jours actifs} many {# jours actifs}}",
+        "consistency": "{activeDays} · {percent} % de cohérence",
+        "avgPerDay": "moyenne de {time}/jour"
+      },
+      "readingStreak": {
+        "title": "Série de lecture",
+        "empty": "Lisez aujourd'hui pour commencer votre séquence",
+        "streakLabel": "{count, plural, =0 {séquence d'une journée} one {séquence d'une journée} other {jours consécutifs} many {jours consécutifs}}",
+        "best": "{count, plural, =0 {Meilleur : # jour} one {Meilleur : # jour} other {Meilleur : # jours} many {Meilleur : # jours}}",
+        "lastSevenDays": "7 derniers jours"
+      },
+      "yearProjection": {
+        "title": "Année projetée",
+        "books": "livres",
+        "trendUp": "Tendance à la hausse",
+        "trendDown": "Tendance à la baisse",
+        "trendSteady": "Un rythme soutenu",
+        "pages": "pages",
+        "hours": "heures",
+        "readCount": "{count} lire",
+        "daysLeft": "{count}j restant"
+      }
+    }
+  },
+  "email": {
+    "title": "Courriel",
+    "subtitle": "Envoyez des livres à votre liseuse par e-mail.",
+    "loadFailed": "Échec du chargement",
+    "saveFailed": "Échec de l'enregistrement",
+    "deleteFailed": "Échec de la suppression",
+    "setDefaultFailed": "Échec de la définition par défaut",
+    "setAsDefault": "Définir par défaut",
+    "saving": "Sauvegarde...",
+    "update": "Mise à jour",
+    "create": "Créer",
+    "deleteConfirm": "Supprimez \"{name}\". Cette action ne peut pas être annulée.",
+    "badge": {
+      "default": "Par défaut",
+      "shared": "Partagé",
+      "system": "Système"
+    },
+    "tabs": {
+      "providers": "Fournisseurs",
+      "recipients": "Destinataires",
+      "groups": "Groupes",
+      "templates": "Modèles",
+      "preferences": "Préférences",
+      "history": "Histoire"
+    },
+    "providers": {
+      "heading": "Fournisseurs SMTP",
+      "add": "Ajouter un fournisseur",
+      "newTitle": "Nouveau fournisseur",
+      "editTitle": "Modifier le fournisseur",
+      "name": "Nom",
+      "namePlaceholder": "par ex. Gmail",
+      "host": "Hôte",
+      "port": "Port",
+      "username": "Nom d'utilisateur",
+      "password": "Mot de passe",
+      "passwordEdit": "Mot de passe (laissez vide pour rester à jour)",
+      "fromName": "Du nom",
+      "fromNamePlaceholder": "Ma bibliothèque",
+      "fromAddress": "De l'adresse",
+      "authentication": "Authentification",
+      "verifyTls": "Vérifier le certificat TLS",
+      "tlsWarning": "La vérification TLS est désactivée. Le certificat du serveur ne sera pas validé - à utiliser uniquement pour les serveurs internes de confiance.",
+      "noFromAddress": "non de l'adresse",
+      "emptyManage": "Aucun fournisseur pour l'instant. Ajoutez un fournisseur SMTP pour commencer à envoyer des e-mails.",
+      "emptyReadonly": "Aucun fournisseur disponible. Demandez à un administrateur d'en ajouter un.",
+      "setSystemTooltip": "Définir comme fournisseur de messagerie système",
+      "removeSystemTooltip": "Supprimer en tant que fournisseur de messagerie système",
+      "testTooltip": "Tester la connexion",
+      "toggleSharing": "Activer le partage",
+      "removeSystemBeforeDelete": "Supprimez la désignation du système avant de supprimer",
+      "notesHeading": "Notes du fournisseur",
+      "notesBody": "Le fournisseur {system} (superutilisateur uniquement) est utilisé pour les e-mails de réinitialisation de mot de passe. Le fournisseur {defaultProvider} est utilisé lors de l'envoi de livres sans fournisseur explicite sélectionné. Les fournisseurs marqués {shared} sont disponibles pour tous les utilisateurs.",
+      "deleteTitle": "Supprimer le fournisseur ?",
+      "nameHostRequired": "Le nom et l'hôte sont requis",
+      "created": "Fournisseur créé",
+      "updated": "Fournisseur mis à jour",
+      "deleted": "\"{name}\" supprimé",
+      "setDefaultSuccess": "\"{name}\" défini par défaut",
+      "unshared": "Fournisseur non partagé",
+      "sharedWithAll": "Fournisseur partagé avec tous les utilisateurs",
+      "updateSharingFailed": "Échec de la mise à jour du partage",
+      "systemRemoved": "\"{name}\" supprimé en tant que fournisseur de messagerie système",
+      "systemSet": "\"{name}\" défini comme fournisseur de messagerie système",
+      "updateSystemFailed": "Échec de la mise à jour du fournisseur système",
+      "connectionSuccess": "Connexion réussie",
+      "connectionFailed": "La connexion a échoué",
+      "testFailed": "Le test a échoué"
+    },
+    "recipients": {
+      "heading": "Destinataires",
+      "add": "Ajouter un destinataire",
+      "newTitle": "Nouveau destinataire",
+      "editTitle": "Modifier le destinataire",
+      "name": "Nom",
+      "namePlaceholder": "Mon Kindle",
+      "emailAddress": "Adresse e-mail",
+      "deviceType": "Type d'appareil",
+      "deviceNone": "Aucun",
+      "deviceOther": "Autre",
+      "preferredFormat": "Format préféré",
+      "formatAuto": "Automatique",
+      "defaultTemplate": "Modèle par défaut",
+      "useAccountDefault": "Utiliser le compte par défaut",
+      "kindleNote": "Les destinataires Kindle reçoivent automatiquement les e-mails avec le sujet « convertir » pour déclencher la conversion du format.",
+      "empty": "Aucun destinataire pour l'instant.",
+      "prefersFormat": "préfère {format}",
+      "deleteTitle": "Supprimer le destinataire ?",
+      "nameEmailRequired": "Le nom et l'e-mail sont requis",
+      "created": "Destinataire créé",
+      "updated": "Destinataire mis à jour",
+      "deleted": "\"{name}\" supprimé",
+      "setDefaultSuccess": "\"{name}\" défini par défaut"
+    },
+    "groups": {
+      "heading": "Groupes de destinataires",
+      "create": "Créer un groupe",
+      "newTitle": "Nouveau groupe",
+      "name": "Nom du groupe",
+      "namePlaceholder": "par ex. Club de lecture",
+      "creating": "Création...",
+      "empty": "Aucun groupe pour l'instant. Créez un groupe à envoyer à plusieurs destinataires à la fois.",
+      "memberCount": "{count, plural, =0 {aucun membre} one {un membre} other {# membres} many {# membres}}",
+      "deleteTooltip": "Supprimer le groupe",
+      "noMembers": "Aucun membre pour l'instant.",
+      "removeMember": "Supprimer",
+      "selectRecipient": "Sélectionnez le destinataire...",
+      "add": "Ajouter",
+      "addMember": "Ajouter un membre",
+      "allRecipientsInGroup": "Tous les destinataires sont déjà dans ce groupe.",
+      "deleteTitle": "Supprimer le groupe ?",
+      "created": "Groupe créé",
+      "createFailed": "Échec de la création du groupe",
+      "deleted": "\"{name}\" supprimé",
+      "memberAdded": "Membre ajouté",
+      "addMemberFailed": "Échec de l'ajout d'un membre",
+      "memberRemoved": "Membre supprimé",
+      "removeMemberFailed": "Échec de la suppression du membre"
+    },
+    "templates": {
+      "heading": "Modèles d'e-mails",
+      "new": "Nouveau modèle",
+      "newTitle": "Nouveau modèle",
+      "editTitle": "Modifier le modèle",
+      "name": "Nom",
+      "namePlaceholder": "Par défaut",
+      "subject": "Sujet",
+      "body": "Corps",
+      "availableVariables": "Variables disponibles",
+      "editTemplate": "Modifier le modèle",
+      "empty": "Aucun modèle pour l'instant.",
+      "notesHeading": "Remarques sur le modèle",
+      "notesBody": "Les modèles système ne peuvent pas être supprimés. Les administrateurs peuvent les modifier. Utilisez des variables telles que {variable} dans les sujets et les corps - elles sont remplacées par les détails du livre au moment de l'envoi.",
+      "deleteTitle": "Supprimer le modèle ?",
+      "nameSubjectRequired": "Le nom et le sujet sont obligatoires",
+      "created": "Modèle créé",
+      "updated": "Modèle mis à jour",
+      "deleted": "\"{name}\" supprimé",
+      "setDefaultSuccess": "\"{name}\" défini par défaut"
+    },
+    "preferences": {
+      "heading": "Préférences de courrier électronique",
+      "defaultProvider": "Fournisseur par défaut",
+      "defaultProviderHint": "Utilisé lorsqu'aucun fournisseur n'est spécifié. S'il est vide, la valeur par défaut du compte est utilisée.",
+      "noneAccountDefault": "Aucun (utiliser le compte par défaut)",
+      "defaultRecipient": "Destinataire par défaut",
+      "defaultRecipientHint": "Utilisé pour un envoi rapide. Doit être configuré pour utiliser l’action d’envoi rapide sur les fiches de livre.",
+      "none": "Aucun",
+      "defaultTemplate": "Modèle par défaut",
+      "defaultTemplateHint": "Utilisé lorsqu'aucun modèle n'est spécifié. Revient à la valeur par défaut du système s'il est vide.",
+      "noneSystemDefault": "Aucun (utiliser les valeurs par défaut du système)",
+      "save": "Enregistrer les préférences",
+      "saved": "Préférences enregistrées"
+    },
+    "history": {
+      "heading": "Envoyer l'historique",
+      "empty": "Aucun e-mail envoyé pour l'instant.",
+      "noSubject": "(pas de sujet)",
+      "loadMore": "Charger plus",
+      "resend": "Renvoyer",
+      "deleteTitle": "Supprimer l'entrée de l'historique ?",
+      "entryDeleted": "Entrée supprimée",
+      "queuedForResend": "En file d'attente pour renvoi",
+      "resendFailed": "Échec du renvoi",
+      "statusSent": "Envoyé",
+      "statusFailed": "Échec",
+      "statusQueued": "En file d'attente",
+      "statusPending": "En attente"
+    },
+    "send": {
+      "title": "Envoyer par e-mail",
+      "bookCount": "{count, plural, =0 {pas de livres} one {un livre} other {# livres} many {# livres}}",
+      "recipients": "Destinataires",
+      "noRecipients": "Aucun destinataire configuré. Ajoutez-en un dans les paramètres de messagerie.",
+      "groups": "Groupes",
+      "options": "Possibilités",
+      "fileFormat": "Format de fichier",
+      "autoRecipientPreference": "Auto (utiliser les préférences du destinataire)",
+      "unknownFormat": "Inconnu",
+      "primarySuffix": "(principal)",
+      "provider": "Fournisseur",
+      "template": "Modèle",
+      "default": "Par défaut",
+      "send": "Envoyer",
+      "sending": "Envoi...",
+      "queued": "{count, plural, =0 {aucun e-mail en file d'attente} one {un e-mail en file d'attente} other {# emails en file d'attente} many {# emails en file d'attente}}",
+      "failed": "Échec de l'envoi"
+    }
+  },
+  "hardcover": {
+    "settings": {
+      "subtitle": "Synchronisez votre progression de lecture, votre statut et vos notes avec Hardcover."
+    },
+    "bookSync": {
+      "label": "Hardcover Synchronisation",
+      "toggleAriaLabel": "Synchronisez ce livre avec Hardcover",
+      "syncNow": "Synchronisez maintenant"
+    },
+    "connection": {
+      "title": "Connexion",
+      "description": "Connectez votre compte Hardcover pour synchroniser les données de lecture.",
+      "connected": "Connecté",
+      "apiToken": "Jeton API",
+      "tokenPlaceholder": "Collez votre jeton Hardcover API",
+      "show": "Afficher",
+      "hide": "Masquer",
+      "findTokenAt": "Trouvez votre jeton sur",
+      "validateToken": "Valider le jeton",
+      "valid": "Valide ({username})",
+      "invalidToken": "Jeton invalide",
+      "syncOptions": "Options de synchronisation",
+      "syncInfo": "La synchronisation s'exécute uniquement pour les livres qui ne sont pas non lus. Cela s’applique aux déclencheurs de statut, de progression et de notation. Ces commutateurs contrôlent le moment où une synchronisation s'exécute.",
+      "syncScope": {
+        "title": "Portée de la synchronisation des livres",
+        "allEligible": {
+          "label": "Tous les livres éligibles",
+          "description": "Synchronisez tout sauf si vous excluez un livre."
+        },
+        "selectedOnly": {
+          "label": "Livres sélectionnés uniquement",
+          "description": "Synchronisez uniquement les livres que vous incluez explicitement."
+        }
+      },
+      "enableSync": {
+        "title": "Activer la synchronisation",
+        "description": "Suspendez toutes les synchronisations Hardcover sans vous déconnecter."
+      },
+      "syncOnStatus": {
+        "title": "Synchronisation lors du changement de statut",
+        "description": "Envoyez des mises à jour lorsque vous marquez un livre comme lu, lu, etc."
+      },
+      "syncOnProgress": {
+        "title": "Synchronisation lors de la mise à jour de la progression",
+        "description": "Poussez la progression de la lecture et les dates auxquelles la progression de BookOrbit ou KOReader change."
+      },
+      "syncOnRating": {
+        "title": "Synchronisation lors du changement de note",
+        "description": "Augmentez votre nombre d'étoiles à Hardcover."
+      },
+      "privacy": {
+        "title": "Confidentialité",
+        "description": "Visibilité par défaut des livres synchronisés sur Hardcover.",
+        "public": "Publique",
+        "followersOnly": "Abonnés uniquement",
+        "private": "Privé"
+      },
+      "disconnect": "Déconnecter",
+      "toast": {
+        "enterToken": "Entrez d'abord votre jeton Hardcover API",
+        "saved": "Paramètres Hardcover enregistrés",
+        "saveFailed": "Échec de l'enregistrement des paramètres",
+        "disconnected": "Hardcover déconnecté"
+      }
+    },
+    "sync": {
+      "title": "Synchronisation manuelle",
+      "description": "Poussez votre {scope} sur Hardcover maintenant.",
+      "scope": {
+        "selected": "livres sélectionnés",
+        "eligible": "livres éligibles"
+      },
+      "checkingPending": "Vérification des éléments en attente...",
+      "pendingOf": "{pending} en attente de {total} livres.",
+      "noBooksInScope": "Aucun livre dans la portée de synchronisation.",
+      "allSynced": "Tous les livres sont déjà synchronisés.",
+      "lastSyncedLabel": "Dernière synchronisation",
+      "lastSuccessfulSync": "Dernière synchronisation réussie",
+      "syncing": "Synchronisation...",
+      "progressCount": "Livres {synced} / {total}",
+      "unavailable": {
+        "permissionDenied": "Vous n'êtes pas autorisé à utiliser la synchronisation Hardcover.",
+        "userDisabled": "La synchronisation est suspendue dans vos paramètres Hardcover."
+      },
+      "button": {
+        "unavailable": "Synchronisation indisponible",
+        "syncNow": "Synchronisez maintenant",
+        "syncNowCount": "Synchroniser maintenant ({count})"
+      },
+      "lastSynced": {
+        "justNow": "Juste maintenant",
+        "minutesAgo": "il y a {count} minutes",
+        "hoursAgo": "{count, plural, =0 {# il y a une heure} one {# il y a une heure} other {# il y a des heures} many {# il y a des heures}}",
+        "daysAgo": "{count, plural, =0 {# il y a un jour} one {# il y a un jour} other {# il y a quelques jours} many {# il y a quelques jours}}"
+      }
+    },
+    "import": {
+      "title": "Extraire l'état de lecture",
+      "description": "Prévisualisez les correspondances Hardcover avant de remplir les statuts BookOrbit vides.",
+      "clear": "Effacer",
+      "preview": "Aperçu",
+      "importProgress": "Progression de l'importation",
+      "reviewMatches": "Revoir les matchs",
+      "importReady": "Prêt à importer",
+      "exactMatches": "{count, plural, =0 {aucune correspondance exacte ne peut être importée sans examen} one {# la correspondance exacte peut être importée sans examen} other {# les correspondances exactes peuvent être importées sans examen} many {# les correspondances exactes peuvent être importées sans examen}}",
+      "progressAvailable": "{count, plural, =0 {aucune mise à jour de progression disponible} one {# mise à jour des progrès disponible} other {# mises à jour de progrès disponibles} many {# mises à jour de progrès disponibles}}",
+      "progressConflicts": "{count, plural, =0 {pas de conflits} one {# conflit} other {# conflits} many {# conflits}}",
+      "unavailable": {
+        "permissionDenied": "Vous n'êtes pas autorisé à utiliser la synchronisation Hardcover.",
+        "missingToken": "Connectez Hardcover avant d'importer.",
+        "userDisabled": "La synchronisation est suspendue dans vos paramètres Hardcover."
+      },
+      "summary": {
+        "ready": "Prêt",
+        "review": "Examen",
+        "conflicts": "Conflits",
+        "unmatched": "Inégalé",
+        "skipped": "Sauté"
+      },
+      "result": {
+        "summary": "{applied} importé{progress}, {failed} a échoué",
+        "progressUpdated": "Progression de {count} mise à jour"
+      },
+      "toast": {
+        "importFailed": "Échec de l'importation de l'état de lecture de Hardcover",
+        "imported": "{count, plural, =0 {aucun statut de lecture importé{progress}} one {# lire le statut importé{progress}} other {# lire les statuts importés{progress}} many {# lire les statuts importés{progress}}}",
+        "progressUpdates": "{count, plural, =0 {aucune mise à jour des progrès} one {# mise à jour des progrès} other {# mises à jour des progrès} many {# mises à jour des progrès}}"
+      }
+    },
+    "review": {
+      "title": "Hardcover révision de l'importation",
+      "subtitle": "{total} Hardcover livres, {matched} correspondant.",
+      "closeAriaLabel": "Fermer l'examen de l'importation",
+      "searchPlaceholder": "Rechercher un titre ou un auteur",
+      "importProgress": "Progression de l'importation",
+      "untitled": "Sans titre",
+      "blank": "vide",
+      "noRows": "Aucune ligne ne correspond aux filtres actuels.",
+      "selectRowAriaLabel": "Sélectionnez {title}",
+      "selectionSummary": "{count} sélectionné : {ready} prêt, {reviewed} examiné.",
+      "selectedProgress": "{count, plural, =0 {aucune mise à jour des progrès} one {# mise à jour des progrès} other {# mises à jour des progrès} many {# mises à jour des progrès}}",
+      "selectReady": "Sélectionnez prêt",
+      "selectPage": "Sélectionner une page",
+      "clearPage": "Effacer la page",
+      "clearSelection": "Effacer la sélection",
+      "importSelected": "Importer la sélection",
+      "previousPage": "Page précédente",
+      "nextPage": "Page suivante",
+      "pageRange": "{start}-{end} sur {total}",
+      "tabs": {
+        "all": "Tout",
+        "ready": "Prêt",
+        "review": "Examen",
+        "conflicts": "Conflits",
+        "unmatched": "Inégalé",
+        "skipped": "Sauté"
+      },
+      "summary": {
+        "ready": "Prêt",
+        "review": "Examen",
+        "conflicts": "Conflits",
+        "unmatched": "Inégalé",
+        "skipped": "Sauté"
+      },
+      "matchOptions": {
+        "all": "Tous les types de matchs"
+      },
+      "matchMethod": {
+        "hardcoverId": "Hardcover identifiant",
+        "isbn": "ISBN",
+        "titleAuthor": "Titre + auteur"
+      },
+      "outcome": {
+        "ready": "Prêt",
+        "review": "Examen",
+        "conflict": "Conflit",
+        "unmatched": "Inégalé",
+        "skipped": "Sauté"
+      },
+      "column": {
+        "progress": "Progrès"
+      }
+    }
+  },
+  "library": {
+    "creator": {
+      "createTitle": "Créer une bibliothèque",
+      "editTitle": "Modifier : {name}",
+      "stepOf": "Étape {current} sur {total}",
+      "unsaved": "Non enregistré",
+      "required": "Obligatoire",
+      "closeAria": "Fermer le créateur de la bibliothèque",
+      "progressAria": "Progression de la configuration de la bibliothèque",
+      "sectionsAria": "Sections des paramètres de la bibliothèque",
+      "loadingAria": "Chargement des paramètres de la bibliothèque",
+      "sections": {
+        "details": "Détails",
+        "folders": "Dossiers",
+        "scanner": "Scanner",
+        "metadata": "Métadonnées",
+        "fileWrite": "Écriture de fichier",
+        "reading": "Lecture",
+        "schedule": "Calendrier",
+        "access": "Accès"
+      },
+      "actions": {
+        "saving": "Sauvegarde…",
+        "saveChanges": "Enregistrer les modifications",
+        "creating": "Création…",
+        "createLibrary": "Créer une bibliothèque"
+      },
+      "details": {
+        "libraryName": "Nom de la bibliothèque",
+        "namePlaceholder": "Ma bibliothèque",
+        "coverStyle": {
+          "title": "Style de couverture",
+          "portrait": "Portrait",
+          "square": "Carré",
+          "hint": "Portrait pour ebook ou bibliothèques mixtes. Square pour les bibliothèques de livres audio uniquement."
+        },
+        "icon": {
+          "label": "Icône",
+          "placeholder": "Choisissez une icône...",
+          "selected": "Sélectionné"
+        }
+      },
+      "folders": {
+        "title": "Analyser les dossiers",
+        "description": "Ajoutez un ou plusieurs répertoires pour rechercher des livres.",
+        "browseAdd": "Parcourir et ajouter un dossier",
+        "browseTitle": "Parcourir les dossiers du serveur",
+        "browseDescription": "Sélectionnez un ou plusieurs dossiers sans quitter le navigateur.",
+        "selectedTitle": "Dossiers sélectionnés",
+        "addFolders": "Ajouter des dossiers",
+        "manualEntry": "Entrez un chemin manuellement",
+        "absolutePath": "Chemin absolu du serveur",
+        "addFolder": "Ajouter un dossier",
+        "removeFolder": "Supprimer {folder}",
+        "manualCheckHint": "Les chemins manuels sont vérifiés avec le reste des dossiers sélectionnés.",
+        "pathPlaceholder": "/chemin/vers/livres",
+        "test": "Tester",
+        "add": "Ajouter",
+        "pathNotAccessible": "Le chemin n'est pas accessible sur le serveur.",
+        "pathAccessible": "Le chemin est accessible.",
+        "pathNotAccessibleShort": "Le chemin n'est pas accessible",
+        "overlapsWith": "Chevauche avec \"{library}\"",
+        "noneAdded": "Aucun dossier ajouté pour l'instant",
+        "runPrescanHint": "Exécutez une pré-analyse pour valider les chemins avant de les enregistrer.",
+        "scanning": "Analyse en cours…",
+        "prescan": "Pré-numérisation"
+      },
+      "scanner": {
+        "scanMode": {
+          "title": "Mode de numérisation",
+          "lockedAria": "Le mode organisation est verrouillé",
+          "lockTooltip": "Le mode d'organisation est corrigé après la création de la bibliothèque, car sa modification peut créer des entrées de livre en double ou manquantes. Pour utiliser un mode différent, créez une nouvelle bibliothèque et effectuez une nouvelle analyse.",
+          "recommended": "Recommandé",
+          "folderAsBook": {
+            "title": "Dossier en tant que livre",
+            "hint": "Tous les fichiers d'un dossier sont regroupés dans un seul livre. Fonctionne bien lorsque vous conservez plusieurs formats, comme EPUB et MOBI, ensemble."
+          },
+          "fileAsBook": {
+            "title": "Classer en tant que livre",
+            "hint": "Traite chaque fichier comme un livre individuel. Idéal pour les bibliothèques avec un format par titre. Évitez si vos livres audio s'étendent sur plusieurs fichiers."
+          }
+        },
+        "allowedFormats": {
+          "title": "Formats autorisés",
+          "allowAll": "Autoriser tout",
+          "allAllowed": "Tous les formats sont autorisés.",
+          "onlySelected": "Seuls les formats sélectionnés seront importés.",
+          "warning": "Les livres dans d’autres formats déjà présents dans la bibliothèque seront marqués comme manquants lors de la prochaine analyse."
+        },
+        "excludePatterns": {
+          "title": "Exclure les modèles",
+          "hintBefore": "Modèles Glob à ignorer pendant l'analyse (par ex. ",
+          "hintAfter": ").",
+          "add": "Ajouter",
+          "empty": "Aucun motif ajouté."
+        }
+      },
+      "metadata": {
+        "sourcePrecedence": {
+          "title": "Priorité des sources",
+          "hint": "La source la plus élevée dans la liste est préférée lorsque plusieurs sont disponibles."
+        },
+        "formatPriority": {
+          "title": "Priorité du format",
+          "hint": "Lorsqu'un livre a plusieurs formats, le format le plus élevé dans la liste est préféré."
+        }
+      },
+      "fileWrite": {
+        "maxFileSizeMb": "Taille maximale du fichier (Mo)",
+        "formatLimits": "Limites de format",
+        "rename": {
+          "title": "Renommer les fichiers après des modifications de métadonnées",
+          "hint": "Renomme les fichiers physiques lorsque le titre, l'auteur, la série ou l'année change, en utilisant le modèle de dénomination de la bibliothèque."
+        },
+        "write": {
+          "title": "Écrire des métadonnées dans des fichiers",
+          "hint": "Lorsqu'elle est activée, l'enregistrement des métadonnées réécrira également les modifications dans le fichier physique sur le disque."
+        },
+        "cover": {
+          "title": "Inclure l'image de couverture",
+          "hint": "Écrit la couverture stockée dans les formats de fichiers pris en charge."
+        },
+        "epub": {
+          "title": "EPUB",
+          "hint": "Écrit les métadonnées dans le fichier OPF à l'intérieur de l'archive EPUB.",
+          "toggleAria": "Écrire les métadonnées EPUB"
+        },
+        "fb2": {
+          "title": "FictionBook (FB2)",
+          "hint": "Réécrit le bloc de description dans les fichiers FB2, sans modifier le texte du livre.",
+          "toggleAria": "Écrire les métadonnées FB2"
+        },
+        "pdf": {
+          "title": "PDF",
+          "hint": "Incorpore les métadonnées dans le dictionnaire d'informations PDF et le flux XMP.",
+          "toggleAria": "Écrire les métadonnées PDF"
+        },
+        "cbx": {
+          "title": "Archives de bandes dessinées (CBX)",
+          "hint": "Écrit ComicInfo.xml dans les archives CBZ et CB7.",
+          "toggleAria": "Écrire les métadonnées des archives de bandes dessinées"
+        },
+        "kindle": {
+          "title": "Kindle (MOBI, AZW3)",
+          "hint": "Écrit les métadonnées dans l'en-tête EXTH des fichiers MOBI, AZW3 et AZW.",
+          "toggleAria": "Écrire des métadonnées Kindle"
+        },
+        "audio": {
+          "title": "Audio",
+          "hint": "Incorpore la couverture stockée dans les fichiers M4B, M4A, MP3 et FLAC.",
+          "toggleAria": "Écrire des couvertures audio"
+        }
+      },
+      "reading": {
+        "readingStart": {
+          "title": "Début de lecture",
+          "hint": "Un livre est marqué comme « lecture » une fois ce pourcentage de progression atteint."
+        },
+        "markAsFinished": {
+          "title": "Marquer comme terminé",
+          "hint": "Un livre est automatiquement marqué comme « lu » lorsque ce pourcentage de progression est atteint."
+        }
+      },
+      "schedule": {
+        "fileWatching": "Surveillance de fichiers",
+        "autoScanSchedule": "Planification d'analyse automatique",
+        "cronExpression": "Expression Cron",
+        "cronInvalid": "Expression cron invalide.",
+        "cronFormat": "Format : minute heure jour mois jour de la semaine",
+        "watchFolders": {
+          "title": "Regarder les dossiers",
+          "hint": "Détectez automatiquement les nouveaux fichiers ajoutés aux dossiers de la bibliothèque."
+        },
+        "presets": {
+          "never": "Jamais",
+          "hourly": "Toutes les heures",
+          "every6Hours": "Toutes les 6 heures",
+          "every12Hours": "Toutes les 12 heures",
+          "daily": "Quotidiennement",
+          "weekly": "Hebdomadaire",
+          "custom": "Personnalisé"
+        },
+        "human": {
+          "disabled": "Analyse automatique désactivée",
+          "hourly": "Toutes les heures",
+          "every6Hours": "Toutes les 6 heures",
+          "every12Hours": "Toutes les 12 heures",
+          "dailyMidnight": "Tous les jours à minuit",
+          "weeklyMonday": "Hebdomadaire le lundi à minuit",
+          "cron": "Cron : {cron}"
+        }
+      },
+      "access": {
+        "title": "Contrôle d'accès",
+        "description": "Les superutilisateurs ont toujours un accès complet. Accordez l’accès aux autres utilisateurs ci-dessous.",
+        "notYetCreated": "L'accès peut être configuré après la création de la bibliothèque.",
+        "selectUser": "Sélectionnez un utilisateur…",
+        "grant": "Accorder",
+        "empty": "Aucun utilisateur n'a encore obtenu l'accès.",
+        "loading": "Chargement des paramètres d'accès...",
+        "userSelectAria": "Utilisateur pour accorder l'accès",
+        "levelSelectAria": "Niveau d'accès à accorder",
+        "levels": {
+          "viewer": "Visionneuse",
+          "editor": "Éditeur",
+          "owner": "Propriétaire"
+        },
+        "columns": {
+          "user": "Utilisateur",
+          "accessLevel": "Niveau d'accès"
+        },
+        "errors": {
+          "grant": "Échec de l'octroi de l'accès",
+          "updateLevel": "Échec de la mise à jour du niveau d'accès",
+          "revoke": "Échec de la révocation de l'accès"
+        }
+      }
+    },
+    "folderPicker": {
+      "title": "Parcourir les dossiers du serveur",
+      "description": "Sélectionnez un ou plusieurs dossiers pour cette bibliothèque.",
+      "closeAria": "Fermer le navigateur de dossiers",
+      "currentFolderAria": "Dossier actuel",
+      "parentFolder": "Aller au dossier parent",
+      "newFolder": "Nouveau dossier",
+      "goUp": "Monter",
+      "filterPlaceholder": "Filtrer les dossiers…",
+      "clearFilterAria": "Effacer le filtre de dossier",
+      "newFolderNamePlaceholder": "Nouveau nom de dossier",
+      "create": "Créer",
+      "loading": "Chargement des dossiers...",
+      "selectCurrent": "Sélectionner le dossier actuel",
+      "noMatches": "Aucun dossier correspondant",
+      "noMatchesHint": "Essayez un autre filtre.",
+      "empty": "Ce dossier est vide",
+      "emptyHint": "Vous pouvez sélectionner le dossier actuel ou en créer un nouveau.",
+      "openFolderAria": "Ouvrir {name}",
+      "selectedCount": "{count, plural, =0 {aucun dossier sélectionné} one {# dossier sélectionné} other {# dossiers sélectionnés} many {# dossiers sélectionnés}}",
+      "noFolders": "Aucun dossier trouvé",
+      "selectFolder": "Sélectionnez ce dossier",
+      "errors": {
+        "readDirectory": "Impossible de lire le répertoire",
+        "connect": "Impossible de se connecter",
+        "invalidName": "Entrez un seul nom de dossier sans barres obliques ni points de début",
+        "createFolder": "Impossible de créer le dossier"
+      }
+    },
+    "upload": {
+      "library": "Bibliothèque",
+      "selectLibrary": "Sélectionnez une bibliothèque...",
+      "targetFolder": "Dossier cible",
+      "addMoreFiles": "Ajouter plus de fichiers",
+      "clearAll": "Tout effacer",
+      "done": "Terminé",
+      "retry": "Réessayer",
+      "upload": "Télécharger",
+      "uploadWithCount": "Télécharger ({count})",
+      "viewInLibrary": "Afficher dans la bibliothèque",
+      "fileCount": "{count, plural, =0 {pas de fichiers} one {# fichier} other {# fichiers} many {# fichiers}}",
+      "booksAdded": "{count, plural, =0 {aucun livre ajouté} one {# livre ajouté} other {# livres ajoutés} many {# livres ajoutés}}",
+      "uploadedFailed": "{done} téléchargé, {failed} a échoué",
+      "progress": "{done} sur {total} en cours de téléchargement...",
+      "header": {
+        "uploading": "Téléchargement...",
+        "complete": "Téléchargement terminé",
+        "uploadTo": "Télécharger sur {library}",
+        "uploadBooks": "Télécharger des livres"
+      },
+      "dropzone": {
+        "title": "Déposez les fichiers ici ou cliquez pour parcourir",
+        "hint": "{formats} - jusqu'à {size} Mo chacun"
+      }
+    }
+  },
+  "metadataScore": {
+    "missingFields": "{count, plural, =0 {aucun champ manquant - modifier les métadonnées} one {# champ manquant - modifier les métadonnées} other {# champs manquants - modifier les métadonnées} many {# champs manquants - modifier les métadonnées}}"
+  },
+  "migration": {
+    "sidebarTitle": "Importation de livres",
+    "status": {
+      "done": "Terminé",
+      "saved": "Enregistré",
+      "running": "Courir",
+      "failed": "Échec"
+    },
+    "badge": {
+      "validated": "Validé",
+      "upToDate": "À jour",
+      "completed": "Terminé"
+    },
+    "steps": {
+      "source": {
+        "short": "Connexion source",
+        "title": "Connexion source",
+        "subtitle": "Configurez la connexion à la base de données à votre instance Booklore source."
+      },
+      "mappings": {
+        "short": "Cartographie des utilisateurs et des chemins",
+        "title": "Cartographie des utilisateurs et des chemins",
+        "subtitle": "Mappez les utilisateurs source avec les utilisateurs cibles et traduisez les chemins de fichiers."
+      },
+      "dryRun": {
+        "short": "Essai à sec",
+        "title": "Essai à sec",
+        "subtitle": "Prévisualisez ce qui sera importé avant d’exécuter la migration en direct."
+      },
+      "migration": {
+        "short": "Exécuter la migration",
+        "title": "Exécuter la migration",
+        "subtitle": "Démarrez l’importation en direct et suivez sa progression."
+      },
+      "report": {
+        "short": "Rapport",
+        "title": "Rapport de migration",
+        "subtitle": "Vérifiez ce qui a été importé et exportez un rapport détaillé."
+      }
+    },
+    "footer": {
+      "continueToMappings": "Continuer vers les mappages",
+      "continueToDryRun": "Continuer à faire un essai à sec",
+      "continueToMigration": "Continuer vers la migration",
+      "viewReport": "Afficher le rapport",
+      "resetSetup": "Réinitialiser la configuration",
+      "stepOf": "Étape {current} sur {total}",
+      "backToSetup": "Retour à la configuration"
+    },
+    "stages": {
+      "init": "Initialisation",
+      "sharedOverlays": "Importer des métadonnées",
+      "bookCovers": "Importer des couvertures",
+      "userState": "Importer des données utilisateur"
+    },
+    "source": {
+      "testConnection": "Tester la connexion",
+      "saveAndValidate": "Enregistrer et valider",
+      "validatedWithWarnings": "Source validée avec avertissements",
+      "fields": {
+        "type": "Type de source",
+        "name": "Nom de la source",
+        "host": "Hôte",
+        "port": "Port",
+        "user": "Utilisateur",
+        "password": "Mot de passe",
+        "passwordSaved": "Enregistré - laisser inchangé",
+        "passwordNotSet": "Aucun mot de passe défini",
+        "database": "Base de données",
+        "mediaRootPath": "Chemin racine du média",
+        "ssl": "Utiliser TLS/SSL"
+      },
+      "mediaPath": {
+        "hintRequired": "Obligatoire pour la migration des couvertures de livres.",
+        "hintAbsolute": "Utilisez un chemin absolu (par exemple : /books). Les chemins relatifs ne sont pas pris en charge.",
+        "hintConfigured": "Chemin d’importation de couverture configuré. Utilisez Test Connection pour vérifier l’accès et la structure des dossiers d’images Booklore.",
+        "buttonOk": "Chemin OK",
+        "buttonIssue": "Problème de chemin",
+        "buttonTest": "Chemin de test"
+      },
+      "compatibility": {
+        "title": "Compatibilité testée",
+        "verifiedAgainst": "Vérifié par rapport à :",
+        "note": "Les versions ultérieures sont probablement compatibles mais n'ont pas été vérifiées. Exécutez d’abord un essai à sec pour confirmer avant de valider les données."
+      },
+      "snapshot": {
+        "title": "Dernier instantané de validation",
+        "sourceVersion": "Version source : {version}",
+        "unknown": "Inconnu",
+        "missingTables": "Tables obligatoires manquantes : {tables}"
+      }
+    },
+    "mappings": {
+      "suggestionsAutoLoad": "Les suggestions des utilisateurs se chargent automatiquement après validation de la source.",
+      "refresh": "Actualiser",
+      "sourceUser": "Utilisateur source",
+      "targetUser": "Utilisateur cible",
+      "noSourceUsersLoaded": "Aucun utilisateur source n'a encore été chargé.",
+      "noActiveTargetUsers": "Aucun utilisateur cible actif trouvé. Créez ou réactivez un utilisateur BookOrbit avant le mappage.",
+      "pathPrefixMappings": "Mappages de préfixes de chemin",
+      "addMapping": "Ajouter un mappage",
+      "pathMappingsExplanation": "Les mappages de chemin traduisent les chemins des fichiers source en chemins cibles afin que les livres puissent être mis en correspondance par emplacement de fichier. Les livres correspondent également à ISBN, au hachage de fichier et au titre/auteur, quels que soient les mappages de chemin.",
+      "noPrefixesFound": "Aucun préfixe trouvé - validez d'abord la source",
+      "selectSourcePrefix": "Sélectionnez le préfixe source...",
+      "selectTargetFolder": "Sélectionnez le dossier cible...",
+      "remove": "Supprimer",
+      "saveMappings": "Enregistrer les mappages",
+      "pathValidation": {
+        "title": "Validation du chemin",
+        "mappedSummary": "{mapped} des {total} livres sources ont un chemin cartographié",
+        "unmatched": "{count} chemins mappés introuvables sur le disque",
+        "allMatched": "Tous les chemins mappés {count} trouvés sur le disque"
+      }
+    },
+    "dryRun": {
+      "run": "Exécuter un essai à sec",
+      "matched": "Correspondances :",
+      "unresolved": "Non résolu :",
+      "duplicates": "Doublons :",
+      "unresolvedSummary": "Résumé non résolu"
+    },
+    "duplicates": {
+      "title": "Résoudre les correspondances de cibles en double",
+      "explanation": "Pour chaque livre cible, choisissez un livre source à conserver. Les choix recommandés sont présélectionnés lorsqu’il existe une seule correspondance la plus forte.",
+      "remainingGroups": "Groupes restants :",
+      "ofCount": "de {total}",
+      "targetBookId": "Livre cible #{id}",
+      "recommended": "Recommandé",
+      "resolveButton": "{count, plural, =0 {Résoudre # dupliquer} one {Résoudre # dupliquer} other {Résoudre # doublons} many {Résoudre # doublons}}",
+      "sourceRecordId": "ID de l'enregistrement source #{id}",
+      "byAuthor": "par {author} (ID : {id})",
+      "byFilePath": "{filePath} (ID : {id})",
+      "bookloreSourceId": "ID de la source du livre : {id}",
+      "libraryBookId": "Livre de bibliothèque #{id}"
+    },
+    "preflight": {
+      "title": "Vérifications avant vol",
+      "allPassed": "Tous les contrôles ont été réussis - prêt à migrer",
+      "sourceValidated": "Source validée",
+      "saveAndValidateSource": "Enregistrer et valider la connexion source",
+      "validateSourceConnection": "Valider la connexion source",
+      "mappingsSaved": "Mappages enregistrés",
+      "saveUserAndPathMappings": "Enregistrer les mappages d'utilisateurs et de chemins",
+      "pathMappingsValidated": "Mappages de chemins validés",
+      "savePathMappingsToValidate": "Enregistrez les mappages de chemin pour les valider",
+      "dryRunUpToDate": "Le test à sec est à jour",
+      "runFreshDryRun": "Exécutez un nouvel essai à sec",
+      "issues": {
+        "saveSource": "Enregistrer les paramètres de connexion source",
+        "validateSource": "Valider la connexion source",
+        "saveMappings": "Enregistrer les mappages d'utilisateurs et de chemins",
+        "savePathMappings": "Enregistrez les mappages de chemin pour les valider",
+        "freshDryRun": "Exécutez un nouvel essai à sec",
+        "resolveDuplicates": "Résoudre les correspondances de livres cibles en double lors de l'essai à sec",
+        "waitForRun": "Attendez la fin de l'exécution active"
+      }
+    },
+    "run": {
+      "confirmPrompt": "Cela lancera la migration en direct. Es-tu sûr?",
+      "confirmStart": "Confirmer le démarrage",
+      "startMigration": "Démarrer la migration",
+      "cancelRun": "Annuler l'exécution",
+      "refreshStatus": "Actualiser le statut",
+      "pollingStopped": "L'interrogation d'état s'est arrêtée en raison d'une erreur.",
+      "retry": "Réessayer",
+      "stage": "Étape : {stage}",
+      "initializing": "initialisation",
+      "ended": "Terminé {time}"
+    },
+    "report": {
+      "noRunYet": "Aucune migration n'a encore été exécutée. Suivez les étapes ci-dessus pour commencer.",
+      "runNumber": "Exécutez #{id}",
+      "notStarted": "Pas démarré",
+      "reloadReport": "Recharger le rapport",
+      "loadFullReport": "Charger le rapport complet",
+      "exportJson": "Exporter JSON",
+      "exportCsv": "Exporter CSV",
+      "migrationFailed": "Échec de la migration",
+      "retryFromLastStage": "Réessayer depuis la dernière étape terminée",
+      "booksSection": "Livres",
+      "metadataOverlays": "Superpositions de métadonnées appliquées",
+      "authorMappings": "Mappages d'auteur remplacés",
+      "narratorMappings": "Mappages du narrateur remplacés",
+      "genreMappings": "Les mappages de genre remplacés",
+      "tagMappings": "Mappages de balises remplacés",
+      "coversImported": "Couvertures importées",
+      "coverImportSkipped": "Importation de la couverture ignorée : chemin racine du média non configuré",
+      "couldNotMatch": "Impossible de correspondre",
+      "userDataSection": "Données utilisateur",
+      "readingStatuses": "Statuts de lecture",
+      "readingProgressEntries": "Lecture des entrées de progression",
+      "audiobookProgressEntries": "Entrées de progression du livre audio",
+      "readingSessions": "Séances de lecture",
+      "bookmarks": "Signets",
+      "annotations": "Annotations",
+      "collectionEntries": "Entrées de collection",
+      "loadFullReportHint": "Cliquez sur « Charger le rapport complet » pour inclure le résumé des correspondances à sec dans le rapport exporté.",
+      "completedNoIssues": "Migration terminée sans livres ni échecs non résolus.",
+      "matchedBooks": "Livres correspondants ({count})",
+      "matchedBooksExplanation": "Ces correspondances à sec ont été utilisées pour décider quels livres de bibliothèque recevaient des données importées.",
+      "sourceBook": "Livre source {id}",
+      "libraryBook": "Livre de bibliothèque {id}",
+      "unresolvedBooks": "Livres non résolus ({count})",
+      "unresolvedBooksExplanation": "Ces livres existent dans la source mais n'ont pu être associés à aucun livre de votre bibliothèque.",
+      "mappedUsers": "Utilisateurs mappés ({count})",
+      "mappedUsersExplanation": "Les totaux par utilisateur proviennent de l'aperçu d'exécution à sec mis en cache avec le plan de migration.",
+      "coverFailures": "{count} a échoué dans les importations de couverture. Les lignes de défaillance détaillées ne sont pas stockées.",
+      "userPreviewCounts": "{statuses} statuts, {progress} entrées de progression, {sessions} sessions de lecture, {bookmarks} signets, {annotations} annotations, {collections} entrées de collection"
+    },
+    "unresolvedReason": {
+      "noTitleAuthorMatch": "Aucun livre correspondant trouvé par titre ou par auteur",
+      "noFilePathMatch": "Le chemin du fichier ne correspond à aucun livre de cette bibliothèque",
+      "noFileHashMatch": "Le hachage du fichier ne correspond à aucun livre de cette bibliothèque",
+      "noIsbnMatch": "ISBN ne correspond à aucun livre de cette bibliothèque",
+      "insufficientSourceData": "Pas assez de métadonnées pour tenter une correspondance",
+      "ambiguousIsbnMatch": "Plusieurs livres correspondent au même ISBN",
+      "ambiguousFileHashMatch": "Plusieurs livres correspondaient au même hachage de fichier",
+      "ambiguousFilePathMatch": "Plusieurs livres correspondaient au même chemin de fichier",
+      "ambiguousTitleAuthorMatch": "Plusieurs livres correspondaient au même titre et au même auteur",
+      "unknown": "Impossible de déterminer la raison"
+    },
+    "matchStrategy": {
+      "isbn": "Correspondant à ISBN",
+      "fileHash": "Correspondance par hachage de fichier",
+      "pathMapping": "Correspondant au chemin du fichier mappé",
+      "titleAuthor": "Assorti par titre et auteur",
+      "unavailable": "Stratégie de correspondance indisponible"
+    },
+    "connectionError": {
+      "unreachable": "Impossible d'atteindre le serveur de base de données. Vérifiez l'hôte et le port.",
+      "authFailed": "L'authentification a échoué. Vérifiez le nom d'utilisateur et le mot de passe.",
+      "databaseNotFound": "Base de données introuvable. Vérifiez le nom de la base de données.",
+      "timeout": "La connexion a expiré. Vérifiez les paramètres de l'hôte et du pare-feu.",
+      "generic": "Le test de connexion a échoué"
+    },
+    "userSelect": {
+      "placeholder": "Sélectionner un utilisateur",
+      "noUsersFound": "Aucun utilisateur trouvé"
+    },
+    "toast": {
+      "initFailed": "Échec de l'initialisation des paramètres de migration",
+      "loadSupportedTypesFailed": "Échec du chargement des types de sources de migration pris en charge",
+      "loadTargetUsersFailed": "Échec du chargement des utilisateurs cibles",
+      "loadTargetFoldersFailed": "Échec du chargement des dossiers de la bibliothèque cible",
+      "noSourceUsers": "Aucun utilisateur source n'a été renvoyé",
+      "suggestionsLoaded": "Suggestions de mappage utilisateur chargées",
+      "loadSuggestionsFailed": "Échec du chargement des suggestions de mappage utilisateur",
+      "sourceFieldsRequired": "L'hôte, l'utilisateur, la base de données et le nom de la source sont requis",
+      "connectionPassedWithWarnings": "Test de connexion réussi avec avertissements",
+      "connectionPassedWithWarningCount": "Test de connexion réussi avec {count} avertissement(s). Premier : {warning}",
+      "connectionPassed": "Test de connexion réussi",
+      "connectionMissingTables": "Connexion correcte, mais {count} table(s) requise(s) sont manquantes",
+      "cannotTestMediaWhileRunning": "Impossible de tester le chemin du support lorsqu'une exécution est active",
+      "mediaPathRequired": "Le chemin racine du média est requis pour l’importation de la couverture.",
+      "mediaPathAbsolute": "Utilisez un chemin absolu (par exemple : /books).",
+      "mediaPathVerified": "Chemin du média vérifié.",
+      "mediaPathValid": "Le chemin du média est valide et lisible",
+      "mediaPathValidationFailed": "La validation du chemin du média a échoué.",
+      "connectionFailedBeforeMedia": "Le test de connexion a échoué avant que la validation du chemin du support ne puisse être terminée.",
+      "cannotModifySourceWhileRunning": "Impossible de modifier la source lorsqu'une exécution est active",
+      "sourceSavedWithWarnings": "Source enregistrée et validée avec {count} avertissement(s)",
+      "sourceSaved": "Source enregistrée et validée",
+      "saveSourceFailed": "Échec de l'enregistrement ou de la validation de la source",
+      "cannotSaveMappingsWhileRunning": "Impossible d'enregistrer les mappages lorsqu'une exécution est active",
+      "saveSourceFirst": "Enregistrez d'abord la source",
+      "mapAtLeastOneUser": "Mapper au moins un utilisateur source à un utilisateur cible",
+      "mapEveryUser": "Mappez chaque utilisateur source avant de l'enregistrer",
+      "pathValidationFailedButSaved": "La validation du chemin a échoué, mais le profil sera toujours enregistré",
+      "mappingsSaved": "Mappages enregistrés",
+      "saveMappingsFailed": "Échec de l'enregistrement des mappages",
+      "cannotDryRunWhileRunning": "Impossible d'exécuter un essai à blanc lorsqu'une exécution est active",
+      "saveMappingsFirst": "Enregistrez d'abord les mappages",
+      "dryRunCompleted": "Essai à sec terminé : {matched} correspondant, {unresolved} non résolu",
+      "dryRunFailed": "Échec de l'essai à sec",
+      "selectSourceForDuplicates": "Sélectionnez un livre source pour tous les {count} groupes en double",
+      "duplicatesResolved": "Correspondances en double résolues",
+      "resolveDuplicatesFailed": "Échec de la résolution des doublons",
+      "preflightNotReady": "Le contrôle en amont de la migration n'est pas prêt",
+      "runDryRunFirst": "Exécutez d'abord un essai à sec",
+      "runStarted": "La migration a démarré",
+      "startFailed": "Échec du démarrage de la migration",
+      "runCancelled": "Exécution de migration annulée",
+      "cancelFailed": "Échec de l'annulation de la migration",
+      "runRetried": "Nouvelle tentative d'exécution de migration – reprise à partir de la dernière étape terminée",
+      "retryFailed": "Échec de la nouvelle tentative de migration",
+      "loadProgressFailed": "Échec du chargement de la progression de l'exécution",
+      "startMigrationFirst": "Commencer la migration en premier",
+      "reportRefreshed": "Exécuter le rapport actualisé",
+      "loadReportFailed": "Échec du chargement du rapport d'exécution",
+      "reportExported": "Rapport exporté sous {format}",
+      "exportFailed": "Échec de l'exportation du rapport de migration"
+    }
+  },
+  "notifications": {
+    "title": "Notifications",
+    "markAllRead": "Marquer tout comme lu",
+    "clear": "Effacer",
+    "empty": "Aucune notification pour l'instant",
+    "loadMore": "Charger plus de notifications",
+    "preferences": {
+      "title": "Notifications",
+      "subtitle": "Choisissez les catégories de notifications que vous souhaitez recevoir.",
+      "saving": "Sauvegarde...",
+      "unsavedChanges": "Modifications non enregistrées",
+      "saved": "Préférences de notification enregistrées",
+      "saveFailed": "Échec de l'enregistrement des préférences",
+      "savePreferenceFailed": "Échec de l'enregistrement des préférences",
+      "whatsNewToggle": "Afficher \"Quoi de neuf\" après les mises à jour",
+      "whatsNewToggleHint": "Une fenêtre contextuelle mettant en évidence les nouvelles fonctionnalités après les mises à jour de l'application. Les archives restent disponibles dans tous les cas."
+    }
+  },
+  "reader": {
+    "retry": "Réessayer",
+    "pdf": {
+      "openError": "Impossible d'ouvrir ce PDF",
+      "preparing": "Préparation du lecteur PDF",
+      "opening": "Ouverture PDF"
+    },
+    "loadingBook": "Chargement du livre…",
+    "failedToLoadBook": "Échec du chargement du livre",
+    "chapterNumber": "Chapitre {number}",
+    "peek": {
+      "badge": "Jetant un coup d'oeil",
+      "startReading": "Commencez à lire"
+    },
+    "toast": {
+      "linkedHighlightError": "Impossible d'ouvrir la position de surbrillance liée",
+      "resumed": "Reprise à {pct}% - {label}"
+    },
+    "header": {
+      "goBack": "Retourner",
+      "tableOfContents": "Table des matières",
+      "toggleBookmark": "Activer/désactiver le signet",
+      "cycleFooterMode": "Mode d'information du pied de page du cycle",
+      "keyboardShortcutsHint": "Raccourcis clavier (?)",
+      "enterFullscreen": "Entrez en plein écran",
+      "exitFullscreen": "Quitter le plein écran",
+      "footerMode": {
+        "pageProgress": "Infos de pied de page : page + progression",
+        "sessionTimeLeft": "Info pied de page : séance de lecture + temps restant",
+        "chapterTimeLeft": "Informations de pied de page : chapitre + temps restant du chapitre"
+      }
+    },
+    "footer": {
+      "previousSection": "Section précédente",
+      "nextSection": "Section suivante",
+      "goToPlaceholder": "45 ou p123",
+      "jumpToLocation": "Aller à l'emplacement",
+      "jumpTooltip": "Aller à % ou à la page (par exemple 45 ou p123)",
+      "go": "Allez"
+    },
+    "settings": {
+      "title": "Paramètres",
+      "ariaLabel": "Paramètres du lecteur",
+      "tabs": {
+        "appearance": "Apparence",
+        "text": "Texte",
+        "layout": "Disposition"
+      },
+      "appearance": {
+        "mode": "Mode",
+        "light": "Lumière",
+        "dark": "Sombre",
+        "colorTheme": "Thème de couleur"
+      },
+      "text": {
+        "fontSize": "Taille de la police",
+        "fontSizeRange": "Plage : 10-32 px",
+        "lineHeight": "Hauteur de ligne",
+        "lineHeightRange": "Plage : 0,8-3,0",
+        "fontFamily": "Famille de polices",
+        "fontFamilyDescription": "Choisissez des polices intégrées ou téléchargées pour le corps du texte.",
+        "builtIn": "Intégré",
+        "yourFonts": "Vos polices"
+      },
+      "layout": {
+        "pageSpreads": "Pages doubles",
+        "pageSpreadsDescription": "Choisissez comment ce EPUB basé sur des images associe les pages.",
+        "bookDefault": "Livre par défaut",
+        "singlePage": "Page unique",
+        "readingFlow": "Flux de lecture",
+        "readingFlowDescription": "Basculez entre le défilement paginé et continu.",
+        "paginated": "Paginé",
+        "scrolled": "Défilé",
+        "textColumns": "Colonnes de texte",
+        "textColumnsRange": "Plage : 1-10",
+        "columnGap": "Écart de colonne",
+        "columnGapRange": "Plage : 0-50 %",
+        "maxWidth": "Largeur maximale",
+        "maxWidthRange": "Plage : 400-1600",
+        "justifyText": "Justifier le texte",
+        "justifyTextDescription": "Activer l’alignement des paragraphes sur toute la largeur.",
+        "hyphenation": "Césure",
+        "hyphenationDescription": "Activez la césure automatique des mots."
+      }
+    },
+    "search": {
+      "placeholder": "Rechercher dans le livre (min {min} caractères)...",
+      "searching": "Recherche…",
+      "tooShort": "Saisissez au moins {min} caractères",
+      "noResults": "Aucun résultat trouvé",
+      "prompt": "Tapez pour rechercher",
+      "resultCount": "{count, plural, =0 {aucun résultat} one {# résultat} other {# résultats} many {# résultats}}"
+    },
+    "sidebar": {
+      "tabs": {
+        "chapters": "Chapitres",
+        "bookmarks": "Signets",
+        "highlights": "Points forts",
+        "toc": "Table des matières",
+        "tocShort": "Table des matières",
+        "marksShort": "Marques",
+        "notesShort": "Remarques"
+      },
+      "pin": "Épingler la barre latérale",
+      "unpin": "Supprimer la barre latérale",
+      "close": "Fermer la barre latérale",
+      "noChapters": "Aucun chapitre trouvé",
+      "noBookmarks": "Pas encore de favoris",
+      "noBookmarksMatch": "Aucun favori ne correspond à vos filtres",
+      "noHighlights": "Pas encore de faits saillants",
+      "noHighlightsMatch": "Aucun surlignage ne correspond à vos filtres",
+      "searchBookmarks": "Rechercher des favoris...",
+      "searchHighlights": "Points forts de la recherche...",
+      "bookmarkFallback": "Marque-page",
+      "locationUnavailable": "Emplacement indisponible",
+      "customColor": "Personnalisé ({color})",
+      "allColors": "Toutes les couleurs",
+      "allChapters": "Tous les chapitres",
+      "notesOnly": "Remarques uniquement",
+      "deleteBookmark": "Supprimer le favori",
+      "deleteHighlight": "Supprimer le surlignage",
+      "approximatePosition": "Synchronisé depuis l'appareil ; position exacte indisponible, passe au chapitre",
+      "sort": {
+        "readingOrder": "Ordre de lecture",
+        "newest": "Le plus récent en premier",
+        "oldest": "Le plus ancien en premier"
+      }
+    },
+    "selection": {
+      "copy": "Copier",
+      "copied": "Copié!",
+      "highlight": "Mettre en surbrillance",
+      "translate": "Traduire",
+      "define": "Définir",
+      "deleteAnnotation": "Supprimer l'annotation",
+      "apply": "Appliquer"
+    },
+    "note": {
+      "title": "Ajouter une note",
+      "placeholder": "Écrivez votre note…"
+    },
+    "dictionary": {
+      "noDefinition": "Aucune définition trouvée",
+      "loadError": "Impossible de charger la définition"
+    },
+    "translation": {
+      "original": "Originale",
+      "translation": "Traduction",
+      "translating": "Traduire...",
+      "noTranslation": "Pas encore de traduction",
+      "viaProvider": "via {provider}",
+      "copyTranslation": "Copier la traduction"
+    },
+    "shortcuts": {
+      "title": "Raccourcis clavier",
+      "groups": {
+        "panels": "Panneaux",
+        "reading": "Lecture",
+        "actions": "Actions"
+      },
+      "toggleToc": "Basculer la table des matières",
+      "toggleSearch": "Activer/désactiver la recherche",
+      "toggleHelp": "Afficher/masquer cette aide",
+      "closePanel": "Fermer le panneau",
+      "prevNextPage": "Page précédente/suivante",
+      "goToStart": "Aller au début du livre",
+      "goToEnd": "Aller à la fin du livre",
+      "toggleBookmark": "Activer/désactiver le signet",
+      "toggleFullscreen": "Basculer en plein écran",
+      "cycleFooterMode": "Mode d'information du pied de page du cycle"
+    },
+    "cbz": {
+      "tabs": {
+        "view": "Voir",
+        "reading": "Lecture",
+        "layout": "Disposition"
+      },
+      "fitMode": "Mode d'ajustement",
+      "background": "Contexte",
+      "scrollMode": "Mode défilement",
+      "scrollModeHint": "Utilisez \"Pas d'espaces\" pour les webtoons et les bandes verticales.",
+      "readingDirection": "Sens de lecture",
+      "pageView": "Affichage des pages",
+      "autoFallback": "Repli automatique",
+      "spreadAlignmentLabel": "Alignement de la propagation",
+      "spreadAlignmentHint": "L’alignement de la propagation n’est pas disponible en mode de repli automatique.",
+      "spreadGap": "Écart de propagation",
+      "spreadGapValue": "{value}px",
+      "focusTwoPageToggle": "Focus sur la bascule de deux pages",
+      "forceTwoPage": "Forcer deux pages",
+      "off": "Désactivé",
+      "on": "Sur",
+      "widePages": "Pages larges",
+      "resetBookViewSettings": "Réinitialiser les paramètres d'affichage du livre",
+      "resetConfirm": "Réinitialiser les paramètres d'affichage de ce livre à vos valeurs par défaut globales ?",
+      "firstPage": "Première page",
+      "lastPage": "Dernière page",
+      "fit": {
+        "page": "Ajustement de la page",
+        "width": "Largeur de page",
+        "height": "Hauteur des pages",
+        "actual": "Taille réelle"
+      },
+      "view": {
+        "single": "Célibataire",
+        "twoPage": "Deux pages"
+      },
+      "scroll": {
+        "paged": "Paginé",
+        "infinite": "Infini",
+        "noGaps": "Aucune lacune"
+      },
+      "direction": {
+        "ltr": "De gauche à droite",
+        "rtl": "R à L"
+      },
+      "spreadAlignment": {
+        "normal": "Normale",
+        "shifted": "Décalé"
+      },
+      "widePage": {
+        "auto": "Automatique",
+        "inSpreads": "En tartinades"
+      },
+      "bg": {
+        "black": "Noir",
+        "gray": "Gris",
+        "white": "Blanc"
+      }
+    },
+    "audiobook": {
+      "untitled": "Sans titre",
+      "loading": "Chargement du livre audio...",
+      "loadError": "Échec du chargement du livre audio",
+      "noAudioFiles": "Aucun fichier audio trouvé pour ce livre.",
+      "speed": "Vitesse",
+      "chapters": "Chapitres",
+      "bookmarks": "Signets",
+      "volume": "Volume",
+      "muted": "En sourdine",
+      "sleep": "Dormir",
+      "chapterAbbrev": "Ch.",
+      "sleepTimer": "Minuterie de mise en veille",
+      "minutes": "{count} minutes",
+      "endOfChapter": "Fin du chapitre",
+      "noChaptersAvailable": "Aucun chapitre disponible",
+      "extend15": "+ 15 minutes",
+      "timeLeft": "({time} restant)",
+      "playbackSpeed": "Vitesse de lecture",
+      "noChapters": "Aucun chapitre disponible.",
+      "noBookmarks": "Aucun favori pour l'instant.",
+      "noBookmarksHint": "Appuyez sur l'icône de signet en haut pour enregistrer votre position actuelle.",
+      "playerSettings": "Paramètres du lecteur",
+      "skipBack": "Revenir en arrière",
+      "skipForward": "Avancer"
+    }
+  },
+  "scanner": {
+    "filesProgress": "Fichiers {processed}/{total}",
+    "booksFound": "{count, plural, =0 {aucun livre trouvé} one {# livre trouvé} other {# livres trouvés} many {# livres trouvés}}"
+  },
+  "series": {
+    "completion": {
+      "readOfTotal": "{read} sur {total} lu ({percentage}%)"
+    },
+    "gaps": {
+      "label": "Lacunes possibles :"
+    },
+    "filters": {
+      "title": "Filtres de série",
+      "clearAll": "Tout effacer",
+      "allLibraries": "Toutes les bibliothèques",
+      "allCompletion": "Tout achèvement",
+      "notStarted": "Pas démarré",
+      "inProgress": "En cours",
+      "complete": "Terminé"
+    },
+    "list": {
+      "title": "Série",
+      "showControlsAria": "Afficher les contrôles de série",
+      "searchPlaceholder": "Rechercher une série ou un auteur",
+      "sortButton": "Trier",
+      "sortBy": "Trier par",
+      "ascending": "Ascendant",
+      "descending": "Décroissant",
+      "ascShort": "Asc.",
+      "descShort": "Description",
+      "filters": "Filtres",
+      "clear": "Effacer",
+      "noMatch": "Aucune série ne correspond à vos filtres.",
+      "empty": "Aucune série trouvée dans vos bibliothèques.",
+      "sort": {
+        "name": "Nom",
+        "bookCount": "Nombre de livres",
+        "recentAdditions": "Ajouts récents",
+        "readingProgress": "Progrès en lecture"
+      }
+    },
+    "detail": {
+      "pageTitle": "Série",
+      "pageTitleNamed": "Série · {name}",
+      "pageTitleWithId": "Série #{id}",
+      "entityName": "Série",
+      "bookCount": "{count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+      "byAuthors": "par {authors}",
+      "moreAuthors": "+{count} plus",
+      "preparingEditor": "Préparation de l'éditeur...",
+      "editMetadata": "Modifier les métadonnées",
+      "firstInSeries": "Premier de la série",
+      "untitled": "Sans titre",
+      "loadingFirstBook": "Chargement de l'aperçu du premier livre...",
+      "showLess": "Afficher moins",
+      "showMore": "Afficher plus",
+      "moreGenres": "+{count} plus",
+      "synopsis": "Résumé",
+      "noDescription": "Aucune description disponible.",
+      "updatingPreview": "Mise à jour de l'aperçu...",
+      "noBooksToPreview": "Aucun livre disponible en aperçu.",
+      "loadingSeries": "Chargement de la série...",
+      "booksHeading": "Livres",
+      "allLibraries": "Toutes les bibliothèques",
+      "groupByMedia": "Regrouper par média",
+      "noBooksFound": "Aucun livre trouvé dans cette série",
+      "trySelectingLibrary": "Essayez de sélectionner une autre bibliothèque.",
+      "allBooksLoaded": "Tous les {count} livres chargés",
+      "leadBookLoadError": "Échec du chargement des détails du livre principal",
+      "noBooksToEdit": "Cette série n'a aucun livre à éditer.",
+      "loadFullSeriesError": "Échec du chargement de la série complète pour modification.",
+      "sort": {
+        "seriesOrder": "Commande de série",
+        "title": "Titre",
+        "recentlyAdded": "Récemment ajouté"
+      },
+      "order": {
+        "ascending": "Ascendant",
+        "descending": "Décroissant"
+      }
+    }
+  },
+  "smartScope": {
+    "syncToKobo": "Synchroniser avec Kobo",
+    "syncToKoboHint": "Les livres correspondant à cette portée apparaîtront sur votre appareil Kobo",
+    "dialog": {
+      "name": "Nom",
+      "namePlaceholder": "par ex. Science-fiction non lue",
+      "icon": "Icône",
+      "iconPlaceholder": "Choisissez une icône...",
+      "nameRequired": "Le nom est requis",
+      "iconRequired": "Choisissez une icône",
+      "create": "Créer",
+      "creating": "Création...",
+      "saving": "Sauvegarde..."
+    },
+    "createDialog": {
+      "title": "Nouvelle lunette intelligente",
+      "visibleToAll": "Visible par tous les utilisateurs",
+      "createFailed": "Échec de la création de Smart Scope"
+    },
+    "saveAsDialog": {
+      "title": "Enregistrer sous SmartScope",
+      "save": "Enregistrer SmartScope",
+      "saveFailed": "Échec de l'enregistrement du Smart Scope"
+    },
+    "editorPanel": {
+      "untitled": "SmartScope sans titre",
+      "subtitle": "Configurer les paramètres de l'étendue intelligente",
+      "counting": "compter...",
+      "bookCount": "{count, plural, =0 {pas de livres} one {un livre} other {# livres} many {# livres}}",
+      "identity": "Identité",
+      "filters": "Filtres",
+      "noFilters": "Aucun filtre défini. Tous les livres accessibles seront inclus dans ce périmètre intelligent.",
+      "buildFromScratch": "Construire à partir de zéro",
+      "replaceWithTemplate": "Remplacer par le modèle :",
+      "defaultSort": "Tri par défaut",
+      "saveChanges": "Enregistrer les modifications",
+      "saveFailed": "Échec de l'enregistrement",
+      "templates": {
+        "hasSeries": "A une série",
+        "addedRecently": "Ajouté récemment",
+        "pdfOnly": "PDF uniquement",
+        "noGenres": "Aucun genre",
+        "epubOnly": "EPUB uniquement"
+      }
+    }
+  },
+  "statistics": {
+    "tabs": {
+      "library": "Statistiques de la bibliothèque",
+      "user": "Ma lecture"
+    },
+    "filter": {
+      "allLibraries": "Toutes les bibliothèques",
+      "librarySelection": "{count} bibliothèques sur {total}"
+    },
+    "config": {
+      "button": "Configurer",
+      "title": "Configurer les graphiques",
+      "description": "Faites glisser pour réorganiser, basculez pour afficher ou masquer.",
+      "reset": "Réinitialiser aux valeurs par défaut"
+    },
+    "summary": {
+      "books": "Livres",
+      "authors": "Auteurs",
+      "series": "Série",
+      "publishers": "Éditeurs",
+      "storage": "Stockage",
+      "genres": "Genre",
+      "languages": "Langues",
+      "published": "Publié",
+      "thisYear": "Cette année",
+      "started": "Commencé",
+      "inProgress": "En cours",
+      "completed": "Terminé",
+      "avgProgress": "Progression moyenne"
+    },
+    "card": {
+      "loadError": "Échec du chargement des données",
+      "emptyTitle": "Aucune donnée pour l'instant",
+      "emptyDescription": "Aucune donnée disponible pour ce graphique",
+      "unknownField": "{count, plural, =0 {aucune donnée pour ce champ} one {# le livre n'a pas de données pour ce champ} other {# les livres n'ont pas de données pour ce champ} many {# les livres n'ont pas de données pour ce champ}}"
+    },
+    "breakdown": {
+      "ariaLabel": "Répartition par source ou format"
+    },
+    "empty": {
+      "notEnoughData": "Pas encore assez de données"
+    },
+    "charts": {
+      "acquisitionLag": {
+        "title": "Décalage d'acquisition"
+      },
+      "booksAddedOverTime": {
+        "title": "Livres ajoutés au fil du temps",
+        "monthly": "Mensuel",
+        "yearly": "Annuel",
+        "allTime": "Tout le temps",
+        "last5Years": "5 dernières années",
+        "lastYear": "L'année dernière"
+      },
+      "formatDistribution": {
+        "title": "Distribution des formats"
+      },
+      "formatShareOverTime": {
+        "title": "Formater le partage au fil du temps"
+      },
+      "genreCooccurrence": {
+        "title": "Cooccurrence des genres"
+      },
+      "genreDistribution": {
+        "title": "Répartition des genres"
+      },
+      "languageDistribution": {
+        "title": "Distribution linguistique"
+      },
+      "largestBooks": {
+        "title": "Top 50 des plus grands livres"
+      },
+      "libraryIntegrity": {
+        "title": "Intégrité de la bibliothèque"
+      },
+      "libraryMetadataCompleteness": {
+        "title": "exhaustivité des métadonnées de la bibliothèque"
+      },
+      "metadataCompleteness": {
+        "title": "exhaustivité des métadonnées"
+      },
+      "metadataFreshness": {
+        "title": "Fraîcheur des métadonnées"
+      },
+      "metadataScoreDistribution": {
+        "title": "Distribution des scores des métadonnées"
+      },
+      "pageCountDistribution": {
+        "title": "Distribution du nombre de pages"
+      },
+      "publicationDecade": {
+        "title": "Décennie des publications"
+      },
+      "publicationYearTimeline": {
+        "title": "Chronologie de l’année de publication"
+      },
+      "storageByFormat": {
+        "title": "Stockage par format"
+      },
+      "topAuthors": {
+        "title": "Top 25 des auteurs"
+      },
+      "topSeries": {
+        "title": "Séries Top 50"
+      },
+      "booksCompleted": {
+        "title": "Livres terminés",
+        "notEnoughData": "Il faut au moins {count} livres terminés pour ce tableau."
+      },
+      "completionLatency": {
+        "title": "Latence d'achèvement",
+        "notEnoughData": "Il faut au moins {count} livres terminés pour ce tableau."
+      },
+      "completionTimeline": {
+        "title": "Calendrier d'achèvement",
+        "notEnoughData": "Il faut au moins {count} livres terminés pour ce tableau."
+      },
+      "favoriteReadingDays": {
+        "title": "Journées de lecture préférées",
+        "notEnoughData": "Besoin d'au moins {count} événements de lecture pour ce graphique."
+      },
+      "genreReadingTime": {
+        "title": "Genre Temps de lecture",
+        "notEnoughData": "Il faut au moins {count} genres avec un temps de lecture pour ce graphique."
+      },
+      "goalTrajectory": {
+        "title": "Rythme vs objectif",
+        "noCompletedTitle": "Aucun livre terminé pour l'instant",
+        "noCompletedDescription": "Remplissez un livre pendant cette période pour comparer votre rythme à votre objectif annuel.",
+        "notEnoughData": "Il faut au moins {count} livres terminés pour ce tableau."
+      },
+      "peakReadingHours": {
+        "title": "Heures de pointe de lecture",
+        "notEnoughData": "Besoin d'au moins {count} événements de lecture pour ce graphique."
+      },
+      "progressFunnel": {
+        "title": "Entonnoir de progression",
+        "modePercent": "Pourcentage",
+        "modeCounts": "Comptes",
+        "modeDropoff": "Dépôt",
+        "started": "Démarré {count}",
+        "notEnoughData": "Il faut au moins {count} livres commencés pour ce graphique.",
+        "noDropOffTitle": "Aucune baisse constatée",
+        "noDropOffDescription": "Chaque livre commencé a progressé à travers toutes les étapes de l'entonnoir au cours de cette période."
+      },
+      "readingClock": {
+        "title": "Horloge de lecture",
+        "notEnoughData": "Besoin d'au moins {count} séances de lecture pour ce graphique."
+      },
+      "readingHeatmap": {
+        "title": "Lecture de la carte thermique",
+        "notEnoughData": "Besoin d'une activité pendant au moins {count} jours pour ce graphique."
+      },
+      "readingPace": {
+        "title": "Rythme de lecture",
+        "notEnoughData": "Besoin d'au moins {count} sessions avec des données de progression pour ce graphique."
+      },
+      "readingSessionTimeline": {
+        "title": "Chronologie de la séance de lecture",
+        "dragOn": "Faire glisser : activé",
+        "dragOff": "Glisser : Désactivé",
+        "prev": "Précédent",
+        "next": "Suivant",
+        "week": "Semaine {week}",
+        "dragHint": "Faites glisser les barres pour déplacer les sessions. La durée est verrouillée et les sessions qui se chevauchent sont rejetées.",
+        "noSessionsTitle": "Pas de séance cette semaine",
+        "noSessionsDescription": "Utilisez Précédent/Suivant ou le sélecteur de semaine pour afficher une semaine différente.",
+        "overlapError": "La session chevauche une autre session dans cette fenêtre",
+        "moveError": "Échec du déplacement de la session"
+      },
+      "sessionArchetypes": {
+        "title": "Archétypes de session"
+      },
+      "sourceDistribution": {
+        "title": "Où vous lisez",
+        "emptyTitle": "Aucune activité de lecture pour l'instant",
+        "emptyDescription": "Lisez sur le Web, KOReader ou Kobo pour voir votre répartition de source."
+      }
+    }
+  },
+  "tools": {
+    "header": {
+      "entityManager": "Gestionnaire d'entité",
+      "bulkRename": "Renommer en masse",
+      "duplicateBooks": "Livres en double"
+    },
+    "entityTypes": {
+      "authors": "Auteurs",
+      "genres": "Genre",
+      "tags": "Balises",
+      "narrators": "Narrateurs",
+      "publishers": "Éditeurs",
+      "languages": "Langues",
+      "series": "Série"
+    },
+    "bulkRename": {
+      "previewToolbar": "Renommer l'aperçu",
+      "renameSettings": "Renommer les paramètres",
+      "library": "Bibliothèque",
+      "selectLibraryPlaceholder": "Sélectionnez une bibliothèque...",
+      "noEligibleLibraries": "Aucune bibliothèque n'a activé le changement de nom de fichier. Activez-le dans les paramètres de la bibliothèque.",
+      "refresh": "Actualiser",
+      "applyRename": "Appliquer Renommer",
+      "showFullPaths": "Afficher les chemins complets",
+      "columnsMenu": "Colonnes",
+      "renamingInProgress": "Renommer des fichiers - vous pouvez annuler à tout moment.",
+      "executionFailed": "Échec du changement de nom groupé",
+      "previewFailed": "Échec du chargement de l'aperçu",
+      "noBooksMatch": "Aucun livre trouvé correspondant au filtre actuel.",
+      "openBookDetails": "Détails du livre ouvert",
+      "columns": {
+        "title": "Titre",
+        "currentPath": "Chemin actuel",
+        "newPath": "Nouveau chemin",
+        "status": "Statut"
+      },
+      "status": {
+        "willRename": "Renommera",
+        "unchanged": "Inchangé",
+        "collision": "Collision",
+        "noPattern": "Aucun modèle",
+        "error": "Erreur"
+      },
+      "filter": {
+        "all": "Tout"
+      },
+      "summary": {
+        "label": "Résumé",
+        "toRename": "{count} à renommer",
+        "unchanged": "{count} inchangé",
+        "collisions": "{count, plural, =0 {# collision} one {# collision} other {# collisions} many {# collisions}}",
+        "errors": "{count, plural, =0 {# erreur} one {# erreur} other {# erreurs} many {# erreurs}}"
+      },
+      "empty": {
+        "title": "Choisissez une bibliothèque pour commencer",
+        "description": "Sélectionnez une bibliothèque ci-dessus pour prévisualiser les modifications de renommage, filtrer par statut et appliquer l'exécution de renommage groupé.",
+        "chooseLibrary": "Choisir la bibliothèque"
+      },
+      "completed": {
+        "title": "Renommage groupé terminé",
+        "stats": "{succeeded} renommé, {failed} a échoué, {skipped} ignoré ({processed} au total)"
+      },
+      "pagination": {
+        "showing": "Affichage de {from}-{to} sur {total}"
+      },
+      "confirmDialog": {
+        "title": "Confirmer le changement de nom en bloc",
+        "body": "{count, plural, =0 {Cela renommera # livre sur disque. Les fichiers présentant des collisions ou des erreurs seront ignorés. Cette action ne peut pas être annulée.} one {Cela renommera # livre sur disque. Les fichiers présentant des collisions ou des erreurs seront ignorés. Cette action ne peut pas être annulée.} other {Cela renommera # livres sur disque. Les fichiers présentant des collisions ou des erreurs seront ignorés. Cette action ne peut pas être annulée.} many {Cela renommera # livres sur disque. Les fichiers présentant des collisions ou des erreurs seront ignorés. Cette action ne peut pas être annulée.}}",
+        "renameButton": "{count, plural, =0 {Renommer # livre} one {Renommer # livre} other {Renommer # livres} many {Renommer # livres}}"
+      }
+    },
+    "bookDuplicates": {
+      "scanSettings": "Paramètres de numérisation",
+      "title": "Livres en double",
+      "description": "Analysez les fichiers et les métadonnées à la recherche d'enregistrements en double potentiels. Rien n'est supprimé lors d'une analyse.",
+      "scope": "Portée de la bibliothèque",
+      "allLibraries": "Toutes les bibliothèques accessibles",
+      "similarity": "Seuil de titre similaire",
+      "explainSimilarity": "Expliquer le seuil de titre similaire",
+      "similarityHelp": "Uniquement pour les correspondances de titre et d'auteur similaires. Au moins un auteur et le type de livre doivent également correspondre. Lower trouve plus de doublons possibles ; plus haut nécessite des titres plus proches. Les fichiers identiques, ISBN et les métadonnées exactes sont vérifiés séparément.",
+      "runScan": "Exécuter une analyse",
+      "rescan": "Nouvelle analyse",
+      "status": {
+        "queued": "Analyse en file d'attente",
+        "running": "Analyse des livres"
+      },
+      "groupsFound": "{count, plural, =0 {Pas de groupes en double} one {Un groupe en double} other {# groupes en double} many {# groupes en double}}",
+      "filter": "Type de correspondance",
+      "allReasons": "Tous les types de matchs",
+      "reasons": {
+        "file_hash": "Ensemble de fichiers identiques",
+        "isbn": "Idem ISBN",
+        "exact_metadata": "Titre exact et auteurs",
+        "fuzzy_metadata": "Titre et auteur similaires"
+      },
+      "similarityValue": "{percent} % de similarité du titre",
+      "notDuplicates": "Pas de doublons",
+      "keepThis": "Gardez ce livre",
+      "discardThis": "Jeter ce livre",
+      "selectKeeperFirst": "Sélectionnez d'abord un gardien",
+      "noDirectMatch": "Pas de match direct avec le gardien",
+      "moreFiles": "+{count} plus",
+      "showDetails": "Afficher les détails",
+      "hideDetails": "Masquer les détails",
+      "deleteSelected": "Supprimer {count} sélectionné",
+      "openBook": "Ouvrir les détails de {title}",
+      "unknownAuthor": "Auteur inconnu",
+      "unknown": "Inconnu",
+      "none": "Aucun",
+      "accessDenied": "Vous n'êtes pas autorisé à utiliser l'outil de duplication de livre.",
+      "pairDetails": "Détails du match",
+      "pairLabel": "{first} et {second}",
+      "fields": {
+        "library": "Bibliothèque",
+        "isbn": "ISBN",
+        "formats": "Formats",
+        "fileLocation": "Fichier",
+        "files": "Fichiers",
+        "readingStatus": "Statut de lecture",
+        "progress": "Progrès",
+        "path": "Chemin de la bibliothèque",
+        "collections": "Collections",
+        "added": "Ajouté",
+        "updated": "Mis à jour"
+      },
+      "initial": {
+        "title": "Trouver des livres en double",
+        "description": "Choisissez une étendue de bibliothèque et un niveau de similarité, puis exécutez une analyse. Aucun livre n'est modifié jusqu'à ce que vous confirmiez explicitement une suppression."
+      },
+      "empty": {
+        "title": "Aucun groupe en double trouvé",
+        "description": "Aucun livre ne correspond à la portée, au niveau de similarité et au filtre de correspondance actuels."
+      },
+      "deleteDialog": {
+        "title": "Supprimer définitivement les livres en double ?",
+        "description": "{count, plural, =0 {Cela supprimera définitivement # livre sélectionné et ses fichiers.} one {Cela supprimera définitivement # livre sélectionné et ses fichiers.} other {Cela supprimera définitivement # livres sélectionnés et leurs fichiers.} many {Cela supprimera définitivement # livres sélectionnés et leurs fichiers.}}",
+        "warning": "Les métadonnées, les collections, les données de lecture et l'état de l'appareil ne sont pas transférés dans le livre tenu. Les données associées aux autres utilisateurs sont également supprimées.",
+        "confirm": "{count, plural, =0 {Supprimer # livre} one {Supprimer # livre} other {Supprimer # livres} many {Supprimer # livres}}",
+        "success": "{count, plural, =0 {Aucun livre supprimé} one {Un livre en double supprimé} other {# livres en double supprimés} many {# livres en double supprimés}}"
+      },
+      "errors": {
+        "start": "Impossible de démarrer l'analyse des doublons.",
+        "status": "Impossible de charger la progression de l'analyse.",
+        "scan": "L'analyse des doublons a échoué. Essayez de l'exécuter à nouveau.",
+        "results": "Impossible de charger les groupes en double.",
+        "delete": "Impossible de supprimer les livres en double sélectionnés."
+      },
+      "pagination": {
+        "label": "Pages de groupes en double",
+        "page": "Page {page} sur {total}"
+      }
+    },
+    "entityManager": {
+      "unknown": "Inconnu",
+      "bookCount": "{count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+      "sortPrefix": "· trier : {sortName}",
+      "selectTargetToKeep": "Sélectionnez la cible à conserver",
+      "writeToFiles": "Écrire dans des fichiers",
+      "writeChangesToFiles": "Écrire des modifications dans des fichiers",
+      "mergeIntoTarget": "Fusionner {count} dans la cible",
+      "modes": {
+        "browse": "Parcourir et gérer",
+        "duplicates": "Rechercher des doublons"
+      },
+      "actions": {
+        "rename": "Renommer",
+        "split": "Diviser"
+      },
+      "duplicates": {
+        "similarity": "Similitude :",
+        "scan": "Analyser",
+        "scanning": "Numérisation...",
+        "computing": "Calcul des candidats...",
+        "computedAt": "Candidats calculés {date}",
+        "recompute": "Recalculer",
+        "noneComputed": "Aucun candidat n'a encore été calculé.",
+        "computeNow": "Calculez maintenant",
+        "emptyTitle": "Rechercher des entités en double",
+        "emptyDescription": "Ajustez le seuil de similarité et cliquez sur Analyser pour détecter les doublons potentiels.",
+        "noneFoundTitle": "Aucun doublon trouvé",
+        "noneFoundDescription": "Aucun doublon potentiel n'a été détecté avec les paramètres actuels.",
+        "clustersFound": "{count, plural, =0 {aucun cluster trouvé} one {# cluster trouvé} other {# clusters trouvés} many {# clusters trouvés}}",
+        "plusOthers": "{count, plural, =0 {+ # autre} one {+ # autre} other {+ # d'autres} many {+ # d'autres}}",
+        "percentSimilar": "{percent}% de similarité",
+        "pairDetails": "Détails de la paire",
+        "dismissEntityTitle": "Ignorer toutes les paires pour cette entité",
+        "dismissPairTitle": "Rejeter cette paire"
+      },
+      "dismissed": {
+        "loading": "Chargement des paires rejetées...",
+        "empty": "Aucune paire rejetée",
+        "restore": "Restaurer",
+        "restoreTitle": "Restaurer cette paire",
+        "hidePairs": "Masquer les paires ignorées",
+        "showPairs": "Afficher les paires rejetées"
+      },
+      "browse": {
+        "searchPlaceholder": "Rechercher...",
+        "emptyOnly": "Vide seulement",
+        "clear": "Effacer",
+        "noEntities": "Aucune entité trouvée",
+        "mergeCount": "Fusionner ({count})",
+        "deleteCount": "Supprimer ({count})",
+        "totalCount": "{count} total",
+        "sortLabel": "trier : {sortName}",
+        "sort": {
+          "nameAsc": "Nom A-Z",
+          "nameDesc": "Nom Z-A",
+          "fewestBooks": "Moins de livres",
+          "mostBooks": "La plupart des livres"
+        }
+      },
+      "deleteMode": {
+        "label": "Mode suppression",
+        "softTitle": "Suppression logicielle",
+        "softDescription": "Dissocier tous les livres mais conserver l'enregistrement de l'entité",
+        "softDescriptionPlural": "Dissocier tous les livres mais conserver les enregistrements de l'entité",
+        "hardTitle": "Suppression définitive",
+        "hardDescription": "Supprimer définitivement l'entité et toutes les associations",
+        "hardDescriptionPlural": "Supprimer définitivement les entités et toutes les associations"
+      },
+      "renameModal": {
+        "title": "Renommer l'entité",
+        "currentName": "Nom actuel",
+        "newName": "Nouveau nom"
+      },
+      "deleteModal": {
+        "title": "Supprimer l'entité",
+        "confirm": "Êtes-vous sûr de vouloir supprimer {name} ?"
+      },
+      "splitModal": {
+        "title": "Diviser l'entité",
+        "splitting": "Fractionnement",
+        "newNames": "Nouveaux noms (min 2)",
+        "namePlaceholder": "Entrez le nom...",
+        "addAnother": "Ajoutez-en un autre"
+      },
+      "bulkDeleteModal": {
+        "title": "Suppression groupée",
+        "confirm": "{count, plural, =0 {Etes-vous sûr de vouloir supprimer # entité sélectionnée ?} one {Etes-vous sûr de vouloir supprimer # entité sélectionnée ?} other {Etes-vous sûr de vouloir supprimer # entités sélectionnées ?} many {Etes-vous sûr de vouloir supprimer # entités sélectionnées ?}}",
+        "deleteButton": "Supprimer {count}"
+      },
+      "mergeModal": {
+        "title": "Fusionner des entités",
+        "description": "Sélectionnez l'entité à conserver. Les autres y seront fusionnés et supprimés."
+      }
+    }
+  },
+  "views": {
+    "entity": {
+      "book": "Livre",
+      "collection": "Collecte",
+      "library": "Bibliothèque",
+      "smartScope": "SmartScope"
+    },
+    "common": {
+      "retry": "Réessayer"
+    },
+    "bookView": {
+      "sort": "Trier",
+      "sortOn": "Sur",
+      "resetSort": "Réinitialiser le tri par défaut",
+      "filters": "Filtres",
+      "clear": "Effacer",
+      "clearAllFilters": "Supprimer tous les filtres",
+      "expandSeries": "Agrandir la série",
+      "collapseSeries": "Réduire la série",
+      "expanded": "Élargi",
+      "exportMetadata": "Exporter les métadonnées",
+      "showControlsAria": "Afficher les contrôles de la bibliothèque",
+      "export": "Exporter",
+      "searchPlaceholder": "Rechercher un titre, un auteur, une série, un narrateur...",
+      "allBooksLoaded": "Tous les {count} livres chargés"
+    },
+    "notFound": {
+      "title": "Page introuvable",
+      "description": "La page que vous recherchez n'existe pas.",
+      "goHome": "Rentre chez toi"
+    },
+    "dashboard": {
+      "customize": "Personnaliser le tableau de bord",
+      "allShelvesHidden": "Toutes les étagères sont cachées.",
+      "greeting": {
+        "night": "Bonne nuit,",
+        "morning": "Bonjour,",
+        "afternoon": "Bonjour,",
+        "evening": "Bonsoir,",
+        "fallbackName": "là"
+      }
+    },
+    "bookDetail": {
+      "title": "Livre",
+      "titleWithId": "Livre n°{id}",
+      "pageTitle": {
+        "book": "Livre · {base}",
+        "editMetadata": "Modifier les métadonnées · {base}",
+        "edit": "Modifier · {base}",
+        "files": "Fichiers · {base}",
+        "readingLog": "Journal de lecture · {base}",
+        "highlights": "Points forts · {base}"
+      }
+    },
+    "bookDock": {
+      "title": "Book Dock",
+      "newFilesDetected": "Nouveaux fichiers détectés",
+      "reconnecting": "Reconnexion",
+      "rescanFailed": "Échec de la nouvelle analyse",
+      "totalInDock": "{size} dans Book Dock",
+      "dropFiles": "Déposez des fichiers dans Book Dock",
+      "supportedFormats": "Pris en charge : {formats}",
+      "empty": {
+        "noSearchMatch": "Aucun fichier ne correspond à \"{query}\"",
+        "noStatusFiles": "Aucun fichier {status}",
+        "uploadPrompt": "Téléchargez des fichiers ou déposez-les dans le dossier Book Dock"
+      },
+      "retry": {
+        "noneToRetry": "Aucun fichier d'erreur à réessayer",
+        "retrying": "{count, plural, =0 {Réessayer un fichier} one {Réessayer un fichier} other {Réessayer # fichiers} many {Réessayer # fichiers}}"
+      },
+      "applyFetched": {
+        "applied": "{count, plural, =0 {Appliqué à aucun fichier} one {Appliqué à un fichier} other {Appliqué à # fichiers} many {Appliqué à # fichiers}}",
+        "skippedEdited": "{count, plural, =0 {j'ai ignoré un fichier car ils ont des modifications manuelles} one {j'ai ignoré un fichier car il comporte des modifications manuelles} other {ignoré # fichiers car ils ont des modifications manuelles} many {ignoré # fichiers car ils ont des modifications manuelles}}",
+        "skippedNoMetadata": "{count, plural, =0 {j'ai ignoré un fichier car ils n'ont pas récupéré de métadonnées} one {j'ai ignoré un fichier car il ne contient aucune métadonnée récupérée} other {ignoré # fichiers car ils n'ont pas de métadonnées récupérées} many {ignoré # fichiers car ils n'ont pas de métadonnées récupérées}}",
+        "noneApplied": "Aucun fichier appliqué ; {reasons}",
+        "noneSelected": "Aucun fichier sélectionné"
+      }
+    },
+    "collection": {
+      "title": "Collecte",
+      "pageTitle": "Collecte · {name}",
+      "pageTitleWithId": "Collection #{id}",
+      "editCollection": "Modifier la collection",
+      "showControlsAria": "Afficher les contrôles de collection",
+      "loadError": "Impossible de charger cette collection",
+      "toast": {
+        "removed": "{count, plural, =0 {Aucun livre n'a été supprimé de la collection} one {Suppression d'un livre de la collection} other {Supprimé # livres de collection} many {Supprimé # livres de collection}}",
+        "removeFailed": "Échec de la suppression des livres de la collection"
+      },
+      "empty": {
+        "noSearchMatch": "Aucun livre ne correspond à cette recherche",
+        "noSearchMatchHint": "Essayez un autre terme de recherche ou effacez la recherche.",
+        "noBooks": "Aucun livre dans cette collection",
+        "noBooksHint": "Sélectionnez des livres de votre bibliothèque et ajoutez-les ici."
+      }
+    },
+    "library": {
+      "title": "Bibliothèque",
+      "pageTitle": "Bibliothèque · {name}",
+      "pageTitleWithId": "Bibliothèque #{id}",
+      "filterRules": "Règles de filtrage",
+      "saveAsSmartScope": "Enregistrer en tant que Smart Scope",
+      "saveScope": "Enregistrer la portée",
+      "saveAsSmartScopeTooltip": "Enregistrez ce filtre en tant que Smart Scope nommé",
+      "saved": "Enregistré",
+      "saveFilter": "Enregistrer le filtre",
+      "filterSaved": "Filtre enregistré",
+      "saveFilterTooltip": "Enregistrer le filtre pour cette bibliothèque",
+      "removeSavedFilter": "Supprimer le filtre enregistré",
+      "empty": {
+        "noFilterMatch": "Aucun livre ne correspond à vos filtres",
+        "noFilterMatchHint": "Essayez d'ajuster ou de supprimer vos filtres pour voir plus de livres.",
+        "clearFilters": "Effacer les filtres",
+        "scanning": "Analyse de votre bibliothèque...",
+        "scanningHint": "Les livres apparaîtront ici au fur et à mesure de leur découverte.",
+        "emptyLibrary": "Votre bibliothèque est vide",
+        "emptyLibraryHint": "Une fois que vous aurez ajouté des livres à cette bibliothèque, ils apparaîtront ici."
+      },
+      "querySelection": {
+        "loadedSelected": "{selected} des {total} livres chargés sélectionnés.",
+        "selectAllMatching": "Sélectionnez tous les {total} livres correspondants"
+      }
+    },
+    "smartScope": {
+      "title": "SmartScope",
+      "pageTitle": "SmartScope · {name}",
+      "pageTitleWithId": "SmartScope #{id}",
+      "defaultName": "Portée intelligente",
+      "filter": "Filtrer",
+      "edit": "Modifier la portée intelligente",
+      "showControlsAria": "Afficher les commandes Smart Scope",
+      "hideFilter": "Masquer le filtre",
+      "showFilter": "Afficher le filtre",
+      "confirmDelete": "Confirmer ?",
+      "loadError": "Impossible de charger ce SmartScope",
+      "toast": {
+        "deleted": "\"{name}\" supprimé",
+        "deleteFailed": "Échec de la suppression de \"{name}\""
+      },
+      "empty": {
+        "noRules": "Aucune règle configurée",
+        "noRulesHint": "Ouvrez l'éditeur pour définir quels livres apparaissent dans ce smartScope à l'aide de filtres et de règles de tri.",
+        "configure": "Configurer SmartScope",
+        "noMatch": "Aucun livre ne correspond à ce smartScope",
+        "noMatchHint": "Essayez d'ajuster les règles de filtrage.",
+        "edit": "Modifier SmartScope"
+      }
+    }
+  },
+  "whatsNew": {
+    "title": "Quoi de neuf",
+    "subtitle": "Tout ce qui est expédié, le plus récent en premier.",
+    "versionPrefix": "Version {version}",
+    "newUpdates": "{count, plural, =0 {pas de nouvelles mises à jour} one {une nouvelle mise à jour} other {# nouvelles mises à jour} many {# nouvelles mises à jour}}",
+    "remindLater": "Rappelle-moi plus tard",
+    "gotIt": "Je l'ai compris",
+    "latest": "Dernier",
+    "fullChangelog": "Journal des modifications complet",
+    "seeAllReleases": "Voir toutes les versions",
+    "versions": "Versions",
+    "currentVersion": "Version actuelle",
+    "youreHere": "Tu es là",
+    "searchPlaceholder": "Rechercher des versions…",
+    "noReleasesFound": "Aucune version trouvée.",
+    "noHighlights": "Aucun fait marquant pour cette version.",
+    "showChangelog": "Afficher le journal des modifications complet",
+    "hideChangelog": "Masquer le journal des modifications complet",
+    "openOnGitHub": "Ouvrir sur GitHub",
+    "loadMore": "Charger plus",
+    "loadingMore": "Chargement…",
+    "loadFailed": "Échec du chargement des versions",
+    "loadMoreFailed": "Impossible de charger d'autres versions. Veuillez réessayer.",
+    "loadErrorHint": "Impossible de charger les versions. Vérifiez votre connexion et réessayez.",
+    "retry": "Réessayer",
+    "imageViewer": "Visionneuse d'images",
+    "closeImage": "Fermer l'image",
+    "previousImage": "Image précédente",
+    "nextImage": "Image suivante"
+  },
+  "titles": {
+    "dashboard": "Tableau de bord",
+    "libraries": "Bibliothèques",
+    "opds": "OPDS",
+    "koboSync": "Kobo Synchronisation",
+    "koreaderSync": "KOReader Synchronisation",
+    "bookDock": "Book Dock",
+    "whatsNew": "Quoi de neuf",
+    "annotations": "Annotations",
+    "achievements": "Réalisations",
+    "statistics": "Statistiques",
+    "authors": "Auteurs",
+    "series": "Série",
+    "entityManager": "Gestionnaire d'entité",
+    "bulkRename": "Renommer en masse",
+    "duplicateBooks": "Livres en double",
+    "notFound": "Introuvable",
+    "signIn": "Connectez-vous",
+    "initialSetup": "Configuration initiale",
+    "forgotPassword": "Mot de passe oublié",
+    "resetPassword": "Réinitialiser le mot de passe",
+    "completingSignIn": "Terminer la connexion",
+    "magicLinkLogin": "Connexion au lien magique",
+    "readPrefix": "Lire",
+    "emailSuffix": "Courriel",
+    "library": "Bibliothèque",
+    "smartScope": "SmartScope",
+    "collection": "Collecte",
+    "author": "Auteur",
+    "book": "Livre",
+    "seriesItem": "Série",
+    "appearance": {
+      "theme": "Affichage",
+      "book-covers": "Couvertures de livres",
+      "icons": "Icônes",
+      "layout": "Disposition de l'affichage",
+      "behavior": "Comportement de la bibliothèque"
+    },
+    "reader": {
+      "general": "Paramètres du lecteur",
+      "ebook": "Lecteur de livres électroniques",
+      "pdf": "PDF Lecteur",
+      "comics": "Lecteur de bandes dessinées",
+      "audio": "Lecteur de livres audio",
+      "fonts": "Polices de lecture"
+    },
+    "email": {
+      "providers": "Fournisseurs",
+      "recipients": "Destinataires",
+      "groups": "Groupes",
+      "templates": "Modèles",
+      "preferences": "Préférences",
+      "history": "Histoire"
+    },
+    "metadata": {
+      "providers": "Fournisseurs",
+      "field-rules": "Règles au niveau du champ",
+      "custom-fields": "Métadonnées personnalisées",
+      "genre-blocklist": "Liste de blocage des genres",
+      "score": "Score de confiance",
+      "auto-fetch": "Récupération automatique du livre",
+      "authors": "Récupération automatique de l'auteur"
+    },
+    "admin": {
+      "users": "Utilisateurs",
+      "account-activity": "Activité du compte",
+      "magic-links": "Liens magiques",
+      "oidc": "OIDC / SSO"
+    },
+    "system": {
+      "file-naming": "Nom du fichier",
+      "book-dock": "Book Dock",
+      "maintenance": "Entretien",
+      "audit-log": "Journal d'audit"
+    },
+    "account": {
+      "profile": "Compte",
+      "privacy": "Confidentialité et partage",
+      "notifications": "Notifications",
+      "restrictions": "Restrictions de contenu"
+    }
+  }
+}

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -467,7 +467,7 @@
       },
       "feedback": {
         "unsavedChanges": "Modifications non enregistrées",
-        "allSaved": "Toutes les modifications enregistrées"
+        "discard": "Abandonner"
       },
       "profile": {
         "securityHeading": "Profil et sécurité",
@@ -484,7 +484,11 @@
         "accountTypeLocal": "Local",
         "nameRequired": "Le nom est requis",
         "updateFailed": "Échec de la mise à jour du profil",
-        "updated": "Profil mis à jour"
+        "updated": "Profil mis à jour",
+        "usernameHint": "Votre nom d'utilisateur ne peut pas être modifié.",
+        "passwordHint": "Modifiez le mot de passe que vous utilisez pour vous connecter.",
+        "passwordHintOidc": "Votre mot de passe est géré par votre fournisseur d'identité.",
+        "passwordHintShared": "Les comptes partagés se connectent via un lien magique et n'ont pas de mot de passe."
       },
       "readingPreferences": {
         "title": "Préférences de lecture",
@@ -492,7 +496,10 @@
         "timezone": "Fuseau horaire",
         "save": "Enregistrer les préférences",
         "enableAchievements": "Activer les réalisations",
-        "enableAchievementsHint": "Suivez la progression des réalisations et affichez l’interface liée aux réalisations. Gérez les notifications de réussite séparément dans Notifications."
+        "enableAchievementsHint": "Suivez la progression des réalisations et affichez l’interface liée aux réalisations. Gérez les notifications de réussite séparément dans Notifications.",
+        "achievementsEnabled": "Réalisations activées",
+        "achievementsDisabled": "Réalisations désactivées",
+        "achievementsSaveFailed": "Échec de la mise à jour de la préférence de réalisations"
       },
       "preferences": {
         "saveFailed": "Échec de l'enregistrement des préférences",
@@ -534,7 +541,9 @@
           "title": "Dissocier l'identité {provider} ?",
           "description": "Entrez votre mot de passe pour confirmer. Vous ne pourrez plus vous connecter avec ce fournisseur.",
           "currentPassword": "Mot de passe actuel"
-        }
+        },
+        "description": "Connectez-vous avec un fournisseur d'identité externe lié à ce compte.",
+        "unlinkAria": "Dissocier {provider}"
       },
       "tour": {
         "title": "Visite guidée",
@@ -563,6 +572,11 @@
           "title": "Genres bloqués",
           "description": "Les livres appartenant à l’un de ces genres vous sont cachés."
         }
+      },
+      "groups": {
+        "profile": "Profil",
+        "preferences": "Préférences",
+        "security": "Sécurité et accès"
       }
     },
     "magicLinks": {
@@ -596,10 +610,10 @@
         "createdBy": "Créé par",
         "expires": "Expire",
         "uses": "Utilisations",
-        "lastUsed": "Dernière utilisation",
         "created": "Créé",
         "status": "Statut",
-        "totalUses": "Utilisations totales"
+        "totalUses": "Utilisations totales",
+        "actions": "Actions"
       },
       "createDialog": {
         "title": "Créer un lien magique",
@@ -627,7 +641,12 @@
       "emptyTitle": "Aucun lien magique n'a encore été créé",
       "emptyHint": "Cliquez sur \"{action}\" pour générer une connexion partageable URL.",
       "noActiveTitle": "Aucun lien magique actif",
-      "noActiveHint": "Tous les liens magiques générés pour cette page ont expiré ou ont été révoqués."
+      "noActiveHint": "Tous les liens magiques générés pour cette page ont expiré ou ont été révoqués.",
+      "copyLinkAria": "Copier le lien pour {label}",
+      "pauseAria": "Suspendre {label}",
+      "resumeAria": "Reprendre {label}",
+      "revokeAria": "Révoquer {label}",
+      "lastUsedLabel": "Dernière utilisation : {date}"
     },
     "oidc": {
       "title": "OIDC / SSO",
@@ -1692,9 +1711,6 @@
         "subtitle": "Contrôlez la manière dont les fichiers sont organisés sur le disque lorsqu'ils sont téléchargés et comment ils sont nommés lors du téléchargement à l'aide de jetons d'espace réservé.",
         "copy": "Copier",
         "previewLabel": "Aperçu :",
-        "fileAsBookPreview": "Fichier en tant qu'aperçu du livre",
-        "folderAsBookPreview": "Dossier en tant qu'aperçu du livre",
-        "downloadPreview": "Télécharger l'aperçu",
         "globalDefaults": "Valeurs par défaut globales",
         "crossPlatform": "Désinfection des chemins multiplateformes",
         "crossPlatformHint": "Sécurisez les noms de fichiers et de dossiers générés sous Windows en remplaçant les caractères non valides et les noms réservés, et en supprimant les points et les espaces de fin. Désactivez uniquement pour les configurations Linux uniquement qui conservent intentionnellement ces caractères.",
@@ -1711,15 +1727,10 @@
         "orgFolderAsBook": "Dossier en tant que livre",
         "orgFileAsBook": "Classer en tant que livre",
         "resetToDefault": "Réinitialiser aux valeurs par défaut",
-        "patternReference": "Référence du modèle",
-        "placeholderReference": "Référence d'espace réservé",
-        "placeholderReferenceHint": "- guide pour créer des modèles de dénomination personnalisés",
         "tokens": "Jetons",
-        "tokensHint": "Copiez rapidement les espaces réservés",
         "clickTokenHint": "Cliquez sur n'importe quel jeton pour le copier dans votre presse-papiers.",
         "copyValue": "Copier {value}",
         "modifiers": "Modificateurs",
-        "modifiersHint": "Transformer les valeurs des jetons",
         "modifiersExplain": "Ajoutez un modificateur à l'intérieur d'un jeton pour transformer sa valeur :",
         "modFirst": "Première valeur uniquement",
         "modSort": "Format Dernier, Premier",
@@ -1728,14 +1739,10 @@
         "folderOnlyPrefix": "Terminez un motif avec",
         "folderOnlySuffix": "pour spécifier un dossier uniquement. Le nom du fichier original sera conservé à l'intérieur.",
         "conditionalLogic": "Logique conditionnelle",
-        "conditionalLogicHint": "Segments facultatifs et solutions de secours",
         "conditionalPart1": "Enveloppez-vous",
         "conditionalPart2": "pour sauter un segment lorsque son jeton est vide. Utiliser",
         "conditionalPart3": "pour une valeur par défaut.",
         "examples": "Exemples",
-        "patternExamples": "Exemples de modèles",
-        "patternExamplesHint": "Modèles prêts à l'emploi pour les styles de bibliothèque courants",
-        "copyPatternTooltip": "Copier le motif dans le presse-papiers",
         "exCalibre": "Style Calibre par défaut",
         "exSeriesReader": "Lecteur de série",
         "exCleanDownload": "Nettoyer le nom du fichier de téléchargement",
@@ -1763,7 +1770,37 @@
         "patternCopied": "Motif copié dans le presse-papiers",
         "copyPatternFailed": "Échec de la copie du modèle",
         "labelCopied": "{label} copié dans le presse-papiers",
-        "copyLabelFailed": "Échec de la copie de {label}"
+        "copyLabelFailed": "Échec de la copie de {label}",
+        "patternHelp": "Aide sur les modèles",
+        "patternHelpDescription": "Jetons, modificateurs et modèles prêts à l'emploi que vous pouvez copier dans n'importe quel champ.",
+        "copyPreview": "Copier {label}",
+        "copyExample": "Copier le modèle {label}",
+        "invalidCharacters": "Le modèle contient des caractères non valides",
+        "fileAsBookSaved": "Valeur par défaut Fichier comme livre enregistrée",
+        "folderAsBookSaved": "Valeur par défaut Dossier comme livre enregistrée",
+        "downloadPatternSaved": "Modèle de téléchargement enregistré",
+        "savePatternFailed": "Échec de l'enregistrement du modèle",
+        "saveDownloadPatternFailed": "Échec de l'enregistrement du modèle de téléchargement",
+        "crossPlatformEnabled": "Désinfection des chemins multiplateformes activée",
+        "crossPlatformDisabled": "Désinfection des chemins multiplateformes désactivée",
+        "crossPlatformSaveFailed": "Échec de l'enregistrement de la désinfection des chemins multiplateformes",
+        "librarySaved": "Modèle enregistré pour {name}",
+        "librarySaveFailed": "Échec de l'enregistrement du modèle de bibliothèque",
+        "saveLibraryPattern": "Enregistrer le modèle pour {name}",
+        "resetLibraryPattern": "Réinitialiser {name} au modèle par défaut",
+        "tokenTitle": "Titre du livre",
+        "tokenSubtitle": "Sous-titre du livre",
+        "tokenAuthors": "Auteur(s), séparés par des virgules",
+        "tokenYear": "Année de publication",
+        "tokenSeries": "Nom de la série",
+        "tokenSeriesIndex": "Index de la série (complété par des zéros)",
+        "tokenPublisher": "Éditeur",
+        "tokenIsbn": "ISBN-13",
+        "tokenLanguage": "Langue",
+        "tokenOriginalFilename": "Nom de fichier d'origine (sans extension)",
+        "tokenExtension": "Extension de fichier (sans point)",
+        "patternHelpIntro": "Les modèles utilisent des jetons comme {titleToken} et {authorsToken}, ainsi que des modificateurs et des segments facultatifs.",
+        "browseTokensAndExamples": "Parcourir les jetons et les exemples"
       },
       "kobo": {
         "title": "Kobo Synchronisation",
@@ -2451,19 +2488,15 @@
     },
     "usersPage": {
       "usersTitle": "Utilisateurs",
-      "magicLinksTitle": "Liens magiques",
       "usersSubtitle": "Gérez les comptes d'utilisateurs et les attributions d'autorisations.",
-      "magicLinksSubtitle": "Créez des liens de connexion partageables pour les comptes partagés.",
       "createUser": "Créer un utilisateur",
-      "createLink": "Créer un lien",
-      "usersTab": "Utilisateurs",
-      "magicLinksTab": "Liens magiques",
       "columns": {
         "name": "Nom",
         "username": "Nom d'utilisateur",
         "email": "Courriel",
         "access": "Accès",
-        "status": "Statut"
+        "status": "Statut",
+        "actions": "Actions"
       },
       "adminBadge": "Administrateur",
       "permissionCount": "{count, plural, =0 {aucune autorisation} one {une autorisation} other {# autorisations} many {# autorisations}}",
@@ -2481,11 +2514,10 @@
       "deleteDialogBody": "Supprimez l'utilisateur \"{username}\". Cette action ne peut pas être annulée.",
       "deleting": "Suppression...",
       "errors": {
-        "loadData": "Échec du chargement des données",
         "load": "Échec du chargement",
-        "deleteUser": "Échec de la suppression de l'utilisateur"
+        "deleteUser": "Échec de la suppression de l'utilisateur",
+        "resetPassword": "Échec de la création d'un lien de réinitialisation du mot de passe"
       },
-      "currentUsers": "Utilisateurs actuels",
       "defaultLibraryAccess": {
         "title": "Accès à la bibliothèque par défaut",
         "subtitle": "Accès de visualisation accordé aux utilisateurs auto-enregistrés et dotés de OIDC.",
@@ -2493,9 +2525,37 @@
         "noLibraries": "Aucune bibliothèque disponible.",
         "save": "Enregistrer les valeurs par défaut",
         "saving": "Sauvegarde...",
-        "saved": "Accès à la bibliothèque par défaut enregistré.",
         "saveError": "Échec de l'enregistrement de l'accès par défaut à la bibliothèque"
-      }
+      },
+      "filters": {
+        "search": "Rechercher des utilisateurs",
+        "searchPlaceholder": "Rechercher par nom, nom d'utilisateur ou e-mail",
+        "sort": "Trier les utilisateurs",
+        "usernameAsc": "Nom d'utilisateur A-Z",
+        "nameAsc": "Nom A-Z",
+        "newest": "Les plus récents d'abord",
+        "oldest": "Les plus anciens d'abord",
+        "apply": "Appliquer",
+        "clear": "Effacer",
+        "state": "Filtrer les utilisateurs",
+        "allUsers": "Tous les utilisateurs",
+        "admins": "Administrateurs",
+        "active": "Actif",
+        "inactive": "Inactif"
+      },
+      "empty": {
+        "title": "Aucun utilisateur pour l'instant",
+        "description": "Créez le premier compte pour commencer.",
+        "filtered": "Aucun utilisateur ne correspond à la recherche et aux filtres actuels."
+      },
+      "pagination": {
+        "label": "Pagination des utilisateurs",
+        "page": "Page {page} sur {totalPages}"
+      },
+      "editUserAria": "Modifier {name}",
+      "resetPasswordAria": "Réinitialiser le mot de passe de {name}",
+      "deleteUserAria": "Supprimer {name}",
+      "moreActionsAria": "Plus d'actions pour {name}"
     }
   },
   "annotations": {
@@ -4298,17 +4358,17 @@
         "title": "Vous appréciez BookOrbit ?",
         "body": "Si BookOrbit vous aide avec votre bibliothèque, pensez à mettre le projet en vedette sur GitHub. Cela aide davantage de personnes à découvrir l’application et prend en charge le développement continu.",
         "cta": "Étoile BookOrbit sur GitHub"
-      }
+      },
+      "surfaceOpacity": "Opacité de la surface",
+      "surfaceOpacityValue": "{value} %"
     },
     "sidebar": {
-      "tagline": "Votre espace de lecture",
       "dashboard": "Tableau de bord",
       "authors": "Auteurs",
       "series": "Série",
       "tools": "Outils",
       "libraries": "Bibliothèques",
       "newLibrary": "Nouvelle bibliothèque",
-      "libraryScanning": "{name} - Numérisation {pct}%",
       "scanProgress": "Livres {processed} / {total}",
       "smartScopes": "Portées intelligentes",
       "newSmartScope": "Nouvelle lunette intelligente",
@@ -4316,15 +4376,41 @@
       "collections": "Collections",
       "newCollection": "Nouvelle collection",
       "noCollections": "Aucune collection pour l'instant",
-      "latest": "Dernier {version}",
       "newReleaseNotes": "Nouvelles notes de version disponibles",
       "support": "Prise en charge de BookOrbit",
-      "supportShort": "Assistance",
       "supportAria": "Soutenez BookOrbit sur Ko-fi",
       "sectionHeader": {
         "add": "Ajouter",
+        "showAll": "Tout afficher",
+        "showCount": "Afficher {count}",
+        "rowsShown": "Lignes affichées",
+        "menuAria": "Options de section pour {section}",
         "reorder": "Réorganiser",
         "doneReordering": "Réorganisation terminée"
+      },
+      "noLibraries": "Aucune bibliothèque pour l'instant",
+      "clearFilter": "Effacer le filtre",
+      "filterSummary": "{shown} sur {total} affichés",
+      "filterLibraries": "Filtrer les bibliothèques",
+      "filterLibrariesPlaceholder": "Filtrer les bibliothèques...",
+      "filterSmartScopes": "Filtrer les portées intelligentes",
+      "filterSmartScopesPlaceholder": "Filtrer les portées intelligentes...",
+      "filterCollections": "Filtrer les collections",
+      "filterCollectionsPlaceholder": "Filtrer les collections...",
+      "seeAllLibraries": "Voir toutes les bibliothèques ({count})",
+      "seeAllSmartScopes": "Voir toutes les portées intelligentes ({count})",
+      "seeAllCollections": "Voir toutes les collections ({count})",
+      "updateAvailable": "Mettre à jour {version}",
+      "zones": {
+        "browse": "Parcourir"
+      },
+      "reorder": {
+        "gripAria": "Réorganiser {name}",
+        "lifted": "{name} soulevé, position {position} sur {total}. Utilisez les touches fléchées pour le déplacer.",
+        "moved": "{name}, position {position} sur {total}",
+        "dropped": "{name} déposé à la position {position} sur {total}",
+        "cancelled": "Réorganisation annulée. {name} est revenu à la position {position} sur {total}.",
+        "filteredHint": "Effacez le filtre pour réorganiser"
       }
     },
     "selectionActionBar": {
@@ -4424,6 +4510,24 @@
         "typeAndEnter": "Tapez et appuyez sur Entrée pour ajouter",
         "pressEnter": "Appuyez sur Entrée pour ajouter"
       }
+    },
+    "entityIndex": {
+      "sortBy": "Trier par",
+      "sort": {
+        "custom": "Ordre personnalisé",
+        "name": "Nom",
+        "bookCount": "Nombre de livres"
+      },
+      "ascending": "Ascendant",
+      "descending": "Décroissant",
+      "clearSearch": "Effacer la recherche",
+      "resultCount": "{shown} sur {total}",
+      "noMatches": "Aucun résultat",
+      "noMatchesHint": "Essayez un autre terme de recherche.",
+      "bookCount": "Livres : {count}",
+      "librariesEmptyHint": "Créez une bibliothèque pour commencer à ajouter des livres.",
+      "smartScopesEmptyHint": "Les portées intelligentes enregistrent un ensemble de filtres que vous utilisez souvent.",
+      "collectionsEmptyHint": "Les collections regroupent les livres que vous choisissez à la main."
     }
   },
   "customIcons": {
@@ -5552,7 +5656,61 @@
       "saveFailed": "Échec de l'enregistrement des préférences",
       "savePreferenceFailed": "Échec de l'enregistrement des préférences",
       "whatsNewToggle": "Afficher \"Quoi de neuf\" après les mises à jour",
-      "whatsNewToggleHint": "Une fenêtre contextuelle mettant en évidence les nouvelles fonctionnalités après les mises à jour de l'application. Les archives restent disponibles dans tous les cas."
+      "whatsNewToggleHint": "Une fenêtre contextuelle mettant en évidence les nouvelles fonctionnalités après les mises à jour de l'application. Les archives restent disponibles dans tous les cas.",
+      "groups": {
+        "library": "Bibliothèque",
+        "files": "Fichiers",
+        "integrations": "Intégrations",
+        "personal": "Personnel",
+        "app": "Mises à jour de l'application"
+      },
+      "enabledCount": "{enabled} sur {total} activés",
+      "categories": {
+        "scanning": {
+          "label": "Analyse de la bibliothèque",
+          "description": "Lorsqu'une analyse de bibliothèque se termine, échoue ou détecte des livres manquants."
+        },
+        "metadata": {
+          "label": "Récupération des métadonnées",
+          "description": "Lorsque les recherches de métadonnées de vos livres aboutissent ou échouent."
+        },
+        "authorEnrichment": {
+          "label": "Enrichissement des auteurs",
+          "description": "Lorsque la récupération des biographies et des photos d'auteurs est terminée."
+        },
+        "fileWriteBack": {
+          "label": "Réécriture dans les fichiers",
+          "description": "Lorsque les métadonnées modifiées sont réécrites dans les fichiers de livres sur le disque."
+        },
+        "fileRename": {
+          "label": "Renommage de fichier",
+          "description": "Lorsqu'un fichier de livre est renommé pour correspondre à votre modèle de dénomination."
+        },
+        "bulkRename": {
+          "label": "Renommage groupé",
+          "description": "Lorsqu'un renommage groupé sur de nombreux livres aboutit ou échoue."
+        },
+        "migration": {
+          "label": "Migration des données",
+          "description": "Lorsqu'une importation depuis un autre outil de bibliothèque aboutit ou échoue."
+        },
+        "bookDock": {
+          "label": "Book Dock",
+          "description": "Lorsque les fichiers déposés dans le dock sont prêts à être examinés ou finalisés."
+        },
+        "koboSync": {
+          "label": "Synchronisation Kobo",
+          "description": "Lorsqu'un appareil Kobo termine la synchronisation avec votre bibliothèque."
+        },
+        "email": {
+          "label": "Envoi par e-mail",
+          "description": "Lorsque l'envoi d'un livre à une adresse e-mail réussit ou échoue."
+        },
+        "achievements": {
+          "label": "Réalisations",
+          "description": "Lorsque vous débloquez une nouvelle réalisation de lecture."
+        }
+      }
     }
   },
   "reader": {
@@ -6628,6 +6786,8 @@
       "privacy": "Confidentialité et partage",
       "notifications": "Notifications",
       "restrictions": "Restrictions de contenu"
-    }
+    },
+    "smartScopes": "Portées intelligentes",
+    "collections": "Collections"
   }
 }

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -1,0 +1,6633 @@
+{
+  "common": {
+    "resetSortAria": "Ripristina l'ordinamento predefinito",
+    "save": "Salva",
+    "cancel": "Annulla",
+    "delete": "Elimina",
+    "edit": "Modifica",
+    "close": "Chiudi",
+    "confirm": "Conferma",
+    "loading": "Caricamento...",
+    "search": "Cerca",
+    "back": "Indietro",
+    "next": "Avanti",
+    "previous": "Precedente",
+    "retry": "Riprova",
+    "yes": "Sì",
+    "no": "No"
+  },
+  "settings": {
+    "privacySharing": {
+      "title": "Privacy e condivisione",
+      "subtitle": "Controlla se gli amministratori possono visualizzare un riepilogo identificabile della tua attività di lettura.",
+      "levelLegend": "Livello di condivisione degli insight di lettura",
+      "current": "Impostazione attuale",
+      "levels": {
+        "private": {
+          "title": "Privato",
+          "description": "Solo tu puoi vedere le tue statistiche di lettura."
+        },
+        "summary": {
+          "title": "Condividi riepilogo",
+          "description": "Condividi abitudini aggregate senza titoli di libri, autori, serie o narratori."
+        },
+        "detailed": {
+          "title": "Condividi approfondimenti dettagliati",
+          "description": "Condividi anche libri, autori, serie, generi e narratori recenti e più importanti."
+        }
+      },
+      "fields": {
+        "frequency": "Frequenza di lettura e giorni attivi",
+        "completion": "Libri aggregati iniziati e completati",
+        "formats": "Distribuzione dei formati",
+        "genres": "Ampia distribuzione di genere",
+        "trend": "Andamento della lettura aggregata",
+        "books": "Titoli di libri attuali, recenti e più letti",
+        "authors": "I migliori autori",
+        "series": "Serie superiore",
+        "narrators": "I migliori narratori"
+      },
+      "confirm": {
+        "shareTitle": "Abilitare {level}?",
+        "shareDescription": "Gli amministratori autorizzati potranno visualizzare le seguenti informazioni.",
+        "stopTitle": "Smettere di condividere approfondimenti di lettura?",
+        "stopDescription": "L'accesso come amministratore verrà bloccato immediatamente. I record di accesso esistenti rimangono nella tua cronologia.",
+        "recordedNotice": "Ogni visualizzazione del profilo amministratore viene registrata e appare nella cronologia degli accessi."
+      },
+      "preview": {
+        "title": "Visualizza l'anteprima del tuo profilo condiviso",
+        "description": "Visualizza le informazioni attualmente disponibili agli amministratori autorizzati.",
+        "action": "Carica anteprima",
+        "readingTime": "Tempo di lettura",
+        "activeDays": "Giornate attive",
+        "started": "I libri sono iniziati",
+        "completed": "Libri completati",
+        "topBooks": "I migliori libri"
+      },
+      "history": {
+        "title": "Cronologia degli accessi al profilo",
+        "description": "Viste recenti dell'amministratore del tuo profilo di lettura condiviso.",
+        "empty": "Nessun amministratore ha visualizzato il tuo profilo di lettura condiviso.",
+        "paginationLabel": "Pagine della cronologia di accesso al profilo"
+      },
+      "durationMinutes": "{count, plural, one {# minuto} other {# minuti} many {# minuti}}",
+      "durationHours": "{count} ore",
+      "unknownTitle": "Libro senza titolo",
+      "errors": {
+        "load": "Impossibile caricare le impostazioni di condivisione.",
+        "save": "Impossibile aggiornare le impostazioni di condivisione.",
+        "preview": "Impossibile caricare l'anteprima del profilo condiviso."
+      }
+    },
+    "appearance": {
+      "language": {
+        "title": "Lingua",
+        "description": "Scegli la lingua utilizzata nell'interfaccia.",
+        "label": "Lingua dell'interfaccia",
+        "loadError": "Impossibile caricare la lingua selezionata",
+        "saveError": "Impossibile salvare la preferenza della lingua"
+      },
+      "pageTitle": "Visualizzazione",
+      "pageSubtitle": "Controlla temi, copertine, layout e come viene presentata la tua libreria.",
+      "mobileSummary": "Tema: {theme} • Accento: {accent} • Sfondo: {background}",
+      "themeMode": {
+        "light": "Luce",
+        "dark": "Buio",
+        "system": "Sistema"
+      },
+      "theme": {
+        "title": "Tema",
+        "colorScheme": {
+          "label": "Combinazione di colori",
+          "hint": "Interfaccia chiara o scura"
+        },
+        "accents": {
+          "grey": "Grigio",
+          "scarlet": "Scarlatto",
+          "vermilion": "Vermiglio",
+          "rose": "Rosa",
+          "copper": "Rame",
+          "orange": "Arancione",
+          "chartreuse": "Certosa",
+          "marigold": "Calendula",
+          "wasabi": "Wasabi",
+          "amber": "Ambra",
+          "malachite": "Malachite",
+          "yellow": "Giallo",
+          "viridian": "Viridiano",
+          "turquoise": "Turchese",
+          "lime": "Calce",
+          "green": "Verde",
+          "acid-green": "Verde acido",
+          "emerald": "Smeraldo",
+          "teal": "Verde acqua",
+          "electric-blue": "Blu elettrico",
+          "cyan": "Ciano",
+          "jade": "Giada",
+          "ultramarine": "Oltremare",
+          "iris": "Iride",
+          "purple": "Viola",
+          "blue": "Blu",
+          "indigo": "Indaco",
+          "violet": "Viola",
+          "amethyst": "Ametista",
+          "fuchsia": "Fucsia",
+          "raspberry": "Lampone",
+          "pink": "Rosa",
+          "white": "Bianco",
+          "rosewater": "Acqua di rose",
+          "salmon": "Salmone",
+          "coral": "Corallo",
+          "sand": "Sabbia",
+          "peach": "Pesca",
+          "pear": "Pera",
+          "flax": "Lino",
+          "sprout": "Germoglio",
+          "butter": "Burro",
+          "aloe": "Aloe",
+          "lemon": "Limone",
+          "foam": "Schiuma",
+          "aqua": "Acqua",
+          "celadon": "Celadon",
+          "sage": "Saggio",
+          "pistachio": "Pistacchio",
+          "mint": "Menta",
+          "seafoam": "Schiuma marina",
+          "baby-blue": "Baby Blu",
+          "powder": "Polvere",
+          "sea-glass": "Vetro di mare",
+          "bluebell": "Campanula",
+          "cornflower": "Fiordaliso",
+          "thistle": "Cardo",
+          "periwinkle": "Pervinca",
+          "wisteria": "Glicine",
+          "lavender": "Lavanda",
+          "mauve": "Malva",
+          "orchid": "Orchidea",
+          "rose-quartz": "Quarzo rosa",
+          "blush": "Arrossire"
+        },
+        "accentColor": {
+          "label": "Colore accento",
+          "hint": "Controlla le evidenziazioni e gli elementi interattivi"
+        },
+        "cornerRadius": {
+          "label": "Raggio dell'angolo",
+          "hint": "Rotondità delle carte e degli elementi dell'interfaccia utente"
+        },
+        "surfaceBrightness": {
+          "label": "Luminosità della superficie",
+          "hint": "Schiarisci le superfici in modalità scura",
+          "reset": "Ripristina"
+        },
+        "libraryBackground": {
+          "title": "Sfondo della biblioteca",
+          "pattern": {
+            "label": "Motivo di sfondo",
+            "hint": "Modello mostrato dietro la griglia del libro"
+          }
+        },
+        "backgroundGroups": {
+          "fundamental": "Fondamentale",
+          "structural": "Strutturale",
+          "ambient": "Ambiente",
+          "refractive": "Rifrattivo"
+        }
+      },
+      "storage": {
+        "title": "Dove salvare le preferenze di aspetto",
+        "active": "Attivo",
+        "notAvailable": "Non disponibile",
+        "device": {
+          "title": "Solo questo dispositivo",
+          "description": "Le preferenze rimangono nel tuo browser. Ideale se desideri un aspetto diverso su dispositivi diversi."
+        },
+        "account": {
+          "title": "Il mio conto",
+          "description": "Le preferenze vengono salvate sul tuo account. Ideale se desideri lo stesso aspetto su ogni dispositivo."
+        },
+        "toasts": {
+          "synced": "Le preferenze verranno ora sincronizzate",
+          "local": "Le preferenze rimarranno su questo dispositivo"
+        },
+        "errors": {
+          "demoRestricted": "L'account con limitazioni demo non può modificare la modalità di archiviazione dei temi",
+          "update": "Impossibile aggiornare la modalità di archiviazione",
+          "generic": "Si è verificato un errore durante l'aggiornamento della modalità di archiviazione"
+        }
+      },
+      "bookCovers": {
+        "title": "Copertine di libri",
+        "displayMode": {
+          "title": "Modalità di visualizzazione della copertina",
+          "hint": "Controlla il modo in cui le copertine reali si adattano agli slot del libro quando le proporzioni differiscono",
+          "blurredFit": {
+            "label": "Vestibilità sfocata",
+            "hint": "Mostra la copertina completa con un riempimento sfocato dietro"
+          },
+          "fillCrop": {
+            "label": "Compila la scheda",
+            "hint": "Riempi l'intero slot ritagliando i bordi quando le proporzioni differiscono"
+          },
+          "naturalBottom": {
+            "label": "Fondo naturale",
+            "hint": "Mantenere il rapporto di copertura originale e ancorare la copertura al fondo"
+          }
+        },
+        "spine": {
+          "title": "Sovrapposizione del dorso del libro",
+          "hint": "Aggiunge un dorso stilizzato e un effetto lucido alle copertine",
+          "off": {
+            "label": "Spento",
+            "hint": "Nessun effetto dorso/lucentezza sulle copertine"
+          },
+          "subtle": {
+            "label": "Sottile",
+            "hint": "Dorso e lucentezza leggeri, più vicini all'aspetto predefinito"
+          },
+          "strong": {
+            "label": "Forte",
+            "hint": "Trattamento dorso e lucentezza più pronunciato"
+          }
+        },
+        "showSpineOnComics": {
+          "label": "Mostra il dorso nei fumetti",
+          "hint": "Applica l'effetto dorso e lucentezza alle copertine dei fumetti (cbz, cbr, cb7)"
+        },
+        "shadow": {
+          "title": "Copri la forza dell'ombra",
+          "hint": "Controlla la profondità sotto le copertine nelle miniature di griglia, elenco, tabella e dashboard",
+          "default": {
+            "label": "Predefinito",
+            "hint": "Elevazione e profondità attuali"
+          },
+          "strong": {
+            "label": "Forte",
+            "hint": "Ombreggiatura più pesante sotto le coperte, simile a uno scaffale"
+          }
+        },
+        "overlays": {
+          "title": "Sovrapposizioni di carte",
+          "hint": "Scegli i metadati mostrati direttamente sulle copertine dei libri",
+          "progressBar": {
+            "label": "Barra di avanzamento",
+            "hint": "Sottile linea colorata lungo il bordo inferiore"
+          },
+          "format": {
+            "label": "Formato del file",
+            "hint": "Badge EPUB, PDF, CBZ con codice colore in basso a destra"
+          },
+          "rating": {
+            "label": "Valutazione",
+            "hint": "Indicatore di valutazione in stelle in basso a sinistra"
+          },
+          "readStatus": {
+            "label": "Leggi lo stato",
+            "hint": "Icona colorata che mostra lo stato corrente della lettura in alto a sinistra"
+          },
+          "seriesPosition": {
+            "label": "Numero di serie",
+            "hint": "Badge che mostra la posizione del libro nella sua serie in alto a destra (ad esempio #3, #1.5)"
+          },
+          "lockStatus": {
+            "label": "Stato di blocco",
+            "hint": "Icona di blocco dei metadati in alto a destra: arancione quando bloccato, verde quando sbloccato"
+          }
+        }
+      },
+      "layout": {
+        "coverSize": "Dimensioni della copertina",
+        "gridSpacing": "Spaziatura della griglia",
+        "gridLayout": {
+          "title": "Layout della griglia della libreria"
+        },
+        "coverSizeBehavior": {
+          "label": "Comportamento delle dimensioni della copertina",
+          "hint": "Controlla se le dimensioni verticale/quadrate e la spaziatura della griglia sono condivise tra tutte le visualizzazioni o mantenute per visualizzazione",
+          "perViewHint": "Modalità per visualizzazione: regola le dimensioni della copertina e la spaziatura dal pannello di visualizzazione di ciascuna visualizzazione.",
+          "syncAll": "Sincronizza tutte le visualizzazioni",
+          "perView": "Dimensioni per visualizzazione"
+        },
+        "portraitCoverSize": {
+          "label": "Formato copertina verticale",
+          "hint": "Utilizzato per librerie e visualizzazioni di ritratti"
+        },
+        "squareCoverSize": {
+          "label": "Formato copertina quadrata",
+          "hint": "Utilizzato per librerie e viste quadrate"
+        },
+        "portraitGridSpacing": {
+          "label": "Spaziatura della griglia verticale",
+          "hint": "Spazio tra le copertine dei ritratti"
+        },
+        "squareGridSpacing": {
+          "label": "Spaziatura della griglia quadrata",
+          "hint": "Spazio tra le coperture quadrate"
+        },
+        "cardInfoMode": {
+          "label": "Modalità informazioni sulla carta",
+          "hint": "Dove mostrare il titolo del libro e l'autore sulle schede a griglia",
+          "onHover": "Al passaggio del mouse",
+          "belowCover": "Sotto la copertina",
+          "off": "Spento"
+        },
+        "primaryCardLabel": {
+          "label": "Etichetta della carta principale",
+          "hint": "Testo mostrato sotto ogni copertina del libro (prima riga)"
+        },
+        "secondaryCardLabel": {
+          "label": "Etichetta della carta secondaria",
+          "hint": "Testo aggiuntivo sotto l'etichetta principale (seconda riga)"
+        },
+        "labelField": {
+          "hidden": "Nascosto",
+          "bookTitle": "Titolo del libro",
+          "seriesTitle": "Titolo della serie",
+          "seriesTitlePosition": "Titolo della serie + posizione",
+          "author": "Autore"
+        },
+        "seriesDisplay": {
+          "title": "Visualizzazione della serie",
+          "collapsedCover": {
+            "label": "Copertina della serie crollata",
+            "hint": "Scegli quale copertina mostrare quando le serie sono compresse nella griglia del libro"
+          },
+          "stack": "Pila",
+          "mosaic": "Mosaico",
+          "first": "Primo",
+          "latest": "Ultimi",
+          "firstUnread": "Primo non letto"
+        },
+        "authorGrid": {
+          "title": "Griglia dell'autore",
+          "coverSize": {
+            "label": "Dimensioni della copertina",
+            "hint": "Larghezza delle copertine dell'autore nella griglia"
+          },
+          "coverShape": {
+            "label": "Forma della copertina",
+            "hint": "Forma delle copertine dell'autore nella griglia"
+          },
+          "circle": "Cerchio",
+          "square": "Quadrato"
+        },
+        "listTableViews": {
+          "title": "Visualizzazioni elenco e tabella"
+        },
+        "zebraStriping": {
+          "label": "Strisce zebrate",
+          "hint": "Colori di sfondo delle righe alternativi per facilitare la scansione"
+        }
+      },
+      "behavior": {
+        "title": "Comportamento della libreria",
+        "thumbnailClicks": {
+          "label": "Clic sulle miniature",
+          "hint": "Scegli cosa succede quando si apre un libro dalle visualizzazioni griglia ed elenco",
+          "readFirst": "Leggi prima",
+          "readFirstHint": "Aprire il lettore quando esiste un file leggibile",
+          "openDetails": "Apri i dettagli",
+          "openDetailsHint": "Vai alla pagina dei dettagli del libro dalla griglia e dall'elenco delle miniature"
+        },
+        "filterPreview": {
+          "label": "Mostra l'anteprima del filtro per impostazione predefinita",
+          "hint": "Espandi il filtro attivo e ordina il riepilogo all'apertura di uno smartScope"
+        },
+        "collapseSeries": {
+          "label": "Comprimi le serie per impostazione predefinita",
+          "hint": "Raggruppa i libri della stessa serie in un'unica scheda nelle visualizzazioni della biblioteca e della raccolta"
+        }
+      },
+      "icons": {
+        "title": "Icone personalizzate",
+        "uploadIcons": "Carica icone",
+        "uploadedCount": "{count, plural, =0 {nessuna icona caricata} one {# icona caricata} other {# icone caricate} many {# icone caricate}}",
+        "searchPlaceholder": "Icone di ricerca",
+        "sort": {
+          "newest": "Più recente",
+          "name": "Nome"
+        },
+        "selectedCount": "{count} selezionato",
+        "clear": "Cancella",
+        "deleteSelected": "Elimina selezionato",
+        "loading": "Caricamento icone...",
+        "emptySearch": "Nessuna icona corrisponde alla tua ricerca.",
+        "emptyNoIcons": "Nessuna icona personalizzata caricata ancora.",
+        "namePlaceholder": "Nome",
+        "checkingUsage": "Verifica dell'utilizzo...",
+        "usedBy": "Utilizzato da {count}",
+        "notUsedYet": "Non ancora utilizzato",
+        "rename": "Rinominare",
+        "replace": "Sostituisci",
+        "usage": {
+          "libraries": "{count, plural, =0 {niente biblioteche} one {# biblioteca} other {# biblioteche} many {# biblioteche}}",
+          "collections": "{count, plural, =0 {nessuna raccolta} one {# raccolta} other {# collezioni} many {# collezioni}}",
+          "smartScopes": "{count, plural, =0 {nessun ambito intelligente} one {# ambito intelligente} other {# ambiti intelligenti} many {# ambiti intelligenti}}"
+        },
+        "confirm": {
+          "deleteOne": "Eliminare \"{name}\"? Gli usi esistenti torneranno alla loro icona predefinita.",
+          "deleteMany": "{count, plural, =0 {Non eliminare alcuna icona?} one {Elimina # icona? Gli usi esistenti torneranno alla loro icona predefinita.} other {Elimina # icone? Gli usi esistenti torneranno alla loro icona predefinita.} many {Elimina # icone? Gli usi esistenti torneranno alla loro icona predefinita.}}"
+        },
+        "toasts": {
+          "saved": "Icona salvata",
+          "updated": "Icona aggiornata",
+          "deleted": "Icona eliminata",
+          "bulkDeleted": "{count, plural, =0 {Nessuna icona eliminata} one {Eliminato # icona} other {Eliminato # icone} many {Eliminato # icone}}",
+          "bulkDeletePartial": "Eliminato {deleted}, {failed} non riuscito"
+        },
+        "errors": {
+          "load": "Impossibile caricare le icone",
+          "save": "Impossibile salvare l'icona",
+          "replace": "Impossibile sostituire l'icona",
+          "delete": "Impossibile eliminare l'icona",
+          "bulkDelete": "Impossibile eliminare le icone"
+        }
+      },
+      "tabs": {
+        "theme": "Tema",
+        "book-covers": "Copertine di libri",
+        "icons": "Icone",
+        "layout": "Disposizione",
+        "behavior": "Comportamento"
+      }
+    },
+    "account": {
+      "title": "Conto",
+      "subtitle": "Gestisci le impostazioni del tuo profilo personale.",
+      "subtitleAll": "Gestisci il tuo profilo e le preferenze di notifica.",
+      "tabs": {
+        "profile": "Profilo",
+        "privacy": "Privacy e condivisione",
+        "notifications": "Notifiche",
+        "restrictions": "Restrizioni"
+      },
+      "demoRestricted": {
+        "cannotEdit": "L'account con limitazioni demo non può modificare le impostazioni dell'account",
+        "notice": "Account con limitazioni demo: la modifica di profilo, password, avatar e identità collegate è disabilitata."
+      },
+      "feedback": {
+        "unsavedChanges": "Modifiche non salvate",
+        "allSaved": "Tutte le modifiche salvate"
+      },
+      "profile": {
+        "securityHeading": "Profilo e sicurezza",
+        "username": "Nome utente",
+        "fullName": "Nome completo",
+        "email": "E-mail",
+        "emailHint": "Contatta un amministratore per modificare il tuo indirizzo email.",
+        "save": "Salva profilo",
+        "saving": "Salvataggio...",
+        "changePassword": "Cambia password",
+        "accountType": "Tipo di conto:",
+        "accountTypeOidc": "OIDC /SSO",
+        "accountTypeShared": "Condiviso",
+        "accountTypeLocal": "Locale",
+        "nameRequired": "Il nome è obbligatorio",
+        "updateFailed": "Impossibile aggiornare il profilo",
+        "updated": "Profilo aggiornato"
+      },
+      "readingPreferences": {
+        "title": "Preferenze di lettura",
+        "timezoneHint": "Il fuso orario viene utilizzato per obiettivi urgenti come Early Bird e All-nighter.",
+        "timezone": "Fuso orario",
+        "save": "Salva le preferenze",
+        "enableAchievements": "Abilita risultati",
+        "enableAchievementsHint": "Tieni traccia dei progressi nei risultati e mostra l'interfaccia relativa ai risultati. Gestisci le notifiche degli obiettivi separatamente in Notifiche."
+      },
+      "preferences": {
+        "saveFailed": "Impossibile salvare le preferenze",
+        "saved": "Preferenze salvate"
+      },
+      "avatar": {
+        "title": "Immagine del profilo",
+        "unknownUser": "Utente sconosciuto",
+        "formatHint": "PNG/JPEG/WEBP fino a {size} MB",
+        "upload": "Carica foto",
+        "replace": "Sostituisci l'immagine",
+        "uploading": "Caricamento...",
+        "remove": "Rimuovi l'immagine",
+        "removing": "Rimozione...",
+        "updated": "Immagine del profilo aggiornata",
+        "uploadFailed": "Impossibile caricare l'immagine del profilo",
+        "removed": "Immagine del profilo rimossa",
+        "removeFailed": "Impossibile rimuovere l'immagine del profilo",
+        "removeConfirm": {
+          "title": "Rimuovere l'immagine del profilo?",
+          "description": "Il tuo avatar verrà rimosso e sostituito con le iniziali.",
+          "confirm": "Rimuovi"
+        }
+      },
+      "connectedAccounts": {
+        "title": "Conti collegati",
+        "unlink": "Scollega",
+        "unlinking": "Scollegamento...",
+        "linkAdditional": "Collega ulteriori fornitori:",
+        "linkProvider": "Collega {provider}",
+        "redirecting": "Reindirizzamento...",
+        "noneConfigured": "Nessun provider OIDC configurato. Chiedi a un amministratore di configurare SSO.",
+        "linkStateFailed": "Impossibile generare lo stato del collegamento",
+        "startLinkFailed": "Impossibile avviare il collegamento OIDC",
+        "unlinkFailed": "Impossibile scollegare",
+        "unlinked": "Identità scollegata",
+        "unlinkIdentityFailed": "Impossibile scollegare l'identità",
+        "unlinkDialog": {
+          "title": "Scollegare l'identità {provider}?",
+          "description": "Inserisci la tua password per confermare. Non potrai più accedere con questo provider.",
+          "currentPassword": "Password attuale"
+        }
+      },
+      "tour": {
+        "title": "Visita guidata",
+        "description": "Riproduci la procedura dettagliata che evidenzia le funzionalità principali dell'app.",
+        "action": "Riprendi il tour"
+      },
+      "restrictions": {
+        "none": {
+          "title": "Nessuna restrizione sui contenuti",
+          "description": "Il tuo account ha accesso completo a tutti i contenuti nelle librerie assegnate."
+        },
+        "banner": "Il tuo account presenta restrizioni sui contenuti applicate da un amministratore. Alcuni libri potrebbero non essere visibili.",
+        "allowedTags": {
+          "title": "Tag consentiti",
+          "description": "Ti verranno mostrati solo i libri che hanno almeno uno di questi tag."
+        },
+        "blockedTags": {
+          "title": "Tag bloccati",
+          "description": "I libri con uno di questi tag ti vengono nascosti."
+        },
+        "allowedGenres": {
+          "title": "Generi consentiti",
+          "description": "Ti verranno mostrati solo i libri che hanno almeno uno di questi generi."
+        },
+        "blockedGenres": {
+          "title": "Generi bloccati",
+          "description": "I libri di uno qualsiasi di questi generi ti sono nascosti."
+        }
+      }
+    },
+    "magicLinks": {
+      "title": "Collegamenti magici",
+      "subtitle": "Crea collegamenti di accesso condivisibili per account condivisi.",
+      "createLink": "Crea collegamento",
+      "noSharedAccounts": "Nessun account condiviso trovato",
+      "noSharedAccountsHint": "Crea prima un account condiviso da {usersPage} per generare collegamenti magici.",
+      "activeLinks": "Collegamenti attivi",
+      "inactiveLinks": "Collegamenti inattivi",
+      "paused": "In pausa",
+      "deletedUser": "Utente eliminato",
+      "expiredPrefix": "Scaduto ",
+      "never": "Nessuna attività registrata",
+      "noExpiry": "Nessuna scadenza",
+      "expired": "Scaduto",
+      "expiresOn": "Scadenza {date}",
+      "revokedOn": "Revocato {date}",
+      "expiredOn": "{date} scaduto",
+      "usesCount": "{count, plural, =0 {nessun utilizzo} one {un uso} other {# usi} many {# usi}}",
+      "copied": "Copiato!",
+      "copyLink": "Copia collegamento",
+      "pause": "Pausa",
+      "resume": "Riprendi",
+      "revoke": "Revoca",
+      "revoking": "Revoca...",
+      "emptyState": "Nessun collegamento magico ancora creato. Fai clic su \"{action}\" per generare un accesso condivisibile URL.",
+      "columns": {
+        "label": "Etichetta",
+        "account": "Conto",
+        "createdBy": "Creato da",
+        "expires": "Scade",
+        "uses": "Usi",
+        "lastUsed": "Ultimo usato",
+        "created": "Creato",
+        "status": "Stato",
+        "totalUses": "Usi totali"
+      },
+      "createDialog": {
+        "title": "Crea un collegamento magico",
+        "description": "Genera un accesso condivisibile URL per un account condiviso.",
+        "sharedAccount": "Conto condiviso",
+        "selectAccount": "Seleziona un account condiviso",
+        "label": "Etichetta",
+        "labelPlaceholder": "ad es. Link demo per la conferenza",
+        "expiresAt": "Scade alle",
+        "optional": "(facoltativo)",
+        "create": "Crea",
+        "creating": "Creazione..."
+      },
+      "revokeDialog": {
+        "title": "Revocare il collegamento magico?",
+        "description": "Ciò invaliderà immediatamente il collegamento e terminerà tutte le sessioni attive per l'account collegato."
+      },
+      "errors": {
+        "create": "Impossibile creare",
+        "copy": "Impossibile copiare il collegamento magico",
+        "update": "Impossibile aggiornare il collegamento magico",
+        "revoke": "Impossibile revocare"
+      },
+      "usersPage": "Pagina utenti",
+      "emptyTitle": "Nessun collegamento magico ancora creato",
+      "emptyHint": "Fai clic su \"{action}\" per generare un accesso condivisibile URL.",
+      "noActiveTitle": "Nessun collegamento magico attivo",
+      "noActiveHint": "Tutti i collegamenti magici generati per questa pagina sono scaduti o sono stati revocati."
+    },
+    "oidc": {
+      "title": "OIDC /SSO",
+      "subtitle": "Gestisci i provider OpenID Connect per il Single Sign-On.",
+      "providers": "Fornitori",
+      "addProvider": "Aggiungi fornitore",
+      "editProvider": "Modifica fornitore",
+      "configureNew": "Configura un nuovo provider OIDC.",
+      "editing": "Modifica {slug}",
+      "enabled": "Abilitato",
+      "disabled": "Disabilitato",
+      "empty": {
+        "title": "Nessun fornitore ancora",
+        "description": "Aggiungi un provider OIDC per abilitare il Single Sign-On per i tuoi utenti."
+      },
+      "form": {
+        "status": "Stato",
+        "enableProvider": "Abilita fornitore",
+        "enableProviderHint": "Mostra questo provider nella pagina di accesso.",
+        "identity": "Identità del fornitore",
+        "slug": "Lumaca",
+        "slugHint": "Identificatore univoco (lettere minuscole, trattini). Non può essere modificato in seguito.",
+        "displayName": "Nome visualizzato",
+        "displayNameHint": "Mostrato sul pulsante di accesso.",
+        "iconUrl": "Icona URL",
+        "iconUrlHint": "Logo opzionale mostrato accanto al pulsante di accesso.",
+        "iconPreviewAlt": "anteprima dell'icona",
+        "connection": "Connessione",
+        "issuerUri": "URI dell'emittente",
+        "issuerUriHint": "La base del provider URL.",
+        "test": "Prova",
+        "testing": "Prova...",
+        "clientId": "ID cliente",
+        "clientSecret": "Segreto del cliente",
+        "clientSecretPlaceholder": "Lascia vuoto per continuare a esistere",
+        "scopes": "Ambiti",
+        "claimMapping": "Mappatura delle rivendicazioni",
+        "previewClaims": "Anteprima delle rivendicazioni",
+        "redirecting": "Reindirizzamento...",
+        "mappedClaims": "Affermazioni mappate",
+        "rawClaims": "Affermazioni grezze",
+        "usernameClaim": "Reclamo nome utente",
+        "nameClaim": "Richiesta di nome",
+        "emailClaim": "Reclamo via e-mail",
+        "groupsClaim": "Reclamo dei gruppi",
+        "autoProvisioning": "Provisioning automatico",
+        "autoProvisionUsers": "Utenti con provisioning automatico",
+        "autoProvisionUsersHint": "Crea account al primo OIDC accesso se l'utente non esiste.",
+        "allowLocalLinking": "Consenti il collegamento dell'account locale",
+        "allowLocalLinkingHint": "Collega l'identità OIDC a un account locale esistente tramite la corrispondenza del nome utente.",
+        "defaultPermissions": "Autorizzazioni predefinite",
+        "defaultPermissionsHint": "Autorizzazioni concesse ai nuovi utenti al primo OIDC accesso.",
+        "createProvider": "Crea fornitore",
+        "saveChanges": "Salva modifiche",
+        "saving": "Salvataggio...",
+        "deleteProvider": "Elimina fornitore",
+        "deleting": "Eliminazione..."
+      },
+      "test": {
+        "connected": "Connesso - {issuer}",
+        "connectionFailed": "Connessione non riuscita",
+        "hide": "Nasconditi",
+        "details": "Dettagli",
+        "supported": "supportato",
+        "notSupported": "non supportato"
+      },
+      "groupMappings": {
+        "title": "Mappature di gruppo",
+        "description": "Associa le rivendicazioni del gruppo OIDC alle autorizzazioni BookOrbit. Sincronizzato ad ogni accesso.",
+        "noPermission": "Nessun permesso",
+        "empty": "Nessuna mappatura del gruppo configurata.",
+        "addMapping": "Aggiungi mappatura",
+        "claimPlaceholder": "OIDC reclamo di gruppo (ad esempio amministratori)",
+        "add": "Aggiungi",
+        "adding": "Aggiunta..."
+      },
+      "toasts": {
+        "providerCreated": "Fornitore creato",
+        "providerSaved": "Fornitore salvato",
+        "providerDeleted": "Fornitore eliminato",
+        "mappingAdded": "Aggiunta la mappatura dei gruppi",
+        "mappingRemoved": "Mappatura del gruppo rimossa"
+      },
+      "errors": {
+        "loadProvider": "Impossibile caricare il provider",
+        "createProvider": "Impossibile creare il fornitore",
+        "save": "Impossibile salvare",
+        "delete": "Impossibile eliminare",
+        "deleteProvider": "Impossibile eliminare il fornitore",
+        "requestFailed": "Richiesta non riuscita",
+        "previewState": "Impossibile generare lo stato di anteprima",
+        "startPreview": "Impossibile avviare l'anteprima",
+        "addMapping": "Impossibile aggiungere la mappatura",
+        "removeMapping": "Impossibile rimuovere la mappatura del gruppo"
+      }
+    },
+    "admin": {
+      "title": "Ammin",
+      "subtitle": "Gestisci gli utenti e le impostazioni di autenticazione.",
+      "system": {
+        "title": "Sistema",
+        "subtitle": "Impostazioni di organizzazione, importazione e manutenzione dei file."
+      },
+      "maintenance": {
+        "title": "Manutenzione",
+        "subtitle": "Gestisci attività in background, indici di sistema e operazioni di manutenzione.",
+        "importGroup": "Importa",
+        "recommendationsGroup": "Raccomandazioni",
+        "achievementsGroup": "Risultati",
+        "updatesGroup": "Aggiornamenti",
+        "importFromBooklore": "Importa da Booklore",
+        "bookloreImportConfigured": "Importazione di Booklore configurata",
+        "migrationRunning": "Migrazione in corso",
+        "migrationCompleted": "Migrazione completata",
+        "migrationFailed": "La migrazione non è riuscita",
+        "importDescription": "Importazione una tantum di libri, metadati e progressi di lettura da una precedente installazione di Booklore.",
+        "configuredDescription": "Fonte: {name}. Nessuna migrazione ancora eseguita: continua la configurazione per eseguire l'importazione.",
+        "runningDescription": "Fase: {stage} - iniziata {started}",
+        "completedDescription": "Da {name} - completato {date}",
+        "migrationErrorGeneric": "Si è verificato un errore durante la migrazione.",
+        "stageInitializing": "inizializzazione",
+        "recently": "recentemente",
+        "getStarted": "Inizia",
+        "continueSetup": "Continua l'installazione",
+        "viewDetails": "Visualizza dettagli",
+        "refreshRecommendationIndex": "Aggiorna l'indice dei consigli",
+        "refreshRecommendationHint": "Aggiorna il motore dei consigli con le ultime modifiche alla libreria. Questo processo viene eseguito in background.",
+        "booksQueuedForProcessing": "{count, plural, =0 {nessun libro in coda per l'elaborazione} one {# libro in coda per l'elaborazione} other {# libri in coda per l'elaborazione} many {# libri in coda per l'elaborazione}}",
+        "run": "Corri",
+        "running": "Correre...",
+        "backfillAchievements": "Risultati di riempimento",
+        "backfillAchievementsHint": "Rivalutare i risultati ottenuti da tutti gli utenti.",
+        "backfillResult": "Utenti {users} elaborati; hai assegnato {awards} premi.",
+        "runBackfill": "Esegui riempimento",
+        "checkForUpdates": "Controlla gli aggiornamenti",
+        "checkForUpdatesHint": "Controlla automaticamente GitHub per una nuova versione all'avvio e mostra un indicatore nella barra laterale quando ne è disponibile una.",
+        "updateChecksEnabled": "Controlli degli aggiornamenti abilitati",
+        "updateChecksDisabled": "Controlli degli aggiornamenti disabilitati",
+        "updateSettingFailed": "Impossibile aggiornare l'impostazione",
+        "booksQueuedForEmbedding": "{count, plural, =0 {nessun libro in coda per l'incorporamento} one {# libro in coda per l'incorporamento} other {# libri in coda per l'incorporamento} many {# libri in coda per l'incorporamento}}",
+        "failed": "Fallito",
+        "unknownError": "Errore sconosciuto",
+        "rebuildEmbeddingsFailed": "Impossibile ricostruire gli incorporamenti: {error}",
+        "achievementBackfillConfirm": "Eseguire il recupero degli obiettivi per tutti gli obiettivi di tutti gli utenti? L'operazione potrebbe richiedere del tempo.",
+        "achievementBackfillComplete": "Recupero obiettivi completato: premi {count} concessi",
+        "backfillRunFailed": "Impossibile eseguire il recupero",
+        "achievementBackfillFailed": "Impossibile eseguire il recupero degli obiettivi: {error}",
+        "uploadsGroup": "Caricamenti",
+        "maxUploadSize": "Limite massimo della dimensione del file da caricare",
+        "maxUploadSizeHint": "Configura il limite di dimensione massima per i caricamenti di file nel sistema.",
+        "save": "Salva",
+        "uploadSizeInvalid": "Il limite della dimensione di caricamento deve essere maggiore di 0",
+        "uploadSizeUpdated": "Limite dimensione caricamento aggiornato"
+      },
+      "migration": {
+        "title": "Migrazione",
+        "subtitle": "Importazione di Booklore una tantum: connetti l'origine, mappa gli utenti, esegui il test, avvia la migrazione ed esporta un report.",
+        "progress": "Progresso",
+        "stepSourceConnection": "Connessione alla sorgente",
+        "stepUserPathMapping": "Mappatura utenti e percorsi",
+        "stepDryRun": "Prova a secco",
+        "stepDryRunTitle": "Prova a secco",
+        "stepRunMigration": "Esegui la migrazione",
+        "stepReport": "Rapporto",
+        "stepReportTitle": "Rapporto sulla migrazione",
+        "subtitleSource": "Configura la connessione al database all'istanza Booklore di origine.",
+        "subtitleMappings": "Mappare gli utenti di origine per gli utenti di destinazione e tradurre i percorsi dei file.",
+        "subtitleDryRun": "Visualizza in anteprima ciò che verrà importato prima di eseguire la migrazione in tempo reale.",
+        "subtitleRun": "Avvia l'importazione dal vivo e monitora il suo progresso.",
+        "subtitleReport": "Rivedi cosa è stato importato ed esporta un rapporto dettagliato.",
+        "continueToMappings": "Continua su Mappature",
+        "continueToDryRun": "Continuare con la prova di prova",
+        "continueToMigration": "Continua con la migrazione",
+        "viewReport": "Visualizza rapporto",
+        "badgeValidated": "Convalidato",
+        "badgeSaved": "Salvato",
+        "badgeUpToDate": "Aggiornato",
+        "badgeCompleted": "Completato",
+        "badgeRunning": "Correre",
+        "badgeFailed": "Fallito",
+        "mediaPathRequired": "Necessario per la migrazione delle copertine dei libri.",
+        "mediaPathAbsolute": "Utilizza un percorso assoluto (ad esempio: /libri). I percorsi relativi non sono supportati.",
+        "mediaPathConfigured": "Percorso di importazione della copertina configurato. Utilizza Prova connessione per verificare l'accesso e la struttura delle cartelle delle immagini di Booklore.",
+        "issueSaveSource": "Salva le impostazioni di connessione dell'origine",
+        "issueValidateSource": "Convalida la connessione di origine",
+        "issueSaveMappings": "Salva mappature di utenti e percorsi",
+        "issueSavePathMappings": "Salva le mappature dei percorsi per convalidarle",
+        "issueFreshDryRun": "Esegui una nuova prova di prova",
+        "issueResolveDuplicates": "Risolvi le corrispondenze duplicate del libro di destinazione durante il test",
+        "issueWaitActiveRun": "Attendi il completamento della corsa attiva",
+        "sourceRecordId": "ID record di origine n.{id}",
+        "byAuthorWithId": "da {author} (ID: {id})",
+        "filePathWithId": "{path} (ID: {id})",
+        "bookloreSourceId": "ID fonte del libro: {id}",
+        "libraryBookNum": "Libro della biblioteca n.{id}",
+        "errorInitialize": "Impossibile inizializzare le impostazioni di migrazione",
+        "errorLoadSourceTypes": "Impossibile caricare i tipi di origine della migrazione supportati",
+        "errorLoadTargetUsers": "Impossibile caricare gli utenti di destinazione",
+        "errorLoadLibraryFolders": "Impossibile caricare le cartelle della libreria di destinazione",
+        "noSourceUsersReturned": "Non è stato restituito alcun utente di origine",
+        "userMappingSuggestionsLoaded": "Suggerimenti per la mappatura degli utenti caricati",
+        "errorLoadSuggestions": "Impossibile caricare i suggerimenti per la mappatura degli utenti",
+        "requiredFields": "Sono obbligatori l'host, l'utente, il database e il nome dell'origine",
+        "connectionTestPassedWithWarnings": "Test di connessione superato con avvisi",
+        "connectionTestPassedWithCount": "Test di connessione superato con {count} avviso/i. Primo: {first}",
+        "connectionTestPassed": "Test di connessione superato",
+        "connectionOkMissingTables": "Connessione ok, ma mancano le tabelle {count} richieste",
+        "cannotTestMediaPathActiveRun": "Impossibile testare il percorso multimediale mentre è attiva un'esecuzione",
+        "mediaRootPathRequiredCover": "Per l'importazione delle copertine è richiesto il percorso radice del supporto.",
+        "useAbsolutePath": "Utilizza un percorso assoluto (ad esempio: /libri).",
+        "mediaPathVerified": "Percorso multimediale verificato.",
+        "mediaPathValidReadable": "Il percorso multimediale è valido e leggibile",
+        "mediaPathValidationFailed": "Convalida del percorso multimediale non riuscita.",
+        "connectionFailedBeforeMediaPath": "Il test di connessione non è riuscito prima del completamento della convalida del percorso multimediale.",
+        "cannotModifySourceActiveRun": "Impossibile modificare l'origine mentre è attiva un'esecuzione",
+        "sourceSavedValidatedWarnings": "Sorgente salvata e convalidata con {count} avviso/i",
+        "sourceSavedValidated": "Sorgente salvata e convalidata",
+        "errorSaveValidateSource": "Impossibile salvare o convalidare la fonte",
+        "cannotSaveMappingsActiveRun": "Impossibile salvare le mappature mentre è attiva una corsa",
+        "saveSourceFirst": "Salva prima la fonte",
+        "mapAtLeastOneUser": "Associa almeno un utente di origine a un utente di destinazione",
+        "mapEveryUser": "Mappa ogni utente di origine prima di salvare",
+        "pathValidationFailedProfileSaved": "La convalida del percorso non è riuscita, ma il profilo verrà comunque salvato",
+        "mappingsSaved": "Mappature salvate",
+        "errorSaveMappings": "Impossibile salvare le mappature",
+        "cannotRunDryRunActiveRun": "Non è possibile eseguire una prova di prova mentre è attiva una corsa",
+        "saveMappingsFirst": "Salvare prima le mappature",
+        "dryRunCompleted": "Prova completata: {matched} corrispondente, {unresolved} non risolto",
+        "dryRunFailed": "Il test di prova non è riuscito",
+        "selectSourceForAllGroups": "Seleziona un libro di origine per tutti i gruppi duplicati {count}",
+        "duplicatesResolved": "Corrispondenze duplicate risolte",
+        "errorResolveDuplicates": "Impossibile risolvere i duplicati",
+        "preflightNotReady": "Verifica preliminare della migrazione non pronta",
+        "runDryRunFirst": "Eseguire prima un test di prova",
+        "runStarted": "È iniziata la corsa di migrazione",
+        "errorStartMigration": "Impossibile avviare la migrazione",
+        "runCancelled": "Esecuzione della migrazione annullata",
+        "errorCancelMigration": "Impossibile annullare la migrazione",
+        "runRetried": "Nuovo tentativo di migrazione: ripresa dall'ultima fase completata",
+        "errorRetryMigration": "Impossibile riprovare la migrazione",
+        "errorLoadRunProgress": "Impossibile caricare l'avanzamento dell'esecuzione",
+        "startMigrationFirst": "Inizia prima la migrazione",
+        "reportRefreshed": "Esegui report aggiornato",
+        "errorLoadReport": "Impossibile caricare il rapporto sull'esecuzione",
+        "reportExported": "Rapporto esportato come {format}",
+        "errorExportReport": "Impossibile esportare il rapporto sulla migrazione",
+        "reasonNoTitleAuthorMatch": "Nessun libro corrispondente trovato per titolo o autore",
+        "reasonNoFilePathMatch": "Il percorso del file non corrisponde ad alcun libro in questa libreria",
+        "reasonNoFileHashMatch": "L'hash del file non corrisponde ad alcun libro in questa libreria",
+        "reasonNoIsbnMatch": "ISBN non corrisponde ad alcun libro in questa libreria",
+        "reasonInsufficientSourceData": "Metadati insufficienti per tentare la corrispondenza",
+        "reasonAmbiguousIsbnMatch": "Più libri corrispondevano allo stesso ISBN",
+        "reasonAmbiguousFileHashMatch": "Più libri corrispondevano allo stesso hash del file",
+        "reasonAmbiguousFilePathMatch": "Più libri corrispondevano allo stesso percorso file",
+        "reasonAmbiguousTitleAuthorMatch": "Più libri corrispondevano allo stesso titolo e autore",
+        "reasonUnknown": "Impossibile determinare il motivo",
+        "strategyIsbn": "Corrispondente a ISBN",
+        "strategyFileHash": "Corrispondente all'hash del file",
+        "strategyPathMapping": "Corrispondente al percorso del file mappato",
+        "strategyTitleAuthor": "Corrispondenza per titolo e autore",
+        "strategyUnavailable": "Strategia di corrispondenza non disponibile",
+        "userPreviewCounts": "Stati {statuses}, voci di avanzamento {progress}, segnalibri {bookmarks}, annotazioni {annotations}, voci di raccolta {collections}",
+        "connErrorUnreachable": "Impossibile raggiungere il server del database. Controlla l'host e la porta.",
+        "connErrorAuth": "Autenticazione non riuscita. Controlla il nome utente e la password.",
+        "connErrorUnknownDatabase": "Banca dati non trovata. Controlla il nome del database.",
+        "connErrorTimeout": "Connessione scaduta. Controlla le impostazioni dell'host e del firewall.",
+        "connErrorGeneric": "Il test di connessione è fallito",
+        "sourceType": "Tipo di origine",
+        "sourceName": "Nome della fonte",
+        "host": "Ospite",
+        "port": "Porto",
+        "user": "Utente",
+        "password": "Parola d'ordine",
+        "passwordSavedPlaceholder": "Salvato: lascia invariato",
+        "passwordEmptyPlaceholder": "Nessuna password impostata",
+        "database": "Banca dati",
+        "mediaRootPath": "Percorso radice multimediale",
+        "pathOk": "Percorso OK",
+        "pathIssue": "Problema del percorso",
+        "testPath": "Percorso di prova",
+        "useTls": "Utilizza TLS/SSL",
+        "testConnection": "Prova connessione",
+        "saveAndValidate": "Salva e convalida",
+        "sourceValidatedWithWarnings": "Fonte convalidata con avvisi",
+        "lastValidationSnapshot": "Ultima istantanea di convalida",
+        "sourceVersion": "Versione sorgente: {version}",
+        "unknown": "Sconosciuto",
+        "missingRequiredTables": "Tabelle obbligatorie mancanti: {tables}",
+        "suggestionsAutoLoad": "I suggerimenti dell'utente vengono caricati automaticamente dopo la convalida dell'origine.",
+        "refresh": "Aggiorna",
+        "sourceUser": "Utente di origine",
+        "targetUser": "Utente di destinazione",
+        "noSourceUsersLoaded": "Nessun utente di origine ancora caricato.",
+        "noActiveTargetUsers": "Nessun utente target attivo trovato. Crea o riattiva un utente BookOrbit prima della mappatura.",
+        "pathPrefixMappings": "Mappature dei prefissi del percorso",
+        "addMapping": "Aggiungi mappatura",
+        "pathMappingsHelp1": "Le mappature dei percorsi traducono i percorsi dei file di origine in percorsi di destinazione in modo che i libri possano essere abbinati in base alla posizione del file. Ad esempio, se la tua libreria Booklore memorizza i file in",
+        "pathMappingsHelp2": "e gli stessi file ora risiedono sotto",
+        "pathMappingsHelp3": ", aggiungi la mappatura qui. Ai libri viene abbinata anche ISBN, hash del file e titolo/autore indipendentemente dalle mappature del percorso: la mappatura del percorso è solo una delle quattro strategie e non limita i libri di origine inclusi nella migrazione.",
+        "noPrefixesFound": "Nessun prefisso trovato: convalida prima la fonte",
+        "selectSourcePrefix": "Seleziona il prefisso di origine...",
+        "selectTargetFolder": "Seleziona la cartella di destinazione...",
+        "remove": "Rimuovi",
+        "pathValidation": "Convalida del percorso",
+        "pathValidationMapped": "{mapped} dei {total} libri di origine hanno un percorso mappato",
+        "pathValidationUnmatched": "{count} percorsi mappati non trovati sul disco: quei libri torneranno a ISBN / corrispondenza del titolo",
+        "pathValidationAllMatched": "Tutti i percorsi mappati {count} trovati sul disco",
+        "saveMappings": "Salva mappature",
+        "runDryRun": "Eseguire il funzionamento a secco",
+        "matched": "Abbinato:",
+        "unresolved": "Irrisolto:",
+        "duplicateMatches": "Corrispondenze duplicate:",
+        "unresolvedSummary": "Sintesi irrisolta",
+        "resolveDuplicateMatches": "Risolvi le corrispondenze target duplicate",
+        "resolveDuplicateHint": "Per ciascun libro di destinazione, scegli un libro di origine da conservare. Le scelte consigliate vengono preselezionate quando esiste una singola corrispondenza più forte.",
+        "remainingGroups": "Gruppi rimanenti:",
+        "ofCount": "di {count}",
+        "targetBookNum": "Libro di destinazione n.{id}",
+        "recommended": "Consigliato",
+        "resolveDuplicatesButton": "{count, plural, =0 {Risolvi # duplicare} one {Risolvi # duplicare} other {Risolvi # duplicati} many {Risolvi # duplicati}}",
+        "preflightChecks": "Controlli preliminari",
+        "allChecksPassed": "Tutti i controlli sono stati superati: pronto per la migrazione",
+        "checkSourceValidated": "Fonte convalidata",
+        "checkSaveValidateSource": "Salva e convalida la connessione di origine",
+        "checkValidateSource": "Convalida la connessione di origine",
+        "checkMappingsSaved": "Mappature salvate",
+        "checkSaveMappings": "Salva mappature di utenti e percorsi",
+        "checkPathMappingsValidated": "Mappature dei percorsi convalidate",
+        "checkSavePathMappings": "Salva le mappature dei percorsi per convalidarle",
+        "checkDryRunUpToDate": "Il test di prova è aggiornato",
+        "checkFreshDryRun": "Esegui una nuova prova di prova",
+        "startConfirmPrompt": "Ciò avvierà la migrazione in tempo reale. Sei sicuro?",
+        "confirmStart": "Conferma inizio",
+        "startMigration": "Avvia la migrazione",
+        "cancelRun": "Annulla esecuzione",
+        "refreshStatus": "Aggiorna stato",
+        "statusPollingStopped": "Il polling dello stato è stato interrotto a causa di un errore.",
+        "retry": "Riprova",
+        "stageLabel": "Fase: {stage}",
+        "stageInitializing": "inizializzazione",
+        "endedLabel": "Terminato {date}",
+        "stageCompleted": "Completato",
+        "stageInit": "Inizializzazione",
+        "stageSharedOverlays": "Importazione di metadati",
+        "stageBookCovers": "Importazione di copertine",
+        "stageUserState": "Importazione dei dati utente",
+        "noRunYet": "Nessuna migrazione ancora eseguita. Completa i passaggi precedenti per iniziare.",
+        "runNum": "Esegui #{id}",
+        "notStarted": "Non iniziato",
+        "reloadReport": "Ricarica rapporto",
+        "loadFullReport": "Carica rapporto completo",
+        "exportJson": "Esporta JSON",
+        "exportCsv": "Esporta CSV",
+        "migrationFailed": "La migrazione non è riuscita",
+        "retryFromLastStage": "Riprova dall'ultima fase completata",
+        "booksCard": "Libri",
+        "metadataOverlaysApplied": "Sovrapposizioni di metadati applicate",
+        "authorMappingsReplaced": "Sostituite le mappature degli autori",
+        "narratorMappingsReplaced": "Le mappature dell'Assistente vocale sono state sostituite",
+        "genreMappingsReplaced": "Le mappature dei generi sono state sostituite",
+        "tagMappingsReplaced": "Sostituite le mappature dei tag",
+        "coversImported": "Copertine importate",
+        "coverImportSkipped": "L'importazione della copertina è stata saltata: il percorso root del supporto non è configurato nell'origine",
+        "couldNotMatch": "Impossibile corrispondere",
+        "userDataCard": "Dati utente",
+        "readingStatuses": "Stati di lettura",
+        "readingProgressEntries": "Lettura delle voci di avanzamento",
+        "audiobookProgressEntries": "Voci di avanzamento dell'audiolibro",
+        "bookmarksLabel": "Segnalibri",
+        "annotationsLabel": "Annotazioni",
+        "collectionEntries": "Voci di raccolta",
+        "loadFullReportHint": "Fai clic su \"Carica rapporto completo\" per includere il riepilogo della partita di prova nel rapporto esportato.",
+        "completedNoIssues": "Migrazione completata senza libri irrisolti o errori.",
+        "matchedBooksHeading": "Libri abbinati ({count})",
+        "matchedBooksHint": "Queste corrispondenze di prova sono state utilizzate per decidere quali libri della biblioteca ricevevano i dati importati.",
+        "sourceBookFallback": "Libro di origine {id}",
+        "libraryBookFallback": "Libro della biblioteca {id}",
+        "unresolvedBooksHeading": "Libri irrisolti ({count})",
+        "unresolvedBooksHint": "Questi libri esistono nell'origine ma non possono essere abbinati ad alcun libro nella tua biblioteca.",
+        "mappedUsersHeading": "Utenti mappati ({count})",
+        "mappedUsersHint": "I totali per utente provengono dall'anteprima di prova memorizzata nella cache con il piano di migrazione.",
+        "coverImportsFailed": "{count} importazione/i di copertine non riuscita. Le righe dettagliate degli errori non vengono archiviate.",
+        "backToSetup": "Torna alla configurazione"
+      },
+      "libraries": {
+        "title": "Biblioteche",
+        "subtitle": "Gestisci le tue librerie multimediali e attiva le scansioni dei contenuti.",
+        "scanAll": "Scansiona tutto",
+        "scanning": "Scansione...",
+        "addLibrary": "Aggiungi libreria",
+        "scan": "Scansiona",
+        "editLibrary": "Modifica libreria",
+        "refreshCovers": "Aggiorna le copertine",
+        "syncMetadataToFiles": "Sincronizza i metadati sui file",
+        "deleteLibrary": "Elimina libreria",
+        "bookCount": "{count, plural, =0 {niente libri} one {# libro} other {# libri} many {# libri}}",
+        "addedDate": "Aggiunto {date}",
+        "fileMode": "Modalità file",
+        "folderMode": "Modalità cartella",
+        "folderCount": "{count, plural, =0 {nessuna cartella} one {# cartella} other {# cartelle} many {# cartelle}}",
+        "watching": "Guardando",
+        "fileWrite": "Scrittura file",
+        "fileRename": "Rinomina file",
+        "emptyTitle": "Nessuna libreria ancora",
+        "emptyHint": "Aggiungi una libreria per iniziare a organizzare i tuoi libri.",
+        "addFirstLibrary": "Aggiungi la tua prima libreria",
+        "deleteConfirmTitle": "Eliminare \"{name}\"?",
+        "deleteConfirmBody": "Questa operazione rimuoverà definitivamente tutti i libri, i metadati, l'avanzamento della lettura, i segnalibri e le annotazioni in questa libreria. Questa operazione non può essere annullata.",
+        "deleteConfirmTypeName": "Digitare il nome della libreria per confermare:",
+        "deleting": "Eliminazione...",
+        "deleteLibraryButton": "Elimina libreria",
+        "syncConfirmTitle": "Sincronizzare i metadati nei file?",
+        "syncConfirmBodyPrefix": "Ciò sovrascriverà i metadati all'interno di ogni file supportato in",
+        "syncConfirmBodySuffix": "direttamente su disco. Questa operazione non può essere annullata.",
+        "syncFiles": "Sincronizza i file",
+        "metadataSynced": "Metadati sincronizzati con i file per \"{name}\"",
+        "fileWriteNotEnabled": "La scrittura del file di metadati non è abilitata per questa libreria. Abilitalo nelle impostazioni della libreria.",
+        "fileSyncFailed": "Sincronizzazione file non riuscita per \"{name}\"",
+        "scanStarted": "Avviata la scansione per \"{name}\"",
+        "scanStartFailed": "Impossibile avviare la scansione per \"{name}\"",
+        "refreshCoversFailed": "Impossibile aggiornare le copertine per \"{name}\"",
+        "scanStartedAll": "Scansione avviata per tutte le biblioteche",
+        "librariesFailedToStart": "{count, plural, =0 {impossibile avviare nessuna libreria} one {# impossibile avviare la libreria} other {# impossibile avviare le librerie} many {# impossibile avviare le librerie}}",
+        "scansStartFailed": "Impossibile avviare le scansioni",
+        "libraryCreated": "Libreria \"{name}\" creata",
+        "libraryUpdated": "Libreria \"{name}\" aggiornata",
+        "libraryDeleted": "\"{name}\" eliminato",
+        "deleteFailed": "Impossibile eliminare la libreria",
+        "scanningProgress": "Scansione {pct}% ({processed}/{total})",
+        "scanDone": "Fatto - {added} aggiunto, {updated} aggiornato",
+        "scanFailedWithError": "Non riuscito: {error}",
+        "scanFailed": "Scansione non riuscita",
+        "refreshingCovers": "Copertine rinfrescanti {pct}% ({processed}/{total})",
+        "coversRefreshed": "Copertine aggiornate ({count} elaborate)"
+      },
+      "authorEnrichment": {
+        "configuration": "Configurazione",
+        "saving": "Salvataggio...",
+        "running": "Correre...",
+        "runEligibleShort": "Corri idoneo",
+        "runAllShort": "Corri tutto",
+        "enableTitle": "Abilita l'arricchimento automatico dell'autore",
+        "enableHint": "Recupera automaticamente le biografie degli autori e le foto del profilo quando i libri vengono aggiunti o aggiornati.",
+        "updateStrategyTitle": "Aggiorna la strategia",
+        "updateStrategyHint": "Cosa fare quando un autore ha già una biografia o una foto.",
+        "writeModeMissingOnly": "Compila solo i dati mancanti (consigliato)",
+        "writeModeAlwaysRefetch": "Aggiorna sempre i dati esistenti",
+        "triggerOnImportTitle": "Attiva all'importazione",
+        "triggerOnImportHint": "Metti in coda gli autori per l'arricchimento quando i libri vengono aggiunti per la prima volta a una libreria.",
+        "eligibilityTitle": "Condizioni di ammissibilità",
+        "eligibilityHint": "Un autore è idoneo se soddisfa una delle condizioni abilitate.",
+        "neverEnrichedTitle": "Mai arricchito",
+        "neverEnrichedHint": "Arricchisci autori che non hanno mai avuto un arricchimento riuscito.",
+        "missingBioTitle": "Biografia mancante",
+        "missingBioHint": "Arricchisci se l'autore non ha una biografia.",
+        "missingPhotoTitle": "Foto mancante",
+        "missingPhotoHint": "Arricchisci se l'autore non ha una foto del profilo.",
+        "runForEligibleAuthors": "Candidati per autori idonei",
+        "eligibleCount": "~{count} idoneo",
+        "runForAllAuthors": "Corri per tutti gli autori",
+        "saved": "Impostazioni di arricchimento dell'autore salvate",
+        "saveFailed": "Impossibile salvare le impostazioni di arricchimento dell'autore",
+        "noEligibleAuthors": "Nessun autore idoneo trovato",
+        "noAuthorsToEnrich": "Nessun autore da arricchire",
+        "queueFailed": "Impossibile mettere in coda il backfill dell'autore"
+      },
+      "scoreWeights": {
+        "groupLabel": "Pesi del punteggio",
+        "assignHintPrefix": "Assegnare un peso a ciascun campo. Peso totale:",
+        "areYouSure": "Sei sicuro?",
+        "resetToDefaultsButton": "Ripristina le impostazioni predefinite",
+        "recalculateAll": "Ricalcola tutto",
+        "confirmReset": "Conferma il ripristino",
+        "reset": "Ripristina",
+        "recalculate": "Ricalcolare",
+        "subtotal": "totale parziale: {count}",
+        "savedRecalculating": "Pesi del punteggio salvati. Ricalcolo dei punteggi della libreria...",
+        "saveFailed": "Impossibile salvare i pesi del punteggio",
+        "recalcStarted": "Il ricalcolo del punteggio è iniziato in background",
+        "recalcFailed": "Ricalcolo non riuscito",
+        "resetToDefaults": "I pesi vengono ripristinati ai valori predefiniti. Salva per applicare."
+      },
+      "tabs": {
+        "users": "Utenti",
+        "account-activity": "Attività dell'account",
+        "magic-links": "Collegamenti magici",
+        "oidc": "OIDC /SSO"
+      }
+    },
+    "common": {
+      "nav": {
+        "libraries": "Biblioteche",
+        "display": "Visualizzazione",
+        "reader": "Lettore",
+        "metadata": "Metadati",
+        "email": "E-mail",
+        "opds": "OPDS",
+        "kobo": "Kobo",
+        "koreader": "KOReader",
+        "hardcover": "Hardcover",
+        "admin": "Ammin",
+        "system": "Sistema",
+        "account": "Conto"
+      }
+    },
+    "metadata": {
+      "title": "Metadati",
+      "noPermission": "Non hai l'autorizzazione per gestire le impostazioni dei metadati.",
+      "fields": {
+        "title": "Titolo",
+        "subtitle": "Sottotitolo",
+        "description": "Descrizione",
+        "cover": "Copertina",
+        "authors": "Autori",
+        "publisher": "Editore",
+        "publishedYear": "Anno di pubblicazione",
+        "language": "Lingua",
+        "pageCount": "Conteggio delle pagine",
+        "communityRating": "Valutazione della comunità",
+        "seriesName": "Nome della serie",
+        "seriesIndex": "Indice delle serie",
+        "genres": "Generi",
+        "narrators": "Narratori",
+        "duration": "Durata",
+        "abridged": "Ridotto"
+      },
+      "mergeStrategy": {
+        "fillMissing": {
+          "label": "Riempi mancante",
+          "description": "Scrivi solo se il campo è attualmente vuoto"
+        },
+        "overwriteIfProvided": {
+          "label": "Sovrascrivi se fornito",
+          "description": "Scrivi se il provider ha restituito un valore"
+        },
+        "overwrite": {
+          "label": "Sovrascrivi sempre",
+          "description": "Sostituisci sempre il valore esistente"
+        }
+      },
+      "autoFetch": {
+        "globalSettings": "Impostazioni globali",
+        "perLibraryOverrides": "Eccezioni per libreria",
+        "saving": "Salvataggio...",
+        "running": "Correre...",
+        "runNow": "Corri adesso",
+        "runForEligible": "Corri per i libri idonei",
+        "enable": {
+          "label": "Abilita il recupero automatico",
+          "hint": "Recupera automaticamente i metadati per i libri idonei."
+        },
+        "triggerOnImport": {
+          "label": "Attiva all'importazione",
+          "hint": "Metti in coda i libri idonei quando vengono aggiunti per la prima volta a una libreria."
+        },
+        "status": {
+          "inQueuePaused": "{count} in coda - in pausa",
+          "remaining": "{count} rimanenti",
+          "eligible": "~{count} idoneo"
+        },
+        "trigger": {
+          "queued": "{count, plural, one {In coda # libro} other {In coda # libri} many {In coda # libri}}",
+          "noneFound": "Nessun libro idoneo trovato"
+        },
+        "lastRun": {
+          "justNow": "proprio adesso",
+          "minutesAgo": "{count}m fa",
+          "hoursAgo": "{count}h fa",
+          "yesterday": "ieri",
+          "daysAgo": "{count} giorni fa",
+          "label": "Ultima corsa: {when}",
+          "labelQueued": "Ultima esecuzione: {when} - libri {count} in coda",
+          "labelNoneEligible": "Ultima esecuzione: {when} - nessun libro idoneo"
+        },
+        "conditions": {
+          "title": "Condizioni di ammissibilità",
+          "hint": "Un libro è idoneo se soddisfa una delle condizioni abilitate.",
+          "noneEnabled": "Nessuna condizione abilitata",
+          "neverFetched": {
+            "label": "Mai recuperato",
+            "hint": "Recupera libri che non hanno mai avuto un tentativo di recupero di metadati.",
+            "summary": "Mai recuperato"
+          },
+          "scoreThreshold": {
+            "label": "Punteggio metadati basso",
+            "hint": "Recupera se il punteggio dei metadati è inferiore a una soglia.",
+            "scoreBelow": "Punteggio qui sotto",
+            "summary": "Punteggio < {threshold}"
+          },
+          "missingFields": {
+            "label": "Campi mancanti",
+            "hint": "Recupera se uno qualsiasi dei campi selezionati è vuoto.",
+            "summary": "{count, plural, one {Mancante # campo} other {Mancante # campi} many {Mancante # campi}}"
+          }
+        },
+        "library": {
+          "inheritingGlobal": "Ereditare le impostazioni predefinite globali",
+          "inheritFromGlobal": "Eredita da globale",
+          "usingGlobalDefaults": "Utilizzo delle impostazioni predefinite globali.",
+          "saveOverride": "Salva override"
+        }
+      },
+      "providers": {
+        "availableSources": "Fonti disponibili",
+        "saveChanges": "Salva modifiche",
+        "test": "Prova",
+        "testing": "Prova...",
+        "enabled": "Abilitato",
+        "retryIn": "Riprova tra {duration}",
+        "runTestBeforeEnabling": "Eseguire il test prima di abilitare",
+        "hardcoverEnableHint": "Eseguire il test con il token corrente per sbloccare l'interruttore di abilitazione.",
+        "badge": {
+          "setupRequired": "Configurazione richiesta",
+          "throttled": "Strozzato",
+          "ready": "Pronto"
+        },
+        "fields": {
+          "apiKey": "API Chiave",
+          "region": "Regione",
+          "cookie": "Biscotto",
+          "coverResolution": "Risoluzione della copertina",
+          "country": "Paese",
+          "language": "Lingua",
+          "ttbKey": "Chiave TTB"
+        },
+        "helpers": {
+          "googleApiKey": "Chiave Google Books API da Google Cloud."
+        },
+        "hints": {
+          "google": "Ampia copertura dall'indice dei libri di Google. Google Books ora richiede una chiave API prima che questo provider possa essere abilitato.",
+          "amazon": "Si consiglia il cookie di sessione. Incolla solo il valore del cookie (no \"Cookie:\").",
+          "goodreads": "La più grande community di lettori del web. Nessuna configurazione richiesta.",
+          "hardcover": "Un'alternativa moderna a Goodreads. Token da hardcover.app/account/api. Il prefisso \"Bearer\" è facoltativo.",
+          "openLibrary": "Il catalogo di libri gratuito di Internet Archive. Nessuna configurazione richiesta.",
+          "itunes": "Il catalogo di libri digitali di Apple. Scegli se recuperare copertine ad alta risoluzione o a risoluzione standard.",
+          "kobo": "Raschia le pagine del libro pubblico di Kobo. Il paese e la lingua devono corrispondere ai percorsi Kobo URL; la protezione dai bot può bloccare le richieste.",
+          "audible": "Estrae i metadati dell'audiolibro da Audible. Non è richiesta alcuna configurazione aggiuntiva.",
+          "audnexus": "Metadati degli audiolibri gestiti dalla comunità. Nessuna configurazione richiesta.",
+          "comicvine": "Metadati dei fumetti da ComicVine. È richiesta una chiave API gratuita da comicvine.gamespot.com.",
+          "ranobedb": "Metadati delle light novel giapponesi da RanobeDB. Nessuna configurazione richiesta.",
+          "lubimyczytac": "Catalogo dei libri polacchi (lubimyczytac.pl). Raschia le pagine dei libri pubblici. Nessuna configurazione richiesta.",
+          "aladin": "Metadati del libro coreano da Aladin (알라딘). È necessaria una chiave TTB di aladin.co.kr."
+        },
+        "blocked": {
+          "google": "Google Books richiede una chiave API prima di poter essere abilitato",
+          "hardcover": "Hardcover richiede una chiave API prima di poter essere abilitato",
+          "hardcoverTest": "Il token Hardcover deve superare il test prima di poter essere abilitato",
+          "comicvine": "ComicVine richiede una chiave API prima di poter essere abilitato",
+          "aladin": "Aladin richiede una chiave TTB prima di poter essere abilitato"
+        }
+      },
+      "fieldRules": {
+        "clearAllProviders": "Cancella tutti i provider",
+        "clearAll": "Cancella tutto",
+        "resetToDefault": "Ripristina le impostazioni predefinite",
+        "reset": "Ripristina",
+        "dragProvidersHint": "Trascina i fornitori da qui su qualsiasi campo per aggiungerli",
+        "dragProviderHere": "trascina un fornitore qui",
+        "howItWorks": {
+          "title": "Come funzionano le regole sul campo",
+          "priorityOrder": {
+            "title": "Ordine di priorità",
+            "body": "Trascina i fornitori nell'elenco per riordinarli. Il provider principale che restituisce un risultato sarà la fonte primaria per quel campo."
+          },
+          "mergeStrategy": {
+            "title": "Strategia di fusione",
+            "fillMissingTerm": "Compila mancanti:",
+            "fillMissingBody": "Scrivi solo se il valore corrente è vuoto.",
+            "overwriteTerm": "Sovrascrivi:",
+            "overwriteBody": "Sostituisci ogni volta che un provider dispone di dati."
+          }
+        },
+        "libraryOverrides": {
+          "title": "Sostituzioni della libreria",
+          "hint": "Espandi una libreria per personalizzare i singoli campi. I campi non sovrascritti ereditano le impostazioni predefinite globali."
+        },
+        "global": {
+          "title": "Impostazioni predefinite globali",
+          "hint": "Regole predefinite applicate a ogni libreria. Sostituisci per libreria di seguito.",
+          "saveDefaults": "Salva impostazioni predefinite",
+          "clearAllConfirm": "Rimuovere tutti i fornitori attivi da ogni campo? L'operazione verrà salvata immediatamente e non potrà essere annullata.",
+          "resetConfirm": "Reimpostare tutte le regole dei campi globali sui valori predefiniti del sistema? Questo sovrascriverà la tua configurazione attuale."
+        },
+        "advanced": {
+          "title": "Comportamento di recupero avanzato",
+          "combineGenres": {
+            "label": "Combina i generi di tutti i fornitori selezionati",
+            "hint": "Raccogli e deduplica i generi da ogni provider assegnato al campo Generi, invece di fermarti al primo risultato."
+          },
+          "storeProviderIds": {
+            "label": "Memorizza gli ID dei fornitori sui libri",
+            "hint": "Quando recuperi i metadati, salva gli ID fornitore restituiti (ISBN, ASIN, Goodreads ID e così via) nel record del libro per ricerche future più accurate."
+          }
+        },
+        "library": {
+          "primary": "Principale:",
+          "overrideCount": "{count, plural, one {# Sostituisci} other {# Sostituisce} many {# Sostituisce}}",
+          "unsavedSuffix": "(non salvato)",
+          "unsavedChanges": "Modifiche non salvate",
+          "globalDefaults": "Impostazioni predefinite globali",
+          "overriding": "Sostituzione: {fields}",
+          "inheritingAll": "Eredita tutte le regole dei metadati globali",
+          "subHint": "I campi non sovrascritti ereditano le impostazioni predefinite globali.",
+          "resetTooltip": "Rimuovi tutte le sostituzioni ed eredita le impostazioni predefinite globali",
+          "clearAllConfirm": "Rimuovere tutti i fornitori attivi da ogni campo in \"{library}\"?",
+          "resetConfirm": "Ripristinare \"{library}\" alle impostazioni predefinite globali? Tutte le sostituzioni della libreria verranno rimosse."
+        },
+        "groups": {
+          "core": "Nucleo",
+          "contributors": "Collaboratori",
+          "publication": "Pubblicazione",
+          "series": "Serie",
+          "classification": "Classificazione",
+          "audiobook": "Audiolibro"
+        },
+        "groupSummary": {
+          "base": "Campi {fields} · {enabled} abilitati",
+          "withOverrides": "{base} · {overrides} sostituisce"
+        },
+        "table": {
+          "field": "Campo",
+          "activeProviders": "Fornitori attivi (ordinati per priorità)",
+          "mergeStrategy": "Strategia di fusione",
+          "status": "Stato"
+        },
+        "field": {
+          "noProviders": "Abilitato ma non ha provider",
+          "empty": "Vuoto",
+          "config": "Configurazione",
+          "custom": "Personalizzato",
+          "default": "Predefinito",
+          "resetToDefault": "Ripristina le impostazioni predefinite"
+        },
+        "reservoir": {
+          "disabled": "{provider} - disabilitato",
+          "notConfigured": "{provider} - non configurato",
+          "dragToAssign": "Trascina per assegnare {provider} a un campo"
+        },
+        "sheet": {
+          "subtitle": "Tocca i fornitori da assegnare, usa le frecce per riordinare",
+          "enableField": "Abilita questo campo durante l'aggiornamento",
+          "providers": "Fornitori",
+          "statusDisabled": "disabilitato",
+          "statusNotConfigured": "non configurato",
+          "done": "Fatto"
+        }
+      },
+      "genreBlocklist": {
+        "heading": "Esclusioni globali di generi",
+        "hint": "I valori esatti del genere in questo elenco vengono rimossi dai risultati del provider prima che i metadati vengano scritti.",
+        "saving": "Risparmiare",
+        "genreValueLabel": "Valore del genere",
+        "addPlaceholder": "Aggiungi un valore di genere, ad esempio Audiolibro",
+        "duplicate": "Questo genere è già bloccato.",
+        "add": "Aggiungi",
+        "filterPlaceholder": "Filtra la lista bloccata",
+        "entryCount": "{count, plural, one {# ingresso} other {# voci} many {# voci}}",
+        "filteredCount": "{shown} di {total}",
+        "noFilterMatch": "Nessun genere bloccato corrisponde al filtro attuale.",
+        "emptyTitle": "Nessun genere bloccato",
+        "emptyHint": "Aggiungi valori esatti come Audiolibro o Adulti per tenerli lontani dai metadati recuperati.",
+        "removeLabel": "Rimuovi {genre}"
+      },
+      "customFields": {
+        "label": "Etichetta",
+        "labelPlaceholder": "ad es. Titolo originale",
+        "labelTooLong": "L'etichetta deve contenere al massimo 255 caratteri",
+        "labelDuplicate": "Esiste già un campo con questa etichetta",
+        "type": "Digitare",
+        "usage": "{count, plural, one {Utilizzato da # libro} other {Utilizzato da # libri} many {Utilizzato da # libri}}",
+        "newField": {
+          "title": "Nuovo campo",
+          "hint": "Definisci un campo di metadati personalizzato e scegli quali librerie utilizzarlo."
+        },
+        "previewToggle": "Visualizza l'anteprima di come appare questo campo durante la modifica di un libro",
+        "untitledField": "Campo senza titolo",
+        "addField": "Aggiungi campo",
+        "fields": "Campi",
+        "fieldsHint": "Trascina per riordinare, modificare etichette, attivare/disattivare librerie o archiviare campi che non ti servono più.",
+        "searchPlaceholder": "Campi di ricerca",
+        "searchAriaLabel": "Cerca campi personalizzati",
+        "emptyTitle": "Nessun campo personalizzato ancora",
+        "emptyHint": "Utilizza il modulo qui sopra per definire il tuo primo campo di metadati personalizzato.",
+        "noMatchTitle": "Nessun campo corrisponde a \"{query}\"",
+        "noMatchHint": "Prova un'etichetta, una chiave o un tipo diverso.",
+        "clearSearchToReorder": "Cancella la ricerca per riordinare",
+        "dragToReorder": "Trascina per riordinare",
+        "dragToReorderField": "Trascina per riordinare il campo",
+        "unsaved": "Non salvato",
+        "archive": "Archivio",
+        "archivedFields": "Campi archiviati",
+        "archivedSummary": "{count, plural, one {# campo archiviato: ripristina o elimina definitivamente.} other {# campi archiviati: ripristina o elimina definitivamente.} many {# campi archiviati: ripristina o elimina definitivamente.}}",
+        "archivedAt": "Archiviato {when}",
+        "restore": "Ripristina",
+        "deleteForever": "Elimina per sempre",
+        "deleteDialog": {
+          "title": "Elimina definitivamente il campo",
+          "bodyBefore": "Questo verrà eliminato definitivamente",
+          "bodyMiddle": "e rimuovere i suoi valori memorizzati da",
+          "bodyAfter": ". Questa operazione non può essere annullata.",
+          "confirmBefore": "Digitare",
+          "confirmAfter": "per confermare",
+          "confirmPlaceholder": "Digitare l'etichetta del campo per confermare"
+        },
+        "preview": "Anteprima",
+        "sampleValue": "Valore del campione",
+        "enabledLibraries": "Biblioteche abilitate",
+        "countOf": "{selected} di {total}",
+        "selectAll": "Seleziona tutto",
+        "clear": "Cancella",
+        "noLibraries": "Nessuna libreria ancora disponibile.",
+        "allLibraries": "Tutte le biblioteche"
+      },
+      "tabs": {
+        "providers": "Fornitori",
+        "field-rules": "Regole sul campo",
+        "custom-fields": "Campi personalizzati",
+        "genre-blocklist": "Blocklist di genere",
+        "score": "Punteggio",
+        "auto-fetch": "Libri",
+        "authors": "Autori"
+      },
+      "tabTitles": {
+        "providers": "Fornitori",
+        "field-rules": "Regole a livello di campo",
+        "custom-fields": "Metadati personalizzati",
+        "genre-blocklist": "Blocklist di genere",
+        "score": "Punteggio di fiducia",
+        "auto-fetch": "Prenota Recupero automatico",
+        "authors": "Recupero automatico dell'autore"
+      },
+      "tabSubtitles": {
+        "providers": "Abilita origini di metadati esterne e configura le relative credenziali.",
+        "field-rules": "Controlla quale fornitore fornisce ciascun campo di metadati e come i valori vengono uniti nelle tue librerie.",
+        "custom-fields": "Definisci campi di metadati personalizzati e scegli quali librerie utilizzarli.",
+        "genre-blocklist": "Impedisci la scrittura nei libri di valori di genere del provider indesiderati.",
+        "score": "Assegna pesi ai campi di metadati per calcolare quanto fidarsi dei risultati recuperati.",
+        "auto-fetch": "Recupera automaticamente copertine, descrizioni e altri dettagli quando nuovi libri vengono aggiunti alla tua libreria.",
+        "authors": "Recupera automaticamente biografie e foto del profilo quando nuovi autori compaiono nella tua libreria."
+      }
+    },
+    "reader": {
+      "resetToDefaults": "Ripristina le impostazioni predefinite",
+      "all": {
+        "title": "Lettore",
+        "subtitle": "Configura le impostazioni predefinite per tutte le modalità di lettura in un unico posto."
+      },
+      "general": {
+        "title": "Lettura",
+        "subtitle": "Comportamento generale che si applica a tutti i tipi di lettori.",
+        "storageLabel": "Dove salvare le preferenze del lettore",
+        "deviceOnly": "Solo questo dispositivo",
+        "deviceOnlyHint": "Le preferenze rimangono nel tuo browser. È meglio se leggi sempre su questo dispositivo o desideri impostazioni diverse per dispositivo.",
+        "myAccount": "Il mio conto",
+        "myAccountHint": "Le preferenze vengono salvate sul tuo account. È meglio se accedi da più dispositivi e desideri un'esperienza coerente ovunque.",
+        "active": "Attivo",
+        "notAvailable": "Non disponibile",
+        "demoCannotChangeStorage": "L'account con limitazioni demo non può modificare la modalità di archiviazione del lettore",
+        "preferencesSynced": "Le preferenze verranno ora sincronizzate",
+        "preferencesLocal": "Le preferenze rimarranno su questo dispositivo",
+        "storageUpdateFailed": "Impossibile aggiornare la modalità di archiviazione",
+        "storageUpdateError": "Si è verificato un errore durante l'aggiornamento della modalità di archiviazione"
+      },
+      "ebook": {
+        "title": "Lettore di eBook",
+        "subtitle": "Impostazioni predefinite applicate all'apertura di file EPUB, MOBI, FB2 e file TXT.",
+        "newBooks": "Nuovi libri",
+        "applySettings": "Applica le mie impostazioni ai nuovi libri",
+        "applySettingsHint": "Quando questa opzione è disattivata, i nuovi libri si aprono con i caratteri e il layout dell'editore. Le tue impostazioni si applicano solo quando cambi qualcosa nel lettore.",
+        "layout": "Disposizione",
+        "readingFlow": "Flusso di lettura",
+        "readingFlowHint": "Sfoglia le pagine impaginate; lo scorrimento scorre continuamente",
+        "paginated": "Paginato",
+        "scrolled": "Scorrito",
+        "fixedLayoutSpread": "Pagine a layout fisso",
+        "fixedLayoutSpreadHint": "Predefinito per manga, fumetti ed EPUB basati su immagini",
+        "bookDefault": "Prenota predefinito",
+        "singlePage": "Pagina singola",
+        "columns": "Colonne",
+        "columnsHint": "Numero di colonne di testo per pagina",
+        "theme": "Tema",
+        "darkMode": "Modalità oscura",
+        "darkModeHint": "Utilizza la variante scura del tema selezionato",
+        "typography": "Tipografia",
+        "font": "Carattere",
+        "fontHint": "Carattere tipografico utilizzato per il corpo del testo",
+        "builtInFonts": "Caratteri incorporati",
+        "yourFonts": "I tuoi caratteri",
+        "fontSize": "Dimensione del carattere",
+        "fontSizeHint": "Dimensione base del testo in pixel",
+        "lineHeight": "Altezza della linea",
+        "lineHeightHint": "Spaziatura verticale tra le righe",
+        "justify": "Giustificare il testo",
+        "justifyHint": "Allinea il testo su entrambi i margini",
+        "hyphenation": "Sillabazione",
+        "hyphenationHint": "Suddivide automaticamente le parole lunghe con trattini",
+        "advanced": "Avanzato",
+        "maxContentWidth": "Larghezza massima del contenuto",
+        "maxContentWidthHint": "Larghezza massima dell'area di testo in pixel",
+        "columnGap": "Spazio tra le colonne",
+        "columnGapHint": "Spaziatura orizzontale su ciascun lato dell'area di testo"
+      },
+      "pdf": {
+        "title": "PDF Lettore",
+        "subtitle": "Impostazioni predefinite applicate all'apertura dei file PDF.",
+        "layout": "Disposizione",
+        "scrollMode": "Modalità di scorrimento",
+        "scrollModeHint": "La pagina viene girata una alla volta; scorre continuamente tutte le pagine",
+        "page": "Pagina",
+        "scrolled": "Scorrito",
+        "pageSpread": "Pagina diffusa",
+        "pageSpreadHint": "Quale numero di pagina inizia a destra nella visualizzazione a due pagine",
+        "spreadNone": "Nessuno",
+        "spreadOdd": "Strano",
+        "spreadEven": "Pari",
+        "zoom": "Zoom",
+        "defaultFit": "Adattamento predefinito",
+        "defaultFitHint": "Come vengono ridimensionate le pagine quando viene aperto un PDF",
+        "fitPage": "Adatta pagina",
+        "fitWidth": "Adatta larghezza",
+        "custom": "Personalizzato",
+        "zoomLevel": "Livello di zoom",
+        "zoomLevelHint": "Fattore di scala per la modalità zoom personalizzata"
+      },
+      "comics": {
+        "title": "Lettore di fumetti",
+        "subtitle": "Impostazioni predefinite applicate all'apertura di file CBZ, CBR e CB7.",
+        "view": "Visualizza",
+        "readingMode": "Modalità di lettura",
+        "readingModeHint": "Come vengono navigate le pagine: utilizza \"Infinito (senza spazi vuoti)\" per i webtoon",
+        "paginated": "Paginato",
+        "infiniteSpaced": "Infinito (distanziato)",
+        "infiniteNoGaps": "Infinito (senza spazi vuoti)",
+        "pageView": "Visualizzazione della pagina",
+        "pageViewHint": "Mostra una o due pagine affiancate",
+        "single": "Singolo",
+        "twoPage": "Due pagine",
+        "fitMode": "Modalità adatta",
+        "fitModeHint": "Come le pagine vengono ridimensionate per adattarsi allo schermo",
+        "fitPage": "Pagina",
+        "fitWidth": "Larghezza",
+        "fitHeight": "Altezza",
+        "fitActual": "Reale",
+        "readingDirection": "Direzione della lettura",
+        "readingDirectionHint": "Da sinistra a destra per i fumetti western; da destra a sinistra per i manga",
+        "ltr": "Da sinistra a destra",
+        "rtl": "Da R a L",
+        "spreadAlignment": "Allineamento della diffusione",
+        "spreadAlignmentHint": "Sposta l'accoppiamento di una pagina dopo la copertina per scansioni separate",
+        "alignmentNormal": "Normale",
+        "alignmentShifted": "Spostato",
+        "spreadGap": "Divario di diffusione",
+        "spreadGapHint": "Spazio tra le pagine nella visualizzazione a due pagine",
+        "spreadGapValue": "{value}px",
+        "widePageHandling": "Gestione di pagine larghe",
+        "widePageHandlingHint": "Auto mostra solo le scansioni ampie in modalità impaginata a due pagine",
+        "widePageAuto": "Automatico",
+        "widePageDisable": "Disabilita",
+        "forceTwoPage": "Forza due pagine su schermi piccoli",
+        "forceTwoPageHint": "Ignora il fallback automatico mobile quando è selezionata la modalità a due pagine impaginate",
+        "off": "Spento",
+        "on": "Su",
+        "display": "Visualizzazione",
+        "backgroundColor": "Colore di sfondo",
+        "backgroundColorHint": "Colore della tela dietro le pagine",
+        "bgBlack": "Nero",
+        "bgGray": "Grigio",
+        "bgWhite": "Bianco"
+      },
+      "audio": {
+        "title": "Lettore di audiolibri",
+        "subtitle": "Impostazioni predefinite applicate durante la riproduzione di M4B, MP3 e altri formati audio.",
+        "playback": "Riproduzione",
+        "playbackSpeed": "Velocità di riproduzione predefinita",
+        "playbackSpeedHint": "Moltiplicatore di velocità applicato all'apertura di un nuovo audiolibro",
+        "volume": "Volume predefinito",
+        "volumeHint": "Livello del volume iniziale (da 0 a 100%)",
+        "skipControls": "Salta i controlli",
+        "skipBack": "Salta indietro la durata",
+        "skipBackHint": "I secondi vengono riavvolti premendo il salto indietro",
+        "skipForward": "Salta la durata in avanti",
+        "skipForwardHint": "I secondi avanzano quando si preme il salto avanti"
+      },
+      "fonts": {
+        "title": "Caratteri",
+        "subtitle": "Carica caratteri personalizzati da utilizzare nel lettore di eBook.",
+        "uploadFonts": "Carica caratteri",
+        "notAvailableDemo": "Non disponibile per i conti demo",
+        "uploading": "Caricamento...",
+        "dropFilesHere": "Rilascia i file qui",
+        "dragFontsPrefix": "Trascina qui i file dei caratteri oppure",
+        "browse": "sfogliare",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - massimo 10 MB ciascuno",
+        "yourFonts": "I tuoi caratteri",
+        "fontsUsed": "{count} / {max} usato",
+        "noFontsYet": "Nessun carattere ancora caricato",
+        "noFontsHint": "Trascina un file di font qui sopra per iniziare.",
+        "fileCount": "{count, plural, =0 {nessun file} one {# file} other {# file} many {# file}}",
+        "pangram": "La veloce volpe marrone salta sopra il cane pigro",
+        "renameFamily": "Rinominare la famiglia",
+        "deleteFamily": "Elimina famiglia",
+        "editVariant": "Modifica peso/stile",
+        "deleteVariant": "Elimina variante",
+        "styleNormal": "Normale",
+        "styleItalic": "Corsivo",
+        "weightThin": "Sottile",
+        "weightExtraLight": "Extra leggero",
+        "weightLight": "Luce",
+        "weightRegular": "Regolare",
+        "weightMedium": "Medio",
+        "weightSemiBold": "Semi audace",
+        "weightBold": "Grassetto",
+        "weightExtraBold": "Molto audace",
+        "weightBlack": "Nero",
+        "renameFamilyFailed": "Impossibile rinominare la famiglia di caratteri",
+        "renamedTo": "Rinominato in \"{name}\"",
+        "updateVariantFailed": "Impossibile aggiornare la variante del carattere",
+        "deleteFontFailed": "Impossibile eliminare il carattere",
+        "deleteFamilyFailed": "Impossibile eliminare la famiglia di caratteri",
+        "demoCannotManage": "L'account con limitazioni demo non può gestire i caratteri",
+        "fileAdded": "\"{name}\" aggiunto",
+        "uploadFailed": "Caricamento non riuscito"
+      },
+      "bookDock": {
+        "title": "Book Dock",
+        "subtitle": "Configura il modo in cui i file vengono elaborati quando entrano nel Book Dock.",
+        "dropFolder": "Rilascia la cartella",
+        "containerPath": "Percorso del contenitore",
+        "containerPathHint": "Copia o sposta i file del libro in questa cartella e verranno automaticamente raccolti ed elaborati da Book Dock. Sono supportate le sottodirectory.",
+        "changePathPrefix": "Per modificare questo percorso, impostare",
+        "changePathMiddle": "nel tuo",
+        "changePathSuffix": "file.",
+        "metadata": "Metadati",
+        "autoFetch": "Recupera automaticamente i metadati dai provider",
+        "autoFetchHint": "Recupera automaticamente i metadati dai provider configurati (Google Books, iTunes, Open Library, ecc.) dopo che un file viene aggiunto a Book Dock.",
+        "autoFinalize": "Finalizzazione automatica",
+        "enableAutoFinalize": "Abilita la finalizzazione automatica",
+        "enableAutoFinalizeHint": "I file con un punteggio di confidenza dei metadati pari o superiore alla soglia verranno finalizzati automaticamente.",
+        "confidenceThreshold": "Soglia di confidenza: {value}%",
+        "thresholdIgnored": "(ignorato in modalità Solo incorporato)",
+        "destinationLibrary": "Biblioteca di destinazione",
+        "selectLibrary": "Seleziona una libreria...",
+        "metadataMode": "Modalità metadati",
+        "metadataModeSafeMerge": "Unione sicura (consigliata)",
+        "metadataModeFetchedOnly": "Solo recuperato",
+        "metadataModeEmbeddedOnly": "Solo incorporato",
+        "destinationFolder": "Cartella di destinazione",
+        "selectFolder": "Seleziona una cartella...",
+        "saveSettingFailed": "Impossibile salvare l'impostazione",
+        "updateSettingFailed": "Impossibile aggiornare l'impostazione",
+        "autoFetchEnabled": "Recupero automatico abilitato",
+        "autoFetchDisabled": "Recupero automatico disabilitato",
+        "autoFinalizeEnabled": "Finalizzazione automatica abilitata",
+        "autoFinalizeDisabled": "Finalizzazione automatica disabilitata",
+        "destinationLibraryUpdated": "Libreria di destinazione aggiornata",
+        "destinationFolderUpdated": "Cartella di destinazione aggiornata",
+        "confidenceThresholdUpdated": "Soglia di confidenza aggiornata",
+        "metadataModeUpdated": "Modalità metadati aggiornata"
+      },
+      "fileNaming": {
+        "title": "Denominazione dei file",
+        "subtitle": "Controlla il modo in cui i file vengono organizzati sul disco quando vengono caricati e il modo in cui vengono denominati quando vengono scaricati utilizzando i token segnaposto.",
+        "copy": "Copia",
+        "previewLabel": "Anteprima:",
+        "fileAsBookPreview": "Archivia come anteprima del libro",
+        "folderAsBookPreview": "Cartella come anteprima del libro",
+        "downloadPreview": "Scarica l'anteprima",
+        "globalDefaults": "Impostazioni predefinite globali",
+        "crossPlatform": "Sanificazione del percorso multipiattaforma",
+        "crossPlatformHint": "Rendi sicuri i nomi di file e cartelle generati su Windows sostituendo i caratteri non validi e i nomi riservati e rimuovendo i punti e gli spazi finali. Disabilita solo per configurazioni solo Linux che mantengono intenzionalmente quei caratteri.",
+        "fileAsBookDefault": "Archivia come predefinito per il libro",
+        "fileAsBookDefaultHint": "Carica modello per le biblioteche utilizzando la modalità File come libro. Ogni file è un libro.",
+        "folderAsBookDefault": "Cartella come predefinita per il libro",
+        "folderAsBookDefaultHint": "Carica modello per le librerie utilizzando la modalità Cartella come libro. Ogni libro deve trovarsi nella propria cartella.",
+        "downloadPattern": "Scarica modello",
+        "downloadPatternHint": "Nomi file suggeriti per download di file singoli e file all'interno di ZIP di esportazione.",
+        "libraryOverrides": "Sostituzioni della libreria",
+        "noLibraries": "Nessuna libreria configurata. Creane uno nelle impostazioni della Libreria per impostare modelli di denominazione personalizzati.",
+        "badgeCustom": "Personalizzato",
+        "badgeDefault": "Predefinito",
+        "orgFolderAsBook": "Cartella come libro",
+        "orgFileAsBook": "Archivia come libro",
+        "resetToDefault": "Ripristina le impostazioni predefinite",
+        "patternReference": "Riferimento al modello",
+        "placeholderReference": "Riferimento al segnaposto",
+        "placeholderReferenceHint": "- guida per la creazione di modelli di denominazione personalizzati",
+        "tokens": "Gettoni",
+        "tokensHint": "Copia rapidamente i segnaposto",
+        "clickTokenHint": "Fai clic su qualsiasi token per copiarlo negli appunti.",
+        "copyValue": "Copia {value}",
+        "modifiers": "Modificatori",
+        "modifiersHint": "Trasforma i valori dei token",
+        "modifiersExplain": "Aggiungi un modificatore all'interno di un token per trasformarne il valore:",
+        "modFirst": "Solo primo valore",
+        "modSort": "Ultimo, Primo formato",
+        "modInitial": "Solo la prima lettera",
+        "modFixed2": "Due cifre decimali",
+        "folderOnlyPrefix": "Termina uno schema con",
+        "folderOnlySuffix": "per specificare solo una cartella. Il nome del file originale verrà conservato al suo interno.",
+        "conditionalLogic": "Logica condizionale",
+        "conditionalLogicHint": "Segmenti facoltativi e fallback",
+        "conditionalPart1": "Avvolgiti",
+        "conditionalPart2": "per saltare un segmento quando il suo token è vuoto. Utilizzare",
+        "conditionalPart3": "per un valore predefinito.",
+        "examples": "Esempi",
+        "patternExamples": "Esempi di modelli",
+        "patternExamplesHint": "Modelli già pronti per gli stili di libreria più comuni",
+        "copyPatternTooltip": "Copia il motivo negli appunti",
+        "exCalibre": "predefinito in stile Calibre",
+        "exSeriesReader": "Lettore di serie",
+        "exCleanDownload": "Pulisci il nome del file di download",
+        "exAlphabetical": "Raggruppamento alfabetico con serie",
+        "exSeriesFallback": "Fallback in serie o autonomo",
+        "exOptionalSubtitle": "Scarica con sottotitoli opzionali",
+        "exMultilingual": "Biblioteca multilingue",
+        "exPublisher": "Organizzato dall'editore",
+        "exStacked": "Cartelle opzionali impilate",
+        "exFolderDrop": "Rilascio della cartella con nome di ordinamento",
+        "caseWithYear": "con anno",
+        "caseNoYear": "nessun anno",
+        "caseInSeries": "in serie",
+        "caseStandalone": "autonomo",
+        "caseNoSeries": "nessuna serie",
+        "caseFull": "pieno",
+        "caseMinimal": "minimo",
+        "caseWithLanguage": "con la lingua",
+        "caseNoLanguage": "nessuna lingua",
+        "caseWithPublisher": "con l'editore",
+        "caseNoPublisher": "nessun editore",
+        "caseAllSet": "tutto pronto",
+        "copiedToClipboard": "{value} copiato negli appunti",
+        "copyTokenFailed": "Impossibile copiare il token",
+        "patternCopied": "Modello copiato negli appunti",
+        "copyPatternFailed": "Impossibile copiare il modello",
+        "labelCopied": "{label} copiato negli appunti",
+        "copyLabelFailed": "Impossibile copiare {label}"
+      },
+      "kobo": {
+        "title": "Kobo Sincronizza",
+        "subtitle": "Accoppia il tuo dispositivo Kobo per sincronizzare la tua libreria.",
+        "copy": "Copia",
+        "never": "Mai",
+        "justNow": "Proprio adesso",
+        "minutesAgo": "{count}m fa",
+        "hoursAgo": "{count}h fa",
+        "daysAgo": "{count}d fa",
+        "loadFailed": "Impossibile caricare",
+        "devicePaired": "Dispositivo accoppiato con successo",
+        "devicePairedHint": "Sei pronto per configurare il tuo Kobo. Seguire le istruzioni riportate di seguito.",
+        "syncUrl": "Sincronizza URL",
+        "urlNotShownAgain": "Questo URL non verrà mostrato più. Mantienilo privato.",
+        "registeredDevices": "Dispositivi registrati",
+        "addDevice": "Aggiungi dispositivo",
+        "deviceName": "Nome del dispositivo",
+        "deviceNamePlaceholder": "ad es. La mia Kobo Bilancia",
+        "creating": "Creazione...",
+        "createDevice": "Crea dispositivo",
+        "createDeviceFailed": "Impossibile creare il dispositivo",
+        "deviceRegistered": "Dispositivo \"{name}\" registrato",
+        "noDevicesYet": "Nessun dispositivo ancora",
+        "noDevicesHint": "Aggiungi un dispositivo per iniziare a sincronizzare i tuoi libri sul tuo Kobo.",
+        "lastSync": "Ultima sincronizzazione: {time}",
+        "renameDevice": "Rinominare il dispositivo",
+        "revokeAccess": "Revoca l'accesso",
+        "deviceRenamed": "Dispositivo rinominato",
+        "renameDeviceFailed": "Impossibile rinominare il dispositivo",
+        "revokeConfirm": "Revocare l'accesso per \"{name}\"? Il dispositivo non sarà in grado di sincronizzarsi finché non verrà riaccoppiato.",
+        "accessRevoked": "Accesso revocato per \"{name}\"",
+        "revokeFailed": "Impossibile revocare l'accesso",
+        "syncUrlCopied": "Sincronizza URL copiato negli appunti",
+        "syncUrlCopyFailed": "Impossibile copiare la sincronizzazione URL",
+        "syncPreferences": "Preferenze di sincronizzazione",
+        "twoWaySync": "Sincronizzazione dell'avanzamento bidirezionale",
+        "twoWaySyncHint": "Sincronizza la posizione di lettura tra BookOrbit e Kobo. Richiede la consegna di KEPUB per posizioni precise e ripristino affidabile della pagina.",
+        "syncHighlights": "Sincronizza i momenti salienti di BookOrbit su Kobo",
+        "syncHighlightsHint": "Invia i momenti salienti realizzati in BookOrbit o KOReader al tuo Kobo. I momenti salienti di Kobo vengono importati in BookOrbit anche quando è disattivato. Le annotazioni collegate sincronizzano le modifiche e le eliminazioni in entrambi i modi. Richiede la consegna KEPUB; il libro su Kobo deve essere il KEPUB scaricato da BookOrbit.",
+        "convertKepub": "Converti in KEPUB",
+        "convertKepubHint": "Invia EPUB idonei come KEPUB. Rimane attivo quando la sincronizzazione dei progressi o le evidenziazioni BookOrbit-to-Kobo sono abilitate. Alla successiva sincronizzazione Kobo, i libri interessati verranno nuovamente offerti come download KEPUB; rimuovi qualsiasi vecchia copia EPUB se Kobo continua ad aprirla.",
+        "forceHyphenation": "Forza la sillabazione",
+        "forceHyphenationHint": "Garantisce una giustificazione coerente del testo. Ciò rigenererà i KEPUB memorizzati nella cache.",
+        "progressThresholds": "Soglie di avanzamento",
+        "progressThresholdsHint": "Definisci quando l'avanzamento della lettura di Kobo aggiorna lo stato della tua biblioteca.",
+        "markAsReading": "Segna come lettura",
+        "markAsReadingHint": "Percentuale minima per spostare un libro in \"Lettura\".",
+        "markAsFinished": "Segna come finito",
+        "markAsFinishedHint": "Soglia percentuale per contrassegnare un libro come \"Finito\".",
+        "kepubLimit": "Limite di conversione KEPUB",
+        "kepubLimitHint": "I libri che superano questo limite vengono inviati come EPUB normali, quindi BookOrbit non sincronizzerà la posizione del lettore con Kobo.",
+        "changesMustBeSaved": "Le modifiche devono essere salvate per avere effetto.",
+        "saving": "Salvataggio...",
+        "saveSyncSettings": "Salva le impostazioni di sincronizzazione",
+        "thresholdOrderError": "La soglia di lettura deve essere inferiore alla soglia di completamento",
+        "saveSettingsFailed": "Impossibile salvare le impostazioni",
+        "settingsSaved": "Kobo impostazioni di sincronizzazione salvate",
+        "saveFailed": "Impossibile salvare",
+        "activity": {
+          "waitingForActivity": "In attesa di attività",
+          "needsAttention": "Ha bisogno di attenzione",
+          "syncHealthy": "Sincronizzazione sana",
+          "never": "Mai",
+          "none": "Nessuno",
+          "unknown": "Sconosciuto",
+          "failureCount": "{count, plural, one {# fallimento} other {# fallimenti} many {# fallimenti}}",
+          "noActivityRecorded": "Nessuna attività di sincronizzazione Kobo è stata registrata.",
+          "lastSuccess": "Ultimo successo {time}",
+          "lastFailure": "Ultimo fallimento {time}",
+          "noFailedActivity": "Nessuna attività Kobo non riuscita nella cronologia recente.",
+          "noActivityYet": "Nessuna attività Kobo ancora.",
+          "event": {
+            "librarySync": "La libreria ha controllato gli aggiornamenti",
+            "bookDownload": "Libro scaricato",
+            "progressUpdate": "Posizione di lettura aggiornata",
+            "annotationsPull": "Evidenziazioni inviate a Kobo",
+            "annotationsPush": "Evidenziazioni ricevute da Kobo"
+          },
+          "outcome": {
+            "failed": "Fallito",
+            "noUpdates": "Nessun aggiornamento",
+            "noChanges": "Nessun cambiamento",
+            "pending": "In sospeso",
+            "completed": "Completato",
+            "downloaded": "Scaricato",
+            "updated": "Aggiornato",
+            "sent": "Inviato",
+            "imported": "Importato"
+          },
+          "failure": {
+            "librarySync": "Il controllo della libreria non è stato completato",
+            "bookDownload": "Il download non è stato completato",
+            "progressUpdate": "La posizione di lettura non è stata aggiornata",
+            "annotationsPull": "I punti salienti non sono stati inviati",
+            "annotationsPush": "Le evidenziazioni non sono state importate"
+          },
+          "chip": {
+            "morePending": "Altro in sospeso",
+            "noUpdatesPending": "Nessun aggiornamento in sospeso",
+            "bookCount": "{count, plural, one {# libro} other {# libri} many {# libri}}",
+            "deletedAnnotations": "{count} annotazioni eliminate",
+            "deviceAlreadyCurrent": "Dispositivo già aggiornato",
+            "freshHighlightData": "Nuovi dati salienti",
+            "created": "{count} creato",
+            "updated": "{count} aggiornato",
+            "deleted": "{count} eliminato",
+            "unchanged": "{count} invariato"
+          },
+          "readingPositionSyncedTitle": "Posizione di lettura sincronizzata: {title}",
+          "readingPositionSynced": "Posizione di lettura sincronizzata",
+          "labelWithTitle": "{label}: {title}",
+          "updateCount": "{count, plural, one {# aggiornamento} other {# aggiornamenti} many {# aggiornamenti}}",
+          "directionToKobo": "BookOrbit -> Kobo",
+          "directionToBookOrbit": "Kobo -> BookOrbit",
+          "twoWaySyncEnabled": "Sincronizzazione bidirezionale abilitata",
+          "deviceProgressSaved": "Avanzamento del dispositivo salvato",
+          "summary": {
+            "noLibraryUpdatesPending": "Nessun aggiornamento della libreria in sospeso per questo dispositivo",
+            "libraryUpdatesPrepared": "{count, plural, one {# aggiornamento della libreria preparato per il dispositivo} other {# aggiornamenti della libreria preparati per il dispositivo} many {# aggiornamenti della libreria preparati per il dispositivo}}",
+            "bookDownloadedBy": "{title} è stato scaricato da {device}",
+            "booksDownloaded": "{count, plural, one {# libro scaricato} other {# libri scaricati} many {# libri scaricati}}",
+            "progressUpdatesSyncedFor": "{count, plural, one {# aggiornamento sullo stato di avanzamento sincronizzato per {title}} other {# aggiornamenti sui progressi sincronizzati per {title}} many {# aggiornamenti sui progressi sincronizzati per {title}}}",
+            "progressUpdatesSynced": "{count, plural, one {# aggiornamento dei progressi sincronizzato} other {# aggiornamenti sui progressi sincronizzati} many {# aggiornamenti sui progressi sincronizzati}}",
+            "newReadingPositionFor": "Kobo ha segnalato una nuova posizione di lettura per {title}",
+            "newReadingPosition": "Kobo ha segnalato una nuova posizione di lettura",
+            "noHighlightChangesNeededFor": "Non sono necessarie modifiche all'evidenziazione per {title}",
+            "noHighlightChangesNeeded": "Non sono necessarie modifiche alle evidenziazioni",
+            "highlightsSentToKoboFor": "{count, plural, one {# evidenziazione inviata a Kobo per {title}} other {# momenti salienti inviati a Kobo per {title}} many {# momenti salienti inviati a Kobo per {title}}}",
+            "highlightsSentToKobo": "{count, plural, one {# evidenziazione inviata a Kobo} other {# momenti salienti inviati a Kobo} many {# momenti salienti inviati a Kobo}}",
+            "noKoboHighlightChangesFor": "Nessuna Kobo evidenzia modifiche per {title}",
+            "noKoboHighlightChanges": "Nessuna modifica all'evidenziazione di Kobo",
+            "highlightsImportedFromKoboFor": "{count, plural, one {# evidenziazione importata da Kobo per {title}} other {# momenti salienti importati da Kobo per {title}} many {# momenti salienti importati da Kobo per {title}}}",
+            "highlightsImportedFromKobo": "{count, plural, one {# evidenziazione importata da Kobo} other {# momenti salienti importati da Kobo} many {# momenti salienti importati da Kobo}}"
+          },
+          "timeRange": "da {from} a {to}",
+          "eventsGrouped": "{count, plural, one {# evento raggruppato} other {# eventi raggruppati} many {# eventi raggruppati}}",
+          "removedDevice": "Dispositivo rimosso",
+          "loadMoreFailed": "Impossibile caricare altra cronologia",
+          "historyRefreshed": "Kobo cronologia di sincronizzazione aggiornata",
+          "refreshFailed": "Impossibile aggiornare la cronologia",
+          "recentActivity": "Attività Kobo recente",
+          "filterAll": "Tutto",
+          "filterFailures": "Fallimenti",
+          "refresh": "Aggiorna",
+          "loadingActivity": "Caricamento attività Kobo...",
+          "noActivityHint": "L'attività di sincronizzazione recente verrà visualizzata dopo un Kobo contatti BookOrbit associati.",
+          "error": "Errore",
+          "loading": "Caricamento...",
+          "loadMore": "Carica più attività"
+        },
+        "howBooksSynced": {
+          "title": "Come vengono sincronizzati i libri",
+          "body": "Per inviare libri al tuo dispositivo Kobo, devi abilitare {syncToKobo} sulle raccolte che contengono tali libri. Apri qualsiasi raccolta dalla barra laterale, fai clic sull'icona Modifica e attiva {syncToKobo}. I libri che non fanno parte di una raccolta abilitata non verranno sincronizzati."
+        },
+        "nextSteps": {
+          "title": "Passaggi successivi",
+          "step1": "1. Configura il tuo dispositivo Kobo per la sincronizzazione con il sistema di sincronizzazione URL sopra.",
+          "step2": "2. In BookOrbit, vai a qualsiasi raccolta dalla barra laterale, fai clic sull'icona Modifica e attiva {syncToKobo}. Solo i libri all'interno delle raccolte abilitate alla sincronizzazione verranno scaricati sul tuo dispositivo."
+        },
+        "syncToKobo": "Sincronizza con Kobo",
+        "tabs": {
+          "syncSettings": "Sincronizza impostazioni",
+          "activityLog": "Registro delle attività"
+        }
+      },
+      "koreader": {
+        "title": "KOReader Sincronizza",
+        "subtitle": "Sfoglia il tuo catalogo BookOrbit in KOReader e sincronizza progressi, attività di lettura, evidenziazioni e modifiche alle annotazioni.",
+        "tabs": {
+          "sync": "Sincronizza impostazioni",
+          "fileNaming": "Denominazione dei file"
+        },
+        "fileNaming": {
+          "accountTitle": "Modello KOReader predefinito dell'account",
+          "accountDescription": "Imposta la cartella relativa e il nome file predefiniti utilizzati dai download del plug-in BookOrbit per il tuo account KOReader. Le regole specifiche del dispositivo possono sovrascriverle di seguito.",
+          "defaultPattern": "Modello predefinito del percorso del libro",
+          "accountHelp": "Il tuo account è predefinito per i download del plug-in KOReader a meno che un dispositivo non abbia una regola personalizzata.",
+          "accountHint": "Utilizzato dai tuoi dispositivi KOReader che non hanno una sostituzione personalizzata.",
+          "preview": "Anteprima",
+          "saveAccount": "Salva l'impostazione predefinita dell'account",
+          "deviceTitle": "Il dispositivo KOReader esegue l'override",
+          "deviceDescription": "Personalizza qualsiasi combinazione di percorsi predefiniti, serie e autonomi. Le righe vuote specifiche del dispositivo ereditano l'impostazione predefinita del dispositivo, che a sua volta può ereditare il modello KOReader predefinito dell'account.",
+          "noDevices": "I dispositivi vengono visualizzati qui dopo la sincronizzazione con BookOrbit.",
+          "customOrganization": "Organizzazione personalizzata",
+          "usingAccountDefault": "Utilizzo dell'account predefinito",
+          "deviceDefaultHelp": "Fallback per questo dispositivo. Lascialo uguale all'impostazione predefinita dell'account per ereditare automaticamente le modifiche future.",
+          "seriesBooks": "Libri in una serie",
+          "seriesHelp": "Percorso facoltativo utilizzato solo per i libri con metadati di serie. Lascia vuoto per utilizzare il modello di percorso predefinito di questo dispositivo.",
+          "standaloneBooks": "Libri senza serie",
+          "standaloneHelp": "Percorso facoltativo utilizzato solo per i libri senza metadati della serie. Lascia vuoto per utilizzare il modello di percorso predefinito di questo dispositivo.",
+          "inheritPlaceholder": "Lascia vuoto per utilizzare il modello predefinito di questo dispositivo",
+          "useAccount": "Utilizza account predefinito",
+          "saveOverride": "Salva override",
+          "loadFailed": "Impossibile caricare le impostazioni di organizzazione dei file",
+          "accountRequired": "Inserisci un modello di percorso del libro predefinito prima di salvare.",
+          "accountSaved": "Modello KOReader predefinito dell'account salvato",
+          "accountSaveFailed": "Impossibile salvare le impostazioni di organizzazione dei file",
+          "deviceUsesAccount": "Il dispositivo ora utilizza il modello KOReader predefinito dell'account",
+          "deviceSaved": "Sostituzione dell'organizzazione del dispositivo salvata",
+          "deviceSaveFailed": "Impossibile salvare l'override del dispositivo",
+          "deviceResetFailed": "Impossibile reimpostare l'override del dispositivo"
+        },
+        "loadingSettings": "Caricamento delle impostazioni KOReader...",
+        "loadFailed": "Impossibile caricare le impostazioni KOReader",
+        "never": "Mai",
+        "justNow": "Proprio adesso",
+        "minutesAgo": "{count}m fa",
+        "hoursAgo": "{count}h fa",
+        "daysAgo": "{count}d fa",
+        "unknown": "Sconosciuto",
+        "updateAvailable": "Aggiornamento disponibile",
+        "upToDate": "Aggiornato",
+        "versionUnknown": "Versione sconosciuta",
+        "latestPlugin": "Plugin più recente: v{version}",
+        "latestPluginUnavailable": "Ultimo plugin non disponibile",
+        "notConfigured": "La sincronizzazione KOReader non è configurata",
+        "notConfiguredHint": "Crea un set di credenziali di sincronizzazione, quindi usale con il plug-in BookOrbit KOReader per la navigazione, i download, l'avanzamento, la lettura di eventi, le evidenziazioni e le eliminazioni.",
+        "createCredentials": "Crea credenziali",
+        "createFormTitle": "Crea KOReader Credenziali di sincronizzazione",
+        "createFormHint": "Queste credenziali autenticano i tuoi dispositivi KOReader con BookOrbit.",
+        "username": "Nome utente",
+        "usernamePlaceholder": "ad es. miolettore",
+        "password": "Parola d'ordine",
+        "passwordPlaceholder": "Minimo 6 caratteri",
+        "creating": "Creazione...",
+        "create": "Crea",
+        "credentialsCreated": "KOReader credenziali di sincronizzazione create",
+        "createCredentialsFailed": "Impossibile creare le credenziali",
+        "status": "KOReader Stato",
+        "refresh": "Aggiorna",
+        "progressSync": "Sincronizzazione dei progressi",
+        "progressSyncHint": "Consenti ai dispositivi KOReader di sincronizzare progressi, attività di lettura, evidenziazioni ed eliminazioni di annotazioni con BookOrbit.",
+        "lastSync": "Ultima sincronizzazione",
+        "syncedBooks": "Libri sincronizzati",
+        "bookCount": "{count, plural, =0 {niente libri} one {# libro} other {# libri} many {# libri}}",
+        "devices": "Dispositivi",
+        "deviceCount": "{count, plural, =0 {nessun dispositivo} one {# dispositivo} other {# dispositivi} many {# dispositivi}}",
+        "credentialsCreatedLabel": "Credenziali create",
+        "setup": "Installazione",
+        "pluginServerUrl": "Server plugin URL",
+        "copied": "Copiato",
+        "copyUrl": "Copia URL",
+        "preconfiguredPlugin": "Plug-in BookOrbit preconfigurato",
+        "preconfiguredPluginHintPrefix": "Scarica un file zip con il server URL e il tuo accesso di sincronizzazione già configurato. Il plugin include la navigazione e la sincronizzazione del catalogo. Copia la cartella in",
+        "preconfiguredPluginHintSuffix": "e riavvia KOReader.",
+        "latestPluginNote": "{label}. Gli aggiornamenti del dispositivo vengono eseguiti dal menu BookOrbit in KOReader.",
+        "preparing": "Preparazione...",
+        "downloadPlugin": "Scarica plugin",
+        "noDevicesSynced": "Nessun dispositivo è stato ancora sincronizzato",
+        "noDevicesSyncedHint": "Installa il plug-in BookOrbit per la sincronizzazione completa o configura la sincronizzazione dell'avanzamento stock di KOReader per gli aggiornamenti relativi ai soli progressi.",
+        "lastSyncLabel": "Ultima sincronizzazione:",
+        "lastBookLabel": "Ultimo libro:",
+        "noneYet": "Nessuno ancora",
+        "pluginActivity": "Attività del plugin",
+        "noPluginActivity": "Non è stata ancora segnalata alcuna attività del plugin.",
+        "lastFullSync": "Ultima sincronizzazione completa: {time}",
+        "latestPluginSuffix": "- ultimo plugin v{version}",
+        "matchedBooks": "Libri abbinati",
+        "readingEvents": "Lettura degli eventi",
+        "highlights": "Punti salienti",
+        "syncedTotals": "Totali sincronizzati",
+        "trashedHighlights": "Punti salienti cestinati",
+        "pendingDeletes": "{count, plural, =0 {nessun highlight eliminato in attesa del riconoscimento del plugin KOReader.} one {# evidenziazione eliminata in attesa del riconoscimento del plugin KOReader.} other {# evidenziazioni cancellate in attesa del riconoscimento del plugin KOReader.} many {# evidenziazioni cancellate in attesa del riconoscimento del plugin KOReader.}}",
+        "failedPositions": "{count, plural, =0 {nessuna posizione evidenziata richiede attenzione.} one {# la posizione evidenziata richiede attenzione.} other {# evidenziare le posizioni che richiedono attenzione.} many {# evidenziare le posizioni che richiedono attenzione.}}",
+        "setupGuide": "Guida all'installazione",
+        "setupSteps": "KOReader passaggi di configurazione",
+        "setupStepsHint": "Utilizza il plug-in BookOrbit per la navigazione del catalogo, i download, i progressi, gli eventi di lettura e le evidenziazioni. Utilizza il plugin stock solo per progredire.",
+        "pluginGuideTitle": "BookOrbit plugin",
+        "pluginStep1": "Scarica il plugin preconfigurato qui sopra.",
+        "pluginStep2Prefix": "Decomprimilo e copialo",
+        "pluginStep2Middle": "a",
+        "pluginStep2Suffix": "sul tuo dispositivo.",
+        "pluginStep3": "Riavvia KOReader. Il server e il login vengono configurati automaticamente.",
+        "pluginStep4Prefix": "Aperto",
+        "pluginStep4Suffix": "per cercare, scaricare e collegare libri da sincronizzare.",
+        "stockGuideTitle": "Plug-in per la sincronizzazione dell'avanzamento delle scorte",
+        "stockStep1Prefix": "Sul tuo dispositivo KOReader, vai a",
+        "stockStep1Suffix": ".",
+        "stockStep2": "Imposta il server di sincronizzazione personalizzato su URL mostrato sopra.",
+        "stockStep3": "Inserisci il nome utente e la password che hai creato, quindi tocca Accedi.",
+        "locationNote": "BookOrbit salva posizioni KOReader compatibili con EPUB dal lettore web. Il ripristino dovrebbe arrivare vicino alla stessa posizione, anche se il posizionamento esatto della linea può variare in base al lettore e al layout EPUB.",
+        "dangerZone": "Zona pericolosa",
+        "deleteCredentials": "Elimina le credenziali KOReader",
+        "deleteCredentialsHint": "Rimuovi le credenziali di sincronizzazione e disconnetti tutti i dispositivi. I dati di avanzamento verranno conservati.",
+        "credentialsDeleted": "Credenziali KOReader eliminate",
+        "deleteCredentialsFailed": "Impossibile eliminare le credenziali",
+        "deleteConfirmTitle": "Eliminare le credenziali KOReader?",
+        "deleteConfirmBody": "Questa operazione rimuoverà le tue credenziali di sincronizzazione e disconnetterà tutti i dispositivi KOReader. I dati di avanzamento esistenti verranno conservati.",
+        "syncEnabled": "KOReader sincronizzazione abilitata",
+        "syncDisabled": "KOReader sincronizzazione disabilitata",
+        "toggleSyncFailed": "Impossibile attivare/disattivare la sincronizzazione",
+        "syncUrlCopied": "Sincronizza URL copiato negli appunti",
+        "syncUrlCopyFailed": "Impossibile copiare la sincronizzazione URL",
+        "statusRefreshed": "Stato di sincronizzazione aggiornato",
+        "refreshFailed": "Impossibile aggiornare",
+        "pluginDownloaded": "Plugin scaricato. Copia bookorbit.koplugin dallo zip a koreader/plugins/ sul tuo dispositivo.",
+        "pluginDownloadFailed": "Impossibile scaricare il plug-in",
+        "hashLinks": {
+          "unmatchedTitle": "Libri KOReader senza eguali",
+          "unmatchedBooks": "Libri senza eguali",
+          "manualTitle": "Manuale KOReader Collegamenti",
+          "refresh": "Aggiorna",
+          "link": "Collegamento",
+          "change": "Cambiare",
+          "unlink": "Scollega",
+          "hash": "Hash:",
+          "lastOpened": "Ultima apertura:",
+          "firstSeen": "Visto per la prima volta:",
+          "lastSeen": "Visto l'ultima volta:",
+          "linked": "Collegato:",
+          "updated": "Aggiornato:",
+          "linkedTo": "Collegato a {title}",
+          "loadingUnmatched": "Caricamento libri senza corrispondenze...",
+          "loadingManual": "Caricamento dei collegamenti hash manuali in corso...",
+          "noUnmatched": "Nessun libro KOReader senza corrispondenza.",
+          "noManual": "Nessun collegamento KOReader manuale.",
+          "pageOf": "Pagina {page} di {total}",
+          "showingRange": "Mostrando {start}-{end} di {total}",
+          "unknownFile": "File KOReader sconosciuto {hash}",
+          "unknownAuthor": "Autore sconosciuto",
+          "noTitleOrAuthor": "Nessun titolo o autore riportato",
+          "bookNumber": "BookOrbit libro n.{id}",
+          "toast": {
+            "unmatchedRefreshed": "Libri senza eguali aggiornati",
+            "unmatchedRefreshFailed": "Impossibile aggiornare i libri senza corrispondenza",
+            "manualRefreshed": "Collegamenti hash manuali aggiornati",
+            "manualRefreshFailed": "Impossibile aggiornare i collegamenti hash manuali",
+            "bookLinked": "Libro collegato",
+            "linkUpdated": "Collegamento aggiornato",
+            "linkFailed": "Impossibile collegare il libro",
+            "linkRemoved": "Collegamento rimosso",
+            "unlinkFailed": "Impossibile scollegare il libro",
+            "unmatchedDismissed": "Libro senza eguali respinto",
+            "dismissFailed": "Impossibile ignorare il libro senza corrispondenza",
+            "allDismissed": "{count, plural, =0 {Nessun libro senza eguali è stato respinto} one {Licenziato # libro senza eguali} other {Licenziato # libri senza eguali} many {Licenziato # libri senza eguali}}",
+            "dismissAllFailed": "Impossibile eliminare tutti i libri senza corrispondenza"
+          },
+          "modal": {
+            "linkTitle": "Collega il libro KOReader",
+            "changeTitle": "Modifica il collegamento KOReader",
+            "bookOrbitBook": "BookOrbit libro",
+            "searchPlaceholder": "Cerca nella tua libreria BookOrbit",
+            "minChars": "Inserisci almeno 2 caratteri.",
+            "searching": "Ricerca...",
+            "noBooksFound": "Nessun libro trovato.",
+            "untitledBook": "Libro senza titolo",
+            "selected": "Selezionato",
+            "select": "Seleziona",
+            "loadMore": "Carica di più",
+            "confirmTitle": "Conferma il collegamento KOReader",
+            "koreader": "KOReader",
+            "bookOrbit": "BookOrbit",
+            "bookId": "ID libro: {id}",
+            "syncedStatsNote": "Le statistiche già sincronizzate rimarranno nel libro BookOrbit corrente.",
+            "chooseDifferent": "Scegli diverso",
+            "saving": "Salvataggio...",
+            "confirmLink": "Conferma collegamento",
+            "unlinkTitle": "Scollegare il libro KOReader?",
+            "unlinkBody": "Le future sincronizzazioni per questo hash non verranno più risolte in {title} finché non verrà nuovamente collegato. Le statistiche già sincronizzate rimarranno nel libro BookOrbit corrente.",
+            "unlinking": "Scollegamento..."
+          },
+          "dismiss": "Ignora",
+          "dismissAll": "Ignora tutto",
+          "dismissing": "Licenziamento...",
+          "unlinking": "Scollegamento...",
+          "unlinkConfirmTitle": "Scollegare il libro KOReader?",
+          "unlinkConfirmBody": "Le future sincronizzazioni per questo hash non verranno più risolte in {title} finché non verrà nuovamente collegato. Le statistiche già sincronizzate rimarranno nel libro BookOrbit corrente.",
+          "dismissConfirmTitle": "Ignorare {title}?",
+          "dismissConfirmBody": "Questa operazione lo rimuoverà dall'elenco dei libri senza corrispondenza. Se un dispositivo segnala nuovamente questo hash, riapparirà come una nuova voce.",
+          "dismissAllConfirmTitle": "{count, plural, =0 {nessun libro senza eguali} one {Ignora tutto # libro senza eguali?} other {Ignora tutto # libri senza eguali?} many {Ignora tutto # libri senza eguali?}}",
+          "dismissAllConfirmBody": "Ciò cancella l'intero elenco di libri senza corrispondenze, non solo la pagina corrente. Se un dispositivo segnala nuovamente uno di questi hash, riapparirà come una nuova voce.",
+          "changeLinkTitle": "Modifica il collegamento KOReader",
+          "linkBookTitle": "Collega il libro KOReader",
+          "bookOrbitBook": "BookOrbit libro",
+          "searchLibraryPlaceholder": "Cerca nella tua libreria BookOrbit",
+          "enterMinChars": "Inserisci almeno 2 caratteri.",
+          "searching": "Ricerca...",
+          "noBooksFound": "Nessun libro trovato.",
+          "untitledBook": "Libro senza titolo",
+          "selected": "Selezionato",
+          "select": "Seleziona",
+          "loadMore": "Carica di più",
+          "loadingMore": "Caricamento...",
+          "confirmLinkTitle": "Conferma il collegamento KOReader",
+          "bookId": "ID libro: {id}",
+          "syncedStatsNote": "Le statistiche già sincronizzate rimarranno nel libro BookOrbit corrente.",
+          "chooseDifferent": "Scegli diverso",
+          "saving": "Salvataggio...",
+          "confirmLink": "Conferma collegamento"
+        },
+        "remove": "Rimuovi",
+        "removing": "Rimozione...",
+        "unmatchedBooks": "Libri senza eguali",
+        "deviceRemoved": "Dispositivo rimosso",
+        "removeDeviceFailed": "Impossibile rimuovere il dispositivo",
+        "removeDeviceConfirmTitle": "Rimuovere {device}?",
+        "removeDeviceConfirmBody": "Questa operazione eliminerà permanentemente i progressi sincronizzati di questo dispositivo, l'attività di lettura e tutte le voci di libri senza corrispondenza non più segnalate da un altro dispositivo. Se il dispositivo si sincronizza nuovamente in un secondo momento, riapparirà come una nuova voce."
+      },
+      "opds": {
+        "title": "OPDS",
+        "subtitle": "Collega app di lettura compatibili con OPDS come KOReader o Thorium Reader alla tua libreria.",
+        "copy": "Copia",
+        "loadFailed": "Impossibile caricare",
+        "server": "Server",
+        "catalogServer": "OPDS Server catalogo",
+        "catalogServerHint": "Consenti ai clienti OPDS di sfogliare e scaricare libri",
+        "endpoint": "Punto finale",
+        "accounts": "OPDS Account",
+        "add": "Aggiungi",
+        "addAccount": "Aggiungi conto",
+        "username": "Nome utente",
+        "usernameLabel": "Nome utente",
+        "usernamePlaceholder": "ad es. koreader",
+        "password": "Parola d'ordine",
+        "passwordPlaceholder": "Minimo 8 caratteri",
+        "defaultSort": "Ordinamento predefinito",
+        "sortLabel": "Ordina",
+        "creating": "Creazione...",
+        "create": "Crea",
+        "noAccounts": "Nessun account OPDS ancora. Creane uno per iniziare a utilizzare i client OPDS.",
+        "hideDetails": "Nascondi dettagli",
+        "showDetails": "Mostra dettagli",
+        "copyUsername": "Copia nome utente",
+        "notes": "OPDS Note",
+        "notesBody": "Utilizza gli account OPDS nelle app di lettura. Mantieni le credenziali private e ruota le password se condivise accidentalmente.",
+        "deleteConfirmTitle": "Eliminare l'account OPDS?",
+        "deleteConfirmBody": "Elimina \"{username}\". Questa azione non può essere annullata.",
+        "sortRecent": "Aggiunto di recente",
+        "sortTitleAsc": "Titolo (A-Z)",
+        "sortTitleDesc": "Titolo (Z-A)",
+        "sortAuthorAsc": "Autore (A-Z)",
+        "sortAuthorDesc": "Autore (Z-A)",
+        "sortSeriesAsc": "Serie (A-Z)",
+        "sortSeriesDesc": "Serie (ZA)",
+        "serverEnabled": "OPDS server abilitato",
+        "serverDisabled": "OPDS server disabilitato",
+        "updateSettingsFailed": "Impossibile aggiornare le impostazioni OPDS",
+        "urlCopied": "OPDS URL copiato negli appunti",
+        "urlCopyFailed": "Impossibile copiare OPDS URL",
+        "createUserFailed": "Impossibile creare l'utente OPDS",
+        "userCreated": "OPDS utente \"{username}\" creato",
+        "sortOrderUpdated": "Ordinamento aggiornato per \"{username}\"",
+        "updateSortFailed": "Impossibile aggiornare l'ordinamento",
+        "userDeleted": "OPDS utente \"{username}\" eliminato",
+        "deleteUserFailed": "Impossibile eliminare l'utente OPDS",
+        "labelCopied": "{label} copiato",
+        "copyLabelFailed": "Impossibile copiare {label}"
+      },
+      "tabs": {
+        "general": "Generale",
+        "ebook": "eBook",
+        "pdf": "PDF",
+        "comics": "Fumetti",
+        "audio": "Audiolibro",
+        "fonts": "Caratteri"
+      }
+    },
+    "system": {
+      "tabs": {
+        "file-naming": "Denominazione dei file",
+        "book-dock": "Book Dock",
+        "maintenance": "Manutenzione",
+        "audit-log": "Registro di controllo"
+      }
+    }
+  },
+  "achievements": {
+    "title": "Risultati",
+    "tiersCount": "Livelli {earned} / {total}",
+    "loadFailed": "Impossibile caricare gli obiettivi",
+    "tryAgain": "Riprova",
+    "noMatchFilter": "Nessun risultato corrisponde a questo filtro",
+    "secretAchievement": "Obiettivo segreto",
+    "earnedOn": "Guadagnato {date}",
+    "whileReading": "Durante la lettura di \"{title}\"",
+    "tierProgress": "Livello {earned} di {total}",
+    "progressToNext": "{current} / {threshold} a {name}",
+    "rarity": {
+      "common": "Comune",
+      "rare": "Raro",
+      "epic": "Epico",
+      "legendary": "Leggendario"
+    },
+    "filter": {
+      "all": "Tutto",
+      "earned": "Guadagnato ({count})",
+      "inProgress": "In corso ({count})",
+      "locked": "Bloccato ({count})"
+    }
+  },
+  "adminFeature": {
+    "accountActivity": {
+      "title": "Attività dell'account",
+      "subtitle": "Controlla l'attività di autenticazione dell'account senza esporre la cronologia di lettura.",
+      "privacyNotice": "Questa pagina segnala solo gli accessi e gli aggiornamenti dell'autenticazione. Non utilizza la cronologia di lettura, l'avanzamento del libro o l'attività della biblioteca.",
+      "privacyLabel": "Informazioni sulla privacy delle attività dell'account",
+      "never": "Mai",
+      "openInsightsFor": "Apri approfondimenti sulla lettura condivisa per {name}",
+      "permissionLabel": "Visualizza l'attività dell'utente",
+      "states": {
+        "recent": "Attivo di recente",
+        "dormant": "Dormiente",
+        "never": "Nessuna attività registrata",
+        "disabled": "Disabilitato"
+      },
+      "filters": {
+        "search": "Cerca account",
+        "searchPlaceholder": "Cerca nome o nome utente",
+        "state": "Stato attività",
+        "allStates": "Tutti gli stati di attività",
+        "provisioning": "Metodo di autenticazione",
+        "allMethods": "Tutti i metodi di autenticazione",
+        "sort": "Ordina i conti",
+        "mostRecent": "Attivo più di recente",
+        "leastRecent": "Attivo meno di recente",
+        "lastLogin": "Accesso più recente",
+        "newest": "Conti più recenti",
+        "oldest": "Conti più vecchi",
+        "name": "Nome",
+        "apply": "Applica",
+        "clear": "Cancella"
+      },
+      "methods": {
+        "local": "Locale",
+        "manual": "Creato dall'amministratore",
+        "oidc": "OIDC /SSO",
+        "shared": "Collegamento magico condiviso"
+      },
+      "columns": {
+        "user": "Utente",
+        "state": "Stato del conto",
+        "lastLogin": "Ultimo accesso",
+        "lastAuthenticated": "Ultimo autenticato",
+        "created": "Creato",
+        "readingInsights": "Approfondimenti di lettura"
+      },
+      "sharing": {
+        "private": "Non condiviso",
+        "summary": "Sintesi condivisa",
+        "detailed": "Condiviso dettagliato"
+      },
+      "empty": {
+        "title": "Nessun account trovato",
+        "description": "Prova a modificare o cancellare i filtri attuali."
+      },
+      "pagination": {
+        "label": "Pagine di attività dell'account",
+        "page": "Pagina {page} di {totalPages}"
+      },
+      "errors": {
+        "load": "Impossibile caricare l'attività dell'account."
+      }
+    },
+    "sharedInsights": {
+      "title": "Approfondimenti di lettura condivisi",
+      "subtitle": "Lettura delle informazioni che questo utente ha scelto volontariamente di condividere.",
+      "auditNotice": "L'accesso a questo profilo è registrato e visibile all'utente.",
+      "period": "Periodo di riferimento",
+      "periodDays": "Ultimi {count} giorni",
+      "durationMinutes": "{count, plural, one {# minuto} other {# minuti} many {# minuti}}",
+      "durationHours": "{count} ore",
+      "metrics": {
+        "sessions": "Sessioni",
+        "readingTime": "Tempo di lettura",
+        "activeDays": "Giornate attive",
+        "started": "I libri sono iniziati",
+        "completed": "Libri completati"
+      },
+      "trend": "Andamento della lettura giornaliera",
+      "emptyTitle": "Nessuna attività di lettura in questo periodo",
+      "noData": "Nessun dato di lettura registrato per questo periodo.",
+      "sourceNames": {
+        "web": "Lettore web",
+        "koreader": "KOReader",
+        "manual": "Manuale",
+        "kobo": "Kobo",
+        "unknown": "Sconosciuto"
+      },
+      "formats": "Formati",
+      "genres": "Generi",
+      "broadGenres": {
+        "science_fiction": "Fantascienza",
+        "fantasy": "Fantasia",
+        "mystery_thriller": "Mistero e thriller",
+        "romance": "Romanticismo",
+        "horror": "Orrore",
+        "history_biography": "Storia e biografia",
+        "science_technology": "Scienza e tecnologia",
+        "business_economics": "Affari ed economia",
+        "self_development": "Autosviluppo",
+        "society_culture": "Società e cultura",
+        "children_young_adult": "Bambini e giovani adulti",
+        "comics_graphic_novels": "Fumetti e graphic novel",
+        "poetry": "Poesia",
+        "other": "Altro"
+      },
+      "sources": "Origini dei dati",
+      "topBooks": "I libri più letti",
+      "recentBooks": "Letto di recente",
+      "unknownTitle": "Libro senza titolo",
+      "top": {
+        "authors": "I migliori autori",
+        "genres": "I migliori generi",
+        "series": "Serie superiore",
+        "narrators": "I migliori narratori"
+      },
+      "errors": {
+        "READING_INSIGHTS_PRIVATE": "Questo utente non sta condividendo approfondimenti sulla lettura.",
+        "READING_INSIGHTS_SUMMARY_ONLY": "Questo utente condivide solo informazioni di riepilogo.",
+        "READING_INSIGHTS_VIEW_SESSION_REQUIRED": "È necessaria una sessione di visualizzazione del profilo.",
+        "READING_INSIGHTS_VIEW_SESSION_INVALID": "Questa vista del profilo è scaduta o non è più valida.",
+        "LOAD_FAILED": "Impossibile caricare gli approfondimenti sulla lettura condivisa.",
+        "cleared": "Non viene visualizzata alcuna informazione sul profilo caricato in precedenza."
+      }
+    },
+    "resetLink": {
+      "title": "Collegamento per la reimpostazione della password",
+      "description": "Condividi questo collegamento con l'utente. Scade tra 15 minuti.",
+      "copy": "Copia",
+      "copied": "Copiato!",
+      "copyFailed": "Copia non riuscita",
+      "notShownAgain": "Questo collegamento non verrà più mostrato."
+    },
+    "userForm": {
+      "editUser": "Modifica utente",
+      "createUser": "Crea utente",
+      "createSharedAccount": "Crea un account condiviso",
+      "sharedBadge": "Condiviso",
+      "active": "Attivo",
+      "suspended": "Sospeso",
+      "tabs": {
+        "general": "generale",
+        "access": "accesso",
+        "restrictions": "restrizioni"
+      },
+      "sharedAccount": "Conto condiviso",
+      "sharedAccountHint": "Nessuna password. L'accesso è consentito solo tramite collegamenti magici.",
+      "sharedAccountManageHint": "Gestisci i collegamenti di accesso da Impostazioni - Collegamenti magici.",
+      "username": "Nome utente",
+      "fullName": "Nome completo",
+      "email": "E-mail",
+      "optional": "(facoltativo)",
+      "libraryAccess": "Accesso alla biblioteca",
+      "noLibrariesSelected": "Nessuna libreria selezionata. L'utente non può visualizzare alcun libro.",
+      "permissions": "Autorizzazioni",
+      "presetStandard": "Norma",
+      "presetAdmin": "Ammin",
+      "presetClearAll": "Cancella tutto",
+      "permissionGroups": {
+        "content": "Contenuto",
+        "devicesAccess": "Dispositivi e accesso",
+        "email": "E-mail",
+        "administration": "Amministrazione",
+        "notifications": "Notifiche",
+        "restrictions": "Restrizioni"
+      },
+      "superuserTarget": "Obiettivo superutente",
+      "superuserTargetHint": "Le restrizioni sui contenuti non possono essere applicate ai superutenti.",
+      "noRestrictions": "Nessuna restrizione sui contenuti",
+      "noRestrictionsHint": "Questo utente ha accesso completo a tutti i libri nelle biblioteche assegnate.",
+      "addRestrictions": "+ Aggiungi restrizioni sui contenuti",
+      "contentRestrictions": "Restrizioni sui contenuti",
+      "remove": "Rimuovi",
+      "includeTags": "Includi tag",
+      "includeTagsHint": "(mostra solo i libri con questi tag)",
+      "excludeTags": "Escludi tag",
+      "excludeTagsHint": "(nascondi i libri con questi tag)",
+      "includeGenres": "Includi i generi",
+      "includeGenresHint": "(mostra solo libri di questi generi)",
+      "excludeGenres": "Escludi i generi",
+      "excludeGenresHint": "(nascondi libri con questi generi)",
+      "searchTagsPlaceholder": "Cerca tag...",
+      "searchGenresPlaceholder": "Cerca generi...",
+      "saving": "Salvataggio...",
+      "errors": {
+        "updateUser": "Impossibile aggiornare l'utente",
+        "updatePermissions": "Impossibile aggiornare le autorizzazioni",
+        "updateLibraryAccess": "Impossibile aggiornare l'accesso alla libreria",
+        "updateContentFilters": "Impossibile aggiornare i filtri dei contenuti",
+        "emailRequired": "L'e-mail è obbligatoria",
+        "createSharedAccount": "Impossibile creare un account condiviso",
+        "createUser": "Impossibile creare l'utente"
+      }
+    },
+    "usersPage": {
+      "usersTitle": "Utenti",
+      "magicLinksTitle": "Collegamenti magici",
+      "usersSubtitle": "Gestire gli account utente e le assegnazioni delle autorizzazioni.",
+      "magicLinksSubtitle": "Crea collegamenti di accesso condivisibili per account condivisi.",
+      "createUser": "Crea utente",
+      "createLink": "Crea collegamento",
+      "usersTab": "Utenti",
+      "magicLinksTab": "Collegamenti magici",
+      "columns": {
+        "name": "Nome",
+        "username": "Nome utente",
+        "email": "E-mail",
+        "access": "Accesso",
+        "status": "Stato"
+      },
+      "adminBadge": "Ammin",
+      "permissionCount": "{count, plural, =0 {nessuna autorizzazione} one {un permesso} other {# autorizzazioni} many {# autorizzazioni}}",
+      "filteredBadge": "Filtrato",
+      "contentRestrictionsActive": "Restrizioni sui contenuti attive",
+      "statusActive": "Attivo",
+      "statusInactive": "Inattivo",
+      "resetPassword": "Reimposta la password",
+      "resetPasswordOidcHint": "Gli utenti OIDC reimpostano le password nel proprio provider di identità",
+      "resetPasswordSharedHint": "Gli account condivisi non hanno password",
+      "resetPasswordOidcHintFull": "Gli utenti OIDC reimpostano le password nel proprio provider di identità.",
+      "resetPasswordSharedHintFull": "Gli account condivisi non hanno password.",
+      "deleteUserAction": "Elimina utente",
+      "deleteDialogTitle": "Eliminare l'utente?",
+      "deleteDialogBody": "Elimina l'utente \"{username}\". Questa azione non può essere annullata.",
+      "deleting": "Eliminazione...",
+      "errors": {
+        "loadData": "Impossibile caricare i dati",
+        "load": "Impossibile caricare",
+        "deleteUser": "Impossibile eliminare l'utente"
+      },
+      "currentUsers": "Utenti attuali",
+      "defaultLibraryAccess": {
+        "title": "Accesso alla libreria predefinito",
+        "subtitle": "Accesso visualizzatore concesso agli utenti autoregistrati e con provisioning OIDC.",
+        "description": "Seleziona le biblioteche assegnate automaticamente ai nuovi utenti.",
+        "noLibraries": "Nessuna libreria disponibile.",
+        "save": "Salva le impostazioni predefinite",
+        "saving": "Salvataggio...",
+        "saved": "Accesso predefinito alla libreria salvato.",
+        "saveError": "Impossibile salvare l'accesso predefinito alla libreria"
+      }
+    }
+  },
+  "annotations": {
+    "unknownBook": "Libro sconosciuto",
+    "styles": {
+      "highlight": "Evidenziare",
+      "underline": "Sottolineare",
+      "strike": "Barrato",
+      "squiggle": "Ondulato",
+      "invert": "Inverti"
+    },
+    "combobox": {
+      "filterByBook": "Filtra per libro",
+      "allBooks": "Tutti i libri",
+      "clearBookFilter": "Cancella filtro libro",
+      "searching": "Ricerca...",
+      "noBooksFound": "Nessun libro trovato"
+    },
+    "bulk": {
+      "countSelected": "{count} selezionato",
+      "pageSelected": "Pagina selezionata",
+      "selectPage": "Seleziona pagina",
+      "clear": "Cancella",
+      "recolorTo": "Ricolora in {color}",
+      "restyleTo": "Cambia stile in {style}"
+    },
+    "chips": {
+      "active": "Attivo:",
+      "removeFilter": "Rimuovi filtro {label}",
+      "clearAll": "Cancella tutto"
+    },
+    "filters": {
+      "colors": "Colori",
+      "dateRange": "Intervallo di date",
+      "fromDate": "Dalla data",
+      "toDate": "Ad oggi",
+      "to": "a",
+      "clearDateRange": "Cancella intervallo di date",
+      "clearAll": "Cancella tutto"
+    },
+    "pagination": {
+      "showing": "Mostrando {start}-{end} di {total}",
+      "pageOf": "Pagina {page} di {totalPages}",
+      "firstPage": "Prima pagina",
+      "previousPage": "Pagina precedente",
+      "nextPage": "Pagina successiva",
+      "lastPage": "Ultima pagina"
+    },
+    "sync": {
+      "loading": "Caricamento dei dettagli di sincronizzazione",
+      "positions": "Posizioni",
+      "devices": "Dispositivi",
+      "retryConversion": "Riprovare la conversione",
+      "noStoredPositions": "Nessuna posizione memorizzata.",
+      "notSynced": "Non ancora sincronizzato con nessun dispositivo.",
+      "upToDate": "Aggiornato",
+      "pendingVersion": "In attesa di v{version}",
+      "syncedAt": "sincronizzato {date}",
+      "format": {
+        "webReader": "Lettore web",
+        "koreader": "KOReader",
+        "pdf": "PDF",
+        "kobo": "Kobo"
+      },
+      "status": {
+        "exact": "Esatto",
+        "repaired": "Riparato",
+        "failed": "Fallito",
+        "pending": "In sospeso"
+      }
+    },
+    "toolbar": {
+      "searchPlaceholder": "Cerca testo e note",
+      "filters": "Filtri",
+      "sortOrder": "Ordinamento",
+      "switchToCompact": "Passa alla visualizzazione compatta",
+      "switchToComfortable": "Passa alla visualizzazione comoda",
+      "compactView": "Vista compatta",
+      "comfortableView": "Vista confortevole"
+    },
+    "listItem": {
+      "pageNumber": "pag. {page}",
+      "chapterNumber": "capitolo {chapter}",
+      "selectAnnotation": "Seleziona annotazione",
+      "collapse": "Crollo",
+      "expand": "Espandi",
+      "hideSyncDetail": "Nascondi i dettagli della sincronizzazione",
+      "showSyncDetail": "Mostra i dettagli della sincronizzazione",
+      "exactPositionUnavailable": "Posizione esatta del lettore non disponibile",
+      "saving": "Risparmiare",
+      "bookDetails": "Dettagli del libro",
+      "openInReader": "Apri nel lettore",
+      "restore": "Ripristina",
+      "deleteForever": "Elimina per sempre",
+      "editNote": "Modifica nota",
+      "addNote": "Aggiungi nota",
+      "colorAndStyle": "Colore e stile",
+      "copied": "Copiato",
+      "copyText": "Copia testo",
+      "trash": "Cestino",
+      "moveToTrash": "Sposta nel cestino"
+    },
+    "hub": {
+      "title": "Annotazioni",
+      "totalCount": "{count} totale",
+      "bookCount": "{count, plural, =0 {niente libri} one {# libro} other {# libri} many {# libri}}",
+      "noteCount": "{count, plural, =0 {nessuna nota} one {# nota} other {# note} many {# note}}",
+      "export": "Esportazione",
+      "exportMarkdown": "Ribasso",
+      "exportCsv": "CSV",
+      "exportJson": "JSON",
+      "notesOnly": "Solo note",
+      "style": "Stile",
+      "source": "Fonte",
+      "bulkTrash": "Cestino",
+      "bulkRestore": "Ripristina",
+      "tabs": {
+        "highlights": "Punti salienti",
+        "trash": "Cestino"
+      },
+      "empty": {
+        "noMatch": "Nessun punto in evidenza corrisponde ai tuoi filtri.",
+        "resetFilters": "Reimposta i filtri",
+        "trashEmpty": "Il cestino è vuoto",
+        "noAnnotations": "Nessuna annotazione ancora. I momenti salienti che crei sul Web o sul tuo e-reader vengono visualizzati qui."
+      },
+      "toast": {
+        "movedToTrash": "Spostato nel cestino",
+        "annotationRestored": "Annotazione ripristinata",
+        "annotationDeletedForever": "Annotazione eliminata per sempre",
+        "failedToDelete": "Impossibile eliminare",
+        "bulkTrashed": "{count, plural, =0 {Nessuna annotazione spostata nel cestino} one {Spostato # annotazione nel cestino} other {Spostato # annotazioni nel cestino} many {Spostato # annotazioni nel cestino}}",
+        "bulkRestored": "{count, plural, =0 {Restaurato senza annotazioni} one {Restaurato # annotazione} other {Restaurato # annotazioni} many {Restaurato # annotazioni}}",
+        "bulkRecolored": "{count, plural, =0 {Ricolorata senza annotazioni} one {Ricolorato # annotazione} other {Ricolorato # annotazioni} many {Ricolorato # annotazioni}}",
+        "bulkRestyled": "{count, plural, =0 {Restyling senza annotazioni} one {Rinnovato # annotazione} other {Rinnovato # annotazioni} many {Rinnovato # annotazioni}}"
+      }
+    }
+  },
+  "audit": {
+    "pageTitle": "Registro di controllo",
+    "pageSubtitle": "Un record delle azioni significative per l'amministratore eseguite nel sistema.",
+    "filters": "Filtri",
+    "noActiveFilters": "Nessun filtro attivo",
+    "clear": "Cancella",
+    "empty": "Nessun registro di controllo trovato",
+    "showMore": "Mostra di più",
+    "showLess": "Mostra meno",
+    "details": "Dettagli",
+    "hideDetails": "Nascondi dettagli",
+    "refresh": "Aggiorna il registro di controllo",
+    "loadError": "Impossibile caricare gli eventi di controllo.",
+    "removeFilter": "Rimuovi filtro: {value}",
+    "allActions": "Tutte le azioni",
+    "allEventTypes": "Tutti i tipi di eventi",
+    "allActors": "Tutti gli attori",
+    "noActionsFound": "Nessuna azione corrispondente",
+    "noActorsFound": "Nessun attore corrispondente",
+    "noResourcesFound": "Nessun tipo di destinazione corrispondente",
+    "unknownAction": "Azione sconosciuta",
+    "unknownResource": "Altro tipo di obiettivo",
+    "allResources": "Tutte le risorse",
+    "allTargetTypes": "Tutti i tipi di target",
+    "quickDates": "Date veloci",
+    "today": "Oggi",
+    "sevenDays": "7 giorni",
+    "thirtyDays": "30 giorni",
+    "userId": "Utente n.{id}",
+    "userIdCompact": "#{id}",
+    "targetAdditional": "e {count, plural, one {# più bersaglio} other {# più obiettivi} many {# più obiettivi}}",
+    "bookImpact": "{count, plural, one {# libro} other {# libri} many {# libri}}",
+    "entryDetailsLabel": "Dettagli per l'evento di controllo n.{id}",
+    "detailEventId": "ID evento",
+    "detailOccurredAt": "Si è verificato",
+    "detailActor": "Attore",
+    "detailCategory": "Categoria",
+    "detailActionLabel": "Azione",
+    "detailEventTypeLabel": "Tipo di evento",
+    "detailIpLabel": "Indirizzo IP",
+    "detailResourceLabel": "Risorsa",
+    "detailResourceIdLabel": "ID risorsa",
+    "detailTargetTypeLabel": "Tipo di obiettivo",
+    "detailTargetIdLabel": "Identificazione dell'obiettivo",
+    "detailAction": "Azione: {value}",
+    "detailIp": "IP: {value}",
+    "detailResource": "Risorsa: {value}",
+    "detailResourceId": "ID risorsa: {value}",
+    "deletedBooks": "Libri eliminati",
+    "deletedBookDetail": "{title} (libro n.{id})",
+    "untitledBook": "Senza titolo",
+    "deletedBooksOmitted": "{count, plural, one {# libro aggiuntivo omesso} other {# libri aggiuntivi omessi} many {# libri aggiuntivi omessi}}",
+    "showing": "Mostrando {from}-{to} di {total}",
+    "prev": "Prec",
+    "chips": {
+      "search": "Cerca: {value}",
+      "action": "Azione: {value}",
+      "eventType": "Tipo di evento: {value}",
+      "actor": "Attore: {value}",
+      "resource": "Risorsa: {value}",
+      "targetType": "Tipo di bersaglio: {value}",
+      "user": "Utente: {value}",
+      "from": "Da: {value}",
+      "to": "A: {value}"
+    },
+    "filterLabels": {
+      "search": "Cerca eventi",
+      "action": "Azione",
+      "eventType": "Tipo di evento (cosa è successo)",
+      "actor": "Attore",
+      "resource": "Risorsa",
+      "targetType": "Tipo di target (cosa interessato)",
+      "userId": "ID utente",
+      "from": "Da",
+      "to": "A"
+    },
+    "filterPlaceholders": {
+      "search": "Descrizione, attore, destinazione o ID",
+      "actor": "Nome utente",
+      "action": "ad es. login.autor",
+      "userId": "ad es. 1"
+    },
+    "columns": {
+      "when": "Quando",
+      "actor": "Attore",
+      "event": "Evento",
+      "target": "Obiettivo",
+      "impact": "Impatto",
+      "user": "Utente",
+      "action": "Azione",
+      "description": "Descrizione",
+      "ip": "IP"
+    },
+    "categories": {
+      "authentication": "Autenticazione",
+      "books": "Libri",
+      "users": "Utenti",
+      "libraries": "Biblioteche",
+      "collections": "Collezioni",
+      "integrations": "Integrazioni",
+      "settings": "Impostazioni",
+      "other": "Altro"
+    },
+    "resourceLabels": {
+      "User": "Utente",
+      "Library": "Biblioteca",
+      "Book": "Libro",
+      "Collection": "Raccolta",
+      "SmartScope": "Ambito intelligente",
+      "BookDockFile": "File di Book Dock",
+      "Author": "Autore",
+      "AppSettings": "Impostazioni dell'applicazione",
+      "Genre": "Genere",
+      "Tag": "Etichetta",
+      "KoboDevice": "dispositivo Kobo",
+      "EmailProvider": "Fornitore di posta elettronica",
+      "EmailTemplate": "Modello di posta elettronica",
+      "EmailRecipient": "Destinatario dell'e-mail",
+      "EmailRecipientGroup": "Gruppo di destinatari di posta elettronica",
+      "Narrator": "Narratore",
+      "Publisher": "Editore",
+      "Language": "Lingua",
+      "Series": "Serie",
+      "OidcIdentity": "OIDC identità",
+      "MagicLinkToken": "Collegamento magico",
+      "ReadingInsightsProfile": "Profilo di approfondimento della lettura"
+    },
+    "actionLabels": {
+      "AuthRegister": "Registra l'account",
+      "AuthLogin": "Accedi",
+      "AuthLoginFailed": "Accesso non riuscito",
+      "AuthLogout": "Esci",
+      "AuthPasswordChange": "Cambia password",
+      "AuthPasswordResetRequest": "Richiedi la reimpostazione della password",
+      "AuthPasswordReset": "Reimposta la password",
+      "AuthPasswordAdminReset": "Reimposta la password dell'utente",
+      "AuthSessionRevoke": "Revoca sessione",
+      "MagicLinkCreate": "Crea un collegamento magico",
+      "MagicLinkLogin": "Accedi con il collegamento magico",
+      "MagicLinkRevoke": "Revoca il collegamento magico",
+      "MagicLinkActivate": "Attiva il collegamento magico",
+      "MagicLinkDeactivate": "Disattiva il collegamento magico",
+      "OidcLogin": "Accedi con OIDC",
+      "OidcUserProvisioned": "Fornisci l'utente OIDC",
+      "OidcIdentityLinked": "Collega l'identità OIDC",
+      "OidcIdentityUnlinked": "Scollega l'identità OIDC",
+      "UserCreate": "Crea utente",
+      "UserUpdate": "Aggiorna utente",
+      "UserSelfUpdate": "Aggiorna il tuo profilo",
+      "UserDelete": "Elimina utente",
+      "UserPermissionSet": "Aggiorna le autorizzazioni dell'utente",
+      "UserSuperuserEnable": "Abilita l'accesso come superutente",
+      "UserSuperuserDisable": "Disabilita l'accesso come superutente",
+      "UserContentFiltersSet": "Aggiorna i filtri dei contenuti",
+      "ReadingInsightsSharingUpdate": "Aggiorna la condivisione degli insight",
+      "ReadingInsightsProfileView": "Visualizza approfondimenti condivisi",
+      "LibraryCreate": "Crea libreria",
+      "LibraryUpdate": "Aggiorna libreria",
+      "LibraryDelete": "Elimina libreria",
+      "LibraryFolderAdd": "Aggiungi la cartella della libreria",
+      "LibraryFolderRemove": "Rimuovi la cartella della libreria",
+      "LibraryAccessGrant": "Concedere l'accesso alla biblioteca",
+      "LibraryAccessUpdate": "Aggiorna l'accesso alla libreria",
+      "LibraryAccessRevoke": "Revocare l'accesso alla biblioteca",
+      "LibraryWriteMetadataToFiles": "Scrivere metadati su file",
+      "LibraryBulkRename": "Rinominare i file della libreria",
+      "BookUpload": "Carica libro",
+      "BookMetadataUpdate": "Aggiorna i metadati del libro",
+      "BookMetadataLocksUpdate": "Aggiorna i blocchi dei metadati",
+      "BookDelete": "Elimina libro",
+      "BookBulkMetadataRefresh": "Aggiorna i metadati del libro",
+      "BookBulkDelete": "Elimina libri",
+      "BookBulkCoverReextract": "Riestrarre le copertine dei libri",
+      "BookBulkSetStatus": "Imposta lo stato del libro",
+      "BookBulkSetRating": "Imposta la valutazione del libro",
+      "BookBulkSetMetadata": "Imposta i metadati del libro",
+      "BookBulkUpdateTags": "Aggiorna i tag del libro",
+      "BookBulkSetMetadataLock": "Imposta i blocchi dei metadati",
+      "BookBulkEditMetadata": "Modifica i metadati del libro",
+      "BookReadingStateReset": "Ripristina lo stato di lettura",
+      "BookWriteAndRename": "Scrivi metadati e rinomina il file",
+      "CollectionCreate": "Crea raccolta",
+      "CollectionUpdate": "Aggiorna la raccolta",
+      "CollectionDelete": "Elimina raccolta",
+      "CollectionBooksAdd": "Aggiungi libri alla raccolta",
+      "CollectionBooksRemove": "Rimuovi libri dalla collezione",
+      "SmartScopeCreate": "Crea un ambito intelligente",
+      "SmartScopeUpdate": "Aggiorna l'ambito intelligente",
+      "SmartScopeDelete": "Elimina l'ambito intelligente",
+      "BookDockFinalize": "Finalizza il file di Book Dock",
+      "AuthorUpdate": "Aggiorna autore",
+      "AuthorDelete": "Elimina autore",
+      "AuthorMerge": "Unisci gli autori",
+      "AuthorEnrichmentConfigUpdate": "Aggiorna l'arricchimento dell'autore",
+      "AuthorEnrichmentPause": "Metti in pausa l'arricchimento dell'autore",
+      "AuthorEnrichmentResume": "Riprendi l'arricchimento dell'autore",
+      "AuthorEnrichmentCancel": "Annulla l'arricchimento dell'autore",
+      "EntityManagerMerge": "Unisci entità",
+      "EntityManagerRename": "Rinominare entità",
+      "EntityManagerDelete": "Elimina entità",
+      "EntityManagerSplit": "Entità divisa",
+      "EntityManagerDismiss": "Ignora duplicato",
+      "EntityManagerUndismiss": "Ripristina duplicato ignorato",
+      "AppSettingsUpdate": "Aggiorna le impostazioni dell'app",
+      "KoboDeviceRegister": "Registra il dispositivo Kobo",
+      "KoboDeviceRename": "Rinomina il dispositivo Kobo",
+      "KoboDeviceRemove": "Rimuovi il dispositivo Kobo",
+      "EmailProviderCreate": "Crea provider di posta elettronica",
+      "EmailProviderUpdate": "Aggiorna il provider di posta elettronica",
+      "EmailProviderDelete": "Elimina provider di posta elettronica",
+      "EmailProviderSetDefault": "Imposta il provider di posta elettronica predefinito",
+      "EmailProviderSetSystem": "Imposta il provider di posta elettronica del sistema",
+      "EmailProviderClearSystem": "Cancella provider di posta elettronica del sistema",
+      "EmailTemplateCreate": "Crea modello di posta elettronica",
+      "EmailTemplateUpdate": "Aggiorna il modello di posta elettronica",
+      "EmailTemplateDelete": "Elimina modello di posta elettronica",
+      "EmailTemplateSetDefault": "Imposta il modello di posta elettronica predefinito",
+      "EmailRecipientCreate": "Crea destinatario e-mail",
+      "EmailRecipientUpdate": "Aggiorna il destinatario dell'e-mail",
+      "EmailRecipientDelete": "Elimina il destinatario dell'e-mail",
+      "EmailRecipientGroupCreate": "Crea gruppo destinatari",
+      "EmailRecipientGroupUpdate": "Aggiorna il gruppo di destinatari",
+      "EmailRecipientGroupDelete": "Elimina il gruppo di destinatari",
+      "EmailRecipientGroupMemberAdd": "Aggiungi destinatario al gruppo",
+      "EmailRecipientGroupMemberRemove": "Rimuovi il destinatario dal gruppo"
+    }
+  },
+  "auth": {
+    "backToSignIn": "Torna per accedere",
+    "themePicker": {
+      "switchToLight": "Passa alla luce",
+      "switchToDark": "Passa allo scuro",
+      "changeRadius": "Modificare il raggio dell'angolo",
+      "changeBackground": "Cambia sfondo",
+      "changeAccent": "Cambia il colore dell'accento"
+    },
+    "fields": {
+      "username": "Nome utente",
+      "password": "Parola d'ordine",
+      "email": "E-mail",
+      "emailAddress": "Indirizzo e-mail",
+      "fullName": "Nome completo",
+      "newPassword": "Nuova password",
+      "confirmPassword": "Conferma la password",
+      "confirmNewPassword": "Conferma la nuova password",
+      "currentPassword": "Password attuale",
+      "passwordHint": "minimo 8 caratteri con maiuscolo, minuscolo e una cifra"
+    },
+    "errors": {
+      "generic": "Qualcosa è andato storto. Per favore riprova.",
+      "passwordsDoNotMatch": "Le password non corrispondono"
+    },
+    "login": {
+      "subtitle": "Accedi al tuo account",
+      "signIn": "Accedi",
+      "signingIn": "Accesso...",
+      "orDivider": "o",
+      "forgotPassword": "Password dimenticata?",
+      "errors": {
+        "invalidCredentials": "Nome utente o password non validi",
+        "tooManyAttempts": "Troppi tentativi di accesso. Attendi un minuto e riprova."
+      }
+    },
+    "oidc": {
+      "loginFailed": "Accesso OIDC non riuscito",
+      "redirecting": "Reindirizzamento...",
+      "signInWith": "Accedi con {provider}",
+      "completingSignIn": "Completamento dell'accesso in corso...",
+      "tryAgain": "Riprova",
+      "errors": {
+        "stateExpired": "La tua sessione di accesso è scaduta. Prova ad accedere di nuovo.",
+        "tokenExchangeFailed": "Impossibile completare l'accesso con il tuo provider. Riprova o contatta l'amministratore.",
+        "userNotProvisioned": "Il tuo account non è stato configurato. Contatta il tuo amministratore per l'accesso.",
+        "userInactive": "Il tuo account è stato disattivato. Contatta il tuo amministratore.",
+        "providerError": "Il tuo provider di identità ha restituito un errore. Per favore riprova.",
+        "missingCodeOrState": "Codice o parametro di stato mancante"
+      },
+      "providerErrors": {
+        "accessDenied": "L'accesso è stato negato dal provider di identità.",
+        "loginRequired": "È richiesta l'autenticazione. Per favore accedi di nuovo.",
+        "interactionRequired": "È necessaria un'ulteriore interazione da parte dell'utente."
+      }
+    },
+    "forgotPassword": {
+      "subtitle": "Reimposta la tua password",
+      "submitted": "Se esiste un account con quell'e-mail, è stato inviato un collegamento di reimpostazione. Controlla la tua casella di posta.",
+      "sending": "Invio...",
+      "sendResetLink": "Invia collegamento di reimpostazione",
+      "errors": {
+        "emailUnavailable": "La reimpostazione della password tramite e-mail non è disponibile. Contatta il tuo amministratore."
+      }
+    },
+    "resetPassword": {
+      "subtitle": "Imposta una nuova password",
+      "saving": "Salvataggio...",
+      "setNewPassword": "Imposta una nuova password",
+      "errors": {
+        "invalidLink": "Collegamento di reimpostazione non valido. Si prega di richiederne uno nuovo.",
+        "invalidOrExpired": "Collegamento di ripristino non valido o scaduto. Si prega di richiederne uno nuovo."
+      }
+    },
+    "setup": {
+      "title": "Configurazione iniziale",
+      "subtitle": "Crea il primo account amministratore.",
+      "setupToken": "Token di configurazione",
+      "setupTokenHint": "(richiesto in produzione)",
+      "creatingAccount": "Creazione dell'account...",
+      "createAccount": "Crea un account amministratore",
+      "errors": {
+        "failed": "Impossibile completare la configurazione"
+      }
+    },
+    "changePassword": {
+      "title": "Cambia password",
+      "saving": "Salvataggio…",
+      "forcedNotice": "È necessario impostare una nuova password prima di continuare.",
+      "errors": {
+        "failed": "Impossibile modificare la password"
+      }
+    },
+    "magicLink": {
+      "signingIn": "Ti sto facendo accedere...",
+      "loginFailed": "Accesso non riuscito",
+      "goToLogin": "Vai al login",
+      "errors": {
+        "noToken": "Nessun token fornito"
+      }
+    }
+  },
+  "author": {
+    "card": {
+      "portraitAlt": "{name} ritratto",
+      "viewDetails": "Visualizza i dettagli dell'autore",
+      "refreshMetadata": "Aggiorna metadati",
+      "deleteAuthor": "Elimina autore"
+    },
+    "listRow": {
+      "noRecentAdditions": "Nessuna aggiunta recente",
+      "portraitAlt": "{name} ritratto"
+    },
+    "filters": {
+      "title": "Filtri dell'autore",
+      "clearAll": "Cancella tutto",
+      "allLibraries": "Tutte le biblioteche",
+      "allAuthors": "Tutti gli autori",
+      "hasPhoto": "Ha una foto",
+      "missingPhoto": "Foto mancante",
+      "minBooks": "Libri minimi",
+      "anyPlaceholder": "Qualunque"
+    },
+    "header": {
+      "never": "Mai",
+      "portraitAlt": "{name} ritratto",
+      "actions": "Azioni",
+      "editAuthor": "Modifica autore",
+      "mergeAuthors": "Unisci autori",
+      "refreshing": "Rinfrescante...",
+      "refreshMetadata": "Aggiorna metadati",
+      "deleteAuthor": "Elimina autore",
+      "showLess": "Mostra meno",
+      "showMore": "Mostra di più",
+      "lookingUpMetadata": "Ricerca dei metadati dell'autore...",
+      "noBiography": "Nessuna biografia disponibile. Utilizza il menu per aggiornare i metadati.",
+      "previewFrom": "Anteprima da {provider}. Salva i metadati per renderli persistenti.",
+      "booksLabel": "Libri",
+      "lastAdded": "Ultimo aggiunto"
+    },
+    "list": {
+      "title": "Autori",
+      "showControlsAria": "Mostra i controlli dell'autore",
+      "searchPlaceholder": "Cerca autori",
+      "sortButton": "Ordina",
+      "sortBy": "Ordina per",
+      "ascending": "Ascendente",
+      "descending": "Discendente",
+      "asc": "Asc",
+      "desc": "Disc",
+      "filters": "Filtri",
+      "clear": "Cancella",
+      "allLoaded": "Tutti gli autori {total} caricati",
+      "sort": {
+        "name": "Nome",
+        "sortName": "Ordina nome",
+        "bookCount": "Conteggio dei libri",
+        "recentAdditions": "Aggiunte recenti",
+        "lastEnriched": "Ultimo arricchito"
+      },
+      "empty": {
+        "title": "Nessun autore trovato",
+        "hint": "Prova a modificare il testo di ricerca, l'ordinamento o il filtro della libreria."
+      },
+      "deleteDialog": {
+        "titleOne": "Eliminare l'autore?",
+        "titleMany": "Eliminare gli autori di {count}?",
+        "descriptionOne": "Ciò rimuove l'autore dal catalogo e lo scollega dai libri associati. Questa azione non può essere annullata.",
+        "descriptionMany": "Ciò rimuove gli autori selezionati dal catalogo e li scollega dai libri associati. Questa azione non può essere annullata."
+      },
+      "selection": {
+        "selectVisible": "Seleziona visibile",
+        "refreshMetadata": "Aggiorna i metadati",
+        "refreshingMetadata": "Aggiornamento dei metadati in corso...",
+        "deleteSelected": "Elimina selezionato",
+        "deleting": "Eliminazione...",
+        "exitSelection": "Esci dalla selezione",
+        "confirmDeleteCount": "{count, plural, =0 {Elimina # autore?} one {Elimina # autore?} other {Elimina # autori?} many {Elimina # autori?}}"
+      },
+      "toast": {
+        "refreshed": "Metadati dell'autore aggiornati",
+        "refreshedNoImage": "I metadati sono stati aggiornati, ma non è stata trovata alcuna immagine dell'autore.",
+        "refreshFailed": "Impossibile aggiornare i metadati dell'autore",
+        "bulkRefreshPartial": "Aggiornamento degli autori {updated}, {failed} non riuscito",
+        "bulkRefreshSuccess": "Metadati aggiornati per {updated} autori",
+        "bulkRefreshFailed": "Impossibile aggiornare gli autori selezionati",
+        "deleteSuccess": "{count, plural, =0 {Eliminati # autori; {books} libri interessati} one {Eliminato # autore; {books} libri interessati} other {Eliminati # autori; {books} libri interessati} many {Eliminati # autori; {books} libri interessati}}",
+        "deleteFailed": "Impossibile eliminare gli autori"
+      }
+    },
+    "detail": {
+      "pageTitle": "Autore",
+      "pageTitleNamed": "Autore · {name}",
+      "pageTitleId": "Autore n.{id}",
+      "entityName": "Autore",
+      "loadingAuthor": "Caricamento autore...",
+      "previewError": "Impossibile caricare i metadati dell'anteprima dell'autore esterno in questo momento.",
+      "edit": {
+        "name": "Nome",
+        "sortName": "Ordina nome",
+        "description": "Descrizione",
+        "image": "Immagine",
+        "uploading": "Caricamento...",
+        "replaceImage": "Sostituisci l'immagine",
+        "uploadImage": "Carica immagine",
+        "removing": "Rimozione...",
+        "removeImage": "Rimuovi l'immagine",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP fino a {size} MB",
+        "saving": "Salvataggio..."
+      },
+      "merge": {
+        "searchPlaceholder": "Cerca autori da unire a questo autore",
+        "searching": "Ricerca...",
+        "bookCount": "{count, plural, =0 {niente libri} one {# libro} other {# libri} many {# libri}}",
+        "selectedSummary": "Autori {count} selezionati, ca. {books} libri interessati.",
+        "merging": "Unione...",
+        "mergeSelected": "Unisci selezionati",
+        "confirmLabel": "Unisci"
+      },
+      "mergeDialog": {
+        "title": "Unire gli autori di {count} in \"{name}\"?",
+        "titleFallback": "Unire gli autori selezionati?",
+        "description": "Ciò unirà gli autori selezionati nell'autore corrente e ricollegherà i libri associati. Questa azione non può essere annullata.",
+        "descriptionEmpty": "Questa azione non può essere annullata."
+      },
+      "deleteDialog": {
+        "title": "Eliminare l'autore?",
+        "description": "Ciò rimuove l'autore dal catalogo e lo scollega dai libri associati. Questa azione non può essere annullata."
+      },
+      "books": {
+        "heading": "Libri",
+        "allLibraries": "Tutte le biblioteche",
+        "asc": "Asc",
+        "desc": "Disc",
+        "ascending": "Ascendente",
+        "descending": "Discendente",
+        "allLoaded": "Tutti i libri {total} caricati",
+        "sort": {
+          "recentlyAdded": "Aggiunto di recente",
+          "title": "Titolo",
+          "publishedYear": "Anno di pubblicazione"
+        },
+        "empty": {
+          "title": "Nessun libro trovato per questo autore",
+          "hint": "Prova a modificare l'ordinamento/ordine o a selezionare un'altra libreria."
+        }
+      },
+      "toast": {
+        "refreshed": "Metadati dell'autore aggiornati",
+        "refreshedNoImage": "I metadati sono stati aggiornati, ma non è stata trovata alcuna immagine dell'autore.",
+        "refreshFailed": "Impossibile aggiornare i metadati dell'autore",
+        "nameRequired": "Il nome dell'autore è obbligatorio",
+        "updated": "Autore aggiornato",
+        "updateFailed": "Impossibile aggiornare l'autore",
+        "imageUpdated": "Immagine dell'autore aggiornata",
+        "imageUploadFailed": "Impossibile caricare l'immagine dell'autore",
+        "imageRemoved": "Immagine dell'autore rimossa",
+        "imageRemoveFailed": "Impossibile rimuovere l'immagine dell'autore",
+        "mergeSuccess": "Autori {count} uniti; libri {books} interessati",
+        "mergeFailed": "Impossibile unire gli autori",
+        "deleteSuccess": "Autore cancellato; libri {books} interessati",
+        "deleteFailed": "Impossibile eliminare l'autore"
+      }
+    }
+  },
+  "book": {
+    "untitled": "Senza titolo",
+    "unknownFormat": "sconosciuto",
+    "collapsedSeries": {
+      "label": "Serie",
+      "bookCount": "{count, plural, =0 {niente libri} one {# libro} other {# libri} many {# libri}}",
+      "readCount": "{count} leggi"
+    },
+    "card": {
+      "missing": "Mancante"
+    },
+    "file": {
+      "primary": "Principale",
+      "audiobook": "Audiolibro"
+    },
+    "actions": {
+      "read": "Segna come letto",
+      "listen": "Ascolta",
+      "peek": "Sbircia",
+      "quickView": "Visualizzazione rapida",
+      "details": "Dettagli",
+      "bookDetails": "Dettagli del libro",
+      "download": "Scarica",
+      "metadata": "Metadati",
+      "editMetadata": "Modifica metadati",
+      "refreshMetadata": "Aggiorna metadati",
+      "regenerateCover": "Rigenera copertura",
+      "addToCollection": "Aggiungi alla raccolta",
+      "setStatus": "Imposta stato",
+      "sendViaEmail": "Invia tramite e-mail",
+      "rate": "Valuta {star}",
+      "openAs": "Apri come {format}"
+    },
+    "readStatus": {
+      "unread": "Non letto",
+      "wantToRead": "Vuoi leggere",
+      "reading": "Lettura",
+      "onHold": "In attesa",
+      "rereading": "Rilettura",
+      "read": "Letto",
+      "skimmed": "Scremato",
+      "abandoned": "Abbandonato"
+    },
+    "download": {
+      "action": "Scarica",
+      "audiobookZip": "Audiolibro (ZIP)",
+      "allFormatsZip": "Tutti i formati (ZIP)",
+      "primaryOnlyZip": "Solo principale (ZIP)"
+    },
+    "sort": {
+      "moveUp": "Vai su",
+      "moveDown": "Spostati giù",
+      "ascending": "Ascendente",
+      "descending": "Discendente",
+      "remove": "Rimuovi",
+      "emptyState": "Nessun ordinamento configurato. Verrà utilizzato il titolo crescente.",
+      "addLevel": "Aggiungi livello di ordinamento"
+    },
+    "filter": {
+      "match": "Corrispondenza",
+      "all": "TUTTI",
+      "any": "QUALSIASI",
+      "ofFollowingRules": "delle seguenti regole",
+      "anyProvider": "Qualsiasi fornitore",
+      "communityRatingProvider": "Fornitore di valutazioni della comunità",
+      "loadingLibraries": "Caricamento librerie...",
+      "noLibrariesAvailable": "Nessuna libreria disponibile",
+      "selectLibrary": "Seleziona libreria...",
+      "selectStatus": "Seleziona lo stato...",
+      "withinLastPlaceholder": "ad es. 7",
+      "unit": {
+        "days": "giorni",
+        "weeks": "settimane",
+        "months": "mesi"
+      },
+      "scorePreset": {
+        "outstanding": "Eccellente",
+        "good": "Buono",
+        "fair": "Discreto",
+        "poor": "Scarso"
+      },
+      "scoreRangePlaceholder": "0-100",
+      "valuePlaceholder": "valore",
+      "maxPlaceholder": "massimo",
+      "to": "a",
+      "group": "Gruppo",
+      "addRule": "Aggiungi regola",
+      "addGroup": "Aggiungi gruppo",
+      "typeToSearch": "Digita per cercare..."
+    },
+    "deleteDialog": {
+      "title": "Eliminare il libro?",
+      "description": "Ciò eliminerà definitivamente il libro e tutti i suoi metadati, file, progressi di lettura e segnalibri. Questa operazione non può essere annullata."
+    },
+    "bulkEdit": {
+      "title": "{count, plural, =0 {Modifica metadati - # libro} one {Modifica metadati - # libro} other {Modifica metadati - # libri} many {Modifica metadati - # libri}}",
+      "instructions": "Attiva/disattiva i campi da modificare, quindi configura i valori. Verranno modificati solo i campi attivati/disattivati.",
+      "invalidYear": "Inserisci un anno valido (solo numeri)",
+      "clearWarning": "Ciò rimuoverà tutti i {field} dai libri selezionati.",
+      "searchPlaceholder": "Cerca {field}...",
+      "enterPlaceholder": "Inserisci {field}",
+      "yearPlaceholder": "ad es. 2024",
+      "leaveEmptyHint": "Lascia vuoto per cancellare questo campo su tutti i libri selezionati.",
+      "applying": "Applicazione...",
+      "apply": "Applica",
+      "mode": {
+        "add": "Aggiungi",
+        "remove": "Rimuovi",
+        "replace": "Sostituisci",
+        "clear": "Cancella"
+      }
+    },
+    "export": {
+      "title": "Esporta metadati",
+      "scope": "Ambito",
+      "selectedRows": "Righe selezionate",
+      "currentlySelected": "{count} attualmente selezionato",
+      "allMatchingRows": "Tutte le righe corrispondenti",
+      "rowsInResult": "{count} righe nel risultato corrente",
+      "format": "Formato",
+      "csvDescription": "Facile da usare con fogli di calcolo, distinta base UTF-8 inclusa",
+      "jsonDescription": "Esportazione strutturata con contesto di metadati",
+      "columns": "Colonne",
+      "canonicalSchema": "Schema canonico stabile",
+      "visibleColumns": "Colonne attualmente visibili",
+      "options": "Opzioni",
+      "includePersonalData": "Includere dati di lettura personali",
+      "includeFilePaths": "Includi percorsi file (avanzato)",
+      "includeContextMeta": "Includi metadati di contesto",
+      "preflight": "Verifica preliminare",
+      "scopeLabel": "Ambito: {summary}",
+      "calculatingSize": "Calcolo delle dimensioni dell'esportazione in corso...",
+      "estimatedSize": "Dimensioni stimate:",
+      "fileLabel": "File: {fileName}",
+      "exportAction": "Esportazione",
+      "selectedRowsSummary": "{count, plural, =0 {# riga selezionata} one {# riga selezionata} other {# righe selezionate} many {# righe selezionate}}",
+      "matchingRowsSummary": "{count, plural, =0 {# riga corrispondente} one {# riga corrispondente} other {# righe corrispondenti} many {# righe corrispondenti}}",
+      "prepareFailed": "Impossibile preparare l'esportazione",
+      "exportStarted": "Iniziata l'esportazione dei metadati: {fileName}",
+      "exportFailed": "Esportazione dei metadati non riuscita"
+    },
+    "columnPanel": {
+      "columnsHeading": "Colonne",
+      "reset": "Ripristina",
+      "tableDensity": "Densità della tabella",
+      "density": {
+        "compact": "Compatto",
+        "comfortable": "Confortevole",
+        "roomy": "Spazioso"
+      },
+      "presets": "Preimpostazioni",
+      "exportBackup": "Esporta preimpostazioni e visualizzazioni salvate",
+      "importBackup": "Importa preimpostazioni e visualizzazioni salvate",
+      "rename": "Rinominare",
+      "renamePrompt": "Inserisci un nuovo nome",
+      "builtIn": "Costruito dentro",
+      "saveCurrentPreset": "Salva la preimpostazione corrente",
+      "savedViews": "Visualizzazioni salvate",
+      "savedViewsEmpty": "Salva l'ordinamento, il layout e i filtri specifici della vista per un rapido riutilizzo.",
+      "saveCurrentView": "Salva la vista corrente",
+      "pinnedLeft": "Appuntato a sinistra",
+      "pinnedRight": "Appuntato a destra",
+      "columns": {
+        "cover": "Copertina",
+        "read": "Letto",
+        "actions": "Azioni"
+      }
+    },
+    "shortcuts": {
+      "title": "Scorciatoie da tastiera",
+      "navigation": {
+        "title": "Navigazione",
+        "moveFocusVertical": "Sposta lo stato attivo su/giù",
+        "moveFocusHorizontal": "Sposta lo stato attivo a sinistra/destra",
+        "jumpFirstColumn": "Vai alla prima colonna",
+        "jumpLastColumn": "Vai all'ultima colonna",
+        "jumpFirstRow": "Vai alla prima riga",
+        "jumpLastRow": "Vai all'ultima riga"
+      },
+      "actions": {
+        "title": "Azioni",
+        "editCell": "Modifica la cella focalizzata",
+        "cancelEditing": "Annulla la modifica/Chiudi la sovrapposizione",
+        "toggleRowSelection": "Attiva/disattiva la selezione della riga",
+        "copyCell": "Copia il valore della cella",
+        "copyRow": "Copia la riga focalizzata"
+      },
+      "general": {
+        "title": "Generale",
+        "toggleHelp": "Attiva/disattiva questa sovrapposizione di aiuto"
+      }
+    },
+    "jumpRail": {
+      "jumpToSection": "Vai alla sezione",
+      "jumpTo": "Vai a {label}",
+      "unknownDate": "Data sconosciuta",
+      "unknownValue": "Valore sconosciuto"
+    },
+    "quickView": {
+      "title": "Prenota visualizzazione rapida",
+      "titleFor": "Visualizzazione rapida per {title}",
+      "description": "Visualizza l'anteprima dei dettagli del libro ed esegui azioni rapide.",
+      "openIn": "Apri tra {provider}",
+      "pages": "{count, plural, =0 {# pagina} one {# pagina} other {# pagine} many {# pagine}}",
+      "primaryFile": "File primario",
+      "fileNumber": "File n.{id}",
+      "showLess": "Mostra meno",
+      "showMore": "Mostra di più",
+      "collections": "Collezioni",
+      "noDescription": "Nessuna descrizione disponibile.",
+      "openMetadataEditor": "Apri l'editor dei metadati",
+      "coverPreview": "Anteprima della copertina del libro",
+      "coverPreviewFor": "Anteprima della copertina di {title}",
+      "coverPreviewDescription": "Finestra di dialogo di anteprima dell'immagine di copertina ingrandita."
+    },
+    "tableView": {
+      "openBookDetails": "Apri i dettagli del libro",
+      "openSeries": "Serie aperta",
+      "metadataRefreshFailed": "Aggiornamento dei metadati non riuscito",
+      "booksSelected": "{count, plural, =0 {# libro selezionato} one {# libro selezionato} other {# libri selezionati} many {# libri selezionati}}",
+      "loadingMoreBooks": "Caricamento di più libri",
+      "sort": "Ordina",
+      "refreshingMetadata": "Aggiornamento dei metadati {processed} / {total}",
+      "failedCount": "{count} non riuscito",
+      "remainingCount": "{count} rimanenti",
+      "readOnlyNotice": "La modifica della tabella è disabilitata sugli schermi più piccoli. Passa all'elenco o alla griglia per azioni più rapide.",
+      "fetching": "Recupero...",
+      "updated": "Aggiornato",
+      "failed": "Fallito",
+      "noBooks": "Nessun libro da visualizzare",
+      "scrollToTop": "Scorri verso l'alto",
+      "selectedStatus": "{count} selezionato",
+      "filtered": "Filtrato",
+      "loadedStatus": "{loaded} di {total} caricati",
+      "bookCount": "{count, plural, =0 {# libro} one {# libro} other {# libri} many {# libri}}",
+      "keyboardShortcutsTitle": "Scorciatoie da tastiera (?)",
+      "showKeyboardShortcuts": "Mostra le scorciatoie da tastiera della tabella",
+      "copyHint": "Copia cella: Ctrl/Cmd+C · Copia riga: Ctrl/Cmd+Maiusc+C"
+    },
+    "detail": {
+      "authorBooks": {
+        "alsoByAuthor": "Anche di questo autore",
+        "alsoByAuthors": "Anche da questi autori"
+      },
+      "header": {
+        "previousBook": "Libro precedente",
+        "nextBook": "Il prossimo libro"
+      },
+      "tabs": {
+        "details": "Dettagli",
+        "editMetadata": "Modifica metadati",
+        "files": "File",
+        "readingLog": "Registro di lettura",
+        "highlights": "Punti salienti"
+      },
+      "discover": {
+        "moreInSeries": "Altro in serie",
+        "byAuthor": "Per autore",
+        "similarBooks": "Libri simili"
+      },
+      "recommended": {
+        "moreLikeThis": "Altri simili"
+      },
+      "series": {
+        "moreInSeries": "Altro nella serie {series}"
+      },
+      "writeRename": {
+        "written": "{count, plural, =0 {nessun campo scritto} one {Scritto (un campo)} other {Scritto (# campi)} many {Scritto (# campi)}}",
+        "writeFailed": "Scrittura fallita",
+        "skipped": "Saltato",
+        "renamedTo": "Rinominato in {name}",
+        "fileRenamed": "File rinominato",
+        "renameFailed": "Rinomina non riuscita",
+        "autoWriteAndRenameDisabled": "La scrittura automatica e la ridenominazione sono disabilitate nelle impostazioni della libreria. Le modifiche non verranno sincronizzate automaticamente nei salvataggi futuri.",
+        "autoWriteDisabled": "La scrittura automatica è disabilitata nelle impostazioni della libreria. Le modifiche non verranno sincronizzate automaticamente nei salvataggi futuri.",
+        "autoRenameDisabled": "La ridenominazione automatica è disabilitata nelle impostazioni della libreria. Le modifiche non verranno sincronizzate automaticamente nei salvataggi futuri.",
+        "writeLabel": "Scrivi:",
+        "renameLabel": "Rinomina:"
+      },
+      "addFile": {
+        "uploading": "Caricamento...",
+        "uploadComplete": "Caricamento completato",
+        "title": "Aggiungi file",
+        "dropzone": {
+          "title": "Trascina i file qui o fai clic per sfogliare",
+          "hint": "epub, pdf, mobi, cbz, m4b e altro - fino a {size} MB ciascuno"
+        },
+        "addMore": "Aggiungi più file",
+        "fileCount": "{count, plural, =0 {nessun file} one {un file} other {# file} many {# file}}",
+        "clearAll": "Cancella tutto",
+        "done": "Fatto",
+        "retry": "Riprova",
+        "filesAdded": "{count, plural, =0 {nessun file aggiunto} one {un file aggiunto} other {# file aggiunti} many {# file aggiunti}}",
+        "uploadedFailed": "{done} caricato, {failed} non riuscito",
+        "uploadingProgress": "{done} di {total} caricamento...",
+        "renameAfter": "Rinomina tutti i file del libro dopo il caricamento",
+        "uploadCount": "Carica ({count})",
+        "upload": "Carica"
+      },
+      "addSession": {
+        "errors": {
+          "invalidDate": "Scegli una data e un'ora valide.",
+          "future": "La sessione non può iniziare in futuro.",
+          "duration": "La durata deve essere compresa tra 1 e 1440 minuti.",
+          "endProgress": "L'avanzamento finale deve essere compreso tra 0 e 100."
+        },
+        "title": "Aggiungi sessione di lettura",
+        "startedAt": "Iniziato alle",
+        "duration": "Durata (minuti)",
+        "endProgress": "Fine avanzamento %",
+        "optional": "Facoltativo",
+        "format": "Formato",
+        "noFormat": "Nessun formato specifico",
+        "saving": "Salvataggio...",
+        "submit": "Aggiungi sessione"
+      },
+      "coverEditor": {
+        "unlockCover": "Sbloccare il coperchio",
+        "lockCover": "Copri serratura",
+        "fileTab": "File",
+        "urlTab": "URL",
+        "chooseImage": "Scegli l'immagine...",
+        "findCoverOnline": "Trova la copertina online",
+        "saving": "Salvataggio...",
+        "saveCover": "Salva la copertina",
+        "revertToOriginal": "Ripristina originale",
+        "regenerateCover": "Rigenera copertura"
+      },
+      "coverSearch": {
+        "title": "Ricerca in linea",
+        "subtitle": "Cerca copertine di libri",
+        "titleField": "Titolo",
+        "authorField": "Autore",
+        "sourceField": "Fonte",
+        "allSources": "Tutte le fonti",
+        "audiobookCovers": "Copertine di audiolibri",
+        "squareHint": "(quadrato)",
+        "searching": "Ricerca...",
+        "findCovers": "Trova copertine",
+        "selectCover": "Seleziona Copertina",
+        "noResultsTitle": "Nessun risultato trovato",
+        "noResultsHint": "Prova a modificare i termini di ricerca",
+        "readyTitle": "Pronto per la ricerca",
+        "readyHint": "Inserisci un titolo e un autore sopra",
+        "resolutionTip": "Suggerimento: le copertine ad alta risoluzione sono contrassegnate in verde"
+      },
+      "details": {
+        "by": "di",
+        "narratedBy": "narrato da",
+        "ratingLocked": "La valutazione è bloccata",
+        "rateStar": "Valuta {star}",
+        "listen": "Ascolta",
+        "read": "Letto",
+        "chooseFormat": "Scegli il formato",
+        "audiobook": "Audiolibro",
+        "primary": "Principale",
+        "peek": "Sbircia",
+        "sendViaEmail": "Invia tramite e-mail",
+        "personalReview": {
+          "title": "Revisione personale",
+          "toggleAria": "Attiva/disattiva la revisione personale",
+          "editAria": "Modifica recensione personale",
+          "placeholder": "Recensione privata",
+          "clearAria": "Chiara recensione personale",
+          "cancelEditAria": "Annulla la modifica della recensione personale"
+        },
+        "editCover": "Modifica copertina",
+        "finished": "Finito",
+        "resetFileProgress": "Reimposta l'avanzamento del file",
+        "resetting": "Reimpostazione...",
+        "resetProgressConfirm": "Reimpostare l'avanzamento della lettura memorizzato per {label}?",
+        "moreCount": "+{count} altri",
+        "untitled": "Senza titolo",
+        "metadataScore": "Punteggio dei metadati",
+        "primaryFormat": "Formato primario",
+        "openIn": "Apri tra {provider}",
+        "showLess": "Mostra meno",
+        "showMore": "Mostra di più",
+        "publisher": "Editore",
+        "published": "Pubblicato",
+        "language": "Lingua",
+        "pages": "Pagine",
+        "duration": "Durata",
+        "edition": "Edizione",
+        "abridged": "Ridotto",
+        "unabridged": "Integrale",
+        "isbn": "ISBN",
+        "fileSize": "Dimensioni del file",
+        "library": "Biblioteca",
+        "added": "Aggiunto",
+        "dateStarted": "Data di inizio",
+        "saving": "Salvataggio...",
+        "cancelDateStartedEdit": "Annulla data di inizio modifica",
+        "editDateStarted": "Data di inizio modifica",
+        "dateFinished": "Data di fine",
+        "cancelDateFinishedEdit": "Annulla data di fine modifica",
+        "editDateFinished": "Data di modifica terminata",
+        "customMetadata": "Metadati personalizzati",
+        "synopsis": "Sinossi",
+        "noDescription": "Nessuna descrizione disponibile.",
+        "dateStartedFutureError": "La data di inizio non può essere futura.",
+        "dateFinishedFutureError": "La data di fine non può essere futura.",
+        "dateFinishedBeforeStartedError": "La data di fine deve essere uguale o successiva alla data di inizio.",
+        "saveReadingDatesError": "Impossibile salvare le date di lettura.",
+        "koboPendingDelete": "In attesa di eliminazione dal dispositivo",
+        "koboPendingDeleteTooltip": "Kobo lo rimuoverà alla prossima sincronizzazione.",
+        "koboRemovedByDevice": "Rimosso dal dispositivo",
+        "koboRemovedByDeviceTooltip": "Kobo ha segnalato la rimozione di questo libro.",
+        "koboNotSynced": "Non sincronizzato",
+        "koboNotSyncedTooltip": "In coda per la prossima sincronizzazione Kobo.",
+        "filesNotFound": "File non trovati",
+        "filesNotFoundDescription": "I file per questo libro non possono più essere trovati sul disco. I metadati sono ancora disponibili. Esegui una scansione della libreria per confermare o rimuovere il record."
+      },
+      "editMetadata": {
+        "fieldCount": "{count, plural, =0 {nessun campo} one {un campo} other {# campi} many {# campi}}",
+        "bookFilesTarget": "file di libri",
+        "formatFilesTarget": "{formats} file",
+        "noPrimaryFile": "Nessun file principale disponibile",
+        "formatNotSupported": "Questo formato di file non supporta il writeback",
+        "formatDisabled": "Il writeback è disabilitato per questo formato",
+        "fileExceedsSizeLimit": "Questo file supera il limite di dimensione del writeback",
+        "writing": "Scrivere...",
+        "saveInProgress": "Salvataggio in corso",
+        "writeManualLibraryDisabled": "Scrivi i metadati su file e rinominali su disco; il writeback automatico è disabilitato per questa libreria",
+        "writeManualTooltip": "Scrivi {fields} in {target} e rinomina su disco",
+        "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "{count, plural, =0 {Nessun campo bloccato saltato} one {Saltato un campo bloccato} other {Saltato # campi bloccati} many {Saltato # campi bloccati}}",
+        "updatedFields": "{count, plural, =0 {aggiornato nessun campo} one {aggiornato un campo} other {aggiornato # campi} many {aggiornato # campi}}",
+        "wroteFieldsToFile": "Ha scritto {fields} nel file",
+        "fileWriteFailedReason": "Scrittura del file non riuscita: {reason}",
+        "fileWriteFailed": "Scrittura del file non riuscita",
+        "fileWriteSkippedReason": "Scrittura file saltata: {reason}",
+        "fileWriteSkipped": "Scrittura del file saltata",
+        "metadataSaved": "Metadati salvati",
+        "metadataWrittenToFile": "Metadati scritti su file",
+        "savedButWriteFailedReason": "Metadati salvati, ma scrittura del file non riuscita: {reason}",
+        "savedButWriteFailed": "Metadati salvati, ma la scrittura del file non è riuscita",
+        "savedWriteSkippedReason": "Metadati salvati, scrittura file saltata: {reason}",
+        "savedWriteSkipped": "Metadati salvati, scrittura del file saltata",
+        "loadFromFileFailed": "Impossibile caricare i metadati dal file",
+        "loadedFieldsFromFile": "{count, plural, =0 {Nessun campo caricato dal file} one {Caricato un campo dal file} other {Caricato # campi dal file} many {Caricato # campi dal file}}",
+        "noMetadataInFile": "Nessun metadato trovato nel file",
+        "loadFromFile": "Carica da file",
+        "loadFromFileTooltip": "Carica i metadati dal file del libro principale",
+        "writeToFile": "Scrivi su file",
+        "autoFill": "Compilazione automatica",
+        "fetchingMetadata": "Recupero dei metadati in corso...",
+        "allFieldsLocked": "Tutti i campi sono bloccati",
+        "autoFillTooltip": "Compila automaticamente i campi utilizzando le tue preferenze sui metadati",
+        "lockAll": "Blocca tutto",
+        "lockAllTooltip": "Blocca tutti i campi",
+        "unlockAll": "Sblocca tutto",
+        "unlockAllTooltip": "Sblocca tutti i campi",
+        "saving": "Salvataggio...",
+        "fileWriteBackDetails": "Dettagli della riscrittura del file",
+        "fileWriteBack": "Riscrittura del file",
+        "enabled": "Abilitato",
+        "saveWritesMetadata": "\"Salva\" scrive i metadati in {target}",
+        "formats": "Formati",
+        "bookFiles": "File di libri",
+        "supportedFields": "Campi supportati",
+        "titleLabel": "Titolo",
+        "subtitleLabel": "Sottotitolo",
+        "authorsLabel": "Autori",
+        "narratorsLabel": "Narratori",
+        "genresLabel": "Generi",
+        "tagsLabel": "Tag",
+        "ratingLabel": "Valutazione",
+        "rateStar": "Valuta {star}",
+        "clear": "Cancella",
+        "communityRatingsLabel": "Valutazioni della comunità",
+        "noProviderRatings": "Nessuna valutazione del fornitore",
+        "seriesLabel": "Serie",
+        "publisherLabel": "Editore",
+        "languageLabel": "Lingua",
+        "yearLabel": "Anno",
+        "pageCountLabel": "Conteggio pagine",
+        "isbn13Label": "ISBN-13",
+        "isbn10Label": "ISBN-10",
+        "durationLabel": "Durata/i",
+        "abridgedLabel": "Ridotto",
+        "providerIds": "ID fornitore",
+        "comicDetails": "Dettagli comici",
+        "comicIssueNumberLabel": "Numero di emissione",
+        "comicVolumeLabel": "Volume",
+        "comicStoryArcsLabel": "Archi narrativi",
+        "comicPencillersLabel": "Disegnatori",
+        "comicInkersLabel": "Inchiostratori",
+        "comicColoristsLabel": "Coloristi",
+        "comicLetterersLabel": "Letteristi",
+        "comicCoverArtistsLabel": "Artisti di copertina",
+        "comicCharactersLabel": "Personaggi",
+        "comicTeamsLabel": "Squadre",
+        "comicLocationsLabel": "Posizioni",
+        "customMetadata": "Metadati personalizzati",
+        "descriptionLabel": "Descrizione",
+        "unlockField": "Sblocca {field}",
+        "lockField": "Blocca {field}",
+        "diffPanel": {
+          "untitled": "Senza titolo",
+          "noFieldsSelected": "Nessun campo selezionato",
+          "fieldsSelected": "{count, plural, =0 {nessun campo selezionato} one {un campo selezionato} other {# campi selezionati} many {# campi selezionati}}",
+          "results": "Risultati",
+          "providerMatches": "{provider} corrispondenze",
+          "selectedOf": "Selezionato {selected} di {total}",
+          "yearUnknown": "Anno sconosciuto",
+          "indexOf": "{index} di {total}",
+          "switchedResult": "Risultato scambiato. Le selezioni precedenti di questo fornitore sono state cancellate.",
+          "selectFieldsToApply": "Seleziona i campi da applicare",
+          "copyMissing": "Copia mancante",
+          "copyAll": "Copia tutto",
+          "hideUnchanged": "Nascondi invariato",
+          "showUnchanged": "Mostra invariato",
+          "current": "Attuale",
+          "noMetadata": "Nessun metadato disponibile da questa fonte.",
+          "noChangedFields": "Nessun campo modificato o mancante. Usa Mostra invariato per ispezionare tutto.",
+          "applyToForm": "Applicare al modulo"
+        },
+        "diff": {
+          "locked": "Bloccato",
+          "previewAlt": "Anteprima",
+          "currentCoverAlt": "Copertura attuale",
+          "newCoverAlt": "Nuova copertina",
+          "pickCoverFromProvider": "Scegli la copertura da un altro fornitore",
+          "pickCoverSource": "Scegli la fonte di copertura",
+          "pickFromProvider": "Scegli da un altro fornitore",
+          "pickSource": "Scegli la fonte",
+          "empty": "vuoto",
+          "showLess": "Mostra meno",
+          "showMore": "Mostra di più",
+          "coverPreviewAlt": "Anteprima della copertina"
+        },
+        "searchDrawer": {
+          "searchTitle": "Cerca metadati",
+          "compareTitle": "Confronta i metadati",
+          "searchSubtitle": "Trova il fornitore migliore per questo libro.",
+          "compareSubtitle": "Rivedi le differenze e applica solo ciò che desideri."
+        },
+        "searchPanel": {
+          "untitledQuery": "Domanda senza titolo",
+          "titlePlaceholder": "Titolo",
+          "authorPlaceholder": "Autore",
+          "isbnPlaceholder": "ISBN",
+          "searching": "Ricerca...",
+          "activeQuery": "Interrogazione attiva",
+          "searchScope": "Ambito di ricerca",
+          "allEnabled": "Tutto abilitato",
+          "all": "Tutto",
+          "fieldRules": "Regole sul campo",
+          "custom": "Personalizzato",
+          "providerNotInFieldRules": "{provider} è abilitato ma non nelle regole di campo",
+          "notInFieldRulesLabel": "Non nelle regole sul campo:",
+          "notInFieldRulesText": "{providers}. Incluso nella ricerca manuale con Tutti abilitati, ma non utilizzato dal recupero automatico dei metadati.",
+          "noResults": "Nessun risultato trovato",
+          "noResultsHint": "Prova a modificare il titolo o l'autore",
+          "searchPrompt": "Cerca sopra, quindi fai clic su un risultato per iniziare a confrontare i metadati."
+        },
+        "writeAndRename": "Scrivi su file e rinomina",
+        "writeAndRenameShort": "Scrivi e rinomina"
+      },
+      "files": {
+        "title": "File di libri",
+        "fileCount": "{count, plural, =0 {nessun file} one {# file} other {# file} many {# file}}",
+        "synced": "Sincronizzato {time}",
+        "sortAria": "Ordina i file",
+        "syncHistory": "Sincronizza la cronologia",
+        "metadataWriteBack": "Write-back dei metadati",
+        "relative": {
+          "seconds": "{value}s fa",
+          "minutes": "{value}m fa",
+          "hours": "{value}h fa",
+          "days": "{value}d fa"
+        },
+        "renameFailed": "Impossibile rinominare il file",
+        "deleteFailed": "Impossibile eliminare il file",
+        "addFile": "Aggiungi file",
+        "lastSynced": "Ultima sincronizzazione: {time}",
+        "sort": {
+          "label": "Ordina:",
+          "name": "Nome",
+          "format": "Formato",
+          "size": "Dimensioni",
+          "date": "Data"
+        },
+        "hidePaths": "Nascondi percorsi",
+        "showPaths": "Mostra percorsi",
+        "hideLog": "Nascondi registro",
+        "viewSyncLog": "Visualizza il registro di sincronizzazione",
+        "noWriteHistory": "Nessuna cronologia scritta ancora.",
+        "fieldsWritten": "{count, plural, =0 {nessun campo} one {un campo} other {# campi} many {# campi}}",
+        "track": "Traccia {number}",
+        "primary": "Principale",
+        "read": "Letto",
+        "play": "Gioca",
+        "peek": "Sbircia",
+        "download": "Scarica",
+        "moreActions": "Più azioni",
+        "rename": "Rinominare",
+        "empty": {
+          "title": "Nessun file allegato",
+          "description": "Questo libro non ha file associati."
+        },
+        "renameModal": {
+          "title": "Rinomina file",
+          "description": "Rinominare il file fisico sul disco.",
+          "placeholder": "Nuovo nome file"
+        },
+        "saving": "Salvataggio...",
+        "deleteModal": {
+          "title": "Eliminare il file?",
+          "description": "Sei sicuro di voler eliminare \"{filename}\"? Questa azione non può essere annullata."
+        },
+        "deleting": "Eliminazione..."
+      },
+      "highlights": {
+        "note": {
+          "placeholder": "Aggiungi una nota...",
+          "saving": "Risparmiare"
+        },
+        "export": {
+          "trigger": "Esportazione",
+          "plainText": "Testo semplice",
+          "page": "Pagina di esportazione",
+          "selected": "Esporta selezionato"
+        },
+        "sort": {
+          "position": "Posizione",
+          "newest": "Prima il più recente",
+          "oldest": "Prima il più vecchio"
+        },
+        "summary": {
+          "highlights": "{count, plural, =0 {nessun punto saliente} one {un punto culminante} other {# evidenzia} many {# evidenzia}}",
+          "notes": "{count, plural, =0 {nessuna nota} one {una nota} other {# note} many {# note}}",
+          "chapters": "{count, plural, =0 {nessun capitolo} one {un capitolo} other {# capitoli} many {# capitoli}}"
+        },
+        "filterByChapter": "Filtra per capitolo",
+        "allChapters": "Tutti i capitoli",
+        "untitled": "Senza titolo",
+        "trash": "Cestino",
+        "empty": {
+          "noMatch": "Nessun punto in evidenza corrisponde ai tuoi filtri.",
+          "resetFilters": "Reimposta i filtri",
+          "none": "Nessun momento saliente per ora",
+          "hint": "Seleziona il testo durante la lettura per creare evidenziazioni"
+        },
+        "uncategorized": "Senza categoria",
+        "paginationUnit": "evidenzia"
+      },
+      "readingLog": {
+        "moreActionsAria": "Altre azioni del registro di lettura",
+        "export": {
+          "button": "Esportazione"
+        },
+        "weekdays": {
+          "sun": "Sole",
+          "mon": "Lun",
+          "tue": "Mar",
+          "wed": "Mercoledì",
+          "thu": "Gio",
+          "fri": "Ven",
+          "sat": "Sab"
+        },
+        "months": {
+          "jan": "Gen",
+          "feb": "Febbraio",
+          "mar": "Mar",
+          "apr": "aprile",
+          "may": "Maggio",
+          "jun": "giugno",
+          "jul": "Lug",
+          "aug": "Agosto",
+          "sep": "Settembre",
+          "oct": "ottobre",
+          "nov": "novembre",
+          "dec": "dicembre"
+        },
+        "heatmap": {
+          "minutesUnit": "min",
+          "title": "Attività",
+          "empty": "Nessuna attività di lettura in questa finestra.",
+          "emptyHint": "Le sessioni registrate qui costruiranno la tua visualizzazione della coerenza."
+        },
+        "hero": {
+          "summaryAria": "Riassunto della lettura",
+          "notSet": "Non impostato",
+          "relative": {
+            "seconds": "{count}s fa",
+            "minutes": "{count}m fa",
+            "hours": "{count}h fa",
+            "days": "{count}d fa",
+            "months": "{count, plural, =0 {# mese fa} one {# mese fa} other {# mesi fa} many {# mesi fa}}",
+            "years": "{count, plural, =0 {# anno fa} one {# anno fa} other {# anni fa} many {# anni fa}}"
+          },
+          "noSessions": "Nessuna sessione",
+          "dateErrors": {
+            "startFuture": "La data di inizio non può essere futura.",
+            "finishFuture": "La data di fine non può essere futura.",
+            "finishBeforeStart": "La data di fine deve essere uguale o successiva alla data di inizio.",
+            "saveFailed": "Impossibile salvare le date di lettura."
+          },
+          "eta": {
+            "max": "99 ore+ per finire",
+            "minutes": "~{m}m per finire",
+            "hours": "~{h}h per finire",
+            "hoursMinutes": "~{h}h {m}m per finire"
+          },
+          "momentum": {
+            "none": "Nessuna attività nelle ultime due settimane",
+            "new": "Nuova attività questa settimana",
+            "up": "+{pct}% rispetto ai 7 giorni precedenti",
+            "down": "{pct}% rispetto ai 7 giorni precedenti",
+            "flat": "Invariato rispetto ai 7 giorni precedenti"
+          },
+          "stats": {
+            "totalTime": "Tempo totale",
+            "sessions": "Sessioni",
+            "avgSession": "Sessione media",
+            "lastRead": "Ultima lettura"
+          },
+          "firstRead": "Prima lettura",
+          "lastRead": "Ultima lettura",
+          "dateStarted": "Data di inizio",
+          "dateFinished": "Data di fine",
+          "addSession": "Aggiungi sessione"
+        },
+        "journey": {
+          "tooltipProgress": "Progresso",
+          "tooltipReading": "Lettura",
+          "minutesUnit": "min",
+          "title": "Viaggio di progresso",
+          "empty": "Nessun dato di avanzamento in questa finestra.",
+          "emptyHint": "I progressi verranno visualizzati dopo che una sessione ha registrato una posizione di lettura."
+        },
+        "sourceSplit": {
+          "title": "Lettura delle fonti",
+          "shortTitle": "Fonti"
+        },
+        "untitled": "Senza titolo",
+        "addSessionFailed": "Impossibile aggiungere la sessione",
+        "filters": {
+          "show": "Mostra",
+          "dateRangeAria": "Intervallo di date della sessione di lettura",
+          "allTime": "Tutto il tempo",
+          "last30": "Ultimi 30 giorni",
+          "last90": "Ultimi 90 giorni",
+          "thisYear": "Quest'anno",
+          "allFormats": "Tutti i formati"
+        },
+        "table": {
+          "title": "Sessioni",
+          "sourceWeb": "Rete",
+          "sourceManual": "Manuale",
+          "colDate": "Data",
+          "colDateMobile": "Data",
+          "colDuration": "Durata",
+          "colDurationMobile": "Durata",
+          "colProgressChange": "Cambiamento di progresso",
+          "colProgressChangeMobile": "Delta",
+          "colEndProgress": "Fine del progresso",
+          "colEndProgressMobile": "Fine",
+          "empty": "Nessuna sessione di lettura ancora registrata.",
+          "emptyHint": "Aggiungi una sessione per iniziare a costruire la cronologia di lettura di questo libro.",
+          "colPace": "Ritmo",
+          "colSource": "Fonte",
+          "colFormatMobile": "Fmt",
+          "colFormat": "Formato",
+          "cancelDelete": "Annulla l'eliminazione",
+          "cancelDeleteAria": "Annulla la sessione di eliminazione",
+          "confirmDeleteTitle": "Fare di nuovo clic per confermare l'eliminazione",
+          "confirmDeleteAria": "Conferma l'eliminazione della sessione",
+          "deleteAria": "Elimina sessione",
+          "loadMore": "Carica di più",
+          "showing": "Visualizzazione di {shown} di {total} sessioni"
+        }
+      },
+      "richDescription": {
+        "linkProtocolError": "Utilizza http, https o mailto.",
+        "bold": "Grassetto",
+        "italic": "Corsivo",
+        "underline": "Sottolineare",
+        "strikethrough": "Barrato",
+        "bulletList": "Elenco puntato",
+        "numberedList": "Elenco numerato",
+        "outdentAria": "Riduci il rientro dell'elemento dell'elenco",
+        "outdent": "Riduci rientro",
+        "indentAria": "Elemento dell'elenco con rientro",
+        "indent": "Rientro",
+        "quote": "Citazione",
+        "editLink": "Modifica collegamento",
+        "link": "Collegamento",
+        "removeLink": "Rimuovi collegamento",
+        "undo": "Annulla",
+        "redo": "Rifare",
+        "clearFormatting": "Cancella formattazione",
+        "previewDescription": "Descrizione in anteprima",
+        "preview": "Anteprima",
+        "linkUrlLabel": "URL del collegamento",
+        "applyLink": "Applicare il collegamento",
+        "apply": "Applica",
+        "cancelLink": "Annulla collegamento",
+        "noDescription": "Nessuna descrizione disponibile."
+      },
+      "seriesMembership": {
+        "addSeries": "Aggiungi serie",
+        "seriesPlaceholder": "Serie",
+        "moveUp": "Vai su",
+        "moveDown": "Spostati giù",
+        "removeSeries": "Rimuovi serie"
+      }
+    },
+    "table": {
+      "actions": {
+        "quickView": "Visualizzazione rapida",
+        "bookDetails": "Dettagli del libro",
+        "editMetadata": "Modifica metadati",
+        "refreshMetadata": "Aggiorna metadati",
+        "addToCollection": "Aggiungi alla raccolta",
+        "sendToDevice": "Invia al dispositivo"
+      },
+      "boolean": {
+        "ariaNotSet": "Non impostato: fare clic per impostare su vero",
+        "ariaTrue": "Vero: fare clic per impostare falso",
+        "ariaFalse": "Falso: fare clic per cancellare"
+      },
+      "chips": {
+        "addPlaceholder": "Aggiungi..."
+      },
+      "cover": {
+        "previewDescription": "Anteprima della copertina del libro",
+        "editDescription": "Modifica la copertina del libro",
+        "editTitle": "Modifica copertina",
+        "editCover": "Modifica copertina",
+        "view": "Visualizza la copertina"
+      },
+      "date": {
+        "justNow": "proprio adesso"
+      },
+      "format": {
+        "unknown": "sconosciuto"
+      },
+      "header": {
+        "sortAscending": "Ordinamento crescente",
+        "sortDescending": "Ordinamento discendente",
+        "clearSort": "Cancella ordinamento",
+        "hideColumn": "Nascondi colonna",
+        "pinLeft": "Perno a sinistra",
+        "pinRight": "Pin a destra",
+        "unpinColumn": "Sblocca colonna",
+        "autoFitWidth": "Adatta automaticamente la larghezza",
+        "autoFitAllColumns": "Adatta automaticamente tutte le colonne",
+        "selectAllBooks": "Seleziona tutti i libri",
+        "shiftClickSecondarySort": "Maiusc+clic per aggiungere l'ordinamento secondario",
+        "clickToSort": "Fare clic per ordinare"
+      },
+      "locks": {
+        "lockAll": "Blocca tutti i campi",
+        "unlockAll": "Sblocca tutti i campi",
+        "lockField": "Blocca campo",
+        "unlockField": "Sblocca campo",
+        "clickToLock": "Fare clic per bloccare",
+        "clickToUnlock": "Fare clic per sbloccare"
+      },
+      "progress": {
+        "complete": "{percent} completato"
+      },
+      "rating": {
+        "label": "Valutazione",
+        "remove": "Rimuovi valutazione",
+        "rate": "Valuta {star} su 5"
+      },
+      "read": {
+        "play": "Gioca",
+        "read": "Letto",
+        "primary": "Principale",
+        "peekFormat": "Sbircia {format}",
+        "chooseFormat": "Scegli il formato per leggere o riprodurre",
+        "fileFallback": "FILE"
+      },
+      "readStatus": {
+        "unread": "Non letto"
+      },
+      "series": {
+        "bookCount": "{count, plural, =0 {(niente libri)} one {(# libro)} other {(# libri)} many {(# libri)}}",
+        "readOfCount": "{read} di {total} letto"
+      },
+      "text": {
+        "openDetails": "Apri i dettagli"
+      }
+    }
+  },
+  "bookMetadataFetch": {
+    "book": {
+      "title": "Recupero metadati"
+    },
+    "author": {
+      "title": "Arricchimento dell'autore"
+    },
+    "stats": {
+      "queued": "In coda",
+      "processing": "Elaborazione",
+      "rateLimited": "Tariffa limitata",
+      "failed": "Fallito"
+    },
+    "actions": {
+      "pause": "Pausa",
+      "resume": "Riprendi",
+      "cancelQueued": "Annulla in coda",
+      "dismissBookStatus": "Ignora lo stato di recupero dei metadati",
+      "dismissAuthorStatus": "Ignora lo stato di arricchimento dell'autore"
+    },
+    "cancel": {
+      "processingWillFinish": "Gli elementi attualmente in elaborazione termineranno.",
+      "confirm": "Conferma annullamento",
+      "keepRunning": "Continua a correre"
+    },
+    "viewFailed": "{count, plural, one {Visualizzane uno fallito} other {Visualizza # fallito} many {Visualizza # fallito}}",
+    "card": {
+      "fetchingMetadata": "Recupero dei metadati",
+      "enrichingAuthors": "Arricchire gli autori",
+      "metadataFetchFinished": "Recupero dei metadati terminato",
+      "authorEnrichmentFinished": "Arricchimento dell'autore terminato"
+    },
+    "label": {
+      "paused": "In pausa",
+      "remaining": "{count} rimanenti",
+      "processing": "{count} elaborazione",
+      "failed": "{count} non riuscito",
+      "rateLimited": "{count} tariffa limitata"
+    },
+    "report": {
+      "bookTitle": "Recupero metadati non riuscito",
+      "authorTitle": "Arricchimenti dell'autore non riusciti",
+      "noFailedItems": "Nessun elemento non riuscito.",
+      "retryAllFailed": "Riprova tutto fallito",
+      "bookFallback": "Libro n.{id}",
+      "authorFallback": "Autore n.{id}",
+      "columns": {
+        "title": "Titolo",
+        "library": "Biblioteca",
+        "author": "Autore",
+        "error": "Errore",
+        "http": "HTTP"
+      }
+    },
+    "toast": {
+      "failedToPause": "Impossibile mettere in pausa",
+      "failedToResume": "Impossibile riprendere",
+      "failedToCancel": "Impossibile annullare",
+      "failedToRetry": "Impossibile riprovare",
+      "failedItemsRequeued": "Elementi non riusciti rimessi in coda",
+      "bookComplete": "Recupero metadati completato - libri {done} aggiornati",
+      "bookDoneWithFailures": "Recupero metadati completato: {done} elaborato, {failed} non riuscito",
+      "authorComplete": "Arricchimento autore completato - autori {done} aggiornati",
+      "authorDoneWithFailures": "Arricchimento dell'autore eseguito: {done} elaborato, {failed} non riuscito"
+    }
+  },
+  "bookDock": {
+    "apply": "Applica",
+    "done": "Fatto",
+    "discard": "Scarta",
+    "finalize": "Finalizzare",
+    "rescan": "Nuova scansione",
+    "uploadAction": "Carica",
+    "uploading": "Caricamento...",
+    "searchPlaceholder": "Cerca file...",
+    "setDestinationAction": "Imposta destinazione",
+    "bulkEditAction": "Modifica collettiva",
+    "applyFetched": "Applica recuperato",
+    "retryErrors": "Riprova errori",
+    "commaSeparated": "separati da virgole",
+    "destinationLibrary": "Biblioteca di destinazione",
+    "destinationFolder": "Cartella di destinazione",
+    "nFailed": "{count} non riuscito",
+    "updatedOfFiles": "Aggiornato {updated} di {total} file",
+    "errorStatus": "Errore {status}",
+    "tab": {
+      "all": "Tutto",
+      "pending": "In sospeso",
+      "ready": "Pronto",
+      "error": "Errore"
+    },
+    "status": {
+      "pending": "In sospeso",
+      "extracting": "Estrarre",
+      "fetching": "Recupero",
+      "ready": "Pronto",
+      "error": "Errore"
+    },
+    "field": {
+      "title": "Titolo",
+      "subtitle": "Sottotitolo",
+      "authors": "Autori",
+      "authorsCommaSeparated": "Autori (separati da virgole)",
+      "publisher": "Editore",
+      "publishedDate": "Data di pubblicazione",
+      "year": "Anno",
+      "language": "Lingua",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "series": "Serie",
+      "seriesIndex": "Serie n.",
+      "genres": "Generi",
+      "genresCommaSeparated": "Generi (separati da virgole)",
+      "description": "Descrizione"
+    },
+    "upload": {
+      "nDone": "{count} fatto",
+      "nFailed": "{count} non riuscito",
+      "nTotal": "{count} totale"
+    },
+    "fileList": {
+      "emptyTitle": "Nessun file nel Book Dock",
+      "emptyMessageDefault": "Carica i file o rilasciali nella cartella Book Dock",
+      "colCurrent": "Attuale",
+      "colNew": "Nuovo",
+      "colFile": "File",
+      "colSize": "Dimensioni",
+      "colFormat": "Formato",
+      "colMatch": "Corrispondenza",
+      "colApply": "Applica",
+      "colStatus": "Stato",
+      "applyFetchedMetadata": "Applica i metadati recuperati",
+      "coverPreview": "Anteprima della copertina",
+      "coverPreviewDescription": "Finestra di dialogo di anteprima dell'immagine di copertina ingrandita.",
+      "currentCoverAlt": "{title} copertina attuale",
+      "newCoverAlt": "{title} nuova copertina",
+      "unknownLibrary": "Biblioteca sconosciuta",
+      "unassigned": "Non assegnato",
+      "targetPath": "Obiettivo: {library} · {path}",
+      "targetUnassigned": "Obiettivo: non assegnato",
+      "targetUnknownPath": "Obiettivo: {library} · Percorso di destinazione sconosciuto"
+    },
+    "sheet": {
+      "saved": "Salvato",
+      "providerMetadataFound": "Metadati del fornitore trovati",
+      "providerMetadataFoundEdited": "Metadati del fornitore trovati: l'applicazione collettiva salterà questo file (hai delle modifiche)",
+      "review": "Recensione",
+      "added": "Aggiunto {date}",
+      "searchMetadata": "Cerca metadati",
+      "results": "Risultati"
+    },
+    "bulkEdit": {
+      "title": "{count, plural, =0 {Modifica in blocco nessun file} one {Modifica collettiva # file} other {Modifica collettiva # file} many {Modifica collettiva # file}}",
+      "resultTitle": "Risultati della modifica collettiva",
+      "instructions": "Attiva/disattiva i campi che desideri aggiornare. Verranno applicati solo i campi abilitati.",
+      "mergeArrays": "Unisci array (aggiungi ai valori esistenti invece di sostituire)",
+      "failed": "La modifica collettiva non è riuscita"
+    },
+    "setDestination": {
+      "title": "{count, plural, =0 {Imposta la destinazione per nessun file} one {Imposta destinazione per # file} other {Imposta destinazione per # file} many {Imposta destinazione per # file}}",
+      "resultTitle": "Destinazione aggiornata",
+      "failed": "Impossibile impostare la destinazione"
+    },
+    "finalizeDialog": {
+      "title": "{count, plural, =0 {Non finalizzare alcun file} one {Finalizzare # file} other {Finalizzare # file} many {Finalizzare # file}}",
+      "resultTitle": "Finalizzare i risultati",
+      "needDestination": "{count, plural, =0 {Senza destinazione: {without} su # file selezionati} one {Senza destinazione: {without} su # file selezionato} other {Senza destinazione: {without} su # file selezionati} many {Senza destinazione: {without} su # file selezionati}}",
+      "allHaveDestination": "Tutti i file selezionati hanno già la destinazione impostata",
+      "defaultDestinationLibrary": "Libreria di destinazione predefinita",
+      "defaultDestinationFolder": "Cartella di destinazione predefinita",
+      "renamePreview": "Rinomina l'anteprima",
+      "moreFiles": "+{count} altri file",
+      "start": "Inizia",
+      "filesFinalized": "{succeeded} di {total} file finalizzati",
+      "checking": "Controllo dei file selezionati...",
+      "readyCount": "{count, plural, =0 {nessun file pronto} one {# file pronto} other {# file pronti} many {# file pronti}}",
+      "duplicateCount": "{count, plural, =0 {nessuno già in biblioteca} one {# già in biblioteca} other {# già in biblioteca} many {# già in biblioteca}}",
+      "conflictCount": "{count, plural, =0 {nessun conflitto di nomi di file} one {# conflitto di nomi di file} other {# conflitti di nomi di file} many {# conflitti di nomi di file}}",
+      "missingDestinationCount": "{count, plural, =0 {nessuna destinazione mancante} one {# destinazione mancante} other {# destinazioni mancanti} many {# destinazioni mancanti}}",
+      "blockedCount": "{count, plural, =0 {nessun file bloccato} one {# file bloccato} other {# file bloccati} many {# file bloccati}}",
+      "moreDuplicates": "+{count} altri già nella libreria",
+      "discardDuplicates": "Scarta i duplicati",
+      "failedCount": "{count, plural, =0 {nessun file ha avuto esito negativo} one {# file non riuscito} other {# file non riusciti} many {# file non riusciti}}",
+      "failedWithDuplicates": "{count, plural, =0 {{failed} non riusciti (# duplicati)} one {{failed} non riusciti (# duplicato)} other {{failed} non riusciti (# duplicati)} many {{failed} non riusciti (# duplicati)}}",
+      "view": "Visualizza",
+      "viewExisting": "Visualizza esistente",
+      "hide": "Nasconditi",
+      "details": "Dettagli",
+      "alreadyExistsSaveAs": "Esiste già: salva come:",
+      "renamePlaceholder": "ad es. {name} (2)",
+      "import": "Importa"
+    }
+  },
+  "collection": {
+    "dialog": {
+      "name": "Nome",
+      "icon": "Icona",
+      "iconPlaceholder": "Scegli un'icona...",
+      "nameRequired": "Il nome è obbligatorio",
+      "iconRequired": "Scegli un'icona",
+      "creating": "Creazione...",
+      "createFailed": "Impossibile creare la raccolta"
+    },
+    "createDialog": {
+      "title": "Nuova collezione",
+      "namePlaceholder": "ad es. Preferiti"
+    },
+    "editDialog": {
+      "title": "Modifica raccolta",
+      "syncToKobo": "Sincronizza con Kobo",
+      "syncToKoboHint": "I libri di questa raccolta verranno visualizzati sul tuo dispositivo Kobo",
+      "deleteCollection": "Elimina raccolta",
+      "confirmDelete": "Confermi?",
+      "deleting": "Eliminazione...",
+      "saving": "Salvataggio...",
+      "deleted": "\"{name}\" eliminato",
+      "updateFailed": "Impossibile aggiornare la raccolta",
+      "deleteFailed": "Impossibile eliminare la raccolta"
+    },
+    "addToSheet": {
+      "title": "Gestisci raccolte",
+      "selectedCount": "{count, plural, =0 {nessun libro selezionato} one {un libro selezionato} other {# libri selezionati} many {# libri selezionati}}",
+      "newCollection": "Nuova collezione",
+      "namePlaceholder": "Nome della raccolta",
+      "create": "Crea",
+      "collections": "Collezioni",
+      "empty": "Nessuna raccolta ancora. Creane uno sopra.",
+      "done": "Fatto",
+      "added": "Aggiunto",
+      "allAdded": "Tutti i {total} aggiunti",
+      "inCollection": "In questa raccolta",
+      "allInCollection": "Tutti i {total} in questa raccolta",
+      "partialInCollection": "{partial} di {total} in questa raccolta",
+      "bookCount": "{count, plural, =0 {niente libri} one {un libro} other {# libri} many {# libri}}",
+      "loadFailed": "Impossibile caricare le raccolte",
+      "createdAndAdded": "{count, plural, =0 {Creato\"{name}\" e non ha aggiunto libri} one {Creato\"{name}\" e ha aggiunto un libro} other {Creato\"{name}\" e aggiunse # libri} many {Creato\"{name}\" e aggiunse # libri}}",
+      "createdButAddFailed": "Creato \"{name}\" ma non è possibile aggiungere libri",
+      "createFailed": "Impossibile creare la raccolta",
+      "addedNewWithExisting": "{count, plural, =0 {Aggiunto un nuovo libro a \"{name}\" ({alreadyHad} già lì)} one {Aggiunto un nuovo libro a \"{name}\" ({alreadyHad} già lì)} other {Aggiunto # nuovi libri a\"{name}\" ({alreadyHad} già lì)} many {Aggiunto # nuovi libri a\"{name}\" ({alreadyHad} già lì)}}",
+      "addedToCollection": "{count, plural, =0 {Nessun libro aggiunto a \"{name}\"} one {Aggiunto un libro a \"{name}\"} other {Aggiunto # libri a\"{name}\"} many {Aggiunto # libri a\"{name}\"}}",
+      "addFailed": "Impossibile aggiungere alla raccolta",
+      "removedFromCollection": "{count, plural, =0 {Nessun libro rimosso da \"{name}\"} one {Rimosso un libro da \"{name}\"} other {Rimosso # libri da \"{name}\"} many {Rimosso # libri da \"{name}\"}}",
+      "removeFailed": "Impossibile rimuovere dalla raccolta"
+    }
+  },
+  "components": {
+    "appHeader": {
+      "searchAllBooks": "Cerca tutti i libri...",
+      "searching": "Ricerca...",
+      "noResults": "Nessun risultato",
+      "loadingMore": "Caricamento di più...",
+      "loadMore": "Carica altro ({loaded}/{total})",
+      "allMatchesShown": "{count, plural, =0 {Tutte e 1 le partite mostrate} one {Tutte e 1 le partite mostrate} other {Tutto # partite mostrate} many {Tutto # partite mostrate}}",
+      "bookCount": "{count, plural, =0 {niente libri} one {# libro} other {# libri} many {# libri}}",
+      "fileCount": "{count, plural, =0 {nessun file} one {# file} other {# file} many {# file}}",
+      "uploadedToast": "Caricato {uploaded}",
+      "uploadFailedToast": "Caricamento non riuscito per {failed}",
+      "uploadPartialToast": "Caricamento {uploaded}, {failed} non riuscito",
+      "bookDock": "Book Dock",
+      "statistics": "Statistiche",
+      "achievements": "Risultati",
+      "annotations": "Annotazioni",
+      "uploadBooks": "Carica libri",
+      "appearance": "Aspetto",
+      "theme": "Tema",
+      "accent": "Accento",
+      "radius": "Raggio",
+      "background": "Sfondo",
+      "settings": "Impostazioni",
+      "whatsNew": "Cosa c'è di nuovo",
+      "documentation": "Documentazione",
+      "help": "Aiuto",
+      "starOnGithub": "Stella su GitHub",
+      "new": "Nuovo",
+      "newReleaseNotes": "Nuove note di rilascio disponibili",
+      "account": "Conto",
+      "changePassword": "Cambia password",
+      "signOut": "Esci",
+      "githubStar": {
+        "title": "Ti piace BookOrbit?",
+        "body": "Se BookOrbit ti sta aiutando con la tua libreria, considera di rendere protagonista il progetto su GitHub. Aiuta più persone a scoprire l'app e supporta lo sviluppo continuo.",
+        "cta": "Speciale BookOrbit su GitHub"
+      }
+    },
+    "sidebar": {
+      "tagline": "Il tuo spazio di lettura",
+      "dashboard": "Cruscotto",
+      "authors": "Autori",
+      "series": "Serie",
+      "tools": "Strumenti",
+      "libraries": "Biblioteche",
+      "newLibrary": "Nuova Biblioteca",
+      "libraryScanning": "{name} - Scansione {pct}%",
+      "scanProgress": "{processed} / {total} libri",
+      "smartScopes": "Ambiti intelligenti",
+      "newSmartScope": "Nuovo ambito intelligente",
+      "noSmartScopes": "Ancora nessuno Smart Scope",
+      "collections": "Collezioni",
+      "newCollection": "Nuova collezione",
+      "noCollections": "Nessuna raccolta ancora",
+      "latest": "Ultimi {version}",
+      "newReleaseNotes": "Nuove note di rilascio disponibili",
+      "support": "Supporto BookOrbit",
+      "supportShort": "Supporto",
+      "supportAria": "Supporta BookOrbit su Ko-fi",
+      "sectionHeader": {
+        "add": "Aggiungi",
+        "reorder": "Riordina",
+        "doneReordering": "Riordino finito"
+      }
+    },
+    "selectionActionBar": {
+      "setReadingStatus": "Imposta lo stato di lettura",
+      "setRating": "Imposta la valutazione",
+      "openMetadataEditor": "Apri l'editor dei metadati",
+      "editIndividually": "Modifica i libri individualmente",
+      "addToCollection": "Aggiungi alla raccolta",
+      "removeFromCollection": "Rimuovi dalla raccolta",
+      "sendViaEmail": "Invia tramite e-mail",
+      "downloadFilesZip": "Scarica i file come ZIP",
+      "moreActions": "Più azioni",
+      "setField": "Imposta campo",
+      "refreshMetadata": "Aggiorna i metadati",
+      "reExtractCover": "Riestrarre il coperchio",
+      "metadataLock": "Blocco dei metadati",
+      "lockAll": "Blocca tutto",
+      "unlockAll": "Sblocca tutto",
+      "exportMetadata": "Esporta metadati",
+      "deleteSelected": "Elimina selezionato",
+      "exitSelection": "Esci dalla selezione",
+      "downloadFilesZipLabel": "Scarica file come ZIP:",
+      "primaryOnly": "Solo principale",
+      "allFormats": "Tutti i formati",
+      "audioOnly": "Solo audio",
+      "setRatingLabel": "Imposta valutazione:",
+      "clear": "Cancella",
+      "setFieldLabel": "Imposta campo:",
+      "apply": "Applica",
+      "fieldPlaceholder": "Lascia vuoto per cancellare",
+      "fieldPlaceholderArray": "Separati da virgole (lasciare vuoto per cancellare)",
+      "deleteConfirm": "{count, plural, =0 {Elimina # libro?} one {Elimina # libro?} other {Elimina # libri?} many {Elimina # libri?}}",
+      "typeDelete": "Digitare ELIMINA"
+    },
+    "viewHeader": {
+      "select": "Seleziona",
+      "display": "Visualizzazione",
+      "displayDescription": "Regola le dimensioni della copertina, la spaziatura della griglia e visualizza le opzioni di visualizzazione.",
+      "columnVisibilityHint": "Utilizza il pannello di visibilità delle colonne nell'intestazione della tabella per mostrare o nascondere le colonne.",
+      "columnVisibilityMobileHint": "La visibilità delle colonne può essere gestita dall'intestazione della tabella.",
+      "searchPlaceholder": "Cerca titolo, autore, serie, narratore...",
+      "mobileSearch": {
+        "description": "Cerca elementi per titolo, autore, serie o narratore.",
+        "done": "Fatto"
+      },
+      "mobileMenu": {
+        "grid": "Griglia",
+        "list": "Elenco",
+        "select": "Seleziona",
+        "exitSelect": "Esci Seleziona"
+      },
+      "displayControls": {
+        "display": "Visualizzazione",
+        "coverSize": "Dimensioni della copertina",
+        "gridGap": "Divario della griglia",
+        "showJumpRails": "Mostra i binari di salto",
+        "columnsHint": "Utilizza il pannello di visibilità delle colonne nell'intestazione della tabella per mostrare o nascondere le colonne.",
+        "coverShape": "Forma della copertina",
+        "circle": "Cerchio",
+        "square": "Quadrato"
+      }
+    },
+    "iconPicker": {
+      "clearSelectionAria": "Cancella l'icona selezionata",
+      "searchLucide": "Cerca icone Lucide...",
+      "searchCustom": "Cerca icone personalizzate...",
+      "chooseIcon": "Scegli un'icona...",
+      "selectIcon": "Seleziona l'icona",
+      "customTab": "Personalizzato",
+      "searching": "Ricerca...",
+      "noIconsMatch": "Nessuna icona corrisponde a \"{query}\"",
+      "typeToSearch": "Digita per cercare in tutte le icone",
+      "noCustomIcons": "Nessuna icona personalizzata caricata",
+      "noIconsAvailable": "Nessuna icona disponibile"
+    },
+    "entityNotFound": {
+      "title": "{entity} non trovato",
+      "description": "Questo {entity} non esiste o è stato eliminato.",
+      "goBack": "Torna indietro"
+    },
+    "themePicker": {
+      "light": "Luce",
+      "dark": "Buio",
+      "system": "Sistema"
+    },
+    "userAvatar": {
+      "profilePicture": "Immagine del profilo",
+      "profilePictureOf": "{name} immagine del profilo"
+    },
+    "ui": {
+      "sidebar": {
+        "title": "Barra laterale",
+        "mobileDescription": "Visualizza la barra laterale mobile.",
+        "toggle": "Attiva/disattiva la barra laterale"
+      },
+      "chipInput": {
+        "typeAndEnter": "Digita e premi Invio per aggiungere",
+        "pressEnter": "Premi Invio per aggiungere"
+      }
+    }
+  },
+  "customIcons": {
+    "dialogTitle": "Carica icone personalizzate",
+    "dialogDescription": "Controlla i nomi prima di aggiungerli alla tua libreria.",
+    "readingFiles": "Lettura dei file...",
+    "dropPrompt": "Rilascia i file SVG o fai clic per sfogliare",
+    "fileLimit": "Fino a {max} file, 128 KB ciascuno",
+    "namePlaceholder": "Nome",
+    "nameRequired": "Il nome è obbligatorio",
+    "invalidSvg": "SVG non valido",
+    "invalidSvgFile": "File SVG non valido",
+    "identicalTo": "Identico a \"{name}\"",
+    "uploadAnyway": "Carica comunque",
+    "skipThisOne": "Salta questo",
+    "readyToUpload": "{count} pronto per il caricamento",
+    "noIconsStaged": "Nessuna icona ancora messa in scena",
+    "uploading": "Caricamento...",
+    "upload": "Carica",
+    "uploadCount": "Carica {count}",
+    "onlySvgSupported": "Sono supportati solo i file SVG",
+    "maxStaged": "Puoi mettere in scena al massimo {max} icone contemporaneamente",
+    "onlyMoreCanStage": "{count, plural, =0 {Non è possibile mettere in scena altre icone} one {Solo # è possibile mettere in scena più icone} other {Solo # è possibile mettere in scena più icone} many {Solo # è possibile mettere in scena più icone}}",
+    "readFailed": "Impossibile leggere i file SVG",
+    "uploadedCount": "{count, plural, =0 {Nessuna icona caricata} one {Caricato # icona} other {Caricato # icone} many {Caricato # icone}}",
+    "uploadedPartial": "Caricamento {created}, {failed} non riuscito",
+    "noIconsUploaded": "Nessuna icona caricata",
+    "uploadFailed": "Impossibile caricare le icone",
+    "uploadFailedEntry": "Caricamento non riuscito"
+  },
+  "dashboard": {
+    "common": {
+      "failedToLoad": "Impossibile caricare",
+      "retry": "Riprova",
+      "untitled": "Senza titolo",
+      "cover": "Copertina",
+      "bookCover": "Copertina del libro"
+    },
+    "scroller": {
+      "failedToLoad": "Impossibile caricare.",
+      "empty": {
+        "continueReading": "Nessun libro in corso ancora. Inizia a leggerne uno per vederlo qui.",
+        "continueListening": "Nessun audiolibro in corso ancora. Inizia ad ascoltarne uno per vederlo qui.",
+        "wantToRead": "Nessun libro contrassegnato come da leggere ancora.",
+        "upNextInSeries": "Nessuna scelta per il prossimo episodio della serie. Termina un volume per far emergere quello successivo.",
+        "recentlyAdded": "Nessun libro ancora nella tua libreria.",
+        "smartScope": "Nessun libro corrisponde a questo smartScope.",
+        "default": "Nessun libro trovato."
+      }
+    },
+    "settings": {
+      "title": "Personalizza la dashboard",
+      "tabs": {
+        "widgets": "Widget",
+        "shelves": "Scaffali"
+      },
+      "reorderHintWidget": "Trascina per riordinare. Seleziona per mostrare o nascondere un widget.",
+      "reorderHintShelf": "Trascina per riordinare. Attiva/disattiva per mostrare o nascondere uno scaffale.",
+      "smartScope": "Ambito intelligente",
+      "noSmartScopes": "Ancora nessuno Smart Scope. Creane uno dalla barra laterale.",
+      "addShelf": "Aggiungi scaffale",
+      "resetToDefaults": "Ripristina le impostazioni predefinite"
+    },
+    "welcome": {
+      "emptyTitle": "La tua libreria è vuota",
+      "noLibrariesTitle": "Nessuna libreria ancora",
+      "emptyDescription": "Crea una libreria per iniziare a organizzare e leggere i tuoi libri. Puntalo su una cartella e farà il resto.",
+      "noLibrariesDescription": "Il tuo amministratore non ha ancora configurato alcuna libreria. Contattali per iniziare.",
+      "createFirstLibrary": "Crea la tua prima libreria"
+    },
+    "widgets": {
+      "currentlyReading": {
+        "title": "Attualmente sto leggendo",
+        "empty": "Nessun libro in corso. Inizia a leggerne uno per vederlo qui.",
+        "continueReading": "Continua a leggere"
+      },
+      "diversityScore": {
+        "title": "Punteggio di diversità",
+        "notEnoughData": "Leggi almeno 3 libri per vedere il tuo punteggio di diversità",
+        "booksAnalyzed": "{count, plural, =0 {nessun libro analizzato} one {# libro analizzato} other {# libri analizzati} many {# libri analizzati}}",
+        "subScores": {
+          "genre": "Genere",
+          "author": "Autore",
+          "era": "Epoca",
+          "language": "Lang"
+        }
+      },
+      "highlightOfTheDay": {
+        "title": "Momento clou della giornata",
+        "empty": "Evidenzia i passaggi durante la lettura per vederli qui"
+      },
+      "libraryOverview": {
+        "title": "Panoramica della biblioteca",
+        "empty": "La tua libreria è vuota. Aggiungi alcuni libri per iniziare.",
+        "addedThisYear": "+{count} aggiunto quest'anno",
+        "stats": {
+          "books": "Libri",
+          "authors": "Autori",
+          "series": "Serie",
+          "storage": "Stoccaggio"
+        }
+      },
+      "longWait": {
+        "title": "La lunga attesa",
+        "empty": "Nessun libro in attesa. Hai iniziato tutto!",
+        "daysWaiting": "giorni di attesa",
+        "pages": "{count, plural, =0 {nessuna pagina} one {# pagina} other {# pagine} many {# pagine}}",
+        "startReading": "Inizia a leggere"
+      },
+      "monthlyChallenge": {
+        "title": "Sfida mensile",
+        "complete": "Completo!"
+      },
+      "neglectedGems": {
+        "title": "Gemme trascurate",
+        "empty": "Tutti i tuoi libri più votati sono stati letti!",
+        "rating": "{rating}/5",
+        "daysWaiting": "{count}d in attesa",
+        "queued": "In coda",
+        "addToQueue": "Aggiungi alla coda",
+        "shuffle": "Mescola"
+      },
+      "readingDna": {
+        "title": "Leggere il DNA",
+        "notEnoughData": "Leggi almeno 5 libri per sbloccare il tuo DNA della lettura",
+        "basedOn": "{count, plural, =0 {Basato su nessun libro} one {Basato su # libro} other {Basato su # libri} many {Basato su # libri}}",
+        "traits": {
+          "length": "Lunghezza",
+          "variety": "Varietà",
+          "rhythm": "Ritmo",
+          "time": "Tempo",
+          "speed": "Velocità"
+        }
+      },
+      "readingGoal": {
+        "title": "Obiettivo di lettura {year}",
+        "setGoalPrompt": "Imposta un obiettivo di lettura per monitorare i tuoi progressi",
+        "setGoal": "Stabilisci l'obiettivo",
+        "booksPerYear": "Libri all'anno",
+        "ofGoal": "di {goal}",
+        "percentComplete": "{percentage}% completato",
+        "editGoal": "Modifica obiettivo"
+      },
+      "readingRhythm": {
+        "title": "Ritmo di lettura",
+        "empty": "Inizia a leggere per vedere il tuo ritmo prendere forma",
+        "activeDays": "{count, plural, =0 {nessun giorno attivo} one {# giornata attiva} other {# giorni attivi} many {# giorni attivi}}",
+        "consistency": "{activeDays} · {percent}% di consistenza",
+        "avgPerDay": "media {time}/giorno"
+      },
+      "readingStreak": {
+        "title": "Striscia di lettura",
+        "empty": "Leggi oggi per iniziare la tua serie di vittorie consecutive",
+        "streakLabel": "{count, plural, =0 {serie di giorni} one {serie di giorni} other {giorni consecutivi} many {giorni consecutivi}}",
+        "best": "{count, plural, =0 {Migliore: # giorno} one {Migliore: # giorno} other {Migliore: # giorni} many {Migliore: # giorni}}",
+        "lastSevenDays": "Ultimi 7 giorni"
+      },
+      "yearProjection": {
+        "title": "Proiezione dell'anno",
+        "books": "libri",
+        "trendUp": "Tendenza in alto",
+        "trendDown": "Tendenza al ribasso",
+        "trendSteady": "Ritmo costante",
+        "pages": "pagine",
+        "hours": "ore",
+        "readCount": "{count} leggi",
+        "daysLeft": "{count}d rimasto"
+      }
+    }
+  },
+  "email": {
+    "title": "E-mail",
+    "subtitle": "Invia libri al tuo e-reader tramite e-mail.",
+    "loadFailed": "Impossibile caricare",
+    "saveFailed": "Impossibile salvare",
+    "deleteFailed": "Impossibile eliminare",
+    "setDefaultFailed": "Impossibile impostare il valore predefinito",
+    "setAsDefault": "Imposta come predefinito",
+    "saving": "Salvataggio...",
+    "update": "Aggiorna",
+    "create": "Crea",
+    "deleteConfirm": "Elimina \"{name}\". Questa azione non può essere annullata.",
+    "badge": {
+      "default": "Predefinito",
+      "shared": "Condiviso",
+      "system": "Sistema"
+    },
+    "tabs": {
+      "providers": "Fornitori",
+      "recipients": "Destinatari",
+      "groups": "Gruppi",
+      "templates": "Modelli",
+      "preferences": "Preferenze",
+      "history": "Storia"
+    },
+    "providers": {
+      "heading": "Provider SMTP",
+      "add": "Aggiungi fornitore",
+      "newTitle": "Nuovo fornitore",
+      "editTitle": "Modifica fornitore",
+      "name": "Nome",
+      "namePlaceholder": "ad es. Gmail",
+      "host": "Ospite",
+      "port": "Porto",
+      "username": "Nome utente",
+      "password": "Parola d'ordine",
+      "passwordEdit": "Password (lascia vuoto per restare aggiornato)",
+      "fromName": "Dal nome",
+      "fromNamePlaceholder": "La mia biblioteca",
+      "fromAddress": "Dall'indirizzo",
+      "authentication": "Autenticazione",
+      "verifyTls": "Verifica il certificato TLS",
+      "tlsWarning": "La verifica TLS è disabilitata. Il certificato del server non verrà convalidato: utilizzare solo per server interni attendibili.",
+      "noFromAddress": "no dall'indirizzo",
+      "emptyManage": "Nessun fornitore ancora. Aggiungi un provider SMTP per iniziare a inviare e-mail.",
+      "emptyReadonly": "Nessun fornitore disponibile. Chiedi a un amministratore di aggiungerne uno.",
+      "setSystemTooltip": "Imposta come provider di posta di sistema",
+      "removeSystemTooltip": "Rimuovi come provider di posta di sistema",
+      "testTooltip": "Testare la connessione",
+      "toggleSharing": "Attiva/disattiva la condivisione",
+      "removeSystemBeforeDelete": "Rimuovere la designazione del sistema prima dell'eliminazione",
+      "notesHeading": "Note del fornitore",
+      "notesBody": "Il provider {system} (solo superutente) viene utilizzato per le e-mail di reimpostazione della password. Il provider {defaultProvider} viene utilizzato quando si inviano libri senza un provider esplicito selezionato. I fornitori contrassegnati con {shared} sono disponibili per tutti gli utenti.",
+      "deleteTitle": "Eliminare il fornitore?",
+      "nameHostRequired": "Nome e host sono obbligatori",
+      "created": "Fornitore creato",
+      "updated": "Fornitore aggiornato",
+      "deleted": "\"{name}\" eliminato",
+      "setDefaultSuccess": "\"{name}\" impostato come predefinito",
+      "unshared": "Fornitore non condiviso",
+      "sharedWithAll": "Provider condiviso con tutti gli utenti",
+      "updateSharingFailed": "Impossibile aggiornare la condivisione",
+      "systemRemoved": "\"{name}\" rimosso come provider di posta di sistema",
+      "systemSet": "\"{name}\" impostato come provider di posta di sistema",
+      "updateSystemFailed": "Impossibile aggiornare il provider di sistema",
+      "connectionSuccess": "Connessione riuscita",
+      "connectionFailed": "Connessione non riuscita",
+      "testFailed": "Prova fallita"
+    },
+    "recipients": {
+      "heading": "Destinatari",
+      "add": "Aggiungi destinatario",
+      "newTitle": "Nuovo destinatario",
+      "editTitle": "Modifica destinatario",
+      "name": "Nome",
+      "namePlaceholder": "Il mio Kindle",
+      "emailAddress": "Indirizzo e-mail",
+      "deviceType": "Tipo di dispositivo",
+      "deviceNone": "Nessuno",
+      "deviceOther": "Altro",
+      "preferredFormat": "Formato preferito",
+      "formatAuto": "Automatico",
+      "defaultTemplate": "Modello predefinito",
+      "useAccountDefault": "Utilizza account predefinito",
+      "kindleNote": "I destinatari Kindle ricevono automaticamente e-mail con oggetto \"converti\" per attivare la conversione del formato.",
+      "empty": "Nessun destinatario ancora.",
+      "prefersFormat": "preferisce {format}",
+      "deleteTitle": "Eliminare il destinatario?",
+      "nameEmailRequired": "Nome ed email sono obbligatori",
+      "created": "Destinatario creato",
+      "updated": "Destinatario aggiornato",
+      "deleted": "\"{name}\" eliminato",
+      "setDefaultSuccess": "\"{name}\" impostato come predefinito"
+    },
+    "groups": {
+      "heading": "Gruppi di destinatari",
+      "create": "Crea gruppo",
+      "newTitle": "Nuovo gruppo",
+      "name": "Nome del gruppo",
+      "namePlaceholder": "ad es. Circolo del libro",
+      "creating": "Creazione...",
+      "empty": "Nessun gruppo ancora. Crea un gruppo per inviare a più destinatari contemporaneamente.",
+      "memberCount": "{count, plural, =0 {nessun membro} one {un membro} other {# membri} many {# membri}}",
+      "deleteTooltip": "Elimina gruppo",
+      "noMembers": "Nessun membro ancora",
+      "removeMember": "Rimuovi",
+      "selectRecipient": "Seleziona destinatario...",
+      "add": "Aggiungi",
+      "addMember": "Aggiungi membro",
+      "allRecipientsInGroup": "Tutti i destinatari sono già in questo gruppo.",
+      "deleteTitle": "Eliminare il gruppo?",
+      "created": "Gruppo creato",
+      "createFailed": "Impossibile creare il gruppo",
+      "deleted": "\"{name}\" eliminato",
+      "memberAdded": "Membro aggiunto",
+      "addMemberFailed": "Impossibile aggiungere membro",
+      "memberRemoved": "Membro rimosso",
+      "removeMemberFailed": "Impossibile rimuovere il membro"
+    },
+    "templates": {
+      "heading": "Modelli di posta elettronica",
+      "new": "Nuovo modello",
+      "newTitle": "Nuovo modello",
+      "editTitle": "Modifica modello",
+      "name": "Nome",
+      "namePlaceholder": "Predefinito",
+      "subject": "Oggetto",
+      "body": "Corpo",
+      "availableVariables": "Variabili disponibili",
+      "editTemplate": "Modifica modello",
+      "empty": "Nessun modello ancora.",
+      "notesHeading": "Note sul modello",
+      "notesBody": "I modelli di sistema non possono essere eliminati. Gli amministratori possono modificarli. Utilizza variabili come {variable} negli argomenti e nei corpi: vengono sostituite con i dettagli del libro al momento dell'invio.",
+      "deleteTitle": "Eliminare il modello?",
+      "nameSubjectRequired": "Nome e oggetto sono obbligatori",
+      "created": "Modello creato",
+      "updated": "Modello aggiornato",
+      "deleted": "\"{name}\" eliminato",
+      "setDefaultSuccess": "\"{name}\" impostato come predefinito"
+    },
+    "preferences": {
+      "heading": "Preferenze e-mail",
+      "defaultProvider": "Fornitore predefinito",
+      "defaultProviderHint": "Utilizzato quando non è specificato alcun provider. Se vuoto, viene utilizzato l'account predefinito.",
+      "noneAccountDefault": "Nessuno (utilizza l'account predefinito)",
+      "defaultRecipient": "Destinatario predefinito",
+      "defaultRecipientHint": "Utilizzato per l'invio rapido. Deve essere impostato per utilizzare l'azione di invio rapido sulle schede del libro.",
+      "none": "Nessuno",
+      "defaultTemplate": "Modello predefinito",
+      "defaultTemplateHint": "Utilizzato quando non è specificato alcun modello. Ritorna alle impostazioni predefinite del sistema se vuoto.",
+      "noneSystemDefault": "Nessuno (utilizza l'impostazione predefinita del sistema)",
+      "save": "Salva le preferenze",
+      "saved": "Preferenze salvate"
+    },
+    "history": {
+      "heading": "Invia cronologia",
+      "empty": "Nessuna email ancora inviata.",
+      "noSubject": "(nessun argomento)",
+      "loadMore": "Carica di più",
+      "resend": "Invia nuovamente",
+      "deleteTitle": "Eliminare la voce della cronologia?",
+      "entryDeleted": "Voce eliminata",
+      "queuedForResend": "In coda per il nuovo invio",
+      "resendFailed": "Impossibile inviare nuovamente",
+      "statusSent": "Inviato",
+      "statusFailed": "Fallito",
+      "statusQueued": "In coda",
+      "statusPending": "In sospeso"
+    },
+    "send": {
+      "title": "Invia tramite e-mail",
+      "bookCount": "{count, plural, =0 {niente libri} one {un libro} other {# libri} many {# libri}}",
+      "recipients": "Destinatari",
+      "noRecipients": "Nessun destinatario configurato. Aggiungine uno nelle Impostazioni email.",
+      "groups": "Gruppi",
+      "options": "Opzioni",
+      "fileFormat": "Formato del file",
+      "autoRecipientPreference": "Auto (usa la preferenza del destinatario)",
+      "unknownFormat": "Sconosciuto",
+      "primarySuffix": "(principale)",
+      "provider": "Fornitore",
+      "template": "Modello",
+      "default": "Predefinito",
+      "send": "Invia",
+      "sending": "Invio...",
+      "queued": "{count, plural, =0 {nessuna email in coda} one {una e-mail in coda} other {# e-mail in coda} many {# e-mail in coda}}",
+      "failed": "Impossibile inviare"
+    }
+  },
+  "hardcover": {
+    "settings": {
+      "subtitle": "Sincronizza i tuoi progressi nella lettura, lo stato e le valutazioni su Hardcover."
+    },
+    "bookSync": {
+      "label": "Hardcover Sincronizza",
+      "toggleAriaLabel": "Sincronizza questo libro con Hardcover",
+      "syncNow": "Sincronizza ora"
+    },
+    "connection": {
+      "title": "Connessione",
+      "description": "Collega il tuo account Hardcover per sincronizzare i dati di lettura.",
+      "connected": "Connesso",
+      "apiToken": "Token API",
+      "tokenPlaceholder": "Incolla il tuo token Hardcover API",
+      "show": "Mostra",
+      "hide": "Nasconditi",
+      "findTokenAt": "Trova il tuo token su",
+      "validateToken": "Convalida token",
+      "valid": "Valido ({username})",
+      "invalidToken": "Token non valido",
+      "syncOptions": "Opzioni di sincronizzazione",
+      "syncInfo": "La sincronizzazione viene eseguita solo per i libri che non sono non letti. Questo vale per gli attivatori di stato, avanzamento e valutazione. Questi interruttori controllano quando viene eseguita una sincronizzazione.",
+      "syncScope": {
+        "title": "Ambito di sincronizzazione del libro",
+        "allEligible": {
+          "label": "Tutti i libri idonei",
+          "description": "Sincronizza tutto a meno che non escludi un libro."
+        },
+        "selectedOnly": {
+          "label": "Solo libri selezionati",
+          "description": "Sincronizza solo i libri che includi esplicitamente."
+        }
+      },
+      "enableSync": {
+        "title": "Abilita la sincronizzazione",
+        "description": "Metti in pausa tutte le Hardcover sincronizzazioni senza disconnetterti."
+      },
+      "syncOnStatus": {
+        "title": "Sincronizzazione al cambiamento di stato",
+        "description": "Invia aggiornamenti quando contrassegni un libro come letto, già letto, ecc."
+      },
+      "syncOnProgress": {
+        "title": "Sincronizzazione sull'aggiornamento dei progressi",
+        "description": "Invia l'avanzamento della lettura e le date quando cambia l'avanzamento di BookOrbit o KOReader."
+      },
+      "syncOnRating": {
+        "title": "Sincronizzazione al cambio di valutazione",
+        "description": "Invia le tue valutazioni a stelle a Hardcover."
+      },
+      "privacy": {
+        "title": "Privacy",
+        "description": "Visibilità predefinita per i libri sincronizzati su Hardcover.",
+        "public": "Pubblico",
+        "followersOnly": "Solo follower",
+        "private": "Privato"
+      },
+      "disconnect": "Disconnetti",
+      "toast": {
+        "enterToken": "Inserisci prima il tuo token Hardcover API",
+        "saved": "Impostazioni Hardcover salvate",
+        "saveFailed": "Impossibile salvare le impostazioni",
+        "disconnected": "Hardcover disconnesso"
+      }
+    },
+    "sync": {
+      "title": "Sincronizzazione manuale",
+      "description": "Invia il tuo {scope} a Hardcover adesso.",
+      "scope": {
+        "selected": "libri selezionati",
+        "eligible": "libri idonei"
+      },
+      "checkingPending": "Controllo degli elementi in sospeso...",
+      "pendingOf": "{pending} libri in attesa di {total}.",
+      "noBooksInScope": "Nessun libro nell'ambito della sincronizzazione.",
+      "allSynced": "Tutti i libri sono già sincronizzati.",
+      "lastSyncedLabel": "Ultima sincronizzazione",
+      "lastSuccessfulSync": "Ultima sincronizzazione riuscita",
+      "syncing": "Sincronizzazione...",
+      "progressCount": "{synced} / {total} libri",
+      "unavailable": {
+        "permissionDenied": "Non hai l'autorizzazione per utilizzare la sincronizzazione Hardcover.",
+        "userDisabled": "La sincronizzazione è sospesa nelle tue impostazioni Hardcover."
+      },
+      "button": {
+        "unavailable": "Sincronizzazione non disponibile",
+        "syncNow": "Sincronizza ora",
+        "syncNowCount": "Sincronizza ora ({count})"
+      },
+      "lastSynced": {
+        "justNow": "Proprio adesso",
+        "minutesAgo": "{count} minuti fa",
+        "hoursAgo": "{count, plural, =0 {# un'ora fa} one {# un'ora fa} other {# ore fa} many {# ore fa}}",
+        "daysAgo": "{count, plural, =0 {# giorno fa} one {# giorno fa} other {# giorni fa} many {# giorni fa}}"
+      }
+    },
+    "import": {
+      "title": "Estrai lo stato di lettura",
+      "description": "Visualizza l'anteprima delle partite Hardcover prima di riempire gli stati BookOrbit vuoti.",
+      "clear": "Cancella",
+      "preview": "Anteprima",
+      "importProgress": "Importa i progressi",
+      "reviewMatches": "Rivedi le partite",
+      "importReady": "Importazione pronta",
+      "exactMatches": "{count, plural, =0 {nessuna corrispondenza esatta può essere importata senza revisione} one {# la corrispondenza esatta può essere importata senza revisione} other {# le corrispondenze esatte possono essere importate senza revisione} many {# le corrispondenze esatte possono essere importate senza revisione}}",
+      "progressAvailable": "{count, plural, =0 {nessun aggiornamento sullo stato di avanzamento disponibile} one {# aggiornamento sullo stato di avanzamento disponibile} other {# aggiornamenti sullo stato di avanzamento disponibili} many {# aggiornamenti sullo stato di avanzamento disponibili}}",
+      "progressConflicts": "{count, plural, =0 {nessun conflitto} one {# conflitto} other {# conflitti} many {# conflitti}}",
+      "unavailable": {
+        "permissionDenied": "Non hai l'autorizzazione per utilizzare la sincronizzazione Hardcover.",
+        "missingToken": "Connetti Hardcover prima dell'importazione.",
+        "userDisabled": "La sincronizzazione è sospesa nelle tue impostazioni Hardcover."
+      },
+      "summary": {
+        "ready": "Pronto",
+        "review": "Recensione",
+        "conflicts": "Conflitti",
+        "unmatched": "Senza eguali",
+        "skipped": "Saltato"
+      },
+      "result": {
+        "summary": "{applied} importato{progress}, {failed} non riuscito",
+        "progressUpdated": "{count} progressi aggiornati"
+      },
+      "toast": {
+        "importFailed": "Impossibile importare lo stato di lettura di Hardcover",
+        "imported": "{count, plural, =0 {nessuno stato di lettura importato{progress}} one {# leggere lo stato importato{progress}} other {# leggere gli stati importati{progress}} many {# leggere gli stati importati{progress}}}",
+        "progressUpdates": "{count, plural, =0 {nessun aggiornamento sullo stato di avanzamento} one {# aggiornamento sullo stato di avanzamento} other {# aggiornamenti sui progressi} many {# aggiornamenti sui progressi}}"
+      }
+    },
+    "review": {
+      "title": "Hardcover revisione dell'importazione",
+      "subtitle": "{total} Hardcover libri, {matched} corrispondenti.",
+      "closeAriaLabel": "Chiudi la revisione dell'importazione",
+      "searchPlaceholder": "Cerca titolo o autore",
+      "importProgress": "Importa i progressi",
+      "untitled": "Senza titolo",
+      "blank": "vuoto",
+      "noRows": "Nessuna riga corrisponde ai filtri correnti.",
+      "selectRowAriaLabel": "Seleziona {title}",
+      "selectionSummary": "{count} selezionato: {ready} pronto, {reviewed} rivisto.",
+      "selectedProgress": "{count, plural, =0 {nessun aggiornamento sullo stato di avanzamento} one {# aggiornamento sullo stato di avanzamento} other {# aggiornamenti sui progressi} many {# aggiornamenti sui progressi}}",
+      "selectReady": "Seleziona pronto",
+      "selectPage": "Seleziona pagina",
+      "clearPage": "Cancella pagina",
+      "clearSelection": "Cancella selezione",
+      "importSelected": "Importa selezionata",
+      "previousPage": "Pagina precedente",
+      "nextPage": "Pagina successiva",
+      "pageRange": "{start}-{end} di {total}",
+      "tabs": {
+        "all": "Tutto",
+        "ready": "Pronto",
+        "review": "Recensione",
+        "conflicts": "Conflitti",
+        "unmatched": "Senza eguali",
+        "skipped": "Saltato"
+      },
+      "summary": {
+        "ready": "Pronto",
+        "review": "Recensione",
+        "conflicts": "Conflitti",
+        "unmatched": "Senza eguali",
+        "skipped": "Saltato"
+      },
+      "matchOptions": {
+        "all": "Tutti i tipi di corrispondenza"
+      },
+      "matchMethod": {
+        "hardcoverId": "HardcoverID",
+        "isbn": "ISBN",
+        "titleAuthor": "Titolo + autore"
+      },
+      "outcome": {
+        "ready": "Pronto",
+        "review": "Recensione",
+        "conflict": "Conflitto",
+        "unmatched": "Senza eguali",
+        "skipped": "Saltato"
+      },
+      "column": {
+        "progress": "Progresso"
+      }
+    }
+  },
+  "library": {
+    "creator": {
+      "createTitle": "Crea libreria",
+      "editTitle": "Modifica: {name}",
+      "stepOf": "Passaggio {current} di {total}",
+      "unsaved": "Non salvato",
+      "required": "Obbligatorio",
+      "closeAria": "Chiudi il creatore della libreria",
+      "progressAria": "Avanzamento della configurazione della libreria",
+      "sectionsAria": "Sezioni delle impostazioni della libreria",
+      "loadingAria": "Caricamento delle impostazioni della libreria",
+      "sections": {
+        "details": "Dettagli",
+        "folders": "Cartelle",
+        "scanner": "Scanner",
+        "metadata": "Metadati",
+        "fileWrite": "Scrivi file",
+        "reading": "Lettura",
+        "schedule": "Programma",
+        "access": "Accesso"
+      },
+      "actions": {
+        "saving": "Salvataggio…",
+        "saveChanges": "Salva modifiche",
+        "creating": "Creazione…",
+        "createLibrary": "Crea libreria"
+      },
+      "details": {
+        "libraryName": "Nome della libreria",
+        "namePlaceholder": "La mia biblioteca",
+        "coverStyle": {
+          "title": "Stile di copertina",
+          "portrait": "Ritratto",
+          "square": "Quadrato",
+          "hint": "Ritratto per ebook o biblioteche miste. Square per le librerie di soli audiolibri."
+        },
+        "icon": {
+          "label": "Icona",
+          "placeholder": "Scegli un'icona...",
+          "selected": "Selezionato"
+        }
+      },
+      "folders": {
+        "title": "Scansione cartelle",
+        "description": "Aggiungi una o più directory per cercare libri.",
+        "browseAdd": "Sfoglia e aggiungi una cartella",
+        "browseTitle": "Sfoglia le cartelle del server",
+        "browseDescription": "Seleziona una o più cartelle senza uscire dal browser.",
+        "selectedTitle": "Cartelle selezionate",
+        "addFolders": "Aggiungi cartelle",
+        "manualEntry": "Immettere un percorso manualmente",
+        "absolutePath": "Percorso assoluto del server",
+        "addFolder": "Aggiungi cartella",
+        "removeFolder": "Rimuovi {folder}",
+        "manualCheckHint": "I percorsi manuali vengono controllati insieme al resto delle cartelle selezionate.",
+        "pathPlaceholder": "/percorso/dei/libri",
+        "test": "Prova",
+        "add": "Aggiungi",
+        "pathNotAccessible": "Il percorso non è accessibile sul server.",
+        "pathAccessible": "Il percorso è accessibile.",
+        "pathNotAccessibleShort": "Il percorso non è accessibile",
+        "overlapsWith": "Si sovrappone a \"{library}\"",
+        "noneAdded": "Nessuna cartella ancora aggiunta",
+        "runPrescanHint": "Esegui una scansione preliminare per convalidare i percorsi prima di salvare.",
+        "scanning": "Scansione…",
+        "prescan": "Prescansione"
+      },
+      "scanner": {
+        "scanMode": {
+          "title": "Modalità di scansione",
+          "lockedAria": "La modalità organizzazione è bloccata",
+          "lockTooltip": "La modalità di organizzazione viene corretta dopo la creazione della libreria perché la modifica può creare voci di libro duplicate o mancanti. Per utilizzare una modalità diversa, creare una nuova libreria ed eseguire nuovamente la scansione.",
+          "recommended": "Consigliato",
+          "folderAsBook": {
+            "title": "Cartella come libro",
+            "hint": "Tutti i file in una cartella sono raggruppati in un unico libro. Funziona bene quando mantieni più formati, come EPUB e MOBI, insieme."
+          },
+          "fileAsBook": {
+            "title": "Archivia come libro",
+            "hint": "Tratta ogni file come un singolo libro. Ideale per le biblioteche con un formato per titolo. Evita se i tuoi audiolibri occupano più file."
+          }
+        },
+        "allowedFormats": {
+          "title": "Formati consentiti",
+          "allowAll": "Consenti tutto",
+          "allAllowed": "Sono ammessi tutti i formati.",
+          "onlySelected": "Verranno importati solo i formati selezionati.",
+          "warning": "I libri in altri formati già presenti nella libreria verranno contrassegnati come mancanti alla scansione successiva."
+        },
+        "excludePatterns": {
+          "title": "Escludi modelli",
+          "hintBefore": "Modelli glob da saltare durante la scansione (ad es. ",
+          "hintAfter": ").",
+          "add": "Aggiungi",
+          "empty": "Nessun modello aggiunto."
+        }
+      },
+      "metadata": {
+        "sourcePrecedence": {
+          "title": "Precedenza della fonte",
+          "hint": "Quando sono disponibili più sorgenti, viene preferita la sorgente più in alto nell'elenco."
+        },
+        "formatPriority": {
+          "title": "Priorità del formato",
+          "hint": "Quando un libro ha più formati, viene preferito il formato più in alto nell'elenco."
+        }
+      },
+      "fileWrite": {
+        "maxFileSizeMb": "Dimensione massima del file (MB)",
+        "formatLimits": "Limiti di formato",
+        "rename": {
+          "title": "Rinominare i file dopo la modifica dei metadati",
+          "hint": "Rinomina i file fisici quando cambia titolo, autore, serie o anno, utilizzando il modello di denominazione della libreria."
+        },
+        "write": {
+          "title": "Scrivere metadati su file",
+          "hint": "Se abilitato, il salvataggio dei metadati riscriverà anche le modifiche nel file fisico su disco."
+        },
+        "cover": {
+          "title": "Includi l'immagine di copertina",
+          "hint": "Riscrive la copertina memorizzata nei formati di file supportati."
+        },
+        "epub": {
+          "title": "EPUB",
+          "hint": "Scrive i metadati nel file OPF all'interno dell'archivio EPUB.",
+          "toggleAria": "Scrivi i metadati EPUB"
+        },
+        "fb2": {
+          "title": "FictionBook (FB2)",
+          "hint": "Riscrive il blocco della descrizione nei file FB2 senza modificare il testo del libro.",
+          "toggleAria": "Scrivi metadati FB2"
+        },
+        "pdf": {
+          "title": "PDF",
+          "hint": "Incorpora i metadati nel dizionario informativo PDF e nel flusso XMP.",
+          "toggleAria": "Scrivi i metadati PDF"
+        },
+        "cbx": {
+          "title": "Archivi di fumetti (CBX)",
+          "hint": "Scrive ComicInfo.xml negli archivi CBZ e CB7.",
+          "toggleAria": "Scrivi metadati di archivio di fumetti"
+        },
+        "kindle": {
+          "title": "Kindle (MOBI, AZW3)",
+          "hint": "Scrive i metadati nell'intestazione EXTH dei file MOBI, AZW3 e AZW.",
+          "toggleAria": "Scrivi metadati Kindle"
+        },
+        "audio": {
+          "title": "Audio",
+          "hint": "Incorpora la copertina memorizzata nei file M4B, M4A, MP3 e FLAC.",
+          "toggleAria": "Scrivi copertine audio"
+        }
+      },
+      "reading": {
+        "readingStart": {
+          "title": "Inizio lettura",
+          "hint": "Un libro viene contrassegnato come \"lettura\" una volta raggiunta questa percentuale di progresso."
+        },
+        "markAsFinished": {
+          "title": "Segna come finito",
+          "hint": "Un libro viene automaticamente contrassegnato come \"letto\" quando viene raggiunta questa percentuale di progresso."
+        }
+      },
+      "schedule": {
+        "fileWatching": "Osservazione dei file",
+        "autoScanSchedule": "Pianificazione della scansione automatica",
+        "cronExpression": "Espressione cron",
+        "cronInvalid": "Espressione cron non valida.",
+        "cronFormat": "Formato: minuto ora giorno mese giorno feriale",
+        "watchFolders": {
+          "title": "Guarda le cartelle",
+          "hint": "Rileva automaticamente i nuovi file aggiunti alle cartelle della libreria."
+        },
+        "presets": {
+          "never": "Mai",
+          "hourly": "Ogni ora",
+          "every6Hours": "Ogni 6 ore",
+          "every12Hours": "Ogni 12 ore",
+          "daily": "Ogni giorno",
+          "weekly": "Settimanale",
+          "custom": "Personalizzato"
+        },
+        "human": {
+          "disabled": "Scansione automatica disabilitata",
+          "hourly": "Ogni ora",
+          "every6Hours": "Ogni 6 ore",
+          "every12Hours": "Ogni 12 ore",
+          "dailyMidnight": "Tutti i giorni a mezzanotte",
+          "weeklyMonday": "Ogni settimana il lunedì a mezzanotte",
+          "cron": "Cronologia: {cron}"
+        }
+      },
+      "access": {
+        "title": "Controllo degli accessi",
+        "description": "I superutenti hanno sempre pieno accesso. Concedi l'accesso ad altri utenti di seguito.",
+        "notYetCreated": "L'accesso può essere configurato dopo la creazione della libreria.",
+        "selectUser": "Seleziona un utente...",
+        "grant": "Concedi",
+        "empty": "A nessun utente è stato ancora concesso l'accesso.",
+        "loading": "Caricamento delle impostazioni di accesso...",
+        "userSelectAria": "Utente a cui concedere l'accesso",
+        "levelSelectAria": "Livello di accesso da concedere",
+        "levels": {
+          "viewer": "Visualizzatore",
+          "editor": "Editore",
+          "owner": "Proprietario"
+        },
+        "columns": {
+          "user": "Utente",
+          "accessLevel": "Livello di accesso"
+        },
+        "errors": {
+          "grant": "Impossibile concedere l'accesso",
+          "updateLevel": "Impossibile aggiornare il livello di accesso",
+          "revoke": "Impossibile revocare l'accesso"
+        }
+      }
+    },
+    "folderPicker": {
+      "title": "Sfoglia le cartelle del server",
+      "description": "Seleziona una o più cartelle per questa libreria.",
+      "closeAria": "Chiudi il browser delle cartelle",
+      "currentFolderAria": "Cartella corrente",
+      "parentFolder": "Vai alla cartella principale",
+      "newFolder": "Nuova cartella",
+      "goUp": "Vai su",
+      "filterPlaceholder": "Filtra cartelle...",
+      "clearFilterAria": "Cancella filtro cartella",
+      "newFolderNamePlaceholder": "Nuovo nome della cartella",
+      "create": "Crea",
+      "loading": "Caricamento cartelle...",
+      "selectCurrent": "Seleziona la cartella corrente",
+      "noMatches": "Nessuna cartella corrispondente",
+      "noMatchesHint": "Prova un filtro diverso.",
+      "empty": "Questa cartella è vuota",
+      "emptyHint": "È possibile selezionare la cartella corrente o crearne una nuova.",
+      "openFolderAria": "Apri {name}",
+      "selectedCount": "{count, plural, =0 {nessuna cartella selezionata} one {# cartella selezionata} other {# cartelle selezionate} many {# cartelle selezionate}}",
+      "noFolders": "Nessuna cartella trovata",
+      "selectFolder": "Seleziona questa cartella",
+      "errors": {
+        "readDirectory": "Impossibile leggere la directory",
+        "connect": "Impossibile connettersi",
+        "invalidName": "Inserisci il nome di una singola cartella senza barre o punti iniziali",
+        "createFolder": "Impossibile creare la cartella"
+      }
+    },
+    "upload": {
+      "library": "Biblioteca",
+      "selectLibrary": "Seleziona una libreria...",
+      "targetFolder": "Cartella di destinazione",
+      "addMoreFiles": "Aggiungi più file",
+      "clearAll": "Cancella tutto",
+      "done": "Fatto",
+      "retry": "Riprova",
+      "upload": "Carica",
+      "uploadWithCount": "Carica ({count})",
+      "viewInLibrary": "Visualizza nella libreria",
+      "fileCount": "{count, plural, =0 {nessun file} one {# file} other {# file} many {# file}}",
+      "booksAdded": "{count, plural, =0 {nessun libro aggiunto} one {# libro aggiunto} other {# libri aggiunti} many {# libri aggiunti}}",
+      "uploadedFailed": "{done} caricato, {failed} non riuscito",
+      "progress": "{done} di {total} caricamento...",
+      "header": {
+        "uploading": "Caricamento...",
+        "complete": "Caricamento completato",
+        "uploadTo": "Carica su {library}",
+        "uploadBooks": "Carica libri"
+      },
+      "dropzone": {
+        "title": "Trascina i file qui o fai clic per sfogliare",
+        "hint": "{formats} - fino a {size} MB ciascuno"
+      }
+    }
+  },
+  "metadataScore": {
+    "missingFields": "{count, plural, =0 {nessun campo mancante: modifica i metadati} one {# campo mancante: modifica metadati} other {# campi mancanti: modifica metadati} many {# campi mancanti: modifica metadati}}"
+  },
+  "migration": {
+    "sidebarTitle": "Importazione di libri",
+    "status": {
+      "done": "Fatto",
+      "saved": "Salvato",
+      "running": "Correre",
+      "failed": "Fallito"
+    },
+    "badge": {
+      "validated": "Convalidato",
+      "upToDate": "Aggiornato",
+      "completed": "Completato"
+    },
+    "steps": {
+      "source": {
+        "short": "Connessione alla sorgente",
+        "title": "Connessione alla sorgente",
+        "subtitle": "Configura la connessione al database all'istanza Booklore di origine."
+      },
+      "mappings": {
+        "short": "Mappatura utenti e percorsi",
+        "title": "Mappatura utenti e percorsi",
+        "subtitle": "Mappare gli utenti di origine per gli utenti di destinazione e tradurre i percorsi dei file."
+      },
+      "dryRun": {
+        "short": "Prova a secco",
+        "title": "Prova a secco",
+        "subtitle": "Visualizza in anteprima ciò che verrà importato prima di eseguire la migrazione in tempo reale."
+      },
+      "migration": {
+        "short": "Esegui la migrazione",
+        "title": "Esegui la migrazione",
+        "subtitle": "Avvia l'importazione dal vivo e monitora il suo progresso."
+      },
+      "report": {
+        "short": "Rapporto",
+        "title": "Rapporto sulla migrazione",
+        "subtitle": "Rivedi cosa è stato importato ed esporta un rapporto dettagliato."
+      }
+    },
+    "footer": {
+      "continueToMappings": "Continua su Mappature",
+      "continueToDryRun": "Continuare con la prova di prova",
+      "continueToMigration": "Continua con la migrazione",
+      "viewReport": "Visualizza rapporto",
+      "resetSetup": "Ripristina configurazione",
+      "stepOf": "Passaggio {current} di {total}",
+      "backToSetup": "Torna alla configurazione"
+    },
+    "stages": {
+      "init": "Inizializzazione",
+      "sharedOverlays": "Importazione di metadati",
+      "bookCovers": "Importazione di copertine",
+      "userState": "Importazione dei dati utente"
+    },
+    "source": {
+      "testConnection": "Prova connessione",
+      "saveAndValidate": "Salva e convalida",
+      "validatedWithWarnings": "Fonte convalidata con avvisi",
+      "fields": {
+        "type": "Tipo di origine",
+        "name": "Nome della fonte",
+        "host": "Ospite",
+        "port": "Porto",
+        "user": "Utente",
+        "password": "Parola d'ordine",
+        "passwordSaved": "Salvato: lascia invariato",
+        "passwordNotSet": "Nessuna password impostata",
+        "database": "Banca dati",
+        "mediaRootPath": "Percorso radice multimediale",
+        "ssl": "Utilizza TLS/SSL"
+      },
+      "mediaPath": {
+        "hintRequired": "Necessario per la migrazione delle copertine dei libri.",
+        "hintAbsolute": "Utilizza un percorso assoluto (ad esempio: /libri). I percorsi relativi non sono supportati.",
+        "hintConfigured": "Percorso di importazione della copertina configurato. Utilizza Prova connessione per verificare l'accesso e la struttura delle cartelle delle immagini di Booklore.",
+        "buttonOk": "Percorso OK",
+        "buttonIssue": "Problema del percorso",
+        "buttonTest": "Percorso di prova"
+      },
+      "compatibility": {
+        "title": "Compatibilità testata",
+        "verifiedAgainst": "Verificato rispetto a:",
+        "note": "Le versioni successive sono probabilmente compatibili ma non sono state verificate. Eseguire prima un test di prova per confermare prima di salvare i dati."
+      },
+      "snapshot": {
+        "title": "Ultima istantanea di convalida",
+        "sourceVersion": "Versione sorgente: {version}",
+        "unknown": "Sconosciuto",
+        "missingTables": "Tabelle obbligatorie mancanti: {tables}"
+      }
+    },
+    "mappings": {
+      "suggestionsAutoLoad": "I suggerimenti dell'utente vengono caricati automaticamente dopo la convalida dell'origine.",
+      "refresh": "Aggiorna",
+      "sourceUser": "Utente di origine",
+      "targetUser": "Utente di destinazione",
+      "noSourceUsersLoaded": "Nessun utente di origine ancora caricato.",
+      "noActiveTargetUsers": "Nessun utente target attivo trovato. Crea o riattiva un utente BookOrbit prima della mappatura.",
+      "pathPrefixMappings": "Mappature dei prefissi del percorso",
+      "addMapping": "Aggiungi mappatura",
+      "pathMappingsExplanation": "Le mappature dei percorsi traducono i percorsi dei file di origine in percorsi di destinazione in modo che i libri possano essere abbinati in base alla posizione del file. Ai libri viene abbinata anche ISBN, hash del file e titolo/autore indipendentemente dalle mappature del percorso.",
+      "noPrefixesFound": "Nessun prefisso trovato: convalida prima la fonte",
+      "selectSourcePrefix": "Seleziona il prefisso di origine...",
+      "selectTargetFolder": "Seleziona la cartella di destinazione...",
+      "remove": "Rimuovi",
+      "saveMappings": "Salva mappature",
+      "pathValidation": {
+        "title": "Convalida del percorso",
+        "mappedSummary": "{mapped} dei {total} libri di origine hanno un percorso mappato",
+        "unmatched": "{count} percorsi mappati non trovati sul disco",
+        "allMatched": "Tutti i percorsi mappati {count} trovati sul disco"
+      }
+    },
+    "dryRun": {
+      "run": "Eseguire il funzionamento a secco",
+      "matched": "Abbinato:",
+      "unresolved": "Irrisolto:",
+      "duplicates": "Duplicati:",
+      "unresolvedSummary": "Sintesi irrisolta"
+    },
+    "duplicates": {
+      "title": "Risolvi le corrispondenze target duplicate",
+      "explanation": "Per ciascun libro di destinazione, scegli un libro di origine da conservare. Le scelte consigliate vengono preselezionate quando esiste una singola corrispondenza più forte.",
+      "remainingGroups": "Gruppi rimanenti:",
+      "ofCount": "di {total}",
+      "targetBookId": "Libro di destinazione n.{id}",
+      "recommended": "Consigliato",
+      "resolveButton": "{count, plural, =0 {Risolvi # duplicare} one {Risolvi # duplicare} other {Risolvi # duplicati} many {Risolvi # duplicati}}",
+      "sourceRecordId": "ID record di origine n.{id}",
+      "byAuthor": "da {author} (ID: {id})",
+      "byFilePath": "{filePath} (ID: {id})",
+      "bookloreSourceId": "ID fonte del libro: {id}",
+      "libraryBookId": "Libro della biblioteca n.{id}"
+    },
+    "preflight": {
+      "title": "Controlli preliminari",
+      "allPassed": "Tutti i controlli sono stati superati: pronto per la migrazione",
+      "sourceValidated": "Fonte convalidata",
+      "saveAndValidateSource": "Salva e convalida la connessione di origine",
+      "validateSourceConnection": "Convalida la connessione di origine",
+      "mappingsSaved": "Mappature salvate",
+      "saveUserAndPathMappings": "Salva mappature di utenti e percorsi",
+      "pathMappingsValidated": "Mappature dei percorsi convalidate",
+      "savePathMappingsToValidate": "Salva le mappature dei percorsi per convalidarle",
+      "dryRunUpToDate": "Il test di prova è aggiornato",
+      "runFreshDryRun": "Esegui una nuova prova di prova",
+      "issues": {
+        "saveSource": "Salva le impostazioni di connessione dell'origine",
+        "validateSource": "Convalida la connessione di origine",
+        "saveMappings": "Salva mappature di utenti e percorsi",
+        "savePathMappings": "Salva le mappature dei percorsi per convalidarle",
+        "freshDryRun": "Esegui una nuova prova di prova",
+        "resolveDuplicates": "Risolvi le corrispondenze duplicate del libro di destinazione durante il test",
+        "waitForRun": "Attendi il completamento della corsa attiva"
+      }
+    },
+    "run": {
+      "confirmPrompt": "Ciò avvierà la migrazione in tempo reale. Sei sicuro?",
+      "confirmStart": "Conferma inizio",
+      "startMigration": "Avvia la migrazione",
+      "cancelRun": "Annulla esecuzione",
+      "refreshStatus": "Aggiorna stato",
+      "pollingStopped": "Il polling dello stato è stato interrotto a causa di un errore.",
+      "retry": "Riprova",
+      "stage": "Fase: {stage}",
+      "initializing": "inizializzazione",
+      "ended": "Terminato {time}"
+    },
+    "report": {
+      "noRunYet": "Nessuna migrazione ancora eseguita. Completa i passaggi precedenti per iniziare.",
+      "runNumber": "Esegui #{id}",
+      "notStarted": "Non iniziato",
+      "reloadReport": "Ricarica rapporto",
+      "loadFullReport": "Carica rapporto completo",
+      "exportJson": "Esporta JSON",
+      "exportCsv": "Esporta CSV",
+      "migrationFailed": "La migrazione non è riuscita",
+      "retryFromLastStage": "Riprova dall'ultima fase completata",
+      "booksSection": "Libri",
+      "metadataOverlays": "Sovrapposizioni di metadati applicate",
+      "authorMappings": "Sostituite le mappature degli autori",
+      "narratorMappings": "Le mappature dell'Assistente vocale sono state sostituite",
+      "genreMappings": "Le mappature dei generi sono state sostituite",
+      "tagMappings": "Sostituite le mappature dei tag",
+      "coversImported": "Copertine importate",
+      "coverImportSkipped": "Importazione della copertina saltata: percorso root del supporto non configurato",
+      "couldNotMatch": "Impossibile corrispondere",
+      "userDataSection": "Dati utente",
+      "readingStatuses": "Stati di lettura",
+      "readingProgressEntries": "Lettura delle voci di avanzamento",
+      "audiobookProgressEntries": "Voci di avanzamento dell'audiolibro",
+      "readingSessions": "Sessioni di lettura",
+      "bookmarks": "Segnalibri",
+      "annotations": "Annotazioni",
+      "collectionEntries": "Voci di raccolta",
+      "loadFullReportHint": "Fai clic su \"Carica rapporto completo\" per includere il riepilogo della partita di prova nel rapporto esportato.",
+      "completedNoIssues": "Migrazione completata senza libri irrisolti o errori.",
+      "matchedBooks": "Libri abbinati ({count})",
+      "matchedBooksExplanation": "Queste corrispondenze di prova sono state utilizzate per decidere quali libri della biblioteca ricevevano i dati importati.",
+      "sourceBook": "Libro di origine {id}",
+      "libraryBook": "Libro della biblioteca {id}",
+      "unresolvedBooks": "Libri irrisolti ({count})",
+      "unresolvedBooksExplanation": "Questi libri esistono nell'origine ma non possono essere abbinati ad alcun libro nella tua biblioteca.",
+      "mappedUsers": "Utenti mappati ({count})",
+      "mappedUsersExplanation": "I totali per utente provengono dall'anteprima di prova memorizzata nella cache con il piano di migrazione.",
+      "coverFailures": "{count} importazione/i di copertine non riuscita. Le righe dettagliate degli errori non vengono archiviate.",
+      "userPreviewCounts": "Stati {statuses}, voci di avanzamento {progress}, sessioni di lettura {sessions}, segnalibri {bookmarks}, annotazioni {annotations}, voci di raccolta {collections}"
+    },
+    "unresolvedReason": {
+      "noTitleAuthorMatch": "Nessun libro corrispondente trovato per titolo o autore",
+      "noFilePathMatch": "Il percorso del file non corrisponde ad alcun libro in questa libreria",
+      "noFileHashMatch": "L'hash del file non corrisponde ad alcun libro in questa libreria",
+      "noIsbnMatch": "ISBN non corrisponde ad alcun libro in questa libreria",
+      "insufficientSourceData": "Metadati insufficienti per tentare la corrispondenza",
+      "ambiguousIsbnMatch": "Più libri corrispondevano allo stesso ISBN",
+      "ambiguousFileHashMatch": "Più libri corrispondevano allo stesso hash del file",
+      "ambiguousFilePathMatch": "Più libri corrispondevano allo stesso percorso file",
+      "ambiguousTitleAuthorMatch": "Più libri corrispondevano allo stesso titolo e autore",
+      "unknown": "Impossibile determinare il motivo"
+    },
+    "matchStrategy": {
+      "isbn": "Corrispondente a ISBN",
+      "fileHash": "Corrispondente all'hash del file",
+      "pathMapping": "Corrispondente al percorso del file mappato",
+      "titleAuthor": "Corrispondenza per titolo e autore",
+      "unavailable": "Strategia di corrispondenza non disponibile"
+    },
+    "connectionError": {
+      "unreachable": "Impossibile raggiungere il server del database. Controlla l'host e la porta.",
+      "authFailed": "Autenticazione non riuscita. Controlla il nome utente e la password.",
+      "databaseNotFound": "Banca dati non trovata. Controlla il nome del database.",
+      "timeout": "Connessione scaduta. Controlla le impostazioni dell'host e del firewall.",
+      "generic": "Il test di connessione è fallito"
+    },
+    "userSelect": {
+      "placeholder": "Seleziona utente",
+      "noUsersFound": "Nessun utente trovato"
+    },
+    "toast": {
+      "initFailed": "Impossibile inizializzare le impostazioni di migrazione",
+      "loadSupportedTypesFailed": "Impossibile caricare i tipi di origine della migrazione supportati",
+      "loadTargetUsersFailed": "Impossibile caricare gli utenti di destinazione",
+      "loadTargetFoldersFailed": "Impossibile caricare le cartelle della libreria di destinazione",
+      "noSourceUsers": "Non è stato restituito alcun utente di origine",
+      "suggestionsLoaded": "Suggerimenti per la mappatura degli utenti caricati",
+      "loadSuggestionsFailed": "Impossibile caricare i suggerimenti per la mappatura degli utenti",
+      "sourceFieldsRequired": "Sono obbligatori l'host, l'utente, il database e il nome dell'origine",
+      "connectionPassedWithWarnings": "Test di connessione superato con avvisi",
+      "connectionPassedWithWarningCount": "Test di connessione superato con {count} avviso/i. Primo: {warning}",
+      "connectionPassed": "Test di connessione superato",
+      "connectionMissingTables": "Connessione ok, ma mancano le tabelle {count} richieste",
+      "cannotTestMediaWhileRunning": "Impossibile testare il percorso multimediale mentre è attiva un'esecuzione",
+      "mediaPathRequired": "Per l'importazione delle copertine è richiesto il percorso radice del supporto.",
+      "mediaPathAbsolute": "Utilizza un percorso assoluto (ad esempio: /libri).",
+      "mediaPathVerified": "Percorso multimediale verificato.",
+      "mediaPathValid": "Il percorso multimediale è valido e leggibile",
+      "mediaPathValidationFailed": "Convalida del percorso multimediale non riuscita.",
+      "connectionFailedBeforeMedia": "Il test di connessione non è riuscito prima del completamento della convalida del percorso multimediale.",
+      "cannotModifySourceWhileRunning": "Impossibile modificare l'origine mentre è attiva un'esecuzione",
+      "sourceSavedWithWarnings": "Sorgente salvata e convalidata con {count} avviso/i",
+      "sourceSaved": "Sorgente salvata e convalidata",
+      "saveSourceFailed": "Impossibile salvare o convalidare la fonte",
+      "cannotSaveMappingsWhileRunning": "Impossibile salvare le mappature mentre è attiva una corsa",
+      "saveSourceFirst": "Salva prima la fonte",
+      "mapAtLeastOneUser": "Associa almeno un utente di origine a un utente di destinazione",
+      "mapEveryUser": "Mappa ogni utente di origine prima di salvare",
+      "pathValidationFailedButSaved": "La convalida del percorso non è riuscita, ma il profilo verrà comunque salvato",
+      "mappingsSaved": "Mappature salvate",
+      "saveMappingsFailed": "Impossibile salvare le mappature",
+      "cannotDryRunWhileRunning": "Non è possibile eseguire una prova di prova mentre è attiva una corsa",
+      "saveMappingsFirst": "Salvare prima le mappature",
+      "dryRunCompleted": "Prova completata: {matched} corrispondente, {unresolved} non risolto",
+      "dryRunFailed": "Il test di prova non è riuscito",
+      "selectSourceForDuplicates": "Seleziona un libro di origine per tutti i gruppi duplicati {count}",
+      "duplicatesResolved": "Corrispondenze duplicate risolte",
+      "resolveDuplicatesFailed": "Impossibile risolvere i duplicati",
+      "preflightNotReady": "Verifica preliminare della migrazione non pronta",
+      "runDryRunFirst": "Eseguire prima un test di prova",
+      "runStarted": "È iniziata la corsa di migrazione",
+      "startFailed": "Impossibile avviare la migrazione",
+      "runCancelled": "Esecuzione della migrazione annullata",
+      "cancelFailed": "Impossibile annullare la migrazione",
+      "runRetried": "Nuovo tentativo di migrazione: ripresa dall'ultima fase completata",
+      "retryFailed": "Impossibile riprovare la migrazione",
+      "loadProgressFailed": "Impossibile caricare l'avanzamento dell'esecuzione",
+      "startMigrationFirst": "Inizia prima la migrazione",
+      "reportRefreshed": "Esegui report aggiornato",
+      "loadReportFailed": "Impossibile caricare il rapporto sull'esecuzione",
+      "reportExported": "Rapporto esportato come {format}",
+      "exportFailed": "Impossibile esportare il rapporto sulla migrazione"
+    }
+  },
+  "notifications": {
+    "title": "Notifiche",
+    "markAllRead": "Segna tutto letto",
+    "clear": "Cancella",
+    "empty": "Nessuna notifica ancora",
+    "loadMore": "Carica più notifiche",
+    "preferences": {
+      "title": "Notifiche",
+      "subtitle": "Scegli quali categorie di notifiche desideri ricevere.",
+      "saving": "Salvataggio...",
+      "unsavedChanges": "Modifiche non salvate",
+      "saved": "Preferenze di notifica salvate",
+      "saveFailed": "Impossibile salvare le preferenze",
+      "savePreferenceFailed": "Impossibile salvare la preferenza",
+      "whatsNewToggle": "Mostra \"Novità\" dopo gli aggiornamenti",
+      "whatsNewToggleHint": "Un popup che evidenzia le nuove funzionalità dopo gli aggiornamenti dell'app. L'archivio rimane disponibile in ogni caso."
+    }
+  },
+  "reader": {
+    "retry": "Riprova",
+    "pdf": {
+      "openError": "Impossibile aprire questo PDF",
+      "preparing": "Preparazione del lettore PDF",
+      "opening": "Apertura PDF"
+    },
+    "loadingBook": "Caricamento libro...",
+    "failedToLoadBook": "Impossibile caricare il libro",
+    "chapterNumber": "Capitolo {number}",
+    "peek": {
+      "badge": "Sbirciare",
+      "startReading": "Inizia a leggere"
+    },
+    "toast": {
+      "linkedHighlightError": "Impossibile aprire la posizione di evidenziazione collegata",
+      "resumed": "Ripresa alle {pct}% - {label}"
+    },
+    "header": {
+      "goBack": "Torna indietro",
+      "tableOfContents": "Sommario",
+      "toggleBookmark": "Attiva/disattiva segnalibro",
+      "cycleFooterMode": "Scorri la modalità informazioni piè di pagina",
+      "keyboardShortcutsHint": "Scorciatoie da tastiera (?)",
+      "enterFullscreen": "Entra a schermo intero",
+      "exitFullscreen": "Esci dallo schermo intero",
+      "footerMode": {
+        "pageProgress": "Informazioni a piè di pagina: pagina + avanzamento",
+        "sessionTimeLeft": "Informazioni a piè di pagina: sessione di lettura + tempo rimanente",
+        "chapterTimeLeft": "Informazioni a piè di pagina: capitolo + tempo capitolo rimasto"
+      }
+    },
+    "footer": {
+      "previousSection": "Sezione precedente",
+      "nextSection": "Sezione successiva",
+      "goToPlaceholder": "45 o p123",
+      "jumpToLocation": "Vai alla posizione",
+      "jumpTooltip": "Vai a % o pagina (ad es. 45 o p123)",
+      "go": "Vai"
+    },
+    "settings": {
+      "title": "Impostazioni",
+      "ariaLabel": "Impostazioni del lettore",
+      "tabs": {
+        "appearance": "Aspetto",
+        "text": "Testo",
+        "layout": "Disposizione"
+      },
+      "appearance": {
+        "mode": "Modalità",
+        "light": "Luce",
+        "dark": "Buio",
+        "colorTheme": "Tema del colore"
+      },
+      "text": {
+        "fontSize": "Dimensione del carattere",
+        "fontSizeRange": "Intervallo: 10-32px",
+        "lineHeight": "Altezza della linea",
+        "lineHeightRange": "Intervallo: 0,8-3,0",
+        "fontFamily": "Famiglia di caratteri",
+        "fontFamilyDescription": "Scegli i caratteri incorporati o caricati per il corpo del testo.",
+        "builtIn": "Integrato",
+        "yourFonts": "I tuoi caratteri"
+      },
+      "layout": {
+        "pageSpreads": "La pagina si allarga",
+        "pageSpreadsDescription": "Scegli come questo EPUB basato su immagini accoppia le pagine.",
+        "bookDefault": "Prenota predefinito",
+        "singlePage": "Pagina singola",
+        "readingFlow": "Flusso di lettura",
+        "readingFlowDescription": "Passa dallo scorrimento pagina a quello continuo.",
+        "paginated": "Paginato",
+        "scrolled": "Scorrito",
+        "textColumns": "Colonne di testo",
+        "textColumnsRange": "Intervallo: 1-10",
+        "columnGap": "Spazio tra le colonne",
+        "columnGapRange": "Intervallo: 0-50%",
+        "maxWidth": "Larghezza massima",
+        "maxWidthRange": "Intervallo: 400-1600",
+        "justifyText": "Giustificare il testo",
+        "justifyTextDescription": "Abilita l'allineamento del paragrafo a larghezza intera.",
+        "hyphenation": "Sillabazione",
+        "hyphenationDescription": "Abilita la sillabazione automatica delle interruzioni di parola."
+      }
+    },
+    "search": {
+      "placeholder": "Cerca nel libro (min {min} caratteri)...",
+      "searching": "Ricerca…",
+      "tooShort": "Digita almeno {min} caratteri",
+      "noResults": "Nessun risultato trovato",
+      "prompt": "Digita per cercare",
+      "resultCount": "{count, plural, =0 {nessun risultato} one {# risultato} other {# risultati} many {# risultati}}"
+    },
+    "sidebar": {
+      "tabs": {
+        "chapters": "Capitoli",
+        "bookmarks": "Segnalibri",
+        "highlights": "Punti salienti",
+        "toc": "Sommario",
+        "tocShort": "SOMMARIO",
+        "marksShort": "Segni",
+        "notesShort": "Note"
+      },
+      "pin": "Barra laterale bloccata",
+      "unpin": "Sblocca la barra laterale",
+      "close": "Chiudi la barra laterale",
+      "noChapters": "Nessun capitolo trovato",
+      "noBookmarks": "Nessun segnalibro ancora",
+      "noBookmarksMatch": "Nessun segnalibro corrisponde ai tuoi filtri",
+      "noHighlights": "Nessun momento saliente per ora",
+      "noHighlightsMatch": "Nessun punto in evidenza corrisponde ai tuoi filtri",
+      "searchBookmarks": "Cerca segnalibri...",
+      "searchHighlights": "Cerca in evidenza...",
+      "bookmarkFallback": "Segnalibro",
+      "locationUnavailable": "Posizione non disponibile",
+      "customColor": "Personalizzato ({color})",
+      "allColors": "Tutti i colori",
+      "allChapters": "Tutti i capitoli",
+      "notesOnly": "Solo note",
+      "deleteBookmark": "Elimina segnalibro",
+      "deleteHighlight": "Elimina l'evidenziazione",
+      "approximatePosition": "Sincronizzato dal dispositivo; posizione esatta non disponibile, salta al capitolo",
+      "sort": {
+        "readingOrder": "Ordine di lettura",
+        "newest": "Prima il più recente",
+        "oldest": "Prima il più vecchio"
+      }
+    },
+    "selection": {
+      "copy": "Copia",
+      "copied": "Copiato!",
+      "highlight": "Evidenziare",
+      "translate": "Traduci",
+      "define": "Definire",
+      "deleteAnnotation": "Elimina annotazione",
+      "apply": "Applica"
+    },
+    "note": {
+      "title": "Aggiungi nota",
+      "placeholder": "Scrivi la tua nota..."
+    },
+    "dictionary": {
+      "noDefinition": "Nessuna definizione trovata",
+      "loadError": "Impossibile caricare la definizione"
+    },
+    "translation": {
+      "original": "Originale",
+      "translation": "Traduzione",
+      "translating": "Traduzione...",
+      "noTranslation": "Nessuna traduzione ancora",
+      "viaProvider": "tramite {provider}",
+      "copyTranslation": "Copia traduzione"
+    },
+    "shortcuts": {
+      "title": "Scorciatoie da tastiera",
+      "groups": {
+        "panels": "Pannelli",
+        "reading": "Lettura",
+        "actions": "Azioni"
+      },
+      "toggleToc": "Attiva/disattiva il sommario",
+      "toggleSearch": "Attiva/disattiva la ricerca",
+      "toggleHelp": "Mostra/nascondi questo aiuto",
+      "closePanel": "Chiudi pannello",
+      "prevNextPage": "Pagina precedente/successiva",
+      "goToStart": "Vai all'inizio del libro",
+      "goToEnd": "Vai alla fine del libro",
+      "toggleBookmark": "Attiva/disattiva segnalibro",
+      "toggleFullscreen": "Attiva/disattiva lo schermo intero",
+      "cycleFooterMode": "Scorri la modalità informazioni piè di pagina"
+    },
+    "cbz": {
+      "tabs": {
+        "view": "Visualizza",
+        "reading": "Lettura",
+        "layout": "Disposizione"
+      },
+      "fitMode": "Modalità adatta",
+      "background": "Sfondo",
+      "scrollMode": "Modalità di scorrimento",
+      "scrollModeHint": "Utilizza \"Nessun intervallo\" per i webtoon e le strisce verticali.",
+      "readingDirection": "Direzione della lettura",
+      "pageView": "Visualizzazione della pagina",
+      "autoFallback": "Fallback automatico",
+      "spreadAlignmentLabel": "Allineamento della diffusione",
+      "spreadAlignmentHint": "L'allineamento dello spread non è disponibile in modalità fallback automatica.",
+      "spreadGap": "Divario di diffusione",
+      "spreadGapValue": "{value}px",
+      "focusTwoPageToggle": "Attiva/disattiva Focus su due pagine",
+      "forceTwoPage": "Forza due pagine",
+      "off": "Spento",
+      "on": "Su",
+      "widePages": "Pagine larghe",
+      "resetBookViewSettings": "Ripristina le impostazioni di visualizzazione del libro",
+      "resetConfirm": "Ripristinare le impostazioni di visualizzazione di questo libro sui valori predefiniti globali?",
+      "firstPage": "Prima pagina",
+      "lastPage": "Ultima pagina",
+      "fit": {
+        "page": "Adatta pagina",
+        "width": "Larghezza della pagina",
+        "height": "Altezza della pagina",
+        "actual": "Dimensioni reali"
+      },
+      "view": {
+        "single": "Singolo",
+        "twoPage": "Due pagine"
+      },
+      "scroll": {
+        "paged": "Paginato",
+        "infinite": "Infinito",
+        "noGaps": "Nessuna lacuna"
+      },
+      "direction": {
+        "ltr": "Da sinistra a destra",
+        "rtl": "Da R a L"
+      },
+      "spreadAlignment": {
+        "normal": "Normale",
+        "shifted": "Spostato"
+      },
+      "widePage": {
+        "auto": "Automatico",
+        "inSpreads": "Negli spread"
+      },
+      "bg": {
+        "black": "Nero",
+        "gray": "Grigio",
+        "white": "Bianco"
+      }
+    },
+    "audiobook": {
+      "untitled": "Senza titolo",
+      "loading": "Caricamento dell'audiolibro...",
+      "loadError": "Impossibile caricare l'audiolibro",
+      "noAudioFiles": "Nessun file audio trovato per questo libro.",
+      "speed": "Velocità",
+      "chapters": "Capitoli",
+      "bookmarks": "Segnalibri",
+      "volume": "Volume",
+      "muted": "Disattivato",
+      "sleep": "Dormi",
+      "chapterAbbrev": "cap.",
+      "sleepTimer": "Temporizzatore di sonno",
+      "minutes": "{count} minuti",
+      "endOfChapter": "Fine del capitolo",
+      "noChaptersAvailable": "Nessun capitolo disponibile",
+      "extend15": "+ 15 minuti",
+      "timeLeft": "({time} rimasto)",
+      "playbackSpeed": "Velocità di riproduzione",
+      "noChapters": "Nessun capitolo disponibile.",
+      "noBookmarks": "Nessun segnalibro ancora.",
+      "noBookmarksHint": "Tocca l'icona del segnalibro in alto per salvare la tua posizione corrente.",
+      "playerSettings": "Impostazioni del giocatore",
+      "skipBack": "Torna indietro",
+      "skipForward": "Vai avanti"
+    }
+  },
+  "scanner": {
+    "filesProgress": "{processed}/{total} file",
+    "booksFound": "{count, plural, =0 {nessun libro trovato} one {# libro trovato} other {# libri trovati} many {# libri trovati}}"
+  },
+  "series": {
+    "completion": {
+      "readOfTotal": "{read} di {total} letto ({percentage}%)"
+    },
+    "gaps": {
+      "label": "Possibili lacune:"
+    },
+    "filters": {
+      "title": "Filtri di serie",
+      "clearAll": "Cancella tutto",
+      "allLibraries": "Tutte le biblioteche",
+      "allCompletion": "Tutto il completamento",
+      "notStarted": "Non iniziato",
+      "inProgress": "In corso",
+      "complete": "Completo"
+    },
+    "list": {
+      "title": "Serie",
+      "showControlsAria": "Mostra i controlli della serie",
+      "searchPlaceholder": "Cerca serie o autore",
+      "sortButton": "Ordina",
+      "sortBy": "Ordina per",
+      "ascending": "Ascendente",
+      "descending": "Discendente",
+      "ascShort": "Asc",
+      "descShort": "Disc",
+      "filters": "Filtri",
+      "clear": "Cancella",
+      "noMatch": "Nessuna serie corrisponde ai tuoi filtri.",
+      "empty": "Nessuna serie trovata nelle tue librerie.",
+      "sort": {
+        "name": "Nome",
+        "bookCount": "Conteggio dei libri",
+        "recentAdditions": "Aggiunte recenti",
+        "readingProgress": "Progresso nella lettura"
+      }
+    },
+    "detail": {
+      "pageTitle": "Serie",
+      "pageTitleNamed": "Serie · {name}",
+      "pageTitleWithId": "Serie n.{id}",
+      "entityName": "Serie",
+      "bookCount": "{count, plural, =0 {niente libri} one {# libro} other {# libri} many {# libri}}",
+      "byAuthors": "di {authors}",
+      "moreAuthors": "+{count} altri",
+      "preparingEditor": "Redazione in preparazione...",
+      "editMetadata": "Modifica metadati",
+      "firstInSeries": "Primo della serie",
+      "untitled": "Senza titolo",
+      "loadingFirstBook": "Caricamento dell'anteprima del primo libro...",
+      "showLess": "Mostra meno",
+      "showMore": "Mostra di più",
+      "moreGenres": "+{count} altri",
+      "synopsis": "Sinossi",
+      "noDescription": "Nessuna descrizione disponibile.",
+      "updatingPreview": "Aggiornamento dell'anteprima...",
+      "noBooksToPreview": "Nessun libro disponibile per l'anteprima.",
+      "loadingSeries": "Caricamento serie...",
+      "booksHeading": "Libri",
+      "allLibraries": "Tutte le biblioteche",
+      "groupByMedia": "Raggruppa per supporto",
+      "noBooksFound": "Nessun libro trovato in questa serie",
+      "trySelectingLibrary": "Prova a selezionare un'altra libreria.",
+      "allBooksLoaded": "Tutti i libri {count} caricati",
+      "leadBookLoadError": "Impossibile caricare i dettagli del libro principale",
+      "noBooksToEdit": "Questa serie non ha libri da modificare.",
+      "loadFullSeriesError": "Impossibile caricare la serie completa per la modifica.",
+      "sort": {
+        "seriesOrder": "Ordine di serie",
+        "title": "Titolo",
+        "recentlyAdded": "Aggiunto di recente"
+      },
+      "order": {
+        "ascending": "Ascendente",
+        "descending": "Discendente"
+      }
+    }
+  },
+  "smartScope": {
+    "syncToKobo": "Sincronizza con Kobo",
+    "syncToKoboHint": "I libri corrispondenti a questo ambito verranno visualizzati sul tuo dispositivo Kobo",
+    "dialog": {
+      "name": "Nome",
+      "namePlaceholder": "ad es. Fantascienza non letta",
+      "icon": "Icona",
+      "iconPlaceholder": "Scegli un'icona...",
+      "nameRequired": "Il nome è obbligatorio",
+      "iconRequired": "Scegli un'icona",
+      "create": "Crea",
+      "creating": "Creazione...",
+      "saving": "Salvataggio..."
+    },
+    "createDialog": {
+      "title": "Nuovo ambito intelligente",
+      "visibleToAll": "Visibile a tutti gli utenti",
+      "createFailed": "Impossibile creare Smart Scope"
+    },
+    "saveAsDialog": {
+      "title": "Salva come SmartScope",
+      "save": "Salva SmartScope",
+      "saveFailed": "Impossibile salvare Smart Scope"
+    },
+    "editorPanel": {
+      "untitled": "SmartScope senza titolo",
+      "subtitle": "Configurare le impostazioni dell'ambito intelligente",
+      "counting": "contare...",
+      "bookCount": "{count, plural, =0 {niente libri} one {un libro} other {# libri} many {# libri}}",
+      "identity": "Identità",
+      "filters": "Filtri",
+      "noFilters": "Nessun filtro impostato. Tutti i libri accessibili saranno inclusi in questo ambito intelligente.",
+      "buildFromScratch": "Costruisci da zero",
+      "replaceWithTemplate": "Sostituisci con il modello:",
+      "defaultSort": "Ordinamento predefinito",
+      "saveChanges": "Salva modifiche",
+      "saveFailed": "Impossibile salvare",
+      "templates": {
+        "hasSeries": "Ha serie",
+        "addedRecently": "Aggiunto di recente",
+        "pdfOnly": "PDF Solo",
+        "noGenres": "Nessun genere",
+        "epubOnly": "EPUB Solo"
+      }
+    }
+  },
+  "statistics": {
+    "tabs": {
+      "library": "Statistiche della biblioteca",
+      "user": "La mia lettura"
+    },
+    "filter": {
+      "allLibraries": "Tutte le biblioteche",
+      "librarySelection": "{count} di {total} Biblioteche"
+    },
+    "config": {
+      "button": "Configura",
+      "title": "Configura grafici",
+      "description": "Trascina per riordinare, attiva/disattiva per mostrare o nascondere.",
+      "reset": "Ripristina le impostazioni predefinite"
+    },
+    "summary": {
+      "books": "Libri",
+      "authors": "Autori",
+      "series": "Serie",
+      "publishers": "Editori",
+      "storage": "Stoccaggio",
+      "genres": "Generi",
+      "languages": "Lingue",
+      "published": "Pubblicato",
+      "thisYear": "Quest'anno",
+      "started": "Iniziato",
+      "inProgress": "In corso",
+      "completed": "Completato",
+      "avgProgress": "Avanzamento medio"
+    },
+    "card": {
+      "loadError": "Impossibile caricare i dati",
+      "emptyTitle": "Nessun dato ancora",
+      "emptyDescription": "Nessun dato disponibile per questo grafico",
+      "unknownField": "{count, plural, =0 {nessun dato per questo campo} one {# il libro non contiene dati per questo campo} other {# i libri non hanno dati per questo campo} many {# i libri non hanno dati per questo campo}}"
+    },
+    "breakdown": {
+      "ariaLabel": "Suddividi per fonte o formato"
+    },
+    "empty": {
+      "notEnoughData": "Dati non ancora sufficienti"
+    },
+    "charts": {
+      "acquisitionLag": {
+        "title": "Ritardo di acquisizione"
+      },
+      "booksAddedOverTime": {
+        "title": "Libri aggiunti nel tempo",
+        "monthly": "Mensile",
+        "yearly": "Annuale",
+        "allTime": "Tutto il tempo",
+        "last5Years": "Ultimi 5 anni",
+        "lastYear": "L'anno scorso"
+      },
+      "formatDistribution": {
+        "title": "Distribuzione dei formati"
+      },
+      "formatShareOverTime": {
+        "title": "Formato condiviso nel tempo"
+      },
+      "genreCooccurrence": {
+        "title": "Genere Co-occorrenza"
+      },
+      "genreDistribution": {
+        "title": "Distribuzione del genere"
+      },
+      "languageDistribution": {
+        "title": "Distribuzione della lingua"
+      },
+      "largestBooks": {
+        "title": "I 50 libri più grandi"
+      },
+      "libraryIntegrity": {
+        "title": "Integrità della biblioteca"
+      },
+      "libraryMetadataCompleteness": {
+        "title": "Completezza dei metadati della libreria"
+      },
+      "metadataCompleteness": {
+        "title": "Completezza dei metadati"
+      },
+      "metadataFreshness": {
+        "title": "Freschezza dei metadati"
+      },
+      "metadataScoreDistribution": {
+        "title": "Distribuzione del punteggio dei metadati"
+      },
+      "pageCountDistribution": {
+        "title": "Distribuzione del conteggio delle pagine"
+      },
+      "publicationDecade": {
+        "title": "Decennio di pubblicazioni"
+      },
+      "publicationYearTimeline": {
+        "title": "Cronologia dell'anno di pubblicazione"
+      },
+      "storageByFormat": {
+        "title": "Archiviazione per formato"
+      },
+      "topAuthors": {
+        "title": "I 25 migliori autori"
+      },
+      "topSeries": {
+        "title": "Le migliori 50 serie"
+      },
+      "booksCompleted": {
+        "title": "Libri completati",
+        "notEnoughData": "Sono necessari almeno {count} libri completati per questo grafico."
+      },
+      "completionLatency": {
+        "title": "Latenza di completamento",
+        "notEnoughData": "Sono necessari almeno {count} libri completati per questo grafico."
+      },
+      "completionTimeline": {
+        "title": "Cronologia di completamento",
+        "notEnoughData": "Sono necessari almeno {count} libri completati per questo grafico."
+      },
+      "favoriteReadingDays": {
+        "title": "Giorni di lettura preferiti",
+        "notEnoughData": "È necessario leggere almeno {count} eventi per questo grafico."
+      },
+      "genreReadingTime": {
+        "title": "Tempo di lettura del genere",
+        "notEnoughData": "Sono necessari almeno {count} generi con tempo di lettura per questo grafico."
+      },
+      "goalTrajectory": {
+        "title": "Ritmo vs Obiettivo",
+        "noCompletedTitle": "Nessun libro ancora completato",
+        "noCompletedDescription": "Completa un libro in questo periodo per confrontare il tuo ritmo con il tuo obiettivo annuale.",
+        "notEnoughData": "Sono necessari almeno {count} libri completati per questo grafico."
+      },
+      "peakReadingHours": {
+        "title": "Ore di punta della lettura",
+        "notEnoughData": "È necessario leggere almeno {count} eventi per questo grafico."
+      },
+      "progressFunnel": {
+        "title": "Imbuto di avanzamento",
+        "modePercent": "Percentuale",
+        "modeCounts": "Conta",
+        "modeDropoff": "Riconsegna",
+        "started": "Iniziato {count}",
+        "notEnoughData": "Sono necessari almeno {count} libri iniziati per questo grafico.",
+        "noDropOffTitle": "Nessun abbandono osservato",
+        "noDropOffDescription": "Ogni libro iniziato è progredito attraverso tutte le fasi della canalizzazione in questo periodo."
+      },
+      "readingClock": {
+        "title": "Orologio da lettura",
+        "notEnoughData": "Sono necessarie almeno {count} sessioni di lettura per questo grafico."
+      },
+      "readingHeatmap": {
+        "title": "Lettura della mappa termica",
+        "notEnoughData": "È necessaria attività per almeno {count} giorni per questo grafico."
+      },
+      "readingPace": {
+        "title": "Ritmo della lettura",
+        "notEnoughData": "Sono necessarie almeno {count} sessioni con dati di avanzamento per questo grafico."
+      },
+      "readingSessionTimeline": {
+        "title": "Cronologia della sessione di lettura",
+        "dragOn": "Trascina: attivato",
+        "dragOff": "Trascina: disattivato",
+        "prev": "Prec",
+        "next": "Avanti",
+        "week": "Settimana {week}",
+        "dragHint": "Trascina le barre per spostare le sessioni. La durata è bloccata e le sessioni sovrapposte vengono rifiutate.",
+        "noSessionsTitle": "Nessuna sessione questa settimana",
+        "noSessionsDescription": "Utilizzare Prec./Successivo o il selettore settimana per visualizzare una settimana diversa.",
+        "overlapError": "La sessione si sovrappone a un'altra sessione in questa finestra",
+        "moveError": "Impossibile spostare la sessione"
+      },
+      "sessionArchetypes": {
+        "title": "Archetipi di sessione"
+      },
+      "sourceDistribution": {
+        "title": "Dove leggi",
+        "emptyTitle": "Nessuna attività di lettura ancora",
+        "emptyDescription": "Leggi sul Web, KOReader o Kobo per vedere la suddivisione della tua fonte."
+      }
+    }
+  },
+  "tools": {
+    "header": {
+      "entityManager": "Responsabile dell'entità",
+      "bulkRename": "Rinomina in blocco",
+      "duplicateBooks": "Libri duplicati"
+    },
+    "entityTypes": {
+      "authors": "Autori",
+      "genres": "Generi",
+      "tags": "Tag",
+      "narrators": "Narratori",
+      "publishers": "Editori",
+      "languages": "Lingue",
+      "series": "Serie"
+    },
+    "bulkRename": {
+      "previewToolbar": "Rinomina l'anteprima",
+      "renameSettings": "Rinominare le impostazioni",
+      "library": "Biblioteca",
+      "selectLibraryPlaceholder": "Seleziona una libreria...",
+      "noEligibleLibraries": "Nessuna libreria ha la ridenominazione dei file abilitata. Abilitalo nelle Impostazioni della Libreria.",
+      "refresh": "Aggiorna",
+      "applyRename": "Applica Rinomina",
+      "showFullPaths": "Mostra percorsi completi",
+      "columnsMenu": "Colonne",
+      "renamingInProgress": "Rinominare i file: puoi annullare in qualsiasi momento.",
+      "executionFailed": "La ridenominazione collettiva non è riuscita",
+      "previewFailed": "Impossibile caricare l'anteprima",
+      "noBooksMatch": "Nessun libro trovato corrispondente al filtro attuale.",
+      "openBookDetails": "Apri i dettagli del libro",
+      "columns": {
+        "title": "Titolo",
+        "currentPath": "Percorso attuale",
+        "newPath": "Nuovo percorso",
+        "status": "Stato"
+      },
+      "status": {
+        "willRename": "Rinominerà",
+        "unchanged": "Invariato",
+        "collision": "Collisione",
+        "noPattern": "Nessun modello",
+        "error": "Errore"
+      },
+      "filter": {
+        "all": "Tutto"
+      },
+      "summary": {
+        "label": "Sommario",
+        "toRename": "{count} per rinominare",
+        "unchanged": "{count} invariato",
+        "collisions": "{count, plural, =0 {# collisione} one {# collisione} other {# collisioni} many {# collisioni}}",
+        "errors": "{count, plural, =0 {# errore} one {# errore} other {# errori} many {# errori}}"
+      },
+      "empty": {
+        "title": "Scegli una libreria per iniziare",
+        "description": "Seleziona una libreria qui sopra per visualizzare in anteprima le modifiche di ridenominazione, filtrare per stato e applicare l'esecuzione di ridenominazione in blocco.",
+        "chooseLibrary": "Scegli Libreria"
+      },
+      "completed": {
+        "title": "Rinominazione collettiva completata",
+        "stats": "{succeeded} rinominato, {failed} fallito, {skipped} saltato ({processed} totale)"
+      },
+      "pagination": {
+        "showing": "Mostrando {from}-{to} di {total}"
+      },
+      "confirmDialog": {
+        "title": "Conferma la ridenominazione collettiva",
+        "body": "{count, plural, =0 {Questo rinominerà # libro su disco. I file con collisioni o errori verranno ignorati. Questa azione non può essere annullata.} one {Questo rinominerà # libro su disco. I file con collisioni o errori verranno ignorati. Questa azione non può essere annullata.} other {Questo rinominerà # libri su disco. I file con collisioni o errori verranno ignorati. Questa azione non può essere annullata.} many {Questo rinominerà # libri su disco. I file con collisioni o errori verranno ignorati. Questa azione non può essere annullata.}}",
+        "renameButton": "{count, plural, =0 {Rinominare # libro} one {Rinominare # libro} other {Rinominare # libri} many {Rinominare # libri}}"
+      }
+    },
+    "bookDuplicates": {
+      "scanSettings": "Impostazioni di scansione",
+      "title": "Libri duplicati",
+      "description": "Scansiona file e metadati per potenziali record duplicati. Durante una scansione non viene eliminato nulla.",
+      "scope": "Ambito della biblioteca",
+      "allLibraries": "Tutte le biblioteche accessibili",
+      "similarity": "Soglia per titoli simili",
+      "explainSimilarity": "Spiegare la soglia dei titoli simili",
+      "similarityHelp": "Solo per corrispondenze di titolo e autore simili. Anche almeno un autore e il tipo di libro devono corrispondere. In basso trova più possibili duplicati; più alto richiede titoli più vicini. I file identici, ISBN e i metadati esatti vengono controllati separatamente.",
+      "runScan": "Esegui la scansione",
+      "rescan": "Nuova scansione",
+      "status": {
+        "queued": "Scansione in coda",
+        "running": "Scansione di libri"
+      },
+      "groupsFound": "{count, plural, =0 {Nessun gruppo duplicato} one {Un gruppo duplicato} other {# gruppi duplicati} many {# gruppi duplicati}}",
+      "filter": "Tipo di corrispondenza",
+      "allReasons": "Tutti i tipi di corrispondenza",
+      "reasons": {
+        "file_hash": "Insieme di file identico",
+        "isbn": "Stesso ISBN",
+        "exact_metadata": "Titolo esatto e autori",
+        "fuzzy_metadata": "Titolo e autore simili"
+      },
+      "similarityValue": "{percent}% di somiglianza del titolo",
+      "notDuplicates": "Non duplicati",
+      "keepThis": "Tieni questo libro",
+      "discardThis": "Scarta questo libro",
+      "selectKeeperFirst": "Seleziona prima un custode",
+      "noDirectMatch": "Nessun confronto diretto con il portiere",
+      "moreFiles": "+{count} altri",
+      "showDetails": "Mostra dettagli",
+      "hideDetails": "Nascondi dettagli",
+      "deleteSelected": "Elimina {count} selezionato",
+      "openBook": "Apri i dettagli per {title}",
+      "unknownAuthor": "Autore sconosciuto",
+      "unknown": "Sconosciuto",
+      "none": "Nessuno",
+      "accessDenied": "Non hai l'autorizzazione per utilizzare lo strumento duplica libro.",
+      "pairDetails": "Dettagli della partita",
+      "pairLabel": "{first} e {second}",
+      "fields": {
+        "library": "Biblioteca",
+        "isbn": "ISBN",
+        "formats": "Formati",
+        "fileLocation": "File",
+        "files": "File",
+        "readingStatus": "Stato di lettura",
+        "progress": "Progresso",
+        "path": "Percorso della biblioteca",
+        "collections": "Collezioni",
+        "added": "Aggiunto",
+        "updated": "Aggiornato"
+      },
+      "initial": {
+        "title": "Trova libri duplicati",
+        "description": "Scegli l'ambito della libreria e il livello di somiglianza, quindi esegui una scansione. Nessun libro verrà modificato finché non confermi esplicitamente l'eliminazione."
+      },
+      "empty": {
+        "title": "Nessun gruppo duplicato trovato",
+        "description": "Nessun libro corrisponde all'ambito, al livello di somiglianza e al filtro di corrispondenza correnti."
+      },
+      "deleteDialog": {
+        "title": "Eliminare definitivamente i libri duplicati?",
+        "description": "{count, plural, =0 {Questo verrà eliminato definitivamente # libro selezionato e i suoi file.} one {Questo verrà eliminato definitivamente # libro selezionato e i suoi file.} other {Questo verrà eliminato definitivamente # libri selezionati e i relativi file.} many {Questo verrà eliminato definitivamente # libri selezionati e i relativi file.}}",
+        "warning": "I metadati, le raccolte, i dati di lettura e lo stato del dispositivo non vengono trasferiti nel libro conservato. Verranno rimossi anche i dati associati di altri utenti.",
+        "confirm": "{count, plural, =0 {Elimina # libro} one {Elimina # libro} other {Elimina # libri} many {Elimina # libri}}",
+        "success": "{count, plural, =0 {Nessun libro eliminato} one {Un libro duplicato eliminato} other {# libri duplicati eliminati} many {# libri duplicati eliminati}}"
+      },
+      "errors": {
+        "start": "Impossibile avviare la scansione duplicata.",
+        "status": "Impossibile caricare l'avanzamento della scansione.",
+        "scan": "La scansione duplicata non è riuscita. Prova a eseguirlo di nuovo.",
+        "results": "Impossibile caricare gruppi duplicati.",
+        "delete": "Impossibile eliminare i libri duplicati selezionati."
+      },
+      "pagination": {
+        "label": "Pagine dei gruppi duplicate",
+        "page": "Pagina {page} di {total}"
+      }
+    },
+    "entityManager": {
+      "unknown": "Sconosciuto",
+      "bookCount": "{count, plural, =0 {niente libri} one {# libro} other {# libri} many {# libri}}",
+      "sortPrefix": "· ordina: {sortName}",
+      "selectTargetToKeep": "Seleziona l'obiettivo da mantenere",
+      "writeToFiles": "Scrivere su file",
+      "writeChangesToFiles": "Scrivere modifiche ai file",
+      "mergeIntoTarget": "Unisci {count} nella destinazione",
+      "modes": {
+        "browse": "Sfoglia e gestisci",
+        "duplicates": "Trova duplicati"
+      },
+      "actions": {
+        "rename": "Rinominare",
+        "split": "Diviso"
+      },
+      "duplicates": {
+        "similarity": "Somiglianza:",
+        "scan": "Scansiona",
+        "scanning": "Scansione...",
+        "computing": "Candidati informatici...",
+        "computedAt": "I candidati hanno calcolato {date}",
+        "recompute": "Ricalcolare",
+        "noneComputed": "Nessun candidato ancora calcolato.",
+        "computeNow": "Calcola adesso",
+        "emptyTitle": "Trova entità duplicate",
+        "emptyDescription": "Regola la soglia di somiglianza e fai clic su Scansione per rilevare potenziali duplicati.",
+        "noneFoundTitle": "Nessun duplicato trovato",
+        "noneFoundDescription": "Non sono stati rilevati potenziali duplicati con le impostazioni attuali.",
+        "clustersFound": "{count, plural, =0 {nessun cluster trovato} one {# gruppo trovato} other {# cluster trovati} many {# cluster trovati}}",
+        "plusOthers": "{count, plural, =0 {+ # altro} one {+ # altro} other {+ # altri} many {+ # altri}}",
+        "percentSimilar": "{percent}% di somiglianza",
+        "pairDetails": "Dettagli della coppia",
+        "dismissEntityTitle": "Ignora tutte le coppie per questa entità",
+        "dismissPairTitle": "Ignora questa coppia"
+      },
+      "dismissed": {
+        "loading": "Caricamento delle coppie ignorate...",
+        "empty": "Nessuna coppia licenziata",
+        "restore": "Ripristina",
+        "restoreTitle": "Ripristina questa coppia",
+        "hidePairs": "Nascondi le coppie ignorate",
+        "showPairs": "Mostra le coppie ignorate"
+      },
+      "browse": {
+        "searchPlaceholder": "Cerca...",
+        "emptyOnly": "Solo vuoto",
+        "clear": "Cancella",
+        "noEntities": "Nessuna entità trovata",
+        "mergeCount": "Unisci ({count})",
+        "deleteCount": "Elimina ({count})",
+        "totalCount": "{count} totale",
+        "sortLabel": "ordina: {sortName}",
+        "sort": {
+          "nameAsc": "Nome dalla A alla Z",
+          "nameDesc": "Nome ZA",
+          "fewestBooks": "Meno libri",
+          "mostBooks": "La maggior parte dei libri"
+        }
+      },
+      "deleteMode": {
+        "label": "Modalità Elimina",
+        "softTitle": "Eliminazione temporanea",
+        "softDescription": "Scollegati da tutti i libri ma conserva il record dell'entità",
+        "softDescriptionPlural": "Scollegati da tutti i libri ma conserva i record dell'entità",
+        "hardTitle": "Eliminazione definitiva",
+        "hardDescription": "Rimuovi l'entità e tutte le associazioni in modo permanente",
+        "hardDescriptionPlural": "Rimuovi le entità e tutte le associazioni in modo permanente"
+      },
+      "renameModal": {
+        "title": "Rinomina entità",
+        "currentName": "Nome attuale",
+        "newName": "Nuovo nome"
+      },
+      "deleteModal": {
+        "title": "Elimina entità",
+        "confirm": "Sei sicuro di voler eliminare {name}?"
+      },
+      "splitModal": {
+        "title": "Entità divisa",
+        "splitting": "Divisione",
+        "newNames": "Nuovi nomi (min 2)",
+        "namePlaceholder": "Inserisci il nome...",
+        "addAnother": "Aggiungine un altro"
+      },
+      "bulkDeleteModal": {
+        "title": "Eliminazione in blocco",
+        "confirm": "{count, plural, =0 {Sei sicuro di voler eliminare? # entità selezionata?} one {Sei sicuro di voler eliminare? # entità selezionata?} other {Sei sicuro di voler eliminare? # entità selezionate?} many {Sei sicuro di voler eliminare? # entità selezionate?}}",
+        "deleteButton": "Elimina {count}"
+      },
+      "mergeModal": {
+        "title": "Unisci entità",
+        "description": "Seleziona quale entità mantenere. Gli altri verranno uniti e rimossi."
+      }
+    }
+  },
+  "views": {
+    "entity": {
+      "book": "Libro",
+      "collection": "Raccolta",
+      "library": "Biblioteca",
+      "smartScope": "SmartScope"
+    },
+    "common": {
+      "retry": "Riprova"
+    },
+    "bookView": {
+      "sort": "Ordina",
+      "sortOn": "Su",
+      "resetSort": "Ripristina l'ordinamento predefinito",
+      "filters": "Filtri",
+      "clear": "Cancella",
+      "clearAllFilters": "Cancella tutti i filtri",
+      "expandSeries": "Espandi serie",
+      "collapseSeries": "Comprimi serie",
+      "expanded": "Espanso",
+      "exportMetadata": "Esporta metadati",
+      "showControlsAria": "Mostra i controlli della libreria",
+      "export": "Esportazione",
+      "searchPlaceholder": "Cerca titolo, autore, serie, narratore...",
+      "allBooksLoaded": "Tutti i libri {count} caricati"
+    },
+    "notFound": {
+      "title": "Pagina non trovata",
+      "description": "La pagina che stai cercando non esiste.",
+      "goHome": "Vai a casa"
+    },
+    "dashboard": {
+      "customize": "Personalizza il cruscotto",
+      "allShelvesHidden": "Tutti gli scaffali sono nascosti.",
+      "greeting": {
+        "night": "Buona notte,",
+        "morning": "buongiorno,",
+        "afternoon": "Buon pomeriggio,",
+        "evening": "Buonasera,",
+        "fallbackName": "lì"
+      }
+    },
+    "bookDetail": {
+      "title": "Libro",
+      "titleWithId": "Libro n.{id}",
+      "pageTitle": {
+        "book": "Prenota · {base}",
+        "editMetadata": "Modifica metadati · {base}",
+        "edit": "Modifica · {base}",
+        "files": "File · {base}",
+        "readingLog": "Registro di lettura · {base}",
+        "highlights": "In evidenza · {base}"
+      }
+    },
+    "bookDock": {
+      "title": "Book Dock",
+      "newFilesDetected": "Nuovi file rilevati",
+      "reconnecting": "Riconnessione",
+      "rescanFailed": "Nuova scansione non riuscita",
+      "totalInDock": "{size} in Book Dock",
+      "dropFiles": "Trascina i file nel Book Dock",
+      "supportedFormats": "Supportato: {formats}",
+      "empty": {
+        "noSearchMatch": "Nessun file corrisponde a \"{query}\"",
+        "noStatusFiles": "Nessun file {status}",
+        "uploadPrompt": "Carica i file o rilasciali nella cartella Book Dock"
+      },
+      "retry": {
+        "noneToRetry": "Nessun file di errore da riprovare",
+        "retrying": "{count, plural, =0 {Nuovo tentativo con un file} one {Nuovo tentativo con un file} other {Nuovo tentativo # file} many {Nuovo tentativo # file}}"
+      },
+      "applyFetched": {
+        "applied": "{count, plural, =0 {Applicato a nessun file} one {Applicato a un file} other {Applicato a # file} many {Applicato a # file}}",
+        "skippedEdited": "{count, plural, =0 {saltato un file perché hanno modifiche manuali} one {saltato un file perché presenta modifiche manuali} other {saltato # file perché hanno modifiche manuali} many {saltato # file perché hanno modifiche manuali}}",
+        "skippedNoMetadata": "{count, plural, =0 {ha saltato un file perché non hanno metadati recuperati} one {ha saltato un file perché non contiene metadati recuperati} other {saltato # file perché non hanno metadati recuperati} many {saltato # file perché non hanno metadati recuperati}}",
+        "noneApplied": "Nessun file applicato; {reasons}",
+        "noneSelected": "Nessun file selezionato"
+      }
+    },
+    "collection": {
+      "title": "Raccolta",
+      "pageTitle": "Collezione · {name}",
+      "pageTitleWithId": "Collezione n.{id}",
+      "editCollection": "Modifica raccolta",
+      "showControlsAria": "Mostra i controlli della raccolta",
+      "loadError": "Impossibile caricare questa raccolta",
+      "toast": {
+        "removed": "{count, plural, =0 {Nessun libro rimosso dalla collezione} one {Rimosso un libro dalla collezione} other {Rimosso # libri da collezione} many {Rimosso # libri da collezione}}",
+        "removeFailed": "Impossibile rimuovere i libri dalla raccolta"
+      },
+      "empty": {
+        "noSearchMatch": "Nessun libro corrisponde a questa ricerca",
+        "noSearchMatchHint": "Prova un termine di ricerca diverso o cancella la ricerca.",
+        "noBooks": "Nessun libro in questa raccolta",
+        "noBooksHint": "Seleziona i libri dalla tua libreria e aggiungili qui."
+      }
+    },
+    "library": {
+      "title": "Biblioteca",
+      "pageTitle": "Biblioteca · {name}",
+      "pageTitleWithId": "Libreria n.{id}",
+      "filterRules": "Regole di filtro",
+      "saveAsSmartScope": "Salva come Smart Scope",
+      "saveScope": "Salva ambito",
+      "saveAsSmartScopeTooltip": "Salva questo filtro come Smart Scope denominato",
+      "saved": "Salvato",
+      "saveFilter": "Salva filtro",
+      "filterSaved": "Filtro salvato",
+      "saveFilterTooltip": "Salva filtro per questa libreria",
+      "removeSavedFilter": "Rimuovi il filtro salvato",
+      "empty": {
+        "noFilterMatch": "Nessun libro corrisponde ai tuoi filtri",
+        "noFilterMatchHint": "Prova a modificare o cancellare i filtri per vedere più libri.",
+        "clearFilters": "Cancella filtri",
+        "scanning": "Scansione della tua libreria...",
+        "scanningHint": "I libri appariranno qui man mano che vengono scoperti.",
+        "emptyLibrary": "La tua libreria è vuota",
+        "emptyLibraryHint": "Una volta aggiunti i libri a questa libreria, verranno visualizzati qui."
+      },
+      "querySelection": {
+        "loadedSelected": "{selected} di {total} libri caricati selezionati.",
+        "selectAllMatching": "Seleziona tutti i {total} libri corrispondenti"
+      }
+    },
+    "smartScope": {
+      "title": "SmartScope",
+      "pageTitle": "SmartScope · {name}",
+      "pageTitleWithId": "SmartScope #{id}",
+      "defaultName": "Ambito intelligente",
+      "filter": "Filtra",
+      "edit": "Modifica ambito intelligente",
+      "showControlsAria": "Mostra i controlli Smart Scope",
+      "hideFilter": "Nascondi filtro",
+      "showFilter": "Mostra filtro",
+      "confirmDelete": "Confermi?",
+      "loadError": "Impossibile caricare questo SmartScope",
+      "toast": {
+        "deleted": "\"{name}\" eliminato",
+        "deleteFailed": "Impossibile eliminare \"{name}\""
+      },
+      "empty": {
+        "noRules": "Nessuna regola configurata",
+        "noRulesHint": "Apri l'editor per definire quali libri visualizzare in questo smartScope utilizzando filtri e regole di ordinamento.",
+        "configure": "Configura SmartScope",
+        "noMatch": "Nessun libro corrisponde a questo smartScope",
+        "noMatchHint": "Prova a modificare le regole del filtro.",
+        "edit": "Modifica SmartScope"
+      }
+    }
+  },
+  "whatsNew": {
+    "title": "Cosa c'è di nuovo",
+    "subtitle": "Tutto ciò che viene spedito, prima il più recente.",
+    "versionPrefix": "Versione {version}",
+    "newUpdates": "{count, plural, =0 {nessun nuovo aggiornamento} one {un nuovo aggiornamento} other {# nuovi aggiornamenti} many {# nuovi aggiornamenti}}",
+    "remindLater": "Ricordamelo più tardi",
+    "gotIt": "Capito",
+    "latest": "Ultimi",
+    "fullChangelog": "Registro delle modifiche completo",
+    "seeAllReleases": "Vedi tutte le versioni",
+    "versions": "Versioni",
+    "currentVersion": "Versione attuale",
+    "youreHere": "Sei qui",
+    "searchPlaceholder": "Cerca versioni…",
+    "noReleasesFound": "Nessuna versione trovata.",
+    "noHighlights": "Nessun punto saliente per questa versione.",
+    "showChangelog": "Mostra il registro delle modifiche completo",
+    "hideChangelog": "Nascondi il registro completo delle modifiche",
+    "openOnGitHub": "Apri su GitHub",
+    "loadMore": "Carica di più",
+    "loadingMore": "Caricamento…",
+    "loadFailed": "Impossibile caricare le versioni",
+    "loadMoreFailed": "Impossibile caricare altre versioni. Per favore riprova.",
+    "loadErrorHint": "Impossibile caricare le versioni. Controlla la connessione e riprova.",
+    "retry": "Riprova",
+    "imageViewer": "Visualizzatore di immagini",
+    "closeImage": "Chiudi immagine",
+    "previousImage": "Immagine precedente",
+    "nextImage": "Immagine successiva"
+  },
+  "titles": {
+    "dashboard": "Cruscotto",
+    "libraries": "Biblioteche",
+    "opds": "OPDS",
+    "koboSync": "Kobo Sincronizza",
+    "koreaderSync": "KOReader Sincronizza",
+    "bookDock": "Book Dock",
+    "whatsNew": "Cosa c'è di nuovo",
+    "annotations": "Annotazioni",
+    "achievements": "Risultati",
+    "statistics": "Statistiche",
+    "authors": "Autori",
+    "series": "Serie",
+    "entityManager": "Responsabile dell'entità",
+    "bulkRename": "Rinomina in blocco",
+    "duplicateBooks": "Libri duplicati",
+    "notFound": "Non trovato",
+    "signIn": "Accedi",
+    "initialSetup": "Configurazione iniziale",
+    "forgotPassword": "Password dimenticata",
+    "resetPassword": "Reimposta password",
+    "completingSignIn": "Completamento dell'accesso",
+    "magicLinkLogin": "Accesso al collegamento magico",
+    "readPrefix": "Leggi",
+    "emailSuffix": "E-mail",
+    "library": "Biblioteca",
+    "smartScope": "SmartScope",
+    "collection": "Raccolta",
+    "author": "Autore",
+    "book": "Libro",
+    "seriesItem": "Serie",
+    "appearance": {
+      "theme": "Visualizzazione",
+      "book-covers": "Copertine di libri",
+      "icons": "Icone",
+      "layout": "Disposizione dello schermo",
+      "behavior": "Comportamento della libreria"
+    },
+    "reader": {
+      "general": "Impostazioni del lettore",
+      "ebook": "Lettore di eBook",
+      "pdf": "PDF Lettore",
+      "comics": "Lettore di fumetti",
+      "audio": "Lettore di audiolibri",
+      "fonts": "Caratteri del lettore"
+    },
+    "email": {
+      "providers": "Fornitori",
+      "recipients": "Destinatari",
+      "groups": "Gruppi",
+      "templates": "Modelli",
+      "preferences": "Preferenze",
+      "history": "Storia"
+    },
+    "metadata": {
+      "providers": "Fornitori",
+      "field-rules": "Regole a livello di campo",
+      "custom-fields": "Metadati personalizzati",
+      "genre-blocklist": "Blocklist di genere",
+      "score": "Punteggio di fiducia",
+      "auto-fetch": "Prenota Recupero automatico",
+      "authors": "Recupero automatico dell'autore"
+    },
+    "admin": {
+      "users": "Utenti",
+      "account-activity": "Attività dell'account",
+      "magic-links": "Collegamenti magici",
+      "oidc": "OIDC /SSO"
+    },
+    "system": {
+      "file-naming": "Denominazione dei file",
+      "book-dock": "Book Dock",
+      "maintenance": "Manutenzione",
+      "audit-log": "Registro di controllo"
+    },
+    "account": {
+      "profile": "Conto",
+      "privacy": "Privacy e condivisione",
+      "notifications": "Notifiche",
+      "restrictions": "Restrizioni sui contenuti"
+    }
+  }
+}

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -467,7 +467,7 @@
       },
       "feedback": {
         "unsavedChanges": "Modifiche non salvate",
-        "allSaved": "Tutte le modifiche salvate"
+        "discard": "Scarta"
       },
       "profile": {
         "securityHeading": "Profilo e sicurezza",
@@ -484,7 +484,11 @@
         "accountTypeLocal": "Locale",
         "nameRequired": "Il nome è obbligatorio",
         "updateFailed": "Impossibile aggiornare il profilo",
-        "updated": "Profilo aggiornato"
+        "updated": "Profilo aggiornato",
+        "usernameHint": "Il tuo nome utente non può essere modificato.",
+        "passwordHint": "Modifica la password che usi per accedere.",
+        "passwordHintOidc": "La tua password è gestita dal tuo provider di identità.",
+        "passwordHintShared": "Gli account condivisi accedono tramite un collegamento magico e non hanno una password."
       },
       "readingPreferences": {
         "title": "Preferenze di lettura",
@@ -492,7 +496,10 @@
         "timezone": "Fuso orario",
         "save": "Salva le preferenze",
         "enableAchievements": "Abilita risultati",
-        "enableAchievementsHint": "Tieni traccia dei progressi nei risultati e mostra l'interfaccia relativa ai risultati. Gestisci le notifiche degli obiettivi separatamente in Notifiche."
+        "enableAchievementsHint": "Tieni traccia dei progressi nei risultati e mostra l'interfaccia relativa ai risultati. Gestisci le notifiche degli obiettivi separatamente in Notifiche.",
+        "achievementsEnabled": "Risultati abilitati",
+        "achievementsDisabled": "Risultati disabilitati",
+        "achievementsSaveFailed": "Impossibile aggiornare la preferenza dei risultati"
       },
       "preferences": {
         "saveFailed": "Impossibile salvare le preferenze",
@@ -534,7 +541,9 @@
           "title": "Scollegare l'identità {provider}?",
           "description": "Inserisci la tua password per confermare. Non potrai più accedere con questo provider.",
           "currentPassword": "Password attuale"
-        }
+        },
+        "description": "Accedi con un provider di identità esterno collegato a questo account.",
+        "unlinkAria": "Scollega {provider}"
       },
       "tour": {
         "title": "Visita guidata",
@@ -563,6 +572,11 @@
           "title": "Generi bloccati",
           "description": "I libri di uno qualsiasi di questi generi ti sono nascosti."
         }
+      },
+      "groups": {
+        "profile": "Profilo",
+        "preferences": "Preferenze",
+        "security": "Sicurezza e accesso"
       }
     },
     "magicLinks": {
@@ -596,10 +610,10 @@
         "createdBy": "Creato da",
         "expires": "Scade",
         "uses": "Usi",
-        "lastUsed": "Ultimo usato",
         "created": "Creato",
         "status": "Stato",
-        "totalUses": "Usi totali"
+        "totalUses": "Usi totali",
+        "actions": "Azioni"
       },
       "createDialog": {
         "title": "Crea un collegamento magico",
@@ -627,7 +641,12 @@
       "emptyTitle": "Nessun collegamento magico ancora creato",
       "emptyHint": "Fai clic su \"{action}\" per generare un accesso condivisibile URL.",
       "noActiveTitle": "Nessun collegamento magico attivo",
-      "noActiveHint": "Tutti i collegamenti magici generati per questa pagina sono scaduti o sono stati revocati."
+      "noActiveHint": "Tutti i collegamenti magici generati per questa pagina sono scaduti o sono stati revocati.",
+      "copyLinkAria": "Copia il collegamento per {label}",
+      "pauseAria": "Metti in pausa {label}",
+      "resumeAria": "Riprendi {label}",
+      "revokeAria": "Revoca {label}",
+      "lastUsedLabel": "Ultimo utilizzo: {date}"
     },
     "oidc": {
       "title": "OIDC /SSO",
@@ -1692,9 +1711,6 @@
         "subtitle": "Controlla il modo in cui i file vengono organizzati sul disco quando vengono caricati e il modo in cui vengono denominati quando vengono scaricati utilizzando i token segnaposto.",
         "copy": "Copia",
         "previewLabel": "Anteprima:",
-        "fileAsBookPreview": "Archivia come anteprima del libro",
-        "folderAsBookPreview": "Cartella come anteprima del libro",
-        "downloadPreview": "Scarica l'anteprima",
         "globalDefaults": "Impostazioni predefinite globali",
         "crossPlatform": "Sanificazione del percorso multipiattaforma",
         "crossPlatformHint": "Rendi sicuri i nomi di file e cartelle generati su Windows sostituendo i caratteri non validi e i nomi riservati e rimuovendo i punti e gli spazi finali. Disabilita solo per configurazioni solo Linux che mantengono intenzionalmente quei caratteri.",
@@ -1711,15 +1727,10 @@
         "orgFolderAsBook": "Cartella come libro",
         "orgFileAsBook": "Archivia come libro",
         "resetToDefault": "Ripristina le impostazioni predefinite",
-        "patternReference": "Riferimento al modello",
-        "placeholderReference": "Riferimento al segnaposto",
-        "placeholderReferenceHint": "- guida per la creazione di modelli di denominazione personalizzati",
         "tokens": "Gettoni",
-        "tokensHint": "Copia rapidamente i segnaposto",
         "clickTokenHint": "Fai clic su qualsiasi token per copiarlo negli appunti.",
         "copyValue": "Copia {value}",
         "modifiers": "Modificatori",
-        "modifiersHint": "Trasforma i valori dei token",
         "modifiersExplain": "Aggiungi un modificatore all'interno di un token per trasformarne il valore:",
         "modFirst": "Solo primo valore",
         "modSort": "Ultimo, Primo formato",
@@ -1728,14 +1739,10 @@
         "folderOnlyPrefix": "Termina uno schema con",
         "folderOnlySuffix": "per specificare solo una cartella. Il nome del file originale verrà conservato al suo interno.",
         "conditionalLogic": "Logica condizionale",
-        "conditionalLogicHint": "Segmenti facoltativi e fallback",
         "conditionalPart1": "Avvolgiti",
         "conditionalPart2": "per saltare un segmento quando il suo token è vuoto. Utilizzare",
         "conditionalPart3": "per un valore predefinito.",
         "examples": "Esempi",
-        "patternExamples": "Esempi di modelli",
-        "patternExamplesHint": "Modelli già pronti per gli stili di libreria più comuni",
-        "copyPatternTooltip": "Copia il motivo negli appunti",
         "exCalibre": "predefinito in stile Calibre",
         "exSeriesReader": "Lettore di serie",
         "exCleanDownload": "Pulisci il nome del file di download",
@@ -1763,7 +1770,37 @@
         "patternCopied": "Modello copiato negli appunti",
         "copyPatternFailed": "Impossibile copiare il modello",
         "labelCopied": "{label} copiato negli appunti",
-        "copyLabelFailed": "Impossibile copiare {label}"
+        "copyLabelFailed": "Impossibile copiare {label}",
+        "patternHelp": "Guida ai modelli",
+        "patternHelpDescription": "Token, modificatori e modelli pronti all'uso da copiare in qualsiasi campo.",
+        "copyPreview": "Copia {label}",
+        "copyExample": "Copia il modello {label}",
+        "invalidCharacters": "Il modello contiene caratteri non validi",
+        "fileAsBookSaved": "Impostazione predefinita Archivia come libro salvata",
+        "folderAsBookSaved": "Impostazione predefinita Cartella come libro salvata",
+        "downloadPatternSaved": "Modello di download salvato",
+        "savePatternFailed": "Impossibile salvare il modello",
+        "saveDownloadPatternFailed": "Impossibile salvare il modello di download",
+        "crossPlatformEnabled": "Sanificazione del percorso multipiattaforma abilitata",
+        "crossPlatformDisabled": "Sanificazione del percorso multipiattaforma disabilitata",
+        "crossPlatformSaveFailed": "Impossibile salvare la sanificazione del percorso multipiattaforma",
+        "librarySaved": "Modello salvato per {name}",
+        "librarySaveFailed": "Impossibile salvare il modello della biblioteca",
+        "saveLibraryPattern": "Salva il modello per {name}",
+        "resetLibraryPattern": "Ripristina {name} al modello predefinito",
+        "tokenTitle": "Titolo del libro",
+        "tokenSubtitle": "Sottotitolo del libro",
+        "tokenAuthors": "Autore/i, separati da virgole",
+        "tokenYear": "Anno di pubblicazione",
+        "tokenSeries": "Nome della serie",
+        "tokenSeriesIndex": "Indice della serie (con zeri iniziali)",
+        "tokenPublisher": "Editore",
+        "tokenIsbn": "ISBN-13",
+        "tokenLanguage": "Lingua",
+        "tokenOriginalFilename": "Nome file originale (senza estensione)",
+        "tokenExtension": "Estensione del file (senza punto)",
+        "patternHelpIntro": "I modelli usano token come {titleToken} e {authorsToken}, oltre a modificatori e segmenti facoltativi.",
+        "browseTokensAndExamples": "Sfoglia token ed esempi"
       },
       "kobo": {
         "title": "Kobo Sincronizza",
@@ -2451,19 +2488,15 @@
     },
     "usersPage": {
       "usersTitle": "Utenti",
-      "magicLinksTitle": "Collegamenti magici",
       "usersSubtitle": "Gestire gli account utente e le assegnazioni delle autorizzazioni.",
-      "magicLinksSubtitle": "Crea collegamenti di accesso condivisibili per account condivisi.",
       "createUser": "Crea utente",
-      "createLink": "Crea collegamento",
-      "usersTab": "Utenti",
-      "magicLinksTab": "Collegamenti magici",
       "columns": {
         "name": "Nome",
         "username": "Nome utente",
         "email": "E-mail",
         "access": "Accesso",
-        "status": "Stato"
+        "status": "Stato",
+        "actions": "Azioni"
       },
       "adminBadge": "Ammin",
       "permissionCount": "{count, plural, =0 {nessuna autorizzazione} one {un permesso} other {# autorizzazioni} many {# autorizzazioni}}",
@@ -2481,11 +2514,10 @@
       "deleteDialogBody": "Elimina l'utente \"{username}\". Questa azione non può essere annullata.",
       "deleting": "Eliminazione...",
       "errors": {
-        "loadData": "Impossibile caricare i dati",
         "load": "Impossibile caricare",
-        "deleteUser": "Impossibile eliminare l'utente"
+        "deleteUser": "Impossibile eliminare l'utente",
+        "resetPassword": "Impossibile creare un collegamento per la reimpostazione della password"
       },
-      "currentUsers": "Utenti attuali",
       "defaultLibraryAccess": {
         "title": "Accesso alla libreria predefinito",
         "subtitle": "Accesso visualizzatore concesso agli utenti autoregistrati e con provisioning OIDC.",
@@ -2493,9 +2525,37 @@
         "noLibraries": "Nessuna libreria disponibile.",
         "save": "Salva le impostazioni predefinite",
         "saving": "Salvataggio...",
-        "saved": "Accesso predefinito alla libreria salvato.",
         "saveError": "Impossibile salvare l'accesso predefinito alla libreria"
-      }
+      },
+      "filters": {
+        "search": "Cerca utenti",
+        "searchPlaceholder": "Cerca per nome, nome utente o email",
+        "sort": "Ordina utenti",
+        "usernameAsc": "Nome utente A-Z",
+        "nameAsc": "Nome A-Z",
+        "newest": "Prima i più recenti",
+        "oldest": "Prima i più vecchi",
+        "apply": "Applica",
+        "clear": "Cancella",
+        "state": "Filtra utenti",
+        "allUsers": "Tutti gli utenti",
+        "admins": "Amministratori",
+        "active": "Attivo",
+        "inactive": "Inattivo"
+      },
+      "empty": {
+        "title": "Ancora nessun utente",
+        "description": "Crea il primo account per iniziare.",
+        "filtered": "Nessun utente corrisponde alla ricerca e ai filtri attuali."
+      },
+      "pagination": {
+        "label": "Impaginazione degli utenti",
+        "page": "Pagina {page} di {totalPages}"
+      },
+      "editUserAria": "Modifica {name}",
+      "resetPasswordAria": "Reimposta la password di {name}",
+      "deleteUserAria": "Elimina {name}",
+      "moreActionsAria": "Altre azioni per {name}"
     }
   },
   "annotations": {
@@ -4298,17 +4358,17 @@
         "title": "Ti piace BookOrbit?",
         "body": "Se BookOrbit ti sta aiutando con la tua libreria, considera di rendere protagonista il progetto su GitHub. Aiuta più persone a scoprire l'app e supporta lo sviluppo continuo.",
         "cta": "Speciale BookOrbit su GitHub"
-      }
+      },
+      "surfaceOpacity": "Opacità della superficie",
+      "surfaceOpacityValue": "{value}%"
     },
     "sidebar": {
-      "tagline": "Il tuo spazio di lettura",
       "dashboard": "Cruscotto",
       "authors": "Autori",
       "series": "Serie",
       "tools": "Strumenti",
       "libraries": "Biblioteche",
       "newLibrary": "Nuova Biblioteca",
-      "libraryScanning": "{name} - Scansione {pct}%",
       "scanProgress": "{processed} / {total} libri",
       "smartScopes": "Ambiti intelligenti",
       "newSmartScope": "Nuovo ambito intelligente",
@@ -4316,15 +4376,41 @@
       "collections": "Collezioni",
       "newCollection": "Nuova collezione",
       "noCollections": "Nessuna raccolta ancora",
-      "latest": "Ultimi {version}",
       "newReleaseNotes": "Nuove note di rilascio disponibili",
       "support": "Supporto BookOrbit",
-      "supportShort": "Supporto",
       "supportAria": "Supporta BookOrbit su Ko-fi",
       "sectionHeader": {
         "add": "Aggiungi",
+        "showAll": "Mostra tutto",
+        "showCount": "Mostra {count}",
+        "rowsShown": "Righe mostrate",
+        "menuAria": "Opzioni della sezione per {section}",
         "reorder": "Riordina",
         "doneReordering": "Riordino finito"
+      },
+      "noLibraries": "Ancora nessuna biblioteca",
+      "clearFilter": "Cancella filtro",
+      "filterSummary": "{shown} di {total} mostrati",
+      "filterLibraries": "Filtra biblioteche",
+      "filterLibrariesPlaceholder": "Filtra biblioteche...",
+      "filterSmartScopes": "Filtra ambiti intelligenti",
+      "filterSmartScopesPlaceholder": "Filtra ambiti intelligenti...",
+      "filterCollections": "Filtra collezioni",
+      "filterCollectionsPlaceholder": "Filtra collezioni...",
+      "seeAllLibraries": "Vedi tutte le biblioteche ({count})",
+      "seeAllSmartScopes": "Vedi tutti gli ambiti intelligenti ({count})",
+      "seeAllCollections": "Vedi tutte le collezioni ({count})",
+      "updateAvailable": "Aggiorna {version}",
+      "zones": {
+        "browse": "Sfoglia"
+      },
+      "reorder": {
+        "gripAria": "Riordina {name}",
+        "lifted": "{name} sollevato, posizione {position} di {total}. Usa i tasti freccia per spostarlo.",
+        "moved": "{name}, posizione {position} di {total}",
+        "dropped": "{name} rilasciato alla posizione {position} di {total}",
+        "cancelled": "Riordino annullato. {name} è tornato alla posizione {position} di {total}.",
+        "filteredHint": "Cancella il filtro per riordinare"
       }
     },
     "selectionActionBar": {
@@ -4424,6 +4510,24 @@
         "typeAndEnter": "Digita e premi Invio per aggiungere",
         "pressEnter": "Premi Invio per aggiungere"
       }
+    },
+    "entityIndex": {
+      "sortBy": "Ordina per",
+      "sort": {
+        "custom": "Ordine personalizzato",
+        "name": "Nome",
+        "bookCount": "Numero di libri"
+      },
+      "ascending": "Ascendente",
+      "descending": "Discendente",
+      "clearSearch": "Cancella la ricerca",
+      "resultCount": "{shown} di {total}",
+      "noMatches": "Nessuna corrispondenza",
+      "noMatchesHint": "Prova con un altro termine di ricerca.",
+      "bookCount": "Libri: {count}",
+      "librariesEmptyHint": "Crea una biblioteca per iniziare ad aggiungere libri.",
+      "smartScopesEmptyHint": "Gli ambiti intelligenti salvano un insieme di filtri che usi spesso.",
+      "collectionsEmptyHint": "Le collezioni raggruppano i libri che scegli manualmente."
     }
   },
   "customIcons": {
@@ -5552,7 +5656,61 @@
       "saveFailed": "Impossibile salvare le preferenze",
       "savePreferenceFailed": "Impossibile salvare la preferenza",
       "whatsNewToggle": "Mostra \"Novità\" dopo gli aggiornamenti",
-      "whatsNewToggleHint": "Un popup che evidenzia le nuove funzionalità dopo gli aggiornamenti dell'app. L'archivio rimane disponibile in ogni caso."
+      "whatsNewToggleHint": "Un popup che evidenzia le nuove funzionalità dopo gli aggiornamenti dell'app. L'archivio rimane disponibile in ogni caso.",
+      "groups": {
+        "library": "Biblioteca",
+        "files": "File",
+        "integrations": "Integrazioni",
+        "personal": "Personale",
+        "app": "Aggiornamenti dell'app"
+      },
+      "enabledCount": "{enabled} di {total} abilitati",
+      "categories": {
+        "scanning": {
+          "label": "Scansione della biblioteca",
+          "description": "Quando una scansione della biblioteca termina, non riesce o trova libri mancanti."
+        },
+        "metadata": {
+          "label": "Recupero dei metadati",
+          "description": "Quando le ricerche di metadati per i tuoi libri vengono completate o non riescono."
+        },
+        "authorEnrichment": {
+          "label": "Arricchimento degli autori",
+          "description": "Quando termina il recupero delle biografie e delle foto degli autori."
+        },
+        "fileWriteBack": {
+          "label": "Riscrittura nei file",
+          "description": "Quando i metadati modificati vengono riscritti nei file dei libri sul disco."
+        },
+        "fileRename": {
+          "label": "Rinomina file",
+          "description": "Quando il file di un libro viene rinominato per corrispondere al tuo modello di denominazione."
+        },
+        "bulkRename": {
+          "label": "Rinomina in blocco",
+          "description": "Quando una rinomina in blocco su molti libri viene completata o non riesce."
+        },
+        "migration": {
+          "label": "Migrazione dei dati",
+          "description": "Quando un'importazione da un altro strumento di biblioteca viene completata o non riesce."
+        },
+        "bookDock": {
+          "label": "Book Dock",
+          "description": "Quando i file rilasciati nel dock sono pronti per la revisione o vengono finalizzati."
+        },
+        "koboSync": {
+          "label": "Sincronizzazione Kobo",
+          "description": "Quando un dispositivo Kobo termina la sincronizzazione con la tua biblioteca."
+        },
+        "email": {
+          "label": "Consegna via email",
+          "description": "Quando l'invio di un libro a un indirizzo email riesce o non riesce."
+        },
+        "achievements": {
+          "label": "Risultati",
+          "description": "Quando sblocchi un nuovo risultato di lettura."
+        }
+      }
     }
   },
   "reader": {
@@ -6628,6 +6786,8 @@
       "privacy": "Privacy e condivisione",
       "notifications": "Notifiche",
       "restrictions": "Restrizioni sui contenuti"
-    }
+    },
+    "smartScopes": "Ambiti intelligenti",
+    "collections": "Collezioni"
   }
 }

--- a/client/src/locales/pl.json
+++ b/client/src/locales/pl.json
@@ -1,0 +1,6633 @@
+{
+  "common": {
+    "resetSortAria": "Zresetuj sortowanie do ustawień domyślnych",
+    "save": "Zapisz",
+    "cancel": "Anuluj",
+    "delete": "Usuń",
+    "edit": "Edytuj",
+    "close": "Zamknij",
+    "confirm": "Potwierdź",
+    "loading": "Ładowanie...",
+    "search": "Szukaj",
+    "back": "Wstecz",
+    "next": "Następny",
+    "previous": "Poprzedni",
+    "retry": "Spróbuj ponownie",
+    "yes": "Tak",
+    "no": "Nie"
+  },
+  "settings": {
+    "privacySharing": {
+      "title": "Prywatność i udostępnianie",
+      "subtitle": "Kontroluj, czy administratorzy mogą zobaczyć możliwe do zidentyfikowania podsumowanie Twojej aktywności związanej z czytaniem.",
+      "levelLegend": "Poziom udostępniania spostrzeżeń dotyczących czytania",
+      "current": "Bieżące ustawienie",
+      "levels": {
+        "private": {
+          "title": "Prywatny",
+          "description": "Tylko Ty możesz zobaczyć swoje statystyki czytelnicze."
+        },
+        "summary": {
+          "title": "Udostępnij podsumowanie",
+          "description": "Dziel się zbiorowymi nawykami bez tytułów książek, autorów, seriali i narratorów."
+        },
+        "detailed": {
+          "title": "Podziel się szczegółowymi spostrzeżeniami",
+          "description": "Udostępniaj także najnowsze i najpopularniejsze książki, autorów, seriale, gatunki i narratorów."
+        }
+      },
+      "fields": {
+        "frequency": "Częstotliwość czytania i dni aktywności",
+        "completion": "Zbiorcze księgi rozpoczęte i zakończone",
+        "formats": "Dystrybucja formatu",
+        "genres": "Szeroka dystrybucja gatunków",
+        "trend": "Ogólny trend czytelniczy",
+        "books": "Aktualne, najnowsze i najczęściej czytane tytuły książek",
+        "authors": "Najlepsi autorzy",
+        "series": "Najlepsze serie",
+        "narrators": "Najlepsi narratorzy"
+      },
+      "confirm": {
+        "shareTitle": "Włącz {level}?",
+        "shareDescription": "Administratorzy posiadający uprawnienia będą mogli zobaczyć następujące informacje.",
+        "stopTitle": "Przestać dzielić się spostrzeżeniami z czytania?",
+        "stopDescription": "Dostęp administratora zostanie natychmiast zablokowany. Istniejące rekordy dostępu pozostają w Twojej historii.",
+        "recordedNotice": "Każde wyświetlenie profilu administratora jest rejestrowane i pojawia się w Twojej historii dostępu."
+      },
+      "preview": {
+        "title": "Wyświetl podgląd swojego udostępnionego profilu",
+        "description": "Zobacz informacje aktualnie dostępne dla autoryzowanych administratorów.",
+        "action": "Załaduj podgląd",
+        "readingTime": "Czas czytania",
+        "activeDays": "Aktywne dni",
+        "started": "Zaczęły się książki",
+        "completed": "Książki ukończone",
+        "topBooks": "Najlepsze książki"
+      },
+      "history": {
+        "title": "Historia dostępu do profilu",
+        "description": "Ostatnie widoki administratora na Twój udostępniony profil czytania.",
+        "empty": "Żaden administrator nie przeglądał Twojego udostępnionego profilu czytania.",
+        "paginationLabel": "Strony historii dostępu do profilu"
+      },
+      "durationMinutes": "{count, plural, one {# minuta} other {# minuty} few {# minuty} many {# minut}}",
+      "durationHours": "{count} godzin",
+      "unknownTitle": "Książka bez tytułu",
+      "errors": {
+        "load": "Nie udało się załadować ustawień udostępniania.",
+        "save": "Nie udało się zaktualizować ustawień udostępniania.",
+        "preview": "Nie udało się załadować podglądu udostępnionego profilu."
+      }
+    },
+    "appearance": {
+      "language": {
+        "title": "Język",
+        "description": "Wybierz język używany w interfejsie.",
+        "label": "Język interfejsu",
+        "loadError": "Nie udało się załadować wybranego języka",
+        "saveError": "Nie udało się zapisać preferencji językowych"
+      },
+      "pageTitle": "Wyświetlanie",
+      "pageSubtitle": "Kontroluj motywy, okładki, układ i sposób prezentacji biblioteki.",
+      "mobileSummary": "Motyw: {theme} • Akcent: {accent} • Tło: {background}",
+      "themeMode": {
+        "light": "Światło",
+        "dark": "Ciemny",
+        "system": "Systemu"
+      },
+      "theme": {
+        "title": "Motyw",
+        "colorScheme": {
+          "label": "Schemat kolorów",
+          "hint": "Jasny lub ciemny interfejs"
+        },
+        "accents": {
+          "grey": "Szary",
+          "scarlet": "Szkarłat",
+          "vermilion": "Cynobrowy",
+          "rose": "Róża",
+          "copper": "Miedź",
+          "orange": "Pomarańczowy",
+          "chartreuse": "Chartreuse",
+          "marigold": "Nagietek",
+          "wasabi": "Wasabi",
+          "amber": "Bursztyn",
+          "malachite": "Malachit",
+          "yellow": "Żółty",
+          "viridian": "Wiridiana",
+          "turquoise": "Turkus",
+          "lime": "Limonka",
+          "green": "Zielony",
+          "acid-green": "Kwasowa zieleń",
+          "emerald": "Szmaragd",
+          "teal": "Turkusowy",
+          "electric-blue": "Elektryczny błękit",
+          "cyan": "Cyjan",
+          "jade": "Jadeit",
+          "ultramarine": "Ultramaryna",
+          "iris": "Irys",
+          "purple": "Fioletowy",
+          "blue": "Niebieski",
+          "indigo": "Indygo",
+          "violet": "Fioletowy",
+          "amethyst": "Ametyst",
+          "fuchsia": "Fuksja",
+          "raspberry": "Malina",
+          "pink": "Różowy",
+          "white": "Biały",
+          "rosewater": "Woda różana",
+          "salmon": "Łosoś",
+          "coral": "Koral",
+          "sand": "Piasek",
+          "peach": "Brzoskwinia",
+          "pear": "Gruszka",
+          "flax": "Len",
+          "sprout": "Kiełkować",
+          "butter": "Masło",
+          "aloe": "Aloes",
+          "lemon": "Cytryna",
+          "foam": "Piana",
+          "aqua": "Woda",
+          "celadon": "Seledyn",
+          "sage": "Szałwia",
+          "pistachio": "Pistacje",
+          "mint": "Mięta",
+          "seafoam": "Piana morska",
+          "baby-blue": "Mały Niebieski",
+          "powder": "Proszek",
+          "sea-glass": "Szkło morskie",
+          "bluebell": "Dzwonek",
+          "cornflower": "Chaber",
+          "thistle": "Oset",
+          "periwinkle": "Barwinek",
+          "wisteria": "Glicynia",
+          "lavender": "Lawenda",
+          "mauve": "fioletowe",
+          "orchid": "Orchidea",
+          "rose-quartz": "Kwarc różowy",
+          "blush": "Rumieniec"
+        },
+        "accentColor": {
+          "label": "Kolor akcentujący",
+          "hint": "Steruje podświetleniami i elementami interaktywnymi"
+        },
+        "cornerRadius": {
+          "label": "Promień narożnika",
+          "hint": "Zaokrąglenie kart i elementów interfejsu użytkownika"
+        },
+        "surfaceBrightness": {
+          "label": "Jasność powierzchni",
+          "hint": "Rozjaśnij powierzchnie w trybie ciemnym",
+          "reset": "Zresetuj"
+        },
+        "libraryBackground": {
+          "title": "Tło biblioteki",
+          "pattern": {
+            "label": "Wzór tła",
+            "hint": "Wzór pokazany za siatką książki"
+          }
+        },
+        "backgroundGroups": {
+          "fundamental": "Podstawowe",
+          "structural": "Strukturalny",
+          "ambient": "Otoczenie",
+          "refractive": "Refrakcyjne"
+        }
+      },
+      "storage": {
+        "title": "Gdzie zapisać preferencje wyglądu",
+        "active": "Aktywny",
+        "notAvailable": "Niedostępne",
+        "device": {
+          "title": "Tylko to urządzenie",
+          "description": "Preferencje pozostają w Twojej przeglądarce. Najlepiej, jeśli chcesz mieć inny wygląd na różnych urządzeniach."
+        },
+        "account": {
+          "title": "Moje konto",
+          "description": "Preferencje są zapisywane na Twoim koncie. Najlepiej, jeśli chcesz mieć taki sam wygląd na każdym urządzeniu."
+        },
+        "toasts": {
+          "synced": "Preferencje zostaną teraz zsynchronizowane",
+          "local": "Preferencje pozostaną na tym urządzeniu"
+        },
+        "errors": {
+          "demoRestricted": "Konto z ograniczeniami demo nie może zmienić trybu przechowywania motywów",
+          "update": "Nie udało się zaktualizować trybu przechowywania",
+          "generic": "Wystąpił błąd podczas aktualizowania trybu przechowywania"
+        }
+      },
+      "bookCovers": {
+        "title": "Okładki książek",
+        "displayMode": {
+          "title": "Tryb wyświetlania okładki",
+          "hint": "Kontroluje dopasowanie prawdziwych okładek do przegródek na książki w przypadku różnych proporcji",
+          "blurredFit": {
+            "label": "Niewyraźne dopasowanie",
+            "hint": "Pokaż całą okładkę z rozmytym wypełnieniem za nią"
+          },
+          "fillCrop": {
+            "label": "Wypełnij kartę",
+            "hint": "Wypełnij całą szczelinę, przycinając krawędzie, gdy proporcje są różne"
+          },
+          "naturalBottom": {
+            "label": "Naturalne dno",
+            "hint": "Zachowaj oryginalne proporcje pokrycia i zamocuj pokrywę do dołu"
+          }
+        },
+        "spine": {
+          "title": "Nakładka na grzbiet książki",
+          "hint": "Dodaje stylizowany grzbiet i efekt połysku do okładek kart",
+          "off": {
+            "label": "Wyłączone",
+            "hint": "Brak efektu grzbietu/połysku na okładkach"
+          },
+          "subtle": {
+            "label": "Subtelny",
+            "hint": "Jasny grzbiet i połysk, bliższy wyglądowi domyślnemu"
+          },
+          "strong": {
+            "label": "Silny",
+            "hint": "Bardziej wyraźny grzbiet i obróbka połysku"
+          }
+        },
+        "showSpineOnComics": {
+          "label": "Pokaż kręgosłup w komiksach",
+          "hint": "Zastosuj efekt grzbietu i połysku do okładek komiksów (cbz, cbr, cb7)"
+        },
+        "shadow": {
+          "title": "Przykryj siłę cienia",
+          "hint": "Kontroluje głębokość pod osłonami w miniaturach siatki, listy, tabeli i pulpitu nawigacyjnego",
+          "default": {
+            "label": "Domyślne",
+            "hint": "Aktualna wysokość i głębokość"
+          },
+          "strong": {
+            "label": "Silny",
+            "hint": "Cięższy cień przypominający półkę pod osłonami"
+          }
+        },
+        "overlays": {
+          "title": "Nakładki na karty",
+          "hint": "Wybierz metadane widoczne bezpośrednio na okładkach książek",
+          "progressBar": {
+            "label": "Pasek postępu",
+            "hint": "Cienka kolorowa linia wzdłuż dolnej krawędzi"
+          },
+          "format": {
+            "label": "Format pliku",
+            "hint": "Oznaczona kolorami plakietka EPUB, PDF, CBZ w prawym dolnym rogu"
+          },
+          "rating": {
+            "label": "Ocena",
+            "hint": "Wskaźnik oceny w postaci gwiazdek w lewym dolnym rogu"
+          },
+          "readStatus": {
+            "label": "Przeczytaj stan",
+            "hint": "Kolorowa ikona pokazująca aktualny stan czytania w lewym górnym rogu"
+          },
+          "seriesPosition": {
+            "label": "Numer serii",
+            "hint": "Plakietka pokazująca pozycję książki w jej serii w prawym górnym rogu (np. #3, #1.5)"
+          },
+          "lockStatus": {
+            "label": "Stan blokady",
+            "hint": "Ikona blokady metadanych w prawym górnym rogu - pomarańczowa po zablokowaniu i zielona po odblokowaniu"
+          }
+        }
+      },
+      "layout": {
+        "coverSize": "Rozmiar okładki",
+        "gridSpacing": "Odstępy siatki",
+        "gridLayout": {
+          "title": "Układ siatki biblioteki"
+        },
+        "coverSizeBehavior": {
+          "label": "Zachowanie rozmiaru okładki",
+          "hint": "Kontroluj, czy rozmiary pionowe/kwadratowe i odstępy w siatce mają być wspólne dla wszystkich widoków, czy zachowywane dla każdego widoku",
+          "perViewHint": "Tryb pojedynczego widoku: dostosuj rozmiar okładki i odstępy na panelu Wyświetlania każdego widoku.",
+          "syncAll": "Synchronizuj wszystkie widoki",
+          "perView": "Rozmiary na widok"
+        },
+        "portraitCoverSize": {
+          "label": "Rozmiar okładki portretowej",
+          "hint": "Używany do bibliotek portretów i widoków"
+        },
+        "squareCoverSize": {
+          "label": "Rozmiar okładki kwadratowej",
+          "hint": "Używany do bibliotek kwadratowych i widoków"
+        },
+        "portraitGridSpacing": {
+          "label": "Odstępy siatki w pionie",
+          "hint": "Przerwa między okładkami portretów"
+        },
+        "squareGridSpacing": {
+          "label": "Odstępy siatki kwadratowej",
+          "hint": "Szczelina pomiędzy kwadratowymi osłonami"
+        },
+        "cardInfoMode": {
+          "label": "Tryb informacji o karcie",
+          "hint": "Gdzie pokazać tytuł książki i autora na kartach siatki",
+          "onHover": "Po najechaniu",
+          "belowCover": "Poniżej okładka",
+          "off": "Wyłączone"
+        },
+        "primaryCardLabel": {
+          "label": "Etykieta karty podstawowej",
+          "hint": "Tekst pokazany pod każdą okładką książki (pierwszy wiersz)"
+        },
+        "secondaryCardLabel": {
+          "label": "Etykieta karty dodatkowej",
+          "hint": "Dodatkowy tekst pod etykietą główną (drugi wiersz)"
+        },
+        "labelField": {
+          "hidden": "Ukryty",
+          "bookTitle": "Tytuł książki",
+          "seriesTitle": "Tytuł serii",
+          "seriesTitlePosition": "Tytuł serii + pozycja",
+          "author": "Autor"
+        },
+        "seriesDisplay": {
+          "title": "Wyświetlacz serii",
+          "collapsedCover": {
+            "label": "Zwinięta okładka serii",
+            "hint": "Wybierz, która okładka będzie wyświetlana, gdy serie zostaną zwinięte w siatce książki"
+          },
+          "stack": "Stos",
+          "mosaic": "Mozaika",
+          "first": "Najpierw",
+          "latest": "Najnowsze",
+          "firstUnread": "Pierwsze nieprzeczytane"
+        },
+        "authorGrid": {
+          "title": "Autorska siatka",
+          "coverSize": {
+            "label": "Rozmiar okładki",
+            "hint": "Szerokość okładek autorskich w siatce"
+          },
+          "coverShape": {
+            "label": "Kształt okładki",
+            "hint": "Kształt okładek autorskich w siatce"
+          },
+          "circle": "Okrąg",
+          "square": "Kwadrat"
+        },
+        "listTableViews": {
+          "title": "Widoki list i tabel"
+        },
+        "zebraStriping": {
+          "label": "Paski zebry",
+          "hint": "Alternatywne kolory tła wierszy dla łatwiejszego skanowania"
+        }
+      },
+      "behavior": {
+        "title": "Zachowanie biblioteki",
+        "thumbnailClicks": {
+          "label": "Kliknięcia miniatur",
+          "hint": "Wybierz, co się stanie podczas otwierania książki w widokach siatki i listy",
+          "readFirst": "Najpierw przeczytaj",
+          "readFirstHint": "Otwórz czytnik, gdy istnieje czytelny plik",
+          "openDetails": "Otwórz szczegóły",
+          "openDetailsHint": "Przejdź do strony szczegółów książki z siatki i listy miniatur"
+        },
+        "filterPreview": {
+          "label": "Domyślnie pokazuj podgląd filtra",
+          "hint": "Rozwiń aktywny filtr i podsumowanie sortowania podczas otwierania smartScope"
+        },
+        "collapseSeries": {
+          "label": "Domyślnie zwiń serię",
+          "hint": "Grupuj książki z tej samej serii w jedną kartę w widokach biblioteki i kolekcji"
+        }
+      },
+      "icons": {
+        "title": "Niestandardowe ikony",
+        "uploadIcons": "Prześlij ikony",
+        "uploadedCount": "{count, plural, =0 {nie przesłano żadnych ikon} one {# ikona przesłana} other {# ikony przesłane} few {Przesłano # ikony} many {Przesłano # ikon}}",
+        "searchPlaceholder": "Szukaj ikon",
+        "sort": {
+          "newest": "Najnowszy",
+          "name": "Imię"
+        },
+        "selectedCount": "Wybrano {count}",
+        "clear": "Wyczyść",
+        "deleteSelected": "Usuń wybrane",
+        "loading": "Ładowanie ikon...",
+        "emptySearch": "Żadna ikona nie pasuje do Twojego wyszukiwania.",
+        "emptyNoIcons": "Nie przesłano jeszcze żadnych ikon niestandardowych.",
+        "namePlaceholder": "Imię",
+        "checkingUsage": "Sprawdzam użycie...",
+        "usedBy": "Używany przez {count}",
+        "notUsedYet": "Jeszcze nie używany",
+        "rename": "Zmień nazwę",
+        "replace": "Wymień",
+        "usage": {
+          "libraries": "{count, plural, =0 {żadnych bibliotek} one {# biblioteka} other {# biblioteki} few {# biblioteki} many {# bibliotek}}",
+          "collections": "{count, plural, =0 {żadnych kolekcji} one {# kolekcja} other {# zbiory} few {# kolekcje} many {# kolekcji}}",
+          "smartScopes": "{count, plural, =0 {żadnych inteligentnych lunet} one {# inteligentny zakres} other {# inteligentne lunety} few {# inteligentne lunety} many {# inteligentnych lunet}}"
+        },
+        "confirm": {
+          "deleteOne": "Usunąć „{name}”? Istniejące zastosowania powrócą do domyślnej ikony.",
+          "deleteMany": "{count, plural, =0 {Nie usunąć żadnych ikon?} one {Usuń # ikona? Istniejące zastosowania powrócą do domyślnej ikony.} other {Usuń # ikony? Istniejące zastosowania powrócą do domyślnej ikony.} few {Usunąć # ikony? Istniejące zastosowania powrócą do domyślnej ikony.} many {Usunąć # ikon? Istniejące zastosowania powrócą do domyślnej ikony.}}"
+        },
+        "toasts": {
+          "saved": "Ikona zapisana",
+          "updated": "Ikona zaktualizowana",
+          "deleted": "Ikona usunięta",
+          "bulkDeleted": "{count, plural, =0 {Nie usunięto żadnych ikon} one {Usunięto # ikona} other {Usunięto # ikony} few {Usunięto # ikony} many {Usunięto # ikon}}",
+          "bulkDeletePartial": "Usunięto {deleted}, {failed} nie powiodło się"
+        },
+        "errors": {
+          "load": "Nie udało się załadować ikon",
+          "save": "Nie udało się zapisać ikony",
+          "replace": "Nie udało się zastąpić ikony",
+          "delete": "Nie udało się usunąć ikony",
+          "bulkDelete": "Nie udało się usunąć ikon"
+        }
+      },
+      "tabs": {
+        "theme": "Motyw",
+        "book-covers": "Okładki książek",
+        "icons": "Ikony",
+        "layout": "Układ",
+        "behavior": "Zachowanie"
+      }
+    },
+    "account": {
+      "title": "Konto",
+      "subtitle": "Zarządzaj ustawieniami swojego profilu osobistego.",
+      "subtitleAll": "Zarządzaj swoim profilem i preferencjami powiadomień.",
+      "tabs": {
+        "profile": "Profil",
+        "privacy": "Prywatność i udostępnianie",
+        "notifications": "Powiadomienia",
+        "restrictions": "Ograniczenia"
+      },
+      "demoRestricted": {
+        "cannotEdit": "Konto z ograniczeniami demo nie może edytować ustawień konta",
+        "notice": "Konto z ograniczeniami demo: edycja profilu, hasła, awatara i połączonych tożsamości jest wyłączona."
+      },
+      "feedback": {
+        "unsavedChanges": "Niezapisane zmiany",
+        "allSaved": "Wszystkie zmiany zostały zapisane"
+      },
+      "profile": {
+        "securityHeading": "Profil i bezpieczeństwo",
+        "username": "Nazwa użytkownika",
+        "fullName": "Pełne imię i nazwisko",
+        "email": "E-mail",
+        "emailHint": "Skontaktuj się z administratorem, aby zmienić swój adres e-mail.",
+        "save": "Zapisz profil",
+        "saving": "Zapisywanie...",
+        "changePassword": "Zmień hasło",
+        "accountType": "Typ konta:",
+        "accountTypeOidc": "OIDC / Jednokrotne logowanie",
+        "accountTypeShared": "Udostępnione",
+        "accountTypeLocal": "Lokalny",
+        "nameRequired": "Imię i nazwisko jest wymagane",
+        "updateFailed": "Nie udało się zaktualizować profilu",
+        "updated": "Profil zaktualizowany"
+      },
+      "readingPreferences": {
+        "title": "Preferencje czytelnicze",
+        "timezoneHint": "Strefa czasowa jest używana w przypadku osiągnięć wrażliwych na czas, takich jak Early Bird i Allnighter.",
+        "timezone": "Strefa czasowa",
+        "save": "Zapisz preferencje",
+        "enableAchievements": "Włącz osiągnięcia",
+        "enableAchievementsHint": "Śledź postęp osiągnięć i wyświetlaj interfejs związany z osiągnięciami. Zarządzaj powiadomieniami o osiągnięciach oddzielnie w Powiadomieniach."
+      },
+      "preferences": {
+        "saveFailed": "Nie udało się zapisać preferencji",
+        "saved": "Preferencje zostały zapisane"
+      },
+      "avatar": {
+        "title": "Zdjęcie profilowe",
+        "unknownUser": "Nieznany użytkownik",
+        "formatHint": "PNG/JPEG/WEBP do {size} MB",
+        "upload": "Prześlij zdjęcie",
+        "replace": "Zamień zdjęcie",
+        "uploading": "Przesyłanie...",
+        "remove": "Usuń zdjęcie",
+        "removing": "Usuwanie...",
+        "updated": "Zdjęcie profilowe zaktualizowane",
+        "uploadFailed": "Nie udało się przesłać zdjęcia profilowego",
+        "removed": "Zdjęcie profilowe usunięte",
+        "removeFailed": "Nie udało się usunąć zdjęcia profilowego",
+        "removeConfirm": {
+          "title": "Usunąć zdjęcie profilowe?",
+          "description": "Twój awatar zostanie usunięty i zastąpiony inicjałami.",
+          "confirm": "Usuń"
+        }
+      },
+      "connectedAccounts": {
+        "title": "Połączone konta",
+        "unlink": "Odłącz",
+        "unlinking": "Odłączanie...",
+        "linkAdditional": "Połącz dodatkowych dostawców:",
+        "linkProvider": "Połącz {provider}",
+        "redirecting": "Przekierowywanie...",
+        "noneConfigured": "Nie skonfigurowano żadnych dostawców OIDC. Poproś administratora o skonfigurowanie logowania jednokrotnego.",
+        "linkStateFailed": "Nie udało się wygenerować stanu łącza",
+        "startLinkFailed": "Nie udało się uruchomić łącza OIDC",
+        "unlinkFailed": "Nie udało się odłączyć",
+        "unlinked": "Tożsamość niepowiązana",
+        "unlinkIdentityFailed": "Nie udało się odłączyć tożsamości",
+        "unlinkDialog": {
+          "title": "Odłączyć tożsamość {provider}?",
+          "description": "Wpisz swoje hasło, aby potwierdzić. Nie będziesz już mógł zalogować się u tego dostawcy.",
+          "currentPassword": "Aktualne hasło"
+        }
+      },
+      "tour": {
+        "title": "Wycieczka z przewodnikiem",
+        "description": "Odtwórz ponownie przewodnik przedstawiający najważniejsze funkcje aplikacji.",
+        "action": "Wybierz się na wycieczkę ponownie"
+      },
+      "restrictions": {
+        "none": {
+          "title": "Brak ograniczeń treści",
+          "description": "Twoje konto ma pełny dostęp do całej zawartości przypisanych bibliotek."
+        },
+        "banner": "Twoje konto ma ograniczenia dotyczące zawartości nałożone przez administratora. Niektóre książki mogą być dla Ciebie niewidoczne.",
+        "allowedTags": {
+          "title": "Dozwolone tagi",
+          "description": "Wyświetlane są tylko książki posiadające co najmniej jeden z tych tagów."
+        },
+        "blockedTags": {
+          "title": "Zablokowane tagi",
+          "description": "Książki z którymkolwiek z tych tagów są przed Tobą ukryte."
+        },
+        "allowedGenres": {
+          "title": "Dozwolone gatunki",
+          "description": "Wyświetlane są tylko książki należące do co najmniej jednego z tych gatunków."
+        },
+        "blockedGenres": {
+          "title": "Zablokowane gatunki",
+          "description": "Książki należące do któregokolwiek z tych gatunków są przed Tobą ukryte."
+        }
+      }
+    },
+    "magicLinks": {
+      "title": "Magiczne linki",
+      "subtitle": "Twórz udostępniane łącza logowania do współdzielonych kont.",
+      "createLink": "Utwórz łącze",
+      "noSharedAccounts": "Nie znaleziono wspólnych kont",
+      "noSharedAccountsHint": "Najpierw utwórz wspólne konto z {usersPage}, aby wygenerować magiczne linki.",
+      "activeLinks": "Aktywne linki",
+      "inactiveLinks": "Nieaktywne linki",
+      "paused": "Wstrzymano",
+      "deletedUser": "Usunięty użytkownik",
+      "expiredPrefix": "Wygasło ",
+      "never": "Brak zarejestrowanej aktywności",
+      "noExpiry": "Brak wygaśnięcia",
+      "expired": "Wygasło",
+      "expiresOn": "Wygasa {date}",
+      "revokedOn": "Unieważniono {date}",
+      "expiredOn": "Wygasło {date}",
+      "usesCount": "{count, plural, =0 {żadnych zastosowań} one {jedno użycie} other {# wykorzystuje} few {# zastosowania} many {# zastosowań}}",
+      "copied": "Skopiowano!",
+      "copyLink": "Skopiuj link",
+      "pause": "Pauza",
+      "resume": "Wznów",
+      "revoke": "Odwołaj",
+      "revoking": "Odwoływanie...",
+      "emptyState": "Nie utworzono jeszcze żadnych magicznych linków. Kliknij „{action}”, aby wygenerować wspólny login URL.",
+      "columns": {
+        "label": "Etykieta",
+        "account": "Konto",
+        "createdBy": "Stworzony przez",
+        "expires": "Wygasa",
+        "uses": "Używa",
+        "lastUsed": "Ostatnio używany",
+        "created": "Utworzono",
+        "status": "Stan",
+        "totalUses": "Całkowita liczba zastosowań"
+      },
+      "createDialog": {
+        "title": "Utwórz magiczny link",
+        "description": "Wygeneruj wspólny login URL dla wspólnego konta.",
+        "sharedAccount": "Wspólne konto",
+        "selectAccount": "Wybierz wspólne konto",
+        "label": "Etykieta",
+        "labelPlaceholder": "np. Link demonstracyjny do konferencji",
+        "expiresAt": "Wygasa o godz",
+        "optional": "(opcjonalnie)",
+        "create": "Utwórz",
+        "creating": "Tworzenie..."
+      },
+      "revokeDialog": {
+        "title": "Unieważnić magiczny link?",
+        "description": "Spowoduje to natychmiastowe unieważnienie połączenia i zakończenie wszystkich aktywnych sesji połączonego konta."
+      },
+      "errors": {
+        "create": "Nie udało się utworzyć",
+        "copy": "Nie udało się skopiować magicznego linku",
+        "update": "Nie udało się zaktualizować magicznego linku",
+        "revoke": "Nie udało się odwołać"
+      },
+      "usersPage": "Strona użytkowników",
+      "emptyTitle": "Nie utworzono jeszcze żadnych magicznych linków",
+      "emptyHint": "Kliknij „{action}”, aby wygenerować wspólny login URL.",
+      "noActiveTitle": "Brak aktywnych magicznych linków",
+      "noActiveHint": "Wszystkie wygenerowane magiczne linki do tej strony wygasły lub zostały unieważnione."
+    },
+    "oidc": {
+      "title": "OIDC / Jednokrotne logowanie",
+      "subtitle": "Zarządzaj dostawcami OpenID Connect w zakresie pojedynczego logowania.",
+      "providers": "Dostawcy",
+      "addProvider": "Dodaj dostawcę",
+      "editProvider": "Edytuj dostawcę",
+      "configureNew": "Skonfiguruj nowego dostawcę OIDC.",
+      "editing": "Edytowanie {slug}",
+      "enabled": "Włączone",
+      "disabled": "Niepełnosprawny",
+      "empty": {
+        "title": "Nie ma jeszcze dostawców",
+        "description": "Dodaj dostawcę OIDC, aby umożliwić użytkownikom logowanie jednokrotne."
+      },
+      "form": {
+        "status": "Stan",
+        "enableProvider": "Włącz dostawcę",
+        "enableProviderHint": "Pokaż tego dostawcę na stronie logowania.",
+        "identity": "Tożsamość dostawcy",
+        "slug": "Ślimak",
+        "slugHint": "Unikalny identyfikator (małe litery, łączniki). Nie można go później zmienić.",
+        "displayName": "Nazwa wyświetlana",
+        "displayNameHint": "Wyświetlane na przycisku logowania.",
+        "iconUrl": "Ikona URL",
+        "iconUrlHint": "Opcjonalne logo wyświetlane obok przycisku logowania.",
+        "iconPreviewAlt": "podgląd ikon",
+        "connection": "Połączenie",
+        "issuerUri": "URI wystawcy",
+        "issuerUriHint": "Baza dostawców URL.",
+        "test": "Testuj",
+        "testing": "Testowanie...",
+        "clientId": "Identyfikator klienta",
+        "clientSecret": "Sekret Klienta",
+        "clientSecretPlaceholder": "Pozostaw puste, aby zachować istniejące",
+        "scopes": "Zakresy",
+        "claimMapping": "Mapowanie roszczeń",
+        "previewClaims": "Podgląd roszczeń",
+        "redirecting": "Przekierowywanie...",
+        "mappedClaims": "Mapowane roszczenia",
+        "rawClaims": "Surowe roszczenia",
+        "usernameClaim": "Roszczenie dotyczące nazwy użytkownika",
+        "nameClaim": "Roszczenie o nazwę",
+        "emailClaim": "Roszczenie e-mailem",
+        "groupsClaim": "Grupy twierdzą",
+        "autoProvisioning": "Automatyczne udostępnianie",
+        "autoProvisionUsers": "Automatyczne udostępnianie użytkowników",
+        "autoProvisionUsersHint": "Utwórz konta przy pierwszym logowaniu OIDC, jeśli użytkownik nie istnieje.",
+        "allowLocalLinking": "Zezwalaj na łączenie kont lokalnych",
+        "allowLocalLinkingHint": "Połącz tożsamość OIDC z istniejącym kontem lokalnym, dopasowując nazwę użytkownika.",
+        "defaultPermissions": "Domyślne uprawnienia",
+        "defaultPermissionsHint": "Uprawnienia nadawane nowym użytkownikom przy pierwszym logowaniu OIDC.",
+        "createProvider": "Utwórz dostawcę",
+        "saveChanges": "Zapisz zmiany",
+        "saving": "Zapisywanie...",
+        "deleteProvider": "Usuń dostawcę",
+        "deleting": "Usuwanie..."
+      },
+      "test": {
+        "connected": "Połączono - {issuer}",
+        "connectionFailed": "Połączenie nie powiodło się",
+        "hide": "Ukryj",
+        "details": "Szczegóły",
+        "supported": "obsługiwane",
+        "notSupported": "nieobsługiwane"
+      },
+      "groupMappings": {
+        "title": "Mapowania grupowe",
+        "description": "Mapuj roszczenia grupy OIDC do uprawnień BookOrbit. Synchronizowane przy każdym logowaniu.",
+        "noPermission": "Brak pozwolenia",
+        "empty": "Nie skonfigurowano mapowań grupowych.",
+        "addMapping": "Dodaj mapowanie",
+        "claimPlaceholder": "OIDC roszczenie grupowe (np. administratorzy)",
+        "add": "Dodaj",
+        "adding": "Dodawanie..."
+      },
+      "toasts": {
+        "providerCreated": "Dostawca został utworzony",
+        "providerSaved": "Dostawca zapisany",
+        "providerDeleted": "Dostawca usunięty",
+        "mappingAdded": "Dodano mapowanie grupowe",
+        "mappingRemoved": "Usunięto mapowanie grupowe"
+      },
+      "errors": {
+        "loadProvider": "Nie udało się załadować dostawcy",
+        "createProvider": "Nie udało się utworzyć dostawcy",
+        "save": "Nie udało się zapisać",
+        "delete": "Nie udało się usunąć",
+        "deleteProvider": "Nie udało się usunąć dostawcy",
+        "requestFailed": "Żądanie nie powiodło się",
+        "previewState": "Nie udało się wygenerować stanu podglądu",
+        "startPreview": "Nie udało się uruchomić podglądu",
+        "addMapping": "Nie udało się dodać mapowania",
+        "removeMapping": "Nie udało się usunąć mapowania grupy"
+      }
+    },
+    "admin": {
+      "title": "Administrator",
+      "subtitle": "Zarządzaj użytkownikami i ustawieniami uwierzytelniania.",
+      "system": {
+        "title": "Systemu",
+        "subtitle": "Ustawienia organizacji, pozyskiwania i konserwacji plików."
+      },
+      "maintenance": {
+        "title": "Konserwacja",
+        "subtitle": "Zarządzaj zadaniami w tle, indeksami systemu i operacjami konserwacyjnymi.",
+        "importGroup": "Importuj",
+        "recommendationsGroup": "Zalecenia",
+        "achievementsGroup": "Osiągnięcia",
+        "updatesGroup": "Aktualizacje",
+        "importFromBooklore": "Import z Booklore",
+        "bookloreImportConfigured": "Skonfigurowano import Booklore",
+        "migrationRunning": "Trwa migracja",
+        "migrationCompleted": "Migracja zakończona",
+        "migrationFailed": "Migracja nie powiodła się",
+        "importDescription": "Jednorazowy import książek, metadanych i postępu czytania z poprzedniej instalacji Booklore.",
+        "configuredDescription": "Źródło: {name}. Nie przeprowadzono jeszcze migracji - kontynuuj konfigurację, aby uruchomić import.",
+        "runningDescription": "Etap: {stage} - rozpoczęty {started}",
+        "completedDescription": "Od {name} - ukończono {date}",
+        "migrationErrorGeneric": "Podczas migracji wystąpił błąd.",
+        "stageInitializing": "inicjowanie",
+        "recently": "niedawno",
+        "getStarted": "Rozpocznij",
+        "continueSetup": "Kontynuuj konfigurację",
+        "viewDetails": "Zobacz szczegóły",
+        "refreshRecommendationIndex": "Odśwież indeks rekomendacji",
+        "refreshRecommendationHint": "Zaktualizuj silnik rekomendacji, uwzględniając najnowsze zmiany w bibliotece. Ten proces działa w tle.",
+        "booksQueuedForProcessing": "{count, plural, =0 {brak książek oczekujących na przetworzenie} one {# książka oczekująca w kolejce do przetworzenia} other {# książki oczekujące w kolejce do przetworzenia} few {# książki w kolejce do przetworzenia} many {# książek w kolejce do przetworzenia}}",
+        "run": "Biegnij",
+        "running": "Bieganie...",
+        "backfillAchievements": "Uzupełnij osiągnięcia",
+        "backfillAchievementsHint": "Ponownie oceń osiągnięcia wszystkich użytkowników.",
+        "backfillResult": "Przetworzono {users} użytkowników; przyznał {awards} nagród.",
+        "runBackfill": "Uruchom uzupełnienie",
+        "checkForUpdates": "Sprawdź aktualizacje",
+        "checkForUpdatesHint": "Automatycznie sprawdzaj GitHub pod kątem nowej wersji podczas uruchamiania i wyświetlaj wskaźnik na pasku bocznym, gdy jest ona dostępna.",
+        "updateChecksEnabled": "Włączono sprawdzanie aktualizacji",
+        "updateChecksDisabled": "Sprawdzanie aktualizacji wyłączone",
+        "updateSettingFailed": "Nie udało się zaktualizować ustawienia",
+        "booksQueuedForEmbedding": "{count, plural, =0 {brak książek oczekujących na osadzenie} one {# książka w kolejce do osadzenia} other {# książki oczekujące w kolejce do osadzenia} few {# książki oczekują w kolejce do umieszczenia} many {# książek w kolejce do umieszczenia}}",
+        "failed": "Nie udało się",
+        "unknownError": "Nieznany błąd",
+        "rebuildEmbeddingsFailed": "Nie udało się odbudować osadzonych elementów: {error}",
+        "achievementBackfillConfirm": "Uruchomić uzupełnianie osiągnięć dla wszystkich osiągnięć dla wszystkich użytkowników? To może chwilę potrwać.",
+        "achievementBackfillComplete": "Uzupełnianie osiągnięć zakończone: przyznano {count} nagród",
+        "backfillRunFailed": "Nie udało się uruchomić uzupełniania",
+        "achievementBackfillFailed": "Nie udało się uruchomić uzupełniania osiągnięć: {error}",
+        "uploadsGroup": "Przesłane",
+        "maxUploadSize": "Maksymalny limit rozmiaru przesyłanego pliku",
+        "maxUploadSizeHint": "Skonfiguruj maksymalny limit rozmiaru plików przesyłanych w systemie.",
+        "save": "Zapisz",
+        "uploadSizeInvalid": "Limit rozmiaru przesyłanych plików musi być większy niż 0",
+        "uploadSizeUpdated": "Zaktualizowano limit rozmiaru przesyłanych plików"
+      },
+      "migration": {
+        "title": "Migracja",
+        "subtitle": "Jednorazowy import Booklore: podłącz źródło, zmapuj użytkowników, wykonaj próbę próbną, rozpocznij migrację i wyeksportuj raport.",
+        "progress": "Postęp",
+        "stepSourceConnection": "Połączenie źródłowe",
+        "stepUserPathMapping": "Mapowanie użytkowników i ścieżek",
+        "stepDryRun": "Praca na sucho",
+        "stepDryRunTitle": "Praca na sucho",
+        "stepRunMigration": "Uruchom migrację",
+        "stepReport": "Raport",
+        "stepReportTitle": "Raport o migracji",
+        "subtitleSource": "Skonfiguruj połączenie bazy danych ze źródłową instancją Booklore.",
+        "subtitleMappings": "Mapuj użytkowników źródłowych na użytkowników docelowych i tłumacz ścieżki plików.",
+        "subtitleDryRun": "Przed uruchomieniem migracji na żywo możesz wyświetlić podgląd tego, co zostanie zaimportowane.",
+        "subtitleRun": "Rozpocznij import na żywo i monitoruj jego postęp.",
+        "subtitleReport": "Sprawdź, co zostało zaimportowane i wyeksportuj szczegółowy raport.",
+        "continueToMappings": "Przejdź do Mapowania",
+        "continueToDryRun": "Kontynuuj próbę próbną",
+        "continueToMigration": "Przejdź do migracji",
+        "viewReport": "Zobacz raport",
+        "badgeValidated": "Zatwierdzone",
+        "badgeSaved": "Zapisano",
+        "badgeUpToDate": "Aktualne",
+        "badgeCompleted": "Ukończono",
+        "badgeRunning": "Bieganie",
+        "badgeFailed": "Nie udało się",
+        "mediaPathRequired": "Wymagane do migracji okładek książek.",
+        "mediaPathAbsolute": "Użyj ścieżki bezwzględnej (na przykład: /books). Ścieżki względne nie są obsługiwane.",
+        "mediaPathConfigured": "Skonfigurowano ścieżkę importu okładek. Użyj połączenia testowego, aby sprawdzić dostęp i strukturę folderów obrazów Booklore.",
+        "issueSaveSource": "Zapisz ustawienia połączenia źródłowego",
+        "issueValidateSource": "Sprawdź połączenie źródłowe",
+        "issueSaveMappings": "Zapisz mapowania użytkowników i ścieżek",
+        "issueSavePathMappings": "Zapisz mapowania ścieżek, aby je sprawdzić",
+        "issueFreshDryRun": "Przeprowadź nową próbę próbną",
+        "issueResolveDuplicates": "Rozwiąż zduplikowane dopasowania księgi docelowej w trybie próbnym",
+        "issueWaitActiveRun": "Poczekaj na zakończenie aktywnego przebiegu",
+        "sourceRecordId": "Identyfikator rekordu źródłowego #{id}",
+        "byAuthorWithId": "autor: {author} (identyfikator: {id})",
+        "filePathWithId": "{path} (identyfikator: {id})",
+        "bookloreSourceId": "Identyfikator źródła Booklore: {id}",
+        "libraryBookNum": "Książka biblioteczna #{id}",
+        "errorInitialize": "Nie udało się zainicjować ustawień migracji",
+        "errorLoadSourceTypes": "Nie udało się załadować obsługiwanych typów źródeł migracji",
+        "errorLoadTargetUsers": "Nie udało się załadować docelowych użytkowników",
+        "errorLoadLibraryFolders": "Nie udało się załadować docelowych folderów biblioteki",
+        "noSourceUsersReturned": "Nie zwrócono żadnych użytkowników źródłowych",
+        "userMappingSuggestionsLoaded": "Załadowano sugestie mapowania użytkownika",
+        "errorLoadSuggestions": "Nie udało się załadować sugestii mapowania użytkownika",
+        "requiredFields": "Wymagane są nazwa hosta, użytkownika, bazy danych i źródła",
+        "connectionTestPassedWithWarnings": "Test połączenia zaliczony z ostrzeżeniami",
+        "connectionTestPassedWithCount": "Test połączenia zaliczony z {count} ostrzeżeniami. Po pierwsze: {first}",
+        "connectionTestPassed": "Test połączenia przeszedł pomyślnie",
+        "connectionOkMissingTables": "Połączenie jest w porządku, ale brakuje {count} wymaganych tabel",
+        "cannotTestMediaPathActiveRun": "Nie można przetestować ścieżki multimediów, gdy przebieg jest aktywny",
+        "mediaRootPathRequiredCover": "Do importowania okładek wymagana jest ścieżka główna nośnika.",
+        "useAbsolutePath": "Użyj ścieżki bezwzględnej (na przykład: /books).",
+        "mediaPathVerified": "Zweryfikowano ścieżkę multimediów.",
+        "mediaPathValidReadable": "Ścieżka multimediów jest prawidłowa i czytelna",
+        "mediaPathValidationFailed": "Sprawdzanie ścieżki multimediów nie powiodło się.",
+        "connectionFailedBeforeMediaPath": "Test połączenia nie powiódł się przed zakończeniem sprawdzania ścieżki nośnika.",
+        "cannotModifySourceActiveRun": "Nie można modyfikować źródła, gdy przebieg jest aktywny",
+        "sourceSavedValidatedWarnings": "Źródło zapisane i sprawdzone z {count} ostrzeżeniami",
+        "sourceSavedValidated": "Źródło zapisane i sprawdzone",
+        "errorSaveValidateSource": "Nie udało się zapisać lub zweryfikować źródła",
+        "cannotSaveMappingsActiveRun": "Nie można zapisać mapowań, gdy przebieg jest aktywny",
+        "saveSourceFirst": "Najpierw zapisz źródło",
+        "mapAtLeastOneUser": "Zamapuj co najmniej jednego użytkownika źródłowego na użytkownika docelowego",
+        "mapEveryUser": "Mapuj każdego użytkownika źródłowego przed zapisaniem",
+        "pathValidationFailedProfileSaved": "Weryfikacja ścieżki nie powiodła się, ale profil nadal zostanie zapisany",
+        "mappingsSaved": "Mapowania zostały zapisane",
+        "errorSaveMappings": "Nie udało się zapisać mapowań",
+        "cannotRunDryRunActiveRun": "Nie można uruchomić trybu próbnego, gdy przebieg jest aktywny",
+        "saveMappingsFirst": "Najpierw zapisz mapowania",
+        "dryRunCompleted": "Próba próbna zakończona: {matched} dopasowana, {unresolved} nierozwiązana",
+        "dryRunFailed": "Próba próbna nie powiodła się",
+        "selectSourceForAllGroups": "Wybierz książkę źródłową dla wszystkich {count} zduplikowanych grup",
+        "duplicatesResolved": "Zduplikowane mecze rozwiązane",
+        "errorResolveDuplicates": "Nie udało się rozwiązać duplikatów",
+        "preflightNotReady": "Wstępna inspekcja migracji nie jest gotowa",
+        "runDryRunFirst": "Najpierw wykonaj próbę na sucho",
+        "runStarted": "Rozpoczęto przebieg migracji",
+        "errorStartMigration": "Nie udało się rozpocząć migracji",
+        "runCancelled": "Przebieg migracji anulowany",
+        "errorCancelMigration": "Nie udało się anulować migracji",
+        "runRetried": "Ponówono próbę migracji - wznawianie od ostatniego ukończonego etapu",
+        "errorRetryMigration": "Nie udało się ponowić próby migracji",
+        "errorLoadRunProgress": "Nie udało się wczytać postępu uruchomienia",
+        "startMigrationFirst": "Najpierw rozpocznij migrację",
+        "reportRefreshed": "Uruchom raport odświeżony",
+        "errorLoadReport": "Nie udało się załadować raportu z uruchomienia",
+        "reportExported": "Raport wyeksportowany jako {format}",
+        "errorExportReport": "Nie udało się wyeksportować raportu migracji",
+        "reasonNoTitleAuthorMatch": "Nie znaleziono pasującej książki według tytułu lub autora",
+        "reasonNoFilePathMatch": "Ścieżka pliku nie pasuje do żadnej książki w tej bibliotece",
+        "reasonNoFileHashMatch": "Skrót pliku nie pasuje do żadnej książki w tej bibliotece",
+        "reasonNoIsbnMatch": "ISBN nie pasuje do żadnej książki w tej bibliotece",
+        "reasonInsufficientSourceData": "Za mało metadanych, aby podjąć próbę dopasowania",
+        "reasonAmbiguousIsbnMatch": "Wiele książek pasuje do tego samego ISBN",
+        "reasonAmbiguousFileHashMatch": "Wiele książek pasowało do tego samego skrótu pliku",
+        "reasonAmbiguousFilePathMatch": "Wiele książek miało tę samą ścieżkę pliku",
+        "reasonAmbiguousTitleAuthorMatch": "Wiele książek miało ten sam tytuł i autora",
+        "reasonUnknown": "Nie udało się określić przyczyny",
+        "strategyIsbn": "Dopasowane przez ISBN",
+        "strategyFileHash": "Dopasowane według skrótu pliku",
+        "strategyPathMapping": "Dopasowane według zmapowanej ścieżki pliku",
+        "strategyTitleAuthor": "Dopasowane według tytułu i autora",
+        "strategyUnavailable": "Strategia meczowa niedostępna",
+        "userPreviewCounts": "{statuses} statusy, {progress} wpisy postępu, {bookmarks} zakładki, {annotations} adnotacje, {collections} wpisy w kolekcji",
+        "connErrorUnreachable": "Nie można połączyć się z serwerem bazy danych. Sprawdź hosta i port.",
+        "connErrorAuth": "Uwierzytelnienie nie powiodło się. Sprawdź nazwę użytkownika i hasło.",
+        "connErrorUnknownDatabase": "Nie znaleziono bazy danych. Sprawdź nazwę bazy danych.",
+        "connErrorTimeout": "Upłynął limit czasu połączenia. Sprawdź ustawienia hosta i zapory sieciowej.",
+        "connErrorGeneric": "Test połączenia nie powiódł się",
+        "sourceType": "Typ źródła",
+        "sourceName": "Nazwa źródła",
+        "host": "Gospodarz",
+        "port": "Portu",
+        "user": "Użytkownik",
+        "password": "Hasło",
+        "passwordSavedPlaceholder": "Zapisano - pozostaw bez zmian",
+        "passwordEmptyPlaceholder": "Nie ustawiono hasła",
+        "database": "Baza danych",
+        "mediaRootPath": "Ścieżka główna multimediów",
+        "pathOk": "Ścieżka w porządku",
+        "pathIssue": "Problem ze ścieżką",
+        "testPath": "Ścieżka testowa",
+        "useTls": "Użyj protokołu TLS/SSL",
+        "testConnection": "Połączenie testowe",
+        "saveAndValidate": "Zapisz i sprawdź",
+        "sourceValidatedWithWarnings": "Źródło potwierdzone z ostrzeżeniami",
+        "lastValidationSnapshot": "Ostatnia migawka weryfikacyjna",
+        "sourceVersion": "Wersja źródłowa: {version}",
+        "unknown": "Nieznany",
+        "missingRequiredTables": "Brakuje wymaganych tabel: {tables}",
+        "suggestionsAutoLoad": "Sugestie użytkowników ładują się automatycznie po sprawdzeniu źródła.",
+        "refresh": "Odśwież",
+        "sourceUser": "Użytkownik źródłowy",
+        "targetUser": "Użytkownik docelowy",
+        "noSourceUsersLoaded": "Nie załadowano jeszcze żadnych użytkowników źródłowych.",
+        "noActiveTargetUsers": "Nie znaleziono aktywnych użytkowników docelowych. Utwórz lub ponownie włącz użytkownika BookOrbit przed mapowaniem.",
+        "pathPrefixMappings": "Mapowania prefiksów ścieżek",
+        "addMapping": "Dodaj mapowanie",
+        "pathMappingsHelp1": "Mapowania ścieżek tłumaczą ścieżki plików źródłowych na ścieżki docelowe, dzięki czemu książki można dopasowywać na podstawie lokalizacji pliku. Na przykład, jeśli Twoja biblioteka Booklore przechowuje pliki w formacie",
+        "pathMappingsHelp2": "i te same pliki znajdują się teraz pod",
+        "pathMappingsHelp3": ", dodaj to mapowanie tutaj. Książki są również dopasowywane za pomocą ISBN, skrótu pliku i tytułu/autora niezależnie od mapowania ścieżek - mapowanie ścieżek to tylko jedna z czterech strategii i nie ogranicza, które książki źródłowe zostaną uwzględnione w migracji.",
+        "noPrefixesFound": "Nie znaleziono prefiksów - najpierw sprawdź źródło",
+        "selectSourcePrefix": "Wybierz prefiks źródłowy...",
+        "selectTargetFolder": "Wybierz folder docelowy...",
+        "remove": "Usuń",
+        "pathValidation": "Walidacja ścieżki",
+        "pathValidationMapped": "{mapped} z {total} książek źródłowych ma zmapowaną ścieżkę",
+        "pathValidationUnmatched": "{count} nie znaleziono zmapowanych ścieżek na dysku - te książki zostaną przywrócone do ISBN / dopasowanie tytułu",
+        "pathValidationAllMatched": "Na dysku znaleziono wszystkie {count} zmapowane ścieżki",
+        "saveMappings": "Zapisz mapowania",
+        "runDryRun": "Uruchomienie na sucho",
+        "matched": "Dopasowane:",
+        "unresolved": "Nierozwiązane:",
+        "duplicateMatches": "Duplikaty dopasowań:",
+        "unresolvedSummary": "Nierozwiązane podsumowanie",
+        "resolveDuplicateMatches": "Rozwiąż zduplikowane dopasowania docelowe",
+        "resolveDuplicateHint": "Dla każdej książki docelowej wybierz jedną książkę źródłową, którą chcesz zachować. Zalecane opcje są wstępnie wybierane, gdy istnieje jedno najsilniejsze dopasowanie.",
+        "remainingGroups": "Pozostałe grupy:",
+        "ofCount": "z {count}",
+        "targetBookNum": "Książka docelowa #{id}",
+        "recommended": "Zalecane",
+        "resolveDuplicatesButton": "{count, plural, =0 {Rozwiąż # duplikat} one {Rozwiąż # duplikat} other {Rozwiąż # duplikaty} few {Rozwiąż # duplikaty} many {Rozwiąż # duplikatów}}",
+        "preflightChecks": "Kontrole przed lotem",
+        "allChecksPassed": "Wszystkie kontrole zostały pomyślnie zakończone - gotowe do migracji",
+        "checkSourceValidated": "Źródło potwierdzone",
+        "checkSaveValidateSource": "Zapisz i zatwierdź połączenie źródłowe",
+        "checkValidateSource": "Sprawdź połączenie źródłowe",
+        "checkMappingsSaved": "Mapowania zostały zapisane",
+        "checkSaveMappings": "Zapisz mapowania użytkowników i ścieżek",
+        "checkPathMappingsValidated": "Zatwierdzono mapowania ścieżek",
+        "checkSavePathMappings": "Zapisz mapowania ścieżek, aby je sprawdzić",
+        "checkDryRunUpToDate": "Praca na sucho jest aktualna",
+        "checkFreshDryRun": "Przeprowadź nową próbę próbną",
+        "startConfirmPrompt": "Rozpocznie się migracja na żywo. Czy jesteś pewien?",
+        "confirmStart": "Potwierdź rozpoczęcie",
+        "startMigration": "Rozpocznij migrację",
+        "cancelRun": "Anuluj bieg",
+        "refreshStatus": "Odśwież stan",
+        "statusPollingStopped": "Odpytywanie stanu zostało zatrzymane z powodu błędu.",
+        "retry": "Spróbuj ponownie",
+        "stageLabel": "Etap: {stage}",
+        "stageInitializing": "inicjowanie",
+        "endedLabel": "Zakończono {date}",
+        "stageCompleted": "Ukończono",
+        "stageInit": "Inicjowanie",
+        "stageSharedOverlays": "Importowanie metadanych",
+        "stageBookCovers": "Import okładek",
+        "stageUserState": "Importowanie danych użytkownika",
+        "noRunYet": "Nie przeprowadzono jeszcze migracji. Aby rozpocząć, wykonaj powyższe kroki.",
+        "runNum": "Uruchom #{id}",
+        "notStarted": "Nie rozpoczęte",
+        "reloadReport": "Załaduj ponownie raport",
+        "loadFullReport": "Załaduj pełny raport",
+        "exportJson": "Eksportuj JSON",
+        "exportCsv": "Eksportuj CSV",
+        "migrationFailed": "Migracja nie powiodła się",
+        "retryFromLastStage": "Spróbuj ponownie od ostatniego ukończonego etapu",
+        "booksCard": "Książki",
+        "metadataOverlaysApplied": "Zastosowano nakładki metadanych",
+        "authorMappingsReplaced": "Zastąpiono mapowania autora",
+        "narratorMappingsReplaced": "Zastąpiono mapowania Narratora",
+        "genreMappingsReplaced": "Zastąpiono mapowania gatunków",
+        "tagMappingsReplaced": "Zastąpiono mapowania tagów",
+        "coversImported": "Okładki importowane",
+        "coverImportSkipped": "Import okładki został pominięty – ścieżka katalogu głównego multimediów nie jest skonfigurowana w źródle",
+        "couldNotMatch": "Nie udało się dopasować",
+        "userDataCard": "Dane użytkownika",
+        "readingStatuses": "Odczyt statusów",
+        "readingProgressEntries": "Czytanie wpisów o postępie",
+        "audiobookProgressEntries": "Wpisy dotyczące postępu audiobooka",
+        "bookmarksLabel": "Zakładki",
+        "annotationsLabel": "Adnotacje",
+        "collectionEntries": "Wpisy kolekcji",
+        "loadFullReportHint": "Kliknij „Załaduj pełny raport”, aby dołączyć podsumowanie dopasowania próbnego do wyeksportowanego raportu.",
+        "completedNoIssues": "Migracja zakończyła się bez nierozwiązanych ksiąg i błędów.",
+        "matchedBooksHeading": "Pasujące książki ({count})",
+        "matchedBooksHint": "Te dopasowania próbne wykorzystano do podjęcia decyzji, które książki biblioteczne otrzymały zaimportowane dane.",
+        "sourceBookFallback": "Książka źródłowa {id}",
+        "libraryBookFallback": "Książka biblioteczna {id}",
+        "unresolvedBooksHeading": "Nierozwiązane książki ({count})",
+        "unresolvedBooksHint": "Te książki istnieją w źródle, ale nie można ich dopasować do żadnej książki w Twojej bibliotece.",
+        "mappedUsersHeading": "Zmapowani użytkownicy ({count})",
+        "mappedUsersHint": "Sumy na użytkownika pochodzą z próbnego podglądu zapisanego w pamięci podręcznej wraz z planem migracji.",
+        "coverImportsFailed": "{count} importowanie okładek nie powiodło się. Szczegółowe wiersze błędów nie są przechowywane.",
+        "backToSetup": "Powrót do konfiguracji"
+      },
+      "libraries": {
+        "title": "Biblioteki",
+        "subtitle": "Zarządzaj bibliotekami multimediów i uruchamiaj skanowanie zawartości.",
+        "scanAll": "Skanuj wszystko",
+        "scanning": "Skanowanie...",
+        "addLibrary": "Dodaj bibliotekę",
+        "scan": "Skanuj",
+        "editLibrary": "Edytuj bibliotekę",
+        "refreshCovers": "Odśwież okładki",
+        "syncMetadataToFiles": "Synchronizuj metadane z plikami",
+        "deleteLibrary": "Usuń bibliotekę",
+        "bookCount": "{count, plural, =0 {żadnych książek} one {# książka} other {# książki} few {# książki} many {# książek}}",
+        "addedDate": "Dodano {date}",
+        "fileMode": "Tryb plików",
+        "folderMode": "Tryb folderu",
+        "folderCount": "{count, plural, =0 {żadnych folderów} one {# folderze} other {# foldery} few {# foldery} many {# folderów}}",
+        "watching": "Oglądanie",
+        "fileWrite": "Zapis pliku",
+        "fileRename": "Zmień nazwę pliku",
+        "emptyTitle": "Nie ma jeszcze bibliotek",
+        "emptyHint": "Dodaj bibliotekę, aby rozpocząć porządkowanie książek.",
+        "addFirstLibrary": "Dodaj swoją pierwszą bibliotekę",
+        "deleteConfirmTitle": "Usunąć „{name}”?",
+        "deleteConfirmBody": "Spowoduje to trwałe usunięcie wszystkich książek, metadanych, postępu czytania, zakładek i adnotacji w tej bibliotece. Tego nie można cofnąć.",
+        "deleteConfirmTypeName": "Wpisz nazwę biblioteki, aby potwierdzić:",
+        "deleting": "Usuwanie...",
+        "deleteLibraryButton": "Usuń bibliotekę",
+        "syncConfirmTitle": "Zsynchronizować metadane z plikami?",
+        "syncConfirmBodyPrefix": "Spowoduje to zastąpienie metadanych w każdym obsługiwanym pliku",
+        "syncConfirmBodySuffix": "bezpośrednio na dysku. Tego nie można cofnąć.",
+        "syncFiles": "Synchronizuj pliki",
+        "metadataSynced": "Metadane zsynchronizowane z plikami dla „{name}”",
+        "fileWriteNotEnabled": "Zapisywanie plików metadanych nie jest włączone dla tej biblioteki. Włącz tę opcję w ustawieniach biblioteki.",
+        "fileSyncFailed": "Synchronizacja pliku nie powiodła się dla „{name}”",
+        "scanStarted": "Rozpoczęto skanowanie dla „{name}”",
+        "scanStartFailed": "Nie udało się rozpocząć skanowania dla „{name}”",
+        "refreshCoversFailed": "Nie udało się odświeżyć okładek dla „{name}”",
+        "scanStartedAll": "Rozpoczęto skanowanie wszystkich bibliotek",
+        "librariesFailedToStart": "{count, plural, =0 {Nie udało się uruchomić żadnej biblioteki} one {# nie udało się uruchomić biblioteki} other {# Nie udało się uruchomić bibliotek} few {Nie udało się uruchomić # bibliotek} many {Nie udało się uruchomić # bibliotek}}",
+        "scansStartFailed": "Nie udało się rozpocząć skanowania",
+        "libraryCreated": "Utworzono bibliotekę „{name}”.",
+        "libraryUpdated": "Zaktualizowano bibliotekę „{name}”.",
+        "libraryDeleted": "„{name}” usunięty",
+        "deleteFailed": "Nie udało się usunąć biblioteki",
+        "scanningProgress": "Skanowanie {pct}% ({processed}/{total})",
+        "scanDone": "Gotowe - dodano {added}, zaktualizowano {updated}",
+        "scanFailedWithError": "Nie udało się: {error}",
+        "scanFailed": "Skanowanie nie powiodło się",
+        "refreshingCovers": "Odświeżające okładki {pct}% ({processed}/{total})",
+        "coversRefreshed": "Okładki odświeżone ({count} przetworzone)"
+      },
+      "authorEnrichment": {
+        "configuration": "Konfiguracja",
+        "saving": "Zapisywanie...",
+        "running": "Bieganie...",
+        "runEligibleShort": "Uruchom kwalifikujący się",
+        "runAllShort": "Uruchom wszystko",
+        "enableTitle": "Włącz automatyczne wzbogacanie autora",
+        "enableHint": "Automatycznie pobieraj biografie autorów i zdjęcia profilowe po dodaniu lub aktualizacji książek.",
+        "updateStrategyTitle": "Aktualizuj strategię",
+        "updateStrategyHint": "Co zrobić, gdy autor ma już biografię lub zdjęcie.",
+        "writeModeMissingOnly": "Uzupełnij tylko brakujące dane (zalecane)",
+        "writeModeAlwaysRefetch": "Zawsze odświeżaj istniejące dane",
+        "triggerOnImportTitle": "Wyzwalaj przy imporcie",
+        "triggerOnImportHint": "Kolejkuj autorów w celu wzbogacenia, gdy książki są po raz pierwszy dodawane do biblioteki.",
+        "eligibilityTitle": "Warunki kwalifikowalności",
+        "eligibilityHint": "Autor kwalifikuje się, jeśli spełnia dowolny włączony warunek.",
+        "neverEnrichedTitle": "Nigdy nie wzbogacany",
+        "neverEnrichedHint": "Wzbogać autorów, którym nigdy nie udało się wzbogacić.",
+        "missingBioTitle": "Brakuje biografii",
+        "missingBioHint": "Wzbogać, jeśli autor nie ma biografii.",
+        "missingPhotoTitle": "Brakujące zdjęcie",
+        "missingPhotoHint": "Wzbogać jeśli autor nie posiada zdjęcia profilowego.",
+        "runForEligibleAuthors": "Bieg dla kwalifikujących się autorów",
+        "eligibleCount": "~{count} kwalifikuje się",
+        "runForAllAuthors": "Uruchom dla wszystkich autorów",
+        "saved": "Ustawienia wzbogacania autora zostały zapisane",
+        "saveFailed": "Nie udało się zapisać ustawień wzbogacania autora",
+        "noEligibleAuthors": "Nie znaleziono odpowiednich autorów",
+        "noAuthorsToEnrich": "Brak autorów do wzbogacenia",
+        "queueFailed": "Nie udało się ustawić w kolejce uzupełnienia autora"
+      },
+      "scoreWeights": {
+        "groupLabel": "Wagi punktowe",
+        "assignHintPrefix": "Przypisz wagę do każdego pola. Całkowita waga:",
+        "areYouSure": "Czy jesteś pewien?",
+        "resetToDefaultsButton": "Przywróć ustawienia domyślne",
+        "recalculateAll": "Przelicz wszystko",
+        "confirmReset": "Potwierdź reset",
+        "reset": "Zresetuj",
+        "recalculate": "Przelicz",
+        "subtotal": "suma częściowa: {count}",
+        "savedRecalculating": "Wagi punktowe zapisane. Ponowne obliczanie wyników biblioteki...",
+        "saveFailed": "Nie udało się zapisać wag wyników",
+        "recalcStarted": "Przeliczanie punktów rozpoczęło się w tle",
+        "recalcFailed": "Ponowne obliczenie nie powiodło się",
+        "resetToDefaults": "Wagi zresetowane do ustawień domyślnych. Zapisz, aby złożyć wniosek."
+      },
+      "tabs": {
+        "users": "Użytkownicy",
+        "account-activity": "Aktywność konta",
+        "magic-links": "Magiczne linki",
+        "oidc": "OIDC / Jednokrotne logowanie"
+      }
+    },
+    "common": {
+      "nav": {
+        "libraries": "Biblioteki",
+        "display": "Wyświetlanie",
+        "reader": "Czytelnik",
+        "metadata": "Metadane",
+        "email": "E-mail",
+        "opds": "OPDS",
+        "kobo": "Kobo",
+        "koreader": "KOReader",
+        "hardcover": "Hardcover",
+        "admin": "Administrator",
+        "system": "Systemu",
+        "account": "Konto"
+      }
+    },
+    "metadata": {
+      "title": "Metadane",
+      "noPermission": "Nie masz uprawnień do zarządzania ustawieniami metadanych.",
+      "fields": {
+        "title": "Tytuł",
+        "subtitle": "Podtytuł",
+        "description": "Opis",
+        "cover": "Okładka",
+        "authors": "Autorzy",
+        "publisher": "Wydawca",
+        "publishedYear": "Rok publikacji",
+        "language": "Język",
+        "pageCount": "Liczba stron",
+        "communityRating": "Ocena społeczności",
+        "seriesName": "Nazwa serii",
+        "seriesIndex": "Indeks serii",
+        "genres": "Gatunki",
+        "narrators": "Narratorzy",
+        "duration": "Czas trwania",
+        "abridged": "Skrócone"
+      },
+      "mergeStrategy": {
+        "fillMissing": {
+          "label": "Brak uzupełnienia",
+          "description": "Wpisz tylko jeśli pole jest aktualnie puste"
+        },
+        "overwriteIfProvided": {
+          "label": "Zastąp, jeśli podano",
+          "description": "Napisz, czy dostawca zwrócił wartość"
+        },
+        "overwrite": {
+          "label": "Zawsze nadpisuj",
+          "description": "Zawsze zastępuj istniejącą wartość"
+        }
+      },
+      "autoFetch": {
+        "globalSettings": "Ustawienia globalne",
+        "perLibraryOverrides": "Ustawienia dla poszczególnych bibliotek",
+        "saving": "Zapisywanie...",
+        "running": "Bieganie...",
+        "runNow": "Uciekaj teraz",
+        "runForEligible": "Biegnij po kwalifikujące się książki",
+        "enable": {
+          "label": "Włącz automatyczne pobieranie",
+          "hint": "Automatycznie pobieraj metadane kwalifikujących się książek."
+        },
+        "triggerOnImport": {
+          "label": "Wyzwalaj przy imporcie",
+          "hint": "Ustawiaj w kolejce kwalifikujące się książki po ich pierwszym dodaniu do biblioteki."
+        },
+        "status": {
+          "inQueuePaused": "{count} w kolejce - wstrzymane",
+          "remaining": "Pozostało {count}",
+          "eligible": "~{count} kwalifikuje się"
+        },
+        "trigger": {
+          "queued": "{count, plural, one {W kolejce # książka} other {W kolejce # książki} few {W kolejce # książki} many {W kolejce # książek}}",
+          "noneFound": "Nie znaleziono odpowiednich książek"
+        },
+        "lastRun": {
+          "justNow": "właśnie teraz",
+          "minutesAgo": "{count}m temu",
+          "hoursAgo": "{count}h temu",
+          "yesterday": "wczoraj",
+          "daysAgo": "{count} dni temu",
+          "label": "Ostatnie uruchomienie: {when}",
+          "labelQueued": "Ostatnie uruchomienie: {when} - w kolejce {count} książek",
+          "labelNoneEligible": "Ostatnie uruchomienie: {when} – brak kwalifikujących się książek"
+        },
+        "conditions": {
+          "title": "Warunki kwalifikowalności",
+          "hint": "Książka kwalifikuje się, jeśli spełnia dowolny włączony warunek.",
+          "noneEnabled": "Nie włączono żadnych warunków",
+          "neverFetched": {
+            "label": "Nigdy nie pobrano",
+            "hint": "Pobierz książki, w przypadku których nigdy nie podjęto próby pobrania metadanych.",
+            "summary": "Nigdy nie pobrano"
+          },
+          "scoreThreshold": {
+            "label": "Niski wynik metadanych",
+            "hint": "Pobierz, jeśli wynik metadanych jest poniżej progu.",
+            "scoreBelow": "Wynik poniżej",
+            "summary": "Wynik < {threshold}"
+          },
+          "missingFields": {
+            "label": "Brakujące pola",
+            "hint": "Pobierz, jeśli którekolwiek z wybranych pól jest puste.",
+            "summary": "{count, plural, one {Brakuje # pola} other {Brakuje # pola} few {Brakuje # pól} many {Brakuje # pól}}"
+          }
+        },
+        "library": {
+          "inheritingGlobal": "Dziedziczenie globalnych ustawień domyślnych",
+          "inheritFromGlobal": "Dziedzicz z global",
+          "usingGlobalDefaults": "Używanie globalnych ustawień domyślnych.",
+          "saveOverride": "Zapisz zastąpienie"
+        }
+      },
+      "providers": {
+        "availableSources": "Dostępne źródła",
+        "saveChanges": "Zapisz zmiany",
+        "test": "Testuj",
+        "testing": "Testowanie...",
+        "enabled": "Włączone",
+        "retryIn": "Spróbuj ponownie za {duration}",
+        "runTestBeforeEnabling": "Uruchom test przed włączeniem",
+        "hardcoverEnableHint": "Uruchom test z bieżącym tokenem, aby odblokować przełącznik włączający.",
+        "badge": {
+          "setupRequired": "Wymagana konfiguracja",
+          "throttled": "Ograniczony",
+          "ready": "Gotowy"
+        },
+        "fields": {
+          "apiKey": "API Klucz",
+          "region": "Region",
+          "cookie": "Ciastko",
+          "coverResolution": "Rozdzielczość okładki",
+          "country": "Kraj",
+          "language": "Język",
+          "ttbKey": "Klucz TTB"
+        },
+        "helpers": {
+          "googleApiKey": "Google Books API klucz z Google Cloud."
+        },
+        "hints": {
+          "google": "Szeroki zasięg z indeksu książek Google. Google Books wymaga teraz klucza API, zanim będzie można włączyć tego dostawcę.",
+          "amazon": "Zalecany jest plik cookie sesji. Wklej tylko wartość pliku cookie (bez „Cookie:”).",
+          "goodreads": "Największa społeczność czytelnicza w sieci. Nie wymaga konfiguracji.",
+          "hardcover": "Nowoczesna alternatywa dla Goodreads. Token z hardcover.app/account/api. Przedrostek „Bearer” jest opcjonalny.",
+          "openLibrary": "Bezpłatny katalog książek Internet Archive. Nie wymaga konfiguracji.",
+          "itunes": "Cyfrowy katalog książek Apple. Wybierz, czy chcesz pobrać okładki w wysokiej czy standardowej rozdzielczości.",
+          "kobo": "Usuwa publiczne strony książek Kobo. Kraj i język muszą pasować do Kobo URL ścieżek; ochrona przed botami może blokować żądania.",
+          "audible": "Pobiera metadane książki audio z Audible. Nie jest wymagana żadna dodatkowa konfiguracja.",
+          "audnexus": "Metadane audiobooków kierowane przez społeczność. Nie wymaga konfiguracji.",
+          "comicvine": "Metadane komiksu z ComicVine. Wymagany jest darmowy klucz API ze strony Comicvine.gamespot.com.",
+          "ranobedb": "Metadane japońskiej powieści lekkiej z RanobeDB. Nie wymaga konfiguracji.",
+          "lubimyczytac": "Katalog książek polskich (lubimyczytac.pl). Zadrapuje strony książek publicznych. Nie wymaga konfiguracji.",
+          "aladin": "Metadane koreańskiej książki od Aladyna (알라딘). Wymagany jest klucz TTB ze strony aladin.co.kr."
+        },
+        "blocked": {
+          "google": "Google Books wymaga klucza API, zanim będzie można go włączyć",
+          "hardcover": "Hardcover wymaga klucza API, zanim będzie można go włączyć",
+          "hardcoverTest": "Token Hardcover musi przejść test, zanim będzie można go włączyć",
+          "comicvine": "ComicVine wymaga klucza API, zanim będzie można go włączyć",
+          "aladin": "Aladin wymaga klucza TTB, zanim będzie można go włączyć"
+        }
+      },
+      "fieldRules": {
+        "clearAllProviders": "Wyczyść wszystkich dostawców",
+        "clearAll": "Wyczyść wszystko",
+        "resetToDefault": "Przywróć ustawienia domyślne",
+        "reset": "Zresetuj",
+        "dragProvidersHint": "Przeciągnij dostawców stąd na dowolne pole, aby ich dodać",
+        "dragProviderHere": "przeciągnij tutaj dostawcę",
+        "howItWorks": {
+          "title": "Jak działają reguły terenowe",
+          "priorityOrder": {
+            "title": "Zamówienie priorytetowe",
+            "body": "Przeciągnij dostawców na listę, aby zmienić ich kolejność. Dostawca znajdujący się najwyżej, który zwróci wynik, będzie głównym źródłem dla tego pola."
+          },
+          "mergeStrategy": {
+            "title": "Strategia połączenia",
+            "fillMissingTerm": "Uzupełnij brakujące:",
+            "fillMissingBody": "Zapisuj tylko wtedy, gdy bieżąca wartość jest pusta.",
+            "overwriteTerm": "Zastąp:",
+            "overwriteBody": "Wymień, gdy dostawca ma dane."
+          }
+        },
+        "libraryOverrides": {
+          "title": "Zastąpienia bibliotek",
+          "hint": "Rozwiń bibliotekę, aby dostosować poszczególne pola. Pola, które nie zostaną zastąpione, dziedziczą globalne ustawienia domyślne."
+        },
+        "global": {
+          "title": "Globalne ustawienia domyślne",
+          "hint": "Domyślne reguły stosowane do każdej biblioteki. Zastąp dla poszczególnych bibliotek poniżej.",
+          "saveDefaults": "Zapisz ustawienia domyślne",
+          "clearAllConfirm": "Usunąć wszystkich aktywnych dostawców z każdego pola? Ta czynność zostanie natychmiast zapisana i nie będzie można jej cofnąć.",
+          "resetConfirm": "Zresetować wszystkie globalne reguły pola do ustawień domyślnych systemu? Spowoduje to zastąpienie bieżącej konfiguracji."
+        },
+        "advanced": {
+          "title": "Zaawansowane zachowanie pobierania",
+          "combineGenres": {
+            "label": "Łącz gatunki od wszystkich wybranych dostawców",
+            "hint": "Zbieraj i deduplikuj gatunki od każdego dostawcy przypisanego do pola Gatunki, zamiast zatrzymywać się na pierwszym wyniku."
+          },
+          "storeProviderIds": {
+            "label": "Przechowuj identyfikatory dostawców na książkach",
+            "hint": "Podczas pobierania metadanych zapisz zwrócone identyfikatory dostawców (ISBN, ASIN, Goodreads ID itp.) w rekordzie księgowym, aby zapewnić dokładniejsze wyszukiwania w przyszłości."
+          }
+        },
+        "library": {
+          "primary": "Główny:",
+          "overrideCount": "{count, plural, one {# Zastąp} other {# Zastępuje} few {# przesłonięcia} many {# przesłonięć}}",
+          "unsavedSuffix": "(niezapisane)",
+          "unsavedChanges": "Niezapisane zmiany",
+          "globalDefaults": "Globalne ustawienia domyślne",
+          "overriding": "Zastąpienie: {fields}",
+          "inheritingAll": "Dziedziczenie wszystkich globalnych reguł metadanych",
+          "subHint": "Pola, które nie zostaną zastąpione, dziedziczą globalne ustawienia domyślne.",
+          "resetTooltip": "Usuń wszystkie przesłonięcia i odziedzicz globalne ustawienia domyślne",
+          "clearAllConfirm": "Usunąć wszystkich aktywnych dostawców z każdego pola w „{library}”?",
+          "resetConfirm": "Zresetować „{library}” do ustawień globalnych? Wszystkie nadpisania bibliotek zostaną usunięte."
+        },
+        "groups": {
+          "core": "Rdzeń",
+          "contributors": "Współautorzy",
+          "publication": "Publikacja",
+          "series": "Seria",
+          "classification": "Klasyfikacja",
+          "audiobook": "Książka audio"
+        },
+        "groupSummary": {
+          "base": "{fields} pola · {enabled} włączone",
+          "withOverrides": "{base} · {overrides} zastępuje"
+        },
+        "table": {
+          "field": "Pole",
+          "activeProviders": "Aktywni dostawcy (w kolejności według priorytetu)",
+          "mergeStrategy": "Strategia połączenia",
+          "status": "Stan"
+        },
+        "field": {
+          "noProviders": "Włączono, ale nie ma dostawców",
+          "empty": "Pusty",
+          "config": "Konfiguracja",
+          "custom": "Niestandardowe",
+          "default": "Domyślne",
+          "resetToDefault": "Przywróć ustawienia domyślne"
+        },
+        "reservoir": {
+          "disabled": "{provider} - wyłączone",
+          "notConfigured": "{provider} - nie skonfigurowano",
+          "dragToAssign": "Przeciągnij, aby przypisać {provider} do pola"
+        },
+        "sheet": {
+          "subtitle": "Stuknij dostawców, aby przypisać, użyj strzałek, aby zmienić kolejność",
+          "enableField": "Włącz to pole podczas odświeżania",
+          "providers": "Dostawcy",
+          "statusDisabled": "wyłączone",
+          "statusNotConfigured": "nie skonfigurowany",
+          "done": "Gotowe"
+        }
+      },
+      "genreBlocklist": {
+        "heading": "Globalne wykluczenia gatunków",
+        "hint": "Dokładne wartości gatunku na tej liście są usuwane z wyników dostawców przed zapisaniem metadanych.",
+        "saving": "Oszczędzanie",
+        "genreValueLabel": "Wartość gatunku",
+        "addPlaceholder": "Dodaj wartość gatunku, na przykład Książka audio",
+        "duplicate": "Ten gatunek jest już zablokowany.",
+        "add": "Dodaj",
+        "filterPlaceholder": "Filtruj listę zablokowanych",
+        "entryCount": "{count, plural, one {# wpis} other {# wpisy} few {# wpisy} many {# wpisów}}",
+        "filteredCount": "{shown} z {total}",
+        "noFilterMatch": "Żadne zablokowane gatunki nie pasują do bieżącego filtra.",
+        "emptyTitle": "Brak zablokowanych gatunków",
+        "emptyHint": "Dodaj dokładne wartości, takie jak Książka audio lub Dorosły, aby nie uwzględniały pobieranych metadanych.",
+        "removeLabel": "Usuń {genre}"
+      },
+      "customFields": {
+        "label": "Etykieta",
+        "labelPlaceholder": "np. Tytuł oryginalny",
+        "labelTooLong": "Etykieta musi mieć maksymalnie 255 znaków",
+        "labelDuplicate": "Pole z tą etykietą już istnieje",
+        "type": "Wpisz",
+        "usage": "{count, plural, one {Używany przez # książka} other {Używany przez # książki} few {Używane przez # książki} many {Używane przez # książek}}",
+        "newField": {
+          "title": "Nowe pole",
+          "hint": "Zdefiniuj niestandardowe pole metadanych i wybierz, które biblioteki z niego korzystają."
+        },
+        "previewToggle": "Podgląd wyglądu tego pola podczas edycji książki",
+        "untitledField": "Pole bez tytułu",
+        "addField": "Dodaj pole",
+        "fields": "Pola",
+        "fieldsHint": "Przeciągnij, aby zmienić kolejność, edytować etykiety, przełączać biblioteki lub archiwizować pola, których już nie potrzebujesz.",
+        "searchPlaceholder": "Pola wyszukiwania",
+        "searchAriaLabel": "Wyszukaj pola niestandardowe",
+        "emptyTitle": "Nie ma jeszcze pól niestandardowych",
+        "emptyHint": "Skorzystaj z powyższego formularza, aby zdefiniować swoje pierwsze niestandardowe pole metadanych.",
+        "noMatchTitle": "Żadne pola nie pasują do „{query}”",
+        "noMatchHint": "Wypróbuj inną etykietę, klucz lub typ.",
+        "clearSearchToReorder": "Wyczyść wyszukiwanie, aby zmienić kolejność",
+        "dragToReorder": "Przeciągnij, aby zmienić kolejność",
+        "dragToReorderField": "Przeciągnij, aby zmienić kolejność pola",
+        "unsaved": "Niezapisane",
+        "archive": "Archiwum",
+        "archivedFields": "Pola zarchiwizowane",
+        "archivedSummary": "{count, plural, one {# pole zarchiwizowane - przywróć lub trwale usuń.} other {# zarchiwizowane pola - przywróć lub trwale usuń.} few {# zarchiwizowane pola - przywróć lub trwale usuń.} many {# zarchiwizowanych pól - przywróć lub trwale usuń.}}",
+        "archivedAt": "Zarchiwizowane {when}",
+        "restore": "Przywróć",
+        "deleteForever": "Usuń na zawsze",
+        "deleteDialog": {
+          "title": "Trwale usuń pole",
+          "bodyBefore": "Spowoduje to trwałe usunięcie",
+          "bodyMiddle": "i usuń zapisane wartości z",
+          "bodyAfter": ". Tego nie można cofnąć.",
+          "confirmBefore": "Wpisz",
+          "confirmAfter": "potwierdzić",
+          "confirmPlaceholder": "Wpisz etykietę pola, aby potwierdzić"
+        },
+        "preview": "Podgląd",
+        "sampleValue": "Wartość próbki",
+        "enabledLibraries": "Włączone biblioteki",
+        "countOf": "{selected} z {total}",
+        "selectAll": "Zaznacz wszystko",
+        "clear": "Wyczyść",
+        "noLibraries": "Nie ma jeszcze dostępnych bibliotek.",
+        "allLibraries": "Wszystkie biblioteki"
+      },
+      "tabs": {
+        "providers": "Dostawcy",
+        "field-rules": "Zasady terenowe",
+        "custom-fields": "Pola niestandardowe",
+        "genre-blocklist": "Lista zablokowanych gatunków",
+        "score": "Wynik",
+        "auto-fetch": "Książki",
+        "authors": "Autorzy"
+      },
+      "tabTitles": {
+        "providers": "Dostawcy",
+        "field-rules": "Zasady na poziomie pola",
+        "custom-fields": "Niestandardowe metadane",
+        "genre-blocklist": "Lista zablokowanych gatunków",
+        "score": "Wynik zaufania",
+        "auto-fetch": "Automatyczne pobieranie książek",
+        "authors": "Automatyczne pobieranie autora"
+      },
+      "tabSubtitles": {
+        "providers": "Włącz zewnętrzne źródła metadanych i skonfiguruj ich poświadczenia.",
+        "field-rules": "Kontroluj, który dostawca dostarcza poszczególne pola metadanych i sposób łączenia wartości w bibliotekach.",
+        "custom-fields": "Zdefiniuj niestandardowe pola metadanych i wybierz, które biblioteki z nich korzystają.",
+        "genre-blocklist": "Zapobiegaj zapisywaniu w książkach niechcianych wartości gatunku dostawcy.",
+        "score": "Przypisz wagi do pól metadanych, aby obliczyć, jak bardzo ufać pobranym wynikom.",
+        "auto-fetch": "Automatycznie pobieraj okładki, opisy i inne szczegóły, gdy do Twojej biblioteki dodawane są nowe książki.",
+        "authors": "Automatycznie pobieraj biografie i zdjęcia profilowe, gdy w Twojej bibliotece pojawią się nowi autorzy."
+      }
+    },
+    "reader": {
+      "resetToDefaults": "Przywróć ustawienia domyślne",
+      "all": {
+        "title": "Czytelnik",
+        "subtitle": "Skonfiguruj ustawienia domyślne dla wszystkich trybów czytania w jednym miejscu."
+      },
+      "general": {
+        "title": "Czytanie",
+        "subtitle": "Ogólne zachowanie, które ma zastosowanie do wszystkich typów czytników.",
+        "storageLabel": "Gdzie zapisać preferencje czytelnika",
+        "deviceOnly": "Tylko to urządzenie",
+        "deviceOnlyHint": "Preferencje pozostają w Twojej przeglądarce. Najlepiej, jeśli zawsze czytasz na tym urządzeniu lub chcesz mieć inne ustawienia na każdym urządzeniu.",
+        "myAccount": "Moje konto",
+        "myAccountHint": "Preferencje są zapisywane na Twoim koncie. Najlepiej, jeśli logujesz się z wielu urządzeń i chcesz mieć wszędzie spójne wrażenia.",
+        "active": "Aktywny",
+        "notAvailable": "Niedostępne",
+        "demoCannotChangeStorage": "Konto z ograniczeniami demo nie może zmienić trybu przechowywania czytnika",
+        "preferencesSynced": "Preferencje zostaną teraz zsynchronizowane",
+        "preferencesLocal": "Preferencje pozostaną na tym urządzeniu",
+        "storageUpdateFailed": "Nie udało się zaktualizować trybu przechowywania",
+        "storageUpdateError": "Wystąpił błąd podczas aktualizowania trybu przechowywania"
+      },
+      "ebook": {
+        "title": "Czytnik e-booków",
+        "subtitle": "Ustawienia domyślne stosowane podczas otwierania plików EPUB, MOBI, FB2 i TXT.",
+        "newBooks": "Nowe książki",
+        "applySettings": "Zastosuj moje ustawienia do nowych książek",
+        "applySettingsHint": "Gdy ta opcja jest wyłączona, nowe książki otwierają się z czcionkami i układem własnym wydawcy. Twoje ustawienia obowiązują tylko wtedy, gdy zmienisz coś w czytniku.",
+        "layout": "Układ",
+        "readingFlow": "Czytanie",
+        "readingFlowHint": "Paginowane strony przewracane; przewijane przepływa w sposób ciągły",
+        "paginated": "Paginowane",
+        "scrolled": "Przewinięte",
+        "fixedLayoutSpread": "Rozkładówki stron o stałym układzie",
+        "fixedLayoutSpreadHint": "Domyślne dla mangi, komiksów i plików EPUB opartych na obrazach",
+        "bookDefault": "Książka domyślna",
+        "singlePage": "Pojedyncza strona",
+        "columns": "Kolumny",
+        "columnsHint": "Liczba kolumn tekstu na stronie",
+        "theme": "Motyw",
+        "darkMode": "Tryb ciemny",
+        "darkModeHint": "Użyj ciemnego wariantu wybranego motywu",
+        "typography": "Typografia",
+        "font": "Czcionka",
+        "fontHint": "Krój pisma używany w tekście głównym",
+        "builtInFonts": "Wbudowane czcionki",
+        "yourFonts": "Twoje czcionki",
+        "fontSize": "Rozmiar czcionki",
+        "fontSizeHint": "Podstawowy rozmiar tekstu w pikselach",
+        "lineHeight": "Wysokość linii",
+        "lineHeightHint": "Pionowe odstępy między wierszami",
+        "justify": "Justuj tekst",
+        "justifyHint": "Wyrównaj tekst do obu marginesów",
+        "hyphenation": "Dzielenie wyrazów",
+        "hyphenationHint": "Automatycznie dziel długie słowa łącznikami",
+        "advanced": "Zaawansowane",
+        "maxContentWidth": "Maksymalna szerokość treści",
+        "maxContentWidthHint": "Maksymalna szerokość obszaru tekstowego w pikselach",
+        "columnGap": "Szczelina kolumny",
+        "columnGapHint": "Poziome wypełnienie po obu stronach obszaru tekstowego"
+      },
+      "pdf": {
+        "title": "PDF Czytelniku",
+        "subtitle": "Ustawienia domyślne stosowane podczas otwierania plików PDF.",
+        "layout": "Układ",
+        "scrollMode": "Tryb przewijania",
+        "scrollModeHint": "Strona przewraca się pojedynczo; ciągłe przewijanie wszystkich stron",
+        "page": "Strona",
+        "scrolled": "Przewinięte",
+        "pageSpread": "Rozprzestrzenianie się strony",
+        "pageSpreadHint": "Który numer strony zaczyna się po prawej stronie w widoku dwustronicowym",
+        "spreadNone": "Żadne",
+        "spreadOdd": "Dziwne",
+        "spreadEven": "Parzyste",
+        "zoom": "Powiększ",
+        "defaultFit": "Domyślne dopasowanie",
+        "defaultFitHint": "Jak strony są skalowane po otwarciu PDF",
+        "fitPage": "Dopasuj stronę",
+        "fitWidth": "Dopasuj szerokość",
+        "custom": "Niestandardowe",
+        "zoomLevel": "Poziom powiększenia",
+        "zoomLevelHint": "Współczynnik skali dla niestandardowego trybu powiększenia"
+      },
+      "comics": {
+        "title": "Czytelnik komiksów",
+        "subtitle": "Ustawienia domyślne stosowane podczas otwierania plików CBZ, CBR i CB7.",
+        "view": "Zobacz",
+        "readingMode": "Tryb czytania",
+        "readingModeHint": "Sposób nawigacji po stronach - w przypadku webtoonów użyj opcji „Infinite (bez przerw)”.",
+        "paginated": "Paginowane",
+        "infiniteSpaced": "Nieskończony (z odstępami)",
+        "infiniteNoGaps": "Nieskończony (bez przerw)",
+        "pageView": "Widok strony",
+        "pageViewHint": "Pokaż jedną lub dwie strony obok siebie",
+        "single": "Pojedynczy",
+        "twoPage": "Dwustronicowe",
+        "fitMode": "Tryb dopasowania",
+        "fitModeHint": "Sposób skalowania stron w celu dopasowania ich do ekranu",
+        "fitPage": "Strona",
+        "fitWidth": "Szerokość",
+        "fitHeight": "Wysokość",
+        "fitActual": "Rzeczywisty",
+        "readingDirection": "Kierunek czytania",
+        "readingDirectionHint": "Od lewej do prawej w przypadku zachodnich komiksów; od prawej do lewej w przypadku mangi",
+        "ltr": "L do R",
+        "rtl": "R do L",
+        "spreadAlignment": "Wyrównanie rozprzestrzeniania się",
+        "spreadAlignmentHint": "Przesuń parowanie o jedną stronę po okładce, aby skanować pojedynczo",
+        "alignmentNormal": "Normalne",
+        "alignmentShifted": "Przesunięty",
+        "spreadGap": "Rozłóż lukę",
+        "spreadGapHint": "Odstęp między stronami w widoku dwustronicowym",
+        "spreadGapValue": "{value}px",
+        "widePageHandling": "Obsługa szerokiej strony",
+        "widePageHandlingHint": "Automatycznie wyświetla same szerokie skany w trybie dwustronicowym",
+        "widePageAuto": "Automat",
+        "widePageDisable": "Wyłącz",
+        "forceTwoPage": "Wymuś dwie strony na małych ekranach",
+        "forceTwoPageHint": "Pomiń automatyczne przywracanie wersji mobilnej, gdy wybrany jest tryb dwóch stron podzielonych na strony",
+        "off": "Wyłączone",
+        "on": "Włączone",
+        "display": "Wyświetlanie",
+        "backgroundColor": "Kolor tła",
+        "backgroundColorHint": "Kolor płótna za stronami",
+        "bgBlack": "Czarny",
+        "bgGray": "Szary",
+        "bgWhite": "Biały"
+      },
+      "audio": {
+        "title": "Odtwarzacz audiobooków",
+        "subtitle": "Ustawienia domyślne stosowane podczas odtwarzania M4B, MP3 i innych formatów audio.",
+        "playback": "Odtwarzanie",
+        "playbackSpeed": "Domyślna prędkość odtwarzania",
+        "playbackSpeedHint": "Mnożnik prędkości zastosowany podczas otwierania nowego audiobooka",
+        "volume": "Domyślna głośność",
+        "volumeHint": "Początkowy poziom głośności (0 do 100%)",
+        "skipControls": "Pomiń kontrolę",
+        "skipBack": "Pomiń czas trwania",
+        "skipBackHint": "Sekundy do tyłu po naciśnięciu przycisku przewijania",
+        "skipForward": "Przeskocz czas trwania do przodu",
+        "skipForwardHint": "Sekundy do przodu po naciśnięciu przycisku przewijania do przodu"
+      },
+      "fonts": {
+        "title": "Czcionki",
+        "subtitle": "Prześlij niestandardowe czcionki do użycia w czytniku e-booków.",
+        "uploadFonts": "Prześlij czcionki",
+        "notAvailableDemo": "Niedostępne dla kont demonstracyjnych",
+        "uploading": "Przesyłanie...",
+        "dropFilesHere": "Upuść pliki tutaj",
+        "dragFontsPrefix": "Przeciągnij tutaj pliki czcionek lub",
+        "browse": "przeglądaj",
+        "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - maksymalnie 10 MB każdy",
+        "yourFonts": "Twoje czcionki",
+        "fontsUsed": "{count} / {max} użyte",
+        "noFontsYet": "Nie przesłano jeszcze żadnych czcionek",
+        "noFontsHint": "Aby rozpocząć, przeciągnij plik czcionki powyżej.",
+        "fileCount": "{count, plural, =0 {żadnych plików} one {# plik} other {# pliki} few {# pliki} many {# plików}}",
+        "pangram": "Szybki brązowy lis przeskakuje leniwego psa",
+        "renameFamily": "Zmień nazwę rodziny",
+        "deleteFamily": "Usuń rodzinę",
+        "editVariant": "Edytuj wagę/styl",
+        "deleteVariant": "Usuń wariant",
+        "styleNormal": "Normalne",
+        "styleItalic": "Kursywa",
+        "weightThin": "Cienki",
+        "weightExtraLight": "Dodatkowe światło",
+        "weightLight": "Światło",
+        "weightRegular": "Regularne",
+        "weightMedium": "Średni",
+        "weightSemiBold": "Półodważne",
+        "weightBold": "Odważne",
+        "weightExtraBold": "Bardzo odważne",
+        "weightBlack": "Czarny",
+        "renameFamilyFailed": "Nie udało się zmienić nazwy rodziny czcionek",
+        "renamedTo": "Zmieniono nazwę na „{name}”",
+        "updateVariantFailed": "Nie udało się zaktualizować wariantu czcionki",
+        "deleteFontFailed": "Nie udało się usunąć czcionki",
+        "deleteFamilyFailed": "Nie udało się usunąć rodziny czcionek",
+        "demoCannotManage": "Konto z ograniczeniami demo nie może zarządzać czcionkami",
+        "fileAdded": "Dodano „{name}”.",
+        "uploadFailed": "Przesyłanie nie powiodło się"
+      },
+      "bookDock": {
+        "title": "Book Dock",
+        "subtitle": "Skonfiguruj sposób przetwarzania plików po wejściu do Book Dock.",
+        "dropFolder": "Upuść folder",
+        "containerPath": "Ścieżka kontenerowa",
+        "containerPathHint": "Skopiuj lub przenieś pliki książek do tego folderu, a zostaną one automatycznie pobrane i przetworzone przez Book Dock. Podkatalogi są obsługiwane.",
+        "changePathPrefix": "Aby zmienić tę ścieżkę, ustaw",
+        "changePathMiddle": "w twoim",
+        "changePathSuffix": "plik.",
+        "metadata": "Metadane",
+        "autoFetch": "Automatyczne pobieranie metadanych od dostawców",
+        "autoFetchHint": "Automatycznie pobieraj metadane od skonfigurowanych dostawców (Google Books, iTunes, Open Library itp.) po dodaniu pliku do Book Dock.",
+        "autoFinalize": "Automatyczna finalizacja",
+        "enableAutoFinalize": "Włącz automatyczne finalizowanie",
+        "enableAutoFinalizeHint": "Pliki, których poziom pewności metadanych jest równy lub wyższy od progu, zostaną automatycznie sfinalizowane.",
+        "confidenceThreshold": "Próg ufności: {value}%",
+        "thresholdIgnored": "(ignorowane w trybie Tylko osadzony)",
+        "destinationLibrary": "Biblioteka docelowa",
+        "selectLibrary": "Wybierz bibliotekę...",
+        "metadataMode": "Tryb metadanych",
+        "metadataModeSafeMerge": "Bezpieczne scalanie (zalecane)",
+        "metadataModeFetchedOnly": "Tylko pobrane",
+        "metadataModeEmbeddedOnly": "Tylko osadzone",
+        "destinationFolder": "Folder docelowy",
+        "selectFolder": "Wybierz folder...",
+        "saveSettingFailed": "Nie udało się zapisać ustawienia",
+        "updateSettingFailed": "Nie udało się zaktualizować ustawienia",
+        "autoFetchEnabled": "Automatyczne pobieranie włączone",
+        "autoFetchDisabled": "Automatyczne pobieranie wyłączone",
+        "autoFinalizeEnabled": "Włączono automatyczne finalizowanie",
+        "autoFinalizeDisabled": "Automatyczne finalizowanie wyłączone",
+        "destinationLibraryUpdated": "Zaktualizowano bibliotekę docelową",
+        "destinationFolderUpdated": "Folder docelowy został zaktualizowany",
+        "confidenceThresholdUpdated": "Zaktualizowano próg ufności",
+        "metadataModeUpdated": "Zaktualizowano tryb metadanych"
+      },
+      "fileNaming": {
+        "title": "Nazewnictwo plików",
+        "subtitle": "Kontroluj sposób, w jaki pliki są zorganizowane na dysku po przesłaniu i jak są nazywane po pobraniu, za pomocą tokenów zastępczych.",
+        "copy": "Kopiuj",
+        "previewLabel": "Podgląd:",
+        "fileAsBookPreview": "Plik jako podgląd książki",
+        "folderAsBookPreview": "Folder jako podgląd książki",
+        "downloadPreview": "Pobierz podgląd",
+        "globalDefaults": "Globalne ustawienia domyślne",
+        "crossPlatform": "Oczyszczanie ścieżek między platformami",
+        "crossPlatformHint": "Zabezpiecz wygenerowane nazwy plików i folderów w systemie Windows, zastępując nieprawidłowe znaki i nazwy zastrzeżone oraz usuwając końcowe kropki i spacje. Wyłącz tylko w przypadku konfiguracji wyłącznie dla systemu Linux, które celowo zachowują te znaki.",
+        "fileAsBookDefault": "Plik jako domyślna książka",
+        "fileAsBookDefaultHint": "Prześlij wzór dla bibliotek przy użyciu trybu Plik jako książka. Każdy plik to jedna książka.",
+        "folderAsBookDefault": "Folder jako domyślny Książka",
+        "folderAsBookDefaultHint": "Prześlij wzór dla bibliotek, korzystając z trybu Folder jako Książka. Każda książka musi znajdować się w osobnym folderze.",
+        "downloadPattern": "Pobierz wzór",
+        "downloadPatternHint": "Sugerowane nazwy plików do pobrania w postaci pojedynczych plików i plików w eksportowanych plikach ZIP.",
+        "libraryOverrides": "Zastąpienia bibliotek",
+        "noLibraries": "Nie skonfigurowano żadnych bibliotek. Utwórz je w ustawieniach biblioteki, aby ustawić niestandardowe wzorce nazewnictwa.",
+        "badgeCustom": "Niestandardowe",
+        "badgeDefault": "Domyślne",
+        "orgFolderAsBook": "Folder jako książka",
+        "orgFileAsBook": "Plik jako książka",
+        "resetToDefault": "Przywróć ustawienia domyślne",
+        "patternReference": "Odniesienie do wzoru",
+        "placeholderReference": "Odniesienie do obiektu zastępczego",
+        "placeholderReferenceHint": "- przewodnik dotyczący tworzenia niestandardowych wzorców nazewnictwa",
+        "tokens": "Żetony",
+        "tokensHint": "Szybko kopiuj symbole zastępcze",
+        "clickTokenHint": "Kliknij dowolny token, aby skopiować go do schowka.",
+        "copyValue": "Skopiuj {value}",
+        "modifiers": "Modyfikatory",
+        "modifiersHint": "Przekształć wartości tokenów",
+        "modifiersExplain": "Dołącz modyfikator wewnątrz tokenu, aby przekształcić jego wartość:",
+        "modFirst": "Tylko pierwsza wartość",
+        "modSort": "Ostatni, pierwszy format",
+        "modInitial": "Tylko pierwsza litera",
+        "modFixed2": "Dwa miejsca po przecinku",
+        "folderOnlyPrefix": "Zakończ wzór za pomocą",
+        "folderOnlySuffix": "aby określić tylko folder. Oryginalna nazwa pliku zostanie w nim zachowana.",
+        "conditionalLogic": "Logika warunkowa",
+        "conditionalLogicHint": "Opcjonalne segmenty i rezerwy",
+        "conditionalPart1": "Zawiń",
+        "conditionalPart2": "aby pominąć segment, gdy jego token jest pusty. Użyj",
+        "conditionalPart3": "dla wartości domyślnej.",
+        "examples": "Przykłady",
+        "patternExamples": "Przykłady wzorów",
+        "patternExamplesHint": "Gotowe wzory dla popularnych stylów bibliotek",
+        "copyPatternTooltip": "Skopiuj wzór do schowka",
+        "exCalibre": "Domyślny styl Calibre",
+        "exSeriesReader": "Czytelnik serii",
+        "exCleanDownload": "Wyczyść nazwę pliku do pobrania",
+        "exAlphabetical": "Grupowanie alfabetyczne z seriami",
+        "exSeriesFallback": "Seria lub samodzielna wersja rezerwowa",
+        "exOptionalSubtitle": "Pobierz z opcjonalnymi napisami",
+        "exMultilingual": "Wielojęzyczna biblioteka",
+        "exPublisher": "Zorganizowane przez wydawcę",
+        "exStacked": "Ułożone opcjonalne foldery",
+        "exFolderDrop": "Upuszczenie folderu z nazwą sortowania",
+        "caseWithYear": "z rokiem",
+        "caseNoYear": "nie ma roku",
+        "caseInSeries": "w serii",
+        "caseStandalone": "samodzielny",
+        "caseNoSeries": "brak serii",
+        "caseFull": "pełny",
+        "caseMinimal": "minimalne",
+        "caseWithLanguage": "z językiem",
+        "caseNoLanguage": "żadnego języka",
+        "caseWithPublisher": "z wydawcą",
+        "caseNoPublisher": "żadnego wydawcy",
+        "caseAllSet": "wszystko gotowe",
+        "copiedToClipboard": "{value} skopiowano do schowka",
+        "copyTokenFailed": "Nie udało się skopiować tokena",
+        "patternCopied": "Wzór skopiowany do schowka",
+        "copyPatternFailed": "Nie udało się skopiować wzoru",
+        "labelCopied": "{label} skopiowano do schowka",
+        "copyLabelFailed": "Nie udało się skopiować {label}"
+      },
+      "kobo": {
+        "title": "Kobo Synchronizacja",
+        "subtitle": "Sparuj urządzenie Kobo, aby zsynchronizować swoją bibliotekę.",
+        "copy": "Kopiuj",
+        "never": "Nigdy",
+        "justNow": "Właśnie teraz",
+        "minutesAgo": "{count}m temu",
+        "hoursAgo": "{count}h temu",
+        "daysAgo": "{count}d temu",
+        "loadFailed": "Nie udało się załadować",
+        "devicePaired": "Urządzenie zostało pomyślnie sparowane",
+        "devicePairedHint": "Możesz już skonfigurować swój Kobo. Postępuj zgodnie z poniższymi instrukcjami.",
+        "syncUrl": "Synchronizuj URL",
+        "urlNotShownAgain": "Ten URL nie będzie wyświetlany ponownie. Zachowaj prywatność.",
+        "registeredDevices": "Zarejestrowane urządzenia",
+        "addDevice": "Dodaj urządzenie",
+        "deviceName": "Nazwa urządzenia",
+        "deviceNamePlaceholder": "np. Moja Kobo Waga",
+        "creating": "Tworzenie...",
+        "createDevice": "Utwórz urządzenie",
+        "createDeviceFailed": "Nie udało się utworzyć urządzenia",
+        "deviceRegistered": "Zarejestrowano urządzenie „{name}”.",
+        "noDevicesYet": "Nie ma jeszcze żadnych urządzeń",
+        "noDevicesHint": "Dodaj urządzenie, aby rozpocząć synchronizację książek z Kobo.",
+        "lastSync": "Ostatnia synchronizacja: {time}",
+        "renameDevice": "Zmień nazwę urządzenia",
+        "revokeAccess": "Odwołaj dostęp",
+        "deviceRenamed": "Zmieniono nazwę urządzenia",
+        "renameDeviceFailed": "Nie udało się zmienić nazwy urządzenia",
+        "revokeConfirm": "Odwołać dostęp dla „{name}”? Urządzenie nie będzie mogło się zsynchronizować, dopóki nie zostanie ponownie sparowane.",
+        "accessRevoked": "Dostęp został odwołany dla „{name}”",
+        "revokeFailed": "Nie udało się odwołać dostępu",
+        "syncUrlCopied": "Synchronizacja URL skopiowana do schowka",
+        "syncUrlCopyFailed": "Nie udało się skopiować synchronizacji URL",
+        "syncPreferences": "Preferencje synchronizacji",
+        "twoWaySync": "Dwukierunkowa synchronizacja postępu",
+        "twoWaySyncHint": "Zsynchronizuj pozycję czytania pomiędzy BookOrbit i Kobo. Wymaga dostawy KEPUB w celu uzyskania precyzyjnych lokalizacji i niezawodnego przywracania stron.",
+        "syncHighlights": "Synchronizuj najważniejsze momenty BookOrbit z Kobo",
+        "syncHighlightsHint": "Wyślij najważniejsze momenty wykonane w BookOrbit lub KOReader do swojego Kobo. Kobo wyróżnienia są importowane do BookOrbit nawet wtedy, gdy ta opcja jest wyłączona. Połączone adnotacje synchronizują zmiany i usuwają je w obie strony. Wymaga dostawy KEPUB; książka na Kobo musi być KEPUB-em pobranym z BookOrbit.",
+        "convertKepub": "Konwertuj na KEPUB",
+        "convertKepubHint": "Wyślij kwalifikujące się pliki EPUB jako KEPUB. Pozostaje włączona, gdy włączona jest synchronizacja postępu lub podświetlanie BookOrbit-do-Kobo. Podczas następnej synchronizacji Kobo książki, których to dotyczy, będą ponownie oferowane jako pliki do pobrania KEPUB; usuń całą starą kopię EPUB, jeśli Kobo ciągle ją otwiera.",
+        "forceHyphenation": "Wymuś dzielenie wyrazów",
+        "forceHyphenationHint": "Zapewnia spójne justowanie tekstu. Spowoduje to zregenerowanie buforowanych KEPUB-ów.",
+        "progressThresholds": "Progi postępu",
+        "progressThresholdsHint": "Określ, kiedy Kobo postęp czytania aktualizuje status Twojej biblioteki.",
+        "markAsReading": "Oznacz jako przeczytane",
+        "markAsReadingHint": "Minimalny procent przeniesienia książki do „Czytanie”.",
+        "markAsFinished": "Oznacz jako gotowe",
+        "markAsFinishedHint": "Procentowy próg oznaczania książki jako „Gotowej”.",
+        "kepubLimit": "Limit konwersji KEPUB",
+        "kepubLimitHint": "Książki przekraczające ten limit są wysyłane jako zwykłe pliki EPUB, więc BookOrbit nie będzie synchronizować pozycji czytelnika z powrotem z Kobo.",
+        "changesMustBeSaved": "Zmiany muszą zostać zapisane, aby zaczęły obowiązywać.",
+        "saving": "Zapisywanie...",
+        "saveSyncSettings": "Zapisz ustawienia synchronizacji",
+        "thresholdOrderError": "Próg odczytu musi być niższy niż próg ukończenia",
+        "saveSettingsFailed": "Nie udało się zapisać ustawień",
+        "settingsSaved": "Kobo ustawienia synchronizacji zostały zapisane",
+        "saveFailed": "Nie udało się zapisać",
+        "activity": {
+          "waitingForActivity": "Oczekiwanie na aktywność",
+          "needsAttention": "Potrzebuje uwagi",
+          "syncHealthy": "Synchronizuj zdrowo",
+          "never": "Nigdy",
+          "none": "Żadne",
+          "unknown": "Nieznany",
+          "failureCount": "{count, plural, one {# porażka} other {# niepowodzenia} few {# niepowodzenia} many {# niepowodzeń}}",
+          "noActivityRecorded": "Nie zarejestrowano żadnej aktywności synchronizacji Kobo.",
+          "lastSuccess": "Ostatni sukces {time}",
+          "lastFailure": "Ostatnia porażka {time}",
+          "noFailedActivity": "Brak nieudanej aktywności Kobo w najnowszej historii.",
+          "noActivityYet": "Nie ma jeszcze żadnej aktywności Kobo.",
+          "event": {
+            "librarySync": "Biblioteka sprawdzona pod kątem aktualizacji",
+            "bookDownload": "Książka pobrana",
+            "progressUpdate": "Pozycja czytania została zaktualizowana",
+            "annotationsPull": "Najciekawsze informacje wysłane do Kobo",
+            "annotationsPush": "Najważniejsze informacje otrzymane od Kobo"
+          },
+          "outcome": {
+            "failed": "Nie udało się",
+            "noUpdates": "Brak aktualizacji",
+            "noChanges": "Żadnych zmian",
+            "pending": "Oczekujące",
+            "completed": "Ukończono",
+            "downloaded": "Pobrano",
+            "updated": "Zaktualizowano",
+            "sent": "Wysłane",
+            "imported": "Importowane"
+          },
+          "failure": {
+            "librarySync": "Sprawdzanie biblioteki nie zostało zakończone",
+            "bookDownload": "Pobieranie nie zostało ukończone",
+            "progressUpdate": "Pozycja odczytu nie została zaktualizowana",
+            "annotationsPull": "Najciekawsze informacje nie zostały wysłane",
+            "annotationsPush": "Najciekawsze momenty nie zostały zaimportowane"
+          },
+          "chip": {
+            "morePending": "Więcej w toku",
+            "noUpdatesPending": "Brak oczekujących aktualizacji",
+            "bookCount": "{count, plural, one {# książka} other {# książki} few {# książki} many {# książek}}",
+            "deletedAnnotations": "{count} usunięte adnotacje",
+            "deviceAlreadyCurrent": "Urządzenie jest już aktualne",
+            "freshHighlightData": "Świeże dane z najważniejszych wydarzeń",
+            "created": "Utworzono {count}",
+            "updated": "{count} zaktualizowano",
+            "deleted": "{count} usunięty",
+            "unchanged": "{count} bez zmian"
+          },
+          "readingPositionSyncedTitle": "Zsynchronizowana pozycja czytania: {title}",
+          "readingPositionSynced": "Pozycja czytania zsynchronizowana",
+          "labelWithTitle": "{label}: {title}",
+          "updateCount": "{count, plural, one {# aktualizacja} other {# aktualizacje} few {# aktualizacje} many {# aktualizacji}}",
+          "directionToKobo": "BookOrbit -> Kobo",
+          "directionToBookOrbit": "Kobo -> BookOrbit",
+          "twoWaySyncEnabled": "Włączono synchronizację dwukierunkową",
+          "deviceProgressSaved": "Postęp urządzenia został zapisany",
+          "summary": {
+            "noLibraryUpdatesPending": "Żadne aktualizacje bibliotek nie oczekują na to urządzenie",
+            "libraryUpdatesPrepared": "{count, plural, one {# aktualizacja biblioteki przygotowana dla urządzenia} other {# aktualizacje bibliotek przygotowane dla urządzenia} few {Przygotowano # aktualizacje bibliotek dla urządzenia} many {Przygotowano # aktualizacji bibliotek dla urządzenia}}",
+            "bookDownloadedBy": "{title} został pobrany przez {device}",
+            "booksDownloaded": "{count, plural, one {# książka pobrana} other {# pobrane książki} few {Pobrano # książki} many {Pobrano # książek}}",
+            "progressUpdatesSyncedFor": "{count, plural, one {# aktualizacja postępu zsynchronizowana dla {title}} other {# synchronizowano aktualizacje postępu {title}} few {# aktualizacje postępu zsynchronizowane dla {title}} many {# aktualizacji postępu zsynchronizowanych dla {title}}}",
+            "progressUpdatesSynced": "{count, plural, one {# aktualizacja postępu zsynchronizowana} other {# zsynchronizowane aktualizacje postępu} few {Zsynchronizowano # aktualizacje postępu} many {Zsynchronizowano # aktualizacji postępu}}",
+            "newReadingPositionFor": "Kobo zgłosił nową pozycję czytania dla {title}",
+            "newReadingPosition": "Kobo zgłosił nową pozycję do czytania",
+            "noHighlightChangesNeededFor": "Nie są potrzebne żadne zmiany podświetlenia dla {title}",
+            "noHighlightChangesNeeded": "Nie są potrzebne żadne zmiany podświetlenia",
+            "highlightsSentToKoboFor": "{count, plural, one {# Wyróżnienie wysłane do Kobo dla {title}} other {# najważniejsze informacje wysłane do Kobo dla {title}} few {# najważniejsze informacje wysłane do Kobo w sprawie {title}} many {# najważniejszych informacji wysłanych do Kobo za {title}}}",
+            "highlightsSentToKobo": "{count, plural, one {# wyróżnienie wysłane do Kobo} other {# najważniejsze informacje wysłane do Kobo} few {# najważniejsze informacje wysłane do Kobo} many {# najważniejszych informacji wysłanych do Kobo}}",
+            "noKoboHighlightChangesFor": "Nie Kobo zmiany podświetlenia dla {title}",
+            "noKoboHighlightChanges": "Nie Kobo zmian podświetlenia",
+            "highlightsImportedFromKoboFor": "{count, plural, one {# wyróżnienie zaimportowane z Kobo dla {title}} other {# najważniejsze momenty zaimportowane z Kobo dla {title}} few {# najważniejsze momenty zaimportowane z Kobo dla {title}} many {# najważniejszych momentów zaimportowanych z Kobo dla {title}}}",
+            "highlightsImportedFromKobo": "{count, plural, one {# wyróżnienie zaimportowane z Kobo} other {# najważniejsze momenty zaimportowane z Kobo} few {# najważniejsze momenty zaimportowane z Kobo} many {# najważniejszych momentów zaimportowanych z Kobo}}"
+          },
+          "timeRange": "{from} do {to}",
+          "eventsGrouped": "{count, plural, one {# wydarzenie zgrupowane} other {# wydarzenia pogrupowane} few {Zgrupowano # wydarzenia} many {Zgrupowano # wydarzeń}}",
+          "removedDevice": "Usunięte urządzenie",
+          "loadMoreFailed": "Nie udało się wczytać dalszej historii",
+          "historyRefreshed": "Kobo historia synchronizacji została odświeżona",
+          "refreshFailed": "Nie udało się odświeżyć historii",
+          "recentActivity": "Ostatnia aktywność Kobo",
+          "filterAll": "Wszystko",
+          "filterFailures": "Awarie",
+          "refresh": "Odśwież",
+          "loadingActivity": "Ładowanie aktywności Kobo...",
+          "noActivityHint": "Ostatnia aktywność synchronizacji pojawi się po sparowanych Kobo kontaktach BookOrbit.",
+          "error": "Błąd",
+          "loading": "Ładowanie...",
+          "loadMore": "Załaduj więcej aktywności"
+        },
+        "howBooksSynced": {
+          "title": "Jak książki są synchronizowane",
+          "body": "Aby wysyłać książki na urządzenie Kobo, musisz włączyć {syncToKobo} w kolekcjach zawierających te książki. Otwórz dowolną kolekcję na pasku bocznym, kliknij ikonę Edytuj i przełącz {syncToKobo}. Książki, które nie są częścią włączonej kolekcji, nie zostaną zsynchronizowane."
+        },
+        "nextSteps": {
+          "title": "Następne kroki",
+          "step1": "1. Skonfiguruj swoje urządzenie Kobo do synchronizacji z synchronizacją URL powyżej.",
+          "step2": "2. W BookOrbit przejdź do dowolnej kolekcji z paska bocznego, kliknij ikonę Edytuj i włącz {syncToKobo}. Na Twoje urządzenie zostaną pobrane tylko książki znajdujące się w kolekcjach z włączoną synchronizacją."
+        },
+        "syncToKobo": "Synchronizuj z Kobo",
+        "tabs": {
+          "syncSettings": "Synchronizuj ustawienia",
+          "activityLog": "Dziennik aktywności"
+        }
+      },
+      "koreader": {
+        "title": "KOReader Synchronizacja",
+        "subtitle": "Przeglądaj swój katalog BookOrbit w KOReader i synchronizuj postępy, aktywność związaną z czytaniem, wyróżnienia i zmiany w adnotacjach.",
+        "tabs": {
+          "sync": "Synchronizuj ustawienia",
+          "fileNaming": "Nazewnictwo plików"
+        },
+        "fileNaming": {
+          "accountTitle": "Domyślny wzór konta KOReader",
+          "accountDescription": "Ustawia domyślny folder względny i nazwę pliku używane przez wtyczki BookOrbit do pobrania dla Twojego konta KOReader. Reguły specyficzne dla urządzenia mogą zastąpić poniższe reguły.",
+          "defaultPattern": "Domyślny wzór ścieżki książki",
+          "accountHelp": "Twoje konto jest domyślnym ustawieniem pobierania wtyczek KOReader, chyba że urządzenie ma niestandardową regułę.",
+          "accountHint": "Używany przez Twoje urządzenia KOReader, które nie mają niestandardowego zastąpienia.",
+          "preview": "Podgląd",
+          "saveAccount": "Zapisz konto domyślne",
+          "deviceTitle": "KOReader zastąpienie urządzenia",
+          "deviceDescription": "Dostosuj dowolną kombinację ścieżek domyślnych, serii i samodzielnych. Puste wiersze dotyczące konkretnego urządzenia dziedziczą ustawienia domyślne urządzenia, które z kolei mogą dziedziczyć domyślny wzorzec konta KOReader.",
+          "noDevices": "Urządzenia pojawiają się tutaj po synchronizacji z BookOrbit.",
+          "customOrganization": "Organizacja niestandardowa",
+          "usingAccountDefault": "Używanie domyślnego konta",
+          "deviceDefaultHelp": "Rozwiązanie zastępcze dla tego urządzenia. Pozostaw tę wartość równą wartości domyślnej konta, aby automatycznie dziedziczyć przyszłe zmiany.",
+          "seriesBooks": "Książki z serii",
+          "seriesHelp": "Opcjonalna ścieżka używana tylko w przypadku książek z metadanymi serii. Pozostaw puste, aby użyć domyślnego wzorca ścieżki tego urządzenia.",
+          "standaloneBooks": "Książki bez serii",
+          "standaloneHelp": "Opcjonalna ścieżka używana tylko w przypadku książek bez metadanych serii. Pozostaw puste, aby użyć domyślnego wzorca ścieżki tego urządzenia.",
+          "inheritPlaceholder": "Pozostaw puste, aby użyć domyślnego wzorca tego urządzenia",
+          "useAccount": "Użyj domyślnego konta",
+          "saveOverride": "Zapisz zastąpienie",
+          "loadFailed": "Nie udało się załadować ustawień organizacji plików",
+          "accountRequired": "Przed zapisaniem wprowadź domyślny wzór ścieżki książki.",
+          "accountSaved": "Domyślny wzór konta KOReader został zapisany",
+          "accountSaveFailed": "Nie udało się zapisać ustawień organizacji plików",
+          "deviceUsesAccount": "Urządzenie używa teraz domyślnego wzorca konta KOReader",
+          "deviceSaved": "Zapisano zastąpienie organizacji urządzenia",
+          "deviceSaveFailed": "Nie udało się zapisać zastąpienia urządzenia",
+          "deviceResetFailed": "Nie udało się zresetować zastąpienia urządzenia"
+        },
+        "loadingSettings": "Ładowanie ustawień KOReader...",
+        "loadFailed": "Nie udało się załadować ustawień KOReader",
+        "never": "Nigdy",
+        "justNow": "Właśnie teraz",
+        "minutesAgo": "{count}m temu",
+        "hoursAgo": "{count}h temu",
+        "daysAgo": "{count}d temu",
+        "unknown": "Nieznany",
+        "updateAvailable": "Dostępna aktualizacja",
+        "upToDate": "Aktualne",
+        "versionUnknown": "Wersja nieznana",
+        "latestPlugin": "Najnowsza wtyczka: v{version}",
+        "latestPluginUnavailable": "Najnowsza wtyczka niedostępna",
+        "notConfigured": "KOReader synchronizacja nie jest skonfigurowana",
+        "notConfiguredHint": "Utwórz jeden zestaw poświadczeń synchronizacji, a następnie używaj ich z wtyczką BookOrbit KOReader do przeglądania, pobierania, postępu, czytania wydarzeń, wyróżnień i usuwania.",
+        "createCredentials": "Utwórz poświadczenia",
+        "createFormTitle": "Utwórz KOReader dane uwierzytelniające synchronizacji",
+        "createFormHint": "Te dane uwierzytelniają Twoje urządzenia KOReader za pomocą BookOrbit.",
+        "username": "Nazwa użytkownika",
+        "usernamePlaceholder": "np. mójczytnik",
+        "password": "Hasło",
+        "passwordPlaceholder": "Min. 6 znaków",
+        "creating": "Tworzenie...",
+        "create": "Utwórz",
+        "credentialsCreated": "Utworzono KOReader dane uwierzytelniające synchronizacji",
+        "createCredentialsFailed": "Nie udało się utworzyć danych uwierzytelniających",
+        "status": "KOReader Stan",
+        "refresh": "Odśwież",
+        "progressSync": "Synchronizacja postępu",
+        "progressSyncHint": "Zezwól urządzeniom KOReader na synchronizację postępu, aktywności związanej z czytaniem, wyróżnień i usuwania adnotacji za pomocą BookOrbit.",
+        "lastSync": "Ostatnia synchronizacja",
+        "syncedBooks": "Zsynchronizowane książki",
+        "bookCount": "{count, plural, =0 {żadnych książek} one {# książka} other {# książki} few {# książki} many {# książek}}",
+        "devices": "Urządzenia",
+        "deviceCount": "{count, plural, =0 {żadnych urządzeń} one {# urządzenie} other {# urządzenia} few {# urządzenia} many {# urządzeń}}",
+        "credentialsCreatedLabel": "Utworzono dane uwierzytelniające",
+        "setup": "Konfiguracja",
+        "pluginServerUrl": "Serwer wtyczek URL",
+        "copied": "Skopiowano",
+        "copyUrl": "Skopiuj URL",
+        "preconfiguredPlugin": "Wstępnie skonfigurowana wtyczka BookOrbit",
+        "preconfiguredPluginHintPrefix": "Pobierz plik zip z serwerem URL i loginem do synchronizacji, który jest już skonfigurowany. Wtyczka umożliwia przeglądanie i synchronizację katalogu. Skopiuj folder do",
+        "preconfiguredPluginHintSuffix": "i uruchom ponownie KOReader.",
+        "latestPluginNote": "{label}. Aktualizacje urządzeń są uruchamiane z menu BookOrbit w KOReader.",
+        "preparing": "Przygotowanie...",
+        "downloadPlugin": "Pobierz wtyczkę",
+        "noDevicesSynced": "Żadne urządzenia nie zostały jeszcze zsynchronizowane",
+        "noDevicesSyncedHint": "Zainstaluj wtyczkę BookOrbit, aby uzyskać pełną synchronizację, lub skonfiguruj synchronizację postępu akcji KOReader dla aktualizacji zawierających tylko postęp.",
+        "lastSyncLabel": "Ostatnia synchronizacja:",
+        "lastBookLabel": "Ostatnia książka:",
+        "noneYet": "Jeszcze żaden",
+        "pluginActivity": "Aktywność wtyczki",
+        "noPluginActivity": "Nie zgłoszono jeszcze żadnej aktywności wtyczki.",
+        "lastFullSync": "Ostatnia pełna synchronizacja: {time}",
+        "latestPluginSuffix": "- najnowsza wtyczka v{version}",
+        "matchedBooks": "Dopasowane książki",
+        "readingEvents": "Czytanie wydarzeń",
+        "highlights": "Najważniejsze",
+        "syncedTotals": "Zsynchronizowane sumy",
+        "trashedHighlights": "Zniszczone najważniejsze momenty",
+        "pendingDeletes": "{count, plural, =0 {brak usuniętych najciekawszych oczekujących na potwierdzenie wtyczki KOReader.} one {# usunięto podświetlenie oczekujące na potwierdzenie wtyczki KOReader.} other {# usunięte najważniejsze momenty oczekujące na potwierdzenie wtyczki KOReader.} few {# usunięte najważniejsze momenty oczekujące na potwierdzenie wtyczki KOReader.} many {# usuniętych fragmentów oczekujących na potwierdzenie wtyczki KOReader.}}",
+        "failedPositions": "{count, plural, =0 {żadne podświetlone pozycje nie wymagają uwagi.} one {# podświetlona pozycja wymaga uwagi.} other {# najważniejsze pozycje wymagają uwagi.} few {# najważniejsze pozycje wymagają uwagi.} many {# najważniejszych pozycji wymaga uwagi.}}",
+        "setupGuide": "Przewodnik konfiguracji",
+        "setupSteps": "KOReader kroki konfiguracji",
+        "setupStepsHint": "Użyj wtyczki BookOrbit do przeglądania katalogów, pobierania, postępu, czytania wydarzeń i najważniejszych wydarzeń. Użyj wtyczki giełdowej tylko do postępu.",
+        "pluginGuideTitle": "Wtyczka BookOrbit",
+        "pluginStep1": "Pobierz wstępnie skonfigurowaną wtyczkę powyżej.",
+        "pluginStep2Prefix": "Rozpakuj i skopiuj",
+        "pluginStep2Middle": "do",
+        "pluginStep2Suffix": "na Twoim urządzeniu.",
+        "pluginStep3": "Uruchom ponownie KOReader. Serwer i login są konfigurowane automatycznie.",
+        "pluginStep4Prefix": "Otwórz",
+        "pluginStep4Suffix": "aby wyszukiwać, pobierać i łączyć książki w celu synchronizacji.",
+        "stockGuideTitle": "Wtyczka synchronizacji postępu akcji",
+        "stockStep1Prefix": "Na urządzeniu KOReader przejdź do",
+        "stockStep1Suffix": ".",
+        "stockStep2": "Ustaw niestandardowy serwer synchronizacji na URL pokazany powyżej.",
+        "stockStep3": "Wprowadź utworzoną nazwę użytkownika i hasło, a następnie dotknij opcji Zaloguj.",
+        "locationNote": "BookOrbit zapisuje lokalizacje KOReader kompatybilne z EPUB z czytnika internetowego. Przywrócenie powinno wylądować blisko tej samej pozycji, chociaż dokładne rozmieszczenie linii może się różnić w zależności od czytnika i układu EPUB.",
+        "dangerZone": "Strefa zagrożenia",
+        "deleteCredentials": "Usuń poświadczenia KOReader",
+        "deleteCredentialsHint": "Usuń dane uwierzytelniające synchronizacji i odłącz wszystkie urządzenia. Dane dotyczące postępu zostaną zachowane.",
+        "credentialsDeleted": "KOReader dane uwierzytelniające zostały usunięte",
+        "deleteCredentialsFailed": "Nie udało się usunąć danych uwierzytelniających",
+        "deleteConfirmTitle": "Usunąć dane uwierzytelniające KOReader?",
+        "deleteConfirmBody": "Spowoduje to usunięcie danych uwierzytelniających synchronizacji i odłączenie wszystkich urządzeń KOReader. Istniejące dane dotyczące postępu zostaną zachowane.",
+        "syncEnabled": "KOReader synchronizacja włączona",
+        "syncDisabled": "KOReader synchronizacja wyłączona",
+        "toggleSyncFailed": "Nie udało się przełączyć synchronizacji",
+        "syncUrlCopied": "Synchronizacja URL skopiowana do schowka",
+        "syncUrlCopyFailed": "Nie udało się skopiować synchronizacji URL",
+        "statusRefreshed": "Stan synchronizacji został odświeżony",
+        "refreshFailed": "Nie udało się odświeżyć",
+        "pluginDownloaded": "Wtyczka pobrana. Skopiuj plik bookorbit.koplugin z zip do koreader/plugins/ na swoim urządzeniu.",
+        "pluginDownloadFailed": "Nie udało się pobrać wtyczki",
+        "hashLinks": {
+          "unmatchedTitle": "Niezrównane KOReader książki",
+          "unmatchedBooks": "Niezrównane książki",
+          "manualTitle": "Podręcznik KOReader Linki",
+          "refresh": "Odśwież",
+          "link": "Link",
+          "change": "Zmień",
+          "unlink": "Odłącz",
+          "hash": "Hash:",
+          "lastOpened": "Ostatnio otwarte:",
+          "firstSeen": "Pierwszy raz widziany:",
+          "lastSeen": "Ostatnio widziany:",
+          "linked": "Połączone:",
+          "updated": "Zaktualizowano:",
+          "linkedTo": "Połączone z {title}",
+          "loadingUnmatched": "Ładowanie niedopasowanych książek...",
+          "loadingManual": "Ładowanie ręcznych linków skrótu...",
+          "noUnmatched": "Brak niedopasowanych KOReader książek.",
+          "noManual": "Brak linków do podręcznika KOReader.",
+          "pageOf": "Strona {page} z {total}",
+          "showingRange": "Wyświetlanie {start}-{end} z {total}",
+          "unknownFile": "Nieznany KOReader plik {hash}",
+          "unknownAuthor": "Nieznany autor",
+          "noTitleOrAuthor": "Nie podano tytułu ani autora",
+          "bookNumber": "BookOrbit książka #{id}",
+          "toast": {
+            "unmatchedRefreshed": "Niezrównane książki odświeżone",
+            "unmatchedRefreshFailed": "Nie udało się odświeżyć niedopasowanych książek",
+            "manualRefreshed": "Odświeżono ręczne łącza skrótu",
+            "manualRefreshFailed": "Nie udało się odświeżyć ręcznych linków skrótu",
+            "bookLinked": "Książka połączona",
+            "linkUpdated": "Link zaktualizowany",
+            "linkFailed": "Nie udało się połączyć książki",
+            "linkRemoved": "Link usunięty",
+            "unlinkFailed": "Nie udało się odłączyć książki",
+            "unmatchedDismissed": "Niedopasowana książka została odrzucona",
+            "dismissFailed": "Nie udało się odrzucić niedopasowanej książki",
+            "allDismissed": "{count, plural, =0 {Nie odrzucono żadnych niedopasowanych książek} one {Zwolniony # niezrównana książka} other {Zwolniony # niezrównane książki} few {Odrzucono # niedopasowane książki} many {Odrzucono # niedopasowanych książek}}",
+            "dismissAllFailed": "Nie udało się odrzucić wszystkich niedopasowanych książek"
+          },
+          "modal": {
+            "linkTitle": "Link do książki KOReader",
+            "changeTitle": "Zmień link KOReader",
+            "bookOrbitBook": "BookOrbit książka",
+            "searchPlaceholder": "Przeszukaj swoją bibliotekę BookOrbit",
+            "minChars": "Wpisz co najmniej 2 znaki.",
+            "searching": "Wyszukiwanie...",
+            "noBooksFound": "Nie znaleziono książek.",
+            "untitledBook": "Książka bez tytułu",
+            "selected": "Wybrane",
+            "select": "Wybierz",
+            "loadMore": "Załaduj więcej",
+            "confirmTitle": "Potwierdź link KOReader",
+            "koreader": "KOReader",
+            "bookOrbit": "BookOrbit",
+            "bookId": "Identyfikator książki: {id}",
+            "syncedStatsNote": "Już zsynchronizowane statystyki pozostaną w ich bieżącej książce BookOrbit.",
+            "chooseDifferent": "Wybierz inny",
+            "saving": "Zapisywanie...",
+            "confirmLink": "Potwierdź link",
+            "unlinkTitle": "Odłączyć książkę KOReader?",
+            "unlinkBody": "Przyszłe synchronizacje tego skrótu przestaną być rozpoznawane na {title}, dopóki nie zostanie ponownie połączone. Już zsynchronizowane statystyki pozostaną w ich bieżącej książce BookOrbit.",
+            "unlinking": "Odłączanie..."
+          },
+          "dismiss": "Odrzuć",
+          "dismissAll": "Odrzuć wszystko",
+          "dismissing": "Odrzucenie...",
+          "unlinking": "Odłączanie...",
+          "unlinkConfirmTitle": "Odłączyć książkę KOReader?",
+          "unlinkConfirmBody": "Przyszłe synchronizacje tego skrótu przestaną być rozpoznawane na {title}, dopóki nie zostanie ponownie połączone. Już zsynchronizowane statystyki pozostaną w ich bieżącej książce BookOrbit.",
+          "dismissConfirmTitle": "Odrzucić {title}?",
+          "dismissConfirmBody": "Spowoduje to usunięcie jej z listy niedopasowanych książek. Jeśli jakiekolwiek urządzenie ponownie zgłosi ten skrót, pojawi się on ponownie jako nowy wpis.",
+          "dismissAllConfirmTitle": "{count, plural, =0 {żadnych niedopasowanych książek} one {Odrzuć wszystko # niezrównana książka?} other {Odrzuć wszystko # niedopasowane książki?} few {Odrzucić wszystkie # niedopasowane książki?} many {Odrzucić wszystkie # niedopasowanych książek?}}",
+          "dismissAllConfirmBody": "Spowoduje to wyczyszczenie całej listy niedopasowanych książek, a nie tylko bieżącej strony. Jeśli jakiekolwiek urządzenie ponownie zgłosi jeden z tych skrótów, pojawi się on ponownie jako nowy wpis.",
+          "changeLinkTitle": "Zmień link KOReader",
+          "linkBookTitle": "Link do książki KOReader",
+          "bookOrbitBook": "BookOrbit książka",
+          "searchLibraryPlaceholder": "Przeszukaj swoją bibliotekę BookOrbit",
+          "enterMinChars": "Wpisz co najmniej 2 znaki.",
+          "searching": "Wyszukiwanie...",
+          "noBooksFound": "Nie znaleziono książek.",
+          "untitledBook": "Książka bez tytułu",
+          "selected": "Wybrane",
+          "select": "Wybierz",
+          "loadMore": "Załaduj więcej",
+          "loadingMore": "Ładowanie...",
+          "confirmLinkTitle": "Potwierdź link KOReader",
+          "bookId": "Identyfikator książki: {id}",
+          "syncedStatsNote": "Już zsynchronizowane statystyki pozostaną w ich bieżącej książce BookOrbit.",
+          "chooseDifferent": "Wybierz inny",
+          "saving": "Zapisywanie...",
+          "confirmLink": "Potwierdź link"
+        },
+        "remove": "Usuń",
+        "removing": "Usuwanie...",
+        "unmatchedBooks": "Niezrównane książki",
+        "deviceRemoved": "Urządzenie usunięte",
+        "removeDeviceFailed": "Nie udało się usunąć urządzenia",
+        "removeDeviceConfirmTitle": "Usunąć {device}?",
+        "removeDeviceConfirmBody": "Spowoduje to trwałe usunięcie zsynchronizowanych postępów, aktywności czytania i wszelkich niedopasowanych wpisów w książkach, które nie są już raportowane przez inne urządzenie. Jeśli później urządzenie zsynchronizuje się ponownie, pojawi się ponownie jako nowy wpis."
+      },
+      "opds": {
+        "title": "OPDS",
+        "subtitle": "Podłącz do swojej biblioteki aplikacje do czytania kompatybilne z OPDS, takie jak KOReader lub Thorium Reader.",
+        "copy": "Kopiuj",
+        "loadFailed": "Nie udało się załadować",
+        "server": "Serwer",
+        "catalogServer": "OPDS Serwer katalogowy",
+        "catalogServerHint": "Zezwalaj klientom OPDS na przeglądanie i pobieranie książek",
+        "endpoint": "Punkt końcowy",
+        "accounts": "OPDS Konta",
+        "add": "Dodaj",
+        "addAccount": "Dodaj konto",
+        "username": "Nazwa użytkownika",
+        "usernameLabel": "Nazwa użytkownika",
+        "usernamePlaceholder": "np. koreańczyk",
+        "password": "Hasło",
+        "passwordPlaceholder": "Min. 8 znaków",
+        "defaultSort": "Sortowanie domyślne",
+        "sortLabel": "Sortuj",
+        "creating": "Tworzenie...",
+        "create": "Utwórz",
+        "noAccounts": "Nie ma jeszcze OPDS kont. Utwórz go, aby zacząć korzystać z klientów OPDS.",
+        "hideDetails": "Ukryj szczegóły",
+        "showDetails": "Pokaż szczegóły",
+        "copyUsername": "Skopiuj nazwę użytkownika",
+        "notes": "OPDS Notatki",
+        "notesBody": "Używaj kont OPDS w aplikacjach czytników. Zachowaj poufność danych uwierzytelniających i zmieniaj hasła, jeśli zostaną przypadkowo udostępnione.",
+        "deleteConfirmTitle": "Usunąć konto OPDS?",
+        "deleteConfirmBody": "Usuń „{username}”. Tej akcji nie można cofnąć.",
+        "sortRecent": "Ostatnio dodane",
+        "sortTitleAsc": "Tytuł (A-Z)",
+        "sortTitleDesc": "Tytuł (Z-A)",
+        "sortAuthorAsc": "Autor (A-Z)",
+        "sortAuthorDesc": "Autor (Z-A)",
+        "sortSeriesAsc": "Seria (A-Z)",
+        "sortSeriesDesc": "Seria (Z-A)",
+        "serverEnabled": "Serwer OPDS włączony",
+        "serverDisabled": "Serwer OPDS wyłączony",
+        "updateSettingsFailed": "Nie udało się zaktualizować ustawień OPDS",
+        "urlCopied": "OPDS URL skopiowano do schowka",
+        "urlCopyFailed": "Nie udało się skopiować OPDS URL",
+        "createUserFailed": "Nie udało się utworzyć użytkownika OPDS",
+        "userCreated": "Utworzono OPDS użytkownika „{username}”.",
+        "sortOrderUpdated": "Zaktualizowano porządek sortowania dla „{username}”",
+        "updateSortFailed": "Nie udało się zaktualizować kolejności sortowania",
+        "userDeleted": "OPDS użytkownik „{username}” usunięty",
+        "deleteUserFailed": "Nie udało się usunąć użytkownika OPDS",
+        "labelCopied": "{label} skopiowane",
+        "copyLabelFailed": "Nie udało się skopiować {label}"
+      },
+      "tabs": {
+        "general": "Generał",
+        "ebook": "eBook",
+        "pdf": "PDF",
+        "comics": "Komiksy",
+        "audio": "Książka audio",
+        "fonts": "Czcionki"
+      }
+    },
+    "system": {
+      "tabs": {
+        "file-naming": "Nazewnictwo plików",
+        "book-dock": "Book Dock",
+        "maintenance": "Konserwacja",
+        "audit-log": "Dziennik audytu"
+      }
+    }
+  },
+  "achievements": {
+    "title": "Osiągnięcia",
+    "tiersCount": "{earned} / {total} poziomów",
+    "loadFailed": "Nie udało się wczytać osiągnięć",
+    "tryAgain": "Spróbuj ponownie",
+    "noMatchFilter": "Żadne osiągnięcia nie pasują do tego filtra",
+    "secretAchievement": "Sekretne osiągnięcie",
+    "earnedOn": "Zdobyto {date}",
+    "whileReading": "Czytając „{title}”",
+    "tierProgress": "Poziom {earned} z {total}",
+    "progressToNext": "{current} / {threshold} do {name}",
+    "rarity": {
+      "common": "Powszechne",
+      "rare": "Rzadkie",
+      "epic": "Epicki",
+      "legendary": "Legendarny"
+    },
+    "filter": {
+      "all": "Wszystko",
+      "earned": "Zdobyte ({count})",
+      "inProgress": "W toku ({count})",
+      "locked": "Zablokowany ({count})"
+    }
+  },
+  "adminFeature": {
+    "accountActivity": {
+      "title": "Aktywność konta",
+      "subtitle": "Przeglądaj aktywność związaną z uwierzytelnianiem konta bez ujawniania historii czytania.",
+      "privacyNotice": "Ta strona raportuje tylko logowania i odświeżenia uwierzytelniania. Nie wykorzystuje historii czytania, postępu książki ani aktywności biblioteki.",
+      "privacyLabel": "Informacje o prywatności aktywności na koncie",
+      "never": "Nigdy",
+      "openInsightsFor": "Otwórz udostępnione statystyki dotyczące czytania dla {name}",
+      "permissionLabel": "Zobacz aktywność użytkownika",
+      "states": {
+        "recent": "Ostatnio aktywny",
+        "dormant": "Uśpiony",
+        "never": "Brak zarejestrowanej aktywności",
+        "disabled": "Niepełnosprawny"
+      },
+      "filters": {
+        "search": "Przeszukaj konta",
+        "searchPlaceholder": "Wyszukaj nazwę lub nazwę użytkownika",
+        "state": "Stan aktywności",
+        "allStates": "Wszystkie stany aktywności",
+        "provisioning": "Metoda uwierzytelniania",
+        "allMethods": "Wszystkie metody uwierzytelniania",
+        "sort": "Sortuj konta",
+        "mostRecent": "Ostatnio aktywny",
+        "leastRecent": "Ostatnio aktywny",
+        "lastLogin": "Najnowsze logowanie",
+        "newest": "Najnowsze konta",
+        "oldest": "Najstarsze konta",
+        "name": "Imię",
+        "apply": "Zastosuj",
+        "clear": "Wyczyść"
+      },
+      "methods": {
+        "local": "Lokalny",
+        "manual": "Utworzony przez administratora",
+        "oidc": "OIDC / Jednokrotne logowanie",
+        "shared": "Udostępniony magiczny link"
+      },
+      "columns": {
+        "user": "Użytkownik",
+        "state": "Stan konta",
+        "lastLogin": "Ostatnie logowanie",
+        "lastAuthenticated": "Ostatnio uwierzytelnione",
+        "created": "Utworzono",
+        "readingInsights": "Czytanie spostrzeżeń"
+      },
+      "sharing": {
+        "private": "Nieudostępnione",
+        "summary": "Podsumowanie udostępnione",
+        "detailed": "Szczegółowe udostępnione"
+      },
+      "empty": {
+        "title": "Nie znaleziono kont",
+        "description": "Spróbuj zmienić lub wyczyścić bieżące filtry."
+      },
+      "pagination": {
+        "label": "Strony aktywności konta",
+        "page": "Strona {page} z {totalPages}"
+      },
+      "errors": {
+        "load": "Nie udało się załadować aktywności na koncie."
+      }
+    },
+    "sharedInsights": {
+      "title": "Wspólne spostrzeżenia z lektury",
+      "subtitle": "Czytanie informacji, które ten użytkownik dobrowolnie zdecydował się udostępnić.",
+      "auditNotice": "Dostęp do tego profilu jest rejestrowany i widoczny dla użytkownika.",
+      "period": "Okres raportowania",
+      "periodDays": "Ostatnie {count} dni",
+      "durationMinutes": "{count, plural, one {# minuta} other {# minuty} few {# minuty} many {# minut}}",
+      "durationHours": "{count} godzin",
+      "metrics": {
+        "sessions": "Sesje",
+        "readingTime": "Czas czytania",
+        "activeDays": "Aktywne dni",
+        "started": "Zaczęły się książki",
+        "completed": "Książki ukończone"
+      },
+      "trend": "Codzienny trend czytelniczy",
+      "emptyTitle": "Brak aktywności czytelniczej w tym okresie",
+      "noData": "Brak zarejestrowanych danych odczytu w tym okresie.",
+      "sourceNames": {
+        "web": "Czytnik internetowy",
+        "koreader": "KOReader",
+        "manual": "Ręczne",
+        "kobo": "Kobo",
+        "unknown": "Nieznany"
+      },
+      "formats": "Formaty",
+      "genres": "Gatunki",
+      "broadGenres": {
+        "science_fiction": "Science-fiction",
+        "fantasy": "Fantazja",
+        "mystery_thriller": "Tajemnica i thriller",
+        "romance": "Romans",
+        "horror": "Przerażenie",
+        "history_biography": "Historia i biografia",
+        "science_technology": "Nauka i technologia",
+        "business_economics": "Biznes i ekonomia",
+        "self_development": "Samorozwój",
+        "society_culture": "Społeczeństwo i kultura",
+        "children_young_adult": "Dzieci i młodzież",
+        "comics_graphic_novels": "Komiksy i powieści graficzne",
+        "poetry": "Poezja",
+        "other": "Inne"
+      },
+      "sources": "Źródła danych",
+      "topBooks": "Najczęściej czytane książki",
+      "recentBooks": "Niedawno przeczytane",
+      "unknownTitle": "Książka bez tytułu",
+      "top": {
+        "authors": "Najlepsi autorzy",
+        "genres": "Najlepsze gatunki",
+        "series": "Najlepsze serie",
+        "narrators": "Najlepsi narratorzy"
+      },
+      "errors": {
+        "READING_INSIGHTS_PRIVATE": "Ten użytkownik nie udostępnia statystyk dotyczących czytania.",
+        "READING_INSIGHTS_SUMMARY_ONLY": "Ten użytkownik udostępnia tylko podsumowujące spostrzeżenia.",
+        "READING_INSIGHTS_VIEW_SESSION_REQUIRED": "Wymagana jest sesja przeglądania profilu.",
+        "READING_INSIGHTS_VIEW_SESSION_INVALID": "Ten widok profilu wygasł lub nie jest już ważny.",
+        "LOAD_FAILED": "Nie udało się wczytać udostępnionych statystyk dotyczących czytania.",
+        "cleared": "Nie są wyświetlane żadne wcześniej załadowane informacje o profilu."
+      }
+    },
+    "resetLink": {
+      "title": "Link do resetowania hasła",
+      "description": "Udostępnij ten link użytkownikowi. Wygasa za 15 minut.",
+      "copy": "Kopiuj",
+      "copied": "Skopiowano!",
+      "copyFailed": "Kopiowanie nie powiodło się",
+      "notShownAgain": "Ten link nie będzie już wyświetlany."
+    },
+    "userForm": {
+      "editUser": "Edytuj użytkownika",
+      "createUser": "Utwórz użytkownika",
+      "createSharedAccount": "Utwórz wspólne konto",
+      "sharedBadge": "Udostępnione",
+      "active": "Aktywny",
+      "suspended": "Zawieszony",
+      "tabs": {
+        "general": "generał",
+        "access": "dostęp",
+        "restrictions": "ograniczenia"
+      },
+      "sharedAccount": "Wspólne konto",
+      "sharedAccountHint": "Brak hasła. Dostęp jest przyznawany wyłącznie poprzez magiczne linki.",
+      "sharedAccountManageHint": "Zarządzaj linkami logowania w Ustawieniach - Magiczne linki.",
+      "username": "Nazwa użytkownika",
+      "fullName": "Pełne imię i nazwisko",
+      "email": "E-mail",
+      "optional": "(opcjonalnie)",
+      "libraryAccess": "Dostęp do biblioteki",
+      "noLibrariesSelected": "Nie wybrano bibliotek. Użytkownik nie może przeglądać żadnych książek.",
+      "permissions": "Uprawnienia",
+      "presetStandard": "Standardowe",
+      "presetAdmin": "Administrator",
+      "presetClearAll": "Wyczyść wszystko",
+      "permissionGroups": {
+        "content": "Treść",
+        "devicesAccess": "Urządzenia i dostęp",
+        "email": "E-mail",
+        "administration": "Administracja",
+        "notifications": "Powiadomienia",
+        "restrictions": "Ograniczenia"
+      },
+      "superuserTarget": "Cel superużytkownika",
+      "superuserTargetHint": "Ograniczeń dotyczących treści nie można zastosować do superużytkowników.",
+      "noRestrictions": "Brak ograniczeń treści",
+      "noRestrictionsHint": "Ten użytkownik ma pełny dostęp do wszystkich książek w przypisanych mu bibliotekach.",
+      "addRestrictions": "+ Dodaj ograniczenia dotyczące treści",
+      "contentRestrictions": "Ograniczenia dotyczące treści",
+      "remove": "Usuń",
+      "includeTags": "Dołącz tagi",
+      "includeTagsHint": "(pokaż tylko książki z tymi tagami)",
+      "excludeTags": "Wyklucz tagi",
+      "excludeTagsHint": "(ukryj książki z tymi tagami)",
+      "includeGenres": "Uwzględnij gatunki",
+      "includeGenresHint": "(pokaż tylko książki z tymi gatunkami)",
+      "excludeGenres": "Wyklucz gatunki",
+      "excludeGenresHint": "(ukryj książki z tymi gatunkami)",
+      "searchTagsPlaceholder": "Wyszukaj tagi...",
+      "searchGenresPlaceholder": "Wyszukaj gatunki...",
+      "saving": "Zapisywanie...",
+      "errors": {
+        "updateUser": "Nie udało się zaktualizować użytkownika",
+        "updatePermissions": "Nie udało się zaktualizować uprawnień",
+        "updateLibraryAccess": "Nie udało się zaktualizować dostępu do biblioteki",
+        "updateContentFilters": "Nie udało się zaktualizować filtrów treści",
+        "emailRequired": "Adres e-mail jest wymagany",
+        "createSharedAccount": "Nie udało się utworzyć wspólnego konta",
+        "createUser": "Nie udało się utworzyć użytkownika"
+      }
+    },
+    "usersPage": {
+      "usersTitle": "Użytkownicy",
+      "magicLinksTitle": "Magiczne linki",
+      "usersSubtitle": "Zarządzaj kontami użytkowników i przypisaniami uprawnień.",
+      "magicLinksSubtitle": "Twórz udostępniane łącza logowania do współdzielonych kont.",
+      "createUser": "Utwórz użytkownika",
+      "createLink": "Utwórz łącze",
+      "usersTab": "Użytkownicy",
+      "magicLinksTab": "Magiczne linki",
+      "columns": {
+        "name": "Imię",
+        "username": "Nazwa użytkownika",
+        "email": "E-mail",
+        "access": "Dostęp",
+        "status": "Stan"
+      },
+      "adminBadge": "Administrator",
+      "permissionCount": "{count, plural, =0 {żadnych uprawnień} one {jedno pozwolenie} other {# uprawnienia} few {# uprawnienia} many {# uprawnień}}",
+      "filteredBadge": "Filtrowane",
+      "contentRestrictionsActive": "Aktywne ograniczenia dotyczące treści",
+      "statusActive": "Aktywny",
+      "statusInactive": "Nieaktywny",
+      "resetPassword": "Zresetuj hasło",
+      "resetPasswordOidcHint": "OIDC użytkownicy resetują hasła u swojego dostawcy tożsamości",
+      "resetPasswordSharedHint": "Konta współdzielone nie mają haseł",
+      "resetPasswordOidcHintFull": "OIDC użytkownicy resetują hasła u swojego dostawcy tożsamości.",
+      "resetPasswordSharedHintFull": "Konta współdzielone nie mają haseł.",
+      "deleteUserAction": "Usuń użytkownika",
+      "deleteDialogTitle": "Usunąć użytkownika?",
+      "deleteDialogBody": "Usuń użytkownika „{username}”. Tej akcji nie można cofnąć.",
+      "deleting": "Usuwanie...",
+      "errors": {
+        "loadData": "Nie udało się załadować danych",
+        "load": "Nie udało się załadować",
+        "deleteUser": "Nie udało się usunąć użytkownika"
+      },
+      "currentUsers": "Aktualni użytkownicy",
+      "defaultLibraryAccess": {
+        "title": "Domyślny dostęp do biblioteki",
+        "subtitle": "Dostęp przeglądającego przyznany użytkownikom zarejestrowanym samodzielnie i korzystającym z OIDC.",
+        "description": "Wybierz biblioteki przypisane automatycznie nowym użytkownikom.",
+        "noLibraries": "Brak dostępnych bibliotek.",
+        "save": "Zapisz ustawienia domyślne",
+        "saving": "Zapisywanie...",
+        "saved": "Domyślny dostęp do biblioteki został zapisany.",
+        "saveError": "Nie udało się zapisać domyślnego dostępu do biblioteki"
+      }
+    }
+  },
+  "annotations": {
+    "unknownBook": "Nieznana książka",
+    "styles": {
+      "highlight": "Zaznacz",
+      "underline": "Podkreśl",
+      "strike": "Przekreślenie",
+      "squiggle": "Faliste",
+      "invert": "Odwróć"
+    },
+    "combobox": {
+      "filterByBook": "Filtruj według książki",
+      "allBooks": "Wszystkie książki",
+      "clearBookFilter": "Wyczyść filtr książki",
+      "searching": "Wyszukiwanie...",
+      "noBooksFound": "Nie znaleziono książek"
+    },
+    "bulk": {
+      "countSelected": "Wybrano {count}",
+      "pageSelected": "Wybrano stronę",
+      "selectPage": "Wybierz stronę",
+      "clear": "Wyczyść",
+      "recolorTo": "Zmień kolor na {color}",
+      "restyleTo": "Zmień styl na {style}"
+    },
+    "chips": {
+      "active": "Aktywny:",
+      "removeFilter": "Usuń filtr {label}",
+      "clearAll": "Wyczyść wszystko"
+    },
+    "filters": {
+      "colors": "Kolory",
+      "dateRange": "Zakres dat",
+      "fromDate": "Od daty",
+      "toDate": "Do tej pory",
+      "to": "do",
+      "clearDateRange": "Wyczyść zakres dat",
+      "clearAll": "Wyczyść wszystko"
+    },
+    "pagination": {
+      "showing": "Wyświetlanie {start}-{end} z {total}",
+      "pageOf": "Strona {page} z {totalPages}",
+      "firstPage": "Pierwsza strona",
+      "previousPage": "Poprzednia strona",
+      "nextPage": "Następna strona",
+      "lastPage": "Ostatnia strona"
+    },
+    "sync": {
+      "loading": "Ładowanie szczegółów synchronizacji",
+      "positions": "Pozycje",
+      "devices": "Urządzenia",
+      "retryConversion": "Ponów próbę konwersji",
+      "noStoredPositions": "Brak zapisanych pozycji.",
+      "notSynced": "Nie zsynchronizowano jeszcze z żadnym urządzeniem.",
+      "upToDate": "Aktualne",
+      "pendingVersion": "Oczekuje v{version}",
+      "syncedAt": "zsynchronizowane {date}",
+      "format": {
+        "webReader": "Czytnik internetowy",
+        "koreader": "KOReader",
+        "pdf": "PDF",
+        "kobo": "Kobo"
+      },
+      "status": {
+        "exact": "Dokładne",
+        "repaired": "Naprawiony",
+        "failed": "Nie udało się",
+        "pending": "Oczekujące"
+      }
+    },
+    "toolbar": {
+      "searchPlaceholder": "Wyszukaj tekst i notatki",
+      "filters": "Filtry",
+      "sortOrder": "Kolejność sortowania",
+      "switchToCompact": "Przełącz na widok kompaktowy",
+      "switchToComfortable": "Przełącz na komfortowy widok",
+      "compactView": "Kompaktowy widok",
+      "comfortableView": "Wygodny widok"
+    },
+    "listItem": {
+      "pageNumber": "str. {page}",
+      "chapterNumber": "rozdział {chapter}",
+      "selectAnnotation": "Wybierz adnotację",
+      "collapse": "Zwiń",
+      "expand": "Rozwiń",
+      "hideSyncDetail": "Ukryj szczegóły synchronizacji",
+      "showSyncDetail": "Pokaż szczegóły synchronizacji",
+      "exactPositionUnavailable": "Dokładna pozycja czytnika jest niedostępna",
+      "saving": "Oszczędzanie",
+      "bookDetails": "Szczegóły książki",
+      "openInReader": "Otwórz w czytniku",
+      "restore": "Przywróć",
+      "deleteForever": "Usuń na zawsze",
+      "editNote": "Edytuj notatkę",
+      "addNote": "Dodaj notatkę",
+      "colorAndStyle": "Kolor i styl",
+      "copied": "Skopiowano",
+      "copyText": "Skopiuj tekst",
+      "trash": "Kosz",
+      "moveToTrash": "Przenieś do kosza"
+    },
+    "hub": {
+      "title": "Adnotacje",
+      "totalCount": "{count} łącznie",
+      "bookCount": "{count, plural, =0 {żadnych książek} one {# książka} other {# książki} few {# książki} many {# książek}}",
+      "noteCount": "{count, plural, =0 {żadnych notatek} one {# uwaga} other {# notatki} few {# notatki} many {# notatek}}",
+      "export": "Eksportuj",
+      "exportMarkdown": "Przecena",
+      "exportCsv": "CSV",
+      "exportJson": "JSON",
+      "notesOnly": "Tylko notatki",
+      "style": "Styl",
+      "source": "Źródło",
+      "bulkTrash": "Kosz",
+      "bulkRestore": "Przywróć",
+      "tabs": {
+        "highlights": "Najważniejsze",
+        "trash": "Kosz"
+      },
+      "empty": {
+        "noMatch": "Żadne najciekawsze momenty nie pasują do wybranych filtrów.",
+        "resetFilters": "Zresetuj filtry",
+        "trashEmpty": "Kosz jest pusty",
+        "noAnnotations": "Nie ma jeszcze żadnych adnotacji. Tutaj pojawiają się skróty, które tworzysz w Internecie lub na swoim czytniku e-booków."
+      },
+      "toast": {
+        "movedToTrash": "Przeniesiono do kosza",
+        "annotationRestored": "Adnotacja przywrócona",
+        "annotationDeletedForever": "Adnotacja usunięta na zawsze",
+        "failedToDelete": "Nie udało się usunąć",
+        "bulkTrashed": "{count, plural, =0 {Nie przeniesiono żadnych adnotacji do kosza} one {Przeniesiony # adnotacja do kosza} other {Przeniesiony # adnotacje do kosza} few {Przeniesiono # adnotacje do kosza} many {Przeniesiono # adnotacji do kosza}}",
+        "bulkRestored": "{count, plural, =0 {Nie przywrócono żadnych adnotacji} one {Przywrócony # adnotacja} other {Przywrócony # adnotacje} few {Przywrócono # adnotacje} many {Przywrócono # adnotacji}}",
+        "bulkRecolored": "{count, plural, =0 {Pokolorowano bez adnotacji} one {Ponowne pokolorowanie # adnotacja} other {Ponowne pokolorowanie # adnotacje} few {Pokolorowano # adnotacje} many {Pokolorowano # adnotacji}}",
+        "bulkRestyled": "{count, plural, =0 {Nie zmieniono stylu żadnej adnotacji} one {Zmieniono styl # adnotacji} other {Zmieniono styl # adnotacji} few {Zmieniono styl # adnotacji} many {Zmieniono styl # adnotacji}}"
+      }
+    }
+  },
+  "audit": {
+    "pageTitle": "Dziennik audytu",
+    "pageSubtitle": "Rejestr działań istotnych dla administratora wykonanych w systemie.",
+    "filters": "Filtry",
+    "noActiveFilters": "Brak aktywnych filtrów",
+    "clear": "Wyczyść",
+    "empty": "Nie znaleziono dzienników kontroli",
+    "showMore": "Pokaż więcej",
+    "showLess": "Pokaż mniej",
+    "details": "Szczegóły",
+    "hideDetails": "Ukryj szczegóły",
+    "refresh": "Odśwież dziennik audytu",
+    "loadError": "Nie udało się wczytać zdarzeń kontroli.",
+    "removeFilter": "Usuń filtr: {value}",
+    "allActions": "Wszystkie działania",
+    "allEventTypes": "Wszystkie typy wydarzeń",
+    "allActors": "Wszyscy aktorzy",
+    "noActionsFound": "Brak pasujących działań",
+    "noActorsFound": "Brak pasujących aktorów",
+    "noResourcesFound": "Brak pasujących typów celów",
+    "unknownAction": "Nieznana akcja",
+    "unknownResource": "Inny typ celu",
+    "allResources": "Wszystkie zasoby",
+    "allTargetTypes": "Wszystkie typy celów",
+    "quickDates": "Szybkie randki",
+    "today": "Dzisiaj",
+    "sevenDays": "7 dni",
+    "thirtyDays": "30 dni",
+    "userId": "Użytkownik #{id}",
+    "userIdCompact": "#{id}",
+    "targetAdditional": "i {count, plural, one {# więcej celu} other {# więcej celów} few {Jeszcze # cele} many {# kolejnych celów}}",
+    "bookImpact": "{count, plural, one {# książka} other {# książki} few {# książki} many {# książek}}",
+    "entryDetailsLabel": "Szczegóły zdarzenia audytu #{id}",
+    "detailEventId": "Identyfikator zdarzenia",
+    "detailOccurredAt": "Wystąpiło",
+    "detailActor": "Aktor",
+    "detailCategory": "Kategoria",
+    "detailActionLabel": "Akcja",
+    "detailEventTypeLabel": "Typ wydarzenia",
+    "detailIpLabel": "Adres IP",
+    "detailResourceLabel": "Zasób",
+    "detailResourceIdLabel": "Identyfikator zasobu",
+    "detailTargetTypeLabel": "Typ celu",
+    "detailTargetIdLabel": "Identyfikator celu",
+    "detailAction": "Akcja: {value}",
+    "detailIp": "IP: {value}",
+    "detailResource": "Zasób: {value}",
+    "detailResourceId": "Identyfikator zasobu: {value}",
+    "deletedBooks": "Usunięte książki",
+    "deletedBookDetail": "{title} (książka #{id})",
+    "untitledBook": "Bez tytułu",
+    "deletedBooksOmitted": "{count, plural, one {# dodatkowa książka pominięta} other {# dodatkowe książki pominięte} few {Pominięto # dodatkowe książki} many {Pominięto # dodatkowych książek}}",
+    "showing": "Wyświetlanie {from}-{to} z {total}",
+    "prev": "Poprzednia",
+    "chips": {
+      "search": "Szukaj: {value}",
+      "action": "Akcja: {value}",
+      "eventType": "Typ wydarzenia: {value}",
+      "actor": "Aktor: {value}",
+      "resource": "Zasób: {value}",
+      "targetType": "Typ celu: {value}",
+      "user": "Użytkownik: {value}",
+      "from": "Od: {value}",
+      "to": "Do: {value}"
+    },
+    "filterLabels": {
+      "search": "Wyszukaj wydarzenia",
+      "action": "Akcja",
+      "eventType": "Typ zdarzenia (co się stało)",
+      "actor": "Aktor",
+      "resource": "Zasób",
+      "targetType": "Typ celu (na co miało to wpływ)",
+      "userId": "Identyfikator użytkownika",
+      "from": "Od",
+      "to": "Do"
+    },
+    "filterPlaceholders": {
+      "search": "Opis, aktor, cel lub identyfikator",
+      "actor": "Nazwa użytkownika",
+      "action": "np. autoryzacja.login",
+      "userId": "np. 1"
+    },
+    "columns": {
+      "when": "Kiedy",
+      "actor": "Aktor",
+      "event": "Wydarzenie",
+      "target": "Cel",
+      "impact": "Wpływ",
+      "user": "Użytkownik",
+      "action": "Akcja",
+      "description": "Opis",
+      "ip": "IP"
+    },
+    "categories": {
+      "authentication": "Uwierzytelnianie",
+      "books": "Książki",
+      "users": "Użytkownicy",
+      "libraries": "Biblioteki",
+      "collections": "Kolekcje",
+      "integrations": "Integracje",
+      "settings": "Ustawienia",
+      "other": "Inne"
+    },
+    "resourceLabels": {
+      "User": "Użytkownik",
+      "Library": "Biblioteka",
+      "Book": "Książka",
+      "Collection": "Kolekcja",
+      "SmartScope": "Inteligentny zakres",
+      "BookDockFile": "Plik Book Dock",
+      "Author": "Autor",
+      "AppSettings": "Ustawienia aplikacji",
+      "Genre": "Gatunek",
+      "Tag": "Oznacz",
+      "KoboDevice": "Kobo urządzenie",
+      "EmailProvider": "Dostawca poczty e-mail",
+      "EmailTemplate": "Szablon e-maila",
+      "EmailRecipient": "Odbiorca e-maila",
+      "EmailRecipientGroup": "Grupa odbiorców wiadomości e-mail",
+      "Narrator": "Narrator",
+      "Publisher": "Wydawca",
+      "Language": "Język",
+      "Series": "Seria",
+      "OidcIdentity": "OIDC tożsamość",
+      "MagicLinkToken": "Magiczny link",
+      "ReadingInsightsProfile": "Czytanie profilu statystyk"
+    },
+    "actionLabels": {
+      "AuthRegister": "Zarejestruj konto",
+      "AuthLogin": "Zaloguj się",
+      "AuthLoginFailed": "Nie udało się zalogować",
+      "AuthLogout": "Wyloguj się",
+      "AuthPasswordChange": "Zmień hasło",
+      "AuthPasswordResetRequest": "Poproś o zresetowanie hasła",
+      "AuthPasswordReset": "Zresetuj hasło",
+      "AuthPasswordAdminReset": "Zresetuj hasło użytkownika",
+      "AuthSessionRevoke": "Odwołaj sesję",
+      "MagicLinkCreate": "Utwórz magiczny link",
+      "MagicLinkLogin": "Zaloguj się za pomocą magicznego linku",
+      "MagicLinkRevoke": "Unieważnij magiczny link",
+      "MagicLinkActivate": "Aktywuj magiczny link",
+      "MagicLinkDeactivate": "Dezaktywuj magiczny link",
+      "OidcLogin": "Zaloguj się za pomocą OIDC",
+      "OidcUserProvisioned": "Udostępnij użytkownika OIDC",
+      "OidcIdentityLinked": "Połącz tożsamość OIDC",
+      "OidcIdentityUnlinked": "Odłącz tożsamość OIDC",
+      "UserCreate": "Utwórz użytkownika",
+      "UserUpdate": "Zaktualizuj użytkownika",
+      "UserSelfUpdate": "Zaktualizuj swój profil",
+      "UserDelete": "Usuń użytkownika",
+      "UserPermissionSet": "Zaktualizuj uprawnienia użytkownika",
+      "UserSuperuserEnable": "Włącz dostęp superużytkownika",
+      "UserSuperuserDisable": "Wyłącz dostęp superużytkownika",
+      "UserContentFiltersSet": "Zaktualizuj filtry treści",
+      "ReadingInsightsSharingUpdate": "Zaktualizuj udostępnianie spostrzeżeń",
+      "ReadingInsightsProfileView": "Wyświetl udostępnione spostrzeżenia",
+      "LibraryCreate": "Utwórz bibliotekę",
+      "LibraryUpdate": "Zaktualizuj bibliotekę",
+      "LibraryDelete": "Usuń bibliotekę",
+      "LibraryFolderAdd": "Dodaj folder biblioteki",
+      "LibraryFolderRemove": "Usuń folder biblioteki",
+      "LibraryAccessGrant": "Przyznaj dostęp do biblioteki",
+      "LibraryAccessUpdate": "Zaktualizuj dostęp do biblioteki",
+      "LibraryAccessRevoke": "Cofnij dostęp do biblioteki",
+      "LibraryWriteMetadataToFiles": "Zapisz metadane do plików",
+      "LibraryBulkRename": "Zmień nazwę plików biblioteki",
+      "BookUpload": "Prześlij książkę",
+      "BookMetadataUpdate": "Zaktualizuj metadane książki",
+      "BookMetadataLocksUpdate": "Zaktualizuj blokady metadanych",
+      "BookDelete": "Usuń książkę",
+      "BookBulkMetadataRefresh": "Odśwież metadane książki",
+      "BookBulkDelete": "Usuń książki",
+      "BookBulkCoverReextract": "Wyjmij ponownie okładki książek",
+      "BookBulkSetStatus": "Ustaw stan książki",
+      "BookBulkSetRating": "Ustaw ocenę książki",
+      "BookBulkSetMetadata": "Ustaw metadane książki",
+      "BookBulkUpdateTags": "Zaktualizuj tagi książek",
+      "BookBulkSetMetadataLock": "Ustaw blokady metadanych",
+      "BookBulkEditMetadata": "Edytuj metadane książki",
+      "BookReadingStateReset": "Zresetuj stan odczytu",
+      "BookWriteAndRename": "Zapisz metadane i zmień nazwę pliku",
+      "CollectionCreate": "Utwórz kolekcję",
+      "CollectionUpdate": "Aktualizuj kolekcję",
+      "CollectionDelete": "Usuń kolekcję",
+      "CollectionBooksAdd": "Dodaj książki do kolekcji",
+      "CollectionBooksRemove": "Usuń książki z kolekcji",
+      "SmartScopeCreate": "Utwórz inteligentny zakres",
+      "SmartScopeUpdate": "Zaktualizuj inteligentny zakres",
+      "SmartScopeDelete": "Usuń inteligentny zakres",
+      "BookDockFinalize": "Finalizuj plik Book Dock",
+      "AuthorUpdate": "Aktualizuj autora",
+      "AuthorDelete": "Usuń autora",
+      "AuthorMerge": "Połącz autorów",
+      "AuthorEnrichmentConfigUpdate": "Zaktualizuj wzbogacenie autora",
+      "AuthorEnrichmentPause": "Wstrzymaj wzbogacanie autora",
+      "AuthorEnrichmentResume": "Wzbogacanie autora CV",
+      "AuthorEnrichmentCancel": "Anuluj wzbogacanie autora",
+      "EntityManagerMerge": "Połącz podmioty",
+      "EntityManagerRename": "Zmień nazwę jednostki",
+      "EntityManagerDelete": "Usuń podmiot",
+      "EntityManagerSplit": "Podziel jednostkę",
+      "EntityManagerDismiss": "Odrzuć duplikat",
+      "EntityManagerUndismiss": "Przywróć usunięty duplikat",
+      "AppSettingsUpdate": "Zaktualizuj ustawienia aplikacji",
+      "KoboDeviceRegister": "Zarejestruj urządzenie Kobo",
+      "KoboDeviceRename": "Zmień nazwę urządzenia Kobo",
+      "KoboDeviceRemove": "Usuń urządzenie Kobo",
+      "EmailProviderCreate": "Utwórz dostawcę poczty e-mail",
+      "EmailProviderUpdate": "Zaktualizuj dostawcę poczty e-mail",
+      "EmailProviderDelete": "Usuń dostawcę poczty e-mail",
+      "EmailProviderSetDefault": "Ustaw domyślnego dostawcę poczty e-mail",
+      "EmailProviderSetSystem": "Ustaw systemowego dostawcę poczty e-mail",
+      "EmailProviderClearSystem": "Wyczyść systemowego dostawcę poczty e-mail",
+      "EmailTemplateCreate": "Utwórz szablon wiadomości e-mail",
+      "EmailTemplateUpdate": "Zaktualizuj szablon wiadomości e-mail",
+      "EmailTemplateDelete": "Usuń szablon e-maila",
+      "EmailTemplateSetDefault": "Ustaw domyślny szablon wiadomości e-mail",
+      "EmailRecipientCreate": "Utwórz odbiorcę wiadomości e-mail",
+      "EmailRecipientUpdate": "Zaktualizuj odbiorcę wiadomości e-mail",
+      "EmailRecipientDelete": "Usuń odbiorcę e-maila",
+      "EmailRecipientGroupCreate": "Utwórz grupę odbiorców",
+      "EmailRecipientGroupUpdate": "Zaktualizuj grupę odbiorców",
+      "EmailRecipientGroupDelete": "Usuń grupę odbiorców",
+      "EmailRecipientGroupMemberAdd": "Dodaj odbiorcę do grupy",
+      "EmailRecipientGroupMemberRemove": "Usuń odbiorcę z grupy"
+    }
+  },
+  "auth": {
+    "backToSignIn": "Wróć do logowania",
+    "themePicker": {
+      "switchToLight": "Przełącz na światło",
+      "switchToDark": "Przełącz na ciemność",
+      "changeRadius": "Zmień promień narożnika",
+      "changeBackground": "Zmień tło",
+      "changeAccent": "Zmień kolor akcentu"
+    },
+    "fields": {
+      "username": "Nazwa użytkownika",
+      "password": "Hasło",
+      "email": "E-mail",
+      "emailAddress": "Adres e-mail",
+      "fullName": "Pełne imię i nazwisko",
+      "newPassword": "Nowe hasło",
+      "confirmPassword": "Potwierdź hasło",
+      "confirmNewPassword": "Potwierdź nowe hasło",
+      "currentPassword": "Aktualne hasło",
+      "passwordHint": "Min. 8 znaków, wielkie i małe litery oraz cyfra"
+    },
+    "errors": {
+      "generic": "Coś poszło nie tak. Spróbuj ponownie.",
+      "passwordsDoNotMatch": "Hasła nie pasują"
+    },
+    "login": {
+      "subtitle": "Zaloguj się na swoje konto",
+      "signIn": "Zaloguj się",
+      "signingIn": "Logowanie...",
+      "orDivider": "lub",
+      "forgotPassword": "Zapomniałeś hasła?",
+      "errors": {
+        "invalidCredentials": "Nieprawidłowa nazwa użytkownika lub hasło",
+        "tooManyAttempts": "Zbyt wiele prób logowania. Poczekaj chwilę i spróbuj ponownie."
+      }
+    },
+    "oidc": {
+      "loginFailed": "OIDC logowanie nie powiodło się",
+      "redirecting": "Przekierowywanie...",
+      "signInWith": "Zaloguj się za pomocą {provider}",
+      "completingSignIn": "Kończę logowanie...",
+      "tryAgain": "Spróbuj ponownie",
+      "errors": {
+        "stateExpired": "Twoja sesja logowania wygasła. Spróbuj zalogować się ponownie.",
+        "tokenExchangeFailed": "Nie udało się dokończyć logowania u Twojego dostawcy. Spróbuj ponownie lub skontaktuj się z administratorem.",
+        "userNotProvisioned": "Twoje konto nie zostało skonfigurowane. Aby uzyskać dostęp, skontaktuj się z administratorem.",
+        "userInactive": "Twoje konto zostało dezaktywowane. Skontaktuj się ze swoim administratorem.",
+        "providerError": "Twój dostawca tożsamości zwrócił błąd. Spróbuj ponownie.",
+        "missingCodeOrState": "Brakujący kod lub parametr stanu"
+      },
+      "providerErrors": {
+        "accessDenied": "Dostawca tożsamości odmówił dostępu.",
+        "loginRequired": "Wymagane jest uwierzytelnienie. Zaloguj się ponownie.",
+        "interactionRequired": "Wymagana jest dodatkowa interakcja użytkownika."
+      }
+    },
+    "forgotPassword": {
+      "subtitle": "Zresetuj swoje hasło",
+      "submitted": "Jeśli istnieje konto z tym adresem e-mail, został wysłany link resetujący. Sprawdź swoją skrzynkę odbiorczą.",
+      "sending": "Wysyłanie...",
+      "sendResetLink": "Wyślij link resetujący",
+      "errors": {
+        "emailUnavailable": "Resetowanie hasła przez e-mail nie jest możliwe. Skontaktuj się ze swoim administratorem."
+      }
+    },
+    "resetPassword": {
+      "subtitle": "Ustaw nowe hasło",
+      "saving": "Zapisywanie...",
+      "setNewPassword": "Ustaw nowe hasło",
+      "errors": {
+        "invalidLink": "Nieprawidłowy link resetowania. Proszę o nowy.",
+        "invalidOrExpired": "Nieprawidłowy lub wygasły link resetowania. Proszę o nowy."
+      }
+    },
+    "setup": {
+      "title": "Konfiguracja wstępna",
+      "subtitle": "Utwórz pierwsze konto administratora.",
+      "setupToken": "Token konfiguracji",
+      "setupTokenHint": "(wymagane w produkcji)",
+      "creatingAccount": "Tworzenie konta...",
+      "createAccount": "Utwórz konto administratora",
+      "errors": {
+        "failed": "Nie udało się dokończyć konfiguracji"
+      }
+    },
+    "changePassword": {
+      "title": "Zmień hasło",
+      "saving": "Zapisuję…",
+      "forcedNotice": "Przed kontynuowaniem musisz ustawić nowe hasło.",
+      "errors": {
+        "failed": "Nie udało się zmienić hasła"
+      }
+    },
+    "magicLink": {
+      "signingIn": "Loguję Cię...",
+      "loginFailed": "Logowanie nie powiodło się",
+      "goToLogin": "Przejdź do logowania",
+      "errors": {
+        "noToken": "Nie podano tokena"
+      }
+    }
+  },
+  "author": {
+    "card": {
+      "portraitAlt": "{name} portret",
+      "viewDetails": "Wyświetl szczegóły autora",
+      "refreshMetadata": "Odśwież metadane",
+      "deleteAuthor": "Usuń autora"
+    },
+    "listRow": {
+      "noRecentAdditions": "Brak nowych dodatków",
+      "portraitAlt": "{name} portret"
+    },
+    "filters": {
+      "title": "Filtry autorskie",
+      "clearAll": "Wyczyść wszystko",
+      "allLibraries": "Wszystkie biblioteki",
+      "allAuthors": "Wszyscy autorzy",
+      "hasPhoto": "Ma zdjęcie",
+      "missingPhoto": "Brakujące zdjęcie",
+      "minBooks": "Min. książki",
+      "anyPlaceholder": "Dowolny"
+    },
+    "header": {
+      "never": "Nigdy",
+      "portraitAlt": "{name} portret",
+      "actions": "Działania",
+      "editAuthor": "Edytuj autora",
+      "mergeAuthors": "Połącz autorów",
+      "refreshing": "Orzeźwiający...",
+      "refreshMetadata": "Odśwież metadane",
+      "deleteAuthor": "Usuń autora",
+      "showLess": "Pokaż mniej",
+      "showMore": "Pokaż więcej",
+      "lookingUpMetadata": "Wyszukiwanie metadanych autora...",
+      "noBiography": "Brak biografii. Użyj menu, aby odświeżyć metadane.",
+      "previewFrom": "Podgląd z {provider}. Zapisz metadane, aby je zachować.",
+      "booksLabel": "Książki",
+      "lastAdded": "Ostatnio dodane"
+    },
+    "list": {
+      "title": "Autorzy",
+      "showControlsAria": "Pokaż kontrolki autora",
+      "searchPlaceholder": "Szukaj autorów",
+      "sortButton": "Sortuj",
+      "sortBy": "Sortuj według",
+      "ascending": "Rosnąco",
+      "descending": "Malejąco",
+      "asc": "rosnąco",
+      "desc": "Opis",
+      "filters": "Filtry",
+      "clear": "Wyczyść",
+      "allLoaded": "Załadowano wszystkich autorów {total}",
+      "sort": {
+        "name": "Imię",
+        "sortName": "Sortuj nazwę",
+        "bookCount": "Liczba książek",
+        "recentAdditions": "Najnowsze dodatki",
+        "lastEnriched": "Ostatnio wzbogacony"
+      },
+      "empty": {
+        "title": "Nie znaleziono autorów",
+        "hint": "Spróbuj zmienić wyszukiwany tekst, sortowanie lub filtr biblioteczny."
+      },
+      "deleteDialog": {
+        "titleOne": "Usunąć autora?",
+        "titleMany": "Usunąć {count} autorów?",
+        "descriptionOne": "Spowoduje to usunięcie autora z katalogu i odłączenie go od powiązanych książek. Tej akcji nie można cofnąć.",
+        "descriptionMany": "Spowoduje to usunięcie wybranych autorów z katalogu i odłączenie ich od powiązanych książek. Tej akcji nie można cofnąć."
+      },
+      "selection": {
+        "selectVisible": "Wybierz widoczne",
+        "refreshMetadata": "Odśwież metadane",
+        "refreshingMetadata": "Odświeżanie metadanych...",
+        "deleteSelected": "Usuń wybrane",
+        "deleting": "Usuwanie...",
+        "exitSelection": "Wyjdź z wyboru",
+        "confirmDeleteCount": "{count, plural, =0 {Usunąć # autorów?} one {Usunąć # autora?} other {Usunąć # autora?} few {Usunąć # autorów?} many {Usunąć # autorów?}}"
+      },
+      "toast": {
+        "refreshed": "Odświeżono metadane autora",
+        "refreshedNoImage": "Metadane zostały odświeżone, ale nie znaleziono obrazu autora.",
+        "refreshFailed": "Nie udało się odświeżyć metadanych autora",
+        "bulkRefreshPartial": "Odświeżenie {updated} autorów, {failed} nie powiodło się",
+        "bulkRefreshSuccess": "Odświeżone metadane dla {updated} autorów",
+        "bulkRefreshFailed": "Nie udało się odświeżyć wybranych autorów",
+        "deleteSuccess": "{count, plural, =0 {Usunięto # autorów; zmieniono {books} książek} one {Usunięto # autora; zmieniono {books} książek} other {Usunięto # autorów; zmieniono {books} książek} few {Usunięto # autorów; zmieniono {books} książek} many {Usunięto # autorów; zmieniono {books} książek}}",
+        "deleteFailed": "Nie udało się usunąć autorów"
+      }
+    },
+    "detail": {
+      "pageTitle": "Autor",
+      "pageTitleNamed": "Autor · {name}",
+      "pageTitleId": "Autor #{id}",
+      "entityName": "Autor",
+      "loadingAuthor": "Ładowanie autora...",
+      "previewError": "Nie można teraz wczytać metadanych podglądu autora zewnętrznego.",
+      "edit": {
+        "name": "Imię",
+        "sortName": "Sortuj nazwę",
+        "description": "Opis",
+        "image": "Obraz",
+        "uploading": "Przesyłanie...",
+        "replaceImage": "Zamień obraz",
+        "uploadImage": "Prześlij obraz",
+        "removing": "Usuwanie...",
+        "removeImage": "Usuń obraz",
+        "imageHint": "PNG/JPEG/WEBP/GIF/BMP do {size} MB",
+        "saving": "Zapisywanie..."
+      },
+      "merge": {
+        "searchPlaceholder": "Wyszukaj autorów, aby połączyć się z tym autorem",
+        "searching": "Wyszukiwanie...",
+        "bookCount": "{count, plural, =0 {żadnych książek} one {# książka} other {# książki} few {# książki} many {# książek}}",
+        "selectedSummary": "Wybrani autorzy {count}, ok. Dotyczy to {books} książek.",
+        "merging": "Łączenie...",
+        "mergeSelected": "Połącz wybrane",
+        "confirmLabel": "Połącz"
+      },
+      "mergeDialog": {
+        "title": "Połączyć {count} autorów z „{name}”?",
+        "titleFallback": "Połączyć wybranych autorów?",
+        "description": "Spowoduje to połączenie wybranych autorów z bieżącym autorem i ponowne połączenie powiązanych książek. Tej akcji nie można cofnąć.",
+        "descriptionEmpty": "Tej akcji nie można cofnąć."
+      },
+      "deleteDialog": {
+        "title": "Usunąć autora?",
+        "description": "Spowoduje to usunięcie autora z katalogu i odłączenie go od powiązanych książek. Tej akcji nie można cofnąć."
+      },
+      "books": {
+        "heading": "Książki",
+        "allLibraries": "Wszystkie biblioteki",
+        "asc": "rosnąco",
+        "desc": "Opis",
+        "ascending": "Rosnąco",
+        "descending": "Malejąco",
+        "allLoaded": "Załadowano wszystkie {total} książki",
+        "sort": {
+          "recentlyAdded": "Ostatnio dodane",
+          "title": "Tytuł",
+          "publishedYear": "Opublikowany rok"
+        },
+        "empty": {
+          "title": "Nie znaleziono książek tego autora",
+          "hint": "Spróbuj zmienić sortowanie/kolejność lub wybrać inną bibliotekę."
+        }
+      },
+      "toast": {
+        "refreshed": "Odświeżono metadane autora",
+        "refreshedNoImage": "Metadane zostały odświeżone, ale nie znaleziono obrazu autora.",
+        "refreshFailed": "Nie udało się odświeżyć metadanych autora",
+        "nameRequired": "Nazwisko autora jest wymagane",
+        "updated": "Autor zaktualizowany",
+        "updateFailed": "Nie udało się zaktualizować autora",
+        "imageUpdated": "Zaktualizowano obraz autora",
+        "imageUploadFailed": "Nie udało się przesłać obrazu autora",
+        "imageRemoved": "Obraz autora został usunięty",
+        "imageRemoveFailed": "Nie udało się usunąć obrazu autora",
+        "mergeSuccess": "Połączono {count} autorów; dotyczy to {books} książek",
+        "mergeFailed": "Nie udało się połączyć autorów",
+        "deleteSuccess": "Usunięty autor; dotyczy to {books} książek",
+        "deleteFailed": "Nie udało się usunąć autora"
+      }
+    }
+  },
+  "book": {
+    "untitled": "Bez tytułu",
+    "unknownFormat": "nieznany",
+    "collapsedSeries": {
+      "label": "Seria",
+      "bookCount": "{count, plural, =0 {żadnych książek} one {# książka} other {# książki} few {# książki} many {# książek}}",
+      "readCount": "{count} przeczytaj"
+    },
+    "card": {
+      "missing": "Brak"
+    },
+    "file": {
+      "primary": "Główny",
+      "audiobook": "Książka audio"
+    },
+    "actions": {
+      "read": "Oznacz jako przeczytaną",
+      "listen": "Słuchaj",
+      "peek": "Zerknij",
+      "quickView": "Szybki podgląd",
+      "details": "Szczegóły",
+      "bookDetails": "Szczegóły książki",
+      "download": "Pobierz",
+      "metadata": "Metadane",
+      "editMetadata": "Edytuj metadane",
+      "refreshMetadata": "Odśwież metadane",
+      "regenerateCover": "Zregeneruj osłonę",
+      "addToCollection": "Dodaj do kolekcji",
+      "setStatus": "Ustaw stan",
+      "sendViaEmail": "Wyślij e-mailem",
+      "rate": "Oceń {star}",
+      "openAs": "Otwórz jako {format}"
+    },
+    "readStatus": {
+      "unread": "Nieprzeczytane",
+      "wantToRead": "Chcesz przeczytać",
+      "reading": "Czytanie",
+      "onHold": "Wstrzymane",
+      "rereading": "Ponowne czytanie",
+      "read": "Przeczytane",
+      "skimmed": "Odtłuszczone",
+      "abandoned": "Opuszczony"
+    },
+    "download": {
+      "action": "Pobierz",
+      "audiobookZip": "Książka audio (ZIP)",
+      "allFormatsZip": "Wszystkie formaty (ZIP)",
+      "primaryOnlyZip": "Tylko podstawowe (ZIP)"
+    },
+    "sort": {
+      "moveUp": "Przesuń się w górę",
+      "moveDown": "Przesuń w dół",
+      "ascending": "Rosnąco",
+      "descending": "Malejąco",
+      "remove": "Usuń",
+      "emptyState": "Nie skonfigurowano sortowania. Tytuł będzie używany w kolejności rosnącej.",
+      "addLevel": "Dodaj poziom sortowania"
+    },
+    "filter": {
+      "match": "Dopasowanie",
+      "all": "WSZYSTKIE",
+      "any": "KAŻDY",
+      "ofFollowingRules": "poniższych zasad",
+      "anyProvider": "Dowolny dostawca",
+      "communityRatingProvider": "Dostawca ocen społecznościowych",
+      "loadingLibraries": "Ładowanie bibliotek...",
+      "noLibrariesAvailable": "Brak dostępnych bibliotek",
+      "selectLibrary": "Wybierz bibliotekę...",
+      "selectStatus": "Wybierz stan...",
+      "withinLastPlaceholder": "np. 7",
+      "unit": {
+        "days": "dni",
+        "weeks": "tygodnie",
+        "months": "miesiące"
+      },
+      "scorePreset": {
+        "outstanding": "Doskonały",
+        "good": "Dobry",
+        "fair": "Przeciętny",
+        "poor": "Słaby"
+      },
+      "scoreRangePlaceholder": "0-100",
+      "valuePlaceholder": "wartość",
+      "maxPlaceholder": "maks",
+      "to": "do",
+      "group": "Grupa",
+      "addRule": "Dodaj regułę",
+      "addGroup": "Dodaj grupę",
+      "typeToSearch": "Wpisz, aby wyszukać..."
+    },
+    "deleteDialog": {
+      "title": "Usunąć książkę?",
+      "description": "Spowoduje to trwałe usunięcie książki wraz ze wszystkimi jej metadanymi, plikami, postępem czytania i zakładkami. Tego nie można cofnąć."
+    },
+    "bulkEdit": {
+      "title": "{count, plural, =0 {Edytuj metadane - # książka} one {Edytuj metadane - # książka} other {Edytuj metadane - # książki} few {Edytuj metadane - # książki} many {Edytuj metadane - # książek}}",
+      "instructions": "Przełącz pola do edycji, a następnie skonfiguruj wartości. Zmienione zostaną tylko pola przełączane.",
+      "invalidYear": "Wpisz prawidłowy rok (tylko cyfry)",
+      "clearWarning": "Spowoduje to usunięcie wszystkich {field} z wybranych książek.",
+      "searchPlaceholder": "Wyszukaj {field}...",
+      "enterPlaceholder": "Wpisz {field}",
+      "yearPlaceholder": "np. 2024",
+      "leaveEmptyHint": "Pozostaw puste, aby wyczyścić to pole we wszystkich wybranych książkach.",
+      "applying": "Stosowanie...",
+      "apply": "Zastosuj",
+      "mode": {
+        "add": "Dodaj",
+        "remove": "Usuń",
+        "replace": "Wymień",
+        "clear": "Wyczyść"
+      }
+    },
+    "export": {
+      "title": "Eksportuj metadane",
+      "scope": "Zakres",
+      "selectedRows": "Wybrane wiersze",
+      "currentlySelected": "{count} aktualnie wybrany",
+      "allMatchingRows": "Wszystkie pasujące wiersze",
+      "rowsInResult": "{count} wierszy w bieżącym wyniku",
+      "format": "Sformatuj",
+      "csvDescription": "Przyjazny dla arkuszy kalkulacyjnych, zawiera BOM UTF-8",
+      "jsonDescription": "Eksport strukturalny z kontekstem metadanych",
+      "columns": "Kolumny",
+      "canonicalSchema": "Stabilny schemat kanoniczny",
+      "visibleColumns": "Bieżące widoczne kolumny",
+      "options": "Opcje",
+      "includePersonalData": "Dołącz osobiste dane do odczytu",
+      "includeFilePaths": "Dołącz ścieżki plików (zaawansowane)",
+      "includeContextMeta": "Dołącz metadane kontekstowe",
+      "preflight": "Lot wstępny",
+      "scopeLabel": "Zakres: {summary}",
+      "calculatingSize": "Obliczanie rozmiaru eksportu...",
+      "estimatedSize": "Szacowany rozmiar:",
+      "fileLabel": "Plik: {fileName}",
+      "exportAction": "Eksportuj",
+      "selectedRowsSummary": "{count, plural, =0 {# wybrany wiersz} one {# wybrany wiersz} other {# wybrane wiersze} few {# wybrane rzędy} many {# wybranych wierszy}}",
+      "matchingRowsSummary": "{count, plural, =0 {# pasujący rząd} one {# pasujący rząd} other {# pasujące rzędy} few {# pasujące rzędy} many {# pasujących rzędów}}",
+      "prepareFailed": "Nie udało się przygotować eksportu",
+      "exportStarted": "Rozpoczęto eksport metadanych: {fileName}",
+      "exportFailed": "Eksport metadanych nie powiódł się"
+    },
+    "columnPanel": {
+      "columnsHeading": "Kolumny",
+      "reset": "Zresetuj",
+      "tableDensity": "Gęstość stołu",
+      "density": {
+        "compact": "Kompaktowy",
+        "comfortable": "Wygodne",
+        "roomy": "Przestronny"
+      },
+      "presets": "Ustawienia wstępne",
+      "exportBackup": "Eksportuj ustawienia wstępne i zapisane widoki",
+      "importBackup": "Importuj gotowe ustawienia i zapisane widoki",
+      "rename": "Zmień nazwę",
+      "renamePrompt": "Wprowadź nową nazwę",
+      "builtIn": "Wbudowany",
+      "saveCurrentPreset": "Zapisz bieżące ustawienie wstępne",
+      "savedViews": "Zapisane widoki",
+      "savedViewsEmpty": "Zapisuj filtry sortowania, układu i widoku, aby móc je szybko wykorzystać ponownie.",
+      "saveCurrentView": "Zapisz bieżący widok",
+      "pinnedLeft": "Przypięty po lewej stronie",
+      "pinnedRight": "Przypięty w prawo",
+      "columns": {
+        "cover": "Okładka",
+        "read": "Przeczytane",
+        "actions": "Działania"
+      }
+    },
+    "shortcuts": {
+      "title": "Skróty klawiaturowe",
+      "navigation": {
+        "title": "Nawigacja",
+        "moveFocusVertical": "Przesuń fokus w górę/w dół",
+        "moveFocusHorizontal": "Przesuń fokus w lewo/w prawo",
+        "jumpFirstColumn": "Skocz do pierwszej kolumny",
+        "jumpLastColumn": "Przejdź do ostatniej kolumny",
+        "jumpFirstRow": "Skocz do pierwszego rzędu",
+        "jumpLastRow": "Przejdź do ostatniego rzędu"
+      },
+      "actions": {
+        "title": "Działania",
+        "editCell": "Edytuj zaznaczoną komórkę",
+        "cancelEditing": "Anuluj edycję / Zamknij nakładkę",
+        "toggleRowSelection": "Przełącz wybór wiersza",
+        "copyCell": "Skopiuj wartość komórki",
+        "copyRow": "Skopiuj wybrany wiersz"
+      },
+      "general": {
+        "title": "Generał",
+        "toggleHelp": "Przełącz tę nakładkę pomocy"
+      }
+    },
+    "jumpRail": {
+      "jumpToSection": "Przejdź do sekcji",
+      "jumpTo": "Skocz do {label}",
+      "unknownDate": "Nieznana data",
+      "unknownValue": "Nieznana wartość"
+    },
+    "quickView": {
+      "title": "Zarezerwuj szybki podgląd",
+      "titleFor": "Szybki podgląd dla {title}",
+      "description": "Przeglądaj szczegóły książki i uruchamiaj szybkie działania.",
+      "openIn": "Otwórz w {provider}",
+      "pages": "{count, plural, =0 {# strona} one {# strona} other {# strony} few {# strony} many {# stron}}",
+      "primaryFile": "Plik podstawowy",
+      "fileNumber": "Plik #{id}",
+      "showLess": "Pokaż mniej",
+      "showMore": "Pokaż więcej",
+      "collections": "Kolekcje",
+      "noDescription": "Brak opisu.",
+      "openMetadataEditor": "Otwórz edytor metadanych",
+      "coverPreview": "Podgląd okładki książki",
+      "coverPreviewFor": "{title} podgląd okładki",
+      "coverPreviewDescription": "Powiększone okno dialogowe podglądu obrazu okładki."
+    },
+    "tableView": {
+      "openBookDetails": "Otwórz szczegóły książki",
+      "openSeries": "Seria otwarta",
+      "metadataRefreshFailed": "Odświeżenie metadanych nie powiodło się",
+      "booksSelected": "{count, plural, =0 {# wybrana książka} one {# wybrana książka} other {# wybrane książki} few {Wybrano # książki} many {Wybrano # książek}}",
+      "loadingMoreBooks": "Ładuję więcej książek",
+      "sort": "Sortuj",
+      "refreshingMetadata": "Odświeżanie metadanych {processed} / {total}",
+      "failedCount": "{count} nie powiodło się",
+      "remainingCount": "Pozostało {count}",
+      "readOnlyNotice": "Edycja tabeli jest wyłączona na mniejszych ekranach. Aby przyspieszyć działanie, przełącz się na listę lub siatkę.",
+      "fetching": "Pobieram...",
+      "updated": "Zaktualizowano",
+      "failed": "Nie udało się",
+      "noBooks": "Brak książek do wyświetlenia",
+      "scrollToTop": "Przewiń do góry",
+      "selectedStatus": "Wybrano {count}",
+      "filtered": "Filtrowane",
+      "loadedStatus": "Załadowano {loaded} z {total}",
+      "bookCount": "{count, plural, =0 {# książka} one {# książka} other {# książki} few {# książki} many {# książek}}",
+      "keyboardShortcutsTitle": "Skróty klawiaturowe (?)",
+      "showKeyboardShortcuts": "Pokaż skróty klawiaturowe tabeli",
+      "copyHint": "Skopiuj komórkę: Ctrl/Cmd+C · Skopiuj wiersz: Ctrl/Cmd+Shift+C"
+    },
+    "detail": {
+      "authorBooks": {
+        "alsoByAuthor": "Również tego autora",
+        "alsoByAuthors": "Również tych autorów"
+      },
+      "header": {
+        "previousBook": "Poprzednia książka",
+        "nextBook": "Następna książka"
+      },
+      "tabs": {
+        "details": "Szczegóły",
+        "editMetadata": "Edytuj metadane",
+        "files": "Pliki",
+        "readingLog": "Czytanie dziennika",
+        "highlights": "Najważniejsze"
+      },
+      "discover": {
+        "moreInSeries": "Więcej w Seriach",
+        "byAuthor": "Przez autora",
+        "similarBooks": "Podobne książki"
+      },
+      "recommended": {
+        "moreLikeThis": "Więcej takich"
+      },
+      "series": {
+        "moreInSeries": "Więcej w serii {series}"
+      },
+      "writeRename": {
+        "written": "{count, plural, =0 {nie zapisano żadnych pól} one {Napisane (jedno pole)} other {Napisane (# pola)} few {Napisane (# pola)} many {Napisane (# pól)}}",
+        "writeFailed": "Zapis nie powiódł się",
+        "skipped": "Pominięte",
+        "renamedTo": "Zmieniono nazwę na {name}",
+        "fileRenamed": "Zmieniono nazwę pliku",
+        "renameFailed": "Zmiana nazwy nie powiodła się",
+        "autoWriteAndRenameDisabled": "Automatyczne zapisywanie i zmiana nazwy są wyłączone w ustawieniach biblioteki. Zmiany nie będą automatycznie synchronizowane przy przyszłych zapisach.",
+        "autoWriteDisabled": "Automatyczne zapisywanie jest wyłączone w ustawieniach biblioteki. Zmiany nie będą automatycznie synchronizowane przy przyszłych zapisach.",
+        "autoRenameDisabled": "Automatyczna zmiana nazwy jest wyłączona w ustawieniach biblioteki. Zmiany nie będą automatycznie synchronizowane przy przyszłych zapisach.",
+        "writeLabel": "Napisz:",
+        "renameLabel": "Zmień nazwę:"
+      },
+      "addFile": {
+        "uploading": "Przesyłanie...",
+        "uploadComplete": "Przesyłanie zakończone",
+        "title": "Dodaj plik",
+        "dropzone": {
+          "title": "Upuść pliki tutaj lub kliknij, aby przeglądać",
+          "hint": "epub, pdf, mobi, cbz, m4b i więcej - do {size} MB każdy"
+        },
+        "addMore": "Dodaj więcej plików",
+        "fileCount": "{count, plural, =0 {żadnych plików} one {jeden plik} other {# pliki} few {# pliki} many {# plików}}",
+        "clearAll": "Wyczyść wszystko",
+        "done": "Gotowe",
+        "retry": "Spróbuj ponownie",
+        "filesAdded": "{count, plural, =0 {nie dodano żadnych plików} one {dodano jeden plik} other {# dodane pliki} few {Dodano # pliki} many {Dodano # plików}}",
+        "uploadedFailed": "{done} przesłano, {failed} nie powiodło się",
+        "uploadingProgress": "{done} z {total} przesyłanie...",
+        "renameAfter": "Zmień nazwę wszystkich plików książek po przesłaniu",
+        "uploadCount": "Prześlij ({count})",
+        "upload": "Prześlij"
+      },
+      "addSession": {
+        "errors": {
+          "invalidDate": "Wybierz prawidłową datę i godzinę.",
+          "future": "Sesja nie może rozpocząć się w przyszłości.",
+          "duration": "Czas trwania musi mieścić się w zakresie od 1 do 1440 minut.",
+          "endProgress": "Postęp zakończenia musi mieścić się w przedziale od 0 do 100."
+        },
+        "title": "Dodaj sesję czytania",
+        "startedAt": "Rozpoczęło się o godz",
+        "duration": "Czas trwania (minuty)",
+        "endProgress": "Zakończ postęp %",
+        "optional": "Opcjonalne",
+        "format": "Sformatuj",
+        "noFormat": "Brak konkretnego formatu",
+        "saving": "Zapisywanie...",
+        "submit": "Dodaj sesję"
+      },
+      "coverEditor": {
+        "unlockCover": "Odblokuj pokrywę",
+        "lockCover": "Osłona zamka",
+        "fileTab": "Plik",
+        "urlTab": "URL",
+        "chooseImage": "Wybierz obraz...",
+        "findCoverOnline": "Znajdź osłonę w Internecie",
+        "saving": "Zapisywanie...",
+        "saveCover": "Zapisz okładkę",
+        "revertToOriginal": "Przywróć oryginał",
+        "regenerateCover": "Zregeneruj osłonę"
+      },
+      "coverSearch": {
+        "title": "Wyszukiwanie w Internecie",
+        "subtitle": "Wyszukaj okładki książek",
+        "titleField": "Tytuł",
+        "authorField": "Autor",
+        "sourceField": "Źródło",
+        "allSources": "Wszystkie źródła",
+        "audiobookCovers": "Okładki audiobooków",
+        "squareHint": "(kwadrat)",
+        "searching": "Wyszukiwanie...",
+        "findCovers": "Znajdź okładki",
+        "selectCover": "Wybierz Okładka",
+        "noResultsTitle": "Nie znaleziono żadnych wyników",
+        "noResultsHint": "Spróbuj dostosować wyszukiwane hasła",
+        "readyTitle": "Gotowy do wyszukiwania",
+        "readyHint": "Wpisz tytuł i autora powyżej",
+        "resolutionTip": "Wskazówka: okładki w wysokiej rozdzielczości są zaznaczone na zielono"
+      },
+      "details": {
+        "by": "przez",
+        "narratedBy": "opowiadane przez",
+        "ratingLocked": "Ocena jest zablokowana",
+        "rateStar": "Oceń {star}",
+        "listen": "Słuchaj",
+        "read": "Przeczytane",
+        "chooseFormat": "Wybierz format",
+        "audiobook": "Książka audio",
+        "primary": "Główny",
+        "peek": "Zerknij",
+        "sendViaEmail": "Wyślij e-mailem",
+        "personalReview": {
+          "title": "Recenzja osobista",
+          "toggleAria": "Przełącz recenzję osobistą",
+          "editAria": "Edytuj recenzję osobistą",
+          "placeholder": "Prywatna recenzja",
+          "clearAria": "Wyraźna recenzja osobista",
+          "cancelEditAria": "Anuluj edycję osobistej recenzji"
+        },
+        "editCover": "Edytuj okładkę",
+        "finished": "Skończone",
+        "resetFileProgress": "Zresetuj postęp pliku",
+        "resetting": "Resetuję...",
+        "resetProgressConfirm": "Zresetować zapisany postęp czytania dla {label}?",
+        "moreCount": "+{count} więcej",
+        "untitled": "Bez tytułu",
+        "metadataScore": "Wynik metadanych",
+        "primaryFormat": "Podstawowy format",
+        "openIn": "Otwórz w {provider}",
+        "showLess": "Pokaż mniej",
+        "showMore": "Pokaż więcej",
+        "publisher": "Wydawca",
+        "published": "Opublikowano",
+        "language": "Język",
+        "pages": "Strony",
+        "duration": "Czas trwania",
+        "edition": "Wydanie",
+        "abridged": "Skrócone",
+        "unabridged": "Pełne",
+        "isbn": "ISBN",
+        "fileSize": "Rozmiar pliku",
+        "library": "Biblioteka",
+        "added": "Dodano",
+        "dateStarted": "Data rozpoczęcia",
+        "saving": "Zapisywanie...",
+        "cancelDateStartedEdit": "Anuluj datę rozpoczęcia edycji",
+        "editDateStarted": "Rozpoczęto edycję daty",
+        "dateFinished": "Data zakończenia",
+        "cancelDateFinishedEdit": "Anuluj datę zakończenia edycji",
+        "editDateFinished": "Data edycji została zakończona",
+        "customMetadata": "Niestandardowe metadane",
+        "synopsis": "Streszczenie",
+        "noDescription": "Brak opisu.",
+        "dateStartedFutureError": "Data rozpoczęcia nie może przypadać w przyszłości.",
+        "dateFinishedFutureError": "Data zakończenia nie może przypadać w przyszłości.",
+        "dateFinishedBeforeStartedError": "Data zakończenia musi przypadać w dniu lub po dacie rozpoczęcia.",
+        "saveReadingDatesError": "Nie udało się zapisać dat przeczytania.",
+        "koboPendingDelete": "Oczekuje na usunięcie z urządzenia",
+        "koboPendingDeleteTooltip": "Kobo usunie go przy następnej synchronizacji.",
+        "koboRemovedByDevice": "Usunięte przez urządzenie",
+        "koboRemovedByDeviceTooltip": "Kobo zgłosił usunięcie tej książki.",
+        "koboNotSynced": "Nie zsynchronizowane",
+        "koboNotSyncedTooltip": "W kolejce do następnej synchronizacji Kobo.",
+        "filesNotFound": "Nie znaleziono plików",
+        "filesNotFoundDescription": "Nie można już znaleźć plików tej książki na dysku. Metadane są nadal dostępne. Uruchom skanowanie biblioteki, aby potwierdzić lub usunąć rekord."
+      },
+      "editMetadata": {
+        "fieldCount": "{count, plural, =0 {żadnych pól} one {jedno pole} other {# pola} few {# pola} many {# pól}}",
+        "bookFilesTarget": "pliki książkowe",
+        "formatFilesTarget": "{formats} plików",
+        "noPrimaryFile": "Brak dostępnego pliku podstawowego",
+        "formatNotSupported": "Ten format pliku nie obsługuje zapisu zwrotnego",
+        "formatDisabled": "Zapisywanie zwrotne jest wyłączone dla tego formatu",
+        "fileExceedsSizeLimit": "Ten plik przekracza limit rozmiaru zapisu zwrotnego",
+        "writing": "Pisanie...",
+        "saveInProgress": "Zapis w toku",
+        "writeManualLibraryDisabled": "Zapisz metadane do pliku i zmień nazwę na dysku; automatyczne zapisywanie zwrotne jest wyłączone dla tej biblioteki",
+        "writeManualTooltip": "Zapisz {fields} na {target} i zmień nazwę na dysku",
+        "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "{count, plural, =0 {Nie pominięto żadnych zablokowanych pól} one {Pominąłem jedno zablokowane pole} other {Pominięte # zamknięte pola} few {Pominąłem # zablokowane pola} many {Pominąłem # zablokowanych pól}}",
+        "updatedFields": "{count, plural, =0 {zaktualizowano brak pól} one {zaktualizowano jedno pole} other {zaktualizowany # pola} few {zaktualizowano # pola} many {zaktualizowano # pól}}",
+        "wroteFieldsToFile": "Zapisano {fields} do pliku",
+        "fileWriteFailedReason": "Zapisanie pliku nie powiodło się: {reason}",
+        "fileWriteFailed": "Zapis pliku nie powiódł się",
+        "fileWriteSkippedReason": "Pominięto zapis pliku: {reason}",
+        "fileWriteSkipped": "Pominięto zapis pliku",
+        "metadataSaved": "Metadane zostały zapisane",
+        "metadataWrittenToFile": "Metadane zapisane do pliku",
+        "savedButWriteFailedReason": "Metadane zostały zapisane, ale zapis pliku nie powiódł się: {reason}",
+        "savedButWriteFailed": "Metadane zostały zapisane, ale zapis pliku nie powiódł się",
+        "savedWriteSkippedReason": "Metadane zostały zapisane, pominięto zapis pliku: {reason}",
+        "savedWriteSkipped": "Metadane zostały zapisane, zapis pliku pominięty",
+        "loadFromFileFailed": "Nie udało się załadować metadanych z pliku",
+        "loadedFieldsFromFile": "{count, plural, =0 {Nie załadowano żadnych pól z pliku} one {Załadowano jedno pole z pliku} other {Załadowano # pola z pliku} few {Załadowano # pola z pliku} many {Załadowano # pól z pliku}}",
+        "noMetadataInFile": "W pliku nie znaleziono metadanych",
+        "loadFromFile": "Załaduj z pliku",
+        "loadFromFileTooltip": "Załaduj metadane z głównego pliku książki",
+        "writeToFile": "Zapisz do pliku",
+        "autoFill": "Automatyczne wypełnianie",
+        "fetchingMetadata": "Pobieram metadane...",
+        "allFieldsLocked": "Wszystkie pola są zablokowane",
+        "autoFillTooltip": "Automatycznie wypełniaj pola, korzystając z preferencji dotyczących metadanych",
+        "lockAll": "Zablokuj wszystko",
+        "lockAllTooltip": "Zablokuj wszystkie pola",
+        "unlockAll": "Odblokuj wszystko",
+        "unlockAllTooltip": "Odblokuj wszystkie pola",
+        "saving": "Zapisywanie...",
+        "fileWriteBackDetails": "Szczegóły zapisywania zwrotnego pliku",
+        "fileWriteBack": "Zapis zwrotny pliku",
+        "enabled": "Włączone",
+        "saveWritesMetadata": "„Zapisz” zapisuje metadane do {target}",
+        "formats": "Formaty",
+        "bookFiles": "Pliki książek",
+        "supportedFields": "Obsługiwane pola",
+        "titleLabel": "Tytuł",
+        "subtitleLabel": "Podtytuł",
+        "authorsLabel": "Autorzy",
+        "narratorsLabel": "Narratorzy",
+        "genresLabel": "Gatunki",
+        "tagsLabel": "Tagi",
+        "ratingLabel": "Ocena",
+        "rateStar": "Oceń {star}",
+        "clear": "Wyczyść",
+        "communityRatingsLabel": "Oceny społeczności",
+        "noProviderRatings": "Brak ocen dostawców",
+        "seriesLabel": "Seria",
+        "publisherLabel": "Wydawca",
+        "languageLabel": "Język",
+        "yearLabel": "Rok",
+        "pageCountLabel": "Liczba stron",
+        "isbn13Label": "ISBN-13",
+        "isbn10Label": "ISBN-10",
+        "durationLabel": "Czas trwania",
+        "abridgedLabel": "Skrócone",
+        "providerIds": "Identyfikatory dostawców",
+        "comicDetails": "Szczegóły komiksu",
+        "comicIssueNumberLabel": "Numer wydania",
+        "comicVolumeLabel": "Tom",
+        "comicStoryArcsLabel": "Łuki fabularne",
+        "comicPencillersLabel": "Ołówki",
+        "comicInkersLabel": "Inkerzy",
+        "comicColoristsLabel": "Koloryści",
+        "comicLetterersLabel": "Literaci",
+        "comicCoverArtistsLabel": "Artyści z okładek",
+        "comicCharactersLabel": "Postacie",
+        "comicTeamsLabel": "Zespoły",
+        "comicLocationsLabel": "Lokalizacje",
+        "customMetadata": "Niestandardowe metadane",
+        "descriptionLabel": "Opis",
+        "unlockField": "Odblokuj {field}",
+        "lockField": "Zablokuj {field}",
+        "diffPanel": {
+          "untitled": "Bez tytułu",
+          "noFieldsSelected": "Nie wybrano żadnych pól",
+          "fieldsSelected": "{count, plural, =0 {nie wybrano żadnych pól} one {wybrane jedno pole} other {# wybrane pola} few {Wybrano # pola} many {Wybrano # pól}}",
+          "results": "Wyniki",
+          "providerMatches": "{provider} dopasowań",
+          "selectedOf": "Wybrano {selected} z {total}",
+          "yearUnknown": "Rok nieznany",
+          "indexOf": "{index} z {total}",
+          "switchedResult": "Przełączony wynik. Poprzednie wybory tego dostawcy zostały usunięte.",
+          "selectFieldsToApply": "Wybierz pola do zastosowania",
+          "copyMissing": "Brak kopii",
+          "copyAll": "Skopiuj wszystko",
+          "hideUnchanged": "Ukryj bez zmian",
+          "showUnchanged": "Pokaż bez zmian",
+          "current": "Aktualny",
+          "noMetadata": "Brak dostępnych metadanych z tego źródła.",
+          "noChangedFields": "Brak zmienionych lub brakujących pól. Użyj opcji Pokaż bez zmian, aby sprawdzić wszystko.",
+          "applyToForm": "Zastosuj do formularza"
+        },
+        "diff": {
+          "locked": "Zablokowane",
+          "previewAlt": "Podgląd",
+          "currentCoverAlt": "Aktualna okładka",
+          "newCoverAlt": "Nowa okładka",
+          "pickCoverFromProvider": "Wybierz ubezpieczenie od innego dostawcy",
+          "pickCoverSource": "Wybierz źródło okładki",
+          "pickFromProvider": "Wybierz od innego dostawcy",
+          "pickSource": "Wybierz źródło",
+          "empty": "pusty",
+          "showLess": "Pokaż mniej",
+          "showMore": "Pokaż więcej",
+          "coverPreviewAlt": "Podgląd okładki"
+        },
+        "searchDrawer": {
+          "searchTitle": "Wyszukaj metadane",
+          "compareTitle": "Porównaj metadane",
+          "searchSubtitle": "Znajdź najlepszego dostawcę dla tej książki.",
+          "compareSubtitle": "Przejrzyj różnice i zastosuj tylko to, co chcesz."
+        },
+        "searchPanel": {
+          "untitledQuery": "Zapytanie bez tytułu",
+          "titlePlaceholder": "Tytuł",
+          "authorPlaceholder": "Autor",
+          "isbnPlaceholder": "ISBN",
+          "searching": "Wyszukiwanie...",
+          "activeQuery": "Aktywne zapytanie",
+          "searchScope": "Zakres wyszukiwania",
+          "allEnabled": "Wszystko włączone",
+          "all": "Wszystko",
+          "fieldRules": "Zasady terenowe",
+          "custom": "Niestandardowe",
+          "providerNotInFieldRules": "{provider} jest włączony, ale nie w regułach polowych",
+          "notInFieldRulesLabel": "Nie w zasadach terenowych:",
+          "notInFieldRulesText": "{providers}. Uwzględniane w wyszukiwaniu ręcznym z włączoną opcją Wszystkie, ale nie używane przez automatyczne pobieranie metadanych.",
+          "noResults": "Nie znaleziono żadnych wyników",
+          "noResultsHint": "Spróbuj dostosować tytuł lub autora",
+          "searchPrompt": "Wyszukaj powyżej, a następnie kliknij wynik, aby rozpocząć porównywanie metadanych."
+        },
+        "writeAndRename": "Zapisz do pliku i zmień nazwę",
+        "writeAndRenameShort": "Napisz i zmień nazwę"
+      },
+      "files": {
+        "title": "Pliki książek",
+        "fileCount": "{count, plural, =0 {żadnych plików} one {# plik} other {# pliki} few {# pliki} many {# plików}}",
+        "synced": "Zsynchronizowano {time}",
+        "sortAria": "Sortuj pliki",
+        "syncHistory": "Synchronizuj historię",
+        "metadataWriteBack": "Zapisywanie zwrotne metadanych",
+        "relative": {
+          "seconds": "{value}s temu",
+          "minutes": "{value}m temu",
+          "hours": "{value}h temu",
+          "days": "{value}d temu"
+        },
+        "renameFailed": "Nie udało się zmienić nazwy pliku",
+        "deleteFailed": "Nie udało się usunąć pliku",
+        "addFile": "Dodaj plik",
+        "lastSynced": "Ostatnia synchronizacja: {time}",
+        "sort": {
+          "label": "Sortuj:",
+          "name": "Imię",
+          "format": "Sformatuj",
+          "size": "Rozmiar",
+          "date": "Data"
+        },
+        "hidePaths": "Ukryj ścieżki",
+        "showPaths": "Pokaż ścieżki",
+        "hideLog": "Ukryj dziennik",
+        "viewSyncLog": "Wyświetl dziennik synchronizacji",
+        "noWriteHistory": "Nie ma jeszcze historii zapisu.",
+        "fieldsWritten": "{count, plural, =0 {żadnych pól} one {jedno pole} other {# pola} few {# pola} many {# pól}}",
+        "track": "Śledź {number}",
+        "primary": "Główny",
+        "read": "Przeczytane",
+        "play": "Zagraj",
+        "peek": "Zerknij",
+        "download": "Pobierz",
+        "moreActions": "Więcej akcji",
+        "rename": "Zmień nazwę",
+        "empty": {
+          "title": "Brak załączonych plików",
+          "description": "Z tą książką nie są powiązane żadne pliki."
+        },
+        "renameModal": {
+          "title": "Zmień nazwę pliku",
+          "description": "Zmień nazwę pliku fizycznego na dysku.",
+          "placeholder": "Nowa nazwa pliku"
+        },
+        "saving": "Zapisywanie...",
+        "deleteModal": {
+          "title": "Usunąć plik?",
+          "description": "Czy na pewno chcesz usunąć „{filename}”? Tej akcji nie można cofnąć."
+        },
+        "deleting": "Usuwanie..."
+      },
+      "highlights": {
+        "note": {
+          "placeholder": "Dodaj notatkę...",
+          "saving": "Oszczędzanie"
+        },
+        "export": {
+          "trigger": "Eksportuj",
+          "plainText": "Zwykły tekst",
+          "page": "Eksportuj stronę",
+          "selected": "Wyeksportuj wybrane"
+        },
+        "sort": {
+          "position": "Pozycja",
+          "newest": "Najpierw najnowsze",
+          "oldest": "Najpierw najstarszy"
+        },
+        "summary": {
+          "highlights": "{count, plural, =0 {żadnych podkreśleń} one {jedna atrakcja} other {# podkreśla} few {# najważniejsze informacje} many {# najważniejszych wydarzeń}}",
+          "notes": "{count, plural, =0 {żadnych notatek} one {jedna uwaga} other {# notatki} few {# notatki} many {# notatek}}",
+          "chapters": "{count, plural, =0 {żadnych rozdziałów} one {jeden rozdział} other {# rozdziały} few {# rozdziały} many {# rozdziałów}}"
+        },
+        "filterByChapter": "Filtruj według rozdziałów",
+        "allChapters": "Wszystkie rozdziały",
+        "untitled": "Bez tytułu",
+        "trash": "Kosz",
+        "empty": {
+          "noMatch": "Żadne najciekawsze momenty nie pasują do wybranych filtrów.",
+          "resetFilters": "Zresetuj filtry",
+          "none": "Nie ma jeszcze żadnych najważniejszych wydarzeń",
+          "hint": "Zaznacz tekst podczas czytania, aby utworzyć wyróżnienia"
+        },
+        "uncategorized": "Bez kategorii",
+        "paginationUnit": "podkreśla"
+      },
+      "readingLog": {
+        "moreActionsAria": "Więcej działań w dzienniku czytania",
+        "export": {
+          "button": "Eksportuj"
+        },
+        "weekdays": {
+          "sun": "niedziela",
+          "mon": "pon",
+          "tue": "wt",
+          "wed": "śr",
+          "thu": "czw",
+          "fri": "piątek",
+          "sat": "sob"
+        },
+        "months": {
+          "jan": "styczeń",
+          "feb": "luty",
+          "mar": "marca",
+          "apr": "kwiecień",
+          "may": "Maj",
+          "jun": "czerwca",
+          "jul": "lipiec",
+          "aug": "sierpień",
+          "sep": "wrzesień",
+          "oct": "paź",
+          "nov": "listopad",
+          "dec": "grudzień"
+        },
+        "heatmap": {
+          "minutesUnit": "min",
+          "title": "Aktywność",
+          "empty": "Brak aktywności czytania w tym oknie.",
+          "emptyHint": "Sesje zarejestrowane tutaj pozwolą Ci zbudować pogląd na temat spójności."
+        },
+        "hero": {
+          "summaryAria": "Podsumowanie lektury",
+          "notSet": "Nie ustawiono",
+          "relative": {
+            "seconds": "{count}s temu",
+            "minutes": "{count}m temu",
+            "hours": "{count}h temu",
+            "days": "{count}d temu",
+            "months": "{count, plural, =0 {# miesiąc temu} one {# miesiąc temu} other {# miesiące temu} few {# miesiące temu} many {# miesięcy temu}}",
+            "years": "{count, plural, =0 {# rok temu} one {# rok temu} other {# lata temu} few {# lata temu} many {# lat temu}}"
+          },
+          "noSessions": "Brak sesji",
+          "dateErrors": {
+            "startFuture": "Data rozpoczęcia nie może przypadać w przyszłości.",
+            "finishFuture": "Data zakończenia nie może przypadać w przyszłości.",
+            "finishBeforeStart": "Data zakończenia musi przypadać w dniu rozpoczęcia lub po nim.",
+            "saveFailed": "Nie udało się zapisać dat przeczytania."
+          },
+          "eta": {
+            "max": "99h+ do końca",
+            "minutes": "~{m}m do końca",
+            "hours": "~{h}h, aby zakończyć",
+            "hoursMinutes": "~{h}h {m}m do końca"
+          },
+          "momentum": {
+            "none": "Brak aktywności przez ostatnie dwa tygodnie",
+            "new": "Nowa aktywność w tym tygodniu",
+            "up": "+{pct}% w porównaniu z poprzednimi 7 dniami",
+            "down": "{pct}% w porównaniu z poprzednimi 7 dniami",
+            "flat": "Bez zmian w porównaniu z poprzednimi 7 dniami"
+          },
+          "stats": {
+            "totalTime": "Całkowity czas",
+            "sessions": "Sesje",
+            "avgSession": "Średnia sesja",
+            "lastRead": "Ostatnia lektura"
+          },
+          "firstRead": "Pierwsza lektura",
+          "lastRead": "Ostatnia lektura",
+          "dateStarted": "Data rozpoczęcia",
+          "dateFinished": "Data zakończenia",
+          "addSession": "Dodaj sesję"
+        },
+        "journey": {
+          "tooltipProgress": "Postęp",
+          "tooltipReading": "Czytanie",
+          "minutesUnit": "min",
+          "title": "Podróż postępu",
+          "empty": "W tym oknie nie ma danych o postępie.",
+          "emptyHint": "Postęp pojawi się po zarejestrowaniu przez sesję pozycji czytania."
+        },
+        "sourceSplit": {
+          "title": "Czytanie źródeł",
+          "shortTitle": "Źródła"
+        },
+        "untitled": "Bez tytułu",
+        "addSessionFailed": "Nie udało się dodać sesji",
+        "filters": {
+          "show": "Pokaż",
+          "dateRangeAria": "Zakres dat sesji czytelniczej",
+          "allTime": "Cały czas",
+          "last30": "Ostatnie 30 dni",
+          "last90": "Ostatnie 90 dni",
+          "thisYear": "W tym roku",
+          "allFormats": "Wszystkie formaty"
+        },
+        "table": {
+          "title": "Sesje",
+          "sourceWeb": "Sieć",
+          "sourceManual": "Ręczne",
+          "colDate": "Data",
+          "colDateMobile": "Data",
+          "colDuration": "Czas trwania",
+          "colDurationMobile": "Czas trwania",
+          "colProgressChange": "Zmiana postępu",
+          "colProgressChangeMobile": "Delta",
+          "colEndProgress": "Koniec postępu",
+          "colEndProgressMobile": "Koniec",
+          "empty": "Nie zarejestrowano jeszcze żadnych sesji czytania.",
+          "emptyHint": "Dodaj sesję, aby rozpocząć tworzenie historii czytania tej książki.",
+          "colPace": "Tempo",
+          "colSource": "Źródło",
+          "colFormatMobile": "Fmt",
+          "colFormat": "Sformatuj",
+          "cancelDelete": "Anuluj usuwanie",
+          "cancelDeleteAria": "Anuluj usuwanie sesji",
+          "confirmDeleteTitle": "Kliknij ponownie, aby potwierdzić usunięcie",
+          "confirmDeleteAria": "Potwierdź usunięcie sesji",
+          "deleteAria": "Usuń sesję",
+          "loadMore": "Załaduj więcej",
+          "showing": "Wyświetlanie {shown} z {total} sesji"
+        }
+      },
+      "richDescription": {
+        "linkProtocolError": "Użyj protokołu http, https lub mailto.",
+        "bold": "Odważne",
+        "italic": "Kursywa",
+        "underline": "Podkreśl",
+        "strikethrough": "Przekreślenie",
+        "bulletList": "Lista punktowana",
+        "numberedList": "Lista numerowana",
+        "outdentAria": "Zmniejsz wcięcie elementu listy",
+        "outdent": "Zmniejsz wcięcie",
+        "indentAria": "Wcięcie elementu listy",
+        "indent": "Wcięcie",
+        "quote": "Cytat",
+        "editLink": "Edytuj link",
+        "link": "Link",
+        "removeLink": "Usuń link",
+        "undo": "Cofnij",
+        "redo": "Powtórz",
+        "clearFormatting": "Wyczyść formatowanie",
+        "previewDescription": "Podgląd opisu",
+        "preview": "Podgląd",
+        "linkUrlLabel": "Adres URL linku",
+        "applyLink": "Zastosuj link",
+        "apply": "Zastosuj",
+        "cancelLink": "Anuluj łącze",
+        "noDescription": "Brak opisu."
+      },
+      "seriesMembership": {
+        "addSeries": "Dodaj serię",
+        "seriesPlaceholder": "Seria",
+        "moveUp": "Przesuń się w górę",
+        "moveDown": "Przesuń w dół",
+        "removeSeries": "Usuń serię"
+      }
+    },
+    "table": {
+      "actions": {
+        "quickView": "Szybki podgląd",
+        "bookDetails": "Szczegóły książki",
+        "editMetadata": "Edytuj metadane",
+        "refreshMetadata": "Odśwież metadane",
+        "addToCollection": "Dodaj do kolekcji",
+        "sendToDevice": "Wyślij do urządzenia"
+      },
+      "boolean": {
+        "ariaNotSet": "Nie ustawiono - kliknij, aby ustawić jako prawdziwe",
+        "ariaTrue": "Prawda - kliknij, aby ustawić fałsz",
+        "ariaFalse": "Fałsz - kliknij, aby wyczyścić"
+      },
+      "chips": {
+        "addPlaceholder": "Dodaj..."
+      },
+      "cover": {
+        "previewDescription": "Podgląd okładki książki",
+        "editDescription": "Edytuj okładkę książki",
+        "editTitle": "Edytuj okładkę",
+        "editCover": "Edytuj okładkę",
+        "view": "Zobacz okładkę"
+      },
+      "date": {
+        "justNow": "właśnie teraz"
+      },
+      "format": {
+        "unknown": "nieznany"
+      },
+      "header": {
+        "sortAscending": "Sortuj rosnąco",
+        "sortDescending": "Sortuj malejąco",
+        "clearSort": "Wyczyść sortowanie",
+        "hideColumn": "Ukryj kolumnę",
+        "pinLeft": "Przypnij lewy",
+        "pinRight": "Przypnij prawy",
+        "unpinColumn": "Odepnij kolumnę",
+        "autoFitWidth": "Szerokość automatycznego dopasowania",
+        "autoFitAllColumns": "Automatyczne dopasowanie wszystkich kolumn",
+        "selectAllBooks": "Wybierz wszystkie książki",
+        "shiftClickSecondarySort": "Shift+kliknięcie, aby dodać sortowanie wtórne",
+        "clickToSort": "Kliknij, aby posortować"
+      },
+      "locks": {
+        "lockAll": "Zablokuj wszystkie pola",
+        "unlockAll": "Odblokuj wszystkie pola",
+        "lockField": "Zablokuj pole",
+        "unlockField": "Odblokuj pole",
+        "clickToLock": "Kliknij, aby zablokować",
+        "clickToUnlock": "Kliknij, aby odblokować"
+      },
+      "progress": {
+        "complete": "{percent} ukończono"
+      },
+      "rating": {
+        "label": "Ocena",
+        "remove": "Usuń ocenę",
+        "rate": "Oceń {star} z 5"
+      },
+      "read": {
+        "play": "Zagraj",
+        "read": "Przeczytane",
+        "primary": "Główny",
+        "peekFormat": "Zerknij {format}",
+        "chooseFormat": "Wybierz format do przeczytania lub odtworzenia",
+        "fileFallback": "PLIK"
+      },
+      "readStatus": {
+        "unread": "Nieprzeczytane"
+      },
+      "series": {
+        "bookCount": "{count, plural, =0 {(bez książek)} one {(# książka)} other {(# książki)} few {(# książki)} many {(# książek)}}",
+        "readOfCount": "{read} z {total} przeczytane"
+      },
+      "text": {
+        "openDetails": "Otwórz szczegóły"
+      }
+    }
+  },
+  "bookMetadataFetch": {
+    "book": {
+      "title": "Pobieranie metadanych"
+    },
+    "author": {
+      "title": "Wzbogacenie autora"
+    },
+    "stats": {
+      "queued": "W kolejce",
+      "processing": "Przetwarzanie",
+      "rateLimited": "Cena ograniczona",
+      "failed": "Nie udało się"
+    },
+    "actions": {
+      "pause": "Pauza",
+      "resume": "Wznów",
+      "cancelQueued": "Anuluj w kolejce",
+      "dismissBookStatus": "Odrzuć stan pobierania metadanych",
+      "dismissAuthorStatus": "Odrzuć status wzbogacenia autora"
+    },
+    "cancel": {
+      "processingWillFinish": "Obecnie przetwarzanie elementów zostanie zakończone.",
+      "confirm": "Potwierdź anulowanie",
+      "keepRunning": "Biegnij dalej"
+    },
+    "viewFailed": "{count, plural, one {Wyświetl jeden nieudany} other {Wyświetl # nieudanego} few {Wyświetl # nieudane} many {Wyświetl # nieudanych}}",
+    "card": {
+      "fetchingMetadata": "Pobieranie metadanych",
+      "enrichingAuthors": "Wzbogacanie autorów",
+      "metadataFetchFinished": "Pobieranie metadanych zostało zakończone",
+      "authorEnrichmentFinished": "Wzbogacanie autora zakończone"
+    },
+    "label": {
+      "paused": "Wstrzymano",
+      "remaining": "Pozostało {count}",
+      "processing": "{count} przetwarzanie",
+      "failed": "{count} nie powiodło się",
+      "rateLimited": "{count} stawka ograniczona"
+    },
+    "report": {
+      "bookTitle": "Nieudane pobieranie metadanych",
+      "authorTitle": "Nieudane wzbogacenia autora",
+      "noFailedItems": "Brak nieudanych elementów.",
+      "retryAllFailed": "Ponowna próba nie powiodła się",
+      "bookFallback": "Książka #{id}",
+      "authorFallback": "Autor #{id}",
+      "columns": {
+        "title": "Tytuł",
+        "library": "Biblioteka",
+        "author": "Autor",
+        "error": "Błąd",
+        "http": "HTTP"
+      }
+    },
+    "toast": {
+      "failedToPause": "Nie udało się wstrzymać",
+      "failedToResume": "Nie udało się wznowić",
+      "failedToCancel": "Nie udało się anulować",
+      "failedToRetry": "Nie udało się ponowić próby",
+      "failedItemsRequeued": "Elementy, które nie powiodły się, ponownie dodano do kolejki",
+      "bookComplete": "Pobieranie metadanych zostało zakończone - zaktualizowano {done} książek",
+      "bookDoneWithFailures": "Pobieranie metadanych zakończone - {done} przetworzone, {failed} nie powiodło się",
+      "authorComplete": "Wzbogacanie autora zakończone - zaktualizowano {done} autorów",
+      "authorDoneWithFailures": "Wzbogacenie autora zakończone - {done} przetworzone, {failed} nie powiodło się"
+    }
+  },
+  "bookDock": {
+    "apply": "Zastosuj",
+    "done": "Gotowe",
+    "discard": "Odrzuć",
+    "finalize": "Sfinalizuj",
+    "rescan": "Skanuj ponownie",
+    "uploadAction": "Prześlij",
+    "uploading": "Przesyłanie...",
+    "searchPlaceholder": "Wyszukaj pliki...",
+    "setDestinationAction": "Ustaw miejsce docelowe",
+    "bulkEditAction": "Edycja zbiorcza",
+    "applyFetched": "Zastosuj pobrane",
+    "retryErrors": "Błędy ponownej próby",
+    "commaSeparated": "oddzielone przecinkami",
+    "destinationLibrary": "Biblioteka docelowa",
+    "destinationFolder": "Folder docelowy",
+    "nFailed": "{count} nie powiodło się",
+    "updatedOfFiles": "Zaktualizowano {updated} z {total} plików",
+    "errorStatus": "Błąd {status}",
+    "tab": {
+      "all": "Wszystko",
+      "pending": "Oczekujące",
+      "ready": "Gotowy",
+      "error": "Błąd"
+    },
+    "status": {
+      "pending": "Oczekujące",
+      "extracting": "Ekstrakcja",
+      "fetching": "Pobieranie",
+      "ready": "Gotowy",
+      "error": "Błąd"
+    },
+    "field": {
+      "title": "Tytuł",
+      "subtitle": "Podtytuł",
+      "authors": "Autorzy",
+      "authorsCommaSeparated": "Autorzy (oddzieleni przecinkami)",
+      "publisher": "Wydawca",
+      "publishedDate": "Data publikacji",
+      "year": "Rok",
+      "language": "Język",
+      "isbn13": "ISBN-13",
+      "isbn10": "ISBN-10",
+      "series": "Seria",
+      "seriesIndex": "Seria #",
+      "genres": "Gatunki",
+      "genresCommaSeparated": "Gatunki (oddzielone przecinkami)",
+      "description": "Opis"
+    },
+    "upload": {
+      "nDone": "{count} gotowe",
+      "nFailed": "{count} nie powiodło się",
+      "nTotal": "{count} łącznie"
+    },
+    "fileList": {
+      "emptyTitle": "Brak plików w Book Dock",
+      "emptyMessageDefault": "Prześlij pliki lub upuść je w folderze Book Dock",
+      "colCurrent": "Aktualny",
+      "colNew": "Nowy",
+      "colFile": "Plik",
+      "colSize": "Rozmiar",
+      "colFormat": "Sformatuj",
+      "colMatch": "Dopasowanie",
+      "colApply": "Zastosuj",
+      "colStatus": "Stan",
+      "applyFetchedMetadata": "Zastosuj pobrane metadane",
+      "coverPreview": "Podgląd okładki",
+      "coverPreviewDescription": "Powiększone okno dialogowe podglądu obrazu okładki.",
+      "currentCoverAlt": "{title} aktualna okładka",
+      "newCoverAlt": "{title} nowa okładka",
+      "unknownLibrary": "Nieznana biblioteka",
+      "unassigned": "Nieprzypisany",
+      "targetPath": "Cel: {library} · {path}",
+      "targetUnassigned": "Cel: nieprzypisany",
+      "targetUnknownPath": "Cel: {library} · Nieznana ścieżka docelowa"
+    },
+    "sheet": {
+      "saved": "Zapisano",
+      "providerMetadataFound": "Znaleziono metadane dostawcy",
+      "providerMetadataFoundEdited": "Znaleziono metadane dostawcy - zastosowanie zbiorcze pominie ten plik (masz zmiany)",
+      "review": "Recenzja",
+      "added": "Dodano {date}",
+      "searchMetadata": "Wyszukaj metadane",
+      "results": "Wyniki"
+    },
+    "bulkEdit": {
+      "title": "{count, plural, =0 {Edycja zbiorcza bez plików} one {Edycja zbiorcza # pliku} other {Edycja zbiorcza # pliku} few {Edycja zbiorcza # plików} many {Edycja zbiorcza # plików}}",
+      "resultTitle": "Wyniki edycji zbiorczej",
+      "instructions": "Przełącz pola, które chcesz zaktualizować. Zastosowane zostaną tylko włączone pola.",
+      "mergeArrays": "Scal tablice (dodaj do istniejących wartości zamiast zastępować)",
+      "failed": "Edycja zbiorcza nie powiodła się"
+    },
+    "setDestination": {
+      "title": "{count, plural, =0 {Ustaw miejsce docelowe bez plików} one {Ustaw miejsce docelowe dla # pliku} other {Ustaw miejsce docelowe dla # pliku} few {Ustaw miejsce docelowe dla # plików} many {Ustaw miejsce docelowe dla # plików}}",
+      "resultTitle": "Miejsce docelowe zaktualizowane",
+      "failed": "Nie udało się ustawić miejsca docelowego"
+    },
+    "finalizeDialog": {
+      "title": "{count, plural, =0 {Nie finalizuj żadnych plików} one {Sfinalizuj # plik} other {Sfinalizuj # pliki} few {Sfinalizuj # pliki} many {Sfinalizuj # plików}}",
+      "resultTitle": "Sfinalizuj wyniki",
+      "needDestination": "{count, plural, =0 {Bez miejsca docelowego: {without} z # wybranych plików} one {Bez miejsca docelowego: {without} z # wybranego pliku} other {Bez miejsca docelowego: {without} z # wybranego pliku} few {Bez miejsca docelowego: {without} z # wybranych plików} many {Bez miejsca docelowego: {without} z # wybranych plików}}",
+      "allHaveDestination": "Wszystkie wybrane pliki mają już ustawione miejsce docelowe",
+      "defaultDestinationLibrary": "Domyślna biblioteka docelowa",
+      "defaultDestinationFolder": "Domyślny folder docelowy",
+      "renamePreview": "Zmień nazwę podglądu",
+      "moreFiles": "+{count} więcej plików",
+      "start": "Zacznij",
+      "filesFinalized": "Sfinalizowano {succeeded} z {total} plików",
+      "checking": "Sprawdzanie wybranych plików...",
+      "readyCount": "{count, plural, =0 {brak gotowych plików} one {# plik gotowy} other {# pliku gotowego} few {# pliki gotowe} many {# plików gotowych}}",
+      "duplicateCount": "{count, plural, =0 {żadna nie jest już w bibliotece} one {# już w bibliotece} other {# już w bibliotece} few {# już w bibliotece} many {# już w bibliotece}}",
+      "conflictCount": "{count, plural, =0 {brak konfliktów nazw plików} one {# konflikt nazw plików} other {# konflikty nazw plików} few {# konflikty nazw plików} many {# konfliktów nazw plików}}",
+      "missingDestinationCount": "{count, plural, =0 {żadnych brakujących miejsc docelowych} one {# brakujący cel} other {# brakujące miejsca docelowe} few {# brakujące cele} many {# brakujących miejsc docelowych}}",
+      "blockedCount": "{count, plural, =0 {żadne pliki nie są zablokowane} one {# plik zablokowany} other {# pliki zablokowane} few {# pliki zablokowane} many {Zablokowano # plików}}",
+      "moreDuplicates": "+{count} więcej już w bibliotece",
+      "discardDuplicates": "Odrzuć duplikaty",
+      "failedCount": "{count, plural, =0 {żadne pliki nie powiodły się} one {# plik nie powiódł się} other {# pliki nie powiodły się} few {# pliki nie powiodły się} many {# plików nie powiodło się}}",
+      "failedWithDuplicates": "{count, plural, =0 {{failed} nieudanych (# duplikatów)} one {{failed} nieudanych (# duplikat)} other {{failed} nieudanych (# duplikatu)} few {{failed} nieudanych (# duplikaty)} many {{failed} nieudanych (# duplikatów)}}",
+      "view": "Zobacz",
+      "viewExisting": "Zobacz istniejące",
+      "hide": "Ukryj",
+      "details": "Szczegóły",
+      "alreadyExistsSaveAs": "Już istnieje - zapisz jako:",
+      "renamePlaceholder": "np. {name} (2)",
+      "import": "Importuj"
+    }
+  },
+  "collection": {
+    "dialog": {
+      "name": "Imię",
+      "icon": "Ikona",
+      "iconPlaceholder": "Wybierz ikonę...",
+      "nameRequired": "Imię i nazwisko jest wymagane",
+      "iconRequired": "Wybierz ikonę",
+      "creating": "Tworzenie...",
+      "createFailed": "Nie udało się utworzyć kolekcji"
+    },
+    "createDialog": {
+      "title": "Nowa kolekcja",
+      "namePlaceholder": "np. Ulubione"
+    },
+    "editDialog": {
+      "title": "Edytuj kolekcję",
+      "syncToKobo": "Synchronizuj z Kobo",
+      "syncToKoboHint": "Książki z tej kolekcji pojawią się na Twoim urządzeniu Kobo",
+      "deleteCollection": "Usuń kolekcję",
+      "confirmDelete": "Potwierdzić?",
+      "deleting": "Usuwanie...",
+      "saving": "Zapisywanie...",
+      "deleted": "„{name}” usunięty",
+      "updateFailed": "Nie udało się zaktualizować kolekcji",
+      "deleteFailed": "Nie udało się usunąć kolekcji"
+    },
+    "addToSheet": {
+      "title": "Zarządzaj kolekcjami",
+      "selectedCount": "{count, plural, =0 {nie wybrano żadnych książek} one {wybrana jedna książka} other {# wybrane książki} few {Wybrano # książki} many {Wybrano # książek}}",
+      "newCollection": "Nowa kolekcja",
+      "namePlaceholder": "Nazwa kolekcji",
+      "create": "Utwórz",
+      "collections": "Kolekcje",
+      "empty": "Nie ma jeszcze żadnych kolekcji. Utwórz jeden powyżej.",
+      "done": "Gotowe",
+      "added": "Dodano",
+      "allAdded": "Dodano wszystkie {total}",
+      "inCollection": "W tej kolekcji",
+      "allInCollection": "Wszystkie {total} w tej kolekcji",
+      "partialInCollection": "{partial} z {total} w tej kolekcji",
+      "bookCount": "{count, plural, =0 {żadnych książek} one {jedna książka} other {# książki} few {# książki} many {# książek}}",
+      "loadFailed": "Nie udało się załadować kolekcji",
+      "createdAndAdded": "{count, plural, =0 {Stworzono \"{name}\" i nie dodano żadnych książek} one {Stworzono \"{name}\" i dodałem jedną książkę} other {Stworzono \"{name}\" i dodał # książki} few {Utworzono „{name}” i dodano # książki} many {Utworzono „{name}” i dodano # książek}}",
+      "createdButAddFailed": "Utworzono „{name}”, ale nie udało się dodać książek",
+      "createFailed": "Nie udało się utworzyć kolekcji",
+      "addedNewWithExisting": "{count, plural, =0 {Dodano jedną nową książkę do „{name}\" ({alreadyHad} już tam)} one {Dodano jedną nową książkę do „{name}\" ({alreadyHad} już tam)} other {Dodano # nowe książki do „{name}\" ({alreadyHad} już tam)} few {Dodano # nowe książki do „{name}” ({alreadyHad} już tam jest)} many {Dodano # nowych książek do „{name}” ({alreadyHad} już tam jest)}}",
+      "addedToCollection": "{count, plural, =0 {Nie dodano żadnych książek do „{name}\"} one {Dodano jedną książkę do „{name}\"} other {Dodano # książki do \"{name}\"} few {Dodano # książki do „{name}”} many {Dodano # książek do „{name}”}}",
+      "addFailed": "Nie udało się dodać do kolekcji",
+      "removedFromCollection": "{count, plural, =0 {Nie usunięto żadnych książek z „{name}\"} one {Usunięto jedną książkę z „{name}\"} other {Usunięto # książki z \"{name}\"} few {Usunięto # książki z „{name}”} many {Usunięto # książek z „{name}”}}",
+      "removeFailed": "Nie udało się usunąć z kolekcji"
+    }
+  },
+  "components": {
+    "appHeader": {
+      "searchAllBooks": "Przeszukaj wszystkie książki...",
+      "searching": "Wyszukiwanie...",
+      "noResults": "Brak wyników",
+      "loadingMore": "Ładowanie więcej...",
+      "loadMore": "Załaduj więcej ({loaded}/{total})",
+      "allMatchesShown": "{count, plural, =0 {Pokazano wszystkie 1 dopasowanie} one {Pokazano wszystkie 1 dopasowanie} other {Wszystko # pokazane mecze} few {Pokazano wszystkie # mecze} many {Pokazano wszystkie # meczów}}",
+      "bookCount": "{count, plural, =0 {żadnych książek} one {# książka} other {# książki} few {# książki} many {# książek}}",
+      "fileCount": "{count, plural, =0 {żadnych plików} one {# plik} other {# pliki} few {# pliki} many {# plików}}",
+      "uploadedToast": "Przesłano {uploaded}",
+      "uploadFailedToast": "Przesyłanie nie powiodło się dla {failed}",
+      "uploadPartialToast": "Przesłanie {uploaded}, {failed} nie powiodło się",
+      "bookDock": "Book Dock",
+      "statistics": "Statystyki",
+      "achievements": "Osiągnięcia",
+      "annotations": "Adnotacje",
+      "uploadBooks": "Prześlij książki",
+      "appearance": "Wygląd",
+      "theme": "Motyw",
+      "accent": "Akcent",
+      "radius": "Promień",
+      "background": "Tło",
+      "settings": "Ustawienia",
+      "whatsNew": "Co nowego",
+      "documentation": "Dokumentacja",
+      "help": "Pomoc",
+      "starOnGithub": "Gwiazda na GitHubie",
+      "new": "Nowy",
+      "newReleaseNotes": "Dostępne są nowe informacje o wydaniu",
+      "account": "Konto",
+      "changePassword": "Zmień hasło",
+      "signOut": "Wyloguj się",
+      "githubStar": {
+        "title": "Podoba Ci się BookOrbit?",
+        "body": "Jeśli BookOrbit pomaga w Twojej bibliotece, rozważ opublikowanie projektu w serwisie GitHub. Pomaga większej liczbie osób odkryć aplikację i wspiera ciągły rozwój.",
+        "cta": "Oznacz gwiazdką BookOrbit w GitHubie"
+      }
+    },
+    "sidebar": {
+      "tagline": "Twoja przestrzeń do czytania",
+      "dashboard": "Pulpit nawigacyjny",
+      "authors": "Autorzy",
+      "series": "Seria",
+      "tools": "Narzędzia",
+      "libraries": "Biblioteki",
+      "newLibrary": "Nowa biblioteka",
+      "libraryScanning": "{name} - Skanowanie {pct}%",
+      "scanProgress": "{processed} / {total} książek",
+      "smartScopes": "Inteligentne lunety",
+      "newSmartScope": "Nowy inteligentny zakres",
+      "noSmartScopes": "Nie ma jeszcze inteligentnych zakresów",
+      "collections": "Kolekcje",
+      "newCollection": "Nowa kolekcja",
+      "noCollections": "Nie ma jeszcze żadnych kolekcji",
+      "latest": "Najnowsze {version}",
+      "newReleaseNotes": "Dostępne są nowe informacje o wydaniu",
+      "support": "Wsparcie BookOrbit",
+      "supportShort": "Wsparcie",
+      "supportAria": "Wesprzyj BookOrbit w Ko-Fi",
+      "sectionHeader": {
+        "add": "Dodaj",
+        "reorder": "Zmień kolejność",
+        "doneReordering": "Zakończono zmianę kolejności"
+      }
+    },
+    "selectionActionBar": {
+      "setReadingStatus": "Ustaw stan czytania",
+      "setRating": "Ustaw ocenę",
+      "openMetadataEditor": "Otwórz edytor metadanych",
+      "editIndividually": "Edytuj książki indywidualnie",
+      "addToCollection": "Dodaj do kolekcji",
+      "removeFromCollection": "Usuń z kolekcji",
+      "sendViaEmail": "Wyślij e-mailem",
+      "downloadFilesZip": "Pobierz pliki w formacie ZIP",
+      "moreActions": "Więcej akcji",
+      "setField": "Ustaw pole",
+      "refreshMetadata": "Odśwież metadane",
+      "reExtractCover": "Ponownie zdejmij pokrywę",
+      "metadataLock": "Blokada metadanych",
+      "lockAll": "Zablokuj wszystko",
+      "unlockAll": "Odblokuj wszystko",
+      "exportMetadata": "Eksportuj metadane",
+      "deleteSelected": "Usuń wybrane",
+      "exitSelection": "Wyjdź z wyboru",
+      "downloadFilesZipLabel": "Pobierz pliki w formacie ZIP:",
+      "primaryOnly": "Tylko główne",
+      "allFormats": "Wszystkie formaty",
+      "audioOnly": "Tylko dźwięk",
+      "setRatingLabel": "Ustaw ocenę:",
+      "clear": "Wyczyść",
+      "setFieldLabel": "Ustaw pole:",
+      "apply": "Zastosuj",
+      "fieldPlaceholder": "Pozostaw puste, aby wyczyścić",
+      "fieldPlaceholderArray": "Oddzielone przecinkami (pozostaw puste, aby wyczyścić)",
+      "deleteConfirm": "{count, plural, =0 {Usuń # książka?} one {Usuń # książka?} other {Usuń # książki?} few {Usunąć # książki?} many {Usunąć # książek?}}",
+      "typeDelete": "Wpisz USUŃ"
+    },
+    "viewHeader": {
+      "select": "Wybierz",
+      "display": "Wyświetlanie",
+      "displayDescription": "Dostosuj rozmiar okładki, odstępy w siatce i wyświetl opcje wyświetlania.",
+      "columnVisibilityHint": "Użyj panelu widoczności kolumn w nagłówku tabeli, aby pokazać lub ukryć kolumny.",
+      "columnVisibilityMobileHint": "Widocznością kolumn można zarządzać z poziomu nagłówka tabeli.",
+      "searchPlaceholder": "Wyszukaj tytuł, autora, serię, narratora...",
+      "mobileSearch": {
+        "description": "Szukaj elementów według tytułu, autora, serii lub narratora.",
+        "done": "Gotowe"
+      },
+      "mobileMenu": {
+        "grid": "Siatka",
+        "list": "Lista",
+        "select": "Wybierz",
+        "exitSelect": "Wyjdź Wybierz"
+      },
+      "displayControls": {
+        "display": "Wyświetlanie",
+        "coverSize": "Rozmiar okładki",
+        "gridGap": "Szczelina siatki",
+        "showJumpRails": "Pokaż szyny skokowe",
+        "columnsHint": "Użyj panelu widoczności kolumn w nagłówku tabeli, aby pokazać lub ukryć kolumny.",
+        "coverShape": "Kształt okładki",
+        "circle": "Okrąg",
+        "square": "Kwadrat"
+      }
+    },
+    "iconPicker": {
+      "clearSelectionAria": "Wyczyść wybraną ikonę",
+      "searchLucide": "Wyszukaj ikony Lucide...",
+      "searchCustom": "Wyszukaj niestandardowe ikony...",
+      "chooseIcon": "Wybierz ikonę...",
+      "selectIcon": "Wybierz ikonę",
+      "customTab": "Niestandardowe",
+      "searching": "Wyszukiwanie...",
+      "noIconsMatch": "Żadna ikona nie pasuje do „{query}”",
+      "typeToSearch": "Wpisz, aby przeszukać wszystkie ikony",
+      "noCustomIcons": "Nie przesłano żadnych niestandardowych ikon",
+      "noIconsAvailable": "Brak dostępnych ikon"
+    },
+    "entityNotFound": {
+      "title": "{entity} nie znaleziono",
+      "description": "Ten {entity} nie istnieje lub został usunięty.",
+      "goBack": "Wróć"
+    },
+    "themePicker": {
+      "light": "Światło",
+      "dark": "Ciemny",
+      "system": "Systemu"
+    },
+    "userAvatar": {
+      "profilePicture": "Zdjęcie profilowe",
+      "profilePictureOf": "{name} zdjęcie profilowe"
+    },
+    "ui": {
+      "sidebar": {
+        "title": "Pasek boczny",
+        "mobileDescription": "Wyświetla mobilny pasek boczny.",
+        "toggle": "Przełącz pasek boczny"
+      },
+      "chipInput": {
+        "typeAndEnter": "Wpisz i naciśnij Enter, aby dodać",
+        "pressEnter": "Naciśnij Enter, aby dodać"
+      }
+    }
+  },
+  "customIcons": {
+    "dialogTitle": "Prześlij niestandardowe ikony",
+    "dialogDescription": "Przejrzyj nazwy przed dodaniem ich do swojej biblioteki.",
+    "readingFiles": "Czytanie plików...",
+    "dropPrompt": "Upuść pliki SVG lub kliknij, aby przeglądać",
+    "fileLimit": "Do {max} plików, każdy o rozmiarze 128 KB",
+    "namePlaceholder": "Imię",
+    "nameRequired": "Imię i nazwisko jest wymagane",
+    "invalidSvg": "Nieprawidłowy plik SVG",
+    "invalidSvgFile": "Nieprawidłowy plik SVG",
+    "identicalTo": "Identyczny z „{name}”",
+    "uploadAnyway": "Prześlij mimo to",
+    "skipThisOne": "Pomiń ten",
+    "readyToUpload": "{count} gotowy do przesłania",
+    "noIconsStaged": "Nie wystawiono jeszcze żadnych ikon",
+    "uploading": "Przesyłanie...",
+    "upload": "Prześlij",
+    "uploadCount": "Prześlij {count}",
+    "onlySvgSupported": "Obsługiwane są tylko pliki SVG",
+    "maxStaged": "Jednocześnie możesz wystawić maksymalnie {max} ikon",
+    "onlyMoreCanStage": "{count, plural, =0 {Nie można wystawiać więcej ikon} one {Tylko # można wystawić więcej ikon} other {Tylko # można wystawić więcej ikon} few {Można wystawić tylko # dodatkowe ikony} many {Można wystawić tylko # dodatkowych ikon}}",
+    "readFailed": "Nie udało się odczytać plików SVG",
+    "uploadedCount": "{count, plural, =0 {Brak przesłanych ikon} one {Przesłano # ikona} other {Przesłano # ikony} few {Przesłano # ikony} many {Przesłano # ikon}}",
+    "uploadedPartial": "Przesłanie {created}, {failed} nie powiodło się",
+    "noIconsUploaded": "Brak przesłanych ikon",
+    "uploadFailed": "Nie udało się przesłać ikon",
+    "uploadFailedEntry": "Przesyłanie nie powiodło się"
+  },
+  "dashboard": {
+    "common": {
+      "failedToLoad": "Nie udało się załadować",
+      "retry": "Spróbuj ponownie",
+      "untitled": "Bez tytułu",
+      "cover": "Okładka",
+      "bookCover": "Okładka książki"
+    },
+    "scroller": {
+      "failedToLoad": "Nie udało się załadować.",
+      "empty": {
+        "continueReading": "Nie ma jeszcze żadnych książek w toku. Zacznij czytać jeden, aby zobaczyć go tutaj.",
+        "continueListening": "Nie ma jeszcze żadnych audiobooków w przygotowaniu. Zacznij słuchać jednego, aby zobaczyć go tutaj.",
+        "wantToRead": "Nie ma jeszcze zaznaczonych książek, które chcę przeczytać.",
+        "upNextInSeries": "Nie ma jeszcze żadnych typów w następnej serii. Zakończ wolumin, aby wydobyć następny.",
+        "recentlyAdded": "Nie ma jeszcze książek w Twojej bibliotece.",
+        "smartScope": "Żadne książki nie pasują do tego smartScope.",
+        "default": "Nie znaleziono książek."
+      }
+    },
+    "settings": {
+      "title": "Dostosuj pulpit nawigacyjny",
+      "tabs": {
+        "widgets": "Widżety",
+        "shelves": "Półki"
+      },
+      "reorderHintWidget": "Przeciągnij, aby zmienić kolejność. Przełącz, aby pokazać lub ukryć widżet.",
+      "reorderHintShelf": "Przeciągnij, aby zmienić kolejność. Przełącz, aby pokazać lub ukryć półkę.",
+      "smartScope": "Inteligentny zakres",
+      "noSmartScopes": "Nie ma jeszcze inteligentnych zakresów. Utwórz go z paska bocznego.",
+      "addShelf": "Dodaj półkę",
+      "resetToDefaults": "Przywróć ustawienia domyślne"
+    },
+    "welcome": {
+      "emptyTitle": "Twoja biblioteka jest pusta",
+      "noLibrariesTitle": "Nie ma jeszcze bibliotek",
+      "emptyDescription": "Utwórz bibliotekę, aby zacząć porządkować i czytać książki. Wskaż mu folder, a on zrobi resztę.",
+      "noLibrariesDescription": "Twój administrator nie skonfigurował jeszcze żadnych bibliotek. Skontaktuj się z nimi, aby rozpocząć.",
+      "createFirstLibrary": "Stwórz swoją pierwszą bibliotekę"
+    },
+    "widgets": {
+      "currentlyReading": {
+        "title": "Aktualnie czytam",
+        "empty": "Brak książek w toku. Zacznij czytać jeden, aby zobaczyć go tutaj.",
+        "continueReading": "Kontynuuj czytanie"
+      },
+      "diversityScore": {
+        "title": "Wynik różnorodności",
+        "notEnoughData": "Przeczytaj co najmniej 3 książki, aby zobaczyć swój wynik różnorodności",
+        "booksAnalyzed": "{count, plural, =0 {nie analizowano żadnych książek} one {# książka analizowana} other {# analizowane książki} few {Przeanalizowano # książki} many {Przeanalizowano # książek}}",
+        "subScores": {
+          "genre": "Gatunek",
+          "author": "Autor",
+          "era": "Era",
+          "language": "Lang"
+        }
+      },
+      "highlightOfTheDay": {
+        "title": "Najważniejsza atrakcja dnia",
+        "empty": "Zaznacz fragmenty podczas czytania, aby zobaczyć je tutaj"
+      },
+      "libraryOverview": {
+        "title": "Przegląd biblioteki",
+        "empty": "Twoja biblioteka jest pusta. Na początek dodaj kilka książek.",
+        "addedThisYear": "+{count} dodano w tym roku",
+        "stats": {
+          "books": "Książki",
+          "authors": "Autorzy",
+          "series": "Seria",
+          "storage": "Przechowywanie"
+        }
+      },
+      "longWait": {
+        "title": "Długie oczekiwanie",
+        "empty": "Żadne książki nie czekają. Zacząłeś wszystko!",
+        "daysWaiting": "dni czekania",
+        "pages": "{count, plural, =0 {żadnych stron} one {# strona} other {# strony} few {# strony} many {# stron}}",
+        "startReading": "Zacznij czytać"
+      },
+      "monthlyChallenge": {
+        "title": "Comiesięczne wyzwanie",
+        "complete": "Kompletne!"
+      },
+      "neglectedGems": {
+        "title": "Zaniedbane klejnoty",
+        "empty": "Wszystkie Twoje najwyżej oceniane książki zostały przeczytane!",
+        "rating": "{rating}/5",
+        "daysWaiting": "{count}d czekam",
+        "queued": "W kolejce",
+        "addToQueue": "Dodaj do kolejki",
+        "shuffle": "Przetasuj"
+      },
+      "readingDna": {
+        "title": "Czytanie DNA",
+        "notEnoughData": "Przeczytaj co najmniej 5 książek, aby odblokować swoje czytelnicze DNA",
+        "basedOn": "{count, plural, =0 {Na podstawie żadnych książek} one {Na podstawie # książki} other {Na podstawie # książki} few {Na podstawie # książek} many {Na podstawie # książek}}",
+        "traits": {
+          "length": "Długość",
+          "variety": "Różnorodność",
+          "rhythm": "Rytm",
+          "time": "Czas",
+          "speed": "Prędkość"
+        }
+      },
+      "readingGoal": {
+        "title": "Cel czytania {year}",
+        "setGoalPrompt": "Ustaw cel czytania, aby śledzić swoje postępy",
+        "setGoal": "Wyznacz cel",
+        "booksPerYear": "Książki rocznie",
+        "ofGoal": "z {goal}",
+        "percentComplete": "Ukończono {percentage}%.",
+        "editGoal": "Edytuj cel"
+      },
+      "readingRhythm": {
+        "title": "Rytm czytania",
+        "empty": "Zacznij czytać, aby zobaczyć, jak Twój rytm nabiera kształtu",
+        "activeDays": "{count, plural, =0 {brak aktywnych dni} one {# aktywny dzień} other {# dni aktywne} few {# dni aktywne} many {# aktywnych dni}}",
+        "consistency": "{activeDays} · {percent}% spójności",
+        "avgPerDay": "średnio {time}/dzień"
+      },
+      "readingStreak": {
+        "title": "Czytelnicza passa",
+        "empty": "Przeczytaj dzisiaj, aby rozpocząć swoją passę",
+        "streakLabel": "{count, plural, =0 {dni z rzędu} one {dzień z rzędu} other {dnia z rzędu} few {dni z rzędu} many {dni z rzędu}}",
+        "best": "{count, plural, =0 {Najlepiej: # dni} one {Najlepiej: # dzień} other {Najlepiej: # dnia} few {Najlepiej: # dni} many {Najlepiej: # dni}}",
+        "lastSevenDays": "Ostatnie 7 dni"
+      },
+      "yearProjection": {
+        "title": "Projekcja roku",
+        "books": "książki",
+        "trendUp": "Trendy",
+        "trendDown": "Trend w dół",
+        "trendSteady": "Stałe tempo",
+        "pages": "strony",
+        "hours": "godziny",
+        "readCount": "{count} przeczytaj",
+        "daysLeft": "Pozostało {count}d"
+      }
+    }
+  },
+  "email": {
+    "title": "E-mail",
+    "subtitle": "Wysyłaj książki do swojego e-czytnika za pośrednictwem poczty elektronicznej.",
+    "loadFailed": "Nie udało się załadować",
+    "saveFailed": "Nie udało się zapisać",
+    "deleteFailed": "Nie udało się usunąć",
+    "setDefaultFailed": "Nie udało się ustawić wartości domyślnej",
+    "setAsDefault": "Ustaw jako domyślny",
+    "saving": "Zapisywanie...",
+    "update": "Aktualizacja",
+    "create": "Utwórz",
+    "deleteConfirm": "Usuń „{name}”. Tej akcji nie można cofnąć.",
+    "badge": {
+      "default": "Domyślne",
+      "shared": "Udostępnione",
+      "system": "Systemu"
+    },
+    "tabs": {
+      "providers": "Dostawcy",
+      "recipients": "Odbiorcy",
+      "groups": "Grupy",
+      "templates": "Szablony",
+      "preferences": "Preferencje",
+      "history": "Historia"
+    },
+    "providers": {
+      "heading": "Dostawcy SMTP",
+      "add": "Dodaj dostawcę",
+      "newTitle": "Nowy dostawca",
+      "editTitle": "Edytuj dostawcę",
+      "name": "Imię",
+      "namePlaceholder": "np. Gmaila",
+      "host": "Gospodarz",
+      "port": "Portu",
+      "username": "Nazwa użytkownika",
+      "password": "Hasło",
+      "passwordEdit": "Hasło (pozostaw puste, aby zachować aktualne)",
+      "fromName": "Od imienia",
+      "fromNamePlaceholder": "Moja biblioteka",
+      "fromAddress": "Z adresu",
+      "authentication": "Uwierzytelnianie",
+      "verifyTls": "Zweryfikuj certyfikat TLS",
+      "tlsWarning": "Weryfikacja TLS jest wyłączona. Certyfikat serwera nie zostanie zweryfikowany - używaj tylko w przypadku zaufanych serwerów wewnętrznych.",
+      "noFromAddress": "nie, z adresu",
+      "emptyManage": "Nie ma jeszcze dostawców. Dodaj dostawcę SMTP, aby rozpocząć wysyłanie e-maili.",
+      "emptyReadonly": "Brak dostępnych dostawców. Poproś administratora o dodanie jednego.",
+      "setSystemTooltip": "Ustaw jako systemowego dostawcę poczty",
+      "removeSystemTooltip": "Usuń jako dostawcę poczty systemowej",
+      "testTooltip": "Połączenie testowe",
+      "toggleSharing": "Przełącz udostępnianie",
+      "removeSystemBeforeDelete": "Przed usunięciem usuń oznaczenie systemu",
+      "notesHeading": "Uwagi dostawcy",
+      "notesBody": "Dostawca {system} (tylko superużytkownik) jest używany do wiadomości e-mail dotyczących resetowania hasła. Dostawca {defaultProvider} jest używany podczas wysyłania książek bez wybranego dostawcy. Dostawcy oznaczeni {shared} są dostępni dla wszystkich użytkowników.",
+      "deleteTitle": "Usunąć dostawcę?",
+      "nameHostRequired": "Imię i gospodarz są wymagane",
+      "created": "Dostawca został utworzony",
+      "updated": "Dostawca zaktualizowany",
+      "deleted": "„{name}” usunięty",
+      "setDefaultSuccess": "„{name}” ustawione jako domyślne",
+      "unshared": "Dostawca nieudostępniony",
+      "sharedWithAll": "Dostawca udostępniony wszystkim użytkownikom",
+      "updateSharingFailed": "Nie udało się zaktualizować udostępniania",
+      "systemRemoved": "„{name}” usunięty jako dostawca poczty systemowej",
+      "systemSet": "„{name}” ustawiony jako dostawca poczty systemowej",
+      "updateSystemFailed": "Nie udało się zaktualizować dostawcy systemu",
+      "connectionSuccess": "Połączenie pomyślne",
+      "connectionFailed": "Połączenie nie powiodło się",
+      "testFailed": "Test nie powiódł się"
+    },
+    "recipients": {
+      "heading": "Odbiorcy",
+      "add": "Dodaj odbiorcę",
+      "newTitle": "Nowy odbiorca",
+      "editTitle": "Edytuj odbiorcę",
+      "name": "Imię",
+      "namePlaceholder": "Mój Kindle",
+      "emailAddress": "Adres e-mail",
+      "deviceType": "Typ urządzenia",
+      "deviceNone": "Żadne",
+      "deviceOther": "Inne",
+      "preferredFormat": "Preferowany format",
+      "formatAuto": "Automat",
+      "defaultTemplate": "Domyślny szablon",
+      "useAccountDefault": "Użyj domyślnego konta",
+      "kindleNote": "Odbiorcy Kindle automatycznie otrzymują e-maile z tematem „konwertuj”, aby uruchomić konwersję formatu.",
+      "empty": "Nie ma jeszcze odbiorców.",
+      "prefersFormat": "woli {format}",
+      "deleteTitle": "Usunąć odbiorcę?",
+      "nameEmailRequired": "Imię i nazwisko oraz adres e-mail są wymagane",
+      "created": "Odbiorca został utworzony",
+      "updated": "Odbiorca zaktualizowany",
+      "deleted": "„{name}” usunięty",
+      "setDefaultSuccess": "„{name}” ustawione jako domyślne"
+    },
+    "groups": {
+      "heading": "Grupy odbiorców",
+      "create": "Utwórz grupę",
+      "newTitle": "Nowa grupa",
+      "name": "Nazwa grupy",
+      "namePlaceholder": "np. Klub Książki",
+      "creating": "Tworzenie...",
+      "empty": "Nie ma jeszcze grup. Utwórz grupę, aby wysłać wiadomość do wielu odbiorców jednocześnie.",
+      "memberCount": "{count, plural, =0 {brak członków} one {# członek} other {# członka} few {# członków} many {# członków}}",
+      "deleteTooltip": "Usuń grupę",
+      "noMembers": "Nie ma jeszcze członków.",
+      "removeMember": "Usuń",
+      "selectRecipient": "Wybierz odbiorcę...",
+      "add": "Dodaj",
+      "addMember": "Dodaj członka",
+      "allRecipientsInGroup": "Wszyscy odbiorcy są już w tej grupie.",
+      "deleteTitle": "Usunąć grupę?",
+      "created": "Grupa utworzona",
+      "createFailed": "Nie udało się utworzyć grupy",
+      "deleted": "„{name}” usunięty",
+      "memberAdded": "Członek dodał",
+      "addMemberFailed": "Nie udało się dodać członka",
+      "memberRemoved": "Członek usunięty",
+      "removeMemberFailed": "Nie udało się usunąć członka"
+    },
+    "templates": {
+      "heading": "Szablony e-maili",
+      "new": "Nowy szablon",
+      "newTitle": "Nowy szablon",
+      "editTitle": "Edytuj szablon",
+      "name": "Imię",
+      "namePlaceholder": "Domyślne",
+      "subject": "Temat",
+      "body": "Ciało",
+      "availableVariables": "Dostępne zmienne",
+      "editTemplate": "Edytuj szablon",
+      "empty": "Nie ma jeszcze żadnych szablonów.",
+      "notesHeading": "Notatki szablonowe",
+      "notesBody": "Szablonów systemowych nie można usunąć. Administratorzy mogą je edytować. Używaj zmiennych takich jak {variable} w tematach i treściach - są one zastępowane szczegółami książki w momencie wysyłania.",
+      "deleteTitle": "Usunąć szablon?",
+      "nameSubjectRequired": "Imię i temat są wymagane",
+      "created": "Szablon został utworzony",
+      "updated": "Szablon zaktualizowany",
+      "deleted": "„{name}” usunięty",
+      "setDefaultSuccess": "„{name}” ustawione jako domyślne"
+    },
+    "preferences": {
+      "heading": "Preferencje poczty e-mail",
+      "defaultProvider": "Domyślny dostawca",
+      "defaultProviderHint": "Używane, gdy nie określono żadnego dostawcy. Jeśli jest pusty, używane jest ustawienie domyślne konta.",
+      "noneAccountDefault": "Brak (użyj domyślnego konta)",
+      "defaultRecipient": "Domyślny odbiorca",
+      "defaultRecipientHint": "Służy do szybkiego wysyłania. Należy ustawić, aby można było używać akcji szybkiego wysyłania na kartach książek.",
+      "none": "Żadne",
+      "defaultTemplate": "Domyślny szablon",
+      "defaultTemplateHint": "Używane, gdy nie określono żadnego szablonu. Przywraca domyślne ustawienia systemu, jeśli jest puste.",
+      "noneSystemDefault": "Brak (użyj domyślnych ustawień systemowych)",
+      "save": "Zapisz preferencje",
+      "saved": "Preferencje zostały zapisane"
+    },
+    "history": {
+      "heading": "Wyślij historię",
+      "empty": "Nie wysłano jeszcze żadnych e-maili.",
+      "noSubject": "(bez tematu)",
+      "loadMore": "Załaduj więcej",
+      "resend": "Wyślij ponownie",
+      "deleteTitle": "Usunąć wpis historii?",
+      "entryDeleted": "Wpis usunięty",
+      "queuedForResend": "W kolejce do ponownego wysłania",
+      "resendFailed": "Nie udało się wysłać ponownie",
+      "statusSent": "Wysłane",
+      "statusFailed": "Nie udało się",
+      "statusQueued": "W kolejce",
+      "statusPending": "Oczekujące"
+    },
+    "send": {
+      "title": "Wyślij e-mailem",
+      "bookCount": "{count, plural, =0 {żadnych książek} one {jedna książka} other {# książki} few {# książki} many {# książek}}",
+      "recipients": "Odbiorcy",
+      "noRecipients": "Nie skonfigurowano odbiorców. Dodaj go w ustawieniach poczty e-mail.",
+      "groups": "Grupy",
+      "options": "Opcje",
+      "fileFormat": "Format pliku",
+      "autoRecipientPreference": "Auto (użyj preferencji odbiorcy)",
+      "unknownFormat": "Nieznany",
+      "primarySuffix": "(główny)",
+      "provider": "Dostawca",
+      "template": "Szablon",
+      "default": "Domyślne",
+      "send": "Wyślij",
+      "sending": "Wysyłanie...",
+      "queued": "{count, plural, =0 {żadnych e-maili w kolejce} one {jeden e-mail w kolejce} other {# e-maile w kolejce} few {# e-maile w kolejce} many {# e-maili w kolejce}}",
+      "failed": "Nie udało się wysłać"
+    }
+  },
+  "hardcover": {
+    "settings": {
+      "subtitle": "Zsynchronizuj swoje postępy w czytaniu, status i oceny z Hardcover."
+    },
+    "bookSync": {
+      "label": "Hardcover Synchronizacja",
+      "toggleAriaLabel": "Zsynchronizuj tę książkę z Hardcover",
+      "syncNow": "Zsynchronizuj teraz"
+    },
+    "connection": {
+      "title": "Połączenie",
+      "description": "Połącz swoje konto Hardcover, aby zsynchronizować dane do odczytu.",
+      "connected": "Połączono",
+      "apiToken": "Token API",
+      "tokenPlaceholder": "Wklej swój token Hardcover API",
+      "show": "Pokaż",
+      "hide": "Ukryj",
+      "findTokenAt": "Znajdź swój token pod adresem",
+      "validateToken": "Zweryfikuj token",
+      "valid": "Ważne ({username})",
+      "invalidToken": "Nieprawidłowy token",
+      "syncOptions": "Opcje synchronizacji",
+      "syncInfo": "Synchronizacja przebiega tylko w przypadku książek, które nie są nieprzeczytane. Dotyczy to wyzwalaczy stanu, postępu i oceny. Te przełączniki kontrolują przebieg synchronizacji.",
+      "syncScope": {
+        "title": "Zakres synchronizacji książek",
+        "allEligible": {
+          "label": "Wszystkie kwalifikujące się książki",
+          "description": "Synchronizuj wszystko, chyba że wykluczysz książkę."
+        },
+        "selectedOnly": {
+          "label": "Tylko wybrane książki",
+          "description": "Synchronizuj tylko książki, które wyraźnie uwzględnisz."
+        }
+      },
+      "enableSync": {
+        "title": "Włącz synchronizację",
+        "description": "Wstrzymaj całą synchronizację Hardcover bez rozłączania."
+      },
+      "syncOnStatus": {
+        "title": "Synchronizuj przy zmianie statusu",
+        "description": "Aktualizacje push, gdy oznaczysz książkę jako przeczytaną, przeczytaną itp."
+      },
+      "syncOnProgress": {
+        "title": "Synchronizuj przy aktualizacji postępu",
+        "description": "Prześlij postęp czytania i daty, gdy postęp BookOrbit lub KOReader ulegnie zmianie."
+      },
+      "syncOnRating": {
+        "title": "Synchronizuj po zmianie oceny",
+        "description": "Przenieś swoje oceny w postaci gwiazdek do Hardcover."
+      },
+      "privacy": {
+        "title": "Prywatność",
+        "description": "Domyślna widoczność zsynchronizowanych książek w Hardcover.",
+        "public": "Publiczne",
+        "followersOnly": "Tylko obserwujący",
+        "private": "Prywatny"
+      },
+      "disconnect": "Rozłącz",
+      "toast": {
+        "enterToken": "Najpierw wprowadź swój token Hardcover API",
+        "saved": "Hardcover ustawienia zostały zapisane",
+        "saveFailed": "Nie udało się zapisać ustawień",
+        "disconnected": "Hardcover rozłączony"
+      }
+    },
+    "sync": {
+      "title": "Synchronizacja ręczna",
+      "description": "Wepchnij teraz swój {scope} do Hardcover.",
+      "scope": {
+        "selected": "wybrane książki",
+        "eligible": "kwalifikujące się książki"
+      },
+      "checkingPending": "Sprawdzanie oczekujących elementów...",
+      "pendingOf": "{pending} oczekuje na wydanie {total} książek.",
+      "noBooksInScope": "Brak książek w zakresie synchronizacji.",
+      "allSynced": "Wszystkie książki są już zsynchronizowane.",
+      "lastSyncedLabel": "Ostatnia synchronizacja",
+      "lastSuccessfulSync": "Ostatnia udana synchronizacja",
+      "syncing": "Synchronizowanie...",
+      "progressCount": "{synced} / {total} książek",
+      "unavailable": {
+        "permissionDenied": "Nie masz uprawnień do używania synchronizacji Hardcover.",
+        "userDisabled": "Synchronizacja Twoich ustawień Hardcover została wstrzymana."
+      },
+      "button": {
+        "unavailable": "Synchronizacja niedostępna",
+        "syncNow": "Zsynchronizuj teraz",
+        "syncNowCount": "Synchronizuj teraz ({count})"
+      },
+      "lastSynced": {
+        "justNow": "Właśnie teraz",
+        "minutesAgo": "{count} min temu",
+        "hoursAgo": "{count, plural, =0 {# godzinę temu} one {# godzinę temu} other {# godziny temu} few {# godziny temu} many {# godzin temu}}",
+        "daysAgo": "{count, plural, =0 {# dni temu} one {# dzień temu} other {# dnia temu} few {# dni temu} many {# dni temu}}"
+      }
+    },
+    "import": {
+      "title": "Wyciągnij status odczytu",
+      "description": "Podgląd dopasowań Hardcover przed wypełnieniem pustych statusów BookOrbit.",
+      "clear": "Wyczyść",
+      "preview": "Podgląd",
+      "importProgress": "Postęp importu",
+      "reviewMatches": "Przejrzyj mecze",
+      "importReady": "Import gotowy",
+      "exactMatches": "{count, plural, =0 {bez sprawdzenia nie można zaimportować żadnych dokładnych dopasowań} one {# dokładne dopasowanie można zaimportować bez sprawdzania} other {# dokładne dopasowania można importować bez sprawdzania} few {Można zaimportować # dokładne dopasowania bez sprawdzania} many {Można zaimportować # dokładnych dopasowań bez sprawdzania}}",
+      "progressAvailable": "{count, plural, =0 {brak dostępnych aktualizacji postępu} one {# dostępna aktualizacja postępu} other {# dostępne aktualizacje postępów} few {Dostępne są # aktualizacje postępu} many {Dostępnych jest # aktualizacji postępu}}",
+      "progressConflicts": "{count, plural, =0 {żadnych konfliktów} one {# konflikt} other {# konflikty} few {# konflikty} many {# konfliktów}}",
+      "unavailable": {
+        "permissionDenied": "Nie masz uprawnień do używania synchronizacji Hardcover.",
+        "missingToken": "Połącz Hardcover przed importem.",
+        "userDisabled": "Synchronizacja Twoich ustawień Hardcover została wstrzymana."
+      },
+      "summary": {
+        "ready": "Gotowy",
+        "review": "Recenzja",
+        "conflicts": "Konflikty",
+        "unmatched": "Niezrównany",
+        "skipped": "Pominięte"
+      },
+      "result": {
+        "summary": "{applied} zaimportowano{progress}, {failed} nie powiodło się",
+        "progressUpdated": "{count} zaktualizowano postęp"
+      },
+      "toast": {
+        "importFailed": "Nie udało się zaimportować stanu odczytu Hardcover",
+        "imported": "{count, plural, =0 {nie zaimportowano żadnych statusów odczytu{progress}} one {# status odczytu zaimportowany{progress}} other {# odczytaj zaimportowane statusy{progress}} few {Zaimportowano # statusy odczytu{progress}} many {Zaimportowano # statusów odczytu{progress}}}",
+        "progressUpdates": "{count, plural, =0 {brak aktualizacji postępów} one {# aktualizacja postępów} other {# aktualizacje postępów} few {# aktualizacje postępu} many {# aktualizacji postępu}}"
+      }
+    },
+    "review": {
+      "title": "Hardcover recenzja importu",
+      "subtitle": "{total} Hardcover książki, {matched} dopasowane.",
+      "closeAriaLabel": "Zamknij przegląd importu",
+      "searchPlaceholder": "Wyszukaj tytuł lub autora",
+      "importProgress": "Postęp importu",
+      "untitled": "Bez tytułu",
+      "blank": "puste",
+      "noRows": "Żaden wiersz nie pasuje do bieżących filtrów.",
+      "selectRowAriaLabel": "Wybierz {title}",
+      "selectionSummary": "{count} wybrane: {ready} gotowe, {reviewed} sprawdzone.",
+      "selectedProgress": "{count, plural, =0 {brak aktualizacji postępów} one {# aktualizacja postępów} other {# aktualizacje postępów} few {# aktualizacje postępu} many {# aktualizacji postępu}}",
+      "selectReady": "Wybierz gotowe",
+      "selectPage": "Wybierz stronę",
+      "clearPage": "Wyczyść stronę",
+      "clearSelection": "Wyczyść wybór",
+      "importSelected": "Importuj wybrane",
+      "previousPage": "Poprzednia strona",
+      "nextPage": "Następna strona",
+      "pageRange": "{start}-{end} z {total}",
+      "tabs": {
+        "all": "Wszystko",
+        "ready": "Gotowy",
+        "review": "Recenzja",
+        "conflicts": "Konflikty",
+        "unmatched": "Niezrównany",
+        "skipped": "Pominięte"
+      },
+      "summary": {
+        "ready": "Gotowy",
+        "review": "Recenzja",
+        "conflicts": "Konflikty",
+        "unmatched": "Niezrównany",
+        "skipped": "Pominięte"
+      },
+      "matchOptions": {
+        "all": "Wszystkie typy dopasowań"
+      },
+      "matchMethod": {
+        "hardcoverId": "Hardcover Identyfikator",
+        "isbn": "ISBN",
+        "titleAuthor": "Tytuł + autor"
+      },
+      "outcome": {
+        "ready": "Gotowy",
+        "review": "Recenzja",
+        "conflict": "Konflikt",
+        "unmatched": "Niezrównany",
+        "skipped": "Pominięte"
+      },
+      "column": {
+        "progress": "Postęp"
+      }
+    }
+  },
+  "library": {
+    "creator": {
+      "createTitle": "Utwórz bibliotekę",
+      "editTitle": "Edycja: {name}",
+      "stepOf": "Krok {current} z {total}",
+      "unsaved": "Niezapisane",
+      "required": "Wymagane",
+      "closeAria": "Zamknij kreatora biblioteki",
+      "progressAria": "Postęp konfiguracji biblioteki",
+      "sectionsAria": "Sekcje ustawień biblioteki",
+      "loadingAria": "Ładowanie ustawień biblioteki",
+      "sections": {
+        "details": "Szczegóły",
+        "folders": "Foldery",
+        "scanner": "Skaner",
+        "metadata": "Metadane",
+        "fileWrite": "Zapis pliku",
+        "reading": "Czytanie",
+        "schedule": "Harmonogram",
+        "access": "Dostęp"
+      },
+      "actions": {
+        "saving": "Zapisuję…",
+        "saveChanges": "Zapisz zmiany",
+        "creating": "Tworzenie…",
+        "createLibrary": "Utwórz bibliotekę"
+      },
+      "details": {
+        "libraryName": "Nazwa biblioteki",
+        "namePlaceholder": "Moja biblioteka",
+        "coverStyle": {
+          "title": "Styl okładki",
+          "portrait": "Portret",
+          "square": "Kwadrat",
+          "hint": "Portret dla bibliotek ebook lub mieszanych. Plac dla bibliotek oferujących wyłącznie audiobooki."
+        },
+        "icon": {
+          "label": "Ikona",
+          "placeholder": "Wybierz ikonę...",
+          "selected": "Wybrane"
+        }
+      },
+      "folders": {
+        "title": "Skanuj foldery",
+        "description": "Dodaj jeden lub więcej katalogów do skanowania w poszukiwaniu książek.",
+        "browseAdd": "Przeglądaj i dodaj folder",
+        "browseTitle": "Przeglądaj foldery serwera",
+        "browseDescription": "Wybierz jeden lub więcej folderów bez opuszczania przeglądarki.",
+        "selectedTitle": "Wybrane foldery",
+        "addFolders": "Dodaj foldery",
+        "manualEntry": "Wprowadź ścieżkę ręcznie",
+        "absolutePath": "Bezwzględna ścieżka serwera",
+        "addFolder": "Dodaj folder",
+        "removeFolder": "Usuń {folder}",
+        "manualCheckHint": "Ręczne ścieżki są sprawdzane razem z resztą wybranych folderów.",
+        "pathPlaceholder": "/ścieżka/do/książek",
+        "test": "Testuj",
+        "add": "Dodaj",
+        "pathNotAccessible": "Ścieżka nie jest dostępna na serwerze.",
+        "pathAccessible": "Ścieżka jest dostępna.",
+        "pathNotAccessibleShort": "Ścieżka nie jest dostępna",
+        "overlapsWith": "Pokrywa się z „{library}”",
+        "noneAdded": "Nie dodano jeszcze żadnych folderów",
+        "runPrescanHint": "Uruchom skanowanie wstępne, aby sprawdzić ścieżki przed zapisaniem.",
+        "scanning": "Skanowanie…",
+        "prescan": "Wstępne skanowanie"
+      },
+      "scanner": {
+        "scanMode": {
+          "title": "Tryb skanowania",
+          "lockedAria": "Tryb organizacji jest zablokowany",
+          "lockTooltip": "Tryb organizacji został naprawiony po utworzeniu biblioteki, ponieważ jego zmiana może spowodować utworzenie zduplikowanych lub brakujących wpisów księgowych. Aby użyć innego trybu, utwórz nową bibliotekę i przeskanuj ponownie.",
+          "recommended": "Zalecane",
+          "folderAsBook": {
+            "title": "Folder jako książka",
+            "hint": "Wszystkie pliki w folderze są zgrupowane w jedną książkę. Działa dobrze, jeśli łączysz wiele formatów, takich jak EPUB i MOBI."
+          },
+          "fileAsBook": {
+            "title": "Plik jako książka",
+            "hint": "Traktuje każdy plik jako osobną książkę. Najlepiej nadaje się do bibliotek z jednym formatem na tytuł. Unikaj, jeśli Twoje audiobooki obejmują wiele plików."
+          }
+        },
+        "allowedFormats": {
+          "title": "Dozwolone formaty",
+          "allowAll": "Zezwalaj na wszystko",
+          "allAllowed": "Wszystkie formaty są dozwolone.",
+          "onlySelected": "Zaimportowane zostaną tylko wybrane formaty.",
+          "warning": "Książki w innych formatach, które znajdują się już w bibliotece, zostaną oznaczone jako brakujące przy następnym skanowaniu."
+        },
+        "excludePatterns": {
+          "title": "Wyklucz wzorce",
+          "hintBefore": "Wzory globu do pominięcia podczas skanowania (np. ",
+          "hintAfter": ").",
+          "add": "Dodaj",
+          "empty": "Nie dodano żadnych wzorów."
+        }
+      },
+      "metadata": {
+        "sourcePrecedence": {
+          "title": "Pierwszeństwo źródła",
+          "hint": "Jeśli dostępnych jest wiele źródeł, preferowane jest najwyższe źródło na liście."
+        },
+        "formatPriority": {
+          "title": "Priorytet formatu",
+          "hint": "Jeśli książka ma wiele formatów, preferowany jest format znajdujący się najwyżej na liście."
+        }
+      },
+      "fileWrite": {
+        "maxFileSizeMb": "Maksymalny rozmiar pliku (MB)",
+        "formatLimits": "Limity formatu",
+        "rename": {
+          "title": "Zmień nazwę plików po zmianie metadanych",
+          "hint": "Zmienia nazwy plików fizycznych w przypadku zmiany tytułu, autora, serii lub roku, korzystając ze wzorca nazewnictwa biblioteki."
+        },
+        "write": {
+          "title": "Zapisz metadane do plików",
+          "hint": "Po włączeniu zapisywanie metadanych powoduje także zapisanie zmian z powrotem w pliku fizycznym na dysku."
+        },
+        "cover": {
+          "title": "Dołącz zdjęcie okładki",
+          "hint": "Zapisuje zapisaną okładkę z powrotem w obsługiwanych formatach plików."
+        },
+        "epub": {
+          "title": "EPUB",
+          "hint": "Zapisuje metadane do pliku OPF w archiwum EPUB.",
+          "toggleAria": "Zapisz metadane EPUB"
+        },
+        "fb2": {
+          "title": "Książka fabularna (FB2)",
+          "hint": "Przepisuje blok opisu w plikach FB2, pozostawiając tekst książki nietknięty.",
+          "toggleAria": "Zapisz metadane FB2"
+        },
+        "pdf": {
+          "title": "PDF",
+          "hint": "Osadza metadane w PDF słowniku informacyjnym i strumieniu XMP.",
+          "toggleAria": "Zapisz metadane PDF"
+        },
+        "cbx": {
+          "title": "Archiwa komiksów (CBX)",
+          "hint": "Zapisuje plik ComicInfo.xml w archiwach CBZ i CB7.",
+          "toggleAria": "Zapisz metadane archiwum komiksu"
+        },
+        "kindle": {
+          "title": "Kindle (MOBI, AZW3)",
+          "hint": "Zapisuje metadane w nagłówku EXTH plików MOBI, AZW3 i AZW.",
+          "toggleAria": "Zapisz metadane Kindle"
+        },
+        "audio": {
+          "title": "Audio",
+          "hint": "Osadza zapisaną okładkę w plikach M4B, M4A, MP3 i FLAC.",
+          "toggleAria": "Napisz covery audio"
+        }
+      },
+      "reading": {
+        "readingStart": {
+          "title": "Początek czytania",
+          "hint": "Po osiągnięciu określonego procentu postępu książka zostaje oznaczona jako „przeczytana”."
+        },
+        "markAsFinished": {
+          "title": "Oznacz jako gotowe",
+          "hint": "Książka jest automatycznie oznaczana jako „przeczytana” po osiągnięciu określonego procentu postępu."
+        }
+      },
+      "schedule": {
+        "fileWatching": "Oglądanie plików",
+        "autoScanSchedule": "Harmonogram automatycznego skanowania",
+        "cronExpression": "Wyrażenie Crona",
+        "cronInvalid": "Nieprawidłowe wyrażenie cron.",
+        "cronFormat": "Format: minuta godzina dzień miesiąc dzień tygodnia",
+        "watchFolders": {
+          "title": "Oglądaj foldery",
+          "hint": "Automatycznie wykrywaj nowe pliki dodane do folderów biblioteki."
+        },
+        "presets": {
+          "never": "Nigdy",
+          "hourly": "Co godzinę",
+          "every6Hours": "Co 6 godzin",
+          "every12Hours": "Co 12 godzin",
+          "daily": "Codziennie",
+          "weekly": "Co tydzień",
+          "custom": "Niestandardowe"
+        },
+        "human": {
+          "disabled": "Automatyczne skanowanie wyłączone",
+          "hourly": "Co godzinę",
+          "every6Hours": "Co 6 godzin",
+          "every12Hours": "Co 12 godzin",
+          "dailyMidnight": "Codziennie o północy",
+          "weeklyMonday": "Co tydzień w poniedziałek o północy",
+          "cron": "Cron: {cron}"
+        }
+      },
+      "access": {
+        "title": "Kontrola dostępu",
+        "description": "Superużytkownicy zawsze mają pełny dostęp. Poniżej przyznaj dostęp innym użytkownikom.",
+        "notYetCreated": "Dostęp można skonfigurować po utworzeniu biblioteki.",
+        "selectUser": "Wybierz użytkownika…",
+        "grant": "Przyznaj",
+        "empty": "Żadnemu użytkownikowi nie przyznano jeszcze dostępu.",
+        "loading": "Ładowanie ustawień dostępu...",
+        "userSelectAria": "Użytkownik, któremu chcesz przyznać dostęp",
+        "levelSelectAria": "Poziom dostępu do przyznania",
+        "levels": {
+          "viewer": "Przeglądarka",
+          "editor": "Redaktor",
+          "owner": "Właściciel"
+        },
+        "columns": {
+          "user": "Użytkownik",
+          "accessLevel": "Poziom dostępu"
+        },
+        "errors": {
+          "grant": "Nie udało się udzielić dostępu",
+          "updateLevel": "Nie udało się zaktualizować poziomu dostępu",
+          "revoke": "Nie udało się odwołać dostępu"
+        }
+      }
+    },
+    "folderPicker": {
+      "title": "Przeglądaj foldery serwera",
+      "description": "Wybierz jeden lub więcej folderów dla tej biblioteki.",
+      "closeAria": "Zamknij przeglądarkę folderów",
+      "currentFolderAria": "Bieżący folder",
+      "parentFolder": "Przejdź do folderu nadrzędnego",
+      "newFolder": "Nowy folder",
+      "goUp": "Idź w górę",
+      "filterPlaceholder": "Filtruj foldery…",
+      "clearFilterAria": "Wyczyść filtr folderów",
+      "newFolderNamePlaceholder": "Nowa nazwa folderu",
+      "create": "Utwórz",
+      "loading": "Ładowanie folderów...",
+      "selectCurrent": "Wybierz bieżący folder",
+      "noMatches": "Brak pasujących folderów",
+      "noMatchesHint": "Wypróbuj inny filtr.",
+      "empty": "Ten folder jest pusty",
+      "emptyHint": "Możesz wybrać bieżący folder lub utworzyć nowy.",
+      "openFolderAria": "Otwórz {name}",
+      "selectedCount": "{count, plural, =0 {nie wybrano żadnych folderów} one {# wybrany folder} other {# wybrane foldery} few {Wybrano # foldery} many {Wybrano # folderów}}",
+      "noFolders": "Nie znaleziono folderów",
+      "selectFolder": "Wybierz ten folder",
+      "errors": {
+        "readDirectory": "Nie można odczytać katalogu",
+        "connect": "Nie udało się połączyć",
+        "invalidName": "Wprowadź pojedynczą nazwę folderu bez ukośników i kropek wiodących",
+        "createFolder": "Nie można utworzyć folderu"
+      }
+    },
+    "upload": {
+      "library": "Biblioteka",
+      "selectLibrary": "Wybierz bibliotekę...",
+      "targetFolder": "Folder docelowy",
+      "addMoreFiles": "Dodaj więcej plików",
+      "clearAll": "Wyczyść wszystko",
+      "done": "Gotowe",
+      "retry": "Spróbuj ponownie",
+      "upload": "Prześlij",
+      "uploadWithCount": "Prześlij ({count})",
+      "viewInLibrary": "Zobacz w Bibliotece",
+      "fileCount": "{count, plural, =0 {żadnych plików} one {# plik} other {# pliki} few {# pliki} many {# plików}}",
+      "booksAdded": "{count, plural, =0 {nie dodano żadnych książek} one {# książka dodana} other {# dodane książki} few {Dodano # książki} many {Dodano # książek}}",
+      "uploadedFailed": "{done} przesłano, {failed} nie powiodło się",
+      "progress": "{done} z {total} przesyłanie...",
+      "header": {
+        "uploading": "Przesyłanie...",
+        "complete": "Przesyłanie zakończone",
+        "uploadTo": "Prześlij do {library}",
+        "uploadBooks": "Prześlij książki"
+      },
+      "dropzone": {
+        "title": "Upuść pliki tutaj lub kliknij, aby przeglądać",
+        "hint": "{formats} - do {size} MB każdy"
+      }
+    }
+  },
+  "metadataScore": {
+    "missingFields": "{count, plural, =0 {nie brakuje żadnych pól - edytuj metadane} one {brakuje # pola - edytuj metadane} other {brakuje # pola - edytuj metadane} few {brakuje # pól - edytuj metadane} many {brakuje # pól - edytuj metadane}}"
+  },
+  "migration": {
+    "sidebarTitle": "Import książek",
+    "status": {
+      "done": "Gotowe",
+      "saved": "Zapisano",
+      "running": "Bieganie",
+      "failed": "Nie udało się"
+    },
+    "badge": {
+      "validated": "Zatwierdzone",
+      "upToDate": "Aktualne",
+      "completed": "Ukończono"
+    },
+    "steps": {
+      "source": {
+        "short": "Połączenie źródłowe",
+        "title": "Połączenie źródłowe",
+        "subtitle": "Skonfiguruj połączenie bazy danych ze źródłową instancją Booklore."
+      },
+      "mappings": {
+        "short": "Mapowanie użytkowników i ścieżek",
+        "title": "Mapowanie użytkowników i ścieżek",
+        "subtitle": "Mapuj użytkowników źródłowych na użytkowników docelowych i tłumacz ścieżki plików."
+      },
+      "dryRun": {
+        "short": "Praca na sucho",
+        "title": "Praca na sucho",
+        "subtitle": "Przed uruchomieniem migracji na żywo możesz wyświetlić podgląd tego, co zostanie zaimportowane."
+      },
+      "migration": {
+        "short": "Uruchom migrację",
+        "title": "Uruchom migrację",
+        "subtitle": "Rozpocznij import na żywo i monitoruj jego postęp."
+      },
+      "report": {
+        "short": "Raport",
+        "title": "Raport o migracji",
+        "subtitle": "Sprawdź, co zostało zaimportowane i wyeksportuj szczegółowy raport."
+      }
+    },
+    "footer": {
+      "continueToMappings": "Przejdź do Mapowania",
+      "continueToDryRun": "Kontynuuj próbę próbną",
+      "continueToMigration": "Przejdź do migracji",
+      "viewReport": "Zobacz raport",
+      "resetSetup": "Zresetuj konfigurację",
+      "stepOf": "Krok {current} z {total}",
+      "backToSetup": "Powrót do konfiguracji"
+    },
+    "stages": {
+      "init": "Inicjowanie",
+      "sharedOverlays": "Importowanie metadanych",
+      "bookCovers": "Import okładek",
+      "userState": "Importowanie danych użytkownika"
+    },
+    "source": {
+      "testConnection": "Połączenie testowe",
+      "saveAndValidate": "Zapisz i sprawdź",
+      "validatedWithWarnings": "Źródło potwierdzone z ostrzeżeniami",
+      "fields": {
+        "type": "Typ źródła",
+        "name": "Nazwa źródła",
+        "host": "Gospodarz",
+        "port": "Portu",
+        "user": "Użytkownik",
+        "password": "Hasło",
+        "passwordSaved": "Zapisano - pozostaw bez zmian",
+        "passwordNotSet": "Nie ustawiono hasła",
+        "database": "Baza danych",
+        "mediaRootPath": "Ścieżka główna multimediów",
+        "ssl": "Użyj protokołu TLS/SSL"
+      },
+      "mediaPath": {
+        "hintRequired": "Wymagane do migracji okładek książek.",
+        "hintAbsolute": "Użyj ścieżki bezwzględnej (na przykład: /books). Ścieżki względne nie są obsługiwane.",
+        "hintConfigured": "Skonfigurowano ścieżkę importu okładek. Użyj połączenia testowego, aby sprawdzić dostęp i strukturę folderów obrazów Booklore.",
+        "buttonOk": "Ścieżka w porządku",
+        "buttonIssue": "Problem ze ścieżką",
+        "buttonTest": "Ścieżka testowa"
+      },
+      "compatibility": {
+        "title": "Przetestowana kompatybilność",
+        "verifiedAgainst": "Zweryfikowano względem:",
+        "note": "Późniejsze wersje są prawdopodobnie kompatybilne, ale nie zostały zweryfikowane. Najpierw wykonaj próbę próbną, aby potwierdzić przed zatwierdzeniem danych."
+      },
+      "snapshot": {
+        "title": "Ostatnia migawka weryfikacyjna",
+        "sourceVersion": "Wersja źródłowa: {version}",
+        "unknown": "Nieznany",
+        "missingTables": "Brakuje wymaganych tabel: {tables}"
+      }
+    },
+    "mappings": {
+      "suggestionsAutoLoad": "Sugestie użytkowników ładują się automatycznie po sprawdzeniu źródła.",
+      "refresh": "Odśwież",
+      "sourceUser": "Użytkownik źródłowy",
+      "targetUser": "Użytkownik docelowy",
+      "noSourceUsersLoaded": "Nie załadowano jeszcze żadnych użytkowników źródłowych.",
+      "noActiveTargetUsers": "Nie znaleziono aktywnych użytkowników docelowych. Utwórz lub ponownie włącz użytkownika BookOrbit przed mapowaniem.",
+      "pathPrefixMappings": "Mapowania prefiksów ścieżek",
+      "addMapping": "Dodaj mapowanie",
+      "pathMappingsExplanation": "Mapowania ścieżek tłumaczą ścieżki plików źródłowych na ścieżki docelowe, dzięki czemu książki można dopasowywać na podstawie lokalizacji pliku. Książki są również dopasowywane za pomocą ISBN, skrótu pliku i tytułu/autora, niezależnie od mapowania ścieżek.",
+      "noPrefixesFound": "Nie znaleziono prefiksów - najpierw sprawdź źródło",
+      "selectSourcePrefix": "Wybierz prefiks źródłowy...",
+      "selectTargetFolder": "Wybierz folder docelowy...",
+      "remove": "Usuń",
+      "saveMappings": "Zapisz mapowania",
+      "pathValidation": {
+        "title": "Walidacja ścieżki",
+        "mappedSummary": "{mapped} z {total} książek źródłowych ma zmapowaną ścieżkę",
+        "unmatched": "{count} zamapowanych ścieżek nie znaleziono na dysku",
+        "allMatched": "Na dysku znaleziono wszystkie {count} zmapowane ścieżki"
+      }
+    },
+    "dryRun": {
+      "run": "Uruchomienie na sucho",
+      "matched": "Dopasowane:",
+      "unresolved": "Nierozwiązane:",
+      "duplicates": "Duplikaty:",
+      "unresolvedSummary": "Nierozwiązane podsumowanie"
+    },
+    "duplicates": {
+      "title": "Rozwiąż zduplikowane dopasowania docelowe",
+      "explanation": "Dla każdej książki docelowej wybierz jedną książkę źródłową, którą chcesz zachować. Zalecane opcje są wstępnie wybierane, gdy istnieje jedno najsilniejsze dopasowanie.",
+      "remainingGroups": "Pozostałe grupy:",
+      "ofCount": "z {total}",
+      "targetBookId": "Książka docelowa #{id}",
+      "recommended": "Zalecane",
+      "resolveButton": "{count, plural, =0 {Rozwiąż # duplikat} one {Rozwiąż # duplikat} other {Rozwiąż # duplikaty} few {Rozwiąż # duplikaty} many {Rozwiąż # duplikatów}}",
+      "sourceRecordId": "Identyfikator rekordu źródłowego #{id}",
+      "byAuthor": "autor: {author} (identyfikator: {id})",
+      "byFilePath": "{filePath} (identyfikator: {id})",
+      "bookloreSourceId": "Identyfikator źródła Booklore: {id}",
+      "libraryBookId": "Książka biblioteczna #{id}"
+    },
+    "preflight": {
+      "title": "Kontrole przed lotem",
+      "allPassed": "Wszystkie kontrole zostały pomyślnie zakończone - gotowe do migracji",
+      "sourceValidated": "Źródło potwierdzone",
+      "saveAndValidateSource": "Zapisz i zatwierdź połączenie źródłowe",
+      "validateSourceConnection": "Sprawdź połączenie źródłowe",
+      "mappingsSaved": "Mapowania zostały zapisane",
+      "saveUserAndPathMappings": "Zapisz mapowania użytkowników i ścieżek",
+      "pathMappingsValidated": "Zatwierdzono mapowania ścieżek",
+      "savePathMappingsToValidate": "Zapisz mapowania ścieżek, aby je sprawdzić",
+      "dryRunUpToDate": "Praca na sucho jest aktualna",
+      "runFreshDryRun": "Przeprowadź nową próbę próbną",
+      "issues": {
+        "saveSource": "Zapisz ustawienia połączenia źródłowego",
+        "validateSource": "Sprawdź połączenie źródłowe",
+        "saveMappings": "Zapisz mapowania użytkowników i ścieżek",
+        "savePathMappings": "Zapisz mapowania ścieżek, aby je sprawdzić",
+        "freshDryRun": "Przeprowadź nową próbę próbną",
+        "resolveDuplicates": "Rozwiąż zduplikowane dopasowania księgi docelowej w trybie próbnym",
+        "waitForRun": "Poczekaj na zakończenie aktywnego przebiegu"
+      }
+    },
+    "run": {
+      "confirmPrompt": "Rozpocznie się migracja na żywo. Czy jesteś pewien?",
+      "confirmStart": "Potwierdź rozpoczęcie",
+      "startMigration": "Rozpocznij migrację",
+      "cancelRun": "Anuluj bieg",
+      "refreshStatus": "Odśwież stan",
+      "pollingStopped": "Odpytywanie stanu zostało zatrzymane z powodu błędu.",
+      "retry": "Spróbuj ponownie",
+      "stage": "Etap: {stage}",
+      "initializing": "inicjowanie",
+      "ended": "Zakończono {time}"
+    },
+    "report": {
+      "noRunYet": "Nie przeprowadzono jeszcze migracji. Aby rozpocząć, wykonaj powyższe kroki.",
+      "runNumber": "Uruchom #{id}",
+      "notStarted": "Nie rozpoczęte",
+      "reloadReport": "Załaduj ponownie raport",
+      "loadFullReport": "Załaduj pełny raport",
+      "exportJson": "Eksportuj JSON",
+      "exportCsv": "Eksportuj CSV",
+      "migrationFailed": "Migracja nie powiodła się",
+      "retryFromLastStage": "Spróbuj ponownie od ostatniego ukończonego etapu",
+      "booksSection": "Książki",
+      "metadataOverlays": "Zastosowano nakładki metadanych",
+      "authorMappings": "Zastąpiono mapowania autora",
+      "narratorMappings": "Zastąpiono mapowania Narratora",
+      "genreMappings": "Zastąpiono mapowania gatunków",
+      "tagMappings": "Zastąpiono mapowania tagów",
+      "coversImported": "Okładki importowane",
+      "coverImportSkipped": "Pominięto import okładki – ścieżka główna nośnika nie została skonfigurowana",
+      "couldNotMatch": "Nie udało się dopasować",
+      "userDataSection": "Dane użytkownika",
+      "readingStatuses": "Odczyt statusów",
+      "readingProgressEntries": "Czytanie wpisów o postępie",
+      "audiobookProgressEntries": "Wpisy dotyczące postępu audiobooka",
+      "readingSessions": "Sesje czytelnicze",
+      "bookmarks": "Zakładki",
+      "annotations": "Adnotacje",
+      "collectionEntries": "Wpisy kolekcji",
+      "loadFullReportHint": "Kliknij „Załaduj pełny raport”, aby dołączyć podsumowanie dopasowania próbnego do wyeksportowanego raportu.",
+      "completedNoIssues": "Migracja zakończyła się bez nierozwiązanych ksiąg i błędów.",
+      "matchedBooks": "Pasujące książki ({count})",
+      "matchedBooksExplanation": "Te dopasowania próbne wykorzystano do podjęcia decyzji, które książki biblioteczne otrzymały zaimportowane dane.",
+      "sourceBook": "Książka źródłowa {id}",
+      "libraryBook": "Książka biblioteczna {id}",
+      "unresolvedBooks": "Nierozwiązane książki ({count})",
+      "unresolvedBooksExplanation": "Te książki istnieją w źródle, ale nie można ich dopasować do żadnej książki w Twojej bibliotece.",
+      "mappedUsers": "Zmapowani użytkownicy ({count})",
+      "mappedUsersExplanation": "Sumy na użytkownika pochodzą z próbnego podglądu zapisanego w pamięci podręcznej wraz z planem migracji.",
+      "coverFailures": "{count} importowanie okładek nie powiodło się. Szczegółowe wiersze błędów nie są przechowywane.",
+      "userPreviewCounts": "{statuses} statusy, {progress} wpisy postępu, {sessions} sesje czytania, {bookmarks} zakładki, {annotations} adnotacje, {collections} wpisy do kolekcji"
+    },
+    "unresolvedReason": {
+      "noTitleAuthorMatch": "Nie znaleziono pasującej książki według tytułu lub autora",
+      "noFilePathMatch": "Ścieżka pliku nie pasuje do żadnej książki w tej bibliotece",
+      "noFileHashMatch": "Skrót pliku nie pasuje do żadnej książki w tej bibliotece",
+      "noIsbnMatch": "ISBN nie pasuje do żadnej książki w tej bibliotece",
+      "insufficientSourceData": "Za mało metadanych, aby podjąć próbę dopasowania",
+      "ambiguousIsbnMatch": "Wiele książek pasuje do tego samego ISBN",
+      "ambiguousFileHashMatch": "Wiele książek pasowało do tego samego skrótu pliku",
+      "ambiguousFilePathMatch": "Wiele książek miało tę samą ścieżkę pliku",
+      "ambiguousTitleAuthorMatch": "Wiele książek miało ten sam tytuł i autora",
+      "unknown": "Nie udało się określić przyczyny"
+    },
+    "matchStrategy": {
+      "isbn": "Dopasowane przez ISBN",
+      "fileHash": "Dopasowane według skrótu pliku",
+      "pathMapping": "Dopasowane według zmapowanej ścieżki pliku",
+      "titleAuthor": "Dopasowane według tytułu i autora",
+      "unavailable": "Strategia meczowa niedostępna"
+    },
+    "connectionError": {
+      "unreachable": "Nie można połączyć się z serwerem bazy danych. Sprawdź hosta i port.",
+      "authFailed": "Uwierzytelnienie nie powiodło się. Sprawdź nazwę użytkownika i hasło.",
+      "databaseNotFound": "Nie znaleziono bazy danych. Sprawdź nazwę bazy danych.",
+      "timeout": "Upłynął limit czasu połączenia. Sprawdź ustawienia hosta i zapory sieciowej.",
+      "generic": "Test połączenia nie powiódł się"
+    },
+    "userSelect": {
+      "placeholder": "Wybierz użytkownika",
+      "noUsersFound": "Nie znaleziono żadnych użytkowników"
+    },
+    "toast": {
+      "initFailed": "Nie udało się zainicjować ustawień migracji",
+      "loadSupportedTypesFailed": "Nie udało się załadować obsługiwanych typów źródeł migracji",
+      "loadTargetUsersFailed": "Nie udało się załadować docelowych użytkowników",
+      "loadTargetFoldersFailed": "Nie udało się załadować docelowych folderów biblioteki",
+      "noSourceUsers": "Nie zwrócono żadnych użytkowników źródłowych",
+      "suggestionsLoaded": "Załadowano sugestie mapowania użytkownika",
+      "loadSuggestionsFailed": "Nie udało się załadować sugestii mapowania użytkownika",
+      "sourceFieldsRequired": "Wymagane są nazwa hosta, użytkownika, bazy danych i źródła",
+      "connectionPassedWithWarnings": "Test połączenia zaliczony z ostrzeżeniami",
+      "connectionPassedWithWarningCount": "Test połączenia zaliczony z {count} ostrzeżeniami. Po pierwsze: {warning}",
+      "connectionPassed": "Test połączenia przeszedł pomyślnie",
+      "connectionMissingTables": "Połączenie jest w porządku, ale brakuje {count} wymaganych tabel",
+      "cannotTestMediaWhileRunning": "Nie można przetestować ścieżki multimediów, gdy przebieg jest aktywny",
+      "mediaPathRequired": "Do importowania okładek wymagana jest ścieżka główna nośnika.",
+      "mediaPathAbsolute": "Użyj ścieżki bezwzględnej (na przykład: /books).",
+      "mediaPathVerified": "Zweryfikowano ścieżkę multimediów.",
+      "mediaPathValid": "Ścieżka multimediów jest prawidłowa i czytelna",
+      "mediaPathValidationFailed": "Sprawdzanie ścieżki multimediów nie powiodło się.",
+      "connectionFailedBeforeMedia": "Test połączenia nie powiódł się przed zakończeniem sprawdzania ścieżki nośnika.",
+      "cannotModifySourceWhileRunning": "Nie można modyfikować źródła, gdy przebieg jest aktywny",
+      "sourceSavedWithWarnings": "Źródło zapisane i sprawdzone z {count} ostrzeżeniami",
+      "sourceSaved": "Źródło zapisane i sprawdzone",
+      "saveSourceFailed": "Nie udało się zapisać lub zweryfikować źródła",
+      "cannotSaveMappingsWhileRunning": "Nie można zapisać mapowań, gdy przebieg jest aktywny",
+      "saveSourceFirst": "Najpierw zapisz źródło",
+      "mapAtLeastOneUser": "Zamapuj co najmniej jednego użytkownika źródłowego na użytkownika docelowego",
+      "mapEveryUser": "Mapuj każdego użytkownika źródłowego przed zapisaniem",
+      "pathValidationFailedButSaved": "Weryfikacja ścieżki nie powiodła się, ale profil nadal zostanie zapisany",
+      "mappingsSaved": "Mapowania zostały zapisane",
+      "saveMappingsFailed": "Nie udało się zapisać mapowań",
+      "cannotDryRunWhileRunning": "Nie można uruchomić trybu próbnego, gdy przebieg jest aktywny",
+      "saveMappingsFirst": "Najpierw zapisz mapowania",
+      "dryRunCompleted": "Próba próbna zakończona: {matched} dopasowana, {unresolved} nierozwiązana",
+      "dryRunFailed": "Próba próbna nie powiodła się",
+      "selectSourceForDuplicates": "Wybierz książkę źródłową dla wszystkich {count} zduplikowanych grup",
+      "duplicatesResolved": "Zduplikowane mecze rozwiązane",
+      "resolveDuplicatesFailed": "Nie udało się rozwiązać duplikatów",
+      "preflightNotReady": "Wstępna inspekcja migracji nie jest gotowa",
+      "runDryRunFirst": "Najpierw wykonaj próbę na sucho",
+      "runStarted": "Rozpoczęto przebieg migracji",
+      "startFailed": "Nie udało się rozpocząć migracji",
+      "runCancelled": "Przebieg migracji anulowany",
+      "cancelFailed": "Nie udało się anulować migracji",
+      "runRetried": "Ponówono próbę migracji - wznawianie od ostatniego ukończonego etapu",
+      "retryFailed": "Nie udało się ponowić próby migracji",
+      "loadProgressFailed": "Nie udało się wczytać postępu uruchomienia",
+      "startMigrationFirst": "Najpierw rozpocznij migrację",
+      "reportRefreshed": "Uruchom raport odświeżony",
+      "loadReportFailed": "Nie udało się załadować raportu z uruchomienia",
+      "reportExported": "Raport wyeksportowany jako {format}",
+      "exportFailed": "Nie udało się wyeksportować raportu migracji"
+    }
+  },
+  "notifications": {
+    "title": "Powiadomienia",
+    "markAllRead": "Zaznacz wszystkie jako przeczytane",
+    "clear": "Wyczyść",
+    "empty": "Nie ma jeszcze żadnych powiadomień",
+    "loadMore": "Załaduj więcej powiadomień",
+    "preferences": {
+      "title": "Powiadomienia",
+      "subtitle": "Wybierz, jakie kategorie powiadomień chcesz otrzymywać.",
+      "saving": "Zapisywanie...",
+      "unsavedChanges": "Niezapisane zmiany",
+      "saved": "Zapisano preferencje powiadomień",
+      "saveFailed": "Nie udało się zapisać preferencji",
+      "savePreferenceFailed": "Nie udało się zapisać preferencji",
+      "whatsNewToggle": "Pokaż „Co nowego” po aktualizacjach",
+      "whatsNewToggleHint": "Wyskakujące okienko prezentujące nowe funkcje po aktualizacji aplikacji. Archiwum pozostaje dostępne w obu przypadkach."
+    }
+  },
+  "reader": {
+    "retry": "Spróbuj ponownie",
+    "pdf": {
+      "openError": "Nie można otworzyć tego PDF",
+      "preparing": "Przygotowanie czytnika PDF",
+      "opening": "Otwarcie PDF"
+    },
+    "loadingBook": "Ładowanie książki…",
+    "failedToLoadBook": "Nie udało się załadować książki",
+    "chapterNumber": "Rozdział {number}",
+    "peek": {
+      "badge": "Zerkanie",
+      "startReading": "Zacznij czytać"
+    },
+    "toast": {
+      "linkedHighlightError": "Nie można otworzyć połączonej pozycji podświetlenia",
+      "resumed": "Wznowiono w {pct}% - {label}"
+    },
+    "header": {
+      "goBack": "Wróć",
+      "tableOfContents": "Spis treści",
+      "toggleBookmark": "Przełącz zakładkę",
+      "cycleFooterMode": "Tryb informacyjny stopki cyklu",
+      "keyboardShortcutsHint": "Skróty klawiaturowe (?)",
+      "enterFullscreen": "Wejdź na pełny ekran",
+      "exitFullscreen": "Wyjdź z pełnego ekranu",
+      "footerMode": {
+        "pageProgress": "Informacje w stopce: strona + postęp",
+        "sessionTimeLeft": "Informacje w stopce: sesja czytania + pozostały czas",
+        "chapterTimeLeft": "Informacje w stopce: rozdział + pozostały czas rozdziału"
+      }
+    },
+    "footer": {
+      "previousSection": "Poprzednia sekcja",
+      "nextSection": "Następna sekcja",
+      "goToPlaceholder": "45 lub s. 123",
+      "jumpToLocation": "Skocz do lokalizacji",
+      "jumpTooltip": "Skok do % lub strony (np. 45 lub p123)",
+      "go": "Idź"
+    },
+    "settings": {
+      "title": "Ustawienia",
+      "ariaLabel": "Ustawienia czytnika",
+      "tabs": {
+        "appearance": "Wygląd",
+        "text": "Tekst",
+        "layout": "Układ"
+      },
+      "appearance": {
+        "mode": "Tryb",
+        "light": "Światło",
+        "dark": "Ciemny",
+        "colorTheme": "Motyw koloru"
+      },
+      "text": {
+        "fontSize": "Rozmiar czcionki",
+        "fontSizeRange": "Zakres: 10-32px",
+        "lineHeight": "Wysokość linii",
+        "lineHeightRange": "Zakres: 0,8-3,0",
+        "fontFamily": "Rodzina czcionek",
+        "fontFamilyDescription": "Wybierz wbudowane lub przesłane czcionki dla tekstu podstawowego.",
+        "builtIn": "Wbudowany",
+        "yourFonts": "Twoje czcionki"
+      },
+      "layout": {
+        "pageSpreads": "Strona się rozprzestrzenia",
+        "pageSpreadsDescription": "Wybierz sposób, w jaki ten oparty na obrazie EPUB łączy strony w pary.",
+        "bookDefault": "Książka domyślna",
+        "singlePage": "Pojedyncza strona",
+        "readingFlow": "Czytanie",
+        "readingFlowDescription": "Przełączanie pomiędzy przewijaniem stronicowanym i ciągłym.",
+        "paginated": "Paginowane",
+        "scrolled": "Przewinięte",
+        "textColumns": "Kolumny tekstowe",
+        "textColumnsRange": "Zakres: 1-10",
+        "columnGap": "Szczelina kolumny",
+        "columnGapRange": "Zakres: 0-50%",
+        "maxWidth": "Maksymalna szerokość",
+        "maxWidthRange": "Zakres: 400-1600",
+        "justifyText": "Justuj tekst",
+        "justifyTextDescription": "Włącz wyrównanie akapitu na całej szerokości.",
+        "hyphenation": "Dzielenie wyrazów",
+        "hyphenationDescription": "Włącz automatyczne dzielenie wyrazów."
+      }
+    },
+    "search": {
+      "placeholder": "Szukaj w książce (min. {min} znaków)...",
+      "searching": "Wyszukiwanie…",
+      "tooShort": "Wpisz co najmniej {min} znaków",
+      "noResults": "Nie znaleziono żadnych wyników",
+      "prompt": "Wpisz, aby wyszukać",
+      "resultCount": "{count, plural, =0 {żadnych wyników} one {# wynik} other {# wyniki} few {# wyniki} many {# wyników}}"
+    },
+    "sidebar": {
+      "tabs": {
+        "chapters": "Rozdziały",
+        "bookmarks": "Zakładki",
+        "highlights": "Najważniejsze",
+        "toc": "Spis treści",
+        "tocShort": "Spis treści",
+        "marksShort": "Znaki",
+        "notesShort": "Notatki"
+      },
+      "pin": "Przypnij pasek boczny",
+      "unpin": "Odepnij pasek boczny",
+      "close": "Zamknij pasek boczny",
+      "noChapters": "Nie znaleziono rozdziałów",
+      "noBookmarks": "Nie ma jeszcze żadnych zakładek",
+      "noBookmarksMatch": "Żadne zakładki nie pasują do wybranych filtrów",
+      "noHighlights": "Nie ma jeszcze żadnych najważniejszych wydarzeń",
+      "noHighlightsMatch": "Żadne najciekawsze momenty nie pasują do wybranych filtrów",
+      "searchBookmarks": "Wyszukaj zakładki...",
+      "searchHighlights": "Wyszukaj najważniejsze informacje...",
+      "bookmarkFallback": "Zakładka",
+      "locationUnavailable": "Lokalizacja niedostępna",
+      "customColor": "Niestandardowe ({color})",
+      "allColors": "Wszystkie kolory",
+      "allChapters": "Wszystkie rozdziały",
+      "notesOnly": "Tylko notatki",
+      "deleteBookmark": "Usuń zakładkę",
+      "deleteHighlight": "Usuń wyróżnienie",
+      "approximatePosition": "Synchronizowane z urządzenia; dokładna pozycja niedostępna, powoduje przejście do rozdziału",
+      "sort": {
+        "readingOrder": "Kolejność czytania",
+        "newest": "Najpierw najnowsze",
+        "oldest": "Najpierw najstarszy"
+      }
+    },
+    "selection": {
+      "copy": "Kopiuj",
+      "copied": "Skopiowano!",
+      "highlight": "Zaznacz",
+      "translate": "Przetłumacz",
+      "define": "Zdefiniuj",
+      "deleteAnnotation": "Usuń adnotację",
+      "apply": "Zastosuj"
+    },
+    "note": {
+      "title": "Dodaj notatkę",
+      "placeholder": "Napisz notatkę…"
+    },
+    "dictionary": {
+      "noDefinition": "Nie znaleziono definicji",
+      "loadError": "Nie można wczytać definicji"
+    },
+    "translation": {
+      "original": "Oryginał",
+      "translation": "Tłumaczenie",
+      "translating": "Tłumaczenie...",
+      "noTranslation": "Nie ma jeszcze tłumaczenia",
+      "viaProvider": "przez {provider}",
+      "copyTranslation": "Kopiuj tłumaczenie"
+    },
+    "shortcuts": {
+      "title": "Skróty klawiaturowe",
+      "groups": {
+        "panels": "Panele",
+        "reading": "Czytanie",
+        "actions": "Działania"
+      },
+      "toggleToc": "Przełącz spis treści",
+      "toggleSearch": "Przełącz wyszukiwanie",
+      "toggleHelp": "Pokaż/ukryj tę pomoc",
+      "closePanel": "Zamknij panel",
+      "prevNextPage": "Poprzednia/następna strona",
+      "goToStart": "Przejdź do początku książki",
+      "goToEnd": "Przejdź do końca książki",
+      "toggleBookmark": "Przełącz zakładkę",
+      "toggleFullscreen": "Przełącz tryb pełnoekranowy",
+      "cycleFooterMode": "Tryb informacyjny stopki cyklu"
+    },
+    "cbz": {
+      "tabs": {
+        "view": "Zobacz",
+        "reading": "Czytanie",
+        "layout": "Układ"
+      },
+      "fitMode": "Tryb dopasowania",
+      "background": "Tło",
+      "scrollMode": "Tryb przewijania",
+      "scrollModeHint": "W przypadku webtoonów i pasków pionowych użyj opcji „Bez przerw”.",
+      "readingDirection": "Kierunek czytania",
+      "pageView": "Widok strony",
+      "autoFallback": "Automatyczny powrót",
+      "spreadAlignmentLabel": "Wyrównanie rozprzestrzeniania się",
+      "spreadAlignmentHint": "Wyrównanie rozkładu jest niedostępne w trybie automatycznego powrotu.",
+      "spreadGap": "Rozłóż lukę",
+      "spreadGapValue": "{value}px",
+      "focusTwoPageToggle": "Przełącznik fokusu na dwie strony",
+      "forceTwoPage": "Wymuś dwie strony",
+      "off": "Wyłączone",
+      "on": "Włączone",
+      "widePages": "Szerokie strony",
+      "resetBookViewSettings": "Zresetuj ustawienia widoku książki",
+      "resetConfirm": "Zresetować ustawienia widoku tej książki do ustawień globalnych?",
+      "firstPage": "Pierwsza strona",
+      "lastPage": "Ostatnia strona",
+      "fit": {
+        "page": "Dopasowanie strony",
+        "width": "Szerokość strony",
+        "height": "Wysokość strony",
+        "actual": "Rzeczywisty rozmiar"
+      },
+      "view": {
+        "single": "Pojedynczy",
+        "twoPage": "Dwustronicowe"
+      },
+      "scroll": {
+        "paged": "Stronicowane",
+        "infinite": "Nieskończony",
+        "noGaps": "Żadnych luk"
+      },
+      "direction": {
+        "ltr": "L do R",
+        "rtl": "R do L"
+      },
+      "spreadAlignment": {
+        "normal": "Normalne",
+        "shifted": "Przesunięty"
+      },
+      "widePage": {
+        "auto": "Automat",
+        "inSpreads": "W spreadach"
+      },
+      "bg": {
+        "black": "Czarny",
+        "gray": "Szary",
+        "white": "Biały"
+      }
+    },
+    "audiobook": {
+      "untitled": "Bez tytułu",
+      "loading": "Ładowanie audiobooka...",
+      "loadError": "Nie udało się załadować audiobooka",
+      "noAudioFiles": "Nie znaleziono plików audio dla tej książki.",
+      "speed": "Prędkość",
+      "chapters": "Rozdziały",
+      "bookmarks": "Zakładki",
+      "volume": "Głośność",
+      "muted": "Wyciszony",
+      "sleep": "Spać",
+      "chapterAbbrev": "Ch.",
+      "sleepTimer": "Timer uśpienia",
+      "minutes": "{count} minut",
+      "endOfChapter": "Koniec rozdziału",
+      "noChaptersAvailable": "Brak dostępnych rozdziałów",
+      "extend15": "+ 15 minut",
+      "timeLeft": "(pozostało {time})",
+      "playbackSpeed": "Szybkość odtwarzania",
+      "noChapters": "Brak dostępnych rozdziałów.",
+      "noBookmarks": "Nie ma jeszcze żadnych zakładek.",
+      "noBookmarksHint": "Kliknij ikonę zakładki u góry, aby zapisać swoją aktualną pozycję.",
+      "playerSettings": "Ustawienia gracza",
+      "skipBack": "Przejdź z powrotem",
+      "skipForward": "Przejdź do przodu"
+    }
+  },
+  "scanner": {
+    "filesProgress": "{processed}/{total} plików",
+    "booksFound": "{count, plural, =0 {nie znaleziono żadnych książek} one {# znaleziona książka} other {# znalezione książki} few {Znaleziono # książki} many {Znaleziono # książek}}"
+  },
+  "series": {
+    "completion": {
+      "readOfTotal": "{read} z {total} przeczytane ({percentage}%)"
+    },
+    "gaps": {
+      "label": "Możliwe luki:"
+    },
+    "filters": {
+      "title": "Filtry serii",
+      "clearAll": "Wyczyść wszystko",
+      "allLibraries": "Wszystkie biblioteki",
+      "allCompletion": "Wszystko ukończone",
+      "notStarted": "Nie rozpoczęte",
+      "inProgress": "W toku",
+      "complete": "Kompletny"
+    },
+    "list": {
+      "title": "Seria",
+      "showControlsAria": "Pokaż kontrolki serii",
+      "searchPlaceholder": "Wyszukaj serię lub autora",
+      "sortButton": "Sortuj",
+      "sortBy": "Sortuj według",
+      "ascending": "Rosnąco",
+      "descending": "Malejąco",
+      "ascShort": "rosnąco",
+      "descShort": "Opis",
+      "filters": "Filtry",
+      "clear": "Wyczyść",
+      "noMatch": "Żadna seria nie pasuje do wybranych filtrów.",
+      "empty": "W Twoich bibliotekach nie znaleziono serii.",
+      "sort": {
+        "name": "Imię",
+        "bookCount": "Liczba książek",
+        "recentAdditions": "Najnowsze dodatki",
+        "readingProgress": "Postęp czytania"
+      }
+    },
+    "detail": {
+      "pageTitle": "Seria",
+      "pageTitleNamed": "Seria · {name}",
+      "pageTitleWithId": "Seria #{id}",
+      "entityName": "Seria",
+      "bookCount": "{count, plural, =0 {żadnych książek} one {# książka} other {# książki} few {# książki} many {# książek}}",
+      "byAuthors": "przez {authors}",
+      "moreAuthors": "+{count} więcej",
+      "preparingEditor": "Przygotowywanie edytora...",
+      "editMetadata": "Edytuj metadane",
+      "firstInSeries": "Pierwszy w serii",
+      "untitled": "Bez tytułu",
+      "loadingFirstBook": "Ładowanie podglądu pierwszej książki...",
+      "showLess": "Pokaż mniej",
+      "showMore": "Pokaż więcej",
+      "moreGenres": "+{count} więcej",
+      "synopsis": "Streszczenie",
+      "noDescription": "Brak opisu.",
+      "updatingPreview": "Aktualizuję podgląd...",
+      "noBooksToPreview": "Brak książek do podglądu.",
+      "loadingSeries": "Ładowanie serii...",
+      "booksHeading": "Książki",
+      "allLibraries": "Wszystkie biblioteki",
+      "groupByMedia": "Grupuj według mediów",
+      "noBooksFound": "Nie znaleziono książek z tej serii",
+      "trySelectingLibrary": "Spróbuj wybrać inną bibliotekę.",
+      "allBooksLoaded": "Załadowano wszystkie {count} książki",
+      "leadBookLoadError": "Nie udało się załadować szczegółów księgi potencjalnych klientów",
+      "noBooksToEdit": "W tej serii nie ma książek do edycji.",
+      "loadFullSeriesError": "Nie udało się wczytać całej serii do edycji.",
+      "sort": {
+        "seriesOrder": "Zamówienie serii",
+        "title": "Tytuł",
+        "recentlyAdded": "Ostatnio dodane"
+      },
+      "order": {
+        "ascending": "Rosnąco",
+        "descending": "Malejąco"
+      }
+    }
+  },
+  "smartScope": {
+    "syncToKobo": "Synchronizuj z Kobo",
+    "syncToKoboHint": "Książki pasujące do tego zakresu pojawią się na Twoim urządzeniu Kobo",
+    "dialog": {
+      "name": "Imię",
+      "namePlaceholder": "np. Nieprzeczytane science-fiction",
+      "icon": "Ikona",
+      "iconPlaceholder": "Wybierz ikonę...",
+      "nameRequired": "Imię i nazwisko jest wymagane",
+      "iconRequired": "Wybierz ikonę",
+      "create": "Utwórz",
+      "creating": "Tworzenie...",
+      "saving": "Zapisywanie..."
+    },
+    "createDialog": {
+      "title": "Nowy inteligentny zakres",
+      "visibleToAll": "Widoczne dla wszystkich użytkowników",
+      "createFailed": "Nie udało się utworzyć inteligentnego zakresu"
+    },
+    "saveAsDialog": {
+      "title": "Zapisz jako SmartScope",
+      "save": "Zapisz SmartScope",
+      "saveFailed": "Nie udało się zapisać inteligentnego zakresu"
+    },
+    "editorPanel": {
+      "untitled": "Bez tytułu SmartScope",
+      "subtitle": "Skonfiguruj ustawienia inteligentnego zasięgu",
+      "counting": "liczenie...",
+      "bookCount": "{count, plural, =0 {żadnych książek} one {jedna książka} other {# książki} few {# książki} many {# książek}}",
+      "identity": "Tożsamość",
+      "filters": "Filtry",
+      "noFilters": "Nie ustawiono żadnych filtrów. Wszystkie dostępne książki zostaną uwzględnione w tym inteligentnym zakresie.",
+      "buildFromScratch": "Buduj od zera",
+      "replaceWithTemplate": "Zamień na szablon:",
+      "defaultSort": "Sortowanie domyślne",
+      "saveChanges": "Zapisz zmiany",
+      "saveFailed": "Nie udało się zapisać",
+      "templates": {
+        "hasSeries": "Ma serię",
+        "addedRecently": "Dodano niedawno",
+        "pdfOnly": "PDF Tylko",
+        "noGenres": "Brak gatunków",
+        "epubOnly": "EPUB Tylko"
+      }
+    }
+  },
+  "statistics": {
+    "tabs": {
+      "library": "Statystyki biblioteki",
+      "user": "Moje czytanie"
+    },
+    "filter": {
+      "allLibraries": "Wszystkie biblioteki",
+      "librarySelection": "{count} z {total} bibliotek"
+    },
+    "config": {
+      "button": "Skonfiguruj",
+      "title": "Konfiguruj wykresy",
+      "description": "Przeciągnij, aby zmienić kolejność, przełącz, aby pokazać lub ukryć.",
+      "reset": "Przywróć ustawienia domyślne"
+    },
+    "summary": {
+      "books": "Książki",
+      "authors": "Autorzy",
+      "series": "Seria",
+      "publishers": "Wydawcy",
+      "storage": "Przechowywanie",
+      "genres": "Gatunki",
+      "languages": "Języki",
+      "published": "Opublikowano",
+      "thisYear": "W tym roku",
+      "started": "Rozpoczęło się",
+      "inProgress": "W toku",
+      "completed": "Ukończono",
+      "avgProgress": "Średni postęp"
+    },
+    "card": {
+      "loadError": "Nie udało się załadować danych",
+      "emptyTitle": "Brak danych",
+      "emptyDescription": "Brak danych dla tego wykresu",
+      "unknownField": "{count, plural, =0 {brak danych dla tego pola} one {# książka nie zawiera danych dla tego pola} other {# książki nie mają danych dla tego pola} few {# książki nie mają danych dla tego pola} many {# książek nie ma danych w tym polu}}"
+    },
+    "breakdown": {
+      "ariaLabel": "Podział według źródła lub formatu"
+    },
+    "empty": {
+      "notEnoughData": "Jeszcze za mało danych"
+    },
+    "charts": {
+      "acquisitionLag": {
+        "title": "Opóźnienie w przejęciu"
+      },
+      "booksAddedOverTime": {
+        "title": "Książki dodawane z biegiem czasu",
+        "monthly": "Miesięcznie",
+        "yearly": "Rocznie",
+        "allTime": "Cały czas",
+        "last5Years": "Ostatnie 5 lat",
+        "lastYear": "Ostatni rok"
+      },
+      "formatDistribution": {
+        "title": "Dystrybucja formatu"
+      },
+      "formatShareOverTime": {
+        "title": "Formatuj udział w czasie"
+      },
+      "genreCooccurrence": {
+        "title": "Współwystępowanie gatunków"
+      },
+      "genreDistribution": {
+        "title": "Dystrybucja gatunku"
+      },
+      "languageDistribution": {
+        "title": "Dystrybucja języka"
+      },
+      "largestBooks": {
+        "title": "Top 50 największych książek"
+      },
+      "libraryIntegrity": {
+        "title": "Uczciwość biblioteki"
+      },
+      "libraryMetadataCompleteness": {
+        "title": "Kompletność metadanych biblioteki"
+      },
+      "metadataCompleteness": {
+        "title": "Kompletność metadanych"
+      },
+      "metadataFreshness": {
+        "title": "Świeżość metadanych"
+      },
+      "metadataScoreDistribution": {
+        "title": "Dystrybucja wyników metadanych"
+      },
+      "pageCountDistribution": {
+        "title": "Dystrybucja liczby stron"
+      },
+      "publicationDecade": {
+        "title": "Dekada publikacji"
+      },
+      "publicationYearTimeline": {
+        "title": "Kalendarium roku publikacji"
+      },
+      "storageByFormat": {
+        "title": "Przechowywanie według formatu"
+      },
+      "topAuthors": {
+        "title": "25 najlepszych autorów"
+      },
+      "topSeries": {
+        "title": "50 najlepszych serii"
+      },
+      "booksCompleted": {
+        "title": "Książki ukończone",
+        "notEnoughData": "Potrzebujesz co najmniej {count} ukończonych książek dla tego wykresu."
+      },
+      "completionLatency": {
+        "title": "Opóźnienie ukończenia",
+        "notEnoughData": "Potrzebujesz co najmniej {count} ukończonych książek dla tego wykresu."
+      },
+      "completionTimeline": {
+        "title": "Harmonogram realizacji",
+        "notEnoughData": "Potrzebujesz co najmniej {count} ukończonych książek dla tego wykresu."
+      },
+      "favoriteReadingDays": {
+        "title": "Ulubione dni czytelnicze",
+        "notEnoughData": "Potrzebujesz co najmniej {count} zdarzeń odczytu dla tego wykresu."
+      },
+      "genreReadingTime": {
+        "title": "Czas czytania gatunku",
+        "notEnoughData": "Potrzebujesz co najmniej {count} gatunków z czasem czytania dla tego wykresu."
+      },
+      "goalTrajectory": {
+        "title": "Tempo kontra cel",
+        "noCompletedTitle": "Nie ma jeszcze ukończonych książek",
+        "noCompletedDescription": "W tym okresie uzupełnij książkę, aby porównać swoje tempo z rocznym celem.",
+        "notEnoughData": "Potrzebujesz co najmniej {count} ukończonych książek dla tego wykresu."
+      },
+      "peakReadingHours": {
+        "title": "Szczytowe godziny czytania",
+        "notEnoughData": "Potrzebujesz co najmniej {count} zdarzeń odczytu dla tego wykresu."
+      },
+      "progressFunnel": {
+        "title": "Lejek postępu",
+        "modePercent": "Procent",
+        "modeCounts": "Liczy się",
+        "modeDropoff": "Zrzut",
+        "started": "Rozpoczęto {count}",
+        "notEnoughData": "Potrzebujesz co najmniej {count} rozpoczętych książek dla tego wykresu.",
+        "noDropOffTitle": "Nie zaobserwowano żadnego spadku",
+        "noDropOffDescription": "Każda rozpoczęta książka przechodziła przez wszystkie etapy ścieżki w tym okresie."
+      },
+      "readingClock": {
+        "title": "Czytanie zegara",
+        "notEnoughData": "Potrzebujesz co najmniej {count} sesji czytania tego wykresu."
+      },
+      "readingHeatmap": {
+        "title": "Czytanie mapy cieplnej",
+        "notEnoughData": "Ten wykres wymaga aktywności przez co najmniej {count} dni."
+      },
+      "readingPace": {
+        "title": "Tempo czytania",
+        "notEnoughData": "Potrzebujesz co najmniej {count} sesji z danymi postępu dla tego wykresu."
+      },
+      "readingSessionTimeline": {
+        "title": "Harmonogram sesji czytelniczej",
+        "dragOn": "Przeciągnij: Włączone",
+        "dragOff": "Przeciągnij: wyłączone",
+        "prev": "Poprzednia",
+        "next": "Następny",
+        "week": "Tydzień {week}",
+        "dragHint": "Przeciągnij paski, aby przenieść sesje. Czas trwania jest zablokowany, a nakładające się sesje są odrzucane.",
+        "noSessionsTitle": "Brak sesji w tym tygodniu",
+        "noSessionsDescription": "Użyj opcji Poprzedni/Następny lub przycisku wyboru tygodnia, aby wyświetlić inny tydzień.",
+        "overlapError": "Sesja nakłada się na inną sesję w tym oknie",
+        "moveError": "Nie udało się przenieść sesji"
+      },
+      "sessionArchetypes": {
+        "title": "Archetypy sesji"
+      },
+      "sourceDistribution": {
+        "title": "Gdzie czytasz",
+        "emptyTitle": "Nie ma jeszcze żadnej aktywności związanej z czytaniem",
+        "emptyDescription": "Przeczytaj w Internecie KOReader lub Kobo, aby zobaczyć podział źródła."
+      }
+    }
+  },
+  "tools": {
+    "header": {
+      "entityManager": "Menedżer podmiotu",
+      "bulkRename": "Zbiorcza zmiana nazwy",
+      "duplicateBooks": "Duplikaty książek"
+    },
+    "entityTypes": {
+      "authors": "Autorzy",
+      "genres": "Gatunki",
+      "tags": "Tagi",
+      "narrators": "Narratorzy",
+      "publishers": "Wydawcy",
+      "languages": "Języki",
+      "series": "Seria"
+    },
+    "bulkRename": {
+      "previewToolbar": "Zmień nazwę podglądu",
+      "renameSettings": "Zmień nazwę ustawień",
+      "library": "Biblioteka",
+      "selectLibraryPlaceholder": "Wybierz bibliotekę...",
+      "noEligibleLibraries": "Żadna biblioteka nie ma włączonej zmiany nazwy pliku. Włącz tę opcję w Ustawieniach biblioteki.",
+      "refresh": "Odśwież",
+      "applyRename": "Zastosuj Zmień nazwę",
+      "showFullPaths": "Pokaż pełne ścieżki",
+      "columnsMenu": "Kolumny",
+      "renamingInProgress": "Zmiana nazwy plików - możesz w każdej chwili zrezygnować.",
+      "executionFailed": "Zbiorcza zmiana nazwy nie powiodła się",
+      "previewFailed": "Nie udało się załadować podglądu",
+      "noBooksMatch": "Nie znaleziono książek pasujących do bieżącego filtra.",
+      "openBookDetails": "Otwórz szczegóły książki",
+      "columns": {
+        "title": "Tytuł",
+        "currentPath": "Aktualna ścieżka",
+        "newPath": "Nowa ścieżka",
+        "status": "Stan"
+      },
+      "status": {
+        "willRename": "Zmieni nazwę",
+        "unchanged": "Niezmienione",
+        "collision": "Kolizja",
+        "noPattern": "Brak wzoru",
+        "error": "Błąd"
+      },
+      "filter": {
+        "all": "Wszystko"
+      },
+      "summary": {
+        "label": "Podsumowanie",
+        "toRename": "{count}, aby zmienić nazwę",
+        "unchanged": "{count} bez zmian",
+        "collisions": "{count, plural, =0 {# kolizja} one {# kolizja} other {# kolizje} few {# kolizje} many {# kolizji}}",
+        "errors": "{count, plural, =0 {# błąd} one {# błąd} other {# błędy} few {# błędy} many {# błędów}}"
+      },
+      "empty": {
+        "title": "Wybierz bibliotekę, aby rozpocząć",
+        "description": "Wybierz bibliotekę powyżej, aby wyświetlić podgląd zmian zmiany nazwy, filtrować według stanu i zastosować zbiorczą zmianę nazwy.",
+        "chooseLibrary": "Wybierz Bibliotekę"
+      },
+      "completed": {
+        "title": "Zbiorcza zmiana nazwy zakończona",
+        "stats": "{succeeded} zmieniono nazwę, {failed} nie powiodło się, {skipped} pominięto (łącznie {processed})"
+      },
+      "pagination": {
+        "showing": "Wyświetlanie {from}-{to} z {total}"
+      },
+      "confirmDialog": {
+        "title": "Potwierdź zbiorczą zmianę nazwy",
+        "body": "{count, plural, =0 {Spowoduje to zmianę nazw # książek na dysku. Pliki z kolizjami lub błędami zostaną pominięte. Tej akcji nie można cofnąć.} one {Spowoduje to zmianę nazwy # książki na dysku. Pliki z kolizjami lub błędami zostaną pominięte. Tej akcji nie można cofnąć.} other {Spowoduje to zmianę nazwy # książki na dysku. Pliki z kolizjami lub błędami zostaną pominięte. Tej akcji nie można cofnąć.} few {Spowoduje to zmianę nazw # książek na dysku. Pliki z kolizjami lub błędami zostaną pominięte. Tej akcji nie można cofnąć.} many {Spowoduje to zmianę nazw # książek na dysku. Pliki z kolizjami lub błędami zostaną pominięte. Tej akcji nie można cofnąć.}}",
+        "renameButton": "{count, plural, =0 {Zmień nazwy # książek} one {Zmień nazwę # książki} other {Zmień nazwę # książki} few {Zmień nazwy # książek} many {Zmień nazwy # książek}}"
+      }
+    },
+    "bookDuplicates": {
+      "scanSettings": "Ustawienia skanowania",
+      "title": "Duplikaty książek",
+      "description": "Skanuj pliki i metadane w poszukiwaniu potencjalnych duplikatów rekordów. Podczas skanowania nic nie jest usuwane.",
+      "scope": "Zakres biblioteki",
+      "allLibraries": "Wszystkie dostępne biblioteki",
+      "similarity": "Próg podobnego tytułu",
+      "explainSimilarity": "Wyjaśnij próg o podobnym tytule",
+      "similarityHelp": "Tylko w przypadku podobnych dopasowań tytułu i autora. Co najmniej jeden autor i typ książki również muszą być zgodne. Opcja Lower pozwala znaleźć więcej możliwych duplikatów; wyższa wymaga bliższych tytułów. Identyczne pliki, ISBN i dokładne metadane są sprawdzane osobno.",
+      "runScan": "Uruchom skanowanie",
+      "rescan": "Skanuj ponownie",
+      "status": {
+        "queued": "Skanowanie w kolejce",
+        "running": "Skanowanie książek"
+      },
+      "groupsFound": "{count, plural, =0 {Brak zduplikowanych grup} one {Jedna zduplikowana grupa} other {# zduplikowanej grupy} few {# zduplikowane grupy} many {# zduplikowanych grup}}",
+      "filter": "Typ dopasowania",
+      "allReasons": "Wszystkie typy dopasowań",
+      "reasons": {
+        "file_hash": "Identyczny zestaw plików",
+        "isbn": "To samo ISBN",
+        "exact_metadata": "Dokładny tytuł i autorzy",
+        "fuzzy_metadata": "Podobny tytuł i autor"
+      },
+      "similarityValue": "{percent}% podobieństwa tytułów",
+      "notDuplicates": "Nie duplikaty",
+      "keepThis": "Zachowaj tę książkę",
+      "discardThis": "Wyrzuć tę książkę",
+      "selectKeeperFirst": "Najpierw wybierz bramkarza",
+      "noDirectMatch": "Brak bezpośredniego meczu z bramkarzem",
+      "moreFiles": "+{count} więcej",
+      "showDetails": "Pokaż szczegóły",
+      "hideDetails": "Ukryj szczegóły",
+      "deleteSelected": "Usuń wybrane {count}",
+      "openBook": "Otwórz szczegóły {title}",
+      "unknownAuthor": "Nieznany autor",
+      "unknown": "Nieznany",
+      "none": "Żadne",
+      "accessDenied": "Nie masz uprawnień do korzystania z narzędzia do tworzenia kopii książek.",
+      "pairDetails": "Szczegóły meczu",
+      "pairLabel": "{first} i {second}",
+      "fields": {
+        "library": "Biblioteka",
+        "isbn": "ISBN",
+        "formats": "Formaty",
+        "fileLocation": "Plik",
+        "files": "Pliki",
+        "readingStatus": "Stan odczytu",
+        "progress": "Postęp",
+        "path": "Ścieżka biblioteczna",
+        "collections": "Kolekcje",
+        "added": "Dodano",
+        "updated": "Zaktualizowano"
+      },
+      "initial": {
+        "title": "Znajdź duplikaty książek",
+        "description": "Wybierz zakres biblioteki i poziom podobieństwa, a następnie uruchom skanowanie. Żadne książki nie zostaną zmienione, dopóki wyraźnie nie potwierdzisz usunięcia."
+      },
+      "empty": {
+        "title": "Nie znaleziono zduplikowanych grup",
+        "description": "Żadne książki nie odpowiadały bieżącemu zakresowi, poziomowi podobieństwa i filtrowi dopasowania."
+      },
+      "deleteDialog": {
+        "title": "Trwale usunąć zduplikowane książki?",
+        "description": "{count, plural, =0 {Spowoduje to trwałe usunięcie # wybranych książek i ich plików.} one {Spowoduje to trwałe usunięcie # wybranej książki i jej plików.} other {Spowoduje to trwałe usunięcie # wybranej książki i jej plików.} few {Spowoduje to trwałe usunięcie # wybranych książek i ich plików.} many {Spowoduje to trwałe usunięcie # wybranych książek i ich plików.}}",
+        "warning": "Metadane, zbiory, dane odczytowe i stan urządzenia nie są przenoszone do prowadzonej księgi. Powiązane dane innych użytkowników są również usuwane.",
+        "confirm": "{count, plural, =0 {Usuń # książka} one {Usuń # książka} other {Usuń # książki} few {Usuń # książki} many {Usuń # książek}}",
+        "success": "{count, plural, =0 {Żadne książki nie zostały usunięte} one {Usunięto jedną zduplikowaną książkę} other {# usunięte zdublowane książki} few {Usunięto # zduplikowane książki} many {Usunięto # zduplikowanych książek}}"
+      },
+      "errors": {
+        "start": "Nie można rozpocząć skanowania duplikatów.",
+        "status": "Nie można wczytać postępu skanowania.",
+        "scan": "Skanowanie duplikatów nie powiodło się. Spróbuj uruchomić go ponownie.",
+        "results": "Nie można wczytać zduplikowanych grup.",
+        "delete": "Nie można usunąć wybranych zduplikowanych książek."
+      },
+      "pagination": {
+        "label": "Zduplikowane strony grup",
+        "page": "Strona {page} z {total}"
+      }
+    },
+    "entityManager": {
+      "unknown": "Nieznany",
+      "bookCount": "{count, plural, =0 {żadnych książek} one {# książka} other {# książki} few {# książki} many {# książek}}",
+      "sortPrefix": "· sortuj: {sortName}",
+      "selectTargetToKeep": "Wybierz cel, który chcesz zachować",
+      "writeToFiles": "Zapis do plików",
+      "writeChangesToFiles": "Zapisz zmiany w plikach",
+      "mergeIntoTarget": "Połącz {count} z celem",
+      "modes": {
+        "browse": "Przeglądaj i zarządzaj",
+        "duplicates": "Znajdź duplikaty"
+      },
+      "actions": {
+        "rename": "Zmień nazwę",
+        "split": "Podziel"
+      },
+      "duplicates": {
+        "similarity": "Podobieństwo:",
+        "scan": "Skanuj",
+        "scanning": "Skanowanie...",
+        "computing": "Kandydaci komputerowi...",
+        "computedAt": "Kandydaci obliczeni {date}",
+        "recompute": "Oblicz ponownie",
+        "noneComputed": "Nie obliczono jeszcze żadnych kandydatów.",
+        "computeNow": "Oblicz teraz",
+        "emptyTitle": "Znajdź zduplikowane elementy",
+        "emptyDescription": "Dostosuj próg podobieństwa i kliknij Skanuj, aby wykryć potencjalne duplikaty.",
+        "noneFoundTitle": "Nie znaleziono duplikatów",
+        "noneFoundDescription": "Przy bieżących ustawieniach nie wykryto żadnych potencjalnych duplikatów.",
+        "clustersFound": "{count, plural, =0 {nie znaleziono klastrów} one {# Znaleziono klaster} other {# znalezione klastry} few {Znaleziono # klastry} many {Znaleziono # klastrów}}",
+        "plusOthers": "{count, plural, =0 {+ # inne} one {+ # inne} other {+ # inni} few {+ # inne} many {+ # innych}}",
+        "percentSimilar": "{percent}% podobieństwa",
+        "pairDetails": "Szczegóły pary",
+        "dismissEntityTitle": "Odrzuć wszystkie pary dla tego elementu",
+        "dismissPairTitle": "Odrzuć tę parę"
+      },
+      "dismissed": {
+        "loading": "Ładowanie odrzuconych par...",
+        "empty": "Żadnych zwolnionych par",
+        "restore": "Przywróć",
+        "restoreTitle": "Przywróć tę parę",
+        "hidePairs": "Ukryj odrzucone pary",
+        "showPairs": "Pokaż odrzucone pary"
+      },
+      "browse": {
+        "searchPlaceholder": "Szukaj...",
+        "emptyOnly": "Tylko pusty",
+        "clear": "Wyczyść",
+        "noEntities": "Nie znaleziono żadnych podmiotów",
+        "mergeCount": "Połącz ({count})",
+        "deleteCount": "Usuń ({count})",
+        "totalCount": "{count} łącznie",
+        "sortLabel": "sortuj: {sortName}",
+        "sort": {
+          "nameAsc": "Imię A-Z",
+          "nameDesc": "Imię Z-A",
+          "fewestBooks": "Najmniej książek",
+          "mostBooks": "Większość książek"
+        }
+      },
+      "deleteMode": {
+        "label": "Tryb usuwania",
+        "softTitle": "Miękkie usuwanie",
+        "softDescription": "Odłącz od wszystkich książek, ale zachowaj rekord jednostki",
+        "softDescriptionPlural": "Odłącz od wszystkich ksiąg, ale zachowaj rekordy encji",
+        "hardTitle": "Twarde usunięcie",
+        "hardDescription": "Trwale usuń podmiot i wszystkie powiązania",
+        "hardDescriptionPlural": "Trwale usuń podmioty i wszystkie powiązania"
+      },
+      "renameModal": {
+        "title": "Zmień nazwę elementu",
+        "currentName": "Obecna nazwa",
+        "newName": "Nowa nazwa"
+      },
+      "deleteModal": {
+        "title": "Usuń element",
+        "confirm": "Czy na pewno chcesz usunąć {name}?"
+      },
+      "splitModal": {
+        "title": "Podziel jednostkę",
+        "splitting": "Dzielenie",
+        "newNames": "Nowe nazwy (min 2)",
+        "namePlaceholder": "Wpisz nazwę...",
+        "addAnother": "Dodaj kolejny"
+      },
+      "bulkDeleteModal": {
+        "title": "Usuń zbiorczo",
+        "confirm": "{count, plural, =0 {Czy na pewno chcesz usunąć # wybrany podmiot?} one {Czy na pewno chcesz usunąć # wybrany podmiot?} other {Czy na pewno chcesz usunąć # wybrane podmioty?} few {Czy na pewno chcesz usunąć # wybrane podmioty?} many {Czy na pewno chcesz usunąć # wybranych podmiotów?}}",
+        "deleteButton": "Usuń {count}"
+      },
+      "mergeModal": {
+        "title": "Połącz podmioty",
+        "description": "Wybierz, który element chcesz zachować. Pozostałe zostaną z nim połączone i usunięte."
+      }
+    }
+  },
+  "views": {
+    "entity": {
+      "book": "Książka",
+      "collection": "Kolekcja",
+      "library": "Biblioteka",
+      "smartScope": "Inteligentny zakres"
+    },
+    "common": {
+      "retry": "Spróbuj ponownie"
+    },
+    "bookView": {
+      "sort": "Sortuj",
+      "sortOn": "Włączone",
+      "resetSort": "Zresetuj sortowanie do ustawień domyślnych",
+      "filters": "Filtry",
+      "clear": "Wyczyść",
+      "clearAllFilters": "Wyczyść wszystkie filtry",
+      "expandSeries": "Rozwiń serię",
+      "collapseSeries": "Zwiń serię",
+      "expanded": "Rozszerzony",
+      "exportMetadata": "Eksportuj metadane",
+      "showControlsAria": "Pokaż kontrolki biblioteki",
+      "export": "Eksportuj",
+      "searchPlaceholder": "Wyszukaj tytuł, autora, serię, narratora...",
+      "allBooksLoaded": "Załadowano wszystkie {count} książki"
+    },
+    "notFound": {
+      "title": "Nie znaleziono strony",
+      "description": "Strona, której szukasz, nie istnieje.",
+      "goHome": "Idź do domu"
+    },
+    "dashboard": {
+      "customize": "Dostosuj pulpit nawigacyjny",
+      "allShelvesHidden": "Wszystkie półki są ukryte.",
+      "greeting": {
+        "night": "Dobranoc,",
+        "morning": "Dzień dobry,",
+        "afternoon": "Dzień dobry,",
+        "evening": "Dobry wieczór,",
+        "fallbackName": "tam"
+      }
+    },
+    "bookDetail": {
+      "title": "Książka",
+      "titleWithId": "Książka #{id}",
+      "pageTitle": {
+        "book": "Zarezerwuj · {base}",
+        "editMetadata": "Edytuj metadane · {base}",
+        "edit": "Edytuj · {base}",
+        "files": "Pliki · {base}",
+        "readingLog": "Czytanie dziennika · {base}",
+        "highlights": "Najważniejsze informacje · {base}"
+      }
+    },
+    "bookDock": {
+      "title": "Book Dock",
+      "newFilesDetected": "Wykryto nowe pliki",
+      "reconnecting": "Ponowne łączenie",
+      "rescanFailed": "Ponowne skanowanie nie powiodło się",
+      "totalInDock": "{size} w Book Dock",
+      "dropFiles": "Upuść pliki do Book Dock",
+      "supportedFormats": "Obsługiwane: {formats}",
+      "empty": {
+        "noSearchMatch": "Żadne pliki nie pasują do „{query}”",
+        "noStatusFiles": "Brak plików {status}",
+        "uploadPrompt": "Prześlij pliki lub upuść je w folderze Book Dock"
+      },
+      "retry": {
+        "noneToRetry": "Brak plików błędów do ponowienia",
+        "retrying": "{count, plural, =0 {Ponawianie próby dla jednego pliku} one {Ponawianie próby dla jednego pliku} other {Ponawianie próby dla # pliku} few {Ponawianie próby dla # plików} many {Ponawianie próby dla # plików}}"
+      },
+      "applyFetched": {
+        "applied": "{count, plural, =0 {Nie zastosowano do żadnych plików} one {Zastosowano do # pliku} other {Zastosowano do # pliku} few {Zastosowano do # plików} many {Zastosowano do # plików}}",
+        "skippedEdited": "{count, plural, =0 {pominąłem jeden plik, ponieważ zawiera on ręczną edycję} one {pominąłem jeden plik, ponieważ zawiera on ręczną edycję} other {pominięte # plików, ponieważ wymagają ręcznej edycji} few {pominąłem # pliki, ponieważ mają one ręczną edycję} many {pominąłem # plików, ponieważ mają one ręczną edycję}}",
+        "skippedNoMetadata": "{count, plural, =0 {pominięto jeden plik, ponieważ nie mają pobranych metadanych} one {pominięto jeden plik, ponieważ nie zawiera on pobranych metadanych} other {pominięte # plików, ponieważ nie mają pobranych metadanych} few {pominięto # pliki, ponieważ nie mają pobranych metadanych} many {pominięto # plików, ponieważ nie mają pobranych metadanych}}",
+        "noneApplied": "Nie zastosowano żadnych plików; {reasons}",
+        "noneSelected": "Nie wybrano plików"
+      }
+    },
+    "collection": {
+      "title": "Kolekcja",
+      "pageTitle": "Kolekcja · {name}",
+      "pageTitleWithId": "Kolekcja #{id}",
+      "editCollection": "Edytuj kolekcję",
+      "showControlsAria": "Pokaż elementy sterujące kolekcją",
+      "loadError": "Nie można załadować tej kolekcji",
+      "toast": {
+        "removed": "{count, plural, =0 {Nie usunięto żadnych książek z kolekcji} one {Usunięto jedną książkę z kolekcji} other {Usunięto # książki z kolekcji} few {Usunięto # książki z kolekcji} many {Usunięto # książek z kolekcji}}",
+        "removeFailed": "Nie udało się usunąć książek z kolekcji"
+      },
+      "empty": {
+        "noSearchMatch": "Żadne książki nie pasują do tego wyszukiwania",
+        "noSearchMatchHint": "Wypróbuj inne wyszukiwane hasło lub wyczyść wyszukiwanie.",
+        "noBooks": "Brak książek w tej kolekcji",
+        "noBooksHint": "Wybierz książki ze swojej biblioteki i dodaj je tutaj."
+      }
+    },
+    "library": {
+      "title": "Biblioteka",
+      "pageTitle": "Biblioteka · {name}",
+      "pageTitleWithId": "Biblioteka #{id}",
+      "filterRules": "Reguły filtrowania",
+      "saveAsSmartScope": "Zapisz jako inteligentny zakres",
+      "saveScope": "Zapisz zakres",
+      "saveAsSmartScopeTooltip": "Zapisz ten filtr jako nazwany inteligentny zakres",
+      "saved": "Zapisano",
+      "saveFilter": "Zapisz filtr",
+      "filterSaved": "Filtr zapisany",
+      "saveFilterTooltip": "Zapisz filtr dla tej biblioteki",
+      "removeSavedFilter": "Usuń zapisany filtr",
+      "empty": {
+        "noFilterMatch": "Żadna książka nie pasuje do wybranych filtrów",
+        "noFilterMatchHint": "Spróbuj dostosować lub wyczyścić filtry, aby zobaczyć więcej książek.",
+        "clearFilters": "Wyczyść filtry",
+        "scanning": "Skanuję Twoją bibliotekę...",
+        "scanningHint": "Książki będą pojawiać się tutaj w miarę ich odkrycia.",
+        "emptyLibrary": "Twoja biblioteka jest pusta",
+        "emptyLibraryHint": "Książki, które dodasz do tej biblioteki, pojawią się tutaj."
+      },
+      "querySelection": {
+        "loadedSelected": "Wybrano {selected} z {total} załadowanych książek.",
+        "selectAllMatching": "Wybierz wszystkie {total} pasujące książki"
+      }
+    },
+    "smartScope": {
+      "title": "Inteligentny zakres",
+      "pageTitle": "SmartScope · {name}",
+      "pageTitleWithId": "SmartScope #{id}",
+      "defaultName": "Inteligentny zakres",
+      "filter": "Filtruj",
+      "edit": "Edytuj inteligentny zakres",
+      "showControlsAria": "Pokaż elementy sterujące inteligentnego zakresu",
+      "hideFilter": "Ukryj filtr",
+      "showFilter": "Pokaż filtr",
+      "confirmDelete": "Potwierdzić?",
+      "loadError": "Nie można załadować tego SmartScope",
+      "toast": {
+        "deleted": "„{name}” usunięty",
+        "deleteFailed": "Nie udało się usunąć „{name}”"
+      },
+      "empty": {
+        "noRules": "Nie skonfigurowano żadnych reguł",
+        "noRulesHint": "Otwórz edytor, aby zdefiniować, które książki pojawią się w tym smartScope, korzystając z filtrów i reguł sortowania.",
+        "configure": "Skonfiguruj SmartScope",
+        "noMatch": "Żadne książki nie pasują do tego smartScope",
+        "noMatchHint": "Spróbuj dostosować reguły filtrowania.",
+        "edit": "Edytuj SmartScope"
+      }
+    }
+  },
+  "whatsNew": {
+    "title": "Co nowego",
+    "subtitle": "Wszystko, co zostało wysłane, najpierw najnowsze.",
+    "versionPrefix": "Wersja {version}",
+    "newUpdates": "{count, plural, =0 {żadnych nowych aktualizacji} one {jedna nowa aktualizacja} other {# nowe aktualizacje} few {# nowe aktualizacje} many {# nowych aktualizacji}}",
+    "remindLater": "Przypomnij mi później",
+    "gotIt": "Rozumiem",
+    "latest": "Najnowsze",
+    "fullChangelog": "Pełny dziennik zmian",
+    "seeAllReleases": "Zobacz wszystkie wydania",
+    "versions": "Wersje",
+    "currentVersion": "Aktualna wersja",
+    "youreHere": "Jesteś tutaj",
+    "searchPlaceholder": "Wyszukaj wydania…",
+    "noReleasesFound": "Nie znaleziono żadnych wydań.",
+    "noHighlights": "Brak najważniejszych informacji w tym wydaniu.",
+    "showChangelog": "Pokaż pełny dziennik zmian",
+    "hideChangelog": "Ukryj pełny dziennik zmian",
+    "openOnGitHub": "Otwórz w GitHubie",
+    "loadMore": "Załaduj więcej",
+    "loadingMore": "Ładowanie…",
+    "loadFailed": "Nie udało się wczytać wersji",
+    "loadMoreFailed": "Nie można załadować więcej wersji. Spróbuj ponownie.",
+    "loadErrorHint": "Nie udało się wczytać wersji. Sprawdź połączenie i spróbuj ponownie.",
+    "retry": "Spróbuj ponownie",
+    "imageViewer": "Przeglądarka obrazów",
+    "closeImage": "Zamknij obraz",
+    "previousImage": "Poprzedni obraz",
+    "nextImage": "Następny obraz"
+  },
+  "titles": {
+    "dashboard": "Pulpit nawigacyjny",
+    "libraries": "Biblioteki",
+    "opds": "OPDS",
+    "koboSync": "Kobo Synchronizacja",
+    "koreaderSync": "KOReader Synchronizacja",
+    "bookDock": "Book Dock",
+    "whatsNew": "Co nowego",
+    "annotations": "Adnotacje",
+    "achievements": "Osiągnięcia",
+    "statistics": "Statystyki",
+    "authors": "Autorzy",
+    "series": "Seria",
+    "entityManager": "Menedżer podmiotu",
+    "bulkRename": "Zbiorcza zmiana nazwy",
+    "duplicateBooks": "Duplikaty książek",
+    "notFound": "Nie znaleziono",
+    "signIn": "Zaloguj się",
+    "initialSetup": "Konfiguracja wstępna",
+    "forgotPassword": "Zapomniałem hasła",
+    "resetPassword": "Zresetuj hasło",
+    "completingSignIn": "Kończenie logowania",
+    "magicLinkLogin": "Logowanie za pomocą magicznego linku",
+    "readPrefix": "Czytaj",
+    "emailSuffix": "E-mail",
+    "library": "Biblioteka",
+    "smartScope": "Inteligentny zakres",
+    "collection": "Kolekcja",
+    "author": "Autor",
+    "book": "Książka",
+    "seriesItem": "Seria",
+    "appearance": {
+      "theme": "Wyświetlanie",
+      "book-covers": "Okładki książek",
+      "icons": "Ikony",
+      "layout": "Układ wyświetlacza",
+      "behavior": "Zachowanie biblioteki"
+    },
+    "reader": {
+      "general": "Ustawienia czytnika",
+      "ebook": "Czytnik e-booków",
+      "pdf": "PDF Czytelniku",
+      "comics": "Czytelnik komiksów",
+      "audio": "Odtwarzacz audiobooków",
+      "fonts": "Czcionki czytnika"
+    },
+    "email": {
+      "providers": "Dostawcy",
+      "recipients": "Odbiorcy",
+      "groups": "Grupy",
+      "templates": "Szablony",
+      "preferences": "Preferencje",
+      "history": "Historia"
+    },
+    "metadata": {
+      "providers": "Dostawcy",
+      "field-rules": "Zasady na poziomie pola",
+      "custom-fields": "Niestandardowe metadane",
+      "genre-blocklist": "Lista zablokowanych gatunków",
+      "score": "Wynik zaufania",
+      "auto-fetch": "Automatyczne pobieranie książek",
+      "authors": "Automatyczne pobieranie autora"
+    },
+    "admin": {
+      "users": "Użytkownicy",
+      "account-activity": "Aktywność konta",
+      "magic-links": "Magiczne linki",
+      "oidc": "OIDC / Jednokrotne logowanie"
+    },
+    "system": {
+      "file-naming": "Nazewnictwo plików",
+      "book-dock": "Book Dock",
+      "maintenance": "Konserwacja",
+      "audit-log": "Dziennik audytu"
+    },
+    "account": {
+      "profile": "Konto",
+      "privacy": "Prywatność i udostępnianie",
+      "notifications": "Powiadomienia",
+      "restrictions": "Ograniczenia dotyczące treści"
+    }
+  }
+}

--- a/client/src/locales/pl.json
+++ b/client/src/locales/pl.json
@@ -467,7 +467,7 @@
       },
       "feedback": {
         "unsavedChanges": "Niezapisane zmiany",
-        "allSaved": "Wszystkie zmiany zostały zapisane"
+        "discard": "Odrzuć"
       },
       "profile": {
         "securityHeading": "Profil i bezpieczeństwo",
@@ -484,7 +484,11 @@
         "accountTypeLocal": "Lokalny",
         "nameRequired": "Imię i nazwisko jest wymagane",
         "updateFailed": "Nie udało się zaktualizować profilu",
-        "updated": "Profil zaktualizowany"
+        "updated": "Profil zaktualizowany",
+        "usernameHint": "Twojej nazwy użytkownika nie można zmienić.",
+        "passwordHint": "Zmień hasło, którego używasz do logowania.",
+        "passwordHintOidc": "Twoim hasłem zarządza dostawca tożsamości.",
+        "passwordHintShared": "Konta współdzielone logują się przez magiczny link i nie mają hasła."
       },
       "readingPreferences": {
         "title": "Preferencje czytelnicze",
@@ -492,7 +496,10 @@
         "timezone": "Strefa czasowa",
         "save": "Zapisz preferencje",
         "enableAchievements": "Włącz osiągnięcia",
-        "enableAchievementsHint": "Śledź postęp osiągnięć i wyświetlaj interfejs związany z osiągnięciami. Zarządzaj powiadomieniami o osiągnięciach oddzielnie w Powiadomieniach."
+        "enableAchievementsHint": "Śledź postęp osiągnięć i wyświetlaj interfejs związany z osiągnięciami. Zarządzaj powiadomieniami o osiągnięciach oddzielnie w Powiadomieniach.",
+        "achievementsEnabled": "Osiągnięcia włączone",
+        "achievementsDisabled": "Osiągnięcia wyłączone",
+        "achievementsSaveFailed": "Nie udało się zaktualizować preferencji osiągnięć"
       },
       "preferences": {
         "saveFailed": "Nie udało się zapisać preferencji",
@@ -534,7 +541,9 @@
           "title": "Odłączyć tożsamość {provider}?",
           "description": "Wpisz swoje hasło, aby potwierdzić. Nie będziesz już mógł zalogować się u tego dostawcy.",
           "currentPassword": "Aktualne hasło"
-        }
+        },
+        "description": "Zaloguj się za pomocą zewnętrznego dostawcy tożsamości powiązanego z tym kontem.",
+        "unlinkAria": "Odłącz {provider}"
       },
       "tour": {
         "title": "Wycieczka z przewodnikiem",
@@ -563,6 +572,11 @@
           "title": "Zablokowane gatunki",
           "description": "Książki należące do któregokolwiek z tych gatunków są przed Tobą ukryte."
         }
+      },
+      "groups": {
+        "profile": "Profil",
+        "preferences": "Preferencje",
+        "security": "Bezpieczeństwo i dostęp"
       }
     },
     "magicLinks": {
@@ -596,10 +610,10 @@
         "createdBy": "Stworzony przez",
         "expires": "Wygasa",
         "uses": "Używa",
-        "lastUsed": "Ostatnio używany",
         "created": "Utworzono",
         "status": "Stan",
-        "totalUses": "Całkowita liczba zastosowań"
+        "totalUses": "Całkowita liczba zastosowań",
+        "actions": "Działania"
       },
       "createDialog": {
         "title": "Utwórz magiczny link",
@@ -627,7 +641,12 @@
       "emptyTitle": "Nie utworzono jeszcze żadnych magicznych linków",
       "emptyHint": "Kliknij „{action}”, aby wygenerować wspólny login URL.",
       "noActiveTitle": "Brak aktywnych magicznych linków",
-      "noActiveHint": "Wszystkie wygenerowane magiczne linki do tej strony wygasły lub zostały unieważnione."
+      "noActiveHint": "Wszystkie wygenerowane magiczne linki do tej strony wygasły lub zostały unieważnione.",
+      "copyLinkAria": "Skopiuj link do {label}",
+      "pauseAria": "Wstrzymaj {label}",
+      "resumeAria": "Wznów {label}",
+      "revokeAria": "Unieważnij {label}",
+      "lastUsedLabel": "Ostatnio użyto: {date}"
     },
     "oidc": {
       "title": "OIDC / Jednokrotne logowanie",
@@ -1692,9 +1711,6 @@
         "subtitle": "Kontroluj sposób, w jaki pliki są zorganizowane na dysku po przesłaniu i jak są nazywane po pobraniu, za pomocą tokenów zastępczych.",
         "copy": "Kopiuj",
         "previewLabel": "Podgląd:",
-        "fileAsBookPreview": "Plik jako podgląd książki",
-        "folderAsBookPreview": "Folder jako podgląd książki",
-        "downloadPreview": "Pobierz podgląd",
         "globalDefaults": "Globalne ustawienia domyślne",
         "crossPlatform": "Oczyszczanie ścieżek między platformami",
         "crossPlatformHint": "Zabezpiecz wygenerowane nazwy plików i folderów w systemie Windows, zastępując nieprawidłowe znaki i nazwy zastrzeżone oraz usuwając końcowe kropki i spacje. Wyłącz tylko w przypadku konfiguracji wyłącznie dla systemu Linux, które celowo zachowują te znaki.",
@@ -1711,15 +1727,10 @@
         "orgFolderAsBook": "Folder jako książka",
         "orgFileAsBook": "Plik jako książka",
         "resetToDefault": "Przywróć ustawienia domyślne",
-        "patternReference": "Odniesienie do wzoru",
-        "placeholderReference": "Odniesienie do obiektu zastępczego",
-        "placeholderReferenceHint": "- przewodnik dotyczący tworzenia niestandardowych wzorców nazewnictwa",
         "tokens": "Żetony",
-        "tokensHint": "Szybko kopiuj symbole zastępcze",
         "clickTokenHint": "Kliknij dowolny token, aby skopiować go do schowka.",
         "copyValue": "Skopiuj {value}",
         "modifiers": "Modyfikatory",
-        "modifiersHint": "Przekształć wartości tokenów",
         "modifiersExplain": "Dołącz modyfikator wewnątrz tokenu, aby przekształcić jego wartość:",
         "modFirst": "Tylko pierwsza wartość",
         "modSort": "Ostatni, pierwszy format",
@@ -1728,14 +1739,10 @@
         "folderOnlyPrefix": "Zakończ wzór za pomocą",
         "folderOnlySuffix": "aby określić tylko folder. Oryginalna nazwa pliku zostanie w nim zachowana.",
         "conditionalLogic": "Logika warunkowa",
-        "conditionalLogicHint": "Opcjonalne segmenty i rezerwy",
         "conditionalPart1": "Zawiń",
         "conditionalPart2": "aby pominąć segment, gdy jego token jest pusty. Użyj",
         "conditionalPart3": "dla wartości domyślnej.",
         "examples": "Przykłady",
-        "patternExamples": "Przykłady wzorów",
-        "patternExamplesHint": "Gotowe wzory dla popularnych stylów bibliotek",
-        "copyPatternTooltip": "Skopiuj wzór do schowka",
         "exCalibre": "Domyślny styl Calibre",
         "exSeriesReader": "Czytelnik serii",
         "exCleanDownload": "Wyczyść nazwę pliku do pobrania",
@@ -1763,7 +1770,37 @@
         "patternCopied": "Wzór skopiowany do schowka",
         "copyPatternFailed": "Nie udało się skopiować wzoru",
         "labelCopied": "{label} skopiowano do schowka",
-        "copyLabelFailed": "Nie udało się skopiować {label}"
+        "copyLabelFailed": "Nie udało się skopiować {label}",
+        "patternHelp": "Pomoc dotycząca wzorców",
+        "patternHelpDescription": "Tokeny, modyfikatory i gotowe wzorce, które możesz skopiować do dowolnego pola.",
+        "copyPreview": "Kopiuj {label}",
+        "copyExample": "Skopiuj wzorzec {label}",
+        "invalidCharacters": "Wzorzec zawiera nieprawidłowe znaki",
+        "fileAsBookSaved": "Zapisano domyślne ustawienie Plik jako książka",
+        "folderAsBookSaved": "Zapisano domyślne ustawienie Folder jako książka",
+        "downloadPatternSaved": "Zapisano wzorzec pobierania",
+        "savePatternFailed": "Nie udało się zapisać wzorca",
+        "saveDownloadPatternFailed": "Nie udało się zapisać wzorca pobierania",
+        "crossPlatformEnabled": "Włączono oczyszczanie ścieżek między platformami",
+        "crossPlatformDisabled": "Wyłączono oczyszczanie ścieżek między platformami",
+        "crossPlatformSaveFailed": "Nie udało się zapisać oczyszczania ścieżek między platformami",
+        "librarySaved": "Zapisano wzorzec dla {name}",
+        "librarySaveFailed": "Nie udało się zapisać wzorca biblioteki",
+        "saveLibraryPattern": "Zapisz wzorzec dla {name}",
+        "resetLibraryPattern": "Przywróć {name} do wzorca domyślnego",
+        "tokenTitle": "Tytuł książki",
+        "tokenSubtitle": "Podtytuł książki",
+        "tokenAuthors": "Autor(zy), oddzieleni przecinkami",
+        "tokenYear": "Rok wydania",
+        "tokenSeries": "Nazwa serii",
+        "tokenSeriesIndex": "Numer w serii (uzupełniony zerami)",
+        "tokenPublisher": "Wydawca",
+        "tokenIsbn": "ISBN-13",
+        "tokenLanguage": "Język",
+        "tokenOriginalFilename": "Oryginalna nazwa pliku (bez rozszerzenia)",
+        "tokenExtension": "Rozszerzenie pliku (bez kropki)",
+        "patternHelpIntro": "Wzorce używają tokenów takich jak {titleToken} i {authorsToken}, a także modyfikatorów i segmentów opcjonalnych.",
+        "browseTokensAndExamples": "Przeglądaj tokeny i przykłady"
       },
       "kobo": {
         "title": "Kobo Synchronizacja",
@@ -2451,19 +2488,15 @@
     },
     "usersPage": {
       "usersTitle": "Użytkownicy",
-      "magicLinksTitle": "Magiczne linki",
       "usersSubtitle": "Zarządzaj kontami użytkowników i przypisaniami uprawnień.",
-      "magicLinksSubtitle": "Twórz udostępniane łącza logowania do współdzielonych kont.",
       "createUser": "Utwórz użytkownika",
-      "createLink": "Utwórz łącze",
-      "usersTab": "Użytkownicy",
-      "magicLinksTab": "Magiczne linki",
       "columns": {
         "name": "Imię",
         "username": "Nazwa użytkownika",
         "email": "E-mail",
         "access": "Dostęp",
-        "status": "Stan"
+        "status": "Stan",
+        "actions": "Działania"
       },
       "adminBadge": "Administrator",
       "permissionCount": "{count, plural, =0 {żadnych uprawnień} one {jedno pozwolenie} other {# uprawnienia} few {# uprawnienia} many {# uprawnień}}",
@@ -2481,11 +2514,10 @@
       "deleteDialogBody": "Usuń użytkownika „{username}”. Tej akcji nie można cofnąć.",
       "deleting": "Usuwanie...",
       "errors": {
-        "loadData": "Nie udało się załadować danych",
         "load": "Nie udało się załadować",
-        "deleteUser": "Nie udało się usunąć użytkownika"
+        "deleteUser": "Nie udało się usunąć użytkownika",
+        "resetPassword": "Nie udało się utworzyć linku do resetowania hasła"
       },
-      "currentUsers": "Aktualni użytkownicy",
       "defaultLibraryAccess": {
         "title": "Domyślny dostęp do biblioteki",
         "subtitle": "Dostęp przeglądającego przyznany użytkownikom zarejestrowanym samodzielnie i korzystającym z OIDC.",
@@ -2493,9 +2525,37 @@
         "noLibraries": "Brak dostępnych bibliotek.",
         "save": "Zapisz ustawienia domyślne",
         "saving": "Zapisywanie...",
-        "saved": "Domyślny dostęp do biblioteki został zapisany.",
         "saveError": "Nie udało się zapisać domyślnego dostępu do biblioteki"
-      }
+      },
+      "filters": {
+        "search": "Szukaj użytkowników",
+        "searchPlaceholder": "Szukaj według imienia, nazwy użytkownika lub adresu e-mail",
+        "sort": "Sortuj użytkowników",
+        "usernameAsc": "Nazwa użytkownika A-Z",
+        "nameAsc": "Imię A-Z",
+        "newest": "Najnowsze najpierw",
+        "oldest": "Najstarsze najpierw",
+        "apply": "Zastosuj",
+        "clear": "Wyczyść",
+        "state": "Filtruj użytkowników",
+        "allUsers": "Wszyscy użytkownicy",
+        "admins": "Administratorzy",
+        "active": "Aktywny",
+        "inactive": "Nieaktywny"
+      },
+      "empty": {
+        "title": "Nie ma jeszcze użytkowników",
+        "description": "Utwórz pierwsze konto, aby rozpocząć.",
+        "filtered": "Żaden użytkownik nie pasuje do bieżącego wyszukiwania i filtrów."
+      },
+      "pagination": {
+        "label": "Paginacja użytkowników",
+        "page": "Strona {page} z {totalPages}"
+      },
+      "editUserAria": "Edytuj {name}",
+      "resetPasswordAria": "Zresetuj hasło dla {name}",
+      "deleteUserAria": "Usuń {name}",
+      "moreActionsAria": "Więcej działań dla {name}"
     }
   },
   "annotations": {
@@ -4298,17 +4358,17 @@
         "title": "Podoba Ci się BookOrbit?",
         "body": "Jeśli BookOrbit pomaga w Twojej bibliotece, rozważ opublikowanie projektu w serwisie GitHub. Pomaga większej liczbie osób odkryć aplikację i wspiera ciągły rozwój.",
         "cta": "Oznacz gwiazdką BookOrbit w GitHubie"
-      }
+      },
+      "surfaceOpacity": "Krycie powierzchni",
+      "surfaceOpacityValue": "{value}%"
     },
     "sidebar": {
-      "tagline": "Twoja przestrzeń do czytania",
       "dashboard": "Pulpit nawigacyjny",
       "authors": "Autorzy",
       "series": "Seria",
       "tools": "Narzędzia",
       "libraries": "Biblioteki",
       "newLibrary": "Nowa biblioteka",
-      "libraryScanning": "{name} - Skanowanie {pct}%",
       "scanProgress": "{processed} / {total} książek",
       "smartScopes": "Inteligentne lunety",
       "newSmartScope": "Nowy inteligentny zakres",
@@ -4316,15 +4376,41 @@
       "collections": "Kolekcje",
       "newCollection": "Nowa kolekcja",
       "noCollections": "Nie ma jeszcze żadnych kolekcji",
-      "latest": "Najnowsze {version}",
       "newReleaseNotes": "Dostępne są nowe informacje o wydaniu",
       "support": "Wsparcie BookOrbit",
-      "supportShort": "Wsparcie",
       "supportAria": "Wesprzyj BookOrbit w Ko-Fi",
       "sectionHeader": {
         "add": "Dodaj",
+        "showAll": "Pokaż wszystko",
+        "showCount": "Pokaż {count}",
+        "rowsShown": "Wyświetlone wiersze",
+        "menuAria": "Opcje sekcji dla {section}",
         "reorder": "Zmień kolejność",
         "doneReordering": "Zakończono zmianę kolejności"
+      },
+      "noLibraries": "Nie ma jeszcze bibliotek",
+      "clearFilter": "Wyczyść filtr",
+      "filterSummary": "Pokazano {shown} z {total}",
+      "filterLibraries": "Filtruj biblioteki",
+      "filterLibrariesPlaceholder": "Filtruj biblioteki...",
+      "filterSmartScopes": "Filtruj inteligentne lunety",
+      "filterSmartScopesPlaceholder": "Filtruj inteligentne lunety...",
+      "filterCollections": "Filtruj kolekcje",
+      "filterCollectionsPlaceholder": "Filtruj kolekcje...",
+      "seeAllLibraries": "Zobacz wszystkie biblioteki ({count})",
+      "seeAllSmartScopes": "Zobacz wszystkie inteligentne lunety ({count})",
+      "seeAllCollections": "Zobacz wszystkie kolekcje ({count})",
+      "updateAvailable": "Aktualizuj {version}",
+      "zones": {
+        "browse": "Przeglądaj"
+      },
+      "reorder": {
+        "gripAria": "Zmień kolejność {name}",
+        "lifted": "Podniesiono {name}, pozycja {position} z {total}. Użyj klawiszy strzałek, aby przenieść element.",
+        "moved": "{name}, pozycja {position} z {total}",
+        "dropped": "Upuszczono {name} na pozycji {position} z {total}",
+        "cancelled": "Anulowano zmianę kolejności. {name} wrócił na pozycję {position} z {total}.",
+        "filteredHint": "Wyczyść filtr, aby zmienić kolejność"
       }
     },
     "selectionActionBar": {
@@ -4424,6 +4510,24 @@
         "typeAndEnter": "Wpisz i naciśnij Enter, aby dodać",
         "pressEnter": "Naciśnij Enter, aby dodać"
       }
+    },
+    "entityIndex": {
+      "sortBy": "Sortuj według",
+      "sort": {
+        "custom": "Kolejność niestandardowa",
+        "name": "Nazwa",
+        "bookCount": "Liczba książek"
+      },
+      "ascending": "Rosnąco",
+      "descending": "Malejąco",
+      "clearSearch": "Wyczyść wyszukiwanie",
+      "resultCount": "{shown} z {total}",
+      "noMatches": "Brak dopasowań",
+      "noMatchesHint": "Spróbuj innego wyszukiwanego hasła.",
+      "bookCount": "Książki: {count}",
+      "librariesEmptyHint": "Utwórz bibliotekę, aby zacząć dodawać książki.",
+      "smartScopesEmptyHint": "Inteligentne lunety zapisują zestaw często używanych filtrów.",
+      "collectionsEmptyHint": "Kolekcje grupują książki wybrane ręcznie."
     }
   },
   "customIcons": {
@@ -5552,7 +5656,61 @@
       "saveFailed": "Nie udało się zapisać preferencji",
       "savePreferenceFailed": "Nie udało się zapisać preferencji",
       "whatsNewToggle": "Pokaż „Co nowego” po aktualizacjach",
-      "whatsNewToggleHint": "Wyskakujące okienko prezentujące nowe funkcje po aktualizacji aplikacji. Archiwum pozostaje dostępne w obu przypadkach."
+      "whatsNewToggleHint": "Wyskakujące okienko prezentujące nowe funkcje po aktualizacji aplikacji. Archiwum pozostaje dostępne w obu przypadkach.",
+      "groups": {
+        "library": "Biblioteka",
+        "files": "Pliki",
+        "integrations": "Integracje",
+        "personal": "Osobiste",
+        "app": "Aktualizacje aplikacji"
+      },
+      "enabledCount": "Włączono {enabled} z {total}",
+      "categories": {
+        "scanning": {
+          "label": "Skanowanie biblioteki",
+          "description": "Gdy skanowanie biblioteki zakończy się, nie powiedzie się lub wykryje brakujące książki."
+        },
+        "metadata": {
+          "label": "Pobieranie metadanych",
+          "description": "Gdy wyszukiwanie metadanych książek zakończy się powodzeniem lub niepowodzeniem."
+        },
+        "authorEnrichment": {
+          "label": "Wzbogacanie danych autorów",
+          "description": "Gdy zakończy się pobieranie biografii i zdjęć autorów."
+        },
+        "fileWriteBack": {
+          "label": "Zapis do plików",
+          "description": "Gdy zmodyfikowane metadane są zapisywane z powrotem w plikach książek na dysku."
+        },
+        "fileRename": {
+          "label": "Zmiana nazwy pliku",
+          "description": "Gdy nazwa pliku książki zostanie zmieniona zgodnie z Twoim wzorcem nazewnictwa."
+        },
+        "bulkRename": {
+          "label": "Zbiorcza zmiana nazw",
+          "description": "Gdy zbiorcza zmiana nazw wielu książek zakończy się powodzeniem lub niepowodzeniem."
+        },
+        "migration": {
+          "label": "Migracja danych",
+          "description": "Gdy import z innego narzędzia bibliotecznego zakończy się powodzeniem lub niepowodzeniem."
+        },
+        "bookDock": {
+          "label": "Book Dock",
+          "description": "Gdy pliki upuszczone w doku są gotowe do przejrzenia lub zostały sfinalizowane."
+        },
+        "koboSync": {
+          "label": "Synchronizacja Kobo",
+          "description": "Gdy urządzenie Kobo zakończy synchronizację z Twoją biblioteką."
+        },
+        "email": {
+          "label": "Dostarczanie e-mailem",
+          "description": "Gdy wysyłanie książki na adres e-mail powiedzie się lub nie powiedzie."
+        },
+        "achievements": {
+          "label": "Osiągnięcia",
+          "description": "Gdy odblokujesz nowe osiągnięcie czytelnicze."
+        }
+      }
     }
   },
   "reader": {
@@ -6628,6 +6786,8 @@
       "privacy": "Prywatność i udostępnianie",
       "notifications": "Powiadomienia",
       "restrictions": "Ograniczenia dotyczące treści"
-    }
+    },
+    "smartScopes": "Inteligentne lunety",
+    "collections": "Kolekcje"
   }
 }

--- a/client/src/stores/__tests__/locale.spec.ts
+++ b/client/src/stores/__tests__/locale.spec.ts
@@ -31,7 +31,11 @@ describe('locale store', () => {
 
     expect(matchSupportedLocale(['nl-NL', 'en-US'])).toBe('nl')
     expect(matchSupportedLocale(['de-DE', 'en-GB'])).toBe('de')
+    expect(matchSupportedLocale(['es-ES', 'en-GB'])).toBe('es')
+    expect(matchSupportedLocale(['fr-FR', 'en-GB'])).toBe('fr')
+    expect(matchSupportedLocale(['it-IT', 'en-GB'])).toBe('it')
     expect(matchSupportedLocale(['nl-BE', 'en'])).toBe('nl')
+    expect(matchSupportedLocale(['pl-PL', 'en-GB'])).toBe('pl')
     expect(matchSupportedLocale(['pt-BR'])).toBe('pt')
   })
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,7 +2,11 @@ preserve_hierarchy: true
 
 export_languages:
   - de
+  - es-ES
+  - fr
+  - it
   - nl
+  - pl
   - pt-BR
   - sl
 

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -1,6 +1,6 @@
 # Localization
 
-BookOrbit uses Vue I18n catalogs under `client/src/locales/`. English is the source language, and Crowdin is the source of truth for German, Dutch, Brazilian Portuguese, and Slovenian translations.
+BookOrbit uses Vue I18n catalogs under `client/src/locales/`. English is the source language, and Crowdin is the source of truth for Dutch, French, German, Italian, Polish, Brazilian Portuguese, Slovenian, and Spanish translations.
 
 ## Supported Catalogs
 
@@ -8,7 +8,11 @@ BookOrbit uses Vue I18n catalogs under `client/src/locales/`. English is the sou
 | -------------------- | ------------------- | --------- |
 | English              | Source language     | `en.json` |
 | German               | `de`                | `de.json` |
+| Spanish              | `es-ES`             | `es.json` |
+| French               | `fr`                | `fr.json` |
+| Italian              | `it`                | `it.json` |
 | Dutch                | `nl`                | `nl.json` |
+| Polish               | `pl`                | `pl.json` |
 | Brazilian Portuguese | `pt-BR`             | `pt.json` |
 | Slovenian            | `sl`                | `sl.json` |
 
@@ -72,7 +76,7 @@ After an English source change reaches `main`:
 2. Translators update target strings in Crowdin.
 3. Crowdin exports the target catalogs to `l10n_main`.
 4. Crowdin opens a pull request to `main`.
-5. CI verifies that the pull request changes only the four target catalogs and runs the normal client checks.
+5. CI verifies that the pull request changes only the eight target catalogs and runs the normal client checks.
 6. A maintainer reviews and squash-merges the pull request.
 7. The `l10n_main` service branch is deleted. Crowdin recreates it for the next export.
 

--- a/packages/types/src/locale.ts
+++ b/packages/types/src/locale.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_LOCALES = ["en", "de", "nl", "pt", "sl"] as const;
+export const SUPPORTED_LOCALES = ["en", "de", "es", "fr", "it", "nl", "pl", "pt", "sl"] as const;
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 
 export const DEFAULT_LOCALE: Locale = "en";
@@ -7,7 +7,11 @@ export const DEFAULT_LOCALE: Locale = "en";
 export const LOCALE_LABELS: Record<Locale, string> = {
   en: "English",
   de: "Deutsch",
+  es: "Español",
+  fr: "Français",
+  it: "Italiano",
   nl: "Nederlands",
+  pl: "Polski",
   pt: "Português",
   sl: "Slovenščina",
 };
@@ -15,7 +19,11 @@ export const LOCALE_LABELS: Record<Locale, string> = {
 export const LOCALE_DIRECTIONS: Record<Locale, "ltr" | "rtl"> = {
   en: "ltr",
   de: "ltr",
+  es: "ltr",
+  fr: "ltr",
+  it: "ltr",
   nl: "ltr",
+  pl: "ltr",
   pt: "ltr",
   sl: "ltr",
 };

--- a/scripts/classify-crowdin-pr.sh
+++ b/scripts/classify-crowdin-pr.sh
@@ -20,7 +20,11 @@ fi
 
 allowed_paths=(
   "client/src/locales/de.json"
+  "client/src/locales/es.json"
+  "client/src/locales/fr.json"
+  "client/src/locales/it.json"
   "client/src/locales/nl.json"
+  "client/src/locales/pl.json"
   "client/src/locales/pt.json"
   "client/src/locales/sl.json"
 )

--- a/server/src/modules/user-preferences/user-preferences.service.test.ts
+++ b/server/src/modules/user-preferences/user-preferences.service.test.ts
@@ -77,7 +77,7 @@ const validDisplayPreferences: DisplayPreferences = {
 };
 
 const validLocalePreferences: LocalePreferences = {
-  locale: 'nl',
+  locale: 'it',
 };
 
 const repo = {
@@ -132,6 +132,13 @@ describe('UserPreferencesService', () => {
   it('upsertLocalePreferences persists validated settings', async () => {
     await expect(service.upsertLocalePreferences(11, validLocalePreferences)).resolves.toBeUndefined();
     expect(repo.upsert).toHaveBeenCalledWith(11, 'locale', validLocalePreferences);
+  });
+
+  it.each(['es', 'fr', 'pl'] as const)('upsertLocalePreferences accepts the %s locale', async (locale) => {
+    const preferences: LocalePreferences = { locale };
+
+    await expect(service.upsertLocalePreferences(11, preferences)).resolves.toBeUndefined();
+    expect(repo.upsert).toHaveBeenCalledWith(11, 'locale', preferences);
   });
 
   it('upsertLocalePreferences rejects unsupported locale', async () => {


### PR DESCRIPTION
## Before you submit

> **New feature?** Please open an issue first and get approval from the maintainers before writing any code.
> PRs that introduce features without a prior discussion will be closed.
>
> **Used AI assistance?** That's fine - but make sure you've read and understood every line of the diff
> before submitting. PRs that show no sign of self-review will be closed without detailed feedback.
>
> **Keep it focused.** One thing per PR. Don't bundle a bug fix with a refactor or unrelated cleanup.
> If it's not ready, open it as a draft instead.

---

## What does this PR do?

Expands BookOrbit's supported interface languages with Spanish, French, Italian, and Polish.

This PR includes:

- Adds complete `es`, `fr`, `it`, and `pl` client message catalogs.
- Registers the four locales in the shared locale contract and language labels.
- Adds the corresponding Crowdin export configuration and permits the new catalogs in Crowdin-generated PRs.
- Extends ICU coverage for each locale's plural rules and localized number formatting.
- Adds browser-locale matching and user-preference coverage for the new locale codes.
- Updates the localization documentation to list all eight Crowdin-managed target languages.

Closes #809

## How did you test this?

- `pnpm run format:check`
  - Result: passed for server and client.
- `pnpm run lint:check`
  - Result: passed for server and client, including locale and style validation.
- `pnpm run typecheck:full`
  - Result: passed for server and client.
- `pnpm run test`
  - Result: passed with 30 chart tests, 9,032 server tests across 631 files, and 3,803 client tests across 347 files.
- `pnpm --filter client validate:locales`
  - Result: validated 9 locale catalogs with 5,325 messages each.
- `pnpm --filter client exec vitest run src/i18n/icu.spec.ts src/stores/__tests__/locale.spec.ts`
  - Result: 55 tests passed across 2 files.
- `pnpm --filter server exec vitest run src/modules/user-preferences/user-preferences.service.test.ts`
  - Result: 99 tests passed.
- The pre-push `pnpm run verify:fast` hook also passed after the final history update.

## Screenshots

The language selector gains Spanish, French, Italian, and Polish options. Add a screenshot of the expanded selector and one representative translated view before submitting the PR.

## Anything non-obvious in the diff?

- The shared application locale is `es`, while Crowdin exports Spanish using `es-ES`.
- Polish ICU tests cover its `one`, `few`, and `many` plural categories, including localized large-number formatting.
- All new catalogs contain the same 5,325 message keys as the source catalog.
- The Crowdin PR classifier now accepts eight translation catalogs instead of four.

## Checklist

- [x] I've read through my own diff
- [ ] This PR was discussed in an issue and has maintainer approval (for new features)
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Spanish, French, Italian, and Polish language options with comprehensive translations across the app.
  - Expanded locale support for language selection and user preferences.

- **Bug Fixes**
  - Improved pluralized message rendering across supported languages, including large counts.

- **Documentation**
  - Updated localization guidance and translation delivery details.

- **Tests**
  - Added coverage for locale matching, preference persistence, and localized pluralization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->