### PR TITLE
no compression for cbz

### DIFF
--- a/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.test.ts
+++ b/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.test.ts
@@ -110,7 +110,7 @@ describe('cbz-zip-patcher', () => {
 
     await writeComicInfoToZip('/books/a.cbz', '<ComicInfo><Title>New</Title></ComicInfo>');
 
-    expect(ZipArchive).toHaveBeenCalledWith({ zlib: { level: 6 } });
+    expect(ZipArchive).toHaveBeenCalledWith({ zlib: { level: 0 } });
     expect(imageEntry.stream).toHaveBeenCalledTimes(1);
     expect(lastArchive.append).toHaveBeenCalledWith(expect.objectContaining({ pipe: expect.any(Function) }), { name: 'pages/001.jpg' });
     expect(lastArchive.append).toHaveBeenCalledWith(Buffer.from('<ComicInfo><Title>New</Title></ComicInfo>', 'utf-8'), {

--- a/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.ts
+++ b/server/src/modules/file-write/formats/cbx/cbz-zip-patcher.ts
@@ -24,7 +24,7 @@ export async function writeComicInfoToZip(filePath: string, xmlContent: string):
   const xmlEntryPath = existing?.path ?? 'ComicInfo.xml';
 
   const tmpPath = join(dirname(filePath), `.cbx-write-${randomUUID()}`);
-  const archive = new ZipArchive({ zlib: { level: 6 } });
+  const archive = new ZipArchive({ zlib: { level: 0 } });
   const output = createWriteStream(tmpPath);
 
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CBZ file rewriting by using a storage-only compression setting, helping preserve archive contents without additional compression.
  * Updated validation to reflect the revised archive configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->