### PR TITLE
fix(metadata): extract and write back comicvine id for comics

### DIFF
--- a/packages/types/src/file-write.ts
+++ b/packages/types/src/file-write.ts
@@ -31,6 +31,7 @@ export const COMMON_PROVIDER_BOOK_FILE_WRITE_FIELDS = [
 ] as const;
 
 export const COMIC_BOOK_FILE_WRITE_FIELDS = [
+  "comicvineId",
   "comicIssueNumber",
   "comicVolumeName",
   "comicPencillers",
@@ -84,6 +85,7 @@ export const BOOK_FILE_WRITE_FIELD_LABELS = {
   koboId: "Kobo ID",
   lubimyczytacId: "LubimyCzytac ID",
   aladinId: "Aladin ID",
+  comicvineId: "ComicVine ID",
   comicIssueNumber: "Issue number",
   comicVolumeName: "Volume",
   comicPencillers: "Pencillers",

--- a/server/src/modules/file-write/file-write.constants.ts
+++ b/server/src/modules/file-write/file-write.constants.ts
@@ -47,6 +47,7 @@ export const COMIC_INFO_MANAGED_NOTES_KEYS = [
   'koboId',
   'lubimyczytacId',
   'aladinId',
+  'comicvineId',
 ] as const satisfies readonly BookWritePayloadKey[];
 
 type ComicInfoProviderKey = (typeof COMIC_INFO_PROVIDER_ID_KEYS)[number];

--- a/server/src/modules/file-write/file-write.constants.ts
+++ b/server/src/modules/file-write/file-write.constants.ts
@@ -31,6 +31,7 @@ export const COMIC_INFO_PROVIDER_ID_KEYS = [
   'googleBooksId',
   'openLibraryId',
   'koboId',
+  'comicvineId',
 ] as const satisfies readonly BookWritePayloadKey[];
 
 export const COMIC_INFO_MANAGED_NOTES_KEYS = [
@@ -57,6 +58,7 @@ export const COMIC_INFO_PROVIDER_WEB_URL_BUILDERS: Record<ComicInfoProviderKey, 
   googleBooksId: (id: string) => `https://books.google.com/books?id=${id}`,
   openLibraryId: (id: string) => `https://openlibrary.org/works/${id}`,
   koboId: (id: string) => `https://www.kobo.com/us/en/ebook/${id}`,
+  comicvineId: (id: string) => `https://comicvine.gamespot.com/-/4000-${id}/`,
 };
 
 export const EPUB_PROVIDER_IDENTIFIER_SCHEMES = {

--- a/server/src/modules/file-write/file-write.repository.test.ts
+++ b/server/src/modules/file-write/file-write.repository.test.ts
@@ -100,6 +100,7 @@ describe('FileWriteRepository', () => {
       openLibraryId: 'ol',
       ranobedbId: 'rn',
       koboId: 'kb',
+      comicvineId: 'cv',
       lubimyczytacId: 'lc',
       aladinId: 'al',
       itunesId: 'it',

--- a/server/src/modules/file-write/file-write.repository.ts
+++ b/server/src/modules/file-write/file-write.repository.ts
@@ -218,6 +218,7 @@ export class FileWriteRepository {
       openLibraryId: meta.openLibraryId,
       ranobedbId: meta.ranobedbId,
       koboId: meta.koboId,
+      comicvineId: meta.comicvineId,
       lubimyczytacId: meta.lubimyczytacId,
       aladinId: meta.aladinId,
       itunesId: meta.itunesId,

--- a/server/src/modules/file-write/formats/cbx/comic-info-builder.test.ts
+++ b/server/src/modules/file-write/formats/cbx/comic-info-builder.test.ts
@@ -165,6 +165,15 @@ describe('buildComicInfoXml', () => {
     expect(parsed.ComicInfo.Web).toBe('https://comicvine.gamespot.com/-/4000-140529/');
   });
 
+  it('keeps comicvineId in Notes when another provider id owns the single Web slot', () => {
+    const xml = buildComicInfoXml(null, { goodreadsId: '111', comicvineId: '140529' }, new Set(['goodreadsId', 'comicvineId']));
+
+    const parsed = parser.parse(xml) as { ComicInfo: Record<string, string> };
+
+    expect(parsed.ComicInfo.Web).toBe('https://www.goodreads.com/book/show/111');
+    expect(parsed.ComicInfo.Notes).toContain('[bookorbit:comicvineId] 140529');
+  });
+
   it('does not overwrite provider-derived Web/Notes when provider fields are excluded from field mask', () => {
     const existing = `<?xml version="1.0"?><ComicInfo><Web>https://www.goodreads.com/book/show/111</Web><Notes>[bookorbit:goodreadsId] 111</Notes></ComicInfo>`;
 

--- a/server/src/modules/file-write/formats/cbx/comic-info-builder.test.ts
+++ b/server/src/modules/file-write/formats/cbx/comic-info-builder.test.ts
@@ -157,6 +157,14 @@ describe('buildComicInfoXml', () => {
     expect(notes).not.toContain('[bookorbit:subtitle] old');
   });
 
+  it('writes comicvineId into Web using the canonical 4000-<id> issue URL', () => {
+    const xml = buildComicInfoXml(null, { comicvineId: '140529' }, new Set(['comicvineId']));
+
+    const parsed = parser.parse(xml) as { ComicInfo: Record<string, string> };
+
+    expect(parsed.ComicInfo.Web).toBe('https://comicvine.gamespot.com/-/4000-140529/');
+  });
+
   it('does not overwrite provider-derived Web/Notes when provider fields are excluded from field mask', () => {
     const existing = `<?xml version="1.0"?><ComicInfo><Web>https://www.goodreads.com/book/show/111</Web><Notes>[bookorbit:goodreadsId] 111</Notes></ComicInfo>`;
 

--- a/server/src/modules/file-write/interfaces/book-write-payload.interface.ts
+++ b/server/src/modules/file-write/interfaces/book-write-payload.interface.ts
@@ -28,6 +28,7 @@ export interface BookWritePayload {
   koboId?: string | null;
   lubimyczytacId?: string | null;
   aladinId?: string | null;
+  comicvineId?: string | null;
   comicIssueNumber?: string | null;
   comicVolumeName?: string | null;
   comicPencillers?: string[];

--- a/server/src/modules/metadata/extractors/comic-format.extractor.ts
+++ b/server/src/modules/metadata/extractors/comic-format.extractor.ts
@@ -50,6 +50,7 @@ export class ComicFormatExtractor implements FormatExtractor {
       openLibraryId: comicMetadata?.openLibraryId ?? null,
       ranobedbId: comicMetadata?.ranobedbId ?? null,
       koboId: comicMetadata?.koboId ?? null,
+      comicvineId: comicMetadata?.comicvineId ?? null,
       lubimyczytacId: comicMetadata?.lubimyczytacId ?? null,
       aladinId: comicMetadata?.aladinId ?? null,
       itunesId: comicMetadata?.itunesId ?? null,

--- a/server/src/modules/metadata/extractors/format-extractor.interface.ts
+++ b/server/src/modules/metadata/extractors/format-extractor.interface.ts
@@ -24,6 +24,7 @@ export interface ParsedBookData {
   openLibraryId?: string | null;
   ranobedbId?: string | null;
   koboId?: string | null;
+  comicvineId?: string | null;
   lubimyczytacId?: string | null;
   aladinId?: string | null;
   itunesId?: string | null;

--- a/server/src/modules/metadata/extractors/format-extractors.test.ts
+++ b/server/src/modules/metadata/extractors/format-extractors.test.ts
@@ -379,6 +379,7 @@ describe('metadata format extractors', () => {
         publishedYear: 2014,
         authors: [],
         genres: [],
+        comicvineId: null,
       }),
     );
   });
@@ -396,6 +397,7 @@ describe('metadata format extractors', () => {
       genres: ['Comics'],
       tags: ['Superhero'],
       ranobedbId: 'comic-ranobe',
+      comicvineId: '140529',
       comicMetadata: { issueNumber: '55', volumeName: 'Batman' },
     });
     mockExtractCbrCover.mockResolvedValue(null);
@@ -405,6 +407,7 @@ describe('metadata format extractors', () => {
         title: 'Batman',
         genres: ['Comics'],
         ranobedbId: 'comic-ranobe',
+        comicvineId: '140529',
         comicMetadata: { issueNumber: '55', volumeName: 'Batman' },
       }),
     );

--- a/server/src/modules/metadata/lib/cbz-metadata.test.ts
+++ b/server/src/modules/metadata/lib/cbz-metadata.test.ts
@@ -263,10 +263,20 @@ describe('extractCbzMetadata', () => {
         expect(r?.comicvineId).toBe('140529');
       });
 
+      it('ignores the Notes fallback when ComicTagger sourced the issue id from another provider', async () => {
+        const xml = `<ComicInfo>
+          <Notes>Tagged with ComicTagger 2.10.0 using info from Metron on 2024-01-02. [Issue ID 55123]</Notes>
+        </ComicInfo>`;
+        mockZipFile(buildZipWithComicInfo(xml));
+
+        const r = await extractCbzMetadata('/book.cbz');
+        expect(r?.comicvineId).toBeNull();
+      });
+
       it('prefers the Web field over the Notes fallback when both are present', async () => {
         const xml = `<ComicInfo>
           <Web>https://comicvine.gamespot.com/amazing-series-1/4000-1/</Web>
-          <Notes>Tagged with ComicTagger. [Issue ID 999999]</Notes>
+          <Notes>Tagged with ComicTagger 1.3.2a5 using info from Comic Vine on 2022-04-16. [Issue ID 999999]</Notes>
         </ComicInfo>`;
         mockZipFile(buildZipWithComicInfo(xml));
 
@@ -279,7 +289,7 @@ describe('extractCbzMetadata', () => {
           <Web>https://comicvine.gamespot.com/amazing-series-1/4000-1/</Web>
           <Notes>
             [bookorbit:comicvineId] 42
-            Tagged with ComicTagger. [Issue ID 999999]
+            Tagged with ComicTagger 1.3.2a5 using info from Comic Vine on 2022-04-16. [Issue ID 999999]
           </Notes>
         </ComicInfo>`;
         mockZipFile(buildZipWithComicInfo(xml));
@@ -298,6 +308,14 @@ describe('extractCbzMetadata', () => {
 
       it('does not confuse a ComicVine volume URL (4050-) with an issue URL (4000-)', async () => {
         const xml = `<ComicInfo><Web>https://comicvine.gamespot.com/amazing-series/4050-9999/</Web></ComicInfo>`;
+        mockZipFile(buildZipWithComicInfo(xml));
+
+        const r = await extractCbzMetadata('/book.cbz');
+        expect(r?.comicvineId).toBeNull();
+      });
+
+      it('only matches 4000- at the start of a path segment', async () => {
+        const xml = `<ComicInfo><Web>https://comicvine.gamespot.com/amazing-series/14000-777/</Web></ComicInfo>`;
         mockZipFile(buildZipWithComicInfo(xml));
 
         const r = await extractCbzMetadata('/book.cbz');

--- a/server/src/modules/metadata/lib/cbz-metadata.test.ts
+++ b/server/src/modules/metadata/lib/cbz-metadata.test.ts
@@ -235,6 +235,75 @@ describe('extractCbzMetadata', () => {
       expect(r?.googleBooksId).toBe('google-1');
       expect(r?.hardcoverEditionId).toBe('8941973');
     });
+
+    describe('ComicVine ID extraction', () => {
+      it('extracts comicvineId from a Web field containing the canonical 4000-<id> issue URL', async () => {
+        const xml = `<ComicInfo><Web>https://comicvine.gamespot.com/amazing-series-1/4000-140529/</Web></ComicInfo>`;
+        mockZipFile(buildZipWithComicInfo(xml));
+
+        const r = await extractCbzMetadata('/book.cbz');
+        expect(r?.comicvineId).toBe('140529');
+      });
+
+      it('extracts comicvineId when Web holds multiple space-separated URLs', async () => {
+        const xml = `<ComicInfo><Web>https://www.example.com/other https://comicvine.gamespot.com/amazing-series-1/4000-140529/</Web></ComicInfo>`;
+        mockZipFile(buildZipWithComicInfo(xml));
+
+        const r = await extractCbzMetadata('/book.cbz');
+        expect(r?.comicvineId).toBe('140529');
+      });
+
+      it('falls back to the "[Issue ID N]" convention in Notes when Web has no ComicVine URL', async () => {
+        const xml = `<ComicInfo>
+          <Notes>Tagged with ComicTagger 1.3.2a5 using info from Comic Vine on 2022-04-16. [Issue ID 140529]</Notes>
+        </ComicInfo>`;
+        mockZipFile(buildZipWithComicInfo(xml));
+
+        const r = await extractCbzMetadata('/book.cbz');
+        expect(r?.comicvineId).toBe('140529');
+      });
+
+      it('prefers the Web field over the Notes fallback when both are present', async () => {
+        const xml = `<ComicInfo>
+          <Web>https://comicvine.gamespot.com/amazing-series-1/4000-1/</Web>
+          <Notes>Tagged with ComicTagger. [Issue ID 999999]</Notes>
+        </ComicInfo>`;
+        mockZipFile(buildZipWithComicInfo(xml));
+
+        const r = await extractCbzMetadata('/book.cbz');
+        expect(r?.comicvineId).toBe('1');
+      });
+
+      it('prefers a managed [bookorbit:comicvineId] note over both Web and the Notes fallback', async () => {
+        const xml = `<ComicInfo>
+          <Web>https://comicvine.gamespot.com/amazing-series-1/4000-1/</Web>
+          <Notes>
+            [bookorbit:comicvineId] 42
+            Tagged with ComicTagger. [Issue ID 999999]
+          </Notes>
+        </ComicInfo>`;
+        mockZipFile(buildZipWithComicInfo(xml));
+
+        const r = await extractCbzMetadata('/book.cbz');
+        expect(r?.comicvineId).toBe('42');
+      });
+
+      it('returns null when neither Web nor Notes reference ComicVine', async () => {
+        const xml = `<ComicInfo><Title>No ComicVine reference</Title></ComicInfo>`;
+        mockZipFile(buildZipWithComicInfo(xml));
+
+        const r = await extractCbzMetadata('/book.cbz');
+        expect(r?.comicvineId).toBeNull();
+      });
+
+      it('does not confuse a ComicVine volume URL (4050-) with an issue URL (4000-)', async () => {
+        const xml = `<ComicInfo><Web>https://comicvine.gamespot.com/amazing-series/4050-9999/</Web></ComicInfo>`;
+        mockZipFile(buildZipWithComicInfo(xml));
+
+        const r = await extractCbzMetadata('/book.cbz');
+        expect(r?.comicvineId).toBeNull();
+      });
+    });
   });
 
   describe('ComicBookInfo/1.0 JSON comment fallback', () => {

--- a/server/src/modules/metadata/lib/cbz-metadata.ts
+++ b/server/src/modules/metadata/lib/cbz-metadata.ts
@@ -45,6 +45,7 @@ export interface ParsedCbzMetadata {
   openLibraryId: string | null;
   ranobedbId: string | null;
   koboId: string | null;
+  comicvineId: string | null;
   lubimyczytacId: string | null;
   aladinId: string | null;
   itunesId: string | null;
@@ -106,6 +107,18 @@ function parseProviderIdsFromWebUrl(
   return {};
 }
 
+function parseComicVineIdFromWebUrl(webUrl: string | null): string | null {
+  if (!webUrl) return null;
+  // Web may hold multiple space-separated URLs, so scan rather than match a fixed prefix.
+  return /comicvine\.gamespot\.com\/[^\s]*?4000-(\d+)/i.exec(webUrl)?.[1] ?? null;
+}
+
+function parseComicVineIdFromNotes(notes: string | null): string | null {
+  if (!notes) return null;
+  // ComicTagger's auto-tag notes end with "... [Issue ID 140529]"; used as a Web fallback only.
+  return /\[Issue ID (\d+)\]/i.exec(notes)?.[1] ?? null;
+}
+
 function parseCbxRating(value: string | null): number | null {
   if (!value) return null;
   const parsed = Number(value);
@@ -145,8 +158,11 @@ function parseComicInfoXml(xmlBuf: Buffer): ParsedCbzMetadata | null {
       year !== null && month !== null && day !== null
         ? (parsePublishedDateKey(`${year}-${String(Math.floor(month)).padStart(2, '0')}-${String(Math.floor(day)).padStart(2, '0')}`) ?? null)
         : null;
-    const managedNotes = parseProjectxManagedNotes(str('Notes'));
-    const providerIdsFromWeb = parseProviderIdsFromWebUrl(str('Web'));
+    const notesText = str('Notes');
+    const webText = str('Web');
+    const managedNotes = parseProjectxManagedNotes(notesText);
+    const providerIdsFromWeb = parseProviderIdsFromWebUrl(webText);
+    const comicvineId = managedNotes.get('comicvineId') ?? parseComicVineIdFromWebUrl(webText) ?? parseComicVineIdFromNotes(notesText) ?? null;
 
     const genres = splitDelimited(str('Genre'));
     const tags = splitDelimited(str('Tags'));
@@ -201,6 +217,7 @@ function parseComicInfoXml(xmlBuf: Buffer): ParsedCbzMetadata | null {
       openLibraryId: managedNotes.get('openLibraryId') ?? providerIdsFromWeb.openLibraryId ?? null,
       ranobedbId: managedNotes.get('ranobedbId') ?? null,
       koboId: managedNotes.get('koboId') ?? providerIdsFromWeb.koboId ?? null,
+      comicvineId,
       lubimyczytacId: managedNotes.get('lubimyczytacId') ?? null,
       aladinId: managedNotes.get('aladinId') ?? null,
       itunesId: null,
@@ -271,6 +288,7 @@ function parseComicBookInfoJson(comment: string): ParsedCbzMetadata | null {
       openLibraryId: null,
       ranobedbId: null,
       koboId: null,
+      comicvineId: null,
       lubimyczytacId: null,
       aladinId: null,
       itunesId: null,

--- a/server/src/modules/metadata/lib/cbz-metadata.ts
+++ b/server/src/modules/metadata/lib/cbz-metadata.ts
@@ -110,13 +110,15 @@ function parseProviderIdsFromWebUrl(
 function parseComicVineIdFromWebUrl(webUrl: string | null): string | null {
   if (!webUrl) return null;
   // Web may hold multiple space-separated URLs, so scan rather than match a fixed prefix.
-  return /comicvine\.gamespot\.com\/[^\s]*?4000-(\d+)/i.exec(webUrl)?.[1] ?? null;
+  // 4000- must start a path segment, otherwise a segment merely ending in it, such as "14000-777", matches too.
+  return /comicvine\.gamespot\.com\/(?:[^\s]*\/)?4000-(\d+)/i.exec(webUrl)?.[1] ?? null;
 }
 
 function parseComicVineIdFromNotes(notes: string | null): string | null {
   if (!notes) return null;
-  // ComicTagger's auto-tag notes end with "... [Issue ID 140529]"; used as a Web fallback only.
-  return /\[Issue ID (\d+)\]/i.exec(notes)?.[1] ?? null;
+  // ComicTagger writes "using info from <source> on <date>. [Issue ID 140529]" for every metadata
+  // source it supports, so the id only belongs to Comic Vine when that source names it.
+  return /using info from Comic\s*Vine\b[^[]*\[Issue ID (\d+)\]/i.exec(notes)?.[1] ?? null;
 }
 
 function parseCbxRating(value: string | null): number | null {

--- a/server/src/modules/metadata/metadata.service.test.ts
+++ b/server/src/modules/metadata/metadata.service.test.ts
@@ -86,7 +86,9 @@ import { mkdir, readFile, readdir, rm, writeFile } from 'fs/promises';
 import { Logger } from '@nestjs/common';
 
 import { authors, bookAuthors, bookGenres, bookMetadata, books, bookTags, genres, tags } from '../../db/schema';
+import { extractCbzMetadata } from './lib/cbz-metadata';
 import { generateThumbnail, imageExt } from './lib/cover';
+import { extractCbzCover } from './lib/cover-cbz';
 import { extractEpubCover } from './lib/cover-epub';
 import { extractEpubMetadata } from './lib/epub';
 import { parseBookFilename } from './lib/filename-parser';
@@ -109,6 +111,8 @@ const mockParseMobiFile = parseMobiFile as MockedFunction<typeof parseMobiFile>;
 const mockParsePdfFile = parsePdfFile as MockedFunction<typeof parsePdfFile>;
 const mockExtractEpubCover = extractEpubCover as MockedFunction<typeof extractEpubCover>;
 const mockExtractEpubMetadata = extractEpubMetadata as MockedFunction<typeof extractEpubMetadata>;
+const mockExtractCbzMetadata = extractCbzMetadata as MockedFunction<typeof extractCbzMetadata>;
+const mockExtractCbzCover = extractCbzCover as MockedFunction<typeof extractCbzCover>;
 const mockExtractAudioMetadata = extractAudioMetadata as MockedFunction<typeof extractAudioMetadata>;
 const mockParseAudioDuration = parseAudioDuration as MockedFunction<typeof parseAudioDuration>;
 
@@ -176,6 +180,8 @@ describe('MetadataService', () => {
     mockParseBookFilename.mockReturnValue({ title: 'Fallback Title', publishedYear: 2001 });
     mockParseMobiFile.mockResolvedValue(null);
     mockParsePdfFile.mockResolvedValue(null);
+    mockExtractCbzMetadata.mockResolvedValue(null);
+    mockExtractCbzCover.mockResolvedValue(null);
     mockExtractEpubMetadata.mockResolvedValue(null);
     mockExtractEpubCover.mockResolvedValue(null);
     mockExtractAudioMetadata.mockResolvedValue({
@@ -618,6 +624,53 @@ describe('MetadataService', () => {
     expect(replaceGenresSpy).toHaveBeenCalledWith(22, ['Fantasy']);
     expect(replaceTagsSpy).toHaveBeenCalledWith(22, ['Shelf']);
     expect(embedder.embedBook).toHaveBeenCalledWith(22);
+  });
+
+  it('extractAndSave(cbz) persists comicvineId parsed from the embedded ComicInfo.xml', async () => {
+    const { db, updateSet } = makeDb();
+    const service = makeService(db);
+    vi.spyOn(service, 'replaceAuthors').mockResolvedValue(undefined);
+    vi.spyOn(service, 'replaceGenres').mockResolvedValue(undefined);
+
+    mockExtractCbzMetadata.mockResolvedValue({
+      title: 'Amazing Series',
+      subtitle: null,
+      seriesName: 'Amazing Series',
+      seriesIndex: 1,
+      description: null,
+      publisher: null,
+      publishedDate: null,
+      publishedYear: null,
+      language: null,
+      pageCount: null,
+      rating: null,
+      isbn10: null,
+      isbn13: null,
+      authors: [],
+      genres: [],
+      tags: [],
+      googleBooksId: null,
+      goodreadsId: null,
+      amazonId: null,
+      hardcoverId: null,
+      hardcoverEditionId: null,
+      openLibraryId: null,
+      ranobedbId: null,
+      koboId: null,
+      comicvineId: '140529',
+      lubimyczytacId: null,
+      aladinId: null,
+      itunesId: null,
+      comicMetadata: null,
+    });
+
+    await service.extractAndSave(23, '/tmp/book.cbz', 'cbz');
+
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        comicvineId: '140529',
+      }),
+    );
   });
 
   it('extractAndSave(mobi) ignores malformed publishedDate values from providers', async () => {

--- a/server/src/modules/metadata/metadata.service.ts
+++ b/server/src/modules/metadata/metadata.service.ts
@@ -651,6 +651,7 @@ export class MetadataService {
       openLibraryId: data.openLibraryId,
       ranobedbId: data.ranobedbId,
       koboId: data.koboId,
+      comicvineId: data.comicvineId,
       lubimyczytacId: data.lubimyczytacId,
       aladinId: data.aladinId,
       itunesId: data.itunesId,
@@ -688,6 +689,7 @@ export class MetadataService {
     if (filtered.openLibraryId !== undefined) scalarFields.openLibraryId = filtered.openLibraryId;
     if (filtered.ranobedbId !== undefined) scalarFields.ranobedbId = filtered.ranobedbId;
     if (filtered.koboId !== undefined) scalarFields.koboId = filtered.koboId;
+    if (filtered.comicvineId !== undefined) scalarFields.comicvineId = filtered.comicvineId;
     if (filtered.lubimyczytacId !== undefined) scalarFields.lubimyczytacId = filtered.lubimyczytacId;
     if (filtered.aladinId !== undefined) scalarFields.aladinId = filtered.aladinId;
     if (filtered.itunesId !== undefined) scalarFields.itunesId = filtered.itunesId;


### PR DESCRIPTION
## Before you submit

> **New feature?** Please open an issue first and get approval from the maintainers before writing any code.
> PRs that introduce features without a prior discussion will be closed.
>
> **Used AI assistance?** That's fine - but make sure you've read and understood every line of the diff
> before submitting. PRs that show no sign of self-review will be closed without detailed feedback.
>
> **Keep it focused.** One thing per PR. Don't bundle a bug fix with a refactor or unrelated cleanup.
> If it's not ready, open it as a draft instead.

---

## What does this PR do?

ComicVine ids were never read from a comic's embedded `ComicInfo.xml` on import, even though every
other provider id (Goodreads, Amazon, Hardcover, Google Books, OpenLibrary, Kobo) already round-trips
through the same `<Web>`/`Notes` fields. Write-back had the same gap: a `comicvineId` resolved via
search/auto-fill was never persisted back into the file.

Closes #840

## How did you test this?

Added unit tests for Web-URL extraction (including multi-URL fields), the ComicTagger Notes fallback,
precedence between the managed note/Web/Notes sources, extractor passthrough, persistence, and
write-back. Ran the full server suite plus lint/format/typecheck for server and client - all green.

## Screenshots

N/A - no UI changes.

## Anything non-obvious in the diff?

The write-back URL builder uses a placeholder slug since only the numeric id is stored; Comic Vine
canonicalizes by the trailing `4000-<id>` segment and ignores the slug before it, same as the other
six provider URL builders in this file, none of which store the original page URL either.

`comicvineId` was scoped to `COMIC_BOOK_FILE_WRITE_FIELDS` rather than the shared provider field list,
so it doesn't bleed into EPUB/FB2/PDF, which have no equivalent identifier scheme for it.

## Checklist

- [x] I've read through my own diff
- [ ] This PR was discussed in an issue and has maintainer approval (for new features)
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ComicVine ID support for comic book metadata.
  * ComicVine IDs can now be extracted from embedded metadata and saved with books.
  * File writing can preserve ComicVine IDs and generate canonical ComicVine issue links.
* **Bug Fixes**
  * Improved handling of ComicVine references when multiple metadata providers are present.
  * Added fallback detection for ComicVine IDs in managed notes and issue URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->