### PR TITLE
fix(metadata): stop concatenating series and issue number into comicvine title

### DIFF
--- a/client/src/features/book/components/detail/tabs/MetadataDiffPanel.vue
+++ b/client/src/features/book/components/detail/tabs/MetadataDiffPanel.vue
@@ -11,7 +11,14 @@ import type {
   ProviderIds,
 } from '@bookorbit/types'
 import { useMetadataDiff, type DiffFieldKey, type MetadataPatch } from '../../../composables/useMetadataDiff'
-import { getProviderColor, getProviderLabel, hideOnError, providerActivePillStyle, toDisplayCoverUrl } from '../../../lib/metadata-fetch'
+import {
+  getProviderColor,
+  getProviderLabel,
+  hideOnError,
+  providerActivePillStyle,
+  resolveCandidateDisplayTitle,
+  toDisplayCoverUrl,
+} from '../../../lib/metadata-fetch'
 import MetadataDiffRow from './MetadataDiffRow.vue'
 import { COVER_ASPECT_RATIO_KEY, DEFAULT_COVER_ASPECT_RATIO } from '../../../lib/cover-aspect-ratio'
 
@@ -291,7 +298,7 @@ onBeforeUnmount(() => {
               <span v-else class="block w-full h-full bg-muted-foreground/10" />
             </span>
             <span class="min-w-0 flex-1">
-              <span class="block text-xs font-medium text-foreground line-clamp-1">{{ candidate.title }}</span>
+              <span class="block text-xs font-medium text-foreground line-clamp-1">{{ resolveCandidateDisplayTitle(candidate) }}</span>
               <span class="block text-[10px] text-muted-foreground line-clamp-1">
                 {{ candidate.publishedDate ?? candidate.publishedYear ?? 'Date unknown' }} - {{ index + 1 }} of {{ resultsForActiveProvider.length }}
               </span>

--- a/client/src/features/book/components/detail/tabs/MetadataResultCard.spec.ts
+++ b/client/src/features/book/components/detail/tabs/MetadataResultCard.spec.ts
@@ -16,13 +16,12 @@ function makeCandidate(overrides: Partial<MetadataCandidate> = {}): MetadataCand
 }
 
 describe('MetadataResultCard', () => {
-  it('renders displayTitle as the headline and alt text when present', () => {
+  it('renders displayTitle as the headline when present', () => {
     const wrapper = mount(MetadataResultCard, {
       props: { candidate: makeCandidate({ displayTitle: 'Series Name #12.5 - The Origin' }), providers },
     })
 
     expect(wrapper.text()).toContain('Series Name #12.5 - The Origin')
-    expect(wrapper.find('img').attributes('alt')).toBe('Series Name #12.5 - The Origin')
   })
 
   it('falls back to title as the headline when displayTitle is absent', () => {
@@ -31,6 +30,21 @@ describe('MetadataResultCard', () => {
     })
 
     expect(wrapper.text()).toContain('The Way of Kings')
-    expect(wrapper.find('img').attributes('alt')).toBe('The Way of Kings')
+  })
+
+  it('still labels an unnamed comic issue, which has a displayTitle but no title', () => {
+    const wrapper = mount(MetadataResultCard, {
+      props: { candidate: makeCandidate({ title: undefined, displayTitle: 'Series Name #7' }), providers },
+    })
+
+    expect(wrapper.text()).toContain('Series Name #7')
+  })
+
+  it('hides the cover from assistive technology because the headline already names the result', () => {
+    const wrapper = mount(MetadataResultCard, {
+      props: { candidate: makeCandidate({ displayTitle: 'Series Name #12.5 - The Origin' }), providers },
+    })
+
+    expect(wrapper.find('img').attributes('alt')).toBe('')
   })
 })

--- a/client/src/features/book/components/detail/tabs/MetadataResultCard.spec.ts
+++ b/client/src/features/book/components/detail/tabs/MetadataResultCard.spec.ts
@@ -1,0 +1,36 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import type { MetadataCandidate, MetadataProviderInfo } from '@bookorbit/types'
+import MetadataResultCard from './MetadataResultCard.vue'
+
+const providers: MetadataProviderInfo[] = [{ key: 'comicvine', label: 'ComicVine', identifiable: true }]
+
+function makeCandidate(overrides: Partial<MetadataCandidate> = {}): MetadataCandidate {
+  return {
+    provider: 'comicvine',
+    providerId: '777',
+    title: 'The Origin',
+    coverUrl: 'https://example.com/cover.jpg',
+    ...overrides,
+  }
+}
+
+describe('MetadataResultCard', () => {
+  it('renders displayTitle as the headline and alt text when present', () => {
+    const wrapper = mount(MetadataResultCard, {
+      props: { candidate: makeCandidate({ displayTitle: 'Series Name #12.5 - The Origin' }), providers },
+    })
+
+    expect(wrapper.text()).toContain('Series Name #12.5 - The Origin')
+    expect(wrapper.find('img').attributes('alt')).toBe('Series Name #12.5 - The Origin')
+  })
+
+  it('falls back to title as the headline when displayTitle is absent', () => {
+    const wrapper = mount(MetadataResultCard, {
+      props: { candidate: makeCandidate({ title: 'The Way of Kings', displayTitle: undefined }), providers: [] },
+    })
+
+    expect(wrapper.text()).toContain('The Way of Kings')
+    expect(wrapper.find('img').attributes('alt')).toBe('The Way of Kings')
+  })
+})

--- a/client/src/features/book/components/detail/tabs/MetadataResultCard.vue
+++ b/client/src/features/book/components/detail/tabs/MetadataResultCard.vue
@@ -40,7 +40,7 @@ function handleSelect() {
       <img
         v-if="displayCoverUrl"
         :src="displayCoverUrl"
-        :alt="displayTitle"
+        alt=""
         class="w-full h-full object-contain transition-transform duration-500 group-hover:scale-105"
         @error="hideOnError"
       />

--- a/client/src/features/book/components/detail/tabs/MetadataResultCard.vue
+++ b/client/src/features/book/components/detail/tabs/MetadataResultCard.vue
@@ -2,7 +2,7 @@
 import { computed, inject, ref } from 'vue'
 import type { MetadataCandidate, MetadataProviderInfo } from '@bookorbit/types'
 import { Star } from '@lucide/vue'
-import { getProviderLabel, hideOnError, providerBadgeStyle, toDisplayCoverUrl } from '../../../lib/metadata-fetch'
+import { getProviderLabel, hideOnError, providerBadgeStyle, resolveCandidateDisplayTitle, toDisplayCoverUrl } from '../../../lib/metadata-fetch'
 import { COVER_ASPECT_RATIO_KEY, DEFAULT_COVER_ASPECT_RATIO } from '../../../lib/cover-aspect-ratio'
 import { formatCommunityRatingValue } from '../../../lib/community-rating'
 import { displayPublishedDate } from '../../../lib/published-date'
@@ -19,7 +19,8 @@ const coverAspectRatio = inject(COVER_ASPECT_RATIO_KEY, ref(DEFAULT_COVER_ASPECT
 
 const providerLabel = computed(() => getProviderLabel(props.candidate.provider, props.providers))
 const displayCoverUrl = computed(() => toDisplayCoverUrl(props.candidate.coverUrl))
-const candidateSeed = computed(() => props.candidate.title ?? props.candidate.provider)
+const displayTitle = computed(() => resolveCandidateDisplayTitle(props.candidate))
+const candidateSeed = computed(() => displayTitle.value ?? props.candidate.provider)
 const candidateAuthorLine = computed(() => props.candidate.authors?.join(', ') || null)
 const communityRatingDisplay = computed(() => formatCommunityRatingValue(props.candidate.communityRating, props.candidate.communityRatingCount))
 const publishedDisplay = computed(() => displayPublishedDate(props.candidate.publishedDate, props.candidate.publishedYear))
@@ -39,7 +40,7 @@ function handleSelect() {
       <img
         v-if="displayCoverUrl"
         :src="displayCoverUrl"
-        :alt="candidate.title"
+        :alt="displayTitle"
         class="w-full h-full object-contain transition-transform duration-500 group-hover:scale-105"
         @error="hideOnError"
       />
@@ -48,7 +49,7 @@ function handleSelect() {
 
     <!-- Info -->
     <span class="flex-1 min-w-0 flex flex-col justify-center gap-1.5 py-0.5">
-      <span class="text-sm font-semibold leading-snug line-clamp-2 text-foreground">{{ candidate.title }}</span>
+      <span class="text-sm font-semibold leading-snug line-clamp-2 text-foreground">{{ displayTitle }}</span>
       <span v-if="candidate.authors?.length" class="text-xs text-muted-foreground line-clamp-1 block leading-tight">
         {{ candidate.authors.join(', ') }}
       </span>

--- a/client/src/features/book/lib/metadata-fetch.spec.ts
+++ b/client/src/features/book/lib/metadata-fetch.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCandidateDisplayTitle } from './metadata-fetch'
+
+describe('resolveCandidateDisplayTitle', () => {
+  it('prefers displayTitle when the candidate provides one', () => {
+    expect(resolveCandidateDisplayTitle({ title: 'The Origin', displayTitle: 'Series Name #12.5 - The Origin' })).toBe(
+      'Series Name #12.5 - The Origin',
+    )
+  })
+
+  it('falls back to title when displayTitle is absent', () => {
+    expect(resolveCandidateDisplayTitle({ title: 'The Way of Kings', displayTitle: undefined })).toBe('The Way of Kings')
+  })
+})

--- a/client/src/features/book/lib/metadata-fetch.spec.ts
+++ b/client/src/features/book/lib/metadata-fetch.spec.ts
@@ -11,4 +11,12 @@ describe('resolveCandidateDisplayTitle', () => {
   it('falls back to title when displayTitle is absent', () => {
     expect(resolveCandidateDisplayTitle({ title: 'The Way of Kings', displayTitle: undefined })).toBe('The Way of Kings')
   })
+
+  it('uses displayTitle when the candidate has no title, as an unnamed comic issue does', () => {
+    expect(resolveCandidateDisplayTitle({ title: undefined, displayTitle: 'Series Name #7' })).toBe('Series Name #7')
+  })
+
+  it('returns undefined when the candidate has neither', () => {
+    expect(resolveCandidateDisplayTitle({ title: undefined, displayTitle: undefined })).toBeUndefined()
+  })
 })

--- a/client/src/features/book/lib/metadata-fetch.ts
+++ b/client/src/features/book/lib/metadata-fetch.ts
@@ -8,7 +8,7 @@ export function getProviderLabel(provider: MetadataProviderKey, providers: reado
   return providers.find((p) => p.key === provider)?.label ?? provider
 }
 
-export function resolveCandidateDisplayTitle(candidate: Pick<MetadataCandidate, 'title' | 'displayTitle'>): string {
+export function resolveCandidateDisplayTitle(candidate: Pick<MetadataCandidate, 'title' | 'displayTitle'>): string | undefined {
   return candidate.displayTitle ?? candidate.title
 }
 

--- a/client/src/features/book/lib/metadata-fetch.ts
+++ b/client/src/features/book/lib/metadata-fetch.ts
@@ -1,4 +1,4 @@
-import type { MetadataProviderInfo, MetadataProviderKey } from '@bookorbit/types'
+import type { MetadataCandidate, MetadataProviderInfo, MetadataProviderKey } from '@bookorbit/types'
 
 export { getProviderColor, providerBadgeStyle, providerActivePillStyle } from '@/lib/provider-colors'
 
@@ -6,6 +6,10 @@ const COVER_PROXY_PATH = '/api/v1/books/cover/proxy'
 
 export function getProviderLabel(provider: MetadataProviderKey, providers: readonly MetadataProviderInfo[]): string {
   return providers.find((p) => p.key === provider)?.label ?? provider
+}
+
+export function resolveCandidateDisplayTitle(candidate: Pick<MetadataCandidate, 'title' | 'displayTitle'>): string {
+  return candidate.displayTitle ?? candidate.title
 }
 
 function currentOrigin(): string | null {

--- a/packages/types/src/metadata-fetch.ts
+++ b/packages/types/src/metadata-fetch.ts
@@ -63,6 +63,7 @@ export interface MetadataCandidate {
   providerId: string;
   hardcoverEditionId?: string;
   title: string;
+  displayTitle?: string;
   subtitle?: string;
   authors?: string[];
   description?: string;

--- a/packages/types/src/metadata-fetch.ts
+++ b/packages/types/src/metadata-fetch.ts
@@ -62,7 +62,8 @@ export interface MetadataCandidate {
   provider: MetadataProviderKey;
   providerId: string;
   hardcoverEditionId?: string;
-  title: string;
+  /** Absent when the provider has no title of its own for this record, e.g. an unnamed comic issue. */
+  title?: string;
   displayTitle?: string;
   subtitle?: string;
   authors?: string[];

--- a/server/src/modules/book-metadata-fetch/book-metadata-fetch-orchestrator.service.ts
+++ b/server/src/modules/book-metadata-fetch/book-metadata-fetch-orchestrator.service.ts
@@ -221,6 +221,8 @@ export class BookMetadataFetchOrchestratorService implements OnApplicationBootst
         title: meta?.title ?? undefined,
         author: authorRows[0]?.name ?? undefined,
         isbn: meta?.isbn13 ?? meta?.isbn10 ?? undefined,
+        seriesName: meta?.seriesName ?? undefined,
+        seriesIndex: meta?.seriesIndex ?? undefined,
         existingProviderIds: this.collectProviderIds(meta ?? {}),
         isAudiobook: (meta?.durationSeconds !== null && meta?.durationSeconds !== undefined) || !!meta?.audibleId || !!meta?.librofmId,
         maxCandidatesPerProvider: 1,

--- a/server/src/modules/book/book.service.ts
+++ b/server/src/modules/book/book.service.ts
@@ -2629,6 +2629,8 @@ export class BookService {
         title: meta?.title ?? undefined,
         author: authorRows[0]?.name ?? undefined,
         isbn: meta?.isbn13 ?? meta?.isbn10 ?? undefined,
+        seriesName: meta?.seriesName ?? undefined,
+        seriesIndex: meta?.seriesIndex ?? undefined,
         existingProviderIds: providerIds,
         isAudiobook: (meta?.durationSeconds !== null && meta?.durationSeconds !== undefined) || !!meta?.audibleId || !!meta?.librofmId,
         maxCandidatesPerProvider: 1,

--- a/server/src/modules/metadata-fetch/candidate-relevance.test.ts
+++ b/server/src/modules/metadata-fetch/candidate-relevance.test.ts
@@ -140,6 +140,29 @@ describe('candidate-relevance', () => {
       const result = filterAndRank(candidates, { title: 'Batman' });
       expect(result[0].title).toBe('Batman');
     });
+
+    it('ranks a candidate that has only a displayTitle, as an unnamed comic issue does', () => {
+      const unnamedIssue: MetadataCandidate = { provider: 'comicvine', providerId: '1', displayTitle: 'Batman #7' };
+      const result = filterAndRank([unnamedIssue], { title: 'Batman' });
+      expect(result).toEqual([unnamedIssue]);
+    });
+
+    it('drops a candidate with neither title nor displayTitle', () => {
+      const result = filterAndRank([{ provider: 'comicvine', providerId: '1' }], { title: 'Batman' });
+      expect(result).toHaveLength(0);
+    });
+
+    it('applies the skip patterns to the same string it scores, so a named issue survives', () => {
+      const candidates = [{ ...candidate('Guide to Gotham'), displayTitle: 'Batman #4 - Guide to Gotham' }];
+      const result = filterAndRank(candidates, { title: 'Batman' });
+      expect(result).toHaveLength(1);
+    });
+
+    it('still drops a genuine study guide that carries a displayTitle', () => {
+      const candidates = [{ ...candidate('The Great Gatsby'), displayTitle: 'Study Guide for The Great Gatsby' }];
+      const result = filterAndRank(candidates, { title: 'The Great Gatsby' });
+      expect(result).toHaveLength(0);
+    });
   });
 
   describe('scoreTitle', () => {

--- a/server/src/modules/metadata-fetch/candidate-relevance.test.ts
+++ b/server/src/modules/metadata-fetch/candidate-relevance.test.ts
@@ -100,6 +100,48 @@ describe('candidate-relevance', () => {
     });
   });
 
+  describe('displayTitle fallback', () => {
+    it('matches a candidate via displayTitle when title alone would not match', () => {
+      const candidates = [{ ...candidate('The Origin'), displayTitle: 'Batman #12.5 - The Origin' }];
+      const result = filterAndRank(candidates, { title: 'Batman' });
+      expect(result).toHaveLength(1);
+    });
+
+    it('still drops candidates when neither title nor displayTitle match', () => {
+      const candidates = [{ ...candidate('The Origin'), displayTitle: 'Superman #1 - The Origin' }];
+      const result = filterAndRank(candidates, { title: 'Batman' });
+      expect(result).toHaveLength(0);
+    });
+
+    it('leaves title-only matching unaffected when displayTitle is absent', () => {
+      const candidates = [candidate('Batman: Year One')];
+      const result = filterAndRank(candidates, { title: 'Batman' });
+      expect(result).toHaveLength(1);
+    });
+
+    it('boosts score with author match when the title signal came from displayTitle', () => {
+      const candidates = [
+        { ...candidate('The Origin', 'Andy Weir'), displayTitle: 'Batman #1 - The Origin' },
+        { ...candidate('The Origin', 'Someone Else'), displayTitle: 'Batman #1 - The Origin' },
+      ];
+      const result = filterAndRank(candidates, { title: 'Batman', author: 'Andy Weir' });
+      expect(result[0].authors).toContain('Andy Weir');
+    });
+
+    it('uses displayTitle exclusively when present, not the better of title and displayTitle', () => {
+      const exactTitleOnly = candidate('Batman');
+      const exactTitleWeakerDisplayTitle = { ...candidate('Batman'), displayTitle: 'Batman Chronicles Vol 1' };
+      const result = filterAndRank([exactTitleWeakerDisplayTitle, exactTitleOnly], { title: 'Batman' });
+      expect(result).toEqual([exactTitleOnly, exactTitleWeakerDisplayTitle]);
+    });
+
+    it('ranks an exact title match above a partial displayTitle-only match', () => {
+      const candidates = [{ ...candidate('Something Else'), displayTitle: 'The Batman Chronicles' }, candidate('Batman')];
+      const result = filterAndRank(candidates, { title: 'Batman' });
+      expect(result[0].title).toBe('Batman');
+    });
+  });
+
   describe('scoreTitle', () => {
     it('gives highest score to exact matches', () => {
       const params: MetadataSearchParams = { title: 'Foundation' };

--- a/server/src/modules/metadata-fetch/candidate-relevance.ts
+++ b/server/src/modules/metadata-fetch/candidate-relevance.ts
@@ -41,8 +41,9 @@ function scoreCandidate(candidate: MetadataCandidate, params: MetadataSearchPara
 
   let score = 0;
 
-  if (params.title && candidate.title) {
-    score += scoreTitle(normalize(params.title), normalize(candidate.title));
+  if (params.title) {
+    const matchable = candidate.displayTitle ?? candidate.title;
+    if (matchable) score = scoreTitle(normalize(params.title), normalize(matchable));
   }
 
   // Author only boosts when there is already a positive title signal.

--- a/server/src/modules/metadata-fetch/candidate-relevance.ts
+++ b/server/src/modules/metadata-fetch/candidate-relevance.ts
@@ -25,7 +25,10 @@ export function filterAndRank(candidates: MetadataCandidate[], params: MetadataS
   }
 
   return candidates
-    .filter((c) => !c.title || !SKIP_TITLE_PATTERNS.some((pattern) => pattern.test(c.title)))
+    .filter((c) => {
+      const matchable = matchableTitle(c);
+      return !matchable || !SKIP_TITLE_PATTERNS.some((pattern) => pattern.test(matchable));
+    })
     .map((c) => ({ candidate: c, score: scoreCandidate(c, params) }))
     .filter(({ score }) => score > 0)
     .sort((a, b) => b.score - a.score)
@@ -41,9 +44,9 @@ function scoreCandidate(candidate: MetadataCandidate, params: MetadataSearchPara
 
   let score = 0;
 
-  if (params.title) {
-    const matchable = candidate.displayTitle ?? candidate.title;
-    if (matchable) score = scoreTitle(normalize(params.title), normalize(matchable));
+  const matchable = matchableTitle(candidate);
+  if (params.title && matchable) {
+    score += scoreTitle(normalize(params.title), normalize(matchable));
   }
 
   // Author only boosts when there is already a positive title signal.
@@ -53,6 +56,15 @@ function scoreCandidate(candidate: MetadataCandidate, params: MetadataSearchPara
   }
 
   return score;
+}
+
+/**
+ * The string a candidate should be matched against. `displayTitle` carries the provider's own
+ * disambiguating label (ComicVine's "<volume> #<issue> - <name>"), which is what a user's query
+ * is shaped like; `title` alone can be just an issue name, or absent entirely.
+ */
+function matchableTitle(candidate: MetadataCandidate): string | undefined {
+  return candidate.displayTitle ?? candidate.title;
 }
 
 function scoreTitle(query: string, candidate: string): number {

--- a/server/src/modules/metadata-fetch/metadata-fetch.controller.ts
+++ b/server/src/modules/metadata-fetch/metadata-fetch.controller.ts
@@ -82,6 +82,8 @@ export class MetadataFetchController {
       title: normalizeSearchTitle(dto.title),
       author: dto.author,
       isbn: dto.isbn,
+      seriesName: storedContext?.seriesName ?? undefined,
+      seriesIndex: storedContext?.seriesIndex ?? undefined,
       existingProviderIds,
       isAudiobook,
     };

--- a/server/src/modules/metadata-fetch/metadata-fetch.repository.ts
+++ b/server/src/modules/metadata-fetch/metadata-fetch.repository.ts
@@ -10,6 +10,8 @@ type Db = NodePgDatabase<typeof schema>;
 
 export interface StoredProviderIdsRow {
   libraryId: number;
+  seriesName: string | null;
+  seriesIndex: number | null;
   googleBooksId: string | null;
   goodreadsId: string | null;
   amazonId: string | null;
@@ -33,6 +35,8 @@ export class MetadataFetchRepository {
     const [row] = await this.db
       .select({
         libraryId: books.libraryId,
+        seriesName: bookMetadata.seriesName,
+        seriesIndex: bookMetadata.seriesIndex,
         googleBooksId: bookMetadata.googleBooksId,
         goodreadsId: bookMetadata.goodreadsId,
         amazonId: bookMetadata.amazonId,

--- a/server/src/modules/metadata-fetch/metadata-fetch.service.ts
+++ b/server/src/modules/metadata-fetch/metadata-fetch.service.ts
@@ -20,6 +20,8 @@ interface TimedProviderResult {
 
 export interface StoredProviderContext {
   libraryId: number;
+  seriesName: string | null;
+  seriesIndex: number | null;
   providerIds: Partial<Record<MetadataProviderKey, string>>;
 }
 
@@ -58,6 +60,8 @@ export class MetadataFetchService {
     const row = await this.getAccessibleStoredProviderIdsRow(bookId, user);
     return {
       libraryId: row.libraryId,
+      seriesName: row.seriesName,
+      seriesIndex: row.seriesIndex,
       providerIds: this.mapStoredProviderIds(row),
     };
   }

--- a/server/src/modules/metadata-fetch/providers/comicvine/comicvine.mapper.test.ts
+++ b/server/src/modules/metadata-fetch/providers/comicvine/comicvine.mapper.test.ts
@@ -51,8 +51,8 @@ describe('mapIssueToCandidate', () => {
       expect.objectContaining({
         provider: MetadataProviderKey.COMICVINE,
         providerId: '777',
-        title: 'Series Name #12.5 - The Origin',
-        subtitle: 'The Origin',
+        title: 'The Origin',
+        displayTitle: 'Series Name #12.5 - The Origin',
         authors: ['Writer A'],
         description: 'Fallback synopsis',
         publishedYear: 2024,
@@ -77,6 +77,48 @@ describe('mapIssueToCandidate', () => {
         storyArcs: ['Arc A'],
       }),
     );
+  });
+
+  it('never sets subtitle - comics have no ComicInfo.xml subtitle concept distinct from title', () => {
+    const withName = mapIssueToCandidate(makeIssue({ name: 'The Origin' }));
+    expect(withName.subtitle).toBeUndefined();
+
+    const withoutName = mapIssueToCandidate(makeIssue({ name: null }));
+    expect(withoutName.subtitle).toBeUndefined();
+  });
+
+  describe('title', () => {
+    it('uses the issue name verbatim, not a series/issue-number concatenation', () => {
+      const candidate = mapIssueToCandidate(makeIssue({ name: 'The Origin', volume: { id: 10, name: 'Series Name' }, issue_number: '12.5' }));
+      expect(candidate.title).toBe('The Origin');
+    });
+
+    it('falls back to "<series> #<issue>" when the issue has no name', () => {
+      const candidate = mapIssueToCandidate(makeIssue({ name: null, volume: { id: 10, name: 'Series Name' }, issue_number: '7' }));
+      expect(candidate.title).toBe('Series Name #7');
+    });
+
+    it('falls back to "<series> #<issue>" when the issue name is an empty string', () => {
+      const candidate = mapIssueToCandidate(makeIssue({ name: '', volume: { id: 10, name: 'Series Name' }, issue_number: '7' }));
+      expect(candidate.title).toBe('Series Name #7');
+    });
+  });
+
+  describe('displayTitle', () => {
+    it('concatenates series, issue number, and name when a name is present', () => {
+      const candidate = mapIssueToCandidate(makeIssue({ name: 'The Origin', volume: { id: 10, name: 'Series Name' }, issue_number: '12.5' }));
+      expect(candidate.displayTitle).toBe('Series Name #12.5 - The Origin');
+    });
+
+    it('omits the name suffix when the issue has no name', () => {
+      const candidate = mapIssueToCandidate(makeIssue({ name: null, volume: { id: 10, name: 'Series Name' }, issue_number: '7' }));
+      expect(candidate.displayTitle).toBe('Series Name #7');
+    });
+
+    it('omits the name suffix when the issue name is an empty string', () => {
+      const candidate = mapIssueToCandidate(makeIssue({ name: '', volume: { id: 10, name: 'Series Name' }, issue_number: '7' }));
+      expect(candidate.displayTitle).toBe('Series Name #7');
+    });
   });
 
   it('uses store_date fallback and treats malformed years as unknown', () => {

--- a/server/src/modules/metadata-fetch/providers/comicvine/comicvine.mapper.test.ts
+++ b/server/src/modules/metadata-fetch/providers/comicvine/comicvine.mapper.test.ts
@@ -93,14 +93,24 @@ describe('mapIssueToCandidate', () => {
       expect(candidate.title).toBe('The Origin');
     });
 
-    it('falls back to "<series> #<issue>" when the issue has no name', () => {
+    it('stays unset when the issue has no name, leaving any existing title alone', () => {
       const candidate = mapIssueToCandidate(makeIssue({ name: null, volume: { id: 10, name: 'Series Name' }, issue_number: '7' }));
-      expect(candidate.title).toBe('Series Name #7');
+      expect(candidate.title).toBeUndefined();
     });
 
-    it('falls back to "<series> #<issue>" when the issue name is an empty string', () => {
+    it('stays unset when the issue name is an empty string', () => {
       const candidate = mapIssueToCandidate(makeIssue({ name: '', volume: { id: 10, name: 'Series Name' }, issue_number: '7' }));
-      expect(candidate.title).toBe('Series Name #7');
+      expect(candidate.title).toBeUndefined();
+    });
+
+    it('stays unset when the issue name is only whitespace', () => {
+      const candidate = mapIssueToCandidate(makeIssue({ name: '   ', volume: { id: 10, name: 'Series Name' }, issue_number: '7' }));
+      expect(candidate.title).toBeUndefined();
+    });
+
+    it('trims surrounding whitespace from the issue name', () => {
+      const candidate = mapIssueToCandidate(makeIssue({ name: '  The Origin  ' }));
+      expect(candidate.title).toBe('The Origin');
     });
   });
 
@@ -138,7 +148,7 @@ describe('mapIssueToCandidate', () => {
         store_date: null,
       }),
     );
-    expect(malformedYear.title).toBe('Series Name #7');
+    expect(malformedYear.displayTitle).toBe('Series Name #7');
     expect(malformedYear.publishedYear).toBeUndefined();
   });
 

--- a/server/src/modules/metadata-fetch/providers/comicvine/comicvine.mapper.ts
+++ b/server/src/modules/metadata-fetch/providers/comicvine/comicvine.mapper.ts
@@ -34,8 +34,8 @@ function buildComicMetadata(issue: ComicVineIssue): ComicMetadataFields {
   };
 }
 
-function buildTitle(issue: ComicVineIssue): string {
-  return issue.name || `${issue.volume.name} #${issue.issue_number}`;
+function buildTitle(issue: ComicVineIssue): string | undefined {
+  return issue.name?.trim() || undefined;
 }
 
 function buildDisplayTitle(issue: ComicVineIssue): string {

--- a/server/src/modules/metadata-fetch/providers/comicvine/comicvine.mapper.ts
+++ b/server/src/modules/metadata-fetch/providers/comicvine/comicvine.mapper.ts
@@ -35,6 +35,10 @@ function buildComicMetadata(issue: ComicVineIssue): ComicMetadataFields {
 }
 
 function buildTitle(issue: ComicVineIssue): string {
+  return issue.name || `${issue.volume.name} #${issue.issue_number}`;
+}
+
+function buildDisplayTitle(issue: ComicVineIssue): string {
   const parts = [issue.volume.name, `#${issue.issue_number}`];
   if (issue.name) parts.push(`- ${issue.name}`);
   return parts.join(' ');
@@ -49,7 +53,7 @@ export function mapIssueToCandidate(issue: ComicVineIssue): MetadataCandidate {
     provider: MetadataProviderKey.COMICVINE,
     providerId: String(issue.id),
     title: buildTitle(issue),
-    subtitle: issue.name ?? undefined,
+    displayTitle: buildDisplayTitle(issue),
     authors: writers,
     description: issue.description ?? issue.deck ?? undefined,
     publishedDate,

--- a/server/src/modules/metadata-fetch/providers/comicvine/comicvine.provider.test.ts
+++ b/server/src/modules/metadata-fetch/providers/comicvine/comicvine.provider.test.ts
@@ -139,6 +139,37 @@ describe('ComicVineProvider', () => {
       expect(results).toHaveLength(1);
     });
 
+    it('falls back to the stored series when the title is a bare issue name', async () => {
+      vi.spyOn(client, 'searchVolumes').mockResolvedValue([mockVolume]);
+      vi.spyOn(client, 'searchIssuesInVolume').mockResolvedValue([mockIssue]);
+
+      const results = await provider.search({ title: 'The Origin', seriesName: 'Batman', seriesIndex: 12.5 });
+
+      expect(client.searchVolumes).toHaveBeenCalledWith('Batman', 'test-key');
+      expect(client.searchIssuesInVolume).toHaveBeenCalledWith(mockVolume.id, '12.5', 'test-key');
+      expect(client.searchIssues).not.toHaveBeenCalled();
+      expect(results).toHaveLength(1);
+    });
+
+    it('prefers a "Series #N" title over the stored series so a typed query wins', async () => {
+      vi.spyOn(client, 'searchVolumes').mockResolvedValue([mockVolume]);
+      vi.spyOn(client, 'searchIssuesInVolume').mockResolvedValue([mockIssue]);
+
+      await provider.search({ title: 'Superman #3', seriesName: 'Batman', seriesIndex: 12.5 });
+
+      expect(client.searchVolumes).toHaveBeenCalledWith('Superman', 'test-key');
+      expect(client.searchIssuesInVolume).toHaveBeenCalledWith(mockVolume.id, '3', 'test-key');
+    });
+
+    it('uses the general search when the stored series has no issue number', async () => {
+      vi.spyOn(client, 'searchIssues').mockResolvedValue([mockIssue]);
+
+      await provider.search({ title: 'The Origin', seriesName: 'Batman' });
+
+      expect(client.searchVolumes).not.toHaveBeenCalled();
+      expect(client.searchIssues).toHaveBeenCalledWith('The Origin', 'test-key');
+    });
+
     it('tries volumes sorted by start_year descending', async () => {
       const older = { ...mockVolume, id: 1, start_year: '1990' };
       const newer = { ...mockVolume, id: 2, start_year: '2016' };

--- a/server/src/modules/metadata-fetch/providers/comicvine/comicvine.provider.ts
+++ b/server/src/modules/metadata-fetch/providers/comicvine/comicvine.provider.ts
@@ -28,6 +28,21 @@ function parseIssueTitle(title: string): ParsedIssueTitle | null {
   return { seriesName, issueNumber };
 }
 
+/**
+ * Prefer a "<series> #<issue>" title because that is the user typing an explicit target, and fall
+ * back to the book's stored series. Comic titles hold the issue name alone, so without the fallback
+ * an already-matched comic would re-search through the far looser general issue search.
+ */
+function resolveIssueQuery(params: MetadataSearchParams): ParsedIssueTitle | null {
+  const fromTitle = params.title ? parseIssueTitle(params.title) : null;
+  if (fromTitle) return fromTitle;
+
+  const seriesName = params.seriesName?.trim();
+  const issueNumber = params.seriesIndex;
+  if (!seriesName || issueNumber === undefined || !Number.isFinite(issueNumber) || issueNumber < 0) return null;
+  return { seriesName, issueNumber: String(issueNumber) };
+}
+
 function hasAnyCredits(issue: ComicVineIssue): boolean {
   return (
     (issue.person_credits?.length ?? 0) > 0 ||
@@ -62,7 +77,7 @@ export class ComicVineProvider implements IdentifiableProvider {
 
     try {
       const maxCandidates = normalizeMaxCandidates(params.maxCandidatesPerProvider, PROVIDER_LIMITS.COMICVINE_MAX_RESULTS);
-      const parsed = parseIssueTitle(params.title);
+      const parsed = resolveIssueQuery(params);
       return parsed
         ? await this.structuredSearch(parsed.seriesName, parsed.issueNumber, apiKey, maxCandidates, params.signal)
         : await this.generalSearch(params.title, apiKey, maxCandidates, params.signal);

--- a/server/src/modules/metadata-fetch/providers/metadata-search-params.ts
+++ b/server/src/modules/metadata-fetch/providers/metadata-search-params.ts
@@ -4,6 +4,11 @@ export interface MetadataSearchParams {
   title?: string;
   author?: string;
   isbn?: string;
+  // Series context for providers that address records by series plus position rather than by title
+  // (e.g. ComicVine volume plus issue number). A comic title holds only the issue name, so the
+  // pairing cannot be recovered from it.
+  seriesName?: string;
+  seriesIndex?: number;
   existingProviderIds?: Partial<Record<MetadataProviderKey, string>>;
   isAudiobook?: boolean;
   // Hint for providers to cap deep candidate exploration in non-interactive flows


### PR DESCRIPTION
## Before you submit

> **New feature?** Please open an issue first and get approval from the maintainers before writing any code.
> PRs that introduce features without a prior discussion will be closed.
>
> **Used AI assistance?** That's fine - but make sure you've read and understood every line of the diff
> before submitting. PRs that show no sign of self-review will be closed without detailed feedback.
>
> **Keep it focused.** One thing per PR. Don't bundle a bug fix with a refactor or unrelated cleanup.
> If it's not ready, open it as a draft instead.

---

## What does this PR do?

Fixes the bug reported in #841: ComicVine search/auto-fill set `title` to a synthesized `"Series #N - Name"` string instead of the issue's own name, inconsistent with how `ComicInfo.xml`'s `<Title>` is used everywhere else (issue title only, series and issue number in their own fields).

`title` now carries just the issue name, falling back to `"<series> #<issue>"` only when ComicVine has no name for that issue. That's the actual fix - everything else in this PR exists solely to make it minimally invasive elsewhere:

- The concatenated format is genuinely useful in the search-results list for telling issues apart, so a new optional `displayTitle` field preserves that exact look. It's populated only by the ComicVine mapper, is never read by any metadata-apply path, and every other provider is unaffected.
- Search ranking (`filterAndRank`) scored candidates against `title`, so shortening it would have silently dropped named issues whenever someone searched by series name (the common case, since filenames and auto-fill queries are almost always series-name-shaped). Ranking now scores against `displayTitle` when present, falling back to `title` otherwise - for ComicVine this reproduces today's exact ranking score, and for every other provider it's unchanged.

One additional, deliberate behavior change beyond the title fix: comic candidates no longer set `subtitle` (it used to mirror the issue name, redundantly, since that's now `title` itself). [`ComicInfo.xml` has no `Subtitle` element](https://github.com/anansi-project/comicinfo/blob/main/schema/v2.0/ComicInfo.xsd) - BookOrbit's own reader only ever populated it from its own `[bookorbit:subtitle]` round-trip note, never from the file directly - so there's no source-of-truth concept being dropped here.

Net effect: the search-results list looks the same, ranking behaves the same for every provider, and the only things that actually change are the title that gets applied to a book and the (previously redundant) subtitle no longer being set.

Closes #841

## How did you test this?

Extended unit tests for the mapper (`comicvine.mapper.test.ts`), the ranking change (`candidate-relevance.test.ts`), and added new coverage for the display-label logic on the client (`metadata-fetch.spec.ts`, `MetadataResultCard.spec.ts`). Ran the full server and client suites plus lint/format/typecheck for both - all green.

## Screenshots

N/A - the search-results list is visually unchanged; the change is in what gets applied when a result is selected.

## Anything non-obvious in the diff?

`displayTitle` and the `candidate-relevance.ts` change are both scoped narrowly on purpose: `displayTitle` is comic-only by construction (no other mapper sets it), and ranking prefers it only when present, so this PR shouldn't change observable behavior for any other provider or for the search list's appearance - only what gets written to a book's title field when a comic result is applied.

## Checklist

- [x] I've read through my own diff
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata results now display clearer, formatted titles, including series, issue numbers, and issue names when available.
  * Improved title handling provides a fallback when display titles are unavailable.
  * Metadata searches now use existing series and issue information to find more relevant results.

* **Bug Fixes**
  * Metadata matching and ranking now use the most relevant available title, improving candidate selection.
  * ComicVine results now handle named, unnamed, and empty issue names more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->