### PR TITLE
i18n(client): sync translations from Crowdin

### DIFF
--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -168,8 +168,7 @@
           "blush": "Vyprázdnit"
         },
         "accentColor": {
-          "label": "Barva zvýraznění",
-          "hint": "Controls highlights and interactive elements"
+          "label": "Barva zvýraznění"
         },
         "cornerRadius": {
           "label": "Corner radius",
@@ -644,7 +643,6 @@
       "noActiveHint": "Všechny generované kouzelné odkazy na tuto stránku vypršely nebo byly zrušeny.",
       "copyLinkAria": "Kopírovat odkaz pro {label}",
       "pauseAria": "Pozastavit {label}",
-      "resumeAria": "Resume {label}",
       "revokeAria": "Revoke {label}",
       "lastUsedLabel": "Naposledy použité {date}"
     },
@@ -715,7 +713,6 @@
       },
       "groupMappings": {
         "title": "Skupinové mapování",
-        "description": "Map OIDC group claims to BookOrbit permissions. Synced on every login.",
         "noPermission": "Bez oprávnění",
         "empty": "Nejsou nakonfigurovány žádné mapování skupin.",
         "addMapping": "Přidat mapování",
@@ -757,7 +754,6 @@
         "recommendationsGroup": "Doporučení",
         "achievementsGroup": "Úspěchy",
         "updatesGroup": "Aktualizace",
-        "importFromBooklore": "Import from Booklore",
         "bookloreImportConfigured": "Import Booklore nakonfigurován",
         "migrationRunning": "Probíhá migrace",
         "migrationCompleted": "Migrace dokončena",
@@ -779,7 +775,7 @@
         "running": "Běhání...",
         "backfillAchievements": "Úspěchy nevyplňování",
         "backfillAchievementsHint": "Přehodnotit úspěchy všech uživatelů.",
-        "backfillResult": "Processed {users} users; granted {awards} awards.",
+        "backfillResult": "Zpracovaní uživatelé {users}; uděleno {awards} ocenění.",
         "runBackfill": "Spustit Backfill",
         "checkForUpdates": "Zkontrolovat aktualizace",
         "checkForUpdatesHint": "Automaticky zkontrolovat GitHub pro nové vydání při startu a zobrazit indikátor v postranním panelu, pokud je k dispozici.",
@@ -851,9 +847,7 @@
         "errorLoadSuggestions": "Nepodařilo se načíst návrhy mapování uživatelů",
         "requiredFields": "Hostitel, uživatel, databáze a zdrojové jméno jsou vyžadovány",
         "connectionTestPassedWithWarnings": "Zkouška připojení prošla varováním",
-        "connectionTestPassedWithCount": "Connection test passed with {count} warning(s). First: {first}",
         "connectionTestPassed": "Test připojení prošel",
-        "connectionOkMissingTables": "Connection ok, but {count} required table(s) are missing",
         "cannotTestMediaPathActiveRun": "Nelze otestovat cestu k médiím, když je běh aktivní",
         "mediaRootPathRequiredCover": "Kořenový adresář médií je vyžadován pro import obalu.",
         "useAbsolutePath": "Použijte absolutní cestu (například: /books).",
@@ -862,7 +856,6 @@
         "mediaPathValidationFailed": "Ověření cesty k médiím selhalo.",
         "connectionFailedBeforeMediaPath": "Test připojení se nezdařil před dokončením ověření cesty média.",
         "cannotModifySourceActiveRun": "Nelze změnit zdroj, pokud je aktivní běh",
-        "sourceSavedValidatedWarnings": "Source saved and validated with {count} warning(s)",
         "sourceSavedValidated": "Zdroj uložen a potvrzen",
         "errorSaveValidateSource": "Nepodařilo se uložit nebo ověřit zdroj",
         "cannotSaveMappingsActiveRun": "Mapování nelze uložit, pokud je aktivní běh",
@@ -874,7 +867,6 @@
         "errorSaveMappings": "Nepodařilo se uložit mapování",
         "cannotRunDryRunActiveRun": "Nelze spustit suchý běh, když je aktivní běh",
         "saveMappingsFirst": "Nejprve uložte mapování",
-        "dryRunCompleted": "Dry-run completed: {matched} matched, {unresolved} unresolved",
         "dryRunFailed": "Dry-run selhal",
         "selectSourceForAllGroups": "Vyberte zdrojovou knihu pro všechny {count} duplicitní skupiny",
         "duplicatesResolved": "Vyřešeny duplicitní shody",
@@ -908,7 +900,6 @@
         "strategyPathMapping": "Odpovídá mapované cestě k souboru",
         "strategyTitleAuthor": "Shoduje se podle názvu a autora",
         "strategyUnavailable": "Strategie zápasu není k dispozici",
-        "userPreviewCounts": "{statuses} statuses, {progress} progress entries, {bookmarks} bookmarks, {annotations} annotations, {collections} collection entries",
         "connErrorUnreachable": "Nelze se připojit k databázovému serveru. Zkontrolujte hostitele a port.",
         "connErrorAuth": "Ověření se nezdařilo. Zkontrolujte uživatelské jméno a heslo.",
         "connErrorUnknownDatabase": "Databáze nebyla nalezena. Zkontrolujte název databáze.",
@@ -962,7 +953,6 @@
         "unresolvedSummary": "Nevyřešené shrnutí",
         "resolveDuplicateMatches": "Vyřešit duplicitní cílové shody",
         "resolveDuplicateHint": "Pro každou cílovou knihu zvolte jednu zdrojovou knihu. Doporučená volba je předem vybrána, pokud existuje jedna nejsilnější shoda.",
-        "remainingGroups": "Remaining groups:",
         "ofCount": "z {count}",
         "targetBookNum": "Cílová kniha #{id}",
         "recommended": "Doporučené",
@@ -1028,7 +1018,6 @@
         "unresolvedBooksHint": "Tyto knihy existují ve zdroji, ale nelze je shodovat s žádnou knihou ve vaší knihovně.",
         "mappedUsersHeading": "Mapovaní uživatelé ({count})",
         "mappedUsersHint": "Celkový počet uživatelů pochází z náhledu suchého běhu v mezipaměti s plánem přechodu.",
-        "coverImportsFailed": "{count} cover import(s) failed. Detailed failure rows are not stored.",
         "backToSetup": "Zpět na nastavení"
       },
       "libraries": {
@@ -1133,15 +1122,10 @@
         "users": "Uživatelé",
         "account-activity": "Aktivita účtu",
         "magic-links": "Kouzelné odkazy",
-        "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
+        "oidc": "OIDC / SSO"
       },
       "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "noFontsYet": "Zatím žádná písma serveru"
       }
     },
     "common": {
@@ -1166,7 +1150,6 @@
       "fields": {
         "title": "Hlava 1 – Celkem",
         "subtitle": "Podtitulek",
-        "description": "Description",
         "cover": "Kryt",
         "authors": "Autoři",
         "publisher": "Vydavatel",
@@ -1221,8 +1204,6 @@
         },
         "lastRun": {
           "justNow": "právě teď",
-          "minutesAgo": "{count}m ago",
-          "hoursAgo": "{count}h ago",
           "yesterday": "včera",
           "daysAgo": "{count, plural, one {Před # dnem} few {před # dny} many {před # dny} other {před # dny}}",
           "label": "Poslední spuštění: {when}",
@@ -1276,7 +1257,6 @@
           "region": "Oblasti",
           "cookie": "Cookie",
           "coverResolution": "Rozlišení titulu",
-          "country": "Country",
           "language": "Jazyk",
           "ttbKey": "TTB klíč"
         },
@@ -1294,16 +1274,13 @@
           "audible": "Pulls audiobook metadata z Audable. Není nutné žádné další nastavení.",
           "audnexus": "audiobook metadata, řízená komunitou. Není vyžadováno žádné nastavení.",
           "comicvine": "Metadata Comic book od ComicVine. Bezplatný API klíč je vyžadován z comicvine.gamespot.com.",
-          "ranobedb": "Japanese light novel metadata from RanobeDB. No setup required.",
-          "lubimyczytac": "Polský katalog knih (lubimyczytac.pl). Stránky s veřejnou knihou. Není nutné nastavit.",
-          "aladin": "Korean book metadata from Aladin (알라딘). A TTB Key from aladin.co.kr is required."
+          "lubimyczytac": "Polský katalog knih (lubimyczytac.pl). Stránky s veřejnou knihou. Není nutné nastavit."
         },
         "blocked": {
           "google": "Google Books vyžaduje API klíč, než může být povoleno",
           "hardcover": "Hardcover vyžaduje klíč API, aby mohl být povolen",
           "hardcoverTest": "Hardcover token musí projít zkouškou, než může být povolen",
-          "comicvine": "Kombinovaná verze vyžaduje API klíč",
-          "aladin": "Aladin requires a TTB Key before it can be enabled"
+          "comicvine": "Kombinovaná verze vyžaduje API klíč"
         }
       },
       "fieldRules": {
@@ -1676,12 +1653,7 @@
         "deleteFamilyFailed": "Nepodařilo se odstranit rodinu písem",
         "demoCannotManage": "Demo-limitovaný účet nemůže spravovat písma",
         "fileAdded": "\"{name}\" přidáno",
-        "uploadFailed": "Nahrávání se nezdařilo",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Nahrávání se nezdařilo"
       },
       "bookDock": {
         "title": "Dok knihy",
@@ -1803,7 +1775,6 @@
         "resetLibraryPattern": "Obnovit {name} na výchozí gesto",
         "tokenTitle": "Název knihy",
         "tokenSubtitle": "Rezervovat titulky",
-        "tokenAuthors": "Author(s), comma-separated",
         "tokenYear": "Rok zveřejnění",
         "tokenSeries": "Název série",
         "tokenSeriesIndex": "Ukazatel série (nulová prošívaná)",
@@ -1821,9 +1792,6 @@
         "copy": "Kopírovat",
         "never": "Nikdy",
         "justNow": "Právě teď",
-        "minutesAgo": "{count}m ago",
-        "hoursAgo": "{count}h ago",
-        "daysAgo": "{count}d ago",
         "loadFailed": "Nepodařilo se načíst",
         "devicePaired": "Zařízení bylo úspěšně spárováno",
         "devicePairedHint": "Jste připraveni nastavit svůj Kobo. Postupujte podle níže uvedených pokynů.",
@@ -2021,9 +1989,6 @@
         "loadFailed": "Nepodařilo se načíst nastavení KOReader",
         "never": "Nikdy",
         "justNow": "Právě teď",
-        "minutesAgo": "{count}m ago",
-        "hoursAgo": "{count}h ago",
-        "daysAgo": "{count}d ago",
         "unknown": "Neznámý",
         "updateAvailable": "K dispozici je aktualizace",
         "upToDate": "Aktuální",
@@ -2081,7 +2046,6 @@
         "failedPositions": "{count, plural, =0 {žádné zvýraznění pozice nepotřebují pozornost.} one {# zvýrazní pozici vyžaduje pozornost.} few {# zvýrazní pozice potřebují pozornost.} many {# zvýrazní pozice potřebují pozornost.} other {# zvýrazní pozice potřebují pozornost.}}",
         "setupGuide": "Průvodce nastavením",
         "setupSteps": "KOReader kroky nastavení",
-        "setupStepsHint": "Use the BookOrbit plugin for catalog browsing, downloads, progress, reading events, and highlights. Use the stock plugin for progress only.",
         "pluginGuideTitle": "Doplněk BookOrbit",
         "pluginStep1": "Stáhněte si přednastavený plugin výše.",
         "pluginStep2Prefix": "Rozbalit a kopírovat",
@@ -2173,7 +2137,6 @@
             "saving": "Ukládání...",
             "confirmLink": "Potvrdit odkaz",
             "unlinkTitle": "Odpojit knihu KOReader?",
-            "unlinkBody": "Future syncs for this hash will stop resolving to {title} until it is linked again. Already synced stats will stay on their current BookOrbit book.",
             "unlinking": "Odpojování..."
           },
           "dismiss": "Odmítnout",
@@ -2181,7 +2144,6 @@
           "dismissing": "Odstraňování...",
           "unlinking": "Odpojování...",
           "unlinkConfirmTitle": "Odpojit knihu KOReader?",
-          "unlinkConfirmBody": "Future syncs for this hash will stop resolving to {title} until it is linked again. Already synced stats will stay on their current BookOrbit book.",
           "dismissConfirmTitle": "Odmítnout {title}?",
           "dismissConfirmBody": "Tím se odstraní z vašeho seznamu neporovnaných knih. Pokud nějaké zařízení tuto hash znovu nahlásí, znovu se objeví jako nový záznam.",
           "dismissAllConfirmTitle": "{count, plural, =0 {žádné neporovnané knihy} one {Odmítnout všechny # neporovnané knihy?} few {Odmítnout všechny # neporovnané knihy?} many {Odmítnout všechny # neporovnané knihy?} other {Odmítnout všechny # neporovnané knihy?}}",
@@ -2797,7 +2759,6 @@
       "impact": "Dopad",
       "user": "Uživatel",
       "action": "Akce",
-      "description": "Description",
       "ip": "IP adresa"
     },
     "categories": {
@@ -2886,7 +2847,6 @@
       "BookBulkUpdateTags": "Aktualizovat značky knihy",
       "BookBulkSetMetadataLock": "Nastavit metadata zámky",
       "BookBulkEditMetadata": "Upravit metadata knihy",
-      "BookBulkMoveLibrary": "Move books to another library",
       "BookReadingStateReset": "Obnovit stav čtení",
       "BookWriteAndRename": "Zapsat metadata a přejmenovat soubor",
       "CollectionCreate": "Vytvořit kolekci",
@@ -3069,7 +3029,6 @@
       "deleteAuthor": "Odstranit autora",
       "showLess": "Zobrazit méně",
       "showMore": "Zobrazit více",
-      "lookingUpMetadata": "Looking up author metadata...",
       "noBiography": "Není k dispozici žádná biografie. Použijte menu pro aktualizaci metadat.",
       "previewFrom": "Náhled z {provider}. Uložte metadata pro jejich zachování.",
       "booksLabel": "Knihy",
@@ -3116,13 +3075,10 @@
       },
       "toast": {
         "refreshed": "Metadata autora obnovena",
-        "refreshedNoImage": "Metadata refreshed, but no author image was found.",
         "refreshFailed": "Aktualizace metadat autora se nezdařila",
-        "bulkRefreshPartial": "Refreshed {updated} author(s), {failed} failed",
         "bulkRefreshSuccess": "Obnovená metadata pro {updated} autor(y)",
         "bulkRefreshFailed": "Nepodařilo se aktualizovat vybrané autory",
-        "deleteSuccess": "{count, plural, =0 {Smazal # autora; ovlivnil to {books} knihy} one {Smazal # autora; ovlivnil to {books} knihy} few {Smazali # autorů; ovlivnili to {books} knihy} many {Smazali # autorů; ovlivnili to {books} knihy} other {Smazali # autorů; ovlivnili to {books} knihy}}",
-        "deleteFailed": "Failed to delete author(s)"
+        "deleteSuccess": "{count, plural, =0 {Smazal # autora; ovlivnil to {books} knihy} one {Smazal # autora; ovlivnil to {books} knihy} few {Smazali # autorů; ovlivnili to {books} knihy} many {Smazali # autorů; ovlivnili to {books} knihy} other {Smazali # autorů; ovlivnili to {books} knihy}}"
       }
     },
     "detail": {
@@ -3135,7 +3091,6 @@
       "edit": {
         "name": "Název",
         "sortName": "Seřadit název",
-        "description": "Description",
         "image": "Obrázek",
         "uploading": "Nahrávám...",
         "replaceImage": "Nahradit obrázek",
@@ -3149,13 +3104,11 @@
         "searchPlaceholder": "Hledat autory pro sloučení do tohoto autora",
         "searching": "Vyhledávání...",
         "bookCount": "{count, plural, =0 {Žádné knihy} one {# kniha} few {# knih} many {# knih} other {# knih}}",
-        "selectedSummary": "Selected {count} author(s), approx. {books} books affected.",
         "merging": "Slučování...",
         "mergeSelected": "Sloučit vybrané",
         "confirmLabel": "Sloučit"
       },
       "mergeDialog": {
-        "title": "Merge {count} author(s) into \"{name}\"?",
         "titleFallback": "Sloučit vybrané autory?",
         "description": "Tímto sloučíte vybrané autory do aktuálního autora a znovu propojte související knihy. Tuto akci nelze vrátit zpět.",
         "descriptionEmpty": "Tuto akci nelze vrátit zpět."
@@ -3184,7 +3137,7 @@
       },
       "toast": {
         "refreshed": "Metadata autora obnovena",
-        "refreshedNoImage": "Metadata refreshed, but no author image was found.",
+        "refreshedNoImage": "Metadata byla aktualizována, ale nebyl nalezen žádný obrázek autora.",
         "refreshFailed": "Aktualizace metadat autora se nezdařila",
         "nameRequired": "Je vyžadováno jméno autora",
         "updated": "Autor byl aktualizován",
@@ -3193,7 +3146,6 @@
         "imageUploadFailed": "Nepodařilo se nahrát obrázek autora",
         "imageRemoved": "Obrázek autora byl odstraněn",
         "imageRemoveFailed": "Nepodařilo se odstranit obrázek autora",
-        "mergeSuccess": "Merged {count} author(s); affected {books} books",
         "mergeFailed": "Sloučení autorů se nezdařilo",
         "deleteSuccess": "Vymazaný autor; ovlivněné knihy {books}",
         "deleteFailed": "Nepodařilo se odstranit autora"
@@ -3205,8 +3157,7 @@
     "unknownFormat": "neznámé",
     "collapsedSeries": {
       "label": "Série",
-      "bookCount": "{count, plural, =0 {Žádné knihy} one {# kniha} few {# knih} many {# knih} other {# knih}}",
-      "readCount": "{count} read"
+      "bookCount": "{count, plural, =0 {Žádné knihy} one {# kniha} few {# knih} many {# knih} other {# knih}}"
     },
     "card": {
       "missing": "Chybějící"
@@ -3311,7 +3262,6 @@
         "communityRating": "Komunitní hodnocení",
         "readProgress": "Průběh čtení",
         "readStatus": "Číst stav",
-        "description": "Description",
         "isbn": "ISBN",
         "metadataScore": "Skóre metadat",
         "cover": "Kryt",
@@ -3345,12 +3295,8 @@
         "isFinished": "je dokončeno",
         "isLocked": "je uzamčen",
         "isUnlocked": "je odemčeno",
-        "isUpNext": "další",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isUpNext": "další"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Jakýkoliv poskytovatel",
       "communityRatingProvider": "Poskytovatel hodnocení Společenství",
       "loadingLibraries": "Načítám knihovny...",
@@ -3371,7 +3317,6 @@
       },
       "scoreRangePlaceholder": "0-100",
       "valuePlaceholder": "hodnota",
-      "maxPlaceholder": "max",
       "to": "do",
       "group": "Skupina",
       "addRule": "Přidat pravidlo",
@@ -3783,7 +3728,6 @@
         "comicTeamsLabel": "Týmy",
         "comicLocationsLabel": "Místa",
         "customMetadata": "Vlastní metadata",
-        "descriptionLabel": "Description",
         "unlockField": "Odemknout {field}",
         "lockField": "Zamknout {field}",
         "diffPanel": {
@@ -3856,10 +3800,7 @@
         "syncHistory": "Historie synchronizace",
         "metadataWriteBack": "Odepsání metadat",
         "relative": {
-          "seconds": "Před {value}s",
-          "minutes": "{value}m ago",
-          "hours": "{value}h ago",
-          "days": "{value}d ago"
+          "seconds": "Před {value}s"
         },
         "renameFailed": "Nepodařilo se přejmenovat soubor",
         "deleteFailed": "Nepodařilo se odstranit soubor",
@@ -3869,8 +3810,7 @@
           "label": "Seřadit:",
           "name": "Název",
           "format": "Formát",
-          "size": "Velikost",
-          "date": "Date"
+          "size": "Velikost"
         },
         "hidePaths": "Skrýt cesty",
         "showPaths": "Zobrazit cesty",
@@ -3961,8 +3901,7 @@
           "aug": "Srp",
           "sep": "Zář",
           "oct": "říjen",
-          "nov": "Lov",
-          "dec": "Dec"
+          "nov": "Lov"
         },
         "heatmap": {
           "minutesUnit": "minuty",
@@ -3975,9 +3914,6 @@
           "notSet": "Nenastaveno",
           "relative": {
             "seconds": "Před {count}s",
-            "minutes": "{count}m ago",
-            "hours": "{count}h ago",
-            "days": "{count}d ago",
             "months": "{count, plural, =0 {Před # měsícem} one {před # měsícem} few {před # měsíci} many {před # měsíci} other {před # měsíci}}",
             "years": "{count, plural, =0 {Před # rokem} one {před # rokem} few {před # lety} many {před # lety} other {před # lety}}"
           },
@@ -3989,7 +3925,6 @@
             "saveFailed": "Nepodařilo se uložit data čtení."
           },
           "eta": {
-            "max": "99h+ to finish",
             "minutes": "~{m}m k dokončení",
             "hours": "~{h}h k dokončení",
             "hoursMinutes": "~{h}h {m}m k dokončení"
@@ -4040,8 +3975,6 @@
           "title": "Relace",
           "sourceWeb": "Webová",
           "sourceManual": "Ruční",
-          "colDate": "Date",
-          "colDateMobile": "Date",
           "colDuration": "Doba trvání",
           "colDurationMobile": "Doba trvání",
           "colProgressChange": "Probíhá změna",
@@ -4095,11 +4028,7 @@
         "seriesPlaceholder": "Série",
         "moveUp": "Posunout nahoru",
         "moveDown": "Přesunout dolů",
-        "removeSeries": "Odstranit sérii",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Odstranit sérii"
       }
     },
     "table": {
@@ -4183,65 +4112,10 @@
     },
     "move": {
       "title": "{count, plural, one {Move # book} few {Move # books} many {Move # books} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
       "folderCount": "{count, plural, one {# folder} few {# folders} many {# folders} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
       "confirm": "{count, plural, one {Move # book} few {Move # books} many {Move # books} other {Move # books}}",
-      "action": "Move to library",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} few {# name conflicts} many {# name conflicts} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "collisions": "{count, plural, one {# name conflict} few {# name conflicts} many {# name conflicts} other {# name conflicts}}"
       }
     }
   },
@@ -4357,8 +4231,7 @@
       "series": "Série",
       "seriesIndex": "Řada #",
       "genres": "Genres",
-      "genresCommaSeparated": "Žánry (oddělené čárkami)",
-      "description": "Description"
+      "genresCommaSeparated": "Žánry (oddělené čárkami)"
     },
     "upload": {
       "nDone": "{count} hotovo",
@@ -4776,14 +4649,6 @@
         "random": "Objevte něco nového",
         "smartScope": "Chytrý rozsah"
       },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
-      },
       "reorderHintWidget": "Přetažením změníte pořadí. Přepnout zobrazení nebo skrytí widgetu.",
       "reorderHintShelf": "Přetažením přeřadíte. Přepnout pro zobrazení nebo skrytí šelfu.",
       "smartScope": "Chytrý rozsah",
@@ -4845,7 +4710,6 @@
         "title": "Zanedbávané Gemy",
         "empty": "Všechny tvé knihy s nejvyšším hodnocením byly přečteny!",
         "rating": "{rating}/5",
-        "daysWaiting": "{count}d waiting",
         "queued": "Ve frontě",
         "addToQueue": "Přidat do fronty",
         "shuffle": "Zamíchat"
@@ -4892,9 +4756,7 @@
         "trendDown": "Populární dolů",
         "trendSteady": "Ustálené tempo",
         "pages": "stránky",
-        "hours": "hodiny",
-        "readCount": "{count} read",
-        "daysLeft": "{count}d left"
+        "hours": "hodiny"
       }
     }
   },
@@ -5178,7 +5040,6 @@
       },
       "lastSynced": {
         "justNow": "Právě teď",
-        "minutesAgo": "{count} min ago",
         "hoursAgo": "{count, plural, =0 {Před # hodinou} one {před # hodinou} few {před # hodinami} many {před # hodinami} other {před # hodinami}}",
         "daysAgo": "{count, plural, =0 {Před # dnem} one {Před # dnem} few {před # dny} many {před # dny} other {před # dny}}"
       }
@@ -5226,7 +5087,6 @@
       "blank": "prázdný",
       "noRows": "Aktuální filtry neodpovídají žádné řádky.",
       "selectRowAriaLabel": "Vybrat {title}",
-      "selectionSummary": "{count} selected: {ready} ready, {reviewed} reviewed.",
       "selectedProgress": "{count, plural, =0 {žádné aktualizace postupu} one {# Průběh aktualizace} few {# Průběžné aktualizace} many {# Průběžné aktualizace} other {# Průběžné aktualizace}}",
       "selectReady": "Vybrat připravený",
       "selectPage": "Vybrat stránku",
@@ -5672,7 +5532,6 @@
     "duplicates": {
       "title": "Vyřešit duplicitní cílové shody",
       "explanation": "Pro každou cílovou knihu zvolte jednu zdrojovou knihu. Doporučená volba je předem vybrána, pokud existuje jedna nejsilnější shoda.",
-      "remainingGroups": "Remaining groups:",
       "ofCount": "z {total}",
       "targetBookId": "Cílová kniha #{id}",
       "recommended": "Doporučené",
@@ -5753,9 +5612,7 @@
       "unresolvedBooks": "Nevyřešené knihy ({count})",
       "unresolvedBooksExplanation": "Tyto knihy existují ve zdroji, ale nelze je shodovat s žádnou knihou ve vaší knihovně.",
       "mappedUsers": "Mapovaní uživatelé ({count})",
-      "mappedUsersExplanation": "Celkový počet uživatelů pochází z náhledu suchého běhu v mezipaměti s plánem přechodu.",
-      "coverFailures": "{count} cover import(s) failed. Detailed failure rows are not stored.",
-      "userPreviewCounts": "{statuses} statuses, {progress} progress entries, {sessions} reading sessions, {bookmarks} bookmarks, {annotations} annotations, {collections} collection entries"
+      "mappedUsersExplanation": "Celkový počet uživatelů pochází z náhledu suchého běhu v mezipaměti s plánem přechodu."
     },
     "unresolvedReason": {
       "noTitleAuthorMatch": "Nebyla nalezena žádná odpovídající kniha podle názvu nebo autora",
@@ -5797,9 +5654,7 @@
       "loadSuggestionsFailed": "Nepodařilo se načíst návrhy mapování uživatelů",
       "sourceFieldsRequired": "Hostitel, uživatel, databáze a zdrojové jméno jsou vyžadovány",
       "connectionPassedWithWarnings": "Zkouška připojení prošla varováním",
-      "connectionPassedWithWarningCount": "Connection test passed with {count} warning(s). First: {warning}",
       "connectionPassed": "Test připojení prošel",
-      "connectionMissingTables": "Connection ok, but {count} required table(s) are missing",
       "cannotTestMediaWhileRunning": "Nelze otestovat cestu k médiím, když je běh aktivní",
       "mediaPathRequired": "Kořenový adresář médií je vyžadován pro import obalu.",
       "mediaPathAbsolute": "Použijte absolutní cestu (například: /books).",
@@ -5808,7 +5663,6 @@
       "mediaPathValidationFailed": "Ověření cesty k médiím selhalo.",
       "connectionFailedBeforeMedia": "Test připojení se nezdařil před dokončením ověření cesty média.",
       "cannotModifySourceWhileRunning": "Nelze změnit zdroj, pokud je aktivní běh",
-      "sourceSavedWithWarnings": "Source saved and validated with {count} warning(s)",
       "sourceSaved": "Zdroj uložen a potvrzen",
       "saveSourceFailed": "Nepodařilo se uložit nebo ověřit zdroj",
       "cannotSaveMappingsWhileRunning": "Mapování nelze uložit, pokud je aktivní běh",
@@ -5820,7 +5674,6 @@
       "saveMappingsFailed": "Nepodařilo se uložit mapování",
       "cannotDryRunWhileRunning": "Nelze spustit suchý běh, když je aktivní běh",
       "saveMappingsFirst": "Nejprve uložte mapování",
-      "dryRunCompleted": "Dry-run completed: {matched} matched, {unresolved} unresolved",
       "dryRunFailed": "Dry-run selhal",
       "selectSourceForDuplicates": "Vyberte zdrojovou knihu pro všechny {count} duplicitní skupiny",
       "duplicatesResolved": "Vyřešeny duplicitní shody",
@@ -5956,67 +5809,22 @@
     "settings": {
       "title": "Nastavení",
       "ariaLabel": "Nastavení čtečky",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Světlý",
         "dark": "Tmavý"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Vestavěné",
-      "fontServer": "Server fonts",
       "fontYours": "Vaše písma",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Měření průtoku",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Rozložení stránky",
       "pageSpreadsHint": "Vyberte si, jak tyto EPUB stránky založené na obrázcích.",
       "spread": {
         "bookDefault": "Výchozí rezervace",
         "singlePage": "Jedna stránka"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Mezera sloupce",
       "justifyText": "Zarovnat text",
-      "hyphenation": "Hyfenace",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Hyfenace"
     },
     "search": {
       "placeholder": "Hledat v knize (min {min} znaků)...",
@@ -6111,9 +5919,6 @@
       "scrollModeHint": "Pro webové hračky a vertikální proužky použijte \"Žádné mezery\".",
       "readingDirection": "Směr čtení",
       "pageView": "Zobrazení stránky",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Zarovnání rozpětí",
       "spreadGap": "Rozšíření mezery",
       "spreadGapValue": "{value}px",
@@ -6188,10 +5993,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} z {total} přečteno ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Možné mezery:"
@@ -6464,8 +6265,7 @@
         "notEnoughData": "Pro tento graf je třeba alespoň číst {count}."
       },
       "readingHeatmap": {
-        "title": "Čtení topné mapy",
-        "notEnoughData": "Need activity on at least {count} days for this chart."
+        "title": "Čtení topné mapy"
       },
       "readingPace": {
         "title": "Čtení tempa",
@@ -6997,8 +6797,7 @@
       "users": "Uživatelé",
       "account-activity": "Aktivita účtu",
       "magic-links": "Kouzelné odkazy",
-      "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / SSO"
     },
     "system": {
       "file-naming": "Pojmenování souborů",

--- a/client/src/locales/da.json
+++ b/client/src/locales/da.json
@@ -168,8 +168,7 @@
           "blush": "Blush"
         },
         "accentColor": {
-          "label": "Accent farve",
-          "hint": "Controls highlights and interactive elements"
+          "label": "Accent farve"
         },
         "cornerRadius": {
           "label": "Corner radius",
@@ -715,7 +714,6 @@
       },
       "groupMappings": {
         "title": "Grupper Tilknytninger",
-        "description": "Map OIDC group claims to BookOrbit permissions. Synced on every login.",
         "noPermission": "Ingen tilladelse",
         "empty": "Ingen gruppe tilknytninger konfigureret.",
         "addMapping": "Tilføj kortlægning",
@@ -757,7 +755,6 @@
         "recommendationsGroup": "Anbefalinger",
         "achievementsGroup": "Bedrifter",
         "updatesGroup": "Opdateringer",
-        "importFromBooklore": "Import from Booklore",
         "bookloreImportConfigured": "Booklore import konfigureret",
         "migrationRunning": "Migration kører",
         "migrationCompleted": "Migration fuldført",
@@ -853,7 +850,6 @@
         "connectionTestPassedWithWarnings": "Forbindelsestest bestået med advarsler",
         "connectionTestPassedWithCount": "Forbindelsestest bestået med {count} advarsel(s). Først: {first}",
         "connectionTestPassed": "Forbindelsestesten bestået",
-        "connectionOkMissingTables": "Connection ok, but {count} required table(s) are missing",
         "cannotTestMediaPathActiveRun": "Kan ikke teste medie sti, mens en kørsel er aktiv",
         "mediaRootPathRequiredCover": "Medie Root-sti er påkrævet til dækimport.",
         "useAbsolutePath": "Brug en absolut sti (for eksempel: /books).",
@@ -1028,7 +1024,6 @@
         "unresolvedBooksHint": "Disse bøger findes i kilden, men kunne ikke matches til nogen bog i dit bibliotek.",
         "mappedUsersHeading": "Tilknyttede brugere ({count})",
         "mappedUsersHint": "Per-bruger totaler kommer fra tør-run preview cached med migreringsplanen.",
-        "coverImportsFailed": "{count} cover import(s) failed. Detailed failure rows are not stored.",
         "backToSetup": "Tilbage til opsætning"
       },
       "libraries": {
@@ -1133,15 +1128,7 @@
         "users": "Brugere",
         "account-activity": "Konto Aktivitet",
         "magic-links": "Magiske Links",
-        "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC / SSO"
       }
     },
     "common": {
@@ -1288,7 +1275,6 @@
           "amazon": "Session cookie anbefales. Indsæt kun cookie værdi (ingen \"Cookie:\").",
           "goodreads": "Det største læsefællesskab på nettet. Ingen opsætning er påkrævet.",
           "hardcover": "Et moderne alternativ til Goodreads. Token fra hardcover.app/account/api. \"Bearer\" præfiks er valgfri.",
-          "openLibrary": "The Internet Archive's free book catalog. No setup required.",
           "itunes": "Apples digitale bogkatalog. Vælg om der skal hentes dæksler af høj eller standard opløsning.",
           "kobo": "Scrapes Kobos offentlige bogsider. Land og sprog skal matche Kobo URL-stier. Bot beskyttelse kan blokere forespørgsler.",
           "audible": "Træk audiobook metadata fra Audible. Ingen yderligere opsætning er påkrævet.",
@@ -1676,12 +1662,7 @@
         "deleteFamilyFailed": "Kunne ikke slette skrifttypefamilien",
         "demoCannotManage": "Demo-begrænset konto kan ikke administrere skrifttyper",
         "fileAdded": "\"{name}\" tilføjet",
-        "uploadFailed": "Upload mislykkedes",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Upload mislykkedes"
       },
       "bookDock": {
         "title": "Book Dock",
@@ -1966,8 +1947,7 @@
           "loadMore": "Indlæs mere aktivitet"
         },
         "howBooksSynced": {
-          "title": "Hvordan bøger synkroniseres",
-          "body": "To send books to your Kobo device, you must enable {syncToKobo} on the collections containing those books. Open any collection from the sidebar, click the Edit icon, and toggle {syncToKobo}. Books that are not part of an enabled collection will not sync."
+          "title": "Hvordan bøger synkroniseres"
         },
         "nextSteps": {
           "title": "Næste Trin",
@@ -2093,7 +2073,6 @@
         "stockGuideTitle": "Plugin til lagerfremdriftssynkronisering",
         "stockStep1Prefix": "Gå til din KOReader enhed",
         "stockStep1Suffix": ".",
-        "stockStep2": "Set the custom sync server to the URL shown above.",
         "stockStep3": "Indtast det brugernavn og den adgangskode, du har oprettet, og tryk derefter på Login.",
         "locationNote": "BookOrbit gemmer KOReader-kompatible EPUB-placeringer fra weblæseren. Gendan skal lande tæt på samme position, selvom nøjagtige linje placering kan variere af læser og EPUB layout.",
         "dangerZone": "Fare Zone",
@@ -2309,7 +2288,6 @@
     "accountActivity": {
       "title": "Konto Aktivitet",
       "subtitle": "Gennemgå kontoautentificeringsaktivitet uden at afsløre læsehistorik.",
-      "privacyNotice": "This page reports sign-ins and authentication refreshes only. It does not use reading history, book progress, or library activity.",
       "privacyLabel": "Om kontoaktivitet privatliv",
       "never": "Aldrig",
       "openInsightsFor": "Åbn delte læseindsigter for {name}",
@@ -2886,7 +2864,6 @@
       "BookBulkUpdateTags": "Opdater bogmærker",
       "BookBulkSetMetadataLock": "Angiv metadata låse",
       "BookBulkEditMetadata": "Rediger bog metadata",
-      "BookBulkMoveLibrary": "Move books to another library",
       "BookReadingStateReset": "Nulstil læsetilstand",
       "BookWriteAndRename": "Skriv metadata og omdøb fil",
       "CollectionCreate": "Opret samling",
@@ -3345,12 +3322,8 @@
         "isFinished": "er færdig",
         "isLocked": "er låst",
         "isUnlocked": "er låst op",
-        "isUpNext": "er oppe næste",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isUpNext": "er oppe næste"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Enhver udbyder",
       "communityRatingProvider": "Community rating provider",
       "loadingLibraries": "Indlæser biblioteker...",
@@ -3698,8 +3671,7 @@
         "koboRemovedByDeviceTooltip": "Kobo rapporterede at denne bog blev fjernet.",
         "koboNotSynced": "Ikke synkroniseret",
         "koboNotSyncedTooltip": "I kø til næste Kobo synkronisering.",
-        "filesNotFound": "Filer ikke fundet",
-        "filesNotFoundDescription": "The file(s) for this book can no longer be found on disk. Metadata is still available. Run a library scan to confirm, or remove the record."
+        "filesNotFound": "Filer ikke fundet"
       },
       "editMetadata": {
         "fieldCount": "{count, plural, =0 {ingen felter} one {et felt} other {# felter}}",
@@ -3953,19 +3925,13 @@
         "months": {
           "jan": "Jan",
           "feb": "Feb",
-          "mar": "Mar",
           "apr": "April",
           "may": "Maj",
           "jun": "Juni",
           "jul": "Juli",
-          "aug": "Aug",
-          "sep": "Sep",
-          "oct": "Okt",
-          "nov": "Nov",
-          "dec": "Dec"
+          "oct": "Okt"
         },
         "heatmap": {
-          "minutesUnit": "min",
           "title": "Aktivitet",
           "empty": "Ingen læsning aktivitet i dette vindue.",
           "emptyHint": "Sessioner, der registreres her, vil bygge din konsistensvisning."
@@ -4016,7 +3982,6 @@
         "journey": {
           "tooltipProgress": "Fremskridt",
           "tooltipReading": "Læser",
-          "minutesUnit": "min",
           "title": "Rejse med fremskridt",
           "empty": "Ingen fremdriftsdata i dette vindue.",
           "emptyHint": "Fremskridt vises efter en session registrerer en læseposition."
@@ -4095,11 +4060,7 @@
         "seriesPlaceholder": "Serie",
         "moveUp": "Flyt op",
         "moveDown": "Flyt ned",
-        "removeSeries": "Fjern serier",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Fjern serier"
       }
     },
     "table": {
@@ -4179,69 +4140,6 @@
       },
       "text": {
         "openDetails": "Åbn detaljer"
-      }
-    },
-    "move": {
-      "title": "{count, plural, one {Move # book} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
-      "folderCount": "{count, plural, one {# folder} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
-      "confirm": "{count, plural, one {Move # book} other {Move # books}}",
-      "action": "Move to library",
-      "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
       }
     }
   },
@@ -4775,14 +4673,6 @@
         "upNextInSeries": "Næste i serie",
         "random": "Opdag Noget Nyt",
         "smartScope": "Smart Anvendelsesområde"
-      },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
       },
       "reorderHintWidget": "Træk for at ændre rækkefølge. Skift for at vise eller skjule en widget.",
       "reorderHintShelf": "Træk for at omarrangere. Skift for at vise eller skjule en hylde.",
@@ -5754,7 +5644,6 @@
       "unresolvedBooksExplanation": "Disse bøger findes i kilden, men kunne ikke matches til nogen bog i dit bibliotek.",
       "mappedUsers": "Tilknyttede brugere ({count})",
       "mappedUsersExplanation": "Per-bruger totaler kommer fra tør-run preview cached med migreringsplanen.",
-      "coverFailures": "{count} cover import(s) failed. Detailed failure rows are not stored.",
       "userPreviewCounts": "{statuses} statusser, {progress} fremdriftsindgange, {sessions} læsessioner, {bookmarks} bogmærker, {annotations} annotationer, {collections} indsamlingsposter"
     },
     "unresolvedReason": {
@@ -5799,7 +5688,6 @@
       "connectionPassedWithWarnings": "Forbindelsestest bestået med advarsler",
       "connectionPassedWithWarningCount": "Forbindelsestest bestået med {count} advarsel(s). Først: {warning}",
       "connectionPassed": "Forbindelsestesten bestået",
-      "connectionMissingTables": "Connection ok, but {count} required table(s) are missing",
       "cannotTestMediaWhileRunning": "Kan ikke teste medie sti, mens en kørsel er aktiv",
       "mediaPathRequired": "Medie Root-sti er påkrævet til dækimport.",
       "mediaPathAbsolute": "Brug en absolut sti (for eksempel: /books).",
@@ -5956,67 +5844,21 @@
     "settings": {
       "title": "Indstillinger",
       "ariaLabel": "Læser indstillinger",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Lys",
         "dark": "Mørk"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Indbygget",
-      "fontServer": "Server fonts",
       "fontYours": "Dine skrifttyper",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Læser flow",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Sidespreads",
       "pageSpreadsHint": "Vælg hvordan dette billede-baserede EPUB par sider.",
       "spread": {
         "bookDefault": "Bogs standard",
         "singlePage": "Enkelt side"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Kolonne mellemrum",
-      "justifyText": "Justér tekst",
-      "hyphenation": "Hyphenation",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "justifyText": "Justér tekst"
     },
     "search": {
       "placeholder": "Søg i bog (min {min} tegn)...",
@@ -6111,9 +5953,6 @@
       "scrollModeHint": "Brug \"Ingen huller\" til webtoons og lodrette strimler.",
       "readingDirection": "Læser retning",
       "pageView": "Side visning",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Spred justering",
       "spreadGap": "Spred mellemrum",
       "spreadGapValue": "{value}px",
@@ -6188,10 +6027,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} af {total} læst ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Mulige huller:"
@@ -6733,7 +6568,6 @@
       },
       "bulkDeleteModal": {
         "title": "Masse Slet",
-        "confirm": "{count, plural, =0 {Are you sure you want to delete # selected entity?} one {Are you sure you want to delete # selected entity?} other {Are you sure you want to delete # selected entities?}}",
         "deleteButton": "Slet {count}"
       },
       "mergeModal": {
@@ -6997,8 +6831,7 @@
       "users": "Brugere",
       "account-activity": "Konto Aktivitet",
       "magic-links": "Magiske Links",
-      "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / SSO"
     },
     "system": {
       "file-naming": "Navngivning Af Fil",

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -104,68 +104,23 @@
         "accents": {
           "grey": "Grau",
           "scarlet": "Scharlachrot",
-          "vermilion": "Vermilion",
           "rose": "Rose",
           "copper": "Kupfer",
           "orange": "Orange",
-          "chartreuse": "Chartreuse",
-          "marigold": "Marigold",
           "wasabi": "Wasabi",
-          "amber": "Amber",
-          "malachite": "Malachite",
           "yellow": "Gelb",
-          "viridian": "Viridian",
           "turquoise": "Türkis",
-          "lime": "Lime",
           "green": "Grün",
-          "acid-green": "Acid Green",
-          "emerald": "Emerald",
-          "teal": "Teal",
-          "electric-blue": "Electric Blue",
           "cyan": "Cyan",
-          "jade": "Jade",
-          "ultramarine": "Ultramarine",
-          "iris": "Iris",
           "purple": "Lila",
           "blue": "Blau",
-          "indigo": "Indigo",
           "violet": "Violett",
-          "amethyst": "Amethyst",
-          "fuchsia": "Fuchsia",
           "raspberry": "Himbeere",
           "pink": "Pink",
           "white": "Weiß",
-          "rosewater": "Rosewater",
-          "salmon": "Salmon",
-          "coral": "Coral",
-          "sand": "Sand",
-          "peach": "Peach",
-          "pear": "Pear",
-          "flax": "Flax",
-          "sprout": "Sprout",
-          "butter": "Butter",
-          "aloe": "Aloe",
-          "lemon": "Lemon",
-          "foam": "Foam",
-          "aqua": "Aqua",
-          "celadon": "Celadon",
-          "sage": "Sage",
-          "pistachio": "Pistachio",
           "mint": "Minzgrün",
-          "seafoam": "Seafoam",
           "baby-blue": "Babyblau",
-          "powder": "Powder",
-          "sea-glass": "Sea Glass",
-          "bluebell": "Bluebell",
-          "cornflower": "Cornflower",
-          "thistle": "Thistle",
-          "periwinkle": "Periwinkle",
-          "wisteria": "Wisteria",
-          "lavender": "Lavendel",
-          "mauve": "Mauve",
-          "orchid": "Orchid",
-          "rose-quartz": "Rose Quartz",
-          "blush": "Blush"
+          "lavender": "Lavendel"
         },
         "accentColor": {
           "label": "Akzentfarbe",
@@ -466,8 +421,7 @@
         "notice": "Demo-eingeschränktes Konto: Das Bearbeiten von Profil, Passwort, Avatar und verknüpften Identitäten ist deaktiviert."
       },
       "feedback": {
-        "unsavedChanges": "Nicht gespeicherte Änderungen",
-        "discard": "Discard"
+        "unsavedChanges": "Nicht gespeicherte Änderungen"
       },
       "profile": {
         "securityHeading": "Profil & Sicherheit",
@@ -487,8 +441,7 @@
         "updated": "Profil aktualisiert",
         "usernameHint": "Ihr Benutzername kann nicht geändert werden.",
         "passwordHint": "Ändern Sie das Passwort, das Sie zum Anmelden verwenden.",
-        "passwordHintOidc": "Ihr Passwort wird von Ihrem Identitätsanbieter verwaltet.",
-        "passwordHintShared": "Shared accounts sign in through a magic link and have no password."
+        "passwordHintOidc": "Ihr Passwort wird von Ihrem Identitätsanbieter verwaltet."
       },
       "readingPreferences": {
         "title": "Leseeinstellungen",
@@ -496,10 +449,7 @@
         "timezone": "Zeitzone",
         "save": "Einstellungen speichern",
         "enableAchievements": "Erfolge aktivieren",
-        "enableAchievementsHint": "Verfolge den Fortschritt bei Erfolgen und zeige die zugehörige Benutzeroberfläche an. Benachrichtigungen für Erfolge können separat unter Benachrichtigungen verwaltet werden.",
-        "achievementsEnabled": "Achievements enabled",
-        "achievementsDisabled": "Achievements disabled",
-        "achievementsSaveFailed": "Failed to update the achievement preference"
+        "enableAchievementsHint": "Verfolge den Fortschritt bei Erfolgen und zeige die zugehörige Benutzeroberfläche an. Benachrichtigungen für Erfolge können separat unter Benachrichtigungen verwaltet werden."
       },
       "preferences": {
         "saveFailed": "Einstellungen konnten nicht gespeichert werden",
@@ -541,9 +491,7 @@
           "title": "Verknüpfung mit {provider}-Identität aufheben?",
           "description": "Geben Sie Ihr Passwort zur Bestätigung ein. Sie können sich mit diesem Anbieter nicht mehr anmelden.",
           "currentPassword": "Aktuelles Passwort"
-        },
-        "description": "Sign in with an external identity provider linked to this account.",
-        "unlinkAria": "Unlink {provider}"
+        }
       },
       "tour": {
         "title": "Geführte Tour",
@@ -572,11 +520,6 @@
           "title": "Blockierte Genres",
           "description": "Bücher mit einem dieser Genres werden für Sie ausgeblendet."
         }
-      },
-      "groups": {
-        "profile": "Profile",
-        "preferences": "Preferences",
-        "security": "Security & access"
       }
     },
     "magicLinks": {
@@ -612,8 +555,7 @@
         "uses": "Verwendungen",
         "created": "Erstellt",
         "status": "Status",
-        "totalUses": "Gesamtverwendungen",
-        "actions": "Actions"
+        "totalUses": "Gesamtverwendungen"
       },
       "createDialog": {
         "title": "Magic Link erstellen",
@@ -641,12 +583,7 @@
       "emptyTitle": "Es wurden noch keine Magic Links erstellt",
       "emptyHint": "Klicken Sie auf \"{action}\", um eine teilbare Anmelde-URL zu generieren.",
       "noActiveTitle": "Keine aktiven Magic Links",
-      "noActiveHint": "Alle generierten Magic Links für diese Seite sind abgelaufen oder wurden widerrufen.",
-      "copyLinkAria": "Copy the link for {label}",
-      "pauseAria": "Pause {label}",
-      "resumeAria": "Resume {label}",
-      "revokeAria": "Revoke {label}",
-      "lastUsedLabel": "Last used {date}"
+      "noActiveHint": "Alle generierten Magic Links für diese Seite sind abgelaufen oder wurden widerrufen."
     },
     "oidc": {
       "title": "OIDC / SSO",
@@ -1133,15 +1070,7 @@
         "users": "Benutzer",
         "account-activity": "Kontoaktivität",
         "magic-links": "Magic Links",
-        "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC / SSO"
       }
     },
     "common": {
@@ -1606,9 +1535,6 @@
         "spreadAlignmentHint": "Paarung nach dem Cover um eine Seite verschieben bei versetzten Scans",
         "alignmentNormal": "Normal",
         "alignmentShifted": "Verschoben",
-        "spreadGap": "Spread gap",
-        "spreadGapHint": "Space between pages in two-page view",
-        "spreadGapValue": "{value}px",
         "widePageHandling": "Umgang mit breiten Seiten",
         "widePageHandlingHint": "Automatisch zeigt breite Scans allein im zweiseitigen seitenweisen Modus an",
         "widePageAuto": "Automatisch",
@@ -1676,12 +1602,7 @@
         "deleteFamilyFailed": "Löschen der Schriftfamilie fehlgeschlagen",
         "demoCannotManage": "Demo-eingeschränktes Konto kann Schriftarten nicht verwalten",
         "fileAdded": "\"{name}\" hinzugefügt",
-        "uploadFailed": "Hochladen fehlgeschlagen",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Hochladen fehlgeschlagen"
       },
       "bookDock": {
         "title": "Book Dock",
@@ -1783,37 +1704,7 @@
         "patternCopied": "Muster in die Zwischenablage kopiert",
         "copyPatternFailed": "Muster konnte nicht kopiert werden",
         "labelCopied": "{label} in die Zwischenablage kopiert",
-        "copyLabelFailed": "{label} konnte nicht kopiert werden",
-        "patternHelp": "Pattern help",
-        "patternHelpDescription": "Tokens, modifiers and ready-made patterns you can copy into any field.",
-        "copyPreview": "Copy {label}",
-        "copyExample": "Copy the {label} pattern",
-        "invalidCharacters": "Pattern contains invalid characters",
-        "fileAsBookSaved": "File as Book default saved",
-        "folderAsBookSaved": "Folder as Book default saved",
-        "downloadPatternSaved": "Download pattern saved",
-        "savePatternFailed": "Failed to save pattern",
-        "saveDownloadPatternFailed": "Failed to save download pattern",
-        "crossPlatformEnabled": "Cross-platform path sanitization enabled",
-        "crossPlatformDisabled": "Cross-platform path sanitization disabled",
-        "crossPlatformSaveFailed": "Failed to save cross-platform path sanitization",
-        "librarySaved": "Pattern saved for {name}",
-        "librarySaveFailed": "Failed to save library pattern",
-        "saveLibraryPattern": "Save pattern for {name}",
-        "resetLibraryPattern": "Reset {name} to the default pattern",
-        "tokenTitle": "Book title",
-        "tokenSubtitle": "Book subtitle",
-        "tokenAuthors": "Author(s), comma-separated",
-        "tokenYear": "Publication year",
-        "tokenSeries": "Series name",
-        "tokenSeriesIndex": "Series index (zero-padded)",
-        "tokenPublisher": "Publisher",
-        "tokenIsbn": "ISBN-13",
-        "tokenLanguage": "Language",
-        "tokenOriginalFilename": "Original filename (without extension)",
-        "tokenExtension": "File extension (without dot)",
-        "patternHelpIntro": "Patterns use tokens like {titleToken} and {authorsToken}, plus modifiers and optional segments.",
-        "browseTokensAndExamples": "Browse tokens and examples"
+        "copyLabelFailed": "{label} konnte nicht kopiert werden"
       },
       "kobo": {
         "title": "Kobo-Synchronisierung",
@@ -2508,8 +2399,7 @@
         "username": "Benutzername",
         "email": "E-Mail",
         "access": "Zugriff",
-        "status": "Status",
-        "actions": "Actions"
+        "status": "Status"
       },
       "adminBadge": "Administrator",
       "permissionCount": "{count, plural, =0 {keine Berechtigungen} one {eine Berechtigung} other {# Berechtigungen}}",
@@ -2528,8 +2418,7 @@
       "deleting": "Wird gelöscht ...",
       "errors": {
         "load": "Laden fehlgeschlagen",
-        "deleteUser": "Löschen des Benutzers fehlgeschlagen",
-        "resetPassword": "Failed to create a password reset link"
+        "deleteUser": "Löschen des Benutzers fehlgeschlagen"
       },
       "defaultLibraryAccess": {
         "title": "Standard-Bibliothekszugriff",
@@ -2539,36 +2428,7 @@
         "save": "Standardwerte speichern",
         "saving": "Wird gespeichert...",
         "saveError": "Speichern des Standard-Bibliothekszugriffs fehlgeschlagen"
-      },
-      "filters": {
-        "search": "Search users",
-        "searchPlaceholder": "Search by name, username or email",
-        "sort": "Sort users",
-        "usernameAsc": "Username A-Z",
-        "nameAsc": "Name A-Z",
-        "newest": "Newest first",
-        "oldest": "Oldest first",
-        "apply": "Apply",
-        "clear": "Clear",
-        "state": "Filter users",
-        "allUsers": "All users",
-        "admins": "Administrators",
-        "active": "Active",
-        "inactive": "Inactive"
-      },
-      "empty": {
-        "title": "No users yet",
-        "description": "Create the first account to get started.",
-        "filtered": "No users match the current search and filters."
-      },
-      "pagination": {
-        "label": "Users pagination",
-        "page": "Page {page} of {totalPages}"
-      },
-      "editUserAria": "Edit {name}",
-      "resetPasswordAria": "Reset the password for {name}",
-      "deleteUserAria": "Delete {name}",
-      "moreActionsAria": "More actions for {name}"
+      }
     }
   },
   "annotations": {
@@ -2718,221 +2578,32 @@
     "showLess": "Weniger anzeigen",
     "details": "Details",
     "hideDetails": "Details ausblenden",
-    "refresh": "Refresh audit log",
-    "loadError": "Could not load audit events.",
-    "removeFilter": "Remove filter: {value}",
-    "allActions": "All actions",
-    "allEventTypes": "All event types",
-    "allActors": "All actors",
-    "noActionsFound": "No matching actions",
-    "noActorsFound": "No matching actors",
-    "noResourcesFound": "No matching target types",
-    "unknownAction": "Unknown action",
-    "unknownResource": "Other target type",
-    "allResources": "All resources",
-    "allTargetTypes": "All target types",
-    "quickDates": "Quick dates",
-    "today": "Today",
-    "sevenDays": "7 days",
-    "thirtyDays": "30 days",
-    "userId": "User #{id}",
-    "userIdCompact": "#{id}",
-    "targetAdditional": "and {count, plural, one {# more target} other {# more targets}}",
-    "bookImpact": "{count, plural, one {# book} other {# books}}",
-    "entryDetailsLabel": "Details for audit event #{id}",
-    "detailEventId": "Event ID",
-    "detailOccurredAt": "Occurred",
-    "detailActor": "Actor",
-    "detailCategory": "Category",
-    "detailActionLabel": "Action",
-    "detailEventTypeLabel": "Event type",
-    "detailIpLabel": "IP address",
-    "detailResourceLabel": "Resource",
-    "detailResourceIdLabel": "Resource ID",
-    "detailTargetTypeLabel": "Target type",
-    "detailTargetIdLabel": "Target ID",
     "detailAction": "Aktion: {value}",
     "detailIp": "IP: {value}",
-    "detailResource": "Resource: {value}",
-    "detailResourceId": "Resource ID: {value}",
-    "deletedBooks": "Deleted books",
-    "deletedBookDetail": "{title} (book #{id})",
-    "untitledBook": "Untitled",
-    "deletedBooksOmitted": "{count, plural, one {# additional book omitted} other {# additional books omitted}}",
     "showing": "Zeige {from}-{to} von {total}",
     "prev": "Zurück",
     "chips": {
-      "search": "Search: {value}",
       "action": "Aktion: {value}",
-      "eventType": "Event type: {value}",
-      "actor": "Actor: {value}",
-      "resource": "Resource: {value}",
-      "targetType": "Target type: {value}",
       "user": "Benutzer: {value}",
       "from": "Von: {value}",
       "to": "Bis: {value}"
     },
     "filterLabels": {
-      "search": "Search events",
       "action": "Aktion",
-      "eventType": "Event type (what happened)",
-      "actor": "Actor",
-      "resource": "Resource",
-      "targetType": "Target type (what was affected)",
       "userId": "Benutzer-ID",
       "from": "Von",
       "to": "Bis"
     },
     "filterPlaceholders": {
-      "search": "Description, actor, target, or ID",
-      "actor": "Username",
       "action": "z. B. auth.login",
       "userId": "z. B. 1"
     },
     "columns": {
       "when": "Wann",
-      "actor": "Actor",
-      "event": "Event",
-      "target": "Target",
-      "impact": "Impact",
       "user": "Benutzer",
       "action": "Aktion",
       "description": "Beschreibung",
       "ip": "IP"
-    },
-    "categories": {
-      "authentication": "Authentication",
-      "books": "Books",
-      "users": "Users",
-      "libraries": "Libraries",
-      "collections": "Collections",
-      "integrations": "Integrations",
-      "settings": "Settings",
-      "other": "Other"
-    },
-    "resourceLabels": {
-      "User": "User",
-      "Library": "Library",
-      "Book": "Book",
-      "Collection": "Collection",
-      "SmartScope": "Smart scope",
-      "BookDockFile": "Book Dock file",
-      "Author": "Author",
-      "AppSettings": "Application settings",
-      "Genre": "Genre",
-      "Tag": "Tag",
-      "KoboDevice": "Kobo device",
-      "EmailProvider": "Email provider",
-      "EmailTemplate": "Email template",
-      "EmailRecipient": "Email recipient",
-      "EmailRecipientGroup": "Email recipient group",
-      "Narrator": "Narrator",
-      "Publisher": "Publisher",
-      "Language": "Language",
-      "Series": "Series",
-      "OidcIdentity": "OIDC identity",
-      "MagicLinkToken": "Magic link",
-      "ReadingInsightsProfile": "Reading insights profile"
-    },
-    "actionLabels": {
-      "AuthRegister": "Register account",
-      "AuthLogin": "Sign in",
-      "AuthLoginFailed": "Failed sign-in",
-      "AuthLogout": "Sign out",
-      "AuthPasswordChange": "Change password",
-      "AuthPasswordResetRequest": "Request password reset",
-      "AuthPasswordReset": "Reset password",
-      "AuthPasswordAdminReset": "Reset user password",
-      "AuthSessionRevoke": "Revoke session",
-      "MagicLinkCreate": "Create magic link",
-      "MagicLinkLogin": "Sign in with magic link",
-      "MagicLinkRevoke": "Revoke magic link",
-      "MagicLinkActivate": "Activate magic link",
-      "MagicLinkDeactivate": "Deactivate magic link",
-      "OidcLogin": "Sign in with OIDC",
-      "OidcUserProvisioned": "Provision OIDC user",
-      "OidcIdentityLinked": "Link OIDC identity",
-      "OidcIdentityUnlinked": "Unlink OIDC identity",
-      "UserCreate": "Create user",
-      "UserUpdate": "Update user",
-      "UserSelfUpdate": "Update own profile",
-      "UserDelete": "Delete user",
-      "UserPermissionSet": "Update user permissions",
-      "UserSuperuserEnable": "Enable superuser access",
-      "UserSuperuserDisable": "Disable superuser access",
-      "UserContentFiltersSet": "Update content filters",
-      "ReadingInsightsSharingUpdate": "Update insight sharing",
-      "ReadingInsightsProfileView": "View shared insights",
-      "LibraryCreate": "Create library",
-      "LibraryUpdate": "Update library",
-      "LibraryDelete": "Delete library",
-      "LibraryFolderAdd": "Add library folder",
-      "LibraryFolderRemove": "Remove library folder",
-      "LibraryAccessGrant": "Grant library access",
-      "LibraryAccessUpdate": "Update library access",
-      "LibraryAccessRevoke": "Revoke library access",
-      "LibraryWriteMetadataToFiles": "Write metadata to files",
-      "LibraryBulkRename": "Rename library files",
-      "BookUpload": "Upload book",
-      "BookMetadataUpdate": "Update book metadata",
-      "BookMetadataLocksUpdate": "Update metadata locks",
-      "BookDelete": "Delete book",
-      "BookBulkMetadataRefresh": "Refresh book metadata",
-      "BookBulkDelete": "Delete books",
-      "BookBulkCoverReextract": "Re-extract book covers",
-      "BookBulkSetStatus": "Set book status",
-      "BookBulkSetRating": "Set book rating",
-      "BookBulkSetMetadata": "Set book metadata",
-      "BookBulkUpdateTags": "Update book tags",
-      "BookBulkSetMetadataLock": "Set metadata locks",
-      "BookBulkEditMetadata": "Edit book metadata",
-      "BookBulkMoveLibrary": "Move books to another library",
-      "BookReadingStateReset": "Reset reading state",
-      "BookWriteAndRename": "Write metadata and rename file",
-      "CollectionCreate": "Create collection",
-      "CollectionUpdate": "Update collection",
-      "CollectionDelete": "Delete collection",
-      "CollectionBooksAdd": "Add books to collection",
-      "CollectionBooksRemove": "Remove books from collection",
-      "SmartScopeCreate": "Create smart scope",
-      "SmartScopeUpdate": "Update smart scope",
-      "SmartScopeDelete": "Delete smart scope",
-      "BookDockFinalize": "Finalize Book Dock file",
-      "AuthorUpdate": "Update author",
-      "AuthorDelete": "Delete author",
-      "AuthorMerge": "Merge authors",
-      "AuthorEnrichmentConfigUpdate": "Update author enrichment",
-      "AuthorEnrichmentPause": "Pause author enrichment",
-      "AuthorEnrichmentResume": "Resume author enrichment",
-      "AuthorEnrichmentCancel": "Cancel author enrichment",
-      "EntityManagerMerge": "Merge entities",
-      "EntityManagerRename": "Rename entity",
-      "EntityManagerDelete": "Delete entity",
-      "EntityManagerSplit": "Split entity",
-      "EntityManagerDismiss": "Dismiss duplicate",
-      "EntityManagerUndismiss": "Restore dismissed duplicate",
-      "AppSettingsUpdate": "Update app settings",
-      "KoboDeviceRegister": "Register Kobo device",
-      "KoboDeviceRename": "Rename Kobo device",
-      "KoboDeviceRemove": "Remove Kobo device",
-      "EmailProviderCreate": "Create email provider",
-      "EmailProviderUpdate": "Update email provider",
-      "EmailProviderDelete": "Delete email provider",
-      "EmailProviderSetDefault": "Set default email provider",
-      "EmailProviderSetSystem": "Set system email provider",
-      "EmailProviderClearSystem": "Clear system email provider",
-      "EmailTemplateCreate": "Create email template",
-      "EmailTemplateUpdate": "Update email template",
-      "EmailTemplateDelete": "Delete email template",
-      "EmailTemplateSetDefault": "Set default email template",
-      "EmailRecipientCreate": "Create email recipient",
-      "EmailRecipientUpdate": "Update email recipient",
-      "EmailRecipientDelete": "Delete email recipient",
-      "EmailRecipientGroupCreate": "Create recipient group",
-      "EmailRecipientGroupUpdate": "Update recipient group",
-      "EmailRecipientGroupDelete": "Delete recipient group",
-      "EmailRecipientGroupMemberAdd": "Add recipient to group",
-      "EmailRecipientGroupMemberRemove": "Remove recipient from group"
     }
   },
   "auth": {
@@ -3254,31 +2925,6 @@
       "moveDown": "Nach unten verschieben",
       "ascending": "Aufsteigend",
       "descending": "Absteigend",
-      "fields": {
-        "author": "Author",
-        "title": "Title",
-        "series": "Series",
-        "seriesIndex": "Series #",
-        "addedAt": "Date Added",
-        "updatedAt": "Date Updated",
-        "publishedDate": "Published Date",
-        "publishedYear": "Published Year",
-        "pageCount": "Page Count",
-        "rating": "Rating",
-        "publisher": "Publisher",
-        "fileSize": "File Size",
-        "readProgress": "Read Progress",
-        "readStatus": "Read Status",
-        "format": "Format",
-        "lastReadAt": "Last Read",
-        "startedAt": "Date Started",
-        "finishedAt": "Date Finished",
-        "random": "Random",
-        "language": "Language",
-        "metadataScore": "Metadata Score"
-      },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "remove": "Entfernen",
       "emptyState": "Keine Sortierung konfiguriert. Titel aufsteigend wird verwendet.",
       "addLevel": "Sortierebene hinzufügen"
@@ -3288,69 +2934,6 @@
       "all": "ALLE",
       "any": "BELIEBIG",
       "ofFollowingRules": "der folgenden Regeln",
-      "fields": {
-        "title": "Title",
-        "publisher": "Publisher",
-        "language": "Language",
-        "series": "Series",
-        "seriesIndex": "Series Index",
-        "publishedDate": "Published Date",
-        "publishedYear": "Published Year",
-        "pageCount": "Page Count",
-        "author": "Author",
-        "genre": "Genre",
-        "tag": "Tag",
-        "collection": "Collection",
-        "library": "Library",
-        "format": "Format",
-        "addedAt": "Added Date",
-        "startedAt": "Date Started",
-        "finishedAt": "Date Finished",
-        "fileAvailability": "File Availability",
-        "rating": "Rating",
-        "communityRating": "Community Rating",
-        "readProgress": "Reading Progress",
-        "readStatus": "Read Status",
-        "description": "Description",
-        "isbn": "ISBN",
-        "metadataScore": "Metadata Score",
-        "cover": "Cover",
-        "lockStatus": "Lock Status",
-        "seriesStatus": "Series Status"
-      },
-      "operators": {
-        "contains": "contains",
-        "notContains": "does not contain",
-        "startsWith": "starts with",
-        "endsWith": "ends with",
-        "eq": "is",
-        "notEq": "is not",
-        "isEmpty": "is empty",
-        "isNotEmpty": "is not empty",
-        "gt": "greater than",
-        "gte": "at least",
-        "lt": "less than",
-        "lte": "at most",
-        "between": "between",
-        "includesAny": "includes any of",
-        "includesAll": "includes all of",
-        "excludesAll": "excludes all of",
-        "before": "before",
-        "after": "after",
-        "withinLast": "within last",
-        "isMissing": "is missing",
-        "isPresent": "is present",
-        "isUnread": "is unread",
-        "isInProgress": "is in progress",
-        "isFinished": "is finished",
-        "isLocked": "is locked",
-        "isUnlocked": "is unlocked",
-        "isUpNext": "is up next",
-        "isTrue": "is yes",
-        "isFalse": "is no"
-      },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Beliebiger Anbieter",
       "communityRatingProvider": "Anbieter der Community-Bewertung",
       "loadingLibraries": "Bibliotheken werden geladen ...",
@@ -4095,11 +3678,7 @@
         "seriesPlaceholder": "Reihe",
         "moveUp": "Nach oben verschieben",
         "moveDown": "Nach unten verschieben",
-        "removeSeries": "Reihe entfernen",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Reihe entfernen"
       }
     },
     "table": {
@@ -4179,69 +3758,6 @@
       },
       "text": {
         "openDetails": "Details öffnen"
-      }
-    },
-    "move": {
-      "title": "{count, plural, one {Move # book} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
-      "folderCount": "{count, plural, one {# folder} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
-      "confirm": "{count, plural, one {Move # book} other {Move # books}}",
-      "action": "Move to library",
-      "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
       }
     }
   },
@@ -4527,9 +4043,7 @@
         "title": "Gefällt Ihnen BookOrbit?",
         "body": "Wenn BookOrbit Ihnen bei Ihrer Bibliothek hilft, geben Sie dem Projekt doch einen Stern auf GitHub. Das hilft mehr Menschen, die App zu entdecken, und unterstützt die weitere Entwicklung.",
         "cta": "BookOrbit auf GitHub mit Stern versehen"
-      },
-      "surfaceOpacity": "Surface opacity",
-      "surfaceOpacityValue": "{value}%"
+      }
     },
     "sidebar": {
       "dashboard": "Übersicht",
@@ -4550,36 +4064,8 @@
       "supportAria": "BookOrbit auf Ko-fi unterstützen",
       "sectionHeader": {
         "add": "Hinzufügen",
-        "showAll": "Show all",
-        "showCount": "Show {count}",
-        "rowsShown": "Rows shown",
-        "menuAria": "Section options for {section}",
         "reorder": "Neu anordnen",
         "doneReordering": "Anordnen abgeschlossen"
-      },
-      "noLibraries": "No libraries yet",
-      "clearFilter": "Clear filter",
-      "filterSummary": "{shown} of {total} shown",
-      "filterLibraries": "Filter libraries",
-      "filterLibrariesPlaceholder": "Filter libraries...",
-      "filterSmartScopes": "Filter smart scopes",
-      "filterSmartScopesPlaceholder": "Filter smart scopes...",
-      "filterCollections": "Filter collections",
-      "filterCollectionsPlaceholder": "Filter collections...",
-      "seeAllLibraries": "See all libraries ({count})",
-      "seeAllSmartScopes": "See all smart scopes ({count})",
-      "seeAllCollections": "See all collections ({count})",
-      "updateAvailable": "Update {version}",
-      "zones": {
-        "browse": "Browse"
-      },
-      "reorder": {
-        "gripAria": "Reorder {name}",
-        "lifted": "{name} lifted, position {position} of {total}. Use the arrow keys to move it.",
-        "moved": "{name}, position {position} of {total}",
-        "dropped": "{name} dropped at position {position} of {total}",
-        "cancelled": "Reorder cancelled. {name} returned to position {position} of {total}.",
-        "filteredHint": "Clear the filter to reorder"
       }
     },
     "selectionActionBar": {
@@ -4635,7 +4121,6 @@
         "display": "Anzeige",
         "coverSize": "Covergröße",
         "gridGap": "Rasterabstand",
-        "showJumpRails": "Show jump rails",
         "columnsHint": "Verwende das Spaltensichtbarkeits-Panel in der Tabellenkopfzeile, um Spalten ein- oder auszublenden.",
         "coverShape": "Coverform",
         "circle": "Kreis",
@@ -4679,24 +4164,6 @@
         "typeAndEnter": "Eingeben und Enter drücken zum Hinzufügen",
         "pressEnter": "Enter drücken zum Hinzufügen"
       }
-    },
-    "entityIndex": {
-      "sortBy": "Sort by",
-      "sort": {
-        "custom": "Custom order",
-        "name": "Name",
-        "bookCount": "Book count"
-      },
-      "ascending": "Ascending",
-      "descending": "Descending",
-      "clearSearch": "Clear search",
-      "resultCount": "{shown} of {total}",
-      "noMatches": "No matches",
-      "noMatchesHint": "Try a different search term.",
-      "bookCount": "Books: {count}",
-      "librariesEmptyHint": "Create a library to start adding books.",
-      "smartScopesEmptyHint": "Smart scopes save a set of filters you use often.",
-      "collectionsEmptyHint": "Collections group books you pick by hand."
     }
   },
   "customIcons": {
@@ -4752,37 +4219,6 @@
       "tabs": {
         "widgets": "Widgets",
         "shelves": "Regale"
-      },
-      "widgetNames": {
-        "readingStreak": "Reading Streak",
-        "currentlyReading": "Currently Reading",
-        "readingGoal": "Reading Goal",
-        "readingDna": "Reading DNA",
-        "monthlyChallenge": "Monthly Challenge",
-        "highlightOfTheDay": "Highlight of the Day",
-        "neglectedGems": "Neglected Gems",
-        "readingRhythm": "Reading Rhythm",
-        "diversityScore": "Diversity Score",
-        "libraryOverview": "Library Overview",
-        "yearProjection": "Year Projection",
-        "longWait": "The Long Wait"
-      },
-      "shelfNames": {
-        "recentlyAdded": "Recently Added",
-        "continueReading": "Continue Reading",
-        "continueListening": "Continue Listening",
-        "wantToRead": "Want to Read",
-        "upNextInSeries": "Up Next in Series",
-        "random": "Discover Something New",
-        "smartScope": "Smart Scope"
-      },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
       },
       "reorderHintWidget": "Ziehen zum Neuanordnen. Umschalten, um ein Widget ein- oder auszublenden.",
       "reorderHintShelf": "Ziehen zum Neuanordnen. Umschalten, um ein Regal ein- oder auszublenden.",
@@ -5398,11 +4834,6 @@
           "hint": "Schreibt Metadaten in die OPF-Datei innerhalb des EPUB-Archivs.",
           "toggleAria": "EPUB-Metadaten schreiben"
         },
-        "fb2": {
-          "title": "FictionBook (FB2)",
-          "hint": "Rewrites the description block inside FB2 files, leaving the book text untouched.",
-          "toggleAria": "Write FB2 metadata"
-        },
         "pdf": {
           "title": "PDF",
           "hint": "Bettet Metadaten in das PDF-Info-Dictionary und den XMP-Stream ein.",
@@ -5412,11 +4843,6 @@
           "title": "Comic-Archive (CBX)",
           "hint": "Schreibt ComicInfo.xml in CBZ- und CB7-Archive.",
           "toggleAria": "Metadaten in Comic-Archive schreiben"
-        },
-        "kindle": {
-          "title": "Kindle (MOBI, AZW3)",
-          "hint": "Writes metadata into the EXTH header of MOBI, AZW3, and AZW files.",
-          "toggleAria": "Write Kindle metadata"
         },
         "audio": {
           "title": "Audio",
@@ -5856,61 +5282,7 @@
       "saveFailed": "Speichern der Einstellungen fehlgeschlagen",
       "savePreferenceFailed": "Speichern der Einstellung fehlgeschlagen",
       "whatsNewToggle": "\"Neuigkeiten\" nach Updates anzeigen",
-      "whatsNewToggleHint": "Ein Popup, das nach App-Updates neue Funktionen hervorhebt. Das Archiv bleibt in jedem Fall verfügbar.",
-      "groups": {
-        "library": "Library",
-        "files": "Files",
-        "integrations": "Integrations",
-        "personal": "Personal",
-        "app": "App updates"
-      },
-      "enabledCount": "{enabled} of {total} enabled",
-      "categories": {
-        "scanning": {
-          "label": "Library scanning",
-          "description": "When a library scan finishes, fails, or finds missing books."
-        },
-        "metadata": {
-          "label": "Metadata fetching",
-          "description": "When metadata lookups for your books complete or fail."
-        },
-        "authorEnrichment": {
-          "label": "Author enrichment",
-          "description": "When author biographies and photos finish being fetched."
-        },
-        "fileWriteBack": {
-          "label": "File write-back",
-          "description": "When edited metadata is written back into book files on disk."
-        },
-        "fileRename": {
-          "label": "File rename",
-          "description": "When a single book file is renamed to match your naming pattern."
-        },
-        "bulkRename": {
-          "label": "Bulk rename",
-          "description": "When a bulk rename across many books completes or fails."
-        },
-        "migration": {
-          "label": "Data migration",
-          "description": "When an import from another library tool completes or fails."
-        },
-        "bookDock": {
-          "label": "Book Dock",
-          "description": "When files dropped into the dock are ready to review or finalized."
-        },
-        "koboSync": {
-          "label": "Kobo sync",
-          "description": "When a Kobo device finishes syncing with your library."
-        },
-        "email": {
-          "label": "Email delivery",
-          "description": "When sending a book to an email address succeeds or fails."
-        },
-        "achievements": {
-          "label": "Achievements",
-          "description": "When you unlock a new reading achievement."
-        }
-      }
+      "whatsNewToggleHint": "Ein Popup, das nach App-Updates neue Funktionen hervorhebt. Das Archiv bleibt in jedem Fall verfügbar."
     }
   },
   "reader": {
@@ -5956,67 +5328,22 @@
     "settings": {
       "title": "Einstellungen",
       "ariaLabel": "Lesereinstellungen",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Hell",
         "dark": "Dunkel"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Integriert",
-      "fontServer": "Server fonts",
       "fontYours": "Ihre Schriftarten",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Lesefluss",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Doppelseiten",
       "pageSpreadsHint": "Wählen Sie, wie dieses bildbasierte EPUB Seiten paart.",
       "spread": {
         "bookDefault": "Buchvorgabe",
         "singlePage": "Einzelseite"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Spaltenabstand",
       "justifyText": "Text ausrichten",
-      "hyphenation": "Silbentrennung",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Silbentrennung"
     },
     "search": {
       "placeholder": "Im Buch suchen (mind. {min} Zeichen)...",
@@ -6111,12 +5438,7 @@
       "scrollModeHint": "Verwenden Sie \"Keine Lücken\" für Webtoons und vertikale Streifen.",
       "readingDirection": "Leserichtung",
       "pageView": "Seitenansicht",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Doppelseitenausrichtung",
-      "spreadGap": "Spread gap",
-      "spreadGapValue": "{value}px",
       "forceTwoPage": "Zwei Seiten erzwingen",
       "widePages": "Breite Seiten",
       "firstPage": "Erste Seite",
@@ -6188,10 +5510,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} von {total} gelesen ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Mögliche Lücken:"
@@ -6270,8 +5588,6 @@
   "smartScope": {
     "syncToKobo": "Mit Kobo synchronisieren",
     "syncToKoboHint": "Bücher, die diesem Bereich entsprechen, werden auf deinem Kobo-Gerät angezeigt",
-    "visibleToAll": "Visible to all users",
-    "visibleToAllHint": "Every user can see and use this smart scope",
     "dialog": {
       "name": "Name",
       "namePlaceholder": "z. B. Ungelesene Science-Fiction",
@@ -6497,8 +5813,7 @@
   "tools": {
     "header": {
       "entityManager": "Entitätsmanager",
-      "bulkRename": "Massenumbenennung",
-      "duplicateBooks": "Duplicate Books"
+      "bulkRename": "Massenumbenennung"
     },
     "entityTypes": {
       "authors": "Autoren",
@@ -6510,8 +5825,6 @@
       "series": "Reihen"
     },
     "bulkRename": {
-      "previewToolbar": "Rename preview",
-      "renameSettings": "Rename settings",
       "library": "Bibliothek",
       "selectLibraryPlaceholder": "Bibliothek auswählen...",
       "noEligibleLibraries": "Für keine Bibliothek ist das Umbenennen von Dateien aktiviert. Aktivieren Sie es in den Bibliothekseinstellungen.",
@@ -6568,12 +5881,7 @@
     "bookDuplicates": {
       "scanSettings": "Scan-Einstellungen",
       "title": "Doppelte Bücher",
-      "description": "Scan files and metadata for potential duplicate records. Nothing is deleted during a scan.",
-      "scope": "Library scope",
       "allLibraries": "Alle verfügbaren Bibliotheken",
-      "similarity": "Similar-title threshold",
-      "explainSimilarity": "Explain the similar-title threshold",
-      "similarityHelp": "Only for Similar title and author matches. At least one author and the book type must also match. Lower finds more possible duplicates; higher requires closer titles. Identical files, ISBN, and exact metadata are checked separately.",
       "runScan": "Scan ausführen",
       "rescan": "Erneut scannen",
       "status": {
@@ -6584,7 +5892,6 @@
       "filter": "Übereinstimmungstyp",
       "allReasons": "Alle Übereinstimmungstypen",
       "reasons": {
-        "file_hash": "Identical file set",
         "isbn": "Gleiche ISBN",
         "exact_metadata": "Exakter Titel und Autoren",
         "fuzzy_metadata": "Ähnlicher Titel und Autor"
@@ -6593,8 +5900,6 @@
       "notDuplicates": "Keine Duplikate",
       "keepThis": "Dieses Buch behalten",
       "discardThis": "Dieses Buch verwerfen",
-      "selectKeeperFirst": "Select a keeper first",
-      "noDirectMatch": "No direct match with keeper",
       "moreFiles": "+{count} weitere",
       "showDetails": "Details anzeigen",
       "hideDetails": "Details ausblenden",
@@ -6603,7 +5908,6 @@
       "unknownAuthor": "Unbekannter Autor",
       "unknown": "Unbekannt",
       "none": "Keine",
-      "accessDenied": "You do not have permission to use the duplicate book tool.",
       "pairDetails": "Übereinstimmungsdetails",
       "pairLabel": "{first} und {second}",
       "fields": {
@@ -6620,17 +5924,11 @@
         "updated": "Aktualisiert"
       },
       "initial": {
-        "title": "Doppelte Bücher finden",
-        "description": "Choose a library scope and similarity level, then run a scan. No books are changed until you explicitly confirm a deletion."
-      },
-      "empty": {
-        "title": "No duplicate groups found",
-        "description": "No books matched the current scope, similarity level, and match filter."
+        "title": "Doppelte Bücher finden"
       },
       "deleteDialog": {
         "title": "Doppelte Bücher dauerhaft löschen?",
         "description": "{count, plural, =0 {This will permanently delete # selected book and its files.} one {This will permanently delete # selected book and its files.} other {This will permanently delete # selected books and their files.}}",
-        "warning": "Metadata, collections, reading data, and device state are not transferred to the kept book. Associated data for other users is also removed.",
         "confirm": "{count, plural, =0 {# Buch löschen} one {# Buch löschen} other {Lösche # Bücher}}",
         "success": "{count, plural, =0 {Keine Bücher gelöscht} one {Ein doppeltes Buch gelöscht} other {# doppelte Bücher gelöscht}}"
       },
@@ -6638,11 +5936,9 @@
         "start": "Duplikats-Scan konnte nicht gestartet werden.",
         "status": "Scanfortschritt konnte nicht geladen werden.",
         "scan": "Duplikats-Scan ist fehlgeschlagen. Erneut versuchen.",
-        "results": "Could not load duplicate groups.",
         "delete": "Die ausgewählten doppelten Bücher konnten nicht gelöscht werden."
       },
       "pagination": {
-        "label": "Duplicate groups pages",
         "page": "Seite {page} von {total}"
       }
     },
@@ -6873,11 +6169,6 @@
       "defaultName": "Smart Scope",
       "filter": "Filter",
       "edit": "Smart Scope bearbeiten",
-      "koboSync": {
-        "label": "Sync to my Kobo",
-        "enabledHint": "Books in this shared Smart Scope sync to your Kobo device. Turn off to stop syncing them.",
-        "disabledHint": "Turn on to sync books in this shared Smart Scope to your Kobo device."
-      },
       "showControlsAria": "Smart-Scope-Steuerelemente anzeigen",
       "hideFilter": "Filter ausblenden",
       "showFilter": "Filter anzeigen",
@@ -6885,10 +6176,7 @@
       "loadError": "Dieser SmartScope konnte nicht geladen werden",
       "toast": {
         "deleted": "\"{name}\" gelöscht",
-        "deleteFailed": "Löschen von \"{name}\" fehlgeschlagen",
-        "koboSyncEnabled": "\"{name}\" now syncs to your Kobo",
-        "koboSyncDisabled": "\"{name}\" no longer syncs to your Kobo",
-        "koboSyncFailed": "Failed to update Kobo sync for \"{name}\""
+        "deleteFailed": "Löschen von \"{name}\" fehlgeschlagen"
       },
       "empty": {
         "noRules": "Keine Regeln konfiguriert",
@@ -6997,8 +6285,7 @@
       "users": "Benutzer",
       "account-activity": "Kontoaktivität",
       "magic-links": "Magic Links",
-      "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / SSO"
     },
     "system": {
       "file-naming": "Dateibenennung",
@@ -7011,8 +6298,6 @@
       "privacy": "Datenschutz und Freigabe",
       "notifications": "Benachrichtigungen",
       "restrictions": "Inhaltsbeschränkungen"
-    },
-    "smartScopes": "Smart Scopes",
-    "collections": "Collections"
+    }
   }
 }

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -637,7 +637,7 @@
         "update": "No se pudo actualizar el enlace mágico",
         "revoke": "No se pudo revocar"
       },
-      "usersPage": "pagina de usuarios",
+      "usersPage": "Página de Usuarios",
       "emptyTitle": "Aún no se han creado enlaces mágicos",
       "emptyHint": "Haga clic en \"{action}\" para generar un inicio de sesión compartible URL.",
       "noActiveTitle": "No hay enlaces mágicos activos",
@@ -1134,14 +1134,14 @@
         "account-activity": "Actividad de la cuenta",
         "magic-links": "Enlaces mágicos",
         "oidc": "OIDC/SSO",
-        "server-fonts": "Server Fonts"
+        "server-fonts": "Fuentes del servidor"
       },
       "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "title": "Fuentes del servidor",
+        "subtitle": "Sube fuentes que cada usuario puede elegir en el lector de libros electrónicos, sin subir las suyas.",
+        "listLabel": "Fuentes del servidor",
+        "noFontsYet": "Aún no hay fuentes del servidor",
+        "noFontsHint": "Las fuentes que añadas aquí aparecen en el lector de cada usuario."
       }
     },
     "common": {
@@ -1527,7 +1527,7 @@
         "layout": "Diseño",
         "readingFlow": "Flujo de lectura",
         "readingFlowHint": "Paginado voltea páginas; el desplazamiento fluye continuamente",
-        "paginated": "paginado",
+        "paginated": "Paginado",
         "scrolled": "Desplazado",
         "fixedLayoutSpread": "Pliegos de página con diseño fijo",
         "fixedLayoutSpreadHint": "Predeterminado para manga, cómics y EPUB basados en imágenes",
@@ -1585,13 +1585,13 @@
         "view": "Ver",
         "readingMode": "Modo de lectura",
         "readingModeHint": "Cómo se navega por las páginas: utilice \"Infinito (sin espacios)\" para los webtoons",
-        "paginated": "paginado",
+        "paginated": "Paginado",
         "infiniteSpaced": "Infinito (espaciado)",
         "infiniteNoGaps": "Infinito (sin espacios)",
         "pageView": "Vista de página",
         "pageViewHint": "Mostrar una o dos páginas una al lado de la otra",
         "single": "soltero",
-        "twoPage": "dos páginas",
+        "twoPage": "Dos páginas",
         "fitMode": "Modo de ajuste",
         "fitModeHint": "Cómo se escalan las páginas para que se ajusten a la pantalla",
         "fitPage": "Página",
@@ -1677,11 +1677,11 @@
         "demoCannotManage": "La cuenta restringida de demostración no puede administrar fuentes",
         "fileAdded": "\"{name}\" añadido",
         "uploadFailed": "Error al subir",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "serverFontsTitle": "Fuentes del servidor (compartidas por admin)",
+        "serverFontsHint": "Estas fuentes provienen del administrador de tu servidor. Desactiva una para mantenerla fuera de tu lector.",
+        "serverFontsShown": "{count} de {total} mostrados",
+        "serverFontsAllHidden": "Todas las fuentes del servidor están ocultas. Su lector sólo ofrecerá sus propias fuentes integradas y sus propias fuentes.",
+        "serverFontVisibilityFailed": "Error al actualizar la visibilidad de las fuentes del servidor"
       },
       "bookDock": {
         "title": "Book Dock",
@@ -2612,8 +2612,8 @@
     "pagination": {
       "showing": "Mostrando {start}-{end} de {total}",
       "pageOf": "Página {page} de {totalPages}",
-      "firstPage": "Primera pagina",
-      "previousPage": "Pagina anterior",
+      "firstPage": "Primera página",
+      "previousPage": "Página anterior",
       "nextPage": "Página siguiente",
       "lastPage": "Última página"
     },
@@ -2886,7 +2886,7 @@
       "BookBulkUpdateTags": "Actualizar etiquetas de libros",
       "BookBulkSetMetadataLock": "Establecer bloqueos de metadatos",
       "BookBulkEditMetadata": "Editar metadatos del libro",
-      "BookBulkMoveLibrary": "Move books to another library",
+      "BookBulkMoveLibrary": "Mover libros a otra biblioteca",
       "BookReadingStateReset": "Restablecer el estado de lectura",
       "BookWriteAndRename": "Escribir metadatos y cambiar el nombre del archivo.",
       "CollectionCreate": "Crear colección",
@@ -3346,11 +3346,11 @@
         "isLocked": "está bloqueado",
         "isUnlocked": "está desbloqueado",
         "isUpNext": "está arriba siguiente",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isTrue": "es sí",
+        "isFalse": "es no"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
+      "customFieldsGroup": "Campos personalizados",
+      "customFieldFallback": "Campo personalizado",
       "anyProvider": "Cualquier proveedor",
       "communityRatingProvider": "Proveedor de calificación comunitaria",
       "loadingLibraries": "Cargando bibliotecas...",
@@ -3669,7 +3669,7 @@
         "publisher": "Editor",
         "published": "Publicado",
         "language": "Idioma",
-        "pages": "paginas",
+        "pages": "Páginas",
         "duration": "Duración",
         "edition": "Edición",
         "abridged": "abreviado",
@@ -4096,10 +4096,10 @@
         "moveUp": "Subir",
         "moveDown": "Bajar",
         "removeSeries": "Quitar serie",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "seriesIndexLabel": "Posición en serie",
+        "totalLabel": "Libros en serie",
+        "totalPlaceholder": "de",
+        "totalHint": "Total de libros en esta serie. Compartido con todos los que tienen esta serie."
       }
     },
     "table": {
@@ -4182,66 +4182,66 @@
       }
     },
     "move": {
-      "title": "{count, plural, one {Move # book} many {Move # books} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
-      "folderCount": "{count, plural, one {# folder} many {# folders} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
-      "confirm": "{count, plural, one {Move # book} many {Move # books} other {Move # books}}",
-      "action": "Move to library",
+      "title": "{count, plural, one {Mueve # libro} many {Mueve # libros} other {Mueve # libros}}",
+      "subtitle": "Los archivos se mueven en el disco a la biblioteca de destino. Esto puede cambiar quién puede ver estos libros.",
+      "searchPlaceholder": "Buscar bibliotecas",
+      "currentLibrary": "Actual",
+      "folderCount": "{count, plural, one {# carpeta} many {# carpetas} other {# carpetas}}",
+      "continue": "Continuar",
+      "back": "Volver",
+      "confirm": "{count, plural, one {Mueve # libro} many {Mueve # libros} other {Mueve # libros}}",
+      "action": "Mover a la biblioteca",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} many {# name conflicts} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
+        "ready": "{count} listos",
+        "collisions": "{count, plural, one {# conflicto de nombres} many {# conflictos de nombres} other {# conflictos de nombres}}",
+        "ineligible": "{count} no puede moverse",
+        "alreadyThere": "{count} ya existe",
+        "collisionsHeading": "Conflicto de nombres",
+        "ineligibleHeading": "No se puede mover",
+        "moreCollisions": "y {count} más"
       },
       "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
+        "suggested": "Uso recomendado",
+        "keep_both": "Dejar ambos",
+        "merge": "Fusionar",
+        "skip": "Saltar"
       },
       "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
+        "folder_path": "Un libro ya utiliza este nombre de carpeta",
+        "file_path": "Un archivo ya utiliza esta ruta",
+        "hash_duplicate": "Ya existe una copia idéntica en esta biblioteca"
       },
       "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
+        "book_not_present": "Faltan los archivos de este libro",
+        "no_content_file": "Este libro no tiene un archivo legible",
+        "multi_file_target_per_file": "El destino almacena un archivo por libro, y este libro tiene archivos {detail}",
+        "no_source_access": "No puedes editar la biblioteca en la que está este libro",
+        "pattern_unresolved": "La biblioteca de destino no tiene patrón de nomenclatura utilizable",
+        "path_too_long": "La ruta de destino es demasiado larga",
+        "path_outside_target_root": "La ruta de destino cae fuera de la carpeta de librerías"
       },
       "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
+        "accessLoss": "{user} dejará de ver {count} de estos libros",
+        "koboImpact": "{count} libros dejarán el Kobo de {user} en la próxima sincronización",
         "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
+          "wrap_into_folder": "{count} libros serán colocados en su propia carpeta",
+          "dissolve_folder": "{count} carpetas de libros se disolverán en archivos individuales"
         },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
+        "crossDevice": "Los archivos se mueven a otra unidad, por lo que se copian, se verifican y se eliminan."
       },
       "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
+        "label": "Moviendo libros a {library}",
+        "failed": "{count} fallidos"
       },
       "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
+        "summary": "{count} libros movidos a {library}",
+        "merged": "{count} fusionados con copias ya existentes",
+        "skipped": "{count} omitidos",
+        "failed": "{count} fallidos"
       },
       "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "success": "{count} libros movidos a {library}",
+        "partial": "Movidos {moved} libros, {failed} fallidos"
       }
     }
   },
@@ -4777,12 +4777,12 @@
         "smartScope": "Alcance Inteligente"
       },
       "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
+        "title": "Diseño de estantería",
+        "description": "Elige cómo se organizan los estantes en pantallas más grandes.",
+        "wide": "Filas anchas",
+        "wideDescription": "Mostrar una casilla por fila.",
+        "twoColumns": "Dos columnas",
+        "twoColumnsDescription": "Mostrar dos estantes por fila."
       },
       "reorderHintWidget": "Arrastre para reordenar. Alternar para mostrar u ocultar un widget.",
       "reorderHintShelf": "Arrastre para reordenar. Alternar para mostrar u ocultar un estante.",
@@ -4891,7 +4891,7 @@
         "trendUp": "Tendencia ascendente",
         "trendDown": "Tendencia a la baja",
         "trendSteady": "ritmo constante",
-        "pages": "paginas",
+        "pages": "páginas",
         "hours": "horas",
         "readCount": "{count} leer",
         "daysLeft": "{count}d queda"
@@ -5233,7 +5233,7 @@
       "clearPage": "Borrar página",
       "clearSelection": "Borrar selección",
       "importSelected": "Importar seleccionado",
-      "previousPage": "Pagina anterior",
+      "previousPage": "Página Anterior",
       "nextPage": "Página siguiente",
       "pageRange": "{start}-{end} de {total}",
       "tabs": {
@@ -5956,66 +5956,66 @@
     "settings": {
       "title": "Configuración",
       "ariaLabel": "Configuración del lector",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
+      "reset": "Restablecer valores predeterminados",
+      "modeLabel": "Modo color",
       "mode": {
-        "light": "Luz",
-        "dark": "oscuro"
+        "light": "Claro",
+        "dark": "Oscuro"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
+      "textSize": "Tamaño de texto",
+      "textSizeSmaller": "Texto más pequeño",
+      "textSizeLarger": "Texto más grande",
       "pixels": "{value} px",
       "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
-      "fontBuiltIn": "Incorporado",
-      "fontServer": "Server fonts",
+      "pageColor": "Color de página",
+      "font": "Fuente",
+      "fontBuiltIn": "Predefinido",
+      "fontServer": "Fuentes del servidor",
       "fontYours": "Tus fuentes",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
+      "lineSpacing": "Interlineado",
+      "pageWidth": "Ancho de página",
+      "pageWidthNarrow": "Estrecho",
+      "pageWidthMedium": "Medio",
+      "pageWidthWide": "Ancho",
+      "pageWidthFull": "Lleno",
       "readingFlow": "Flujo de lectura",
       "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
+        "paginated": "Páginas",
+        "scrolled": "Desplazar"
       },
       "pageSpreads": "Extensiones de página",
-      "pageSpreadsHint": "Elija cómo este EPUB basado en imágenes empareja páginas.",
+      "pageSpreadsHint": "Elige cómo se emparejan las páginas de este EPUB basado en imágenes.",
       "spread": {
-        "bookDefault": "Reservar por defecto",
-        "singlePage": "Una sola página"
+        "bookDefault": "Libro por defecto",
+        "singlePage": "Página única"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
+      "advanced": "Diseño avanzado",
+      "columns": "Columnas",
+      "columnsFewer": "Menos columnas",
+      "columnsMore": "Más Columnas",
       "columnGap": "Espacio de columna",
       "justifyText": "Justificar texto",
       "hyphenation": "Separación de sílabas",
       "themes": {
-        "default": "Default",
-        "gray": "Gray",
+        "default": "Por defecto",
+        "gray": "Gris",
         "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
+        "crimson": "Carmesí",
+        "meadow": "Verde prado",
+        "rosewood": "Palo de rosa",
+        "azure": "Azul celeste ",
+        "dawnlight": "Luz del amanecer",
+        "ember": "Ascua",
         "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
+        "ocean": "Océano",
+        "mist": "Niebla",
         "amoled": "AMOLED"
       },
       "fonts": {
-        "bookDefault": "Book default",
+        "bookDefault": "Libro por defecto",
         "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
+        "sansSerif": "Sans Serif",
+        "monospace": "Monoespaciado"
       }
     },
     "search": {
@@ -6111,15 +6111,12 @@
       "scrollModeHint": "Utilice \"Sin espacios\" para webtoons y tiras verticales.",
       "readingDirection": "dirección de lectura",
       "pageView": "Vista de página",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Alineación extendida",
       "spreadGap": "Brecha de propagación",
       "spreadGapValue": "{value}px",
       "forceTwoPage": "Forzar dos páginas",
-      "widePages": "paginas anchas",
-      "firstPage": "Primera pagina",
+      "widePages": "Páginas anchas",
+      "firstPage": "Primera página",
       "lastPage": "Última página",
       "fit": {
         "page": "Ajuste de página",
@@ -6132,7 +6129,7 @@
         "twoPage": "dos páginas"
       },
       "scroll": {
-        "paged": "paginado",
+        "paged": "Paginado",
         "infinite": "infinito",
         "noGaps": "Sin espacios"
       },
@@ -6190,8 +6187,8 @@
       "readOfTotal": "{read} de {total} leído ({percentage}%)"
     },
     "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
+      "label": "En la biblioteca",
+      "ownedOfExpected": "{owned} de {expected} en la biblioteca"
     },
     "gaps": {
       "label": "Posibles lagunas:"
@@ -6998,7 +6995,7 @@
       "account-activity": "Actividad de la cuenta",
       "magic-links": "Enlaces mágicos",
       "oidc": "OIDC/SSO",
-      "server-fonts": "Server Fonts"
+      "server-fonts": "Fuentes del servidor"
     },
     "system": {
       "file-naming": "Nomenclatura de archivos",

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -89,7 +89,6 @@
       },
       "pageTitle": "Näyttö",
       "pageSubtitle": "Hallitse teemoja, kansia, ulkoasua ja miten kirjastosi esitetään.",
-      "mobileSummary": "Theme: {theme} • Accent: {accent} • Background: {background}",
       "themeMode": {
         "light": "Vaalea",
         "dark": "Tumma",
@@ -168,8 +167,7 @@
           "blush": "Punastuminen"
         },
         "accentColor": {
-          "label": "Korostuksen väri",
-          "hint": "Controls highlights and interactive elements"
+          "label": "Korostuksen väri"
         },
         "cornerRadius": {
           "label": "Corner radius",
@@ -432,8 +430,7 @@
           "saved": "Kuvake tallennettu",
           "updated": "Kuvake päivitetty",
           "deleted": "Kuvake poistettu",
-          "bulkDeleted": "{count, plural, =0 {ei poistanut kuvakkeita} one {Poistettu # kuvake} other {Poistettu # kuvakkeita}}",
-          "bulkDeletePartial": "Deleted {deleted}, {failed} failed"
+          "bulkDeleted": "{count, plural, =0 {ei poistanut kuvakkeita} one {Poistettu # kuvake} other {Poistettu # kuvakkeita}}"
         },
         "errors": {
           "load": "Kuvakkeiden lataaminen epäonnistui",
@@ -594,7 +591,6 @@
       "noExpiry": "Ei vanhentunut",
       "expired": "Vanhentunut",
       "expiresOn": "Vanhenee {date}",
-      "revokedOn": "Revoked {date}",
       "expiredOn": "Vanhentunut {date}",
       "usesCount": "{count, plural, =0 {ei käytä} one {yksi käyttää} other {# käyttää}}",
       "copied": "Kopioitu!",
@@ -645,8 +641,7 @@
       "copyLinkAria": "Kopioi linkki kohteelle {label}",
       "pauseAria": "Keskeytä {label}",
       "resumeAria": "Jatka {label}",
-      "revokeAria": "Revoke {label}",
-      "lastUsedLabel": "Last used {date}"
+      "revokeAria": "Revoke {label}"
     },
     "oidc": {
       "title": "OIDC / SSO",
@@ -670,13 +665,11 @@
         "slug": "Slug",
         "slugHint": "Yksilöllinen tunniste (pienet kirjaimet, väliviivat). Myöhemmin ei voi muuttaa.",
         "displayName": "Näytön Nimi",
-        "displayNameHint": "Shown on the login button.",
         "iconUrl": "Kuvakkeen URL",
         "iconUrlHint": "Valinnainen logo näytetään kirjautumispainikkeen vieressä.",
         "iconPreviewAlt": "kuvakkeen esikatselu",
         "connection": "Yhteys",
         "issuerUri": "Myöntäjän URI",
-        "issuerUriHint": "The provider's base URL.",
         "test": "Testi",
         "testing": "Testataan...",
         "clientId": "Asiakkaan Tunnus",
@@ -715,7 +708,6 @@
       },
       "groupMappings": {
         "title": "Ryhmän Kartoitukset",
-        "description": "Map OIDC group claims to BookOrbit permissions. Synced on every login.",
         "noPermission": "Ei oikeuksia",
         "empty": "Ryhmämäärityksiä ei ole määritetty.",
         "addMapping": "Lisää kartoitus",
@@ -757,15 +749,12 @@
         "recommendationsGroup": "Suositukset",
         "achievementsGroup": "Saavutukset",
         "updatesGroup": "Päivitykset",
-        "importFromBooklore": "Import from Booklore",
         "bookloreImportConfigured": "Bookloren tuonti määritetty",
         "migrationRunning": "Siirtolaisuus käynnissä",
         "migrationCompleted": "Muuttoliike valmis",
         "migrationFailed": "Siirto epäonnistui",
         "importDescription": "Kertaluonteinen tuonti kirjoja, metadataa ja lukeminen edistymistä edellisen Booklore asennus.",
         "configuredDescription": "Lähde: {name}. Ei siirtolaisuutta vielä - jatka tuonnin käynnistämistä.",
-        "runningDescription": "Stage: {stage} - started {started}",
-        "completedDescription": "From {name} - completed {date}",
         "migrationErrorGeneric": "Siirron aikana tapahtui virhe.",
         "stageInitializing": "alustetaan",
         "recently": "äskettäin",
@@ -779,7 +768,6 @@
         "running": "Käynnissä...",
         "backfillAchievements": "Backfill saavutukset",
         "backfillAchievementsHint": "Arvioi saavutukset uudelleen kaikkien käyttäjien kesken.",
-        "backfillResult": "Processed {users} users; granted {awards} awards.",
         "runBackfill": "Suorita Backfill",
         "checkForUpdates": "Tarkista päivitykset",
         "checkForUpdatesHint": "Tarkista GitHub automaattisesti uuden version käynnistyksen yhteydessä ja näytä ilmaisin sivupalkissa, kun sellainen on saatavilla.",
@@ -829,7 +817,6 @@
         "badgeFailed": "Epäonnistui",
         "mediaPathRequired": "Vaaditaan kirjasivujen siirtämiseen.",
         "mediaPathAbsolute": "Käytä absoluuttista polkua (esimerkiksi /books). Suhteellisia polkuja ei tueta.",
-        "mediaPathConfigured": "Cover import path configured. Use Test Connection to verify access and Booklore images folder structure.",
         "issueSaveSource": "Tallenna lähdeyhteysasetukset",
         "issueValidateSource": "Vahvista lähdeyhteys",
         "issueSaveMappings": "Tallenna käyttäjän ja polun sidokset",
@@ -838,7 +825,6 @@
         "issueResolveDuplicates": "Ratkaise kaksoiskappaleet kohdekirjasta löydettävissä kuivan ajon aikana",
         "issueWaitActiveRun": "Odota aktiivista suoritusta lopettaaksesi",
         "sourceRecordId": "Lähdetietueen ID #{id}",
-        "byAuthorWithId": "by {author} (ID: {id})",
         "filePathWithId": "{path} (ID: {id})",
         "bookloreSourceId": "Booklore source ID: {id}",
         "libraryBookNum": "Kirjaston kirja #{id}",
@@ -851,9 +837,7 @@
         "errorLoadSuggestions": "Käyttäjän kartoitusehdotuksia ei voitu ladata",
         "requiredFields": "Isäntän, käyttäjän, tietokannan ja lähdekoodin nimi vaaditaan",
         "connectionTestPassedWithWarnings": "Yhteyden testi läpäisi varoitukset",
-        "connectionTestPassedWithCount": "Connection test passed with {count} warning(s). First: {first}",
         "connectionTestPassed": "Yhteyden testi ohitettu",
-        "connectionOkMissingTables": "Connection ok, but {count} required table(s) are missing",
         "cannotTestMediaPathActiveRun": "Mediareittiä ei voi testata, kun suoritus on aktiivinen",
         "mediaRootPathRequiredCover": "Media Root polkua tarvitaan kansi tuontiin.",
         "useAbsolutePath": "Käytä absoluuttista polkua (esimerkiksi /books).",
@@ -862,7 +846,6 @@
         "mediaPathValidationFailed": "Mediapolun vahvistus epäonnistui.",
         "connectionFailedBeforeMediaPath": "Yhteystesti epäonnistui ennen kuin mediapolun vahvistus voidaan suorittaa.",
         "cannotModifySourceActiveRun": "Lähdekoodia ei voi muokata, kun suoritus on aktiivinen",
-        "sourceSavedValidatedWarnings": "Source saved and validated with {count} warning(s)",
         "sourceSavedValidated": "Lähde tallennettu ja vahvistettu",
         "errorSaveValidateSource": "Lähdekoodin tallennus tai validointi epäonnistui",
         "cannotSaveMappingsActiveRun": "Yhdistämisiä ei voi tallentaa kun suoritus on aktiivinen",
@@ -874,7 +857,6 @@
         "errorSaveMappings": "Yhdistämisten tallennus epäonnistui",
         "cannotRunDryRunActiveRun": "Ei voida suorittaa kuivaajaa kun suoritus on aktiivinen",
         "saveMappingsFirst": "Tallenna kartoitukset ensin",
-        "dryRunCompleted": "Dry-run completed: {matched} matched, {unresolved} unresolved",
         "dryRunFailed": "Dry-run epäonnistui",
         "selectSourceForAllGroups": "Valitse lähdekirja kaikille {count} kaksoisryhmälle",
         "duplicatesResolved": "Kaksoiskappaleet ratkaistut",
@@ -908,7 +890,6 @@
         "strategyPathMapping": "Yhdistetty yhdistettyyn tiedostopolkuun",
         "strategyTitleAuthor": "Täsmätty otsikon ja tekijän mukaan",
         "strategyUnavailable": "Match strategia ei käytettävissä",
-        "userPreviewCounts": "{statuses} statuses, {progress} progress entries, {bookmarks} bookmarks, {annotations} annotations, {collections} collection entries",
         "connErrorUnreachable": "Ei saatu yhteyttä tietokantapalvelimeen. Tarkista isäntä ja portti.",
         "connErrorAuth": "Todennus epäonnistui. Tarkista käyttäjätunnus ja salasana.",
         "connErrorUnknownDatabase": "Tietokantaa ei löytynyt. Tarkista tietokannan nimi.",
@@ -951,9 +932,7 @@
         "selectTargetFolder": "Select target folder...",
         "remove": "Poista",
         "pathValidation": "Reitin vahvistus",
-        "pathValidationMapped": "{mapped} of {total} source books have a mapped path",
         "pathValidationUnmatched": "{count} yhdistettyä polkua ei löydy levyltä - nuo kirjat palaavat ISBN / otsikon täsmäytykseen",
-        "pathValidationAllMatched": "All {count} mapped paths found on disk",
         "saveMappings": "Tallenna Kartoitukset",
         "runDryRun": "Suorita Dry-Run",
         "matched": "Osumat:",
@@ -1024,11 +1003,9 @@
         "matchedBooksHint": "Näitä kuivausjuoksupisteitä käytettiin päättämään mitkä kirjaston kirjat vastaanottivat tuotuja tietoja.",
         "sourceBookFallback": "Lähdekirja {id}",
         "libraryBookFallback": "Kirjaston kirja {id}",
-        "unresolvedBooksHeading": "Unresolved books ({count})",
         "unresolvedBooksHint": "Nämä kirjat ovat olemassa lähteessä, mutta niitä ei voitu sovittaa mihinkään kirjaan kirjastostasi.",
         "mappedUsersHeading": "Kartoitetut käyttäjät ({count})",
         "mappedUsersHint": "Käyttäjän yhteenlasketut määrät tulevat kuivakäyttöisestä esikatselusta, joka välimuistissa siirtymissuunnitelmassa.",
-        "coverImportsFailed": "{count} cover import(s) failed. Detailed failure rows are not stored.",
         "backToSetup": "Takaisin asetuksiin"
       },
       "libraries": {
@@ -1075,11 +1052,8 @@
         "libraryUpdated": "Kirjasto \"{name}\" päivitetty",
         "libraryDeleted": "\"{name}\" poistettu",
         "deleteFailed": "Kirjaston poisto epäonnistui",
-        "scanningProgress": "Scanning {pct}% ({processed}/{total})",
-        "scanDone": "Done - {added} added, {updated} updated",
         "scanFailedWithError": "Epäonnistui: {error}",
         "scanFailed": "Skannaus epäonnistui",
-        "refreshingCovers": "Refreshing covers {pct}% ({processed}/{total})",
         "coversRefreshed": "Kattaa päivitetyt ({count} käsitelty)"
       },
       "authorEnrichment": {
@@ -1133,15 +1107,7 @@
         "users": "Käyttäjät",
         "account-activity": "Tilin Toiminta",
         "magic-links": "Magic Linkit",
-        "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC / SSO"
       }
     },
     "common": {
@@ -1226,7 +1192,6 @@
           "yesterday": "eilen",
           "daysAgo": "{count, plural, one {# päivä sitten} other {# päivää sitten}}",
           "label": "Viimeksi suoritettu: {when}",
-          "labelQueued": "Last run: {when} - queued {count} books",
           "labelNoneEligible": "Viimeksi käytetty: {when} - ei hyväksyttäviä kirjoja"
         },
         "conditions": {
@@ -1295,8 +1260,7 @@
           "audnexus": "Yhteisön ohjaamat äänikirjan metatiedot. Asennusta ei tarvita.",
           "comicvine": "Comic book metadata ComicVinesta. Ilmainen API-avain vaaditaan Comicvine.gamespot.com:lta.",
           "ranobedb": "Japanin kevyt uusi metatiedot RanobeDB. Ei asetuksia tarvita.",
-          "lubimyczytac": "Puolan kirjaluettelo (lubimyczytac.pl). Scrapes julkinen kirja-sivut. Ei asennus tarvita.",
-          "aladin": "Korean book metadata from Aladin (알라딘). A TTB Key from aladin.co.kr is required."
+          "lubimyczytac": "Puolan kirjaluettelo (lubimyczytac.pl). Scrapes julkinen kirja-sivut. Ei asennus tarvita."
         },
         "blocked": {
           "google": "Google Books vaatii API-avaimen ennen kuin se voidaan ottaa käyttöön",
@@ -1370,10 +1334,6 @@
           "classification": "Luokitus",
           "audiobook": "Äänikirja"
         },
-        "groupSummary": {
-          "base": "{fields} fields · {enabled} enabled",
-          "withOverrides": "{base} · {overrides} overrides"
-        },
         "table": {
           "field": "Kenttä",
           "activeProviders": "Aktiiviset Palveluntarjoajat (tilattu prioriteetin mukaan)",
@@ -1412,11 +1372,9 @@
         "add": "Lisää",
         "filterPlaceholder": "Suodata lohkolista",
         "entryCount": "{count, plural, one {# merkintä} other {# merkintää}}",
-        "filteredCount": "{shown} of {total}",
         "noFilterMatch": "Mikään estetty tyylilaji ei vastaa nykyistä suodatinta.",
         "emptyTitle": "Ei estettyjä tyylilajeja",
-        "emptyHint": "Lisää tarkat arvot, kuten Audiobook tai Adult pitämään ne poissa haetuista metatiedoista.",
-        "removeLabel": "Remove {genre}"
+        "emptyHint": "Lisää tarkat arvot, kuten Audiobook tai Adult pitämään ne poissa haetuista metatiedoista."
       },
       "customFields": {
         "label": "Tunniste",
@@ -1462,7 +1420,6 @@
         "preview": "Esikatselu",
         "sampleValue": "Näytteen arvo",
         "enabledLibraries": "Käytössä Olevat Kirjastot",
-        "countOf": "{selected} of {total}",
         "selectAll": "Valitse kaikki",
         "clear": "Tyhjennä",
         "noLibraries": "Kirjastoja ei ole vielä saatavilla.",
@@ -1530,7 +1487,6 @@
         "paginated": "Sivutettu",
         "scrolled": "Vieritetty",
         "fixedLayoutSpread": "Kiinteät asettelun sivut",
-        "fixedLayoutSpreadHint": "Default for manga, comics, and image-based EPUBs",
         "bookDefault": "Varaa oletus",
         "singlePage": "Yksi sivu",
         "columns": "Sarakkeet",
@@ -1649,7 +1605,6 @@
         "browse": "selaa",
         "fileTypesHint": "TTF, OTF, WOFF, WOFF2 - max 10 MB kukin",
         "yourFonts": "Sinun Fontit",
-        "fontsUsed": "{count} / {max} used",
         "noFontsYet": "Kirjasimia ei ole vielä ladattu",
         "noFontsHint": "Vedä kirjasintiedosto yläpuolelle päästäksesi alkuun.",
         "fileCount": "{count, plural, =0 {ei tiedostoja} one {# tiedosto} other {# tiedostoa}}",
@@ -1676,12 +1631,7 @@
         "deleteFamilyFailed": "Kirjasinperheen poistaminen epäonnistui",
         "demoCannotManage": "Demo-rajoitettu tili ei voi hallita kirjasimia",
         "fileAdded": "\"{name}\" lisätty",
-        "uploadFailed": "Lähetys epäonnistui",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Lähetys epäonnistui"
       },
       "bookDock": {
         "title": "Kirja Telakka",
@@ -1812,7 +1762,6 @@
         "tokenLanguage": "Kieli",
         "tokenOriginalFilename": "Alkuperäinen tiedostonimi (ilman laajennusta)",
         "tokenExtension": "Tiedostopääte (ilman pistettä)",
-        "patternHelpIntro": "Patterns use tokens like {titleToken} and {authorsToken}, plus modifiers and optional segments.",
         "browseTokensAndExamples": "Selaa kuponkeja ja esimerkkejä"
       },
       "kobo": {
@@ -1854,10 +1803,7 @@
         "twoWaySyncHint": "Synkronoi lukusijainti BookOrbitin ja Kobon välillä. Vaatii KEPUB-toimituksen tarkkojen sijaintien varalta ja luotettavan sivun palautuksen.",
         "syncHighlights": "Synkronoi BookOrbit kohokohdat Koboon",
         "syncHighlightsHint": "Lähetä BookOrbitissa tai KOReaderissa tehdyt kohokohdat Koboon. Kobo kohokohdat tuodaan BookOrbitiin, vaikka se olisi pois päältä. Yhdistetyt kommentit synkronoivat muokkauksia ja poistavat molemmat. Vaatii KEPUB-toimitusta; Kobon kirjan tulee olla KEPUB ladattu BookOrbitista.",
-        "convertKepub": "Convert to KEPUB",
-        "convertKepubHint": "Send eligible EPUBs as KEPUB. This stays on when progress sync or BookOrbit-to-Kobo highlights are enabled. On the next Kobo sync, affected books are offered again as KEPUB downloads; remove any old EPUB copy if Kobo keeps opening it.",
         "forceHyphenation": "Pakota välkkyminen",
-        "forceHyphenationHint": "Ensures consistent text justification. This will regenerate cached KEPUBs.",
         "progressThresholds": "Edistymisen Kynnysarvot",
         "progressThresholdsHint": "Määrittele kun Kobon lukeminen päivittää kirjaston tilaa.",
         "markAsReading": "Merkitse luetuksi",
@@ -1925,7 +1871,6 @@
           },
           "readingPositionSyncedTitle": "Lukeminen synkronoitu: {title}",
           "readingPositionSynced": "Lukeminen synkronoitu",
-          "labelWithTitle": "{label}: {title}",
           "updateCount": "{count, plural, one {# päivitys} other {# päivitystä}}",
           "directionToKobo": "Kirjankierto -> Kobo",
           "directionToBookOrbit": "Kobo - > Kirjankierto",
@@ -1934,7 +1879,6 @@
           "summary": {
             "noLibraryUpdatesPending": "Tälle laitteelle ei odoteta yhtään kirjastopäivitystä",
             "libraryUpdatesPrepared": "{count, plural, one {# kirjaston päivitys valmiina laitteelle} other {# kirjaston päivitystä valmiina laitteelle}}",
-            "bookDownloadedBy": "{title} was downloaded by {device}",
             "booksDownloaded": "{count, plural, one {# kirja ladattu} other {# kirjaa ladattu}}",
             "progressUpdatesSyncedFor": "{count, plural, one {# edistymispäivitystä synkronoitu {title}} other {# edistymispäivitystä synkronoitu {title}}}",
             "progressUpdatesSynced": "{count, plural, one {# edistymispäivitystä synkronoitu} other {# edistymispäivitystä synkronoitu}}",
@@ -1949,7 +1893,6 @@
             "highlightsImportedFromKoboFor": "{count, plural, one {# korostus tuotu Kobosta {title}} other {# kohokohtaa tuotu Kobosta {title}}}",
             "highlightsImportedFromKobo": "{count, plural, one {# korostus tuotu Kobosta} other {# kohokohtia tuotu Kobosta}}"
           },
-          "timeRange": "{from} to {to}",
           "eventsGrouped": "{count, plural, one {# tapahtuma ryhmitelty} other {# tapahtumaa ryhmitelty}}",
           "removedDevice": "Poistettu laite",
           "loadMoreFailed": "Ei voitu ladata lisää historiaa",
@@ -1966,8 +1909,7 @@
           "loadMore": "Lataa lisää toimintaa"
         },
         "howBooksSynced": {
-          "title": "Kuinka kirjat synkronoidaan",
-          "body": "To send books to your Kobo device, you must enable {syncToKobo} on the collections containing those books. Open any collection from the sidebar, click the Edit icon, and toggle {syncToKobo}. Books that are not part of an enabled collection will not sync."
+          "title": "Kuinka kirjat synkronoidaan"
         },
         "nextSteps": {
           "title": "Seuraavat Vaiheet",
@@ -2131,9 +2073,6 @@
           "loadingManual": "Ladataan manuaalisia tiivistelinkkejä...",
           "noUnmatched": "KOReader-kirjoja ei löytynyt.",
           "noManual": "Ei manuaalista KOReader-linkkiä.",
-          "pageOf": "Page {page} of {total}",
-          "showingRange": "Showing {start}-{end} of {total}",
-          "unknownFile": "Unknown KOReader file {hash}",
           "unknownAuthor": "Tuntematon tekijä",
           "noTitleOrAuthor": "Ei julkaistua otsikkoa tai kirjoittajaa",
           "bookNumber": "Kirjanorbit- kirja #{id}",
@@ -2210,7 +2149,6 @@
         "unmatchedBooks": "Vastaamattomat kirjat",
         "deviceRemoved": "Laite poistettu",
         "removeDeviceFailed": "Laitteen poistaminen epäonnistui",
-        "removeDeviceConfirmTitle": "Remove {device}?",
         "removeDeviceConfirmBody": "Tämä poistaa pysyvästi tämän laitteen synkronoidun etenemisen, lukemisen toiminnan, ja kaikki vastaamattomat kirjamerkinnät eivät enää ole toisen laitteen ilmoittamia. Jos laite synkronoi uudelleen myöhemmin, se ilmaantuu uudelleen uutena kohteena."
       },
       "opds": {
@@ -2283,15 +2221,11 @@
   },
   "achievements": {
     "title": "Saavutukset",
-    "tiersCount": "{earned} / {total} tiers",
     "loadFailed": "Saavutusten lataaminen epäonnistui",
     "tryAgain": "Yritä uudelleen",
     "noMatchFilter": "Suodatinta ei vastaa saavutuksia",
     "secretAchievement": "Salainen Saavutus",
-    "earnedOn": "Earned {date}",
     "whileReading": "Lukeessa “{title}”",
-    "tierProgress": "Tier {earned} of {total}",
-    "progressToNext": "{current} / {threshold} to {name}",
     "rarity": {
       "common": "Yleinen",
       "rare": "Harvinainen",
@@ -2361,8 +2295,7 @@
         "description": "Yritä muuttaa tai tyhjentää nykyiset suodattimet."
       },
       "pagination": {
-        "label": "Tilin toimintasivut",
-        "page": "Page {page} of {totalPages}"
+        "label": "Tilin toimintasivut"
       },
       "errors": {
         "load": "Tilin aktiviteetin lataaminen epäonnistui."
@@ -2373,7 +2306,6 @@
       "subtitle": "Lukeminen tätä käyttäjää vapaaehtoisesti päätti jakaa.",
       "auditNotice": "Pääsy tähän profiiliin on tallennettu ja näkyvä käyttäjälle.",
       "period": "Raportointijakso",
-      "periodDays": "Last {count} days",
       "durationMinutes": "{count, plural, one {# minuutti} other {# minuuttia}}",
       "durationHours": "{count, plural, one {# tunti} other {# tuntia}}",
       "metrics": {
@@ -2562,8 +2494,7 @@
         "filtered": "Yksikään käyttäjä ei vastaa nykyistä hakua ja suodattimia."
       },
       "pagination": {
-        "label": "Käyttäjien sivutus",
-        "page": "Page {page} of {totalPages}"
+        "label": "Käyttäjien sivutus"
       },
       "editUserAria": "Muokkaa {name}",
       "resetPasswordAria": "Nollaa salasana: {name}",
@@ -2592,8 +2523,7 @@
       "pageSelected": "Sivu valittu",
       "selectPage": "Valitse sivu",
       "clear": "Tyhjennä",
-      "recolorTo": "Suorita & {color}",
-      "restyleTo": "Restyle to {style}"
+      "recolorTo": "Suorita & {color}"
     },
     "chips": {
       "active": "Aktiivinen:",
@@ -2610,8 +2540,6 @@
       "clearAll": "Tyhjennä kaikki"
     },
     "pagination": {
-      "showing": "Showing {start}-{end} of {total}",
-      "pageOf": "Page {page} of {totalPages}",
       "firstPage": "Ensimmäinen sivu",
       "previousPage": "Edellinen sivu",
       "nextPage": "Seuraava sivu",
@@ -2675,7 +2603,6 @@
       "title": "Huomautukset",
       "totalCount": "{count} yhteensä",
       "bookCount": "{count, plural, =0 {ei kirjoja} one {# kirja} other {# kirjoja}}",
-      "noteCount": "{count, plural, =0 {no notes} one {# note} other {# notes}}",
       "export": "Vie",
       "exportMarkdown": "Markdown",
       "exportCsv": "CSV",
@@ -2756,10 +2683,8 @@
     "detailResource": "Resurssi: {value}",
     "detailResourceId": "Resurssitunnus: {value}",
     "deletedBooks": "Poistetut kirjat",
-    "deletedBookDetail": "{title} (book #{id})",
     "untitledBook": "Nimetön",
     "deletedBooksOmitted": "{count, plural, one {# ylimääräistä kirjaa jätettiin pois} other {# ylimääräistä kirjaa jätettiin pois}}",
-    "showing": "Showing {from}-{to} of {total}",
     "prev": "Edellinen",
     "chips": {
       "search": "Haku: {value}",
@@ -2849,7 +2774,6 @@
       "MagicLinkRevoke": "Peruuta maaginen linkki",
       "MagicLinkActivate": "Aktivoi magic linkki",
       "MagicLinkDeactivate": "Poista magic linkki käytöstä",
-      "OidcLogin": "Sign in with OIDC",
       "OidcUserProvisioned": "Provision OIDC käyttäjä",
       "OidcIdentityLinked": "Linkin OIDC henkilöllisyys",
       "OidcIdentityUnlinked": "Poista yhteys OIDC identiteettiin",
@@ -2886,7 +2810,6 @@
       "BookBulkUpdateTags": "Päivitä kirjan tunnisteet",
       "BookBulkSetMetadataLock": "Aseta metadatan lukitukset",
       "BookBulkEditMetadata": "Muokkaa kirjan metatietoja",
-      "BookBulkMoveLibrary": "Move books to another library",
       "BookReadingStateReset": "Palauta lukemisen tila",
       "BookWriteAndRename": "Kirjoita metatiedot ja uudelleennimeä tiedosto",
       "CollectionCreate": "Luo kokoelma",
@@ -3087,7 +3010,6 @@
       "desc": "Desc",
       "filters": "Suodattimet",
       "clear": "Tyhjennä",
-      "allLoaded": "All {total} authors loaded",
       "sort": {
         "name": "Nimi",
         "sortName": "Lajittele Nimi",
@@ -3118,8 +3040,6 @@
         "refreshed": "Tekijän metatiedot päivitetty",
         "refreshedNoImage": "Metatiedot päivitetty, mutta kirjoittajan kuvaa ei löytynyt.",
         "refreshFailed": "Kirjoittajan metatietojen päivitys epäonnistui",
-        "bulkRefreshPartial": "Refreshed {updated} author(s), {failed} failed",
-        "bulkRefreshSuccess": "Refreshed metadata for {updated} author(s)",
         "bulkRefreshFailed": "Valittujen kirjoittajien päivittäminen epäonnistui",
         "deleteSuccess": "{count, plural, =0 {Poistettu # tekijä, vaikutti {books} kirjat} one {Poistettu # tekijä, vaikutti {books} kirjat} other {Poistettu # tekijää; vaikutti {books} kirjoja}}",
         "deleteFailed": "Tekijän (kirjoittajien) poistaminen epäonnistui"
@@ -3149,13 +3069,11 @@
         "searchPlaceholder": "Etsi kirjoittajia yhdistääksesi tämän kirjoittajan",
         "searching": "Haetaan...",
         "bookCount": "{count, plural, =0 {ei kirjoja} one {# kirja} other {# kirjoja}}",
-        "selectedSummary": "Selected {count} author(s), approx. {books} books affected.",
         "merging": "Yhdistetään...",
         "mergeSelected": "Yhdistä Valitut",
         "confirmLabel": "Yhdistä"
       },
       "mergeDialog": {
-        "title": "Merge {count} author(s) into \"{name}\"?",
         "titleFallback": "Yhdistä valitut kirjoittajat?",
         "description": "Tämä yhdistää valitut kirjoittajat nykyiseen kirjoittajaan ja linkittää liittyvät kirjat. Tätä toimintoa ei voi perua.",
         "descriptionEmpty": "Tätä toimintoa ei voi peruuttaa."
@@ -3193,7 +3111,6 @@
         "imageUploadFailed": "Kuvan lataaminen ei onnistunut",
         "imageRemoved": "Kirjoittajan kuva poistettu",
         "imageRemoveFailed": "Kuvan poisto epäonnistui",
-        "mergeSuccess": "Merged {count} author(s); affected {books} books",
         "mergeFailed": "Tekijöiden yhdistäminen epäonnistui",
         "deleteSuccess": "Poistettu kirjailija; vaikuttaa {books} kirjoihin",
         "deleteFailed": "Käyttäjän poisto epäonnistui"
@@ -3345,12 +3262,8 @@
         "isFinished": "on valmis",
         "isLocked": "on lukittu",
         "isUnlocked": "on avattu",
-        "isUpNext": "on ylös seuraava",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isUpNext": "on ylös seuraava"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Mikä tahansa tarjoaja",
       "communityRatingProvider": "Yhteisön luokituspalvelujen tarjoaja",
       "loadingLibraries": "Ladataan kirjastoja...",
@@ -3371,7 +3284,6 @@
       },
       "scoreRangePlaceholder": "0-100",
       "valuePlaceholder": "arvo",
-      "maxPlaceholder": "max",
       "to": "päättyen",
       "group": "Ryhmä",
       "addRule": "Lisää sääntö",
@@ -3493,7 +3405,6 @@
       "openIn": "Avaa nimellä {provider}",
       "pages": "{count, plural, =0 {# sivu} one {# sivu} other {# sivua}}",
       "primaryFile": "Ensisijainen Tiedosto",
-      "fileNumber": "File #{id}",
       "showLess": "Näytä vähemmän",
       "showMore": "Näytä lisää",
       "collections": "Kokoelmat",
@@ -3510,7 +3421,6 @@
       "booksSelected": "{count, plural, =0 {# kirja valittu} one {# kirja valittu} other {# kirjaa valittu}}",
       "loadingMoreBooks": "Ladataan lisää kirjoja",
       "sort": "Järjestä",
-      "refreshingMetadata": "Refreshing metadata {processed} / {total}",
       "failedCount": "{count} epäonnistui",
       "remainingCount": "{count} jäljellä",
       "readOnlyNotice": "Taulujen muokkaus on poistettu käytöstä pienemmillä ruudukoilla. Siirry listaan tai ruudukkoon nopeampia toimintoja varten.",
@@ -3521,7 +3431,6 @@
       "scrollToTop": "Vieritä ylös",
       "selectedStatus": "{count} valittu",
       "filtered": "Suodatettu",
-      "loadedStatus": "{loaded} of {total} loaded",
       "bookCount": "{count, plural, =0 {# kirja} one {# kirja} other {# kirjaa}}",
       "keyboardShortcutsTitle": "Näppäimistön pikakuvakkeet (?)",
       "showKeyboardShortcuts": "Näytä pöytänäppäimistön pikakuvakkeet",
@@ -3581,8 +3490,6 @@
         "done": "Valmis",
         "retry": "Yritä Uudelleen",
         "filesAdded": "{count, plural, =0 {mitään tiedostoja ei lisätty} one {yksi tiedosto lisättiin} other {# tiedostoa lisätty}}",
-        "uploadedFailed": "{done} uploaded, {failed} failed",
-        "uploadingProgress": "{done} of {total} uploading...",
         "renameAfter": "Nimeä kaikki kirjatiedostot uudelleen lähetyksen jälkeen",
         "uploadCount": "Lataa ({count})",
         "upload": "Lähetä"
@@ -3698,8 +3605,7 @@
         "koboRemovedByDeviceTooltip": "Kobo raportoi tästä kirjasta poistettu.",
         "koboNotSynced": "Ei synkronoitu",
         "koboNotSyncedTooltip": "Jonossa seuraavaa Kobon synkronointia varten.",
-        "filesNotFound": "Tiedostoja ei löytynyt",
-        "filesNotFoundDescription": "The file(s) for this book can no longer be found on disk. Metadata is still available. Run a library scan to confirm, or remove the record."
+        "filesNotFound": "Tiedostoja ei löytynyt"
       },
       "editMetadata": {
         "fieldCount": "{count, plural, =0 {ei kenttiä} one {yksi kenttä} other {# kenttää}}",
@@ -3712,11 +3618,8 @@
         "writing": "Kirjoitetaan...",
         "saveInProgress": "Tallenna käynnissä",
         "writeManualLibraryDisabled": "Kirjoita metatiedot tiedostoon ja uudelleennimeä levylle; automaattinen kirjoitus-takaisinkirjaus on poistettu käytöstä tässä kirjastossa",
-        "writeManualTooltip": "Write {fields} to {target} and rename on disk",
-        "applyResult": "{skipped}, {updated}",
         "skippedLockedFields": "{count, plural, =0 {Ei lukittuja kenttiä} one {Ohitettu yksi lukittu kenttä} other {Ohitettu # lukittua kenttää}}",
         "updatedFields": "{count, plural, =0 {ei päivitetty kenttiä} one {päivitti yhtä kenttää} other {päivitti # kenttiä}}",
-        "wroteFieldsToFile": "Wrote {fields} to file",
         "fileWriteFailedReason": "Tiedoston kirjoittaminen epäonnistui: {reason}",
         "fileWriteFailed": "Tiedoston kirjoittaminen epäonnistui",
         "fileWriteSkippedReason": "Tiedostotyyppi ohitettu: {reason}",
@@ -3792,9 +3695,7 @@
           "fieldsSelected": "{count, plural, =0 {kenttiä ei ole valittu} one {yksi kenttä valittu} other {# kenttää valittu}}",
           "results": "Tulokset",
           "providerMatches": "{provider} osumaa",
-          "selectedOf": "Selected {selected} of {total}",
           "yearUnknown": "Tuntematon vuosi",
-          "indexOf": "{index} of {total}",
           "switchedResult": "Vaihdettu tulos. Tämän palveluntarjoajan aiemmat valinnat tyhjennettiin.",
           "selectFieldsToApply": "Valitse sovellettavat kentät",
           "copyMissing": "Kopioi Puuttuu",
@@ -3864,7 +3765,6 @@
         "renameFailed": "Tiedoston uudelleennimeäminen epäonnistui",
         "deleteFailed": "Tiedoston poistaminen epäonnistui",
         "addFile": "Lisää Tiedosto",
-        "lastSynced": "Last synced: {time}",
         "sort": {
           "label": "Järjestä:",
           "name": "Nimi",
@@ -3991,8 +3891,7 @@
           "eta": {
             "max": "99h+ loppuun",
             "minutes": "~{m}m loppuun",
-            "hours": "~{h}h loppuun",
-            "hoursMinutes": "~{h}h {m}m to finish"
+            "hours": "~{h}h loppuun"
           },
           "momentum": {
             "none": "Ei toimintaa kahden viimeksi kuluneen viikon aikana",
@@ -4059,8 +3958,7 @@
           "confirmDeleteTitle": "Klikkaa uudelleen vahvistaaksesi poisto",
           "confirmDeleteAria": "Vahvista istunnon poistaminen",
           "deleteAria": "Poista istunto",
-          "loadMore": "Lataa lisää",
-          "showing": "Showing {shown} of {total} sessions"
+          "loadMore": "Lataa lisää"
         }
       },
       "richDescription": {
@@ -4095,11 +3993,7 @@
         "seriesPlaceholder": "Sarja",
         "moveUp": "Siirrä ylös",
         "moveDown": "Siirrä alas",
-        "removeSeries": "Poista sarja",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Poista sarja"
       }
     },
     "table": {
@@ -4174,74 +4068,10 @@
         "unread": "Lukemattomat"
       },
       "series": {
-        "bookCount": "{count, plural, =0 {(ei kirjoja)} one {(# kirja)} other {(# kirjaa)}}",
-        "readOfCount": "{read} of {total} read"
+        "bookCount": "{count, plural, =0 {(ei kirjoja)} one {(# kirja)} other {(# kirjaa)}}"
       },
       "text": {
         "openDetails": "Avaa tiedot"
-      }
-    },
-    "move": {
-      "title": "{count, plural, one {Move # book} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
-      "folderCount": "{count, plural, one {# folder} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
-      "confirm": "{count, plural, one {Move # book} other {Move # books}}",
-      "action": "Move to library",
-      "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
       }
     }
   },
@@ -4306,9 +4136,7 @@
       "failedToRetry": "Ei voitu yrittää uudelleen",
       "failedItemsRequeued": "Vaaditut kohteet",
       "bookComplete": "Metatietojen haku valmis - {done} kirjaa päivitetty",
-      "bookDoneWithFailures": "Metadata fetch done - {done} processed, {failed} failed",
-      "authorComplete": "Tekijän rikastus valmis - {done} kirjoittajaa päivitetty",
-      "authorDoneWithFailures": "Author enrichment done - {done} processed, {failed} failed"
+      "authorComplete": "Tekijän rikastus valmis - {done} kirjoittajaa päivitetty"
     }
   },
   "bookDock": {
@@ -4328,7 +4156,6 @@
     "destinationLibrary": "Kohteen Kirjasto",
     "destinationFolder": "Kohdekansio",
     "nFailed": "{count} epäonnistui",
-    "updatedOfFiles": "Updated {updated} of {total} files",
     "errorStatus": "Virhe {status}",
     "tab": {
       "all": "Kaikki",
@@ -4418,7 +4245,6 @@
       "renamePreview": "Nimeä esikatselu uudelleen",
       "moreFiles": "+{count} tiedostoa lisää",
       "start": "Aloita",
-      "filesFinalized": "{succeeded} of {total} files finalized",
       "checking": "Tarkistetaan valittuja tiedostoja...",
       "readyCount": "{count, plural, =0 {ei ole valmiita tiedostoja} one {# tiedosto valmis} other {# tiedostoa valmis}}",
       "duplicateCount": "{count, plural, =0 {ei ole jo kirjastossa} one {# jo kirjastossa} other {# jo kirjastossa}}",
@@ -4457,7 +4283,6 @@
       "syncToKobo": "Synkronoi Koboon",
       "syncToKoboHint": "Tämän kokoelman kirjat tulevat näkyviin Kobo-laitteellasi",
       "deleteCollection": "Poista kokoelma",
-      "confirmDelete": "Confirm?",
       "deleting": "Poistetaan...",
       "saving": "Tallennetaan...",
       "deleted": "\"{name}\" poistettu",
@@ -4474,10 +4299,8 @@
       "empty": "Ei vielä kokoelmia. Luo yksi yllä.",
       "done": "Valmis",
       "added": "Lisätty",
-      "allAdded": "All {total} added",
       "inCollection": "Tässä kokoelmassa",
       "allInCollection": "Kaikki {total} tässä kokoelmassa",
-      "partialInCollection": "{partial} of {total} in this collection",
       "bookCount": "{count, plural, =0 {ei kirjoja} one {yksi kirja} other {# kirjoja}}",
       "loadFailed": "Kokoelmien lataaminen epäonnistui",
       "createdAndAdded": "{count, plural, =0 {Luotu \"{name}\" eikä lisännyt kirjoja} one {Luotu \"{name}\" ja lisäsi yhden kirjan} other {Luotu \"{name}\" ja lisäsi # kirjoja}}",
@@ -4496,13 +4319,11 @@
       "searching": "Haetaan...",
       "noResults": "Ei tuloksia",
       "loadingMore": "Ladataan lisää...",
-      "loadMore": "Load more ({loaded}/{total})",
       "allMatchesShown": "{count, plural, =0 {Kaikki 1 ottelu näkyi} one {Kaikki 1 ottelu näkyi} other {Kaikki # osumaa näkyi}}",
       "bookCount": "{count, plural, =0 {ei kirjoja} one {# kirja} other {# kirjoja}}",
       "fileCount": "{count, plural, =0 {ei tiedostoja} one {# tiedosto} other {# tiedostoa}}",
       "uploadedToast": "Ladattu {uploaded}",
       "uploadFailedToast": "Lataaminen epäonnistui {failed} kohdalla",
-      "uploadPartialToast": "Uploaded {uploaded}, {failed} failed",
       "bookDock": "Kirja Telakka",
       "statistics": "Tilastot",
       "achievements": "Saavutukset",
@@ -4538,7 +4359,6 @@
       "tools": "Työkalut",
       "libraries": "Kirjastot",
       "newLibrary": "Uusi Kirjasto",
-      "scanProgress": "{processed} / {total} books",
       "smartScopes": "Älykkäät Kohteet",
       "newSmartScope": "Uusi Älykäs Laajuus",
       "noSmartScopes": "Ei vielä älykkäitä kopioita",
@@ -4559,7 +4379,6 @@
       },
       "noLibraries": "Ei vielä kirjastoja",
       "clearFilter": "Tyhjennä suodatin",
-      "filterSummary": "{shown} of {total} shown",
       "filterLibraries": "Suodata kirjastot",
       "filterLibrariesPlaceholder": "Suodata kirjastoja...",
       "filterSmartScopes": "Suodata älykkäitä soveltamisaloja",
@@ -4575,10 +4394,6 @@
       },
       "reorder": {
         "gripAria": "Järjestä {name}",
-        "lifted": "{name} lifted, position {position} of {total}. Use the arrow keys to move it.",
-        "moved": "{name}, position {position} of {total}",
-        "dropped": "{name} dropped at position {position} of {total}",
-        "cancelled": "Reorder cancelled. {name} returned to position {position} of {total}.",
         "filteredHint": "Tyhjennä suodatin järjestääksesi uudelleen"
       }
     },
@@ -4657,7 +4472,6 @@
     },
     "entityNotFound": {
       "title": "{entity} ei löytynyt",
-      "description": "This {entity} doesn't exist or has been deleted.",
       "goBack": "Mene takaisin"
     },
     "themePicker": {
@@ -4690,7 +4504,6 @@
       "ascending": "Nouseva",
       "descending": "Laskeva",
       "clearSearch": "Tyhjennä haku",
-      "resultCount": "{shown} of {total}",
       "noMatches": "Ei osumia",
       "noMatchesHint": "Kokeile toista hakutermiä.",
       "bookCount": "Kirjat: {count}",
@@ -4704,7 +4517,6 @@
     "dialogDescription": "Tarkista nimet ennen kuin lisäät ne kirjastoon.",
     "readingFiles": "Luetaan tiedostoja...",
     "dropPrompt": "Pudota SVG-tiedostot tai klikkaa selataksesi",
-    "fileLimit": "Up to {max} files, 128 KB each",
     "namePlaceholder": "Nimi",
     "nameRequired": "Nimi vaaditaan",
     "invalidSvg": "Virheellinen SVG",
@@ -4722,7 +4534,6 @@
     "onlyMoreCanStage": "{count, plural, =0 {Enää kuvakkeita ei voi lavastaa} one {Vain # lisää kuvaketta voidaan lavastaa} other {Vain # lisää kuvakkeita voidaan lavastaa}}",
     "readFailed": "SVG-tiedostoja ei voitu lukea",
     "uploadedCount": "{count, plural, =0 {Ei kuvakkeita ladattu} one {Ladattu # kuvake} other {Ladattu # kuvakkeita}}",
-    "uploadedPartial": "Uploaded {created}, {failed} failed",
     "noIconsUploaded": "Ei ladattuja kuvakkeita",
     "uploadFailed": "Kuvakkeiden lataaminen epäonnistui",
     "uploadFailedEntry": "Lähetys epäonnistui"
@@ -4775,14 +4586,6 @@
         "upNextInSeries": "Seuraava ylös Sarjassa",
         "random": "Löydä Jotain Uutta",
         "smartScope": "Älykäs Laajuus"
-      },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
       },
       "reorderHintWidget": "Vedä järjestääksesi. Vaihda näyttääksesi tai piilottaaksesi widgetin.",
       "reorderHintShelf": "Vedä järjestääksesi. Vaihda näyttääksesi tai piilottaaksesi hyllyn.",
@@ -4950,7 +4753,6 @@
       "toggleSharing": "Vaihda jakaminen",
       "removeSystemBeforeDelete": "Poista järjestelmän tunnus ennen poistamista",
       "notesHeading": "Tarjoajan Muistiinpanot",
-      "notesBody": "The {system} provider (superuser only) is used for password reset emails. The {defaultProvider} provider is used when sending books with no explicit provider selected. Providers marked {shared} are available to all users.",
       "deleteTitle": "Poistetaanko tarjoaja?",
       "nameHostRequired": "Nimi ja isäntä vaaditaan",
       "created": "Tarjoaja luotu",
@@ -5160,21 +4962,18 @@
         "eligible": "tukikelpoiset kirjat"
       },
       "checkingPending": "Tarkistetaan odottavia kohteita...",
-      "pendingOf": "{pending} pending of {total} books.",
       "noBooksInScope": "Ei kirjoja synkronoidussa laajuudessa.",
       "allSynced": "Kaikki kirjat on jo synkronoitu.",
       "lastSyncedLabel": "Viimeksi synkronoitu",
       "lastSuccessfulSync": "Viimeisin onnistunut synkronointi",
       "syncing": "Synkronoi...",
-      "progressCount": "{synced} / {total} books",
       "unavailable": {
         "permissionDenied": "Sinulla ei ole oikeuksia käyttää Hardcover synkronointia.",
         "userDisabled": "Synkronointi on keskeytetty Hardcover asetuksissa."
       },
       "button": {
         "unavailable": "Sync unavailable",
-        "syncNow": "Synkronoi nyt",
-        "syncNowCount": "Sync now ({count})"
+        "syncNow": "Synkronoi nyt"
       },
       "lastSynced": {
         "justNow": "Juuri nyt",
@@ -5207,7 +5006,6 @@
         "skipped": "Ohitettu"
       },
       "result": {
-        "summary": "{applied} imported{progress}, {failed} failed",
         "progressUpdated": "{count} edistys päivitetty"
       },
       "toast": {
@@ -5218,7 +5016,6 @@
     },
     "review": {
       "title": "Kovakantinen tuontitarkastelu",
-      "subtitle": "{total} Hardcover books, {matched} matched.",
       "closeAriaLabel": "Sulje tuonnin arvostelu",
       "searchPlaceholder": "Etsi otsikko tai tekijä",
       "importProgress": "Tuonti edistyminen",
@@ -5226,7 +5023,6 @@
       "blank": "tyhjä",
       "noRows": "Mikään rivi ei vastaa nykyisiä suodattimia.",
       "selectRowAriaLabel": "Valitse {title}",
-      "selectionSummary": "{count} selected: {ready} ready, {reviewed} reviewed.",
       "selectedProgress": "{count, plural, =0 {ei edistymispäivityksiä} one {# edistymispäivitys} other {# edistymispäivitystä}}",
       "selectReady": "Valitse valmis",
       "selectPage": "Valitse sivu",
@@ -5235,7 +5031,6 @@
       "importSelected": "Tuo valitut",
       "previousPage": "Edellinen sivu",
       "nextPage": "Seuraava sivu",
-      "pageRange": "{start}-{end} of {total}",
       "tabs": {
         "all": "Kaikki",
         "ready": "Valmis",
@@ -5275,7 +5070,6 @@
     "creator": {
       "createTitle": "Luo Kirjasto",
       "editTitle": "Muokkaa: {name}",
-      "stepOf": "Step {current} of {total}",
       "unsaved": "Tallentamaton",
       "required": "Pakollinen",
       "closeAria": "Sulje kirjaston luoja",
@@ -5324,7 +5118,6 @@
         "manualEntry": "Syötä polku manuaalisesti",
         "absolutePath": "Absoluuttinen palvelimen polku",
         "addFolder": "Lisää kansio",
-        "removeFolder": "Remove {folder}",
         "manualCheckHint": "Manuaaliset polut on tarkistettu yhdessä muiden valittujen kansioiden kanssa.",
         "pathPlaceholder": "/polku/to/kirjat",
         "test": "Testi",
@@ -5497,7 +5290,6 @@
       "parentFolder": "Siirry ylempään kansioon",
       "newFolder": "Uusi kansio",
       "goUp": "Mene ylös",
-      "filterPlaceholder": "Filter folders…",
       "clearFilterAria": "Tyhjennä kansion suodatin",
       "newFolderNamePlaceholder": "Uuden kansion nimi",
       "create": "Luo",
@@ -5531,8 +5323,6 @@
       "viewInLibrary": "Näytä kirjastossa",
       "fileCount": "{count, plural, =0 {ei tiedostoja} one {# tiedosto} other {# tiedostoa}}",
       "booksAdded": "{count, plural, =0 {kirjoja ei lisätty} one {# kirja lisätty} other {# kirjaa lisätty}}",
-      "uploadedFailed": "{done} uploaded, {failed} failed",
-      "progress": "{done} of {total} uploading...",
       "header": {
         "uploading": "Lähetetään...",
         "complete": "Lataus valmis",
@@ -5540,8 +5330,7 @@
         "uploadBooks": "Lataa Kirjat"
       },
       "dropzone": {
-        "title": "Pudota tiedostot tähän tai klikkaa selataksesi",
-        "hint": "{formats} - up to {size} MB each"
+        "title": "Pudota tiedostot tähän tai klikkaa selataksesi"
       }
     }
   },
@@ -5594,7 +5383,6 @@
       "continueToMigration": "Jatka siirtolaisuuteen",
       "viewReport": "Näytä Raportti",
       "resetSetup": "Reset Setup",
-      "stepOf": "Step {current} of {total}",
       "backToSetup": "Takaisin asetuksiin"
     },
     "stages": {
@@ -5623,7 +5411,6 @@
       "mediaPath": {
         "hintRequired": "Vaaditaan kirjasivujen siirtämiseen.",
         "hintAbsolute": "Käytä absoluuttista polkua (esimerkiksi /books). Suhteellisia polkuja ei tueta.",
-        "hintConfigured": "Cover import path configured. Use Test Connection to verify access and Booklore images folder structure.",
         "buttonOk": "Polku OK",
         "buttonIssue": "Reitin Ongelma",
         "buttonTest": "Testaa Polku"
@@ -5657,9 +5444,7 @@
       "saveMappings": "Tallenna Kartoitukset",
       "pathValidation": {
         "title": "Reitin vahvistus",
-        "mappedSummary": "{mapped} of {total} source books have a mapped path",
-        "unmatched": "{count} yhdistettyä polkua ei löydy levyltä",
-        "allMatched": "All {count} mapped paths found on disk"
+        "unmatched": "{count} yhdistettyä polkua ei löydy levyltä"
       }
     },
     "dryRun": {
@@ -5678,7 +5463,6 @@
       "recommended": "Suositeltu",
       "resolveButton": "{count, plural, =0 {Ratkaise # kaksoiskappaletta} one {Ratkaise # kaksoiskappaletta} other {Ratkaise # kaksoiskappaletta}}",
       "sourceRecordId": "Lähdetietueen ID #{id}",
-      "byAuthor": "by {author} (ID: {id})",
       "byFilePath": "{filePath} (ID: {id})",
       "bookloreSourceId": "Booklore source ID: {id}",
       "libraryBookId": "Kirjaston kirja #{id}"
@@ -5750,12 +5534,9 @@
       "matchedBooksExplanation": "Näitä kuivausjuoksupisteitä käytettiin päättämään mitkä kirjaston kirjat vastaanottivat tuotuja tietoja.",
       "sourceBook": "Lähdekirja {id}",
       "libraryBook": "Kirjaston kirja {id}",
-      "unresolvedBooks": "Unresolved books ({count})",
       "unresolvedBooksExplanation": "Nämä kirjat ovat olemassa lähteessä, mutta niitä ei voitu sovittaa mihinkään kirjaan kirjastostasi.",
       "mappedUsers": "Kartoitetut käyttäjät ({count})",
-      "mappedUsersExplanation": "Käyttäjän yhteenlasketut määrät tulevat kuivakäyttöisestä esikatselusta, joka välimuistissa siirtymissuunnitelmassa.",
-      "coverFailures": "{count} cover import(s) failed. Detailed failure rows are not stored.",
-      "userPreviewCounts": "{statuses} statuses, {progress} progress entries, {sessions} reading sessions, {bookmarks} bookmarks, {annotations} annotations, {collections} collection entries"
+      "mappedUsersExplanation": "Käyttäjän yhteenlasketut määrät tulevat kuivakäyttöisestä esikatselusta, joka välimuistissa siirtymissuunnitelmassa."
     },
     "unresolvedReason": {
       "noTitleAuthorMatch": "Vastaavaa kirjaa ei löytynyt otsikon tai tekijän mukaan",
@@ -5797,9 +5578,7 @@
       "loadSuggestionsFailed": "Käyttäjän kartoitusehdotuksia ei voitu ladata",
       "sourceFieldsRequired": "Isäntän, käyttäjän, tietokannan ja lähdekoodin nimi vaaditaan",
       "connectionPassedWithWarnings": "Yhteyden testi läpäisi varoitukset",
-      "connectionPassedWithWarningCount": "Connection test passed with {count} warning(s). First: {warning}",
       "connectionPassed": "Yhteyden testi ohitettu",
-      "connectionMissingTables": "Connection ok, but {count} required table(s) are missing",
       "cannotTestMediaWhileRunning": "Mediareittiä ei voi testata, kun suoritus on aktiivinen",
       "mediaPathRequired": "Media Root polkua tarvitaan kansi tuontiin.",
       "mediaPathAbsolute": "Käytä absoluuttista polkua (esimerkiksi /books).",
@@ -5808,7 +5587,6 @@
       "mediaPathValidationFailed": "Mediapolun vahvistus epäonnistui.",
       "connectionFailedBeforeMedia": "Yhteystesti epäonnistui ennen kuin mediapolun vahvistus voidaan suorittaa.",
       "cannotModifySourceWhileRunning": "Lähdekoodia ei voi muokata, kun suoritus on aktiivinen",
-      "sourceSavedWithWarnings": "Source saved and validated with {count} warning(s)",
       "sourceSaved": "Lähde tallennettu ja vahvistettu",
       "saveSourceFailed": "Lähdekoodin tallennus tai validointi epäonnistui",
       "cannotSaveMappingsWhileRunning": "Yhdistämisiä ei voi tallentaa kun suoritus on aktiivinen",
@@ -5820,7 +5598,6 @@
       "saveMappingsFailed": "Yhdistämisten tallennus epäonnistui",
       "cannotDryRunWhileRunning": "Ei voida suorittaa kuivaajaa kun suoritus on aktiivinen",
       "saveMappingsFirst": "Tallenna kartoitukset ensin",
-      "dryRunCompleted": "Dry-run completed: {matched} matched, {unresolved} unresolved",
       "dryRunFailed": "Dry-run epäonnistui",
       "selectSourceForDuplicates": "Valitse lähdekirja kaikille {count} kaksoisryhmälle",
       "duplicatesResolved": "Kaksoiskappaleet ratkaistut",
@@ -5864,7 +5641,6 @@
         "personal": "Henkilökohtainen",
         "app": "Sovellusten päivitykset"
       },
-      "enabledCount": "{enabled} of {total} enabled",
       "categories": {
         "scanning": {
           "label": "Kirjaston skannaaminen",
@@ -5916,7 +5692,6 @@
   "reader": {
     "retry": "Yritä Uudelleen",
     "pdf": {
-      "openError": "Unable to open this PDF",
       "preparing": "Valmistellaan PDF-lukijaa",
       "opening": "Avataan PDF"
     },
@@ -5928,8 +5703,7 @@
       "startReading": "Aloita lukeminen"
     },
     "toast": {
-      "linkedHighlightError": "Linkitetyn korostuksen sijaintia ei voitu avata",
-      "resumed": "Resumed at {pct}% - {label}"
+      "linkedHighlightError": "Linkitetyn korostuksen sijaintia ei voitu avata"
     },
     "header": {
       "goBack": "Mene takaisin",
@@ -5956,72 +5730,25 @@
     "settings": {
       "title": "Asetukset",
       "ariaLabel": "Lukijan asetukset",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Vaalea",
         "dark": "Tumma"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Sisäänrakennettu",
-      "fontServer": "Server fonts",
       "fontYours": "Kirjasimesi",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Lukemisen virta",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Sivun levitykset",
       "pageSpreadsHint": "Valitse, miten tämä kuvapohjainen EPUB paria sivut.",
       "spread": {
         "bookDefault": "Varaa oletus",
         "singlePage": "Yksi sivu"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Sarakkeen väli",
       "justifyText": "Tasaa teksti",
-      "hyphenation": "Hyfenaatio",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Hyfenaatio"
     },
     "search": {
-      "placeholder": "Search in book (min {min} chars)...",
       "searching": "Etsitään…",
-      "tooShort": "Type at least {min} characters",
       "noResults": "Tuloksia ei löytynyt",
       "prompt": "Kirjoita haettavaksi",
       "resultCount": "{count, plural, =0 {ei tuloksia} one {# tulos} other {# tulokset}}"
@@ -6111,9 +5838,6 @@
       "scrollModeHint": "Käytä \"Ei aukkoja\" webtooneille ja pystysuorille nauhoille.",
       "readingDirection": "Lukemisen suunta",
       "pageView": "Sivun näkymä",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Levityksen kohdistus",
       "spreadGap": "Leviämisen väli",
       "spreadGapValue": "{value}px",
@@ -6145,8 +5869,7 @@
         "shifted": "Siirretty"
       },
       "widePage": {
-        "auto": "Automaattinen",
-        "inSpreads": "In spreads"
+        "auto": "Automaattinen"
       },
       "bg": {
         "black": "Musta",
@@ -6182,17 +5905,9 @@
     }
   },
   "scanner": {
-    "filesProgress": "{processed}/{total} files",
     "booksFound": "{count, plural, =0 {kirjoja ei löytynyt} one {# kirja löytyi} other {# kirjaa löytyi}}"
   },
   "series": {
-    "completion": {
-      "readOfTotal": "{read} of {total} read ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
-    },
     "gaps": {
       "label": "Mahdolliset puutteet:"
     },
@@ -6320,8 +6035,7 @@
       "user": "Minun Lukemistani"
     },
     "filter": {
-      "allLibraries": "Kaikki Kirjastot",
-      "librarySelection": "{count} of {total} Libraries"
+      "allLibraries": "Kaikki Kirjastot"
     },
     "config": {
       "button": "Määritä",
@@ -6553,11 +6267,7 @@
         "chooseLibrary": "Valitse Kirjasto"
       },
       "completed": {
-        "title": "Bulk uudelleennimeäminen valmis",
-        "stats": "{succeeded} renamed, {failed} failed, {skipped} skipped ({processed} total)"
-      },
-      "pagination": {
-        "showing": "Showing {from}-{to} of {total}"
+        "title": "Bulk uudelleennimeäminen valmis"
       },
       "confirmDialog": {
         "title": "Vahvista Bulk Uudelleennimeä",
@@ -6598,14 +6308,12 @@
       "moreFiles": "+{count} lisää",
       "showDetails": "Näytä tiedot",
       "hideDetails": "Piilota tiedot",
-      "deleteSelected": "Delete {count} selected",
       "openBook": "Avaa tiedot kohteelle {title}",
       "unknownAuthor": "Tuntematon tekijä",
       "unknown": "Tuntematon",
       "none": "Ei Mitään",
       "accessDenied": "Sinulla ei ole lupaa käyttää kaksoiskappaletta kirjan työkalua.",
       "pairDetails": "Täsmää tiedot",
-      "pairLabel": "{first} and {second}",
       "fields": {
         "library": "Kirjasto",
         "isbn": "ISBN",
@@ -6642,8 +6350,7 @@
         "delete": "Valittuja kaksoiskirjoja ei voitu poistaa."
       },
       "pagination": {
-        "label": "Kahdenna ryhmien sivut",
-        "page": "Page {page} of {total}"
+        "label": "Kahdenna ryhmien sivut"
       }
     },
     "entityManager": {
@@ -6721,8 +6428,7 @@
         "newName": "Uusi nimi"
       },
       "deleteModal": {
-        "title": "Poista Entiteetti",
-        "confirm": "Are you sure you want to delete {name}?"
+        "title": "Poista Entiteetti"
       },
       "splitModal": {
         "title": "Jaa Entiteetti",
@@ -6733,7 +6439,6 @@
       },
       "bulkDeleteModal": {
         "title": "Bulk Poisto",
-        "confirm": "{count, plural, =0 {Are you sure you want to delete # selected entity?} one {Are you sure you want to delete # selected entity?} other {Are you sure you want to delete # selected entities?}}",
         "deleteButton": "Poista {count}"
       },
       "mergeModal": {
@@ -6817,7 +6522,6 @@
         "applied": "{count, plural, =0 {Ei sovellettu tiedostoihin} one {Sovelletaan yhteen tiedostoon} other {Sovelletaan # tiedostoon}}",
         "skippedEdited": "{count, plural, =0 {ohitti yhden tiedoston, koska ne ovat manuaalisesti muokanneet} one {ohitettu yksi tiedosto, koska se on manuaalisesti muokannut} other {ohitettu # tiedostoa, koska ne ovat manuaalisia muokkauksia}}",
         "skippedNoMetadata": "{count, plural, =0 {ohitti yhden tiedoston, koska niillä ei ole haettua metadataa} one {ohitettu yksi tiedosto, koska sillä ei ole haettua metadataa} other {ohitettu # tiedostoa, koska niillä ei ole haettua metadataa}}",
-        "noneApplied": "No files applied; {reasons}",
         "noneSelected": "Ei valittuja tiedostoja"
       }
     },
@@ -6862,7 +6566,6 @@
         "emptyLibraryHint": "Kun lisäät kirjoja tähän kirjastoon, ne näkyvät täällä."
       },
       "querySelection": {
-        "loadedSelected": "{selected} of {total} loaded books selected.",
         "selectAllMatching": "Valitse kaikki {total} vastaavat kirjat"
       }
     },
@@ -6881,7 +6584,6 @@
       "showControlsAria": "Näytä Smart Scope -toiminnot",
       "hideFilter": "Piilota suodatin",
       "showFilter": "Näytä suodatin",
-      "confirmDelete": "Confirm?",
       "loadError": "SmartScope ei voitu ladata",
       "toast": {
         "deleted": "\"{name}\" poistettu",
@@ -6913,7 +6615,6 @@
     "versions": "Versiot",
     "currentVersion": "Nykyinen versio",
     "youreHere": "Olet täällä",
-    "searchPlaceholder": "Search releases…",
     "noReleasesFound": "Julkaisuja ei löytynyt.",
     "noHighlights": "Ei kohokohtia tälle julkaisulle.",
     "showChangelog": "Näytä koko muutosloki",
@@ -6997,8 +6698,7 @@
       "users": "Käyttäjät",
       "account-activity": "Tilin Toiminta",
       "magic-links": "Magic Linkit",
-      "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / SSO"
     },
     "system": {
       "file-naming": "Tiedoston Nimeäminen",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -1134,14 +1134,14 @@
         "account-activity": "Activité du compte",
         "magic-links": "Liens magiques",
         "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
+        "server-fonts": "Polices du serveur"
       },
       "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "title": "Polices du serveur",
+        "subtitle": "Téléversez des polices directement disponibles pour tous les utilisateurs dans le lecteur d'eBook.",
+        "listLabel": "Polices du serveur",
+        "noFontsYet": "Aucune police disponible sur le serveur pour le moment",
+        "noFontsHint": "Les polices que vous ajoutez ici sont disponibles dans le lecteur de tous les utilisateurs."
       }
     },
     "common": {
@@ -1677,11 +1677,11 @@
         "demoCannotManage": "Le compte restreint à la démo ne peut pas gérer les polices",
         "fileAdded": "\"{name}\" ajouté",
         "uploadFailed": "Échec du téléchargement",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "serverFontsTitle": "Polices du serveur (partagées par l'admin)",
+        "serverFontsHint": "Ces polices proviennent de l'admin du serveur. Désactivez-en une pour qu'elle ne soit plus disponible dans votre lecteur.",
+        "serverFontsShown": "{count} sur {total} disponibles",
+        "serverFontsAllHidden": "Toutes les polices du serveur sont désactivées. Votre lecteur ne proposera que les polices intégrées et vos propres polices.",
+        "serverFontVisibilityFailed": "Échec de mise à jour des polices disponibles sur le serveur"
       },
       "bookDock": {
         "title": "Book Dock",
@@ -2886,7 +2886,7 @@
       "BookBulkUpdateTags": "Mettre à jour les balises du livre",
       "BookBulkSetMetadataLock": "Définir des verrous de métadonnées",
       "BookBulkEditMetadata": "Modifier les métadonnées du livre",
-      "BookBulkMoveLibrary": "Move books to another library",
+      "BookBulkMoveLibrary": "Déplacer les livres vers une autre bibliothèque",
       "BookReadingStateReset": "Réinitialiser l'état de lecture",
       "BookWriteAndRename": "Écrire les métadonnées et renommer le fichier",
       "CollectionCreate": "Créer une collection",
@@ -3346,11 +3346,11 @@
         "isLocked": "est verrouillé",
         "isUnlocked": "n'est pas verrouillé",
         "isUpNext": "est à la suite",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isTrue": "est Vrai",
+        "isFalse": "est Faux"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
+      "customFieldsGroup": "Champs personnalisés",
+      "customFieldFallback": "Champ personalisé",
       "anyProvider": "N'importe quel fournisseur",
       "communityRatingProvider": "Fournisseur de notation communautaire",
       "loadingLibraries": "Chargement des bibliothèques...",
@@ -4096,10 +4096,10 @@
         "moveUp": "Monter",
         "moveDown": "Descendre",
         "removeSeries": "Supprimer la série",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "seriesIndexLabel": "Position dans les séries",
+        "totalLabel": "Livres dans la série",
+        "totalPlaceholder": "sur",
+        "totalHint": "Nombre de tomes dans cette série. Partagé avec tous ceux qui ont cette série."
       }
     },
     "table": {
@@ -4182,66 +4182,66 @@
       }
     },
     "move": {
-      "title": "{count, plural, one {Move # book} many {Move # books} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
+      "title": "{count, plural, one {Déplacez # livre} many {Déplacez # livres} other {Déplacez # livres}}",
+      "subtitle": "Les fichiers sont déplacés sur le disque vers la bibliothèque choisie. Cela peut changer la visibilité de ces livres pour les utilisateurs.",
+      "searchPlaceholder": "Rechercher dans les bibliothèques",
+      "currentLibrary": "Actuelle",
       "folderCount": "{count, plural, one {# folder} many {# folders} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
-      "confirm": "{count, plural, one {Move # book} many {Move # books} other {Move # books}}",
-      "action": "Move to library",
+      "continue": "Continuer",
+      "back": "Précédent",
+      "confirm": "{count, plural, one {Déplacer # book} many {Déplacer # books} other {Déplacer # books}}",
+      "action": "Déplacer vers la bibliothèque",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} many {# name conflicts} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
+        "ready": "{count} prêt",
+        "collisions": "{count, plural, one {# conflit de nom} many {# conflits de nom} other {# conflits de nom}}",
+        "ineligible": "{count} ne peut pas être déplacé",
+        "alreadyThere": "{count} déjà présent",
+        "collisionsHeading": "Conflit de noms",
+        "ineligibleHeading": "Ne peut pas être déplacé",
+        "moreCollisions": "et {count} autres"
       },
       "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
+        "suggested": "Utiliser la suggestion",
+        "keep_both": "Garder les deux",
+        "merge": "Fusionner",
+        "skip": "Passer"
       },
       "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
+        "folder_path": "Un livre utilise déjà ce nom de dossier",
+        "file_path": "Un fichier utilise déjà ce chemin",
+        "hash_duplicate": "Une copie identique existe déjà dans cette bibliothèque"
       },
       "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
+        "book_not_present": "Les fichiers de ce livre sont manquants",
+        "no_content_file": "Ce livre n'a aucun fichier lisible",
+        "multi_file_target_per_file": "La destination stocke un fichier par livre, et ce livre a {detail} fichiers",
+        "no_source_access": "Vous ne pouvez pas modifier la bibliothèque dans laquelle se trouve ce livre",
+        "pattern_unresolved": "La bibliothèque de destination n'a pas de motif de nommage utilisable",
+        "path_too_long": "Le chemin de destination est trop long",
+        "path_outside_target_root": "Le chemin de destination est en hors du dossier de la bibliothèque"
       },
       "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
+        "accessLoss": "{user} ne verra plus {count} de ces livres",
+        "koboImpact": "{count} livres seront supprimés de la Kobo de {user} lors de la prochaine synchronisation",
         "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
+          "wrap_into_folder": "{count} livres seront placés dans leur propre dossier",
+          "dissolve_folder": "{count} dossiers de livres seront changés en fichiers uniques"
         },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
+        "crossDevice": "Les fichiers sont déplacés vers un autre lecteur : ils sont copiés, vérifiés, puis supprimés."
       },
       "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
+        "label": "Déplacement des livres vers {library}",
+        "failed": "{count} en échec"
       },
       "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
+        "summary": "{count} livres déplacés vers {library}",
+        "merged": "{count} fusionnés avec des copies existantes",
+        "skipped": "{count} ignorés",
+        "failed": "{count} en échec"
       },
       "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "success": "{count} livres déplacés vers {library}",
+        "partial": "{moved} livres déplacés, {failed} en échec"
       }
     }
   },
@@ -4777,12 +4777,12 @@
         "smartScope": "Collection Intelligente"
       },
       "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
+        "title": "Disposition de l'étagère",
+        "description": "Choisissez comment les étagères sont disposées sur des écrans plus grands.",
+        "wide": "Large rangées",
+        "wideDescription": "Afficher une étagère par ligne.",
+        "twoColumns": "Deux colonnes",
+        "twoColumnsDescription": "Afficher une étagère par ligne."
       },
       "reorderHintWidget": "Faites glisser pour réorganiser. Basculez pour afficher ou masquer un widget.",
       "reorderHintShelf": "Faites glisser pour réorganiser. Basculez pour afficher ou masquer une étagère.",
@@ -5956,65 +5956,65 @@
     "settings": {
       "title": "Paramètres",
       "ariaLabel": "Paramètres du lecteur",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
+      "reset": "Rétablir les valeurs par défaut",
+      "modeLabel": "Style de couleur",
       "mode": {
-        "light": "Lumière",
+        "light": "Clair",
         "dark": "Sombre"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
+      "textSize": "Taille du texte",
+      "textSizeSmaller": "Texte plus petits",
+      "textSizeLarger": "Texte plus grand",
       "pixels": "{value} px",
       "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
-      "fontBuiltIn": "Intégré",
-      "fontServer": "Server fonts",
+      "pageColor": "Couleur de la page",
+      "font": "Police",
+      "fontBuiltIn": "Intégrée",
+      "fontServer": "Polices du serveur",
       "fontYours": "Vos polices",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
-      "readingFlow": "Flux de lecture",
+      "lineSpacing": "Interligne",
+      "pageWidth": "Largeur de page",
+      "pageWidthNarrow": "Étroite",
+      "pageWidthMedium": "Moyenne",
+      "pageWidthWide": "Large",
+      "pageWidthFull": "Pleine",
+      "readingFlow": "Mode de lecture",
       "flow": {
         "paginated": "Pages",
-        "scrolled": "Scroll"
+        "scrolled": "Défilement"
       },
-      "pageSpreads": "Pages doubles",
-      "pageSpreadsHint": "Choisissez comment ce EPUB basé sur des images associe les pages.",
+      "pageSpreads": "Double-pages",
+      "pageSpreadsHint": "Choisissez comment cet EPUB d'images affiche les pages.",
       "spread": {
-        "bookDefault": "Livre par défaut",
+        "bookDefault": "Par défaut",
         "singlePage": "Page unique"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
-      "columnGap": "Écart de colonne",
+      "advanced": "Mise en page Avancée",
+      "columns": "Colonnes",
+      "columnsFewer": "Moins de colonnes",
+      "columnsMore": "Plus de colonnes",
+      "columnGap": "Espace de colonne",
       "justifyText": "Justifier le texte",
       "hyphenation": "Césure",
       "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
+        "default": "Par défaut",
+        "gray": "Gris",
+        "sepia": "Sépia",
+        "crimson": "Cramoisi",
+        "meadow": "Prairie",
+        "rosewood": "Rose-rouge",
+        "azure": "Azur",
+        "dawnlight": "Aube",
+        "ember": "Ambre",
+        "aurora": "Aurore",
+        "ocean": "Océan",
+        "mist": "Brume",
         "amoled": "AMOLED"
       },
       "fonts": {
-        "bookDefault": "Book default",
+        "bookDefault": "Police du livre par défaut",
         "serif": "Serif",
-        "sansSerif": "Sans-serif",
+        "sansSerif": "Sans Serif",
         "monospace": "Monospace"
       }
     },
@@ -6111,9 +6111,6 @@
       "scrollModeHint": "Utilisez \"Pas d'espaces\" pour les webtoons et les bandes verticales.",
       "readingDirection": "Sens de lecture",
       "pageView": "Affichage des pages",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Alignement de la propagation",
       "spreadGap": "Écart de propagation",
       "spreadGapValue": "{value}px",
@@ -6190,8 +6187,8 @@
       "readOfTotal": "{read} sur {total} lu ({percentage}%)"
     },
     "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
+      "label": "Dans la bibliothèque",
+      "ownedOfExpected": "{owned} de {expected} dans la bibliothèque"
     },
     "gaps": {
       "label": "Lacunes possibles :"
@@ -6998,7 +6995,7 @@
       "account-activity": "Activité du compte",
       "magic-links": "Liens magiques",
       "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "server-fonts": "Polices du serveur"
     },
     "system": {
       "file-naming": "Nom du fichier",

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -1133,15 +1133,7 @@
         "users": "Utenti",
         "account-activity": "Attività dell'account",
         "magic-links": "Collegamenti magici",
-        "oidc": "OIDC /SSO",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC /SSO"
       }
     },
     "common": {
@@ -1676,12 +1668,7 @@
         "deleteFamilyFailed": "Impossibile eliminare la famiglia di caratteri",
         "demoCannotManage": "L'account con limitazioni demo non può gestire i caratteri",
         "fileAdded": "\"{name}\" aggiunto",
-        "uploadFailed": "Caricamento non riuscito",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Caricamento non riuscito"
       },
       "bookDock": {
         "title": "Book Dock",
@@ -2886,7 +2873,6 @@
       "BookBulkUpdateTags": "Aggiorna i tag del libro",
       "BookBulkSetMetadataLock": "Imposta i blocchi dei metadati",
       "BookBulkEditMetadata": "Modifica i metadati del libro",
-      "BookBulkMoveLibrary": "Move books to another library",
       "BookReadingStateReset": "Ripristina lo stato di lettura",
       "BookWriteAndRename": "Scrivi metadati e rinomina il file",
       "CollectionCreate": "Crea raccolta",
@@ -3254,31 +3240,6 @@
       "moveDown": "Spostati giù",
       "ascending": "Ascendente",
       "descending": "Discendente",
-      "fields": {
-        "author": "Author",
-        "title": "Title",
-        "series": "Series",
-        "seriesIndex": "Series #",
-        "addedAt": "Date Added",
-        "updatedAt": "Date Updated",
-        "publishedDate": "Published Date",
-        "publishedYear": "Published Year",
-        "pageCount": "Page Count",
-        "rating": "Rating",
-        "publisher": "Publisher",
-        "fileSize": "File Size",
-        "readProgress": "Read Progress",
-        "readStatus": "Read Status",
-        "format": "Format",
-        "lastReadAt": "Last Read",
-        "startedAt": "Date Started",
-        "finishedAt": "Date Finished",
-        "random": "Random",
-        "language": "Language",
-        "metadataScore": "Metadata Score"
-      },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "remove": "Rimuovi",
       "emptyState": "Nessun ordinamento configurato. Verrà utilizzato il titolo crescente.",
       "addLevel": "Aggiungi livello di ordinamento"
@@ -3288,69 +3249,6 @@
       "all": "TUTTI",
       "any": "QUALSIASI",
       "ofFollowingRules": "delle seguenti regole",
-      "fields": {
-        "title": "Title",
-        "publisher": "Publisher",
-        "language": "Language",
-        "series": "Series",
-        "seriesIndex": "Series Index",
-        "publishedDate": "Published Date",
-        "publishedYear": "Published Year",
-        "pageCount": "Page Count",
-        "author": "Author",
-        "genre": "Genre",
-        "tag": "Tag",
-        "collection": "Collection",
-        "library": "Library",
-        "format": "Format",
-        "addedAt": "Added Date",
-        "startedAt": "Date Started",
-        "finishedAt": "Date Finished",
-        "fileAvailability": "File Availability",
-        "rating": "Rating",
-        "communityRating": "Community Rating",
-        "readProgress": "Reading Progress",
-        "readStatus": "Read Status",
-        "description": "Description",
-        "isbn": "ISBN",
-        "metadataScore": "Metadata Score",
-        "cover": "Cover",
-        "lockStatus": "Lock Status",
-        "seriesStatus": "Series Status"
-      },
-      "operators": {
-        "contains": "contains",
-        "notContains": "does not contain",
-        "startsWith": "starts with",
-        "endsWith": "ends with",
-        "eq": "is",
-        "notEq": "is not",
-        "isEmpty": "is empty",
-        "isNotEmpty": "is not empty",
-        "gt": "greater than",
-        "gte": "at least",
-        "lt": "less than",
-        "lte": "at most",
-        "between": "between",
-        "includesAny": "includes any of",
-        "includesAll": "includes all of",
-        "excludesAll": "excludes all of",
-        "before": "before",
-        "after": "after",
-        "withinLast": "within last",
-        "isMissing": "is missing",
-        "isPresent": "is present",
-        "isUnread": "is unread",
-        "isInProgress": "is in progress",
-        "isFinished": "is finished",
-        "isLocked": "is locked",
-        "isUnlocked": "is unlocked",
-        "isUpNext": "is up next",
-        "isTrue": "is yes",
-        "isFalse": "is no"
-      },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Qualsiasi fornitore",
       "communityRatingProvider": "Fornitore di valutazioni della comunità",
       "loadingLibraries": "Caricamento librerie...",
@@ -4095,11 +3993,7 @@
         "seriesPlaceholder": "Serie",
         "moveUp": "Vai su",
         "moveDown": "Spostati giù",
-        "removeSeries": "Rimuovi serie",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Rimuovi serie"
       }
     },
     "table": {
@@ -4183,65 +4077,10 @@
     },
     "move": {
       "title": "{count, plural, one {Move # book} many {Move # books} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
       "folderCount": "{count, plural, one {# folder} many {# folders} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
       "confirm": "{count, plural, one {Move # book} many {Move # books} other {Move # books}}",
-      "action": "Move to library",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} many {# name conflicts} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "collisions": "{count, plural, one {# name conflict} many {# name conflicts} other {# name conflicts}}"
       }
     }
   },
@@ -4752,37 +4591,6 @@
       "tabs": {
         "widgets": "Widget",
         "shelves": "Scaffali"
-      },
-      "widgetNames": {
-        "readingStreak": "Reading Streak",
-        "currentlyReading": "Currently Reading",
-        "readingGoal": "Reading Goal",
-        "readingDna": "Reading DNA",
-        "monthlyChallenge": "Monthly Challenge",
-        "highlightOfTheDay": "Highlight of the Day",
-        "neglectedGems": "Neglected Gems",
-        "readingRhythm": "Reading Rhythm",
-        "diversityScore": "Diversity Score",
-        "libraryOverview": "Library Overview",
-        "yearProjection": "Year Projection",
-        "longWait": "The Long Wait"
-      },
-      "shelfNames": {
-        "recentlyAdded": "Recently Added",
-        "continueReading": "Continue Reading",
-        "continueListening": "Continue Listening",
-        "wantToRead": "Want to Read",
-        "upNextInSeries": "Up Next in Series",
-        "random": "Discover Something New",
-        "smartScope": "Smart Scope"
-      },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
       },
       "reorderHintWidget": "Trascina per riordinare. Seleziona per mostrare o nascondere un widget.",
       "reorderHintShelf": "Trascina per riordinare. Attiva/disattiva per mostrare o nascondere uno scaffale.",
@@ -5956,67 +5764,22 @@
     "settings": {
       "title": "Impostazioni",
       "ariaLabel": "Impostazioni del lettore",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Luce",
         "dark": "Buio"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Integrato",
-      "fontServer": "Server fonts",
       "fontYours": "I tuoi caratteri",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Flusso di lettura",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "La pagina si allarga",
       "pageSpreadsHint": "Scegli come questo EPUB basato su immagini accoppia le pagine.",
       "spread": {
         "bookDefault": "Prenota predefinito",
         "singlePage": "Pagina singola"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Spazio tra le colonne",
       "justifyText": "Giustificare il testo",
-      "hyphenation": "Sillabazione",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Sillabazione"
     },
     "search": {
       "placeholder": "Cerca nel libro (min {min} caratteri)...",
@@ -6111,9 +5874,6 @@
       "scrollModeHint": "Utilizza \"Nessun intervallo\" per i webtoon e le strisce verticali.",
       "readingDirection": "Direzione della lettura",
       "pageView": "Visualizzazione della pagina",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Allineamento della diffusione",
       "spreadGap": "Divario di diffusione",
       "spreadGapValue": "{value}px",
@@ -6188,10 +5948,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} di {total} letto ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Possibili lacune:"
@@ -6270,8 +6026,6 @@
   "smartScope": {
     "syncToKobo": "Sincronizza con Kobo",
     "syncToKoboHint": "I libri corrispondenti a questo ambito verranno visualizzati sul tuo dispositivo Kobo",
-    "visibleToAll": "Visible to all users",
-    "visibleToAllHint": "Every user can see and use this smart scope",
     "dialog": {
       "name": "Nome",
       "namePlaceholder": "ad es. Fantascienza non letta",
@@ -6873,11 +6627,6 @@
       "defaultName": "Ambito intelligente",
       "filter": "Filtra",
       "edit": "Modifica ambito intelligente",
-      "koboSync": {
-        "label": "Sync to my Kobo",
-        "enabledHint": "Books in this shared Smart Scope sync to your Kobo device. Turn off to stop syncing them.",
-        "disabledHint": "Turn on to sync books in this shared Smart Scope to your Kobo device."
-      },
       "showControlsAria": "Mostra i controlli Smart Scope",
       "hideFilter": "Nascondi filtro",
       "showFilter": "Mostra filtro",
@@ -6885,10 +6634,7 @@
       "loadError": "Impossibile caricare questo SmartScope",
       "toast": {
         "deleted": "\"{name}\" eliminato",
-        "deleteFailed": "Impossibile eliminare \"{name}\"",
-        "koboSyncEnabled": "\"{name}\" now syncs to your Kobo",
-        "koboSyncDisabled": "\"{name}\" no longer syncs to your Kobo",
-        "koboSyncFailed": "Failed to update Kobo sync for \"{name}\""
+        "deleteFailed": "Impossibile eliminare \"{name}\""
       },
       "empty": {
         "noRules": "Nessuna regola configurata",
@@ -6997,8 +6743,7 @@
       "users": "Utenti",
       "account-activity": "Attività dell'account",
       "magic-links": "Collegamenti magici",
-      "oidc": "OIDC /SSO",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC /SSO"
     },
     "system": {
       "file-naming": "Denominazione dei file",

--- a/client/src/locales/nl.json
+++ b/client/src/locales/nl.json
@@ -92,8 +92,7 @@
       "mobileSummary": "Thema: {theme} • Accent: {accent} • Achtergrond: {background}",
       "themeMode": {
         "light": "Licht",
-        "dark": "Donker",
-        "system": "System"
+        "dark": "Donker"
       },
       "theme": {
         "title": "Thema",
@@ -102,70 +101,8 @@
           "hint": "Lichte of donkere interface"
         },
         "accents": {
-          "grey": "Grey",
-          "scarlet": "Scarlet",
-          "vermilion": "Vermilion",
-          "rose": "Rose",
-          "copper": "Copper",
-          "orange": "Orange",
-          "chartreuse": "Chartreuse",
-          "marigold": "Marigold",
-          "wasabi": "Wasabi",
-          "amber": "Amber",
-          "malachite": "Malachite",
-          "yellow": "Yellow",
-          "viridian": "Viridian",
-          "turquoise": "Turquoise",
-          "lime": "Lime",
-          "green": "Green",
-          "acid-green": "Acid Green",
-          "emerald": "Emerald",
-          "teal": "Teal",
-          "electric-blue": "Electric Blue",
-          "cyan": "Cyan",
-          "jade": "Jade",
-          "ultramarine": "Ultramarine",
           "iris": "Iris",
-          "purple": "Paars",
-          "blue": "Blue",
-          "indigo": "Indigo",
-          "violet": "Violet",
-          "amethyst": "Amethyst",
-          "fuchsia": "Fuchsia",
-          "raspberry": "Raspberry",
-          "pink": "Pink",
-          "white": "White",
-          "rosewater": "Rosewater",
-          "salmon": "Salmon",
-          "coral": "Coral",
-          "sand": "Sand",
-          "peach": "Peach",
-          "pear": "Pear",
-          "flax": "Flax",
-          "sprout": "Sprout",
-          "butter": "Butter",
-          "aloe": "Aloe",
-          "lemon": "Lemon",
-          "foam": "Foam",
-          "aqua": "Aqua",
-          "celadon": "Celadon",
-          "sage": "Sage",
-          "pistachio": "Pistachio",
-          "mint": "Mint",
-          "seafoam": "Seafoam",
-          "baby-blue": "Baby Blue",
-          "powder": "Powder",
-          "sea-glass": "Sea Glass",
-          "bluebell": "Bluebell",
-          "cornflower": "Cornflower",
-          "thistle": "Thistle",
-          "periwinkle": "Periwinkle",
-          "wisteria": "Wisteria",
-          "lavender": "Lavender",
-          "mauve": "Mauve",
-          "orchid": "Orchid",
-          "rose-quartz": "Rose Quartz",
-          "blush": "Blush"
+          "purple": "Paars"
         },
         "accentColor": {
           "label": "Accentkleur",
@@ -466,8 +403,7 @@
         "notice": "Demo-beperkt account: het bewerken van profiel, wachtwoord, avatar en gekoppelde identiteiten is uitgeschakeld."
       },
       "feedback": {
-        "unsavedChanges": "Niet-opgeslagen wijzigingen",
-        "discard": "Discard"
+        "unsavedChanges": "Niet-opgeslagen wijzigingen"
       },
       "profile": {
         "securityHeading": "Profiel & Beveiliging",
@@ -484,11 +420,7 @@
         "accountTypeLocal": "Lokaal",
         "nameRequired": "Naam is verplicht",
         "updateFailed": "Bijwerken van profiel mislukt",
-        "updated": "Profiel bijgewerkt",
-        "usernameHint": "Your username cannot be changed.",
-        "passwordHint": "Change the password you use to sign in.",
-        "passwordHintOidc": "Your password is managed by your identity provider.",
-        "passwordHintShared": "Shared accounts sign in through a magic link and have no password."
+        "updated": "Profiel bijgewerkt"
       },
       "readingPreferences": {
         "title": "Leesvoorkeuren",
@@ -496,10 +428,7 @@
         "timezone": "Tijdzone",
         "save": "Voorkeuren opslaan",
         "enableAchievements": "Prestaties inschakelen",
-        "enableAchievementsHint": "Houd de voortgang van prestaties bij en toon prestatiegerelateerde onderdelen. Beheer prestatiemeldingen afzonderlijk onder Meldingen.",
-        "achievementsEnabled": "Achievements enabled",
-        "achievementsDisabled": "Achievements disabled",
-        "achievementsSaveFailed": "Failed to update the achievement preference"
+        "enableAchievementsHint": "Houd de voortgang van prestaties bij en toon prestatiegerelateerde onderdelen. Beheer prestatiemeldingen afzonderlijk onder Meldingen."
       },
       "preferences": {
         "saveFailed": "Opslaan van voorkeuren mislukt",
@@ -541,9 +470,7 @@
           "title": "{provider}-identiteit ontkoppelen?",
           "description": "Voer je wachtwoord in om te bevestigen. Je kunt daarna niet meer inloggen met deze provider.",
           "currentPassword": "Huidig wachtwoord"
-        },
-        "description": "Sign in with an external identity provider linked to this account.",
-        "unlinkAria": "Unlink {provider}"
+        }
       },
       "tour": {
         "title": "Rondleiding",
@@ -572,11 +499,6 @@
           "title": "Geblokkeerde genres",
           "description": "Boeken met een van deze genres worden voor je verborgen."
         }
-      },
-      "groups": {
-        "profile": "Profile",
-        "preferences": "Preferences",
-        "security": "Security & access"
       }
     },
     "magicLinks": {
@@ -612,8 +534,7 @@
         "uses": "Gebruik",
         "created": "Gemaakt",
         "status": "Status",
-        "totalUses": "Totaal gebruik",
-        "actions": "Actions"
+        "totalUses": "Totaal gebruik"
       },
       "createDialog": {
         "title": "Magic link maken",
@@ -641,12 +562,7 @@
       "emptyTitle": "Nog geen magische links aangemaakt",
       "emptyHint": "Klik op \"{action}\" om een deelbare login-URL te genereren.",
       "noActiveTitle": "Geen actieve magische links",
-      "noActiveHint": "Alle gegenereerde magische links voor deze pagina zijn verlopen of ingetrokken.",
-      "copyLinkAria": "Copy the link for {label}",
-      "pauseAria": "Pause {label}",
-      "resumeAria": "Resume {label}",
-      "revokeAria": "Revoke {label}",
-      "lastUsedLabel": "Last used {date}"
+      "noActiveHint": "Alle gegenereerde magische links voor deze pagina zijn verlopen of ingetrokken."
     },
     "oidc": {
       "title": "OIDC / SSO",
@@ -1133,15 +1049,7 @@
         "users": "Gebruikers",
         "account-activity": "Accountactiviteit",
         "magic-links": "Magische links",
-        "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC / SSO"
       }
     },
     "common": {
@@ -1606,9 +1514,6 @@
         "spreadAlignmentHint": "Verschuif de koppeling met één pagina na de omslag voor scans die net verschoven zijn",
         "alignmentNormal": "Normaal",
         "alignmentShifted": "Verschoven",
-        "spreadGap": "Spread gap",
-        "spreadGapHint": "Space between pages in two-page view",
-        "spreadGapValue": "{value}px",
         "widePageHandling": "Verwerking van brede pagina's",
         "widePageHandlingHint": "Auto toont brede scans alleen in gepagineerde modus met twee pagina's",
         "widePageAuto": "Auto",
@@ -1676,12 +1581,7 @@
         "deleteFamilyFailed": "Kan lettertypefamilie niet verwijderen",
         "demoCannotManage": "Demo-beperkt account kan geen lettertypen beheren",
         "fileAdded": "\"{name}\" toegevoegd",
-        "uploadFailed": "Uploaden mislukt",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Uploaden mislukt"
       },
       "bookDock": {
         "title": "Book Dock",
@@ -1784,36 +1684,9 @@
         "copyPatternFailed": "Kan patroon niet kopiëren",
         "labelCopied": "{label} gekopieerd naar klembord",
         "copyLabelFailed": "Kan {label} niet kopiëren",
-        "patternHelp": "Pattern help",
-        "patternHelpDescription": "Tokens, modifiers and ready-made patterns you can copy into any field.",
-        "copyPreview": "Copy {label}",
-        "copyExample": "Copy the {label} pattern",
-        "invalidCharacters": "Pattern contains invalid characters",
-        "fileAsBookSaved": "File as Book default saved",
-        "folderAsBookSaved": "Folder as Book default saved",
-        "downloadPatternSaved": "Download pattern saved",
-        "savePatternFailed": "Failed to save pattern",
-        "saveDownloadPatternFailed": "Failed to save download pattern",
-        "crossPlatformEnabled": "Cross-platform path sanitization enabled",
-        "crossPlatformDisabled": "Cross-platform path sanitization disabled",
-        "crossPlatformSaveFailed": "Failed to save cross-platform path sanitization",
-        "librarySaved": "Pattern saved for {name}",
-        "librarySaveFailed": "Failed to save library pattern",
-        "saveLibraryPattern": "Save pattern for {name}",
-        "resetLibraryPattern": "Reset {name} to the default pattern",
         "tokenTitle": "Titel",
-        "tokenSubtitle": "Book subtitle",
-        "tokenAuthors": "Author(s), comma-separated",
-        "tokenYear": "Publication year",
-        "tokenSeries": "Series name",
-        "tokenSeriesIndex": "Series index (zero-padded)",
-        "tokenPublisher": "Publisher",
         "tokenIsbn": "ISBN-13",
-        "tokenLanguage": "Taal",
-        "tokenOriginalFilename": "Original filename (without extension)",
-        "tokenExtension": "File extension (without dot)",
-        "patternHelpIntro": "Patterns use tokens like {titleToken} and {authorsToken}, plus modifiers and optional segments.",
-        "browseTokensAndExamples": "Browse tokens and examples"
+        "tokenLanguage": "Taal"
       },
       "kobo": {
         "title": "Kobo-synchronisatie",
@@ -2508,8 +2381,7 @@
         "username": "Gebruikersnaam",
         "email": "E-mail",
         "access": "Toegang",
-        "status": "Status",
-        "actions": "Actions"
+        "status": "Status"
       },
       "adminBadge": "Beheer",
       "permissionCount": "{count, plural, =0 {geen rechten} one {één recht} other {# rechten}}",
@@ -2528,8 +2400,7 @@
       "deleting": "Verwijderen...",
       "errors": {
         "load": "Laden mislukt",
-        "deleteUser": "Gebruiker verwijderen mislukt",
-        "resetPassword": "Failed to create a password reset link"
+        "deleteUser": "Gebruiker verwijderen mislukt"
       },
       "defaultLibraryAccess": {
         "title": "Standaard bibliotheektoegang",
@@ -2540,35 +2411,9 @@
         "saving": "Opslaan...",
         "saveError": "Opslaan van standaard bibliotheektoegang mislukt"
       },
-      "filters": {
-        "search": "Search users",
-        "searchPlaceholder": "Search by name, username or email",
-        "sort": "Sort users",
-        "usernameAsc": "Username A-Z",
-        "nameAsc": "Name A-Z",
-        "newest": "Newest first",
-        "oldest": "Oldest first",
-        "apply": "Apply",
-        "clear": "Clear",
-        "state": "Filter users",
-        "allUsers": "All users",
-        "admins": "Administrators",
-        "active": "Active",
-        "inactive": "Inactive"
-      },
-      "empty": {
-        "title": "No users yet",
-        "description": "Create the first account to get started.",
-        "filtered": "No users match the current search and filters."
-      },
       "pagination": {
-        "label": "Users pagination",
         "page": "Pagina {page} van {totalPages}"
-      },
-      "editUserAria": "Edit {name}",
-      "resetPasswordAria": "Reset the password for {name}",
-      "deleteUserAria": "Delete {name}",
-      "moreActionsAria": "More actions for {name}"
+      }
     }
   },
   "annotations": {
@@ -2718,221 +2563,34 @@
     "showLess": "Minder tonen",
     "details": "Details",
     "hideDetails": "Details verbergen",
-    "refresh": "Refresh audit log",
     "loadError": "Kan geen audit gebeurtenissen laden.",
-    "removeFilter": "Remove filter: {value}",
-    "allActions": "All actions",
-    "allEventTypes": "All event types",
-    "allActors": "All actors",
-    "noActionsFound": "No matching actions",
-    "noActorsFound": "No matching actors",
-    "noResourcesFound": "No matching target types",
-    "unknownAction": "Unknown action",
-    "unknownResource": "Other target type",
-    "allResources": "All resources",
-    "allTargetTypes": "All target types",
-    "quickDates": "Quick dates",
-    "today": "Today",
-    "sevenDays": "7 days",
-    "thirtyDays": "30 days",
-    "userId": "User #{id}",
-    "userIdCompact": "#{id}",
-    "targetAdditional": "and {count, plural, one {# more target} other {# more targets}}",
     "bookImpact": "{count, plural, one {# book} other {# books}}",
-    "entryDetailsLabel": "Details for audit event #{id}",
-    "detailEventId": "Event ID",
-    "detailOccurredAt": "Occurred",
-    "detailActor": "Actor",
-    "detailCategory": "Category",
-    "detailActionLabel": "Action",
-    "detailEventTypeLabel": "Event type",
-    "detailIpLabel": "IP address",
-    "detailResourceLabel": "Resource",
-    "detailResourceIdLabel": "Resource ID",
-    "detailTargetTypeLabel": "Target type",
-    "detailTargetIdLabel": "Target ID",
     "detailAction": "Actie: {value}",
     "detailIp": "IP: {value}",
-    "detailResource": "Resource: {value}",
-    "detailResourceId": "Resource ID: {value}",
-    "deletedBooks": "Deleted books",
-    "deletedBookDetail": "{title} (book #{id})",
-    "untitledBook": "Untitled",
-    "deletedBooksOmitted": "{count, plural, one {# additional book omitted} other {# additional books omitted}}",
     "showing": "{from}-{to} van {total} weergegeven",
     "prev": "Vorige",
     "chips": {
-      "search": "Search: {value}",
       "action": "Actie: {value}",
-      "eventType": "Event type: {value}",
-      "actor": "Actor: {value}",
-      "resource": "Resource: {value}",
-      "targetType": "Target type: {value}",
       "user": "Gebruiker: {value}",
       "from": "Van: {value}",
       "to": "Tot: {value}"
     },
     "filterLabels": {
-      "search": "Search events",
       "action": "Actie",
-      "eventType": "Event type (what happened)",
-      "actor": "Actor",
-      "resource": "Resource",
-      "targetType": "Target type (what was affected)",
       "userId": "Gebruikers-ID",
       "from": "Van",
       "to": "Tot"
     },
     "filterPlaceholders": {
-      "search": "Description, actor, target, or ID",
-      "actor": "Username",
       "action": "bijv. auth.login",
       "userId": "bijv. 1"
     },
     "columns": {
       "when": "Wanneer",
-      "actor": "Actor",
-      "event": "Event",
-      "target": "Target",
-      "impact": "Impact",
       "user": "Gebruiker",
       "action": "Actie",
       "description": "Beschrijving",
       "ip": "IP"
-    },
-    "categories": {
-      "authentication": "Authentication",
-      "books": "Books",
-      "users": "Users",
-      "libraries": "Libraries",
-      "collections": "Collections",
-      "integrations": "Integrations",
-      "settings": "Settings",
-      "other": "Other"
-    },
-    "resourceLabels": {
-      "User": "User",
-      "Library": "Library",
-      "Book": "Book",
-      "Collection": "Collection",
-      "SmartScope": "Smart scope",
-      "BookDockFile": "Book Dock file",
-      "Author": "Author",
-      "AppSettings": "Application settings",
-      "Genre": "Genre",
-      "Tag": "Tag",
-      "KoboDevice": "Kobo device",
-      "EmailProvider": "Email provider",
-      "EmailTemplate": "Email template",
-      "EmailRecipient": "Email recipient",
-      "EmailRecipientGroup": "Email recipient group",
-      "Narrator": "Narrator",
-      "Publisher": "Publisher",
-      "Language": "Language",
-      "Series": "Series",
-      "OidcIdentity": "OIDC identity",
-      "MagicLinkToken": "Magic link",
-      "ReadingInsightsProfile": "Reading insights profile"
-    },
-    "actionLabels": {
-      "AuthRegister": "Register account",
-      "AuthLogin": "Sign in",
-      "AuthLoginFailed": "Failed sign-in",
-      "AuthLogout": "Sign out",
-      "AuthPasswordChange": "Change password",
-      "AuthPasswordResetRequest": "Request password reset",
-      "AuthPasswordReset": "Reset password",
-      "AuthPasswordAdminReset": "Reset user password",
-      "AuthSessionRevoke": "Revoke session",
-      "MagicLinkCreate": "Create magic link",
-      "MagicLinkLogin": "Sign in with magic link",
-      "MagicLinkRevoke": "Revoke magic link",
-      "MagicLinkActivate": "Activate magic link",
-      "MagicLinkDeactivate": "Deactivate magic link",
-      "OidcLogin": "Sign in with OIDC",
-      "OidcUserProvisioned": "Provision OIDC user",
-      "OidcIdentityLinked": "Link OIDC identity",
-      "OidcIdentityUnlinked": "Unlink OIDC identity",
-      "UserCreate": "Create user",
-      "UserUpdate": "Update user",
-      "UserSelfUpdate": "Update own profile",
-      "UserDelete": "Delete user",
-      "UserPermissionSet": "Update user permissions",
-      "UserSuperuserEnable": "Enable superuser access",
-      "UserSuperuserDisable": "Disable superuser access",
-      "UserContentFiltersSet": "Update content filters",
-      "ReadingInsightsSharingUpdate": "Update insight sharing",
-      "ReadingInsightsProfileView": "View shared insights",
-      "LibraryCreate": "Create library",
-      "LibraryUpdate": "Update library",
-      "LibraryDelete": "Delete library",
-      "LibraryFolderAdd": "Add library folder",
-      "LibraryFolderRemove": "Remove library folder",
-      "LibraryAccessGrant": "Grant library access",
-      "LibraryAccessUpdate": "Update library access",
-      "LibraryAccessRevoke": "Revoke library access",
-      "LibraryWriteMetadataToFiles": "Write metadata to files",
-      "LibraryBulkRename": "Rename library files",
-      "BookUpload": "Upload book",
-      "BookMetadataUpdate": "Update book metadata",
-      "BookMetadataLocksUpdate": "Update metadata locks",
-      "BookDelete": "Delete book",
-      "BookBulkMetadataRefresh": "Refresh book metadata",
-      "BookBulkDelete": "Delete books",
-      "BookBulkCoverReextract": "Re-extract book covers",
-      "BookBulkSetStatus": "Set book status",
-      "BookBulkSetRating": "Set book rating",
-      "BookBulkSetMetadata": "Set book metadata",
-      "BookBulkUpdateTags": "Update book tags",
-      "BookBulkSetMetadataLock": "Set metadata locks",
-      "BookBulkEditMetadata": "Edit book metadata",
-      "BookBulkMoveLibrary": "Move books to another library",
-      "BookReadingStateReset": "Reset reading state",
-      "BookWriteAndRename": "Write metadata and rename file",
-      "CollectionCreate": "Create collection",
-      "CollectionUpdate": "Update collection",
-      "CollectionDelete": "Delete collection",
-      "CollectionBooksAdd": "Add books to collection",
-      "CollectionBooksRemove": "Remove books from collection",
-      "SmartScopeCreate": "Create smart scope",
-      "SmartScopeUpdate": "Update smart scope",
-      "SmartScopeDelete": "Delete smart scope",
-      "BookDockFinalize": "Finalize Book Dock file",
-      "AuthorUpdate": "Update author",
-      "AuthorDelete": "Delete author",
-      "AuthorMerge": "Merge authors",
-      "AuthorEnrichmentConfigUpdate": "Update author enrichment",
-      "AuthorEnrichmentPause": "Pause author enrichment",
-      "AuthorEnrichmentResume": "Resume author enrichment",
-      "AuthorEnrichmentCancel": "Cancel author enrichment",
-      "EntityManagerMerge": "Merge entities",
-      "EntityManagerRename": "Rename entity",
-      "EntityManagerDelete": "Delete entity",
-      "EntityManagerSplit": "Split entity",
-      "EntityManagerDismiss": "Dismiss duplicate",
-      "EntityManagerUndismiss": "Restore dismissed duplicate",
-      "AppSettingsUpdate": "Update app settings",
-      "KoboDeviceRegister": "Register Kobo device",
-      "KoboDeviceRename": "Rename Kobo device",
-      "KoboDeviceRemove": "Remove Kobo device",
-      "EmailProviderCreate": "Create email provider",
-      "EmailProviderUpdate": "Update email provider",
-      "EmailProviderDelete": "Delete email provider",
-      "EmailProviderSetDefault": "Set default email provider",
-      "EmailProviderSetSystem": "Set system email provider",
-      "EmailProviderClearSystem": "Clear system email provider",
-      "EmailTemplateCreate": "Create email template",
-      "EmailTemplateUpdate": "Update email template",
-      "EmailTemplateDelete": "Delete email template",
-      "EmailTemplateSetDefault": "Set default email template",
-      "EmailRecipientCreate": "Create email recipient",
-      "EmailRecipientUpdate": "Update email recipient",
-      "EmailRecipientDelete": "Delete email recipient",
-      "EmailRecipientGroupCreate": "Create recipient group",
-      "EmailRecipientGroupUpdate": "Update recipient group",
-      "EmailRecipientGroupDelete": "Delete recipient group",
-      "EmailRecipientGroupMemberAdd": "Add recipient to group",
-      "EmailRecipientGroupMemberRemove": "Remove recipient from group"
     }
   },
   "auth": {
@@ -3254,31 +2912,6 @@
       "moveDown": "Omlaag verplaatsen",
       "ascending": "Oplopend",
       "descending": "Aflopend",
-      "fields": {
-        "author": "Author",
-        "title": "Title",
-        "series": "Series",
-        "seriesIndex": "Series #",
-        "addedAt": "Date Added",
-        "updatedAt": "Date Updated",
-        "publishedDate": "Published Date",
-        "publishedYear": "Published Year",
-        "pageCount": "Page Count",
-        "rating": "Rating",
-        "publisher": "Publisher",
-        "fileSize": "File Size",
-        "readProgress": "Read Progress",
-        "readStatus": "Read Status",
-        "format": "Format",
-        "lastReadAt": "Last Read",
-        "startedAt": "Date Started",
-        "finishedAt": "Date Finished",
-        "random": "Random",
-        "language": "Language",
-        "metadataScore": "Metadata Score"
-      },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "remove": "Verwijderen",
       "emptyState": "Geen sortering ingesteld. Titel oplopend wordt gebruikt.",
       "addLevel": "Sorteerniveau toevoegen"
@@ -3288,69 +2921,6 @@
       "all": "ALLE",
       "any": "ELKE",
       "ofFollowingRules": "van de volgende regels",
-      "fields": {
-        "title": "Title",
-        "publisher": "Publisher",
-        "language": "Language",
-        "series": "Series",
-        "seriesIndex": "Series Index",
-        "publishedDate": "Published Date",
-        "publishedYear": "Published Year",
-        "pageCount": "Page Count",
-        "author": "Author",
-        "genre": "Genre",
-        "tag": "Tag",
-        "collection": "Collection",
-        "library": "Library",
-        "format": "Format",
-        "addedAt": "Added Date",
-        "startedAt": "Date Started",
-        "finishedAt": "Date Finished",
-        "fileAvailability": "File Availability",
-        "rating": "Rating",
-        "communityRating": "Community Rating",
-        "readProgress": "Reading Progress",
-        "readStatus": "Read Status",
-        "description": "Description",
-        "isbn": "ISBN",
-        "metadataScore": "Metadata Score",
-        "cover": "Cover",
-        "lockStatus": "Lock Status",
-        "seriesStatus": "Series Status"
-      },
-      "operators": {
-        "contains": "contains",
-        "notContains": "does not contain",
-        "startsWith": "starts with",
-        "endsWith": "ends with",
-        "eq": "is",
-        "notEq": "is not",
-        "isEmpty": "is empty",
-        "isNotEmpty": "is not empty",
-        "gt": "greater than",
-        "gte": "at least",
-        "lt": "less than",
-        "lte": "at most",
-        "between": "between",
-        "includesAny": "includes any of",
-        "includesAll": "includes all of",
-        "excludesAll": "excludes all of",
-        "before": "before",
-        "after": "after",
-        "withinLast": "within last",
-        "isMissing": "is missing",
-        "isPresent": "is present",
-        "isUnread": "is unread",
-        "isInProgress": "is in progress",
-        "isFinished": "is finished",
-        "isLocked": "is locked",
-        "isUnlocked": "is unlocked",
-        "isUpNext": "is up next",
-        "isTrue": "is yes",
-        "isFalse": "is no"
-      },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Elke aanbieder",
       "communityRatingProvider": "Aanbieder van communitybeoordeling",
       "loadingLibraries": "Bibliotheken laden...",
@@ -3482,9 +3052,7 @@
     },
     "jumpRail": {
       "jumpToSection": "Naar sectie springen",
-      "jumpTo": "Naar {label} springen",
-      "unknownDate": "Unknown date",
-      "unknownValue": "Unknown value"
+      "jumpTo": "Naar {label} springen"
     },
     "quickView": {
       "title": "Snelweergave boek",
@@ -4095,11 +3663,7 @@
         "seriesPlaceholder": "Reeks",
         "moveUp": "Omhoog",
         "moveDown": "Omlaag",
-        "removeSeries": "Reeks verwijderen",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Reeks verwijderen"
       }
     },
     "table": {
@@ -4179,69 +3743,6 @@
       },
       "text": {
         "openDetails": "Details openen"
-      }
-    },
-    "move": {
-      "title": "{count, plural, one {Move # book} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
-      "folderCount": "{count, plural, one {# folder} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
-      "confirm": "{count, plural, one {Move # book} other {Move # books}}",
-      "action": "Move to library",
-      "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
       }
     }
   },
@@ -4527,9 +4028,7 @@
         "title": "Vind je BookOrbit leuk?",
         "body": "Als BookOrbit je helpt met je bibliotheek, overweeg dan om het project een ster te geven op GitHub. Het helpt meer mensen de app te ontdekken en ondersteunt de doorlopende ontwikkeling.",
         "cta": "Geef BookOrbit een ster op GitHub"
-      },
-      "surfaceOpacity": "Surface opacity",
-      "surfaceOpacityValue": "{value}%"
+      }
     },
     "sidebar": {
       "dashboard": "Dashboard",
@@ -4550,36 +4049,8 @@
       "supportAria": "BookOrbit ondersteunen op Ko-fi",
       "sectionHeader": {
         "add": "Toevoegen",
-        "showAll": "Show all",
-        "showCount": "Show {count}",
-        "rowsShown": "Rows shown",
-        "menuAria": "Section options for {section}",
         "reorder": "Herschikken",
         "doneReordering": "Klaar met herschikken"
-      },
-      "noLibraries": "No libraries yet",
-      "clearFilter": "Clear filter",
-      "filterSummary": "{shown} of {total} shown",
-      "filterLibraries": "Filter libraries",
-      "filterLibrariesPlaceholder": "Filter libraries...",
-      "filterSmartScopes": "Filter smart scopes",
-      "filterSmartScopesPlaceholder": "Filter smart scopes...",
-      "filterCollections": "Filter collections",
-      "filterCollectionsPlaceholder": "Filter collections...",
-      "seeAllLibraries": "See all libraries ({count})",
-      "seeAllSmartScopes": "See all smart scopes ({count})",
-      "seeAllCollections": "See all collections ({count})",
-      "updateAvailable": "Update {version}",
-      "zones": {
-        "browse": "Browse"
-      },
-      "reorder": {
-        "gripAria": "Reorder {name}",
-        "lifted": "{name} lifted, position {position} of {total}. Use the arrow keys to move it.",
-        "moved": "{name}, position {position} of {total}",
-        "dropped": "{name} dropped at position {position} of {total}",
-        "cancelled": "Reorder cancelled. {name} returned to position {position} of {total}.",
-        "filteredHint": "Clear the filter to reorder"
       }
     },
     "selectionActionBar": {
@@ -4635,7 +4106,6 @@
         "display": "Weergave",
         "coverSize": "Omslaggrootte",
         "gridGap": "Rasterafstand",
-        "showJumpRails": "Show jump rails",
         "columnsHint": "Gebruik het paneel voor kolomzichtbaarheid in de tabelkop om kolommen te tonen of te verbergen.",
         "coverShape": "Omslagvorm",
         "circle": "Cirkel",
@@ -4662,8 +4132,7 @@
     },
     "themePicker": {
       "light": "Licht",
-      "dark": "Donker",
-      "system": "System"
+      "dark": "Donker"
     },
     "userAvatar": {
       "profilePicture": "Profielfoto",
@@ -4679,24 +4148,6 @@
         "typeAndEnter": "Typ en druk op Enter om toe te voegen",
         "pressEnter": "Druk op Enter om toe te voegen"
       }
-    },
-    "entityIndex": {
-      "sortBy": "Sort by",
-      "sort": {
-        "custom": "Custom order",
-        "name": "Name",
-        "bookCount": "Book count"
-      },
-      "ascending": "Ascending",
-      "descending": "Descending",
-      "clearSearch": "Clear search",
-      "resultCount": "{shown} of {total}",
-      "noMatches": "No matches",
-      "noMatchesHint": "Try a different search term.",
-      "bookCount": "Books: {count}",
-      "librariesEmptyHint": "Create a library to start adding books.",
-      "smartScopesEmptyHint": "Smart scopes save a set of filters you use often.",
-      "collectionsEmptyHint": "Collections group books you pick by hand."
     }
   },
   "customIcons": {
@@ -4752,37 +4203,6 @@
       "tabs": {
         "widgets": "Widgets",
         "shelves": "Planken"
-      },
-      "widgetNames": {
-        "readingStreak": "Reading Streak",
-        "currentlyReading": "Currently Reading",
-        "readingGoal": "Reading Goal",
-        "readingDna": "Reading DNA",
-        "monthlyChallenge": "Monthly Challenge",
-        "highlightOfTheDay": "Highlight of the Day",
-        "neglectedGems": "Neglected Gems",
-        "readingRhythm": "Reading Rhythm",
-        "diversityScore": "Diversity Score",
-        "libraryOverview": "Library Overview",
-        "yearProjection": "Year Projection",
-        "longWait": "The Long Wait"
-      },
-      "shelfNames": {
-        "recentlyAdded": "Recently Added",
-        "continueReading": "Continue Reading",
-        "continueListening": "Continue Listening",
-        "wantToRead": "Want to Read",
-        "upNextInSeries": "Up Next in Series",
-        "random": "Discover Something New",
-        "smartScope": "Smart Scope"
-      },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
       },
       "reorderHintWidget": "Sleep om te herordenen. Schakel in of uit om een widget te tonen of verbergen.",
       "reorderHintShelf": "Sleep om te herordenen. Schakel in of uit om een plank te tonen of verbergen.",
@@ -5398,11 +4818,6 @@
           "hint": "Schrijft metadata naar het OPF-bestand in het EPUB-archief.",
           "toggleAria": "EPUB-metadata schrijven"
         },
-        "fb2": {
-          "title": "FictionBook (FB2)",
-          "hint": "Rewrites the description block inside FB2 files, leaving the book text untouched.",
-          "toggleAria": "Write FB2 metadata"
-        },
         "pdf": {
           "title": "PDF",
           "hint": "Sluit metadata in de PDF Info-dictionary en XMP-stream in.",
@@ -5412,11 +4827,6 @@
           "title": "Striparchieven (CBX)",
           "hint": "Schrijft ComicInfo.xml naar CBZ- en CB7-archieven.",
           "toggleAria": "Metadata naar striparchieven schrijven"
-        },
-        "kindle": {
-          "title": "Kindle (MOBI, AZW3)",
-          "hint": "Writes metadata into the EXTH header of MOBI, AZW3, and AZW files.",
-          "toggleAria": "Write Kindle metadata"
         },
         "audio": {
           "title": "Audio",
@@ -5856,61 +5266,7 @@
       "saveFailed": "Opslaan van voorkeuren mislukt",
       "savePreferenceFailed": "Opslaan van voorkeur mislukt",
       "whatsNewToggle": "\"Wat is er nieuw\" tonen na updates",
-      "whatsNewToggleHint": "Een popup die nieuwe functies benadrukt nadat de app is bijgewerkt. Het archief blijft hoe dan ook beschikbaar.",
-      "groups": {
-        "library": "Library",
-        "files": "Files",
-        "integrations": "Integrations",
-        "personal": "Personal",
-        "app": "App updates"
-      },
-      "enabledCount": "{enabled} of {total} enabled",
-      "categories": {
-        "scanning": {
-          "label": "Library scanning",
-          "description": "When a library scan finishes, fails, or finds missing books."
-        },
-        "metadata": {
-          "label": "Metadata fetching",
-          "description": "When metadata lookups for your books complete or fail."
-        },
-        "authorEnrichment": {
-          "label": "Author enrichment",
-          "description": "When author biographies and photos finish being fetched."
-        },
-        "fileWriteBack": {
-          "label": "File write-back",
-          "description": "When edited metadata is written back into book files on disk."
-        },
-        "fileRename": {
-          "label": "File rename",
-          "description": "When a single book file is renamed to match your naming pattern."
-        },
-        "bulkRename": {
-          "label": "Bulk rename",
-          "description": "When a bulk rename across many books completes or fails."
-        },
-        "migration": {
-          "label": "Data migration",
-          "description": "When an import from another library tool completes or fails."
-        },
-        "bookDock": {
-          "label": "Book Dock",
-          "description": "When files dropped into the dock are ready to review or finalized."
-        },
-        "koboSync": {
-          "label": "Kobo sync",
-          "description": "When a Kobo device finishes syncing with your library."
-        },
-        "email": {
-          "label": "Email delivery",
-          "description": "When sending a book to an email address succeeds or fails."
-        },
-        "achievements": {
-          "label": "Achievements",
-          "description": "When you unlock a new reading achievement."
-        }
-      }
+      "whatsNewToggleHint": "Een popup die nieuwe functies benadrukt nadat de app is bijgewerkt. Het archief blijft hoe dan ook beschikbaar."
     }
   },
   "reader": {
@@ -5956,67 +5312,22 @@
     "settings": {
       "title": "Instellingen",
       "ariaLabel": "Lezerinstellingen",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Licht",
         "dark": "Donker"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Ingebouwd",
-      "fontServer": "Server fonts",
       "fontYours": "Jouw lettertypen",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Leesstroom",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Paginaspreads",
       "pageSpreadsHint": "Kies hoe deze op afbeeldingen gebaseerde EPUB pagina's koppelt.",
       "spread": {
         "bookDefault": "Standaard van boek",
         "singlePage": "Enkele pagina"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Kolomtussenruimte",
       "justifyText": "Tekst uitvullen",
-      "hyphenation": "Woordafbreking",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Woordafbreking"
     },
     "search": {
       "placeholder": "Zoeken in boek (min. {min} tekens)...",
@@ -6111,12 +5422,7 @@
       "scrollModeHint": "Gebruik \"Geen tussenruimte\" voor webtoons en verticale stroken.",
       "readingDirection": "Leesrichting",
       "pageView": "Paginaweergave",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Spreaduitlijning",
-      "spreadGap": "Spread gap",
-      "spreadGapValue": "{value}px",
       "forceTwoPage": "Twee pagina's forceren",
       "widePages": "Brede pagina's",
       "firstPage": "Eerste pagina",
@@ -6188,10 +5494,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} van {total} gelezen ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Mogelijke hiaten:"
@@ -6270,8 +5572,6 @@
   "smartScope": {
     "syncToKobo": "Synchroniseren met Kobo",
     "syncToKoboHint": "Boeken die aan dit bereik voldoen, verschijnen op uw Kobo-apparaat",
-    "visibleToAll": "Visible to all users",
-    "visibleToAllHint": "Every user can see and use this smart scope",
     "dialog": {
       "name": "Naam",
       "namePlaceholder": "bijv. Ongelezen sci-fi",
@@ -6497,8 +5797,7 @@
   "tools": {
     "header": {
       "entityManager": "Entiteitenbeheer",
-      "bulkRename": "Bulk hernoemen",
-      "duplicateBooks": "Duplicate Books"
+      "bulkRename": "Bulk hernoemen"
     },
     "entityTypes": {
       "authors": "Auteurs",
@@ -6510,8 +5809,6 @@
       "series": "Reeksen"
     },
     "bulkRename": {
-      "previewToolbar": "Rename preview",
-      "renameSettings": "Rename settings",
       "library": "Bibliotheek",
       "selectLibraryPlaceholder": "Selecteer een bibliotheek...",
       "noEligibleLibraries": "Geen bibliotheken hebben bestand hernoemen ingeschakeld. Schakel het in bij Bibliotheekinstellingen.",
@@ -6566,84 +5863,11 @@
       }
     },
     "bookDuplicates": {
-      "scanSettings": "Scan settings",
-      "title": "Duplicate Books",
-      "description": "Scan files and metadata for potential duplicate records. Nothing is deleted during a scan.",
-      "scope": "Library scope",
-      "allLibraries": "All accessible libraries",
-      "similarity": "Similar-title threshold",
-      "explainSimilarity": "Explain the similar-title threshold",
-      "similarityHelp": "Only for Similar title and author matches. At least one author and the book type must also match. Lower finds more possible duplicates; higher requires closer titles. Identical files, ISBN, and exact metadata are checked separately.",
-      "runScan": "Run scan",
-      "rescan": "Rescan",
-      "status": {
-        "queued": "Scan queued",
-        "running": "Scanning books"
-      },
       "groupsFound": "{count, plural, =0 {No duplicate groups} one {One duplicate group} other {# duplicate groups}}",
-      "filter": "Match type",
-      "allReasons": "All match types",
-      "reasons": {
-        "file_hash": "Identical file set",
-        "isbn": "Same ISBN",
-        "exact_metadata": "Exact title and authors",
-        "fuzzy_metadata": "Similar title and author"
-      },
-      "similarityValue": "{percent}% title similarity",
-      "notDuplicates": "Not duplicates",
-      "keepThis": "Keep this book",
-      "discardThis": "Discard this book",
-      "selectKeeperFirst": "Select a keeper first",
-      "noDirectMatch": "No direct match with keeper",
-      "moreFiles": "+{count} more",
-      "showDetails": "Show details",
-      "hideDetails": "Hide details",
-      "deleteSelected": "Delete {count} selected",
-      "openBook": "Open details for {title}",
-      "unknownAuthor": "Unknown author",
-      "unknown": "Unknown",
-      "none": "None",
-      "accessDenied": "You do not have permission to use the duplicate book tool.",
-      "pairDetails": "Match details",
-      "pairLabel": "{first} and {second}",
-      "fields": {
-        "library": "Library",
-        "isbn": "ISBN",
-        "formats": "Formats",
-        "fileLocation": "File",
-        "files": "Files",
-        "readingStatus": "Reading status",
-        "progress": "Progress",
-        "path": "Library path",
-        "collections": "Collections",
-        "added": "Added",
-        "updated": "Updated"
-      },
-      "initial": {
-        "title": "Find duplicate books",
-        "description": "Choose a library scope and similarity level, then run a scan. No books are changed until you explicitly confirm a deletion."
-      },
-      "empty": {
-        "title": "No duplicate groups found",
-        "description": "No books matched the current scope, similarity level, and match filter."
-      },
       "deleteDialog": {
-        "title": "Permanently delete duplicate books?",
         "description": "{count, plural, =0 {This will permanently delete # selected book and its files.} one {This will permanently delete # selected book and its files.} other {This will permanently delete # selected books and their files.}}",
-        "warning": "Metadata, collections, reading data, and device state are not transferred to the kept book. Associated data for other users is also removed.",
         "confirm": "{count, plural, =0 {Delete # book} one {Delete # book} other {Delete # books}}",
         "success": "{count, plural, =0 {No books deleted} one {One duplicate book deleted} other {# duplicate books deleted}}"
-      },
-      "errors": {
-        "start": "Could not start the duplicate scan.",
-        "status": "Could not load scan progress.",
-        "scan": "The duplicate scan failed. Try running it again.",
-        "results": "Could not load duplicate groups.",
-        "delete": "Could not delete the selected duplicate books."
-      },
-      "pagination": {
-        "label": "Duplicate groups pages",
-        "page": "Page {page} of {total}"
       }
     },
     "entityManager": {
@@ -6873,11 +6097,6 @@
       "defaultName": "Smart scope",
       "filter": "Filter",
       "edit": "Smart Scope bewerken",
-      "koboSync": {
-        "label": "Sync to my Kobo",
-        "enabledHint": "Books in this shared Smart Scope sync to your Kobo device. Turn off to stop syncing them.",
-        "disabledHint": "Turn on to sync books in this shared Smart Scope to your Kobo device."
-      },
       "showControlsAria": "Smart Scope-bediening tonen",
       "hideFilter": "Filter verbergen",
       "showFilter": "Filter tonen",
@@ -6885,10 +6104,7 @@
       "loadError": "Kan deze SmartScope niet laden",
       "toast": {
         "deleted": "\"{name}\" verwijderd",
-        "deleteFailed": "Verwijderen van \"{name}\" mislukt",
-        "koboSyncEnabled": "\"{name}\" now syncs to your Kobo",
-        "koboSyncDisabled": "\"{name}\" no longer syncs to your Kobo",
-        "koboSyncFailed": "Failed to update Kobo sync for \"{name}\""
+        "deleteFailed": "Verwijderen van \"{name}\" mislukt"
       },
       "empty": {
         "noRules": "Geen regels ingesteld",
@@ -6945,7 +6161,6 @@
     "series": "Reeksen",
     "entityManager": "Entiteitenbeheer",
     "bulkRename": "Bulksgewijs hernoemen",
-    "duplicateBooks": "Duplicate Books",
     "notFound": "Niet gevonden",
     "signIn": "Inloggen",
     "initialSetup": "Eerste installatie",
@@ -6997,8 +6212,7 @@
       "users": "Gebruikers",
       "account-activity": "Accountactiviteit",
       "magic-links": "Magische links",
-      "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / SSO"
     },
     "system": {
       "file-naming": "Bestandsnaamgeving",
@@ -7011,8 +6225,6 @@
       "privacy": "Privacy en delen",
       "notifications": "Meldingen",
       "restrictions": "Inhoudsbeperkingen"
-    },
-    "smartScopes": "Smart Scopes",
-    "collections": "Collections"
+    }
   }
 }

--- a/client/src/locales/pl.json
+++ b/client/src/locales/pl.json
@@ -1133,15 +1133,7 @@
         "users": "Użytkownicy",
         "account-activity": "Aktywność konta",
         "magic-links": "Magiczne linki",
-        "oidc": "OIDC / Jednokrotne logowanie",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC / Jednokrotne logowanie"
       }
     },
     "common": {
@@ -1676,12 +1668,7 @@
         "deleteFamilyFailed": "Nie udało się usunąć rodziny czcionek",
         "demoCannotManage": "Konto z ograniczeniami demo nie może zarządzać czcionkami",
         "fileAdded": "Dodano „{name}”.",
-        "uploadFailed": "Przesyłanie nie powiodło się",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Przesyłanie nie powiodło się"
       },
       "bookDock": {
         "title": "Book Dock",
@@ -2886,7 +2873,6 @@
       "BookBulkUpdateTags": "Zaktualizuj tagi książek",
       "BookBulkSetMetadataLock": "Ustaw blokady metadanych",
       "BookBulkEditMetadata": "Edytuj metadane książki",
-      "BookBulkMoveLibrary": "Move books to another library",
       "BookReadingStateReset": "Zresetuj stan odczytu",
       "BookWriteAndRename": "Zapisz metadane i zmień nazwę pliku",
       "CollectionCreate": "Utwórz kolekcję",
@@ -3254,31 +3240,6 @@
       "moveDown": "Przesuń w dół",
       "ascending": "Rosnąco",
       "descending": "Malejąco",
-      "fields": {
-        "author": "Author",
-        "title": "Title",
-        "series": "Series",
-        "seriesIndex": "Series #",
-        "addedAt": "Date Added",
-        "updatedAt": "Date Updated",
-        "publishedDate": "Published Date",
-        "publishedYear": "Published Year",
-        "pageCount": "Page Count",
-        "rating": "Rating",
-        "publisher": "Publisher",
-        "fileSize": "File Size",
-        "readProgress": "Read Progress",
-        "readStatus": "Read Status",
-        "format": "Format",
-        "lastReadAt": "Last Read",
-        "startedAt": "Date Started",
-        "finishedAt": "Date Finished",
-        "random": "Random",
-        "language": "Language",
-        "metadataScore": "Metadata Score"
-      },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "remove": "Usuń",
       "emptyState": "Nie skonfigurowano sortowania. Tytuł będzie używany w kolejności rosnącej.",
       "addLevel": "Dodaj poziom sortowania"
@@ -3289,68 +3250,8 @@
       "any": "KAŻDY",
       "ofFollowingRules": "poniższych zasad",
       "fields": {
-        "title": "Title",
-        "publisher": "Publisher",
-        "language": "Language",
-        "series": "Series",
-        "seriesIndex": "Series Index",
-        "publishedDate": "Published Date",
-        "publishedYear": "Published Year",
-        "pageCount": "Page Count",
-        "author": "Author",
-        "genre": "Genre",
-        "tag": "Tag",
-        "collection": "Collection",
-        "library": "Library",
-        "format": "Format",
-        "addedAt": "Added Date",
-        "startedAt": "Date Started",
-        "finishedAt": "Date Finished",
-        "fileAvailability": "File Availability",
-        "rating": "Rating",
-        "communityRating": "Community Rating",
-        "readProgress": "Reading Progress",
-        "readStatus": "Read Status",
-        "description": "Description",
-        "isbn": "ISBN",
-        "metadataScore": "Metadata Score",
-        "cover": "Cover",
-        "lockStatus": "Lock Status",
-        "seriesStatus": "Series Status"
+        "series": "Seria"
       },
-      "operators": {
-        "contains": "contains",
-        "notContains": "does not contain",
-        "startsWith": "starts with",
-        "endsWith": "ends with",
-        "eq": "is",
-        "notEq": "is not",
-        "isEmpty": "is empty",
-        "isNotEmpty": "is not empty",
-        "gt": "greater than",
-        "gte": "at least",
-        "lt": "less than",
-        "lte": "at most",
-        "between": "between",
-        "includesAny": "includes any of",
-        "includesAll": "includes all of",
-        "excludesAll": "excludes all of",
-        "before": "before",
-        "after": "after",
-        "withinLast": "within last",
-        "isMissing": "is missing",
-        "isPresent": "is present",
-        "isUnread": "is unread",
-        "isInProgress": "is in progress",
-        "isFinished": "is finished",
-        "isLocked": "is locked",
-        "isUnlocked": "is unlocked",
-        "isUpNext": "is up next",
-        "isTrue": "is yes",
-        "isFalse": "is no"
-      },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Dowolny dostawca",
       "communityRatingProvider": "Dostawca ocen społecznościowych",
       "loadingLibraries": "Ładowanie bibliotek...",
@@ -4095,11 +3996,7 @@
         "seriesPlaceholder": "Seria",
         "moveUp": "Przesuń się w górę",
         "moveDown": "Przesuń w dół",
-        "removeSeries": "Usuń serię",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Usuń serię"
       }
     },
     "table": {
@@ -4183,65 +4080,10 @@
     },
     "move": {
       "title": "{count, plural, one {Move # book} few {Move # books} many {Move # books} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
       "folderCount": "{count, plural, one {# folder} few {# folders} many {# folders} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
       "confirm": "{count, plural, one {Move # book} few {Move # books} many {Move # books} other {Move # books}}",
-      "action": "Move to library",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} few {# name conflicts} many {# name conflicts} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "collisions": "{count, plural, one {# name conflict} few {# name conflicts} many {# name conflicts} other {# name conflicts}}"
       }
     }
   },
@@ -4752,37 +4594,6 @@
       "tabs": {
         "widgets": "Widżety",
         "shelves": "Półki"
-      },
-      "widgetNames": {
-        "readingStreak": "Reading Streak",
-        "currentlyReading": "Currently Reading",
-        "readingGoal": "Reading Goal",
-        "readingDna": "Reading DNA",
-        "monthlyChallenge": "Monthly Challenge",
-        "highlightOfTheDay": "Highlight of the Day",
-        "neglectedGems": "Neglected Gems",
-        "readingRhythm": "Reading Rhythm",
-        "diversityScore": "Diversity Score",
-        "libraryOverview": "Library Overview",
-        "yearProjection": "Year Projection",
-        "longWait": "The Long Wait"
-      },
-      "shelfNames": {
-        "recentlyAdded": "Recently Added",
-        "continueReading": "Continue Reading",
-        "continueListening": "Continue Listening",
-        "wantToRead": "Want to Read",
-        "upNextInSeries": "Up Next in Series",
-        "random": "Discover Something New",
-        "smartScope": "Smart Scope"
-      },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
       },
       "reorderHintWidget": "Przeciągnij, aby zmienić kolejność. Przełącz, aby pokazać lub ukryć widżet.",
       "reorderHintShelf": "Przeciągnij, aby zmienić kolejność. Przełącz, aby pokazać lub ukryć półkę.",
@@ -5956,67 +5767,22 @@
     "settings": {
       "title": "Ustawienia",
       "ariaLabel": "Ustawienia czytnika",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Światło",
         "dark": "Ciemny"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Wbudowany",
-      "fontServer": "Server fonts",
       "fontYours": "Twoje czcionki",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Czytanie",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Strona się rozprzestrzenia",
       "pageSpreadsHint": "Wybierz sposób, w jaki ten oparty na obrazie EPUB łączy strony w pary.",
       "spread": {
         "bookDefault": "Książka domyślna",
         "singlePage": "Pojedyncza strona"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Szczelina kolumny",
       "justifyText": "Justuj tekst",
-      "hyphenation": "Dzielenie wyrazów",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Dzielenie wyrazów"
     },
     "search": {
       "placeholder": "Szukaj w książce (min. {min} znaków)...",
@@ -6111,9 +5877,6 @@
       "scrollModeHint": "W przypadku webtoonów i pasków pionowych użyj opcji „Bez przerw”.",
       "readingDirection": "Kierunek czytania",
       "pageView": "Widok strony",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Wyrównanie rozprzestrzeniania się",
       "spreadGap": "Rozłóż lukę",
       "spreadGapValue": "{value}px",
@@ -6188,10 +5951,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} z {total} przeczytane ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Możliwe luki:"
@@ -6270,8 +6029,6 @@
   "smartScope": {
     "syncToKobo": "Synchronizuj z Kobo",
     "syncToKoboHint": "Książki pasujące do tego zakresu pojawią się na Twoim urządzeniu Kobo",
-    "visibleToAll": "Visible to all users",
-    "visibleToAllHint": "Every user can see and use this smart scope",
     "dialog": {
       "name": "Imię",
       "namePlaceholder": "np. Nieprzeczytane science-fiction",
@@ -6873,11 +6630,6 @@
       "defaultName": "Inteligentny zakres",
       "filter": "Filtruj",
       "edit": "Edytuj inteligentny zakres",
-      "koboSync": {
-        "label": "Sync to my Kobo",
-        "enabledHint": "Books in this shared Smart Scope sync to your Kobo device. Turn off to stop syncing them.",
-        "disabledHint": "Turn on to sync books in this shared Smart Scope to your Kobo device."
-      },
       "showControlsAria": "Pokaż elementy sterujące inteligentnego zakresu",
       "hideFilter": "Ukryj filtr",
       "showFilter": "Pokaż filtr",
@@ -6885,10 +6637,7 @@
       "loadError": "Nie można załadować tego SmartScope",
       "toast": {
         "deleted": "„{name}” usunięty",
-        "deleteFailed": "Nie udało się usunąć „{name}”",
-        "koboSyncEnabled": "\"{name}\" now syncs to your Kobo",
-        "koboSyncDisabled": "\"{name}\" no longer syncs to your Kobo",
-        "koboSyncFailed": "Failed to update Kobo sync for \"{name}\""
+        "deleteFailed": "Nie udało się usunąć „{name}”"
       },
       "empty": {
         "noRules": "Nie skonfigurowano żadnych reguł",
@@ -6997,8 +6746,7 @@
       "users": "Użytkownicy",
       "account-activity": "Aktywność konta",
       "magic-links": "Magiczne linki",
-      "oidc": "OIDC / Jednokrotne logowanie",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / Jednokrotne logowanie"
     },
     "system": {
       "file-naming": "Nazewnictwo plików",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -1133,15 +1133,7 @@
         "users": "Usuários",
         "account-activity": "Atividade da Conta",
         "magic-links": "Links Mágicos",
-        "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC / SSO"
       }
     },
     "common": {
@@ -1676,12 +1668,7 @@
         "deleteFamilyFailed": "Falha ao excluir família de fontes",
         "demoCannotManage": "A conta restrita de demonstração não pode gerenciar fontes",
         "fileAdded": "\"{name}\" adicionada",
-        "uploadFailed": "Falha no envio",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Falha no envio"
       },
       "bookDock": {
         "title": "Doca de Livros (Book Dock)",
@@ -2886,7 +2873,6 @@
       "BookBulkUpdateTags": "Atualizar tags do livro",
       "BookBulkSetMetadataLock": "Definir bloqueios de metadados",
       "BookBulkEditMetadata": "Editar metadados do livro",
-      "BookBulkMoveLibrary": "Move books to another library",
       "BookReadingStateReset": "Redefinir estado de leitura",
       "BookWriteAndRename": "Escrever metadados e renomear arquivo",
       "CollectionCreate": "Criar nova coleção",
@@ -3345,12 +3331,8 @@
         "isFinished": "está finalizado",
         "isLocked": "está bloqueado",
         "isUnlocked": "está desbloqueado",
-        "isUpNext": "é a próxima",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isUpNext": "é a próxima"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Qualquer provedor",
       "communityRatingProvider": "Provedor de avaliação da comunidade",
       "loadingLibraries": "Carregando bibliotecas...",
@@ -4095,11 +4077,7 @@
         "seriesPlaceholder": "Série",
         "moveUp": "Mover para cima",
         "moveDown": "Mover para baixo",
-        "removeSeries": "Remover série",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Remover série"
       }
     },
     "table": {
@@ -4183,65 +4161,10 @@
     },
     "move": {
       "title": "{count, plural, one {Move # book} many {Move # books} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
       "folderCount": "{count, plural, one {# folder} many {# folders} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
       "confirm": "{count, plural, one {Move # book} many {Move # books} other {Move # books}}",
-      "action": "Move to library",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} many {# name conflicts} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "collisions": "{count, plural, one {# name conflict} many {# name conflicts} other {# name conflicts}}"
       }
     }
   },
@@ -4775,14 +4698,6 @@
         "upNextInSeries": "A Seguir na série",
         "random": "Descubra algo novo",
         "smartScope": "Escopo inteligente"
-      },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
       },
       "reorderHintWidget": "Arraste para reordenar. Alterne para mostrar ou ocultar um widget.",
       "reorderHintShelf": "Arraste para reordenar. Alterne para mostrar ou ocultar uma prateleira.",
@@ -5956,67 +5871,22 @@
     "settings": {
       "title": "Configurações",
       "ariaLabel": "Configurações do Leitor",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Claro",
         "dark": "Escuro"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Internas",
-      "fontServer": "Server fonts",
       "fontYours": "Suas fontes",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Fluxo de leitura",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Disposição das páginas",
       "pageSpreadsHint": "Escolha como esse EPUB baseado em imagem emparelha as páginas.",
       "spread": {
         "bookDefault": "Padrão do livro",
         "singlePage": "Página única"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Espaçamento das colunas",
       "justifyText": "Justificar texto",
-      "hyphenation": "Hifenização",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Hifenização"
     },
     "search": {
       "placeholder": "Buscar no livro (mín. de {min} letras)...",
@@ -6111,9 +5981,6 @@
       "scrollModeHint": "Use \"Sem lacunas\" para webtoons e tiras verticais.",
       "readingDirection": "Direção de leitura",
       "pageView": "Visualização da página",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Alinhamento das páginas",
       "spreadGap": "Espalhar espaço",
       "spreadGapValue": "{value}px",
@@ -6188,10 +6055,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} de {total} lido(s) ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Possíveis lacunas:"
@@ -6997,8 +6860,7 @@
       "users": "Usuários",
       "account-activity": "Atividade da Conta",
       "magic-links": "Links Mágicos",
-      "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / SSO"
     },
     "system": {
       "file-naming": "Nomeação de Arquivos",

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -168,8 +168,7 @@
           "blush": "Смешать"
         },
         "accentColor": {
-          "label": "Цвет акцента",
-          "hint": "Controls highlights and interactive elements"
+          "label": "Цвет акцента"
         },
         "cornerRadius": {
           "label": "Corner radius",
@@ -715,7 +714,6 @@
       },
       "groupMappings": {
         "title": "Сопоставления групп",
-        "description": "Map OIDC group claims to BookOrbit permissions. Synced on every login.",
         "noPermission": "Нет разрешения",
         "empty": "Привязки групп не настроены.",
         "addMapping": "Добавить сопоставление",
@@ -757,14 +755,11 @@
         "recommendationsGroup": "Рекомендации",
         "achievementsGroup": "Достижения",
         "updatesGroup": "Обновления",
-        "importFromBooklore": "Import from Booklore",
         "bookloreImportConfigured": "Буккорный импорт настроен",
         "migrationRunning": "Миграция запущена",
         "migrationCompleted": "Миграция завершена",
         "migrationFailed": "Сбой миграции",
-        "importDescription": "One-time import of books, metadata, and reading progress from a previous Booklore installation.",
         "configuredDescription": "Источник: {name}. Переход пока не запущен - продолжайте установку для импорта.",
-        "runningDescription": "Stage: {stage} - started {started}",
         "completedDescription": "От {name} - завершено {date}",
         "migrationErrorGeneric": "Произошла ошибка во время миграции.",
         "stageInitializing": "инициализация",
@@ -851,9 +846,7 @@
         "errorLoadSuggestions": "Не удалось загрузить пользовательское сопоставление предложений",
         "requiredFields": "Требуется имя хоста, пользователя, базы данных и хоста",
         "connectionTestPassedWithWarnings": "Проверка соединения пройдена с предупреждениями",
-        "connectionTestPassedWithCount": "Connection test passed with {count} warning(s). First: {first}",
         "connectionTestPassed": "Проверка соединения пройдена",
-        "connectionOkMissingTables": "Connection ok, but {count} required table(s) are missing",
         "cannotTestMediaPathActiveRun": "Невозможно протестировать путь к медиафайлу, пока запуск активен",
         "mediaRootPathRequiredCover": "Для импортирования необходим корневой путь к файлу.",
         "useAbsolutePath": "Используйте абсолютный путь (например: /books).",
@@ -862,7 +855,6 @@
         "mediaPathValidationFailed": "Ошибка проверки пути к файлу.",
         "connectionFailedBeforeMediaPath": "Проверка соединения не удалась, прежде чем проверка пути к медиафайлу будет завершена.",
         "cannotModifySourceActiveRun": "Невозможно изменить источник, пока запуск активен",
-        "sourceSavedValidatedWarnings": "Source saved and validated with {count} warning(s)",
         "sourceSavedValidated": "Источник сохранен и проверен",
         "errorSaveValidateSource": "Не удалось сохранить или проверить источник",
         "cannotSaveMappingsActiveRun": "Невозможно сохранить сопоставления, пока запуск активен",
@@ -1133,15 +1125,7 @@
         "users": "Пользователи",
         "account-activity": "Активность аккаунта",
         "magic-links": "Волшебные ссылки",
-        "oidc": "OIDC / ССО",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC / ССО"
       }
     },
     "common": {
@@ -1212,7 +1196,6 @@
         },
         "status": {
           "inQueuePaused": "{count} в очереди - приостановлено",
-          "remaining": "{count} remaining",
           "eligible": "~{count} права"
         },
         "trigger": {
@@ -1221,8 +1204,6 @@
         },
         "lastRun": {
           "justNow": "только что",
-          "minutesAgo": "{count}m ago",
-          "hoursAgo": "{count}h ago",
           "yesterday": "вчера",
           "daysAgo": "{count, plural, one {# день назад} few {# дней назад} many {# дней назад} other {# дней назад}}",
           "label": "Последний запуск: {when}",
@@ -1295,8 +1276,7 @@
           "audnexus": "Метаданные аудиокниги, управляемые сообществом. Установка не требуется.",
           "comicvine": "Метаданные книги комиксов от ComicVine. Требуется бесплатный ключ API с comicvine.gamespot.com.",
           "ranobedb": "Японские светлые метаданные из RanobeDB. Установка не требуется.",
-          "lubimyczytac": "Каталог польских книг (lubimyczytac.pl). Страницы публичных книг не требуются.",
-          "aladin": "Korean book metadata from Aladin (알라딘). A TTB Key from aladin.co.kr is required."
+          "lubimyczytac": "Каталог польских книг (lubimyczytac.pl). Страницы публичных книг не требуются."
         },
         "blocked": {
           "google": "Книги Google требуют ключ API перед включением",
@@ -1345,8 +1325,7 @@
             "hint": "Собирайте и deduplicate жанров из каждого поставщика, назначенного в поле Genres, вместо того, чтобы останавливаться на первом результате."
           },
           "storeProviderIds": {
-            "label": "ID провайдера магазина в книгах",
-            "hint": "When fetching metadata, save the returned provider IDs (ISBN, ASIN, Goodreads ID, etc.) on the book record for more accurate future lookups."
+            "label": "ID провайдера магазина в книгах"
           }
         },
         "library": {
@@ -1676,12 +1655,7 @@
         "deleteFamilyFailed": "Не удалось удалить семейство шрифтов",
         "demoCannotManage": "Ограниченный демо-аккаунт не может управлять шрифтами",
         "fileAdded": "\"{name}\" добавлен",
-        "uploadFailed": "Загрузка не удалась",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Загрузка не удалась"
       },
       "bookDock": {
         "title": "Книжный док-бар",
@@ -1694,7 +1668,6 @@
         "changePathSuffix": "файл.",
         "metadata": "Метаданные",
         "autoFetch": "Автозагрузка метаданных от провайдеров",
-        "autoFetchHint": "Automatically fetch metadata from configured providers (Google Books, iTunes, Open Library, etc.) after a file is added to Book Dock.",
         "autoFinalize": "Автозавершение",
         "enableAutoFinalize": "Включить автозавершение",
         "enableAutoFinalizeHint": "Файлы с оценкой достоверности метаданных на или выше порога будут автоматически завершены.",
@@ -1821,9 +1794,6 @@
         "copy": "Копировать",
         "never": "Никогда",
         "justNow": "Только что",
-        "minutesAgo": "{count}m ago",
-        "hoursAgo": "{count}h ago",
-        "daysAgo": "{count}d ago",
         "loadFailed": "Не удалось загрузить",
         "devicePaired": "Устройство успешно соединено",
         "devicePairedHint": "Вы готовы к настройке Kobo. Следуйте инструкциям ниже.",
@@ -2021,9 +1991,6 @@
         "loadFailed": "Не удалось загрузить настройки KOReader",
         "never": "Никогда",
         "justNow": "Только что",
-        "minutesAgo": "{count}m ago",
-        "hoursAgo": "{count}h ago",
-        "daysAgo": "{count}d ago",
         "unknown": "Неизвестен",
         "updateAvailable": "Доступно обновление",
         "upToDate": "Актуально",
@@ -2173,7 +2140,6 @@
             "saving": "Сохранение...",
             "confirmLink": "Подтвердите ссылку",
             "unlinkTitle": "Отменить привязку книги KOReader?",
-            "unlinkBody": "Future syncs for this hash will stop resolving to {title} until it is linked again. Already synced stats will stay on their current BookOrbit book.",
             "unlinking": "Отсоединение..."
           },
           "dismiss": "Отклонить",
@@ -2181,7 +2147,6 @@
           "dismissing": "Отклонено...",
           "unlinking": "Отсоединение...",
           "unlinkConfirmTitle": "Отменить привязку книги KOReader?",
-          "unlinkConfirmBody": "Future syncs for this hash will stop resolving to {title} until it is linked again. Already synced stats will stay on their current BookOrbit book.",
           "dismissConfirmTitle": "Закрыть {title}?",
           "dismissConfirmBody": "Это удалит его из списка несовпадающих книг. Если какое-либо устройство сообщит об этом хэше, он снова появится как новая запись.",
           "dismissAllConfirmTitle": "{count, plural, =0 {Нет несовпадающих книг} one {Распусти все # несовпадающую книгу?} few {Исключи все # несовпадающие книги?} many {Исключи все # несовпадающие книги?} other {Исключи все # несовпадающие книги?}}",
@@ -2373,7 +2338,6 @@
       "subtitle": "Чтение информации, которую пользователь добровольно решил поделиться.",
       "auditNotice": "Доступ к этому профилю записан и виден пользователю.",
       "period": "Отчетный период",
-      "periodDays": "Last {count} days",
       "durationMinutes": "{count, plural, one {# минута} few {# минут} many {# минут} other {# минут}}",
       "durationHours": "{count, plural, one {# час} few {# часов} many {# часов} other {# часов}}",
       "metrics": {
@@ -2673,7 +2637,6 @@
     },
     "hub": {
       "title": "Аннотации",
-      "totalCount": "{count} total",
       "bookCount": "{count, plural, =0 {нет книг} one {# книга} few {# книги} many {# книги} other {# книги}}",
       "noteCount": "{count, plural, =0 {нет заметок} one {# Примечание} few {# заметки} many {# заметки} other {# заметки}}",
       "export": "Экспорт",
@@ -2886,7 +2849,6 @@
       "BookBulkUpdateTags": "Обновить теги книги",
       "BookBulkSetMetadataLock": "Установка блокировок метаданных",
       "BookBulkEditMetadata": "Изменить метаданные книги",
-      "BookBulkMoveLibrary": "Move books to another library",
       "BookReadingStateReset": "Сбросить состояние чтения",
       "BookWriteAndRename": "Запись метаданных и переименование файла",
       "CollectionCreate": "Создать коллекцию",
@@ -3195,7 +3157,6 @@
         "imageRemoveFailed": "Не удалось удалить изображение автора",
         "mergeSuccess": "Объединенные {count} автора(ы); затрагиваемые книги {books}",
         "mergeFailed": "Не удалось объединить авторов",
-        "deleteSuccess": "Deleted author; affected {books} books",
         "deleteFailed": "Не удалось удалить автора"
       }
     }
@@ -3345,12 +3306,8 @@
         "isFinished": "завершён",
         "isLocked": "заблокирован",
         "isUnlocked": "разблокирован",
-        "isUpNext": "дальше",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isUpNext": "дальше"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Любой провайдер",
       "communityRatingProvider": "Поставщик рейтинга сообщества",
       "loadingLibraries": "Загрузка библиотек...",
@@ -3512,7 +3469,6 @@
       "sort": "Сортировка",
       "refreshingMetadata": "Обновление метаданных {processed} / {total}",
       "failedCount": "{count} не удалось",
-      "remainingCount": "{count} remaining",
       "readOnlyNotice": "Редактирование таблицы отключено на небольших экранах. Переключитесь на список или сетку для более быстрых действий.",
       "fetching": "Извлечение...",
       "updated": "Обновлено",
@@ -3855,12 +3811,6 @@
         "sortAria": "Сортировать файлы",
         "syncHistory": "История синхронизации",
         "metadataWriteBack": "Записать метаданные обратно",
-        "relative": {
-          "seconds": "{value}s ago",
-          "minutes": "{value}m ago",
-          "hours": "{value}h ago",
-          "days": "{value}d ago"
-        },
         "renameFailed": "Не удалось переименовать файл",
         "deleteFailed": "Не удалось удалить файл",
         "addFile": "Добавить файл",
@@ -3974,10 +3924,6 @@
           "summaryAria": "Чтение сводки",
           "notSet": "Не задано",
           "relative": {
-            "seconds": "{count}s ago",
-            "minutes": "{count}m ago",
-            "hours": "{count}h ago",
-            "days": "{count}d ago",
             "months": "{count, plural, =0 {# месяц назад} one {# месяц назад} few {# месяцев назад} many {# месяцев назад} other {# месяцев назад}}",
             "years": "{count, plural, =0 {# год назад} one {# год назад} few {# лет назад} many {# лет назад} other {# лет назад}}"
           },
@@ -4095,11 +4041,7 @@
         "seriesPlaceholder": "Серии",
         "moveUp": "Вверх",
         "moveDown": "Сдвинуть вниз",
-        "removeSeries": "Удалить серию",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Удалить серию"
       }
     },
     "table": {
@@ -4154,9 +4096,6 @@
         "clickToLock": "Нажмите, чтобы заблокировать",
         "clickToUnlock": "Нажмите, чтобы разблокировать"
       },
-      "progress": {
-        "complete": "{percent} complete"
-      },
       "rating": {
         "label": "Рейтинг",
         "remove": "Удалить оценку",
@@ -4183,65 +4122,10 @@
     },
     "move": {
       "title": "{count, plural, one {Move # book} few {Move # books} many {Move # books} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
       "folderCount": "{count, plural, one {# folder} few {# folders} many {# folders} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
       "confirm": "{count, plural, one {Move # book} few {Move # books} many {Move # books} other {Move # books}}",
-      "action": "Move to library",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} few {# name conflicts} many {# name conflicts} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "collisions": "{count, plural, one {# name conflict} few {# name conflicts} many {# name conflicts} other {# name conflicts}}"
       }
     }
   },
@@ -4279,7 +4163,6 @@
     },
     "label": {
       "paused": "Пауза",
-      "remaining": "{count} remaining",
       "processing": "Обработка {count}",
       "failed": "{count} не удалось",
       "rateLimited": "Курс {count} ограничен"
@@ -4362,8 +4245,7 @@
     },
     "upload": {
       "nDone": "{count} завершён",
-      "nFailed": "{count} не удалось",
-      "nTotal": "{count} total"
+      "nFailed": "{count} не удалось"
     },
     "fileList": {
       "emptyTitle": "Нет файлов в книжном док-баре",
@@ -4776,14 +4658,6 @@
         "random": "Откройте для себя что-то новое",
         "smartScope": "Умный охват"
       },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
-      },
       "reorderHintWidget": "Перетащите для переупорядочения. Переключите, чтобы показать или скрыть виджет.",
       "reorderHintShelf": "Перетащите для переупорядочения. Переключите, чтобы показать или скрыть полку.",
       "smartScope": "Умный охват",
@@ -4893,8 +4767,7 @@
         "trendSteady": "Стабильный темп",
         "pages": "страницы",
         "hours": "часов",
-        "readCount": "Прочитано {count}",
-        "daysLeft": "{count}d left"
+        "readCount": "Прочитано {count}"
       }
     }
   },
@@ -4950,7 +4823,6 @@
       "toggleSharing": "Переключить обмен",
       "removeSystemBeforeDelete": "Удалить обозначение системы перед удалением",
       "notesHeading": "Примечания поставщика",
-      "notesBody": "The {system} provider (superuser only) is used for password reset emails. The {defaultProvider} provider is used when sending books with no explicit provider selected. Providers marked {shared} are available to all users.",
       "deleteTitle": "Удалить поставщика?",
       "nameHostRequired": "Имя и хост обязательны",
       "created": "Поставщик создан",
@@ -5126,8 +4998,7 @@
         "description": "Приостановить синхронизацию оборудования без отключения."
       },
       "syncOnStatus": {
-        "title": "Синхронизация при смене статуса",
-        "description": "Push updates when you mark a book as reading, read, etc."
+        "title": "Синхронизация при смене статуса"
       },
       "syncOnProgress": {
         "title": "Синхронизация при обновлении",
@@ -5178,7 +5049,6 @@
       },
       "lastSynced": {
         "justNow": "Только что",
-        "minutesAgo": "{count} min ago",
         "hoursAgo": "{count, plural, =0 {# час назад} one {# час назад} few {# часов назад} many {# часов назад} other {# часов назад}}",
         "daysAgo": "{count, plural, =0 {# день назад} one {# день назад} few {# дней назад} many {# дней назад} other {# дней назад}}"
       }
@@ -5218,7 +5088,6 @@
     },
     "review": {
       "title": "Обзор темы импорт с тяжелым обложкой",
-      "subtitle": "{total} Hardcover books, {matched} matched.",
       "closeAriaLabel": "Закрыть обзор импорта",
       "searchPlaceholder": "Поиск по заголовку или автору",
       "importProgress": "Прогресс импорта",
@@ -5754,8 +5623,7 @@
       "unresolvedBooksExplanation": "Эти книги существуют в исходном коде, но не могут быть сопоставлены ни с одной книгой в вашей библиотеке.",
       "mappedUsers": "Сопоставленные пользователи ({count})",
       "mappedUsersExplanation": "Полноценное количество пользователей поступает из кэшированного плана перехода.",
-      "coverFailures": "{count} импорт(ы) обложки не удалось. Подробные строки с ошибками не сохранены.",
-      "userPreviewCounts": "{statuses} statuses, {progress} progress entries, {sessions} reading sessions, {bookmarks} bookmarks, {annotations} annotations, {collections} collection entries"
+      "coverFailures": "{count} импорт(ы) обложки не удалось. Подробные строки с ошибками не сохранены."
     },
     "unresolvedReason": {
       "noTitleAuthorMatch": "Соответствующая книга по названию или автору не найдена",
@@ -5797,9 +5665,7 @@
       "loadSuggestionsFailed": "Не удалось загрузить пользовательское сопоставление предложений",
       "sourceFieldsRequired": "Требуется имя хоста, пользователя, базы данных и хоста",
       "connectionPassedWithWarnings": "Проверка соединения пройдена с предупреждениями",
-      "connectionPassedWithWarningCount": "Connection test passed with {count} warning(s). First: {warning}",
       "connectionPassed": "Проверка соединения пройдена",
-      "connectionMissingTables": "Connection ok, but {count} required table(s) are missing",
       "cannotTestMediaWhileRunning": "Невозможно протестировать путь к медиафайлу, пока запуск активен",
       "mediaPathRequired": "Для импортирования необходим корневой путь к файлу.",
       "mediaPathAbsolute": "Используйте абсолютный путь (например: /books).",
@@ -5808,7 +5674,6 @@
       "mediaPathValidationFailed": "Ошибка проверки пути к файлу.",
       "connectionFailedBeforeMedia": "Проверка соединения не удалась, прежде чем проверка пути к медиафайлу будет завершена.",
       "cannotModifySourceWhileRunning": "Невозможно изменить источник, пока запуск активен",
-      "sourceSavedWithWarnings": "Source saved and validated with {count} warning(s)",
       "sourceSaved": "Источник сохранен и проверен",
       "saveSourceFailed": "Не удалось сохранить или проверить источник",
       "cannotSaveMappingsWhileRunning": "Невозможно сохранить сопоставления, пока запуск активен",
@@ -5956,67 +5821,22 @@
     "settings": {
       "title": "Настройки",
       "ariaLabel": "Настройки чтения",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Светлая",
         "dark": "Тёмная"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Встроенный",
-      "fontServer": "Server fonts",
       "fontYours": "Ваши шрифты",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Чтение потока",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Спреды страниц",
       "pageSpreadsHint": "Выберите, как это пары страниц EPUB на основе образа.",
       "spread": {
         "bookDefault": "Книга по умолчанию",
         "singlePage": "Одна страница"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Разрыв столбцов",
       "justifyText": "Выровнять текст по ширине",
-      "hyphenation": "Перенос",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Перенос"
     },
     "search": {
       "placeholder": "Поиск в бронировании (мин. {min} символов)...",
@@ -6111,9 +5931,6 @@
       "scrollModeHint": "Используйте \"Без пробелов\" для вебсайтов и вертикальных полос.",
       "readingDirection": "Направление чтения",
       "pageView": "Вид страницы",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Распространение выравнивания",
       "spreadGap": "Распространяемый разрыв",
       "spreadGapValue": "{value}px",
@@ -6188,10 +6005,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} прочитанного {total} ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Возможные пробелы:"
@@ -6697,7 +6510,6 @@
         "noEntities": "Объекты не найдены",
         "mergeCount": "Слияние ({count})",
         "deleteCount": "Удалить ({count})",
-        "totalCount": "{count} total",
         "sortLabel": "сортировка: {sortName}",
         "sort": {
           "nameAsc": "Имя А-Я",
@@ -6777,7 +6589,6 @@
       "customize": "Настроить панель инструментов",
       "allShelvesHidden": "Все полки скрыты.",
       "greeting": {
-        "night": "Good night,",
         "morning": "Доброе утро,",
         "afternoon": "Добрый день,",
         "evening": "Добрый вечер,",
@@ -6862,7 +6673,6 @@
         "emptyLibraryHint": "Как только вы добавите книги в эту библиотеку, они появятся здесь."
       },
       "querySelection": {
-        "loadedSelected": "{selected} of {total} loaded books selected.",
         "selectAllMatching": "Выбрать все {total} подходящие книги"
       }
     },
@@ -6997,8 +6807,7 @@
       "users": "Пользователи",
       "account-activity": "Активность аккаунта",
       "magic-links": "Волшебные ссылки",
-      "oidc": "OIDC / ССО",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / ССО"
     },
     "system": {
       "file-naming": "Именование файлов",

--- a/client/src/locales/sl.json
+++ b/client/src/locales/sl.json
@@ -1134,14 +1134,14 @@
         "account-activity": "Dejavnost računov",
         "magic-links": "Čarobne povezave",
         "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
+        "server-fonts": "Strežniške pisave"
       },
       "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "title": "Strežniške pisave",
+        "subtitle": "Naložite pisave, ki jih lahko vsak uporabnik izbere v bralniku e-knjig, ne da bi moral naložiti svoje.",
+        "listLabel": "Strežniške pisave",
+        "noFontsYet": "Še ni strežniških pisav",
+        "noFontsHint": "Pisave, ki jih dodate tukaj, se prikažejo v bralniku vsakega uporabnika."
       }
     },
     "common": {
@@ -1677,11 +1677,11 @@
         "demoCannotManage": "Demo-omejeni račun ne more upravljati pisav",
         "fileAdded": "\"{name}\" dodano",
         "uploadFailed": "Nalaganje ni uspelo",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "serverFontsTitle": "Strežniške pisave (v skupni rabi s strani skrbnika)",
+        "serverFontsHint": "Te pisave vam je poslal skrbnik strežnika. Eno izklopite, da je ne boste videli v bralniku.",
+        "serverFontsShown": "{count} od {total} prikazanih",
+        "serverFontsAllHidden": "Vse strežniške pisave so skrite. Vaš bralnik bo ponudil samo vgrajene in vaše lastne pisave.",
+        "serverFontVisibilityFailed": "Vidnosti pisave strežnika ni bilo mogoče posodobiti"
       },
       "bookDock": {
         "title": "Odložišče knjig",
@@ -2886,7 +2886,7 @@
       "BookBulkUpdateTags": "Posodobi oznake knjig",
       "BookBulkSetMetadataLock": "Nastavitev zaklepanja metapodatkov",
       "BookBulkEditMetadata": "Urejanje metapodatkov knjige",
-      "BookBulkMoveLibrary": "Move books to another library",
+      "BookBulkMoveLibrary": "Prestavi knjige v drugo knjižnico",
       "BookReadingStateReset": "Ponastavi stanje branja",
       "BookWriteAndRename": "Zapiši metapodatke in preimenuj datoteko",
       "CollectionCreate": "Ustvari zbirko",
@@ -3346,11 +3346,11 @@
         "isLocked": "je zaklenjeno",
         "isUnlocked": "je odklenjeno",
         "isUpNext": "je naslednje",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isTrue": "je da",
+        "isFalse": "je ne"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
+      "customFieldsGroup": "Polja po meri",
+      "customFieldFallback": "Polje po meri",
       "anyProvider": "Kateri koli ponudnik",
       "communityRatingProvider": "Ponudnik ocen skupnosti",
       "loadingLibraries": "Nalaganje knjižnic ...",
@@ -4096,10 +4096,10 @@
         "moveUp": "Premakni navzgor",
         "moveDown": "Premakni navzdol",
         "removeSeries": "Odstrani serijo",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "seriesIndexLabel": "Vrstni red v seriji",
+        "totalLabel": "Knjige v seriji",
+        "totalPlaceholder": "od",
+        "totalHint": "Skupno število knjig v tej seriji. Deljeno z vsemi, ki imajo to serijo."
       }
     },
     "table": {
@@ -4182,66 +4182,66 @@
       }
     },
     "move": {
-      "title": "{count, plural, one {Move # book} two {Move # books} few {Move # books} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
-      "folderCount": "{count, plural, one {# folder} two {# folders} few {# folders} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
-      "confirm": "{count, plural, one {Move # book} two {Move # books} few {Move # books} other {Move # books}}",
-      "action": "Move to library",
+      "title": "{count, plural, one {Premakni # knjigo} two {Premakni # knjigi} few {Premakni # knjige} other {Premakni # knjig}}",
+      "subtitle": "Datoteke se premaknejo na disku v ciljno knjižnico. To lahko spremeni, kdo lahko vidi te knjige.",
+      "searchPlaceholder": "Iskanje po knjižnicah",
+      "currentLibrary": "Trenutno",
+      "folderCount": "{count, plural, one {# mapa} two {# mapi} few {# mape} other {# map}}",
+      "continue": "Nadaljuj",
+      "back": "Nazaj",
+      "confirm": "{count, plural, one {Premakni # knjigo} two {Premakni # knjigi} few {Premakni # knjige} other {Premakni # knjig}}",
+      "action": "Premakni v knjižnico",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} two {# name conflicts} few {# name conflicts} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
+        "ready": "{count} pripravljeno",
+        "collisions": "{count, plural, one {# spor pri imenu} two {# spora pri imenu} few {# spori pri imenu} other {# sporov pri imenu}}",
+        "ineligible": "{count} se ne more premakniti",
+        "alreadyThere": "{count} je že tam",
+        "collisionsHeading": "Konflikt imen",
+        "ineligibleHeading": "Se ne more premakniti",
+        "moreCollisions": "in še {count} več"
       },
       "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
+        "suggested": "Uporabi predlagano",
+        "keep_both": "Obdrži oboje",
+        "merge": "Združi",
+        "skip": "Preskoči"
       },
       "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
+        "folder_path": "To ime mape že uporablja knjiga",
+        "file_path": "Datoteka že uporablja to pot",
+        "hash_duplicate": "Identičen izvod je že v tej knjižnici"
       },
       "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
+        "book_not_present": "Datoteke za to knjigo manjkajo",
+        "no_content_file": "Ta knjiga nima berljive datoteke",
+        "multi_file_target_per_file": "Cilj shrani eno datoteko na knjigo, ta knjiga pa ima {detail} datotek",
+        "no_source_access": "Knjižnice, v kateri je ta knjiga, ne morete urejati",
+        "pattern_unresolved": "Ciljna knjižnica nima uporabnega vzorca poimenovanja",
+        "path_too_long": "Ciljna pot bi bila predolga",
+        "path_outside_target_root": "Ciljna pot bi bila zunaj mape knjižnice"
       },
       "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
+        "accessLoss": "{user} ne bo več videl {count} teh knjig",
+        "koboImpact": "{count} knjig bo zapustilo Kobo uporabnika {user} ob naslednji sinhronizaciji",
         "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
+          "wrap_into_folder": "{count} knjig bo vsaka shranjena v svoji mapi",
+          "dissolve_folder": "{count} map s knjigami bo raztopljenih v posamezne datoteke"
         },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
+        "crossDevice": "Datoteke se premaknejo na drug pogon, kjer se kopirajo, preverijo in nato odstranijo."
       },
       "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
+        "label": "Prestavitev knjig v {library}",
+        "failed": "{count} neuspešno"
       },
       "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
+        "summary": "Premaknjenih {count} knjig v {library}",
+        "merged": "{count} združeno s kopijami, ki so že tam",
+        "skipped": "{count} preskočeno",
+        "failed": "{count} neuspešno"
       },
       "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "success": "Premaknjenih {count} knjig v {library}",
+        "partial": "Premaknjenih {moved} knjig, {failed} ni uspelo"
       }
     }
   },
@@ -4777,12 +4777,12 @@
         "smartScope": "Pametni obseg"
       },
       "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
+        "title": "Razporeditev polic",
+        "description": "Izberite, kako so police razporejene na večjih zaslonih.",
+        "wide": "Široke vrstice",
+        "wideDescription": "Prikaži eno polico na vrsto.",
+        "twoColumns": "Dva stolpca",
+        "twoColumnsDescription": "Prikažite dve polici na vrsto."
       },
       "reorderHintWidget": "Povleci za spremembo vrstnega reda. Preklopi za prikaz ali skritje gradnika.",
       "reorderHintShelf": "Povleci za spremembo vrstnega reda. Preklopi za prikaz ali skritje police.",
@@ -5956,63 +5956,63 @@
     "settings": {
       "title": "Nastavitve",
       "ariaLabel": "Nastavitve bralnika",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
+      "reset": "Ponastavi na privzeto",
+      "modeLabel": "Barvni način",
       "mode": {
         "light": "Svetlo",
         "dark": "Temno"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
+      "textSize": "Velikost besedila",
+      "textSizeSmaller": "Manjše besedilo",
+      "textSizeLarger": "Večje besedilo",
       "pixels": "{value} px",
       "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
+      "pageColor": "Barva strani",
+      "font": "Pisava",
       "fontBuiltIn": "Vgrajeno",
-      "fontServer": "Server fonts",
+      "fontServer": "Strežniške pisave",
       "fontYours": "Vaše pisave",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
+      "lineSpacing": "Razmik med vrsticami",
+      "pageWidth": "Širina strani",
+      "pageWidthNarrow": "Ozko",
+      "pageWidthMedium": "Srednje",
+      "pageWidthWide": "Široko",
+      "pageWidthFull": "Polno",
       "readingFlow": "Potek branja",
       "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
+        "paginated": "Strani",
+        "scrolled": "Pomikanje"
       },
-      "pageSpreads": "Razpon strani",
-      "pageSpreadsHint": "Izberite, kako ta na slikah temelječ EPUB združuje strani.",
+      "pageSpreads": "Razpored strani",
+      "pageSpreadsHint": "Izberite, kako ta slikovna datoteka EPUB združuje strani.",
       "spread": {
         "bookDefault": "Privzeto za knjigo",
         "singlePage": "Ena stran"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
+      "advanced": "Napredna postavitev",
+      "columns": "Stolpci",
+      "columnsFewer": "Manj stolpcev",
+      "columnsMore": "Več stolpcev",
       "columnGap": "Razmik med stolpci",
       "justifyText": "Poravnaj besedilo",
       "hyphenation": "Deljenje besed",
       "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
+        "default": "Privzeto",
+        "gray": "Siva",
+        "sepia": "Sepija",
+        "crimson": "Škrlatna",
+        "meadow": "Travnik",
+        "rosewood": "Palisandr",
+        "azure": "Azur",
+        "dawnlight": "Zora",
+        "ember": "Žerjavica",
+        "aurora": "Avrora",
         "ocean": "Ocean",
-        "mist": "Mist",
+        "mist": "Meglica",
         "amoled": "AMOLED"
       },
       "fonts": {
-        "bookDefault": "Book default",
+        "bookDefault": "Privzeto za knjigo",
         "serif": "Serif",
         "sansSerif": "Sans-serif",
         "monospace": "Monospace"
@@ -6111,9 +6111,6 @@
       "scrollModeHint": "Uporabite \"Brez vrzeli\" za webtoone in navpične trakove.",
       "readingDirection": "Smer branja",
       "pageView": "Pogled strani",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Poravnava razpona",
       "spreadGap": "Razmik",
       "spreadGapValue": "{value}px",
@@ -6190,8 +6187,8 @@
       "readOfTotal": "prebranih {read} od {total} ({percentage} %)"
     },
     "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
+      "label": "V knjižnici",
+      "ownedOfExpected": "{owned} od {expected} v knjižnici"
     },
     "gaps": {
       "label": "Možne vrzeli:"
@@ -6998,7 +6995,7 @@
       "account-activity": "Dejavnost računa",
       "magic-links": "Čarobne povezave",
       "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "server-fonts": "Strežniške pisave"
     },
     "system": {
       "file-naming": "Poimenovanje datotek",

--- a/client/src/locales/sv.json
+++ b/client/src/locales/sv.json
@@ -168,8 +168,7 @@
           "blush": "Blush"
         },
         "accentColor": {
-          "label": "Accent färg",
-          "hint": "Controls highlights and interactive elements"
+          "label": "Accent färg"
         },
         "cornerRadius": {
           "label": "Corner radius",
@@ -199,8 +198,7 @@
         "active": "Aktiv",
         "notAvailable": "Inte tillgänglig",
         "device": {
-          "title": "Endast denna enhet",
-          "description": "Preferences stay in your browser. Best if you want a different look on different devices."
+          "title": "Endast denna enhet"
         },
         "account": {
           "title": "Mitt konto",
@@ -482,7 +480,6 @@
         "accountTypeOidc": "OIDC / SSO",
         "accountTypeShared": "Delad",
         "accountTypeLocal": "Lokal",
-        "nameRequired": "Name is required",
         "updateFailed": "Det gick inte att uppdatera profil",
         "updated": "Profil uppdaterad",
         "usernameHint": "Ditt användarnamn kan inte ändras.",
@@ -715,7 +712,6 @@
       },
       "groupMappings": {
         "title": "Grupp Mappningar",
-        "description": "Map OIDC group claims to BookOrbit permissions. Synced on every login.",
         "noPermission": "Ingen behörighet",
         "empty": "Inga gruppmappningar konfigurerade.",
         "addMapping": "Lägg till mappning",
@@ -757,7 +753,6 @@
         "recommendationsGroup": "Rekommendationer",
         "achievementsGroup": "Prestationer",
         "updatesGroup": "Uppdateringar",
-        "importFromBooklore": "Import from Booklore",
         "bookloreImportConfigured": "Booklore import konfigurerad",
         "migrationRunning": "Migrering igång",
         "migrationCompleted": "Migration slutförd",
@@ -851,7 +846,6 @@
         "errorLoadSuggestions": "Misslyckades att ladda förslag på användarmappning",
         "requiredFields": "Värd, användare, databas och källnamn krävs",
         "connectionTestPassedWithWarnings": "Anslutningstest klarat med varningar",
-        "connectionTestPassedWithCount": "Connection test passed with {count} warning(s). First: {first}",
         "connectionTestPassed": "Anslutningstest godkänd",
         "connectionOkMissingTables": "Anslutning ok, men {count} obligatoriska tabell(er) saknas",
         "cannotTestMediaPathActiveRun": "Kan inte testa mediasökväg medan en körning är aktiv",
@@ -1133,15 +1127,7 @@
         "users": "Användare",
         "account-activity": "Konto aktivitet",
         "magic-links": "Magiska länkar",
-        "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC / SSO"
       }
     },
     "common": {
@@ -1295,8 +1281,7 @@
           "audnexus": "Gemenskapsdriven ljudbok metadata. Ingen installation krävs.",
           "comicvine": "Comic bok metadata från ComicVine. En gratis API-nyckel krävs från comicvine.gamespot.com.",
           "ranobedb": "Japansk ljusroman metadata från RanobeDB. Ingen installation krävs.",
-          "lubimyczytac": "Polsk bokkatalog (lubimyczytac.pl). Scrapes offentliga boksidor. Ingen installation krävs.",
-          "aladin": "Korean book metadata from Aladin (알라딘). A TTB Key from aladin.co.kr is required."
+          "lubimyczytac": "Polsk bokkatalog (lubimyczytac.pl). Scrapes offentliga boksidor. Ingen installation krävs."
         },
         "blocked": {
           "google": "Google Books kräver en API-nyckel innan den kan aktiveras",
@@ -1676,12 +1661,7 @@
         "deleteFamilyFailed": "Det gick inte att ta bort typsnittsfamilj",
         "demoCannotManage": "Demobegränsat konto kan inte hantera typsnitt",
         "fileAdded": "\"{name}\" tillagd",
-        "uploadFailed": "Uppladdningen misslyckades",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Uppladdningen misslyckades"
       },
       "bookDock": {
         "title": "Boka Docka",
@@ -1865,7 +1845,6 @@
         "markAsFinished": "Markera som slutförd",
         "markAsFinishedHint": "Procentuell tröskel för att markera en bok som \"Avslutad\".",
         "kepubLimit": "KEPUB konverteringsgräns",
-        "kepubLimitHint": "Books above this limit are sent as regular EPUBs, so BookOrbit will not sync their reader position back to Kobo.",
         "changesMustBeSaved": "Ändringar måste sparas för att träda i kraft.",
         "saving": "Sparar...",
         "saveSyncSettings": "Spara synkroniseringsinställningar",
@@ -2178,7 +2157,6 @@
           },
           "dismiss": "Avfärda",
           "dismissAll": "Avfärda alla",
-          "dismissing": "Dismissing...",
           "unlinking": "Avlänkar...",
           "unlinkConfirmTitle": "Avlänka KOReader boken?",
           "unlinkConfirmBody": "Framtida synkroniseringar för detta hash kommer sluta lösa {title} tills det är länkat igen. Synkroniserade värden kommer att stanna kvar på sin nuvarande bokbok.",
@@ -2886,7 +2864,6 @@
       "BookBulkUpdateTags": "Uppdatera boktaggar",
       "BookBulkSetMetadataLock": "Ställ in metadatafunktioner",
       "BookBulkEditMetadata": "Redigera bokens metadata",
-      "BookBulkMoveLibrary": "Move books to another library",
       "BookReadingStateReset": "Återställ läsläge",
       "BookWriteAndRename": "Skriv metadata och byt namn på fil",
       "CollectionCreate": "Skapa samling",
@@ -3119,10 +3096,8 @@
         "refreshedNoImage": "Metadata uppdaterad, men ingen författarbild hittades.",
         "refreshFailed": "Det gick inte att uppdatera författarens metadata",
         "bulkRefreshPartial": "Uppdaterade {updated} författare(er), {failed} misslyckades",
-        "bulkRefreshSuccess": "Refreshed metadata for {updated} author(s)",
         "bulkRefreshFailed": "Det gick inte att uppdatera valda författare",
-        "deleteSuccess": "{count, plural, =0 {Borttagna # författare; påverkade {books} böcker} one {Borttagna # författare; påverkade {books} böcker} other {Borttagna # författare; påverkade {books} böcker}}",
-        "deleteFailed": "Failed to delete author(s)"
+        "deleteSuccess": "{count, plural, =0 {Borttagna # författare; påverkade {books} böcker} one {Borttagna # författare; påverkade {books} böcker} other {Borttagna # författare; påverkade {books} böcker}}"
       }
     },
     "detail": {
@@ -3155,7 +3130,6 @@
         "confirmLabel": "Sammanfoga"
       },
       "mergeDialog": {
-        "title": "Merge {count} author(s) into \"{name}\"?",
         "titleFallback": "Slå ihop valda författare?",
         "description": "Detta kommer att sammanfoga valda författare till den nuvarande författaren och länka associerade böcker. Denna åtgärd kan inte ångras.",
         "descriptionEmpty": "Denna åtgärd kan inte ångras."
@@ -3345,12 +3319,8 @@
         "isFinished": "är klar",
         "isLocked": "är låst",
         "isUnlocked": "är upplåst",
-        "isUpNext": "är uppe nästa",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isUpNext": "är uppe nästa"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Valfri leverantör",
       "communityRatingProvider": "Gemenskapens betygsleverantör",
       "loadingLibraries": "Laddar bibliotek...",
@@ -3715,7 +3685,6 @@
         "writeManualTooltip": "Skriv {fields} till {target} och byt namn på disk",
         "applyResult": "{skipped}, {updated}",
         "skippedLockedFields": "{count, plural, =0 {Hoppade över inga låsta fält} one {Hoppade över ett låst fält} other {Hoppade över # låsta fält}}",
-        "updatedFields": "{count, plural, =0 {updated no fields} one {updated one field} other {updated # fields}}",
         "wroteFieldsToFile": "Skrev {fields} till fil",
         "fileWriteFailedReason": "Filskrivning misslyckades: {reason}",
         "fileWriteFailed": "Filskrivning misslyckades",
@@ -4095,11 +4064,7 @@
         "seriesPlaceholder": "Serie",
         "moveUp": "Flytta upp",
         "moveDown": "Flytta ner",
-        "removeSeries": "Ta bort serie",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Ta bort serie"
       }
     },
     "table": {
@@ -4179,69 +4144,6 @@
       },
       "text": {
         "openDetails": "Öppna detaljer"
-      }
-    },
-    "move": {
-      "title": "{count, plural, one {Move # book} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
-      "folderCount": "{count, plural, one {# folder} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
-      "confirm": "{count, plural, one {Move # book} other {Move # books}}",
-      "action": "Move to library",
-      "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
       }
     }
   },
@@ -4443,7 +4345,6 @@
       "name": "Namn",
       "icon": "Ikon",
       "iconPlaceholder": "Välj en ikon...",
-      "nameRequired": "Name is required",
       "iconRequired": "Välj en ikon",
       "creating": "Skapar...",
       "createFailed": "Det gick inte att skapa samling"
@@ -4706,7 +4607,6 @@
     "dropPrompt": "Släpp SVG-filer eller klicka för att bläddra",
     "fileLimit": "Upp till {max} filer, 128 KB vardera",
     "namePlaceholder": "Namn",
-    "nameRequired": "Name is required",
     "invalidSvg": "Ogiltig SVG",
     "invalidSvgFile": "Ogiltig SVG-fil",
     "identicalTo": "Identisk till \"{name}\"",
@@ -4721,7 +4621,6 @@
     "maxStaged": "Du kan iscensätta som mest {max} ikoner på en gång",
     "onlyMoreCanStage": "{count, plural, =0 {Inga fler ikoner kan iscensättas} one {Endast # fler ikoner kan iscensättas} other {Endast # fler ikoner kan iscensättas}}",
     "readFailed": "Det gick inte att läsa SVG-filer",
-    "uploadedCount": "{count, plural, =0 {No icons uploaded} one {Uploaded # icon} other {Uploaded # icons}}",
     "uploadedPartial": "Uppladdad {created}, {failed} misslyckades",
     "noIconsUploaded": "Inga ikoner uppladdade",
     "uploadFailed": "Misslyckades att ladda upp ikoner",
@@ -4775,14 +4674,6 @@
         "upNextInSeries": "Nästa i serien",
         "random": "Upptäck något nytt",
         "smartScope": "Smart omfattning"
-      },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
       },
       "reorderHintWidget": "Dra för att ordna om. Växla för att visa eller dölja en widget.",
       "reorderHintShelf": "Dra för att ordna om. Växla för att visa eller dölja en hylla.",
@@ -5797,7 +5688,6 @@
       "loadSuggestionsFailed": "Misslyckades att ladda förslag på användarmappning",
       "sourceFieldsRequired": "Värd, användare, databas och källnamn krävs",
       "connectionPassedWithWarnings": "Anslutningstest klarat med varningar",
-      "connectionPassedWithWarningCount": "Connection test passed with {count} warning(s). First: {warning}",
       "connectionPassed": "Anslutningstest godkänd",
       "connectionMissingTables": "Anslutning ok, men {count} obligatoriska tabell(er) saknas",
       "cannotTestMediaWhileRunning": "Kan inte testa mediasökväg medan en körning är aktiv",
@@ -5956,67 +5846,22 @@
     "settings": {
       "title": "Inställningar",
       "ariaLabel": "Inställningar för läsare",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Ljus",
         "dark": "Mörk"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Inbyggd",
-      "fontServer": "Server fonts",
       "fontYours": "Dina typsnitt",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Läser flöde",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Sid spreads",
       "pageSpreadsHint": "Välj hur denna bildbaserade EPUB parar sidor.",
       "spread": {
         "bookDefault": "Bokens standard",
         "singlePage": "Enda sidan"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Kolumn mellanrum",
       "justifyText": "Justera text",
-      "hyphenation": "Hyfenering",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Hyfenering"
     },
     "search": {
       "placeholder": "Sök i bok (min {min} chars)...",
@@ -6111,9 +5956,6 @@
       "scrollModeHint": "Använd \"Inga luckor\" för webtoons och vertikala remsor.",
       "readingDirection": "Läsa riktning",
       "pageView": "Sidvy",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Sprid justering",
       "spreadGap": "Sprid mellanrum",
       "spreadGapValue": "{value}px",
@@ -6188,10 +6030,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} av {total} läst ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Möjliga mellanrum:"
@@ -6277,7 +6115,6 @@
       "namePlaceholder": "t.ex. olästa Sci-Fi",
       "icon": "Ikon",
       "iconPlaceholder": "Välj en ikon...",
-      "nameRequired": "Name is required",
       "iconRequired": "Välj en ikon",
       "create": "Skapa",
       "creating": "Skapar...",
@@ -6733,7 +6570,6 @@
       },
       "bulkDeleteModal": {
         "title": "Radera massa",
-        "confirm": "{count, plural, =0 {Are you sure you want to delete # selected entity?} one {Are you sure you want to delete # selected entity?} other {Are you sure you want to delete # selected entities?}}",
         "deleteButton": "Ta bort {count}"
       },
       "mergeModal": {
@@ -6997,8 +6833,7 @@
       "users": "Användare",
       "account-activity": "Konto aktivitet",
       "magic-links": "Magiska länkar",
-      "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / SSO"
     },
     "system": {
       "file-naming": "Namngivning av fil",

--- a/client/src/locales/uk.json
+++ b/client/src/locales/uk.json
@@ -81,7 +81,6 @@
     },
     "appearance": {
       "language": {
-        "title": "Language",
         "description": "Виберіть мову, яка використовується в інтерфейсі.",
         "label": "Мова інтерфейсу",
         "loadError": "Не вдалося завантажити вибрану мову",
@@ -89,7 +88,6 @@
       },
       "pageTitle": "Відображати",
       "pageSubtitle": "Контрольні теми, обкладинки, розмітки та те, як представлена ваша бібліотека.",
-      "mobileSummary": "Theme: {theme} • Accent: {accent} • Background: {background}",
       "themeMode": {
         "light": "Світла",
         "dark": "Темна",
@@ -168,8 +166,7 @@
           "blush": "Блаш"
         },
         "accentColor": {
-          "label": "Колір акценту",
-          "hint": "Controls highlights and interactive elements"
+          "label": "Колір акценту"
         },
         "cornerRadius": {
           "label": "Corner radius",
@@ -529,7 +526,6 @@
         "unlink": "Розірвання зв'язку",
         "unlinking": "Від'єднання...",
         "linkAdditional": "Додати додаткових постачальників:",
-        "linkProvider": "Link {provider}",
         "redirecting": "Перенаправлення...",
         "noneConfigured": "Не налаштовано жодного провайдера OIDC. Зверніться до адміністратора для налаштування SSO.",
         "linkStateFailed": "Не вдалося згенерувати стан посилань",
@@ -593,7 +589,6 @@
       "never": "Записи активності відсутні",
       "noExpiry": "Немає терміну дії",
       "expired": "Термін дії закінчився",
-      "expiresOn": "Expires {date}",
       "revokedOn": "Відкликано {date}",
       "expiredOn": "Минув термін дії {date}",
       "usesCount": "{count, plural, =0 {не використовує} one {один використовувати} few {# використовувати} many {# використовувати} other {# використовувати}}",
@@ -639,12 +634,10 @@
       },
       "usersPage": "Сторінка користувачів",
       "emptyTitle": "Поки що відсутні магічні посилання",
-      "emptyHint": "Click \"{action}\" to generate a shareable login URL.",
       "noActiveTitle": "Немає активних магічних посилань",
       "noActiveHint": "Всі згенеровані магічні посилання для цієї сторінки закінчилися або були відкликані.",
       "copyLinkAria": "Скопіювати посилання на {label}",
       "pauseAria": "Призупинити {label}",
-      "resumeAria": "Resume {label}",
       "revokeAria": "Revoke {label}",
       "lastUsedLabel": "Востаннє використано {date}"
     },
@@ -655,7 +648,6 @@
       "addProvider": "Постачальник",
       "editProvider": "Редагувати постачальника",
       "configureNew": "Налаштування нового постачальника OIDC.",
-      "editing": "Editing {slug}",
       "enabled": "Увімкнено",
       "disabled": "Вимкнено",
       "empty": {
@@ -715,7 +707,6 @@
       },
       "groupMappings": {
         "title": "Співставлення груп",
-        "description": "Map OIDC group claims to BookOrbit permissions. Synced on every login.",
         "noPermission": "Немає дозволу",
         "empty": "Не налаштовано групове зіставлення.",
         "addMapping": "Додати відображення",
@@ -757,14 +748,12 @@
         "recommendationsGroup": "Рекомендації",
         "achievementsGroup": "Досягнення",
         "updatesGroup": "Оновлення",
-        "importFromBooklore": "Import from Booklore",
         "bookloreImportConfigured": "Імпорт Booklore налаштований",
         "migrationRunning": "Міграція працює",
         "migrationCompleted": "Міграція завершена",
         "migrationFailed": "Міграція не вдалася",
         "importDescription": "Імпорт книг, метаданих та читання результатів з попереднього оновлення книг.",
         "configuredDescription": "Джерело: {name}. Перемог не запущено, поки що - продовжити налаштування для імпорту.",
-        "runningDescription": "Stage: {stage} - started {started}",
         "completedDescription": "З {name} - завершено {date}",
         "migrationErrorGeneric": "Сталася помилка під час міграції.",
         "stageInitializing": "ініціалізація",
@@ -779,7 +768,6 @@
         "running": "Працює...",
         "backfillAchievements": "Досягнення зворотного заповнення",
         "backfillAchievementsHint": "Повторне виконання досягнень для всіх користувачів.",
-        "backfillResult": "Processed {users} users; granted {awards} awards.",
         "runBackfill": "Запустити фонове заповнення",
         "checkForUpdates": "Перевірити наявність оновлень",
         "checkForUpdatesHint": "Автоматично перевіряйте GitHub на новий реліз при запуску і показуйте індикатор в бічній панелі, коли він доступний.",
@@ -791,9 +779,7 @@
         "unknownError": "Невідома помилка",
         "rebuildEmbeddingsFailed": "Не вдалося перебудувати вкладення: {error}",
         "achievementBackfillConfirm": "Запустити відновлення досягнень для всіх досягнень у всіх користувачах? Це може зайняти деякий час.",
-        "achievementBackfillComplete": "Achievement backfill complete: {count} awards granted",
         "backfillRunFailed": "Не вдалося виконати резервне заповнення",
-        "achievementBackfillFailed": "Failed to run achievement backfill: {error}",
         "uploadsGroup": "Вивантаження",
         "maxUploadSize": "Максимальний ліміт розміру файлу для завантаження",
         "maxUploadSizeHint": "Налаштування максимального розміру завантаження файлів по всій системі.",
@@ -840,7 +826,6 @@
         "sourceRecordId": "ID вихідного запису #{id}",
         "byAuthorWithId": "від {author} (ID: {id})",
         "filePathWithId": "{path} (ID: {id})",
-        "bookloreSourceId": "Booklore source ID: {id}",
         "libraryBookNum": "Бібліотечна книга #{id}",
         "errorInitialize": "Не вдалося ініціалізувати налаштування міграції",
         "errorLoadSourceTypes": "Не вдалося завантажити підтримувані типи міграції",
@@ -851,7 +836,6 @@
         "errorLoadSuggestions": "Не вдалося завантажити пропозиції зіставлень користувачів",
         "requiredFields": "Потрібно вказати ім'я хоста, ім'я бази даних, бази даних і початкового тексту",
         "connectionTestPassedWithWarnings": "Тестування підключення пройшло з попередженнями",
-        "connectionTestPassedWithCount": "Connection test passed with {count} warning(s). First: {first}",
         "connectionTestPassed": "Тестування з'єднання пройдено",
         "connectionOkMissingTables": "Підключення до ok, але {count} обов'язкова таблиця (ів) відсутня",
         "cannotTestMediaPathActiveRun": "Неможливо перевірити шлях до медіа, коли запускається",
@@ -862,7 +846,6 @@
         "mediaPathValidationFailed": "Помилка перевірки шляху медіа.",
         "connectionFailedBeforeMediaPath": "Помилка під час перевірки підключення до медіа-шляху.",
         "cannotModifySourceActiveRun": "Не вдалося змінити джерело, поки запускається",
-        "sourceSavedValidatedWarnings": "Source saved and validated with {count} warning(s)",
         "sourceSavedValidated": "Джерело збережено та перевірене",
         "errorSaveValidateSource": "Не вдалося зберегти або перевірити джерело",
         "cannotSaveMappingsActiveRun": "Не вдалося зберегти зіставлення, коли запускається",
@@ -932,7 +915,6 @@
         "saveAndValidate": "Зберегти та підтвердити",
         "sourceValidatedWithWarnings": "Джерело перевірене з попередженнями",
         "lastValidationSnapshot": "Остання перевірка, знімок",
-        "sourceVersion": "Source version: {version}",
         "unknown": "Не вказано",
         "missingRequiredTables": "Відсутні необхідні таблиці: {tables}",
         "suggestionsAutoLoad": "Завантаження пропозицій користувачів автоматично після перевірки джерела.",
@@ -985,7 +967,6 @@
         "refreshStatus": "Оновити статус",
         "statusPollingStopped": "Опитування стану зупинено через помилку.",
         "retry": "Повторити спробу",
-        "stageLabel": "Stage: {stage}",
         "stageInitializing": "ініціалізація",
         "endedLabel": "Завершено {date}",
         "stageCompleted": "Завершені",
@@ -1028,7 +1009,6 @@
         "unresolvedBooksHint": "Ці книги є у джерелі, але не можуть бути розміщені в будь-якій книзі у вашій бібліотеці.",
         "mappedUsersHeading": "Згорнуті користувачі ({count})",
         "mappedUsersHint": "Сукупності користувачів беруться з багатоосновного попереднього перегляду сушного схованки з планом міграції.",
-        "coverImportsFailed": "{count} cover import(s) failed. Detailed failure rows are not stored.",
         "backToSetup": "Назад до налаштувань"
       },
       "libraries": {
@@ -1053,7 +1033,6 @@
         "emptyTitle": "Немає бібліотек",
         "emptyHint": "Додайте бібліотеку, щоб почати організовувати свої книжки.",
         "addFirstLibrary": "Додайте вашу першу бібліотеку",
-        "deleteConfirmTitle": "Delete \"{name}\"?",
         "deleteConfirmBody": "Це остаточно видалить всі книги, метадата, операції читання, закладки та анотації в цій бібліотеці. Цю дію неможливо скасувати.",
         "deleteConfirmTypeName": "Введіть ім'я бібліотеки для підтвердження:",
         "deleting": "Видалення...",
@@ -1062,7 +1041,6 @@
         "syncConfirmBodyPrefix": "Це буде перезаписувати метадані всередині кожного підтримуваного файлу",
         "syncConfirmBodySuffix": "прямо на диску. Це неможливо скасувати.",
         "syncFiles": "Синхронізація файлів",
-        "metadataSynced": "Metadata synced to files for \"{name}\"",
         "fileWriteNotEnabled": "Запис файлу метаданих не увімкнено для цієї бібліотеки. Увімкніть його в налаштуваннях бібліотеки.",
         "fileSyncFailed": "Не вдалося синхронізувати файл для \"{name}\"",
         "scanStarted": "Сканування розпочато \"{name}\"",
@@ -1077,7 +1055,6 @@
         "deleteFailed": "Не вдалося вилучити бібліотеку",
         "scanningProgress": "Сканування {pct}% ({processed}/{total})",
         "scanDone": "Готово - {added} додано, {updated} оновлено",
-        "scanFailedWithError": "Failed: {error}",
         "scanFailed": "Помилка сканування",
         "refreshingCovers": "Оновлення обкладинки {pct}% ({processed}/{total})",
         "coversRefreshed": "Обкладинки оновлені ({count} оброблено)"
@@ -1133,15 +1110,7 @@
         "users": "Спільноти",
         "account-activity": "Активність облікового запису",
         "magic-links": "Магічні посилання",
-        "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
-      },
-      "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "oidc": "OIDC / SSO"
       }
     },
     "common": {
@@ -1171,7 +1140,6 @@
         "authors": "Автори",
         "publisher": "Автор",
         "publishedYear": "Рік публікації",
-        "language": "Language",
         "pageCount": "Кількість сторінок",
         "communityRating": "Рейтинг спільноти",
         "seriesName": "Назва серії",
@@ -1221,8 +1189,6 @@
         },
         "lastRun": {
           "justNow": "прямо зараз",
-          "minutesAgo": "{count}m ago",
-          "hoursAgo": "{count}h ago",
           "yesterday": "вчора",
           "daysAgo": "{count, plural, one {# день тому} few {# днів тому} many {# днів тому} other {# днів тому}}",
           "label": "Останній запуск: {when}",
@@ -1263,7 +1229,6 @@
         "test": "Тест",
         "testing": "Тестування...",
         "enabled": "Увімкнено",
-        "retryIn": "Retry in {duration}",
         "runTestBeforeEnabling": "Запустіть тестове тестування перед увімкненням",
         "hardcoverEnableHint": "Запустити тест з поточним токеном щоб розблокувати перемикач включення.",
         "badge": {
@@ -1277,7 +1242,6 @@
           "cookie": "Печиво",
           "coverResolution": "Роздільна здатність обкладинки",
           "country": "Країна",
-          "language": "Language",
           "ttbKey": "TTB ключ"
         },
         "helpers": {
@@ -1295,8 +1259,7 @@
           "audnexus": "Метадані аудіосуд. не потрібно налаштувати.",
           "comicvine": "Для ComicVine потрібен безкоштовний ключ API з comicvine.gamespot.com.",
           "ranobedb": "Японські світлові метадані RanobeDB. Без налаштувань.",
-          "lubimyczytac": "Польський каталог книг (lubimyczytac.pl). публічні сторінки публічних книг. Не потрібна установка.",
-          "aladin": "Korean book metadata from Aladin (알라딘). A TTB Key from aladin.co.kr is required."
+          "lubimyczytac": "Польський каталог книг (lubimyczytac.pl). публічні сторінки публічних книг. Не потрібна установка."
         },
         "blocked": {
           "google": "Для активації модуля Google Books потрібен ключ API",
@@ -1345,8 +1308,7 @@
             "hint": "Збирайте та перекладайте жанри від кожного провайдера, призначеного для поля Жанрів, а не припиняйте на перший результат."
           },
           "storeProviderIds": {
-            "label": "Ідентифікатори провайдера магазину у книгах",
-            "hint": "When fetching metadata, save the returned provider IDs (ISBN, ASIN, Goodreads ID, etc.) on the book record for more accurate future lookups."
+            "label": "Ідентифікатори провайдера магазину у книгах"
           }
         },
         "library": {
@@ -1390,7 +1352,6 @@
         },
         "reservoir": {
           "disabled": "{provider} - вимкнено",
-          "notConfigured": "{provider} - not configured",
           "dragToAssign": "Перетягніть, щоб призначити {provider} для поля"
         },
         "sheet": {
@@ -1438,7 +1399,6 @@
         "searchAriaLabel": "Пошук настроюваних полів",
         "emptyTitle": "Немає настроюваних полів",
         "emptyHint": "Використовуйте форму вище, щоб визначити ваше перше поле метаданих.",
-        "noMatchTitle": "No fields match \"{query}\"",
         "noMatchHint": "Спробуйте іншу мітку, ключ або тип.",
         "clearSearchToReorder": "Очистити поле пошуку для зміни порядку",
         "dragToReorder": "Перетягніть для зміни порядку",
@@ -1447,7 +1407,6 @@
         "archive": "Архів",
         "archivedFields": "Архівні поля",
         "archivedSummary": "{count, plural, one {# archived field - restore or permanently delete.} few {# archived fields - restore or permanently delete.} many {# archived fields - restore or permanently delete.} other {# archived fields - restore or permanently delete.}}",
-        "archivedAt": "Archived {when}",
         "restore": "Відновити",
         "deleteForever": "Видалити назавжди",
         "deleteDialog": {
@@ -1676,12 +1635,7 @@
         "deleteFamilyFailed": "Не вдалося вилучити сімейство шрифтів",
         "demoCannotManage": "Обмежений доступ до демо-ліміту не можна керувати шрифтами",
         "fileAdded": "\"{name}\" додано",
-        "uploadFailed": "Не вдалося завантажити",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "uploadFailed": "Не вдалося завантажити"
       },
       "bookDock": {
         "title": "Книга док",
@@ -1799,17 +1753,14 @@
         "crossPlatformSaveFailed": "Не вдалося зберегти крос-платформенне розташування",
         "librarySaved": "Шаблон збережено для {name}",
         "librarySaveFailed": "Не вдалося зберегти шаблон бібліотеки",
-        "saveLibraryPattern": "Save pattern for {name}",
         "resetLibraryPattern": "Скинути шаблон {name} на типовий",
         "tokenTitle": "Назва книги",
         "tokenSubtitle": "Підзаголовок книги",
-        "tokenAuthors": "Author(s), comma-separated",
         "tokenYear": "Рік публікації",
         "tokenSeries": "Назва серії",
         "tokenSeriesIndex": "Індекс серії (0 відкладено)",
         "tokenPublisher": "Автор",
         "tokenIsbn": "ІСБН-13",
-        "tokenLanguage": "Language",
         "tokenOriginalFilename": "Початкове ім'я файлу (без розширення)",
         "tokenExtension": "Розширення файлу (без крапки)",
         "patternHelpIntro": "Шаблони використовують токени типу {titleToken} і {authorsToken}, плюс модифікатори та додаткові сегменти.",
@@ -1821,8 +1772,6 @@
         "copy": "Копія",
         "never": "Ніколи",
         "justNow": "Щойно",
-        "minutesAgo": "{count}m ago",
-        "hoursAgo": "{count}h ago",
         "daysAgo": "{count}d тому",
         "loadFailed": "Не вдалося завантажити",
         "devicePaired": "Пристрій успішно сформовано",
@@ -1839,7 +1788,6 @@
         "deviceRegistered": "Пристрій \" зареєстровано{name}\"",
         "noDevicesYet": "У вас ще немає пристроїв",
         "noDevicesHint": "Додайте пристрій, щоб розпочати синхронізацію ваших книг до вашого Кобо.",
-        "lastSync": "Last sync: {time}",
         "renameDevice": "Перейменувати пристрій",
         "revokeAccess": "Скасувати доступ",
         "deviceRenamed": "Пристрій перейменовано",
@@ -1920,12 +1868,10 @@
             "freshHighlightData": "Дані свіжого підсвічування",
             "created": "Створено {count}",
             "updated": "{count} оновлено",
-            "deleted": "Видалено {count}",
-            "unchanged": "{count} unchanged"
+            "deleted": "Видалено {count}"
           },
           "readingPositionSyncedTitle": "Читання синхронізовано: {title}",
           "readingPositionSynced": "Читання позиції синхронізоване",
-          "labelWithTitle": "{label}: {title}",
           "updateCount": "{count, plural, one {# оновлення} few {# оновлень} many {# оновлень} other {# оновлень}}",
           "directionToKobo": "BookOrbit -> Кобо",
           "directionToBookOrbit": "Кобо -> BookOrbit",
@@ -1934,13 +1880,11 @@
           "summary": {
             "noLibraryUpdatesPending": "Немає оновлень бібліотеки для цього пристрою",
             "libraryUpdatesPrepared": "{count, plural, one {# оновлення бібліотеки підготовлене для пристрою} few {# оновлення бібліотек, які підготувалися до пристрою} many {# оновлення бібліотек, які підготувалися до пристрою} other {# оновлення бібліотек, які підготувалися до пристрою}}",
-            "bookDownloadedBy": "{title} was downloaded by {device}",
             "booksDownloaded": "{count, plural, one {# книг завантажена} few {# книг завантажені} many {# книг завантажені} other {# книг завантажені}}",
             "progressUpdatesSyncedFor": "{count, plural, one {#поступ синхронізоване для {title}} few {# оновлення поступу синхронізоване для {title}} many {# оновлення поступу синхронізоване для {title}} other {# оновлення поступу синхронізоване для {title}}}",
             "progressUpdatesSynced": "{count, plural, one {#поступ синхронізовано} few {# оновлення поступу синхронізовано} many {# оновлення поступу синхронізовано} other {# оновлення поступу синхронізовано}}",
             "newReadingPositionFor": "Кобо повідомив про нову позицію читання {title}",
             "newReadingPosition": "Кобо повідомив про нову позицію читання",
-            "noHighlightChangesNeededFor": "No highlight changes needed for {title}",
             "noHighlightChangesNeeded": "Не потрібні зміни підсвічування",
             "highlightsSentToKoboFor": "{count, plural, one {# підсвічування відправляється Кобо за {title}} few {# підсвічування відправляється до Кобо за {title}} many {# підсвічування відправляється до Кобо за {title}} other {# підсвічування відправляється до Кобо за {title}}}",
             "highlightsSentToKobo": "{count, plural, one {# highlight sent to Kobo} few {# highlights sent to Kobo} many {# highlights sent to Kobo} other {# highlights sent to Kobo}}",
@@ -2021,8 +1965,6 @@
         "loadFailed": "Не вдалося завантажити параметри KOReader",
         "never": "Ніколи",
         "justNow": "Щойно",
-        "minutesAgo": "{count}m ago",
-        "hoursAgo": "{count}h ago",
         "daysAgo": "{count}d тому",
         "unknown": "Не вказано",
         "updateAvailable": "Доступне оновлення",
@@ -2070,7 +2012,6 @@
         "noneYet": "Ще немає",
         "pluginActivity": "Активність плагінів",
         "noPluginActivity": "Ще не було повідомлено про активність плагіна.",
-        "lastFullSync": "Last full sync: {time}",
         "latestPluginSuffix": "- останній плагін v{version}",
         "matchedBooks": "Відповідні книги",
         "readingEvents": "Читання подій",
@@ -2167,13 +2108,11 @@
             "confirmTitle": "Підтвердити посилання KOReader",
             "koreader": "KOReader",
             "bookOrbit": "Книжкова орбіта",
-            "bookId": "Book ID: {id}",
             "syncedStatsNote": "Вже синхронізована статистика залишатиметься у своїй поточній книзі Книги Закладок.",
             "chooseDifferent": "Виберіть інше",
             "saving": "Збереження...",
             "confirmLink": "Підтвердити посилання",
             "unlinkTitle": "Від'єднати книгу KOReader?",
-            "unlinkBody": "Future syncs for this hash will stop resolving to {title} until it is linked again. Already synced stats will stay on their current BookOrbit book.",
             "unlinking": "Від'єднання..."
           },
           "dismiss": "Відхилити",
@@ -2181,7 +2120,6 @@
           "dismissing": "Відключення...",
           "unlinking": "Від'єднання...",
           "unlinkConfirmTitle": "Від'єднати книгу KOReader?",
-          "unlinkConfirmBody": "Future syncs for this hash will stop resolving to {title} until it is linked again. Already synced stats will stay on their current BookOrbit book.",
           "dismissConfirmTitle": "Відхилити {title}?",
           "dismissConfirmBody": "Це видалить його з вашого невідповідного списку книг. Якщо будь-який пристрій повідомить про цей хеш знову, він з'явиться знову як новий запис.",
           "dismissAllConfirmTitle": "{count, plural, =0 {no unmatched books} one {Dismiss all # unmatched book?} few {Dismiss all # unmatched books?} many {Dismiss all # unmatched books?} other {Dismiss all # unmatched books?}}",
@@ -2199,7 +2137,6 @@
           "loadMore": "Завантажити ще",
           "loadingMore": "Завантажується...",
           "confirmLinkTitle": "Підтвердити посилання KOReader",
-          "bookId": "Book ID: {id}",
           "syncedStatsNote": "Вже синхронізована статистика залишатиметься у своїй поточній книзі Книги Закладок.",
           "chooseDifferent": "Виберіть інше",
           "saving": "Збереження...",
@@ -2256,11 +2193,8 @@
         "urlCopyFailed": "Не вдалося скопіювати URL-адреси OPDS",
         "createUserFailed": "Не вдалося створити користувача OPDS",
         "userCreated": "Створено OPDS користувач \"{username}\"",
-        "sortOrderUpdated": "Sort order updated for \"{username}\"",
         "updateSortFailed": "Не вдалося оновити порядок сортування",
-        "userDeleted": "OPDS user \"{username}\" deleted",
         "deleteUserFailed": "Не вдалося видалити користувача OPDS",
-        "labelCopied": "{label} copied",
         "copyLabelFailed": "Не вдалося скопіювати {label}"
       },
       "tabs": {
@@ -2566,7 +2500,6 @@
         "page": "Сторінка {page} з {totalPages}"
       },
       "editUserAria": "Редагувати {name}",
-      "resetPasswordAria": "Reset the password for {name}",
       "deleteUserAria": "Видалити {name}",
       "moreActionsAria": "Додаткові дії для {name}"
     }
@@ -2650,7 +2583,6 @@
       "comfortableView": "Комфортний перегляд"
     },
     "listItem": {
-      "pageNumber": "p. {page}",
       "chapterNumber": "глава {chapter}",
       "selectAnnotation": "Вибрати анотацію",
       "collapse": "Згорнути",
@@ -2673,7 +2605,6 @@
     },
     "hub": {
       "title": "Анотації",
-      "totalCount": "{count} total",
       "bookCount": "{count, plural, =0 {жодної книги} one {# книга} few {# книг} many {# книг} other {# книг}}",
       "noteCount": "{count, plural, =0 {Нотатки немає} one {# примітка} few {# примітки} many {# примітки} other {# примітки}}",
       "export": "Експорт",
@@ -2720,7 +2651,6 @@
     "hideDetails": "Приховати подробиці",
     "refresh": "Оновити журнал аудиту",
     "loadError": "Не вдалося завантажити події аудиту.",
-    "removeFilter": "Remove filter: {value}",
     "allActions": "Всі дії",
     "allEventTypes": "Всі типи подій",
     "allActors": "Усі актори",
@@ -2751,10 +2681,8 @@
     "detailResourceIdLabel": "ID Ресурсу",
     "detailTargetTypeLabel": "Target type",
     "detailTargetIdLabel": "Target ID",
-    "detailAction": "Action: {value}",
     "detailIp": "IP: {value}",
     "detailResource": "Ресурс: {value}",
-    "detailResourceId": "Resource ID: {value}",
     "deletedBooks": "Видалені книги",
     "deletedBookDetail": "{title} (книга #{id})",
     "untitledBook": "Без назви",
@@ -2763,13 +2691,9 @@
     "prev": "Попередня",
     "chips": {
       "search": "Пошук: {value}",
-      "action": "Action: {value}",
-      "eventType": "Event type: {value}",
-      "actor": "Actor: {value}",
       "resource": "Ресурс: {value}",
       "targetType": "Target type: {value}",
       "user": "Користувач: {value}",
-      "from": "From: {value}",
       "to": "До: {value}"
     },
     "filterLabels": {
@@ -2828,7 +2752,6 @@
       "EmailRecipientGroup": "Група одержувача електронною поштою",
       "Narrator": "Оповідач",
       "Publisher": "Автор",
-      "Language": "Language",
       "Series": "Серія",
       "OidcIdentity": "Ідентичність OIDC",
       "MagicLinkToken": "Магічне посилання",
@@ -2886,7 +2809,6 @@
       "BookBulkUpdateTags": "Оновити теги книги",
       "BookBulkSetMetadataLock": "Призначені блоки метаданих",
       "BookBulkEditMetadata": "Редагувати метадані книги",
-      "BookBulkMoveLibrary": "Move books to another library",
       "BookReadingStateReset": "Скинути статус читання",
       "BookWriteAndRename": "Записати метадані і перейменувати файл",
       "CollectionCreate": "Створити колекцію",
@@ -2974,7 +2896,6 @@
     "oidc": {
       "loginFailed": "Помилка входу OIDC",
       "redirecting": "Перенаправлення...",
-      "signInWith": "Sign in with {provider}",
       "completingSignIn": "Завершення входу...",
       "tryAgain": "Спробуйте ще раз",
       "errors": {
@@ -3119,10 +3040,8 @@
         "refreshedNoImage": "Метадані оновлено, але зображення автора не було знайдено.",
         "refreshFailed": "Не вдалося оновити метадані автора",
         "bulkRefreshPartial": "Оновлено {updated} автора(ів), {failed} не вдалося",
-        "bulkRefreshSuccess": "Refreshed metadata for {updated} author(s)",
         "bulkRefreshFailed": "Не вдалося оновити вибрані автори",
-        "deleteSuccess": "{count, plural, =0 {Deleted # author; affected {books} books} one {Deleted # author; affected {books} books} few {Deleted # authors; affected {books} books} many {Deleted # authors; affected {books} books} other {Deleted # authors; affected {books} books}}",
-        "deleteFailed": "Failed to delete author(s)"
+        "deleteSuccess": "{count, plural, =0 {Deleted # author; affected {books} books} one {Deleted # author; affected {books} books} few {Deleted # authors; affected {books} books} many {Deleted # authors; affected {books} books} other {Deleted # authors; affected {books} books}}"
       }
     },
     "detail": {
@@ -3142,20 +3061,17 @@
         "uploadImage": "Вивантажити зображення",
         "removing": "Видалення...",
         "removeImage": "Remove image",
-        "imageHint": "PNG/JPEG/WEBP/GIF/BMP up to {size} MB",
         "saving": "Збереження..."
       },
       "merge": {
         "searchPlaceholder": "Пошук авторів, щоб об'єднати їх у цьому авторі",
         "searching": "Пошук...",
         "bookCount": "{count, plural, =0 {жодної книги} one {# книга} few {# книг} many {# книг} other {# книг}}",
-        "selectedSummary": "Selected {count} author(s), approx. {books} books affected.",
         "merging": "Злиття...",
         "mergeSelected": "Об'єднати вибрані",
         "confirmLabel": "Об'єднати"
       },
       "mergeDialog": {
-        "title": "Merge {count} author(s) into \"{name}\"?",
         "titleFallback": "Об'єднати вибраних авторів?",
         "description": "Це об’єднить вибраних авторів у поточного автора і повторно зв'яже асоційовані книги. Цю дію не можна скасувати.",
         "descriptionEmpty": "Цю дію не можна скасувати."
@@ -3193,7 +3109,6 @@
         "imageUploadFailed": "Не вдалося завантажити зображення автора",
         "imageRemoved": "Зображення автора видалено",
         "imageRemoveFailed": "Не вдалося видалити зображення автора",
-        "mergeSuccess": "Merged {count} author(s); affected {books} books",
         "mergeFailed": "Не вдалося об'єднати авторів",
         "deleteSuccess": "Вилучений автора; була врахована книга {books}",
         "deleteFailed": "Не вдалося видалити автора"
@@ -3230,8 +3145,7 @@
       "addToCollection": "Додати до колекції",
       "setStatus": "Встановити статус",
       "sendViaEmail": "Надіслати через ел. пошту",
-      "rate": "Оцінити {star}",
-      "openAs": "Open as {format}"
+      "rate": "Оцінити {star}"
     },
     "readStatus": {
       "unread": "Непрочитані",
@@ -3274,7 +3188,6 @@
         "startedAt": "Дата початку",
         "finishedAt": "Дата завершення",
         "random": "Випадковий",
-        "language": "Language",
         "metadataScore": "Оцінка метаданих"
       },
       "customFieldsGroup": "Додаткові поля",
@@ -3291,7 +3204,6 @@
       "fields": {
         "title": "Найменування",
         "publisher": "Автор",
-        "language": "Language",
         "series": "Серія",
         "seriesIndex": "Індекс серії",
         "publishedDate": "Дата публікації",
@@ -3345,12 +3257,8 @@
         "isFinished": "завершено",
         "isLocked": "заблокований",
         "isUnlocked": "розблоковано",
-        "isUpNext": "є наступним",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isUpNext": "є наступним"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "Будь-який постачальник",
       "communityRatingProvider": "Постачальник рейтингу спільноти",
       "loadingLibraries": "Завантаження бібліотеки...",
@@ -3418,10 +3326,8 @@
       "includeFilePaths": "Додати шляхи до файлу (додатково)",
       "includeContextMeta": "Включити контекстні метадані",
       "preflight": "Попереднє світло",
-      "scopeLabel": "Scope: {summary}",
       "calculatingSize": "Розрахунок розміру експорту...",
       "estimatedSize": "Розрахунковий розмір:",
-      "fileLabel": "File: {fileName}",
       "exportAction": "Експорт",
       "selectedRowsSummary": "{count, plural, =0 {# обраний рядок} one {# вибраний рядок} few {# вибраних рядків} many {# вибраних рядків} other {# вибраних рядків}}",
       "matchingRowsSummary": "{count, plural, =0 {# відповідний рядок} one {# відповідний рядок} few {! # відповідні рядки} many {! # відповідні рядки} other {! # відповідні рядки}}",
@@ -3490,7 +3396,6 @@
       "title": "Швидкий перегляд книги",
       "titleFor": "Швидкий перегляд для {title}",
       "description": "Перегляд відомостей про книгу та виконання швидких дій.",
-      "openIn": "Open in {provider}",
       "pages": "{count, plural, =0 {# сторінка} one {# сторінка} few {# сторінки} many {# сторінки} other {# сторінки}}",
       "primaryFile": "Основний файл",
       "fileNumber": "Файл #{id}",
@@ -3511,7 +3416,6 @@
       "loadingMoreBooks": "Завантаження інших книг",
       "sort": "Упорядкувати",
       "refreshingMetadata": "Оновлення метаданих {processed} / {total}",
-      "failedCount": "{count} failed",
       "remainingCount": "Залишилося {count}",
       "readOnlyNotice": "Редагування таблиць вимкнено на менших екранах. Перемкніться на список або сітка для виконання швидших дій.",
       "fetching": "Отримання...",
@@ -3663,12 +3567,10 @@
         "untitled": "Без назви",
         "metadataScore": "Оцінка метаданих",
         "primaryFormat": "Основний формат",
-        "openIn": "Open in {provider}",
         "showLess": "Показати менше",
         "showMore": "Показати більше",
         "publisher": "Автор",
         "published": "Опубліковано",
-        "language": "Language",
         "pages": "Сторінки",
         "duration": "Тривалість",
         "edition": "Видання",
@@ -3698,8 +3600,7 @@
         "koboRemovedByDeviceTooltip": "Кобо повідомив про цю книгу видалено.",
         "koboNotSynced": "Не синхронізовано",
         "koboNotSyncedTooltip": "У черзі до наступного синхронізації Кобо.",
-        "filesNotFound": "Файли не знайдено",
-        "filesNotFoundDescription": "The file(s) for this book can no longer be found on disk. Metadata is still available. Run a library scan to confirm, or remove the record."
+        "filesNotFound": "Файли не знайдено"
       },
       "editMetadata": {
         "fieldCount": "{count, plural, =0 {Немає полів} one {одне поле} few {# поля} many {# поля} other {# поля}}",
@@ -3713,17 +3614,14 @@
         "saveInProgress": "Збереження в процесі",
         "writeManualLibraryDisabled": "Запис метаданих у файл і перейменування на диск; автоматичне резервне копіювання запису вимкнено в цій бібліотеці",
         "writeManualTooltip": "Записати {fields} в {target} та перейменувати на диску",
-        "applyResult": "{skipped}, {updated}",
         "skippedLockedFields": "{count, plural, =0 {Не пропуск заблокованих полів} one {Пропущене по одному заблокованому полі} few {Пропущені # заблоковані поля} many {Пропущені # заблоковані поля} other {Пропущені # заблоковані поля}}",
         "updatedFields": "{count, plural, =0 {updated no fields} one {updated one field} few {updated # fields} many {updated # fields} other {updated # fields}}",
-        "wroteFieldsToFile": "Wrote {fields} to file",
         "fileWriteFailedReason": "Помилка запису файлу: {reason}",
         "fileWriteFailed": "Не вдалося записати файл",
         "fileWriteSkippedReason": "Пропущений запис файлу: {reason}",
         "fileWriteSkipped": "Файл для запису пропущений",
         "metadataSaved": "Метадані збережені",
         "metadataWrittenToFile": "Метадані, записані в файл",
-        "savedButWriteFailedReason": "Metadata saved, but file write failed: {reason}",
         "savedButWriteFailed": "Метадані збережені, але запис файлу не вдалося",
         "savedWriteSkippedReason": "Метадані збережені, файл перезапису: {reason}",
         "savedWriteSkipped": "Метадані збережені, файл перезаписується",
@@ -3745,7 +3643,6 @@
         "fileWriteBackDetails": "Подробиці запису",
         "fileWriteBack": "Повернутися до змісту",
         "enabled": "Увімкнено",
-        "saveWritesMetadata": "'Save' writes metadata to {target}",
         "formats": "Формати",
         "bookFiles": "Файли книги",
         "supportedFields": "Підтримувані поля",
@@ -3762,7 +3659,6 @@
         "noProviderRatings": "Немає рейтингу провайдера",
         "seriesLabel": "Серія",
         "publisherLabel": "Автор",
-        "languageLabel": "Language",
         "yearLabel": "Рік",
         "pageCountLabel": "Кількість сторінок",
         "isbn13Label": "ІСБН-13",
@@ -3851,20 +3747,16 @@
       "files": {
         "title": "Файли книги",
         "fileCount": "{count, plural, =0 {Немає файлів} one {# файл} few {# файл} many {# файл} other {# файл}}",
-        "synced": "Synced {time}",
         "sortAria": "Сортування файлів",
         "syncHistory": "Історія синхронізації",
         "metadataWriteBack": "Метадані запису-назад",
         "relative": {
           "seconds": "{value}s тому",
-          "minutes": "{value}m ago",
-          "hours": "{value}h ago",
           "days": "{value}d тому"
         },
         "renameFailed": "Не вдалося перейменувати файл",
         "deleteFailed": "Не вдалося вилучити файл",
         "addFile": "Додати файл",
-        "lastSynced": "Last synced: {time}",
         "sort": {
           "label": "Сортувати:",
           "name": "Ім'я",
@@ -3897,8 +3789,7 @@
         },
         "saving": "Збереження...",
         "deleteModal": {
-          "title": "Видалити файл?",
-          "description": "Are you sure you want to delete \"{filename}\"? This action cannot be undone."
+          "title": "Видалити файл?"
         },
         "deleting": "Видалення..."
       },
@@ -3975,8 +3866,6 @@
           "notSet": "Не задано",
           "relative": {
             "seconds": "{count}s тому",
-            "minutes": "{count}m ago",
-            "hours": "{count}h ago",
             "days": "{count}d тому",
             "months": "{count, plural, =0 {# місяць тому} one {# місяць тому} few {# місяців тому} many {# місяців тому} other {# місяців тому}}",
             "years": "{count, plural, =0 {# рік тому} one {# рік тому} few {# роки тому} many {# роки тому} other {# роки тому}}"
@@ -4095,11 +3984,7 @@
         "seriesPlaceholder": "Серія",
         "moveUp": "Посунути вгору",
         "moveDown": "Посунути вниз",
-        "removeSeries": "Видалити послідовність",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "Видалити послідовність"
       }
     },
     "table": {
@@ -4183,65 +4068,10 @@
     },
     "move": {
       "title": "{count, plural, one {Move # book} few {Move # books} many {Move # books} other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
       "folderCount": "{count, plural, one {# folder} few {# folders} many {# folders} other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
       "confirm": "{count, plural, one {Move # book} few {Move # books} many {Move # books} other {Move # books}}",
-      "action": "Move to library",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, one {# name conflict} few {# name conflicts} many {# name conflicts} other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "collisions": "{count, plural, one {# name conflict} few {# name conflicts} many {# name conflicts} other {# name conflicts}}"
       }
     }
   },
@@ -4281,7 +4111,6 @@
       "paused": "Призупинено",
       "remaining": "Залишилося {count}",
       "processing": "Обробка {count}",
-      "failed": "{count} failed",
       "rateLimited": "Обмежена ставка {count}"
     },
     "report": {
@@ -4307,8 +4136,7 @@
       "failedItemsRequeued": "Невдала спроба елементів",
       "bookComplete": "Метадані завершено - змінено {done} книг",
       "bookDoneWithFailures": "Метадані зроблено - {done} оброблений, {failed} невдалий",
-      "authorComplete": "Збагачення автора завершено - змінилося авторів {done}",
-      "authorDoneWithFailures": "Author enrichment done - {done} processed, {failed} failed"
+      "authorComplete": "Збагачення автора завершено - змінилося авторів {done}"
     }
   },
   "bookDock": {
@@ -4327,7 +4155,6 @@
     "commaSeparated": "відокремлені комами",
     "destinationLibrary": "Бібліотека призначення",
     "destinationFolder": "Тека призначення",
-    "nFailed": "{count} failed",
     "updatedOfFiles": "Оновлено {updated} з файлів {total}",
     "errorStatus": "Помилка {status}",
     "tab": {
@@ -4351,7 +4178,6 @@
       "publisher": "Автор",
       "publishedDate": "Дата публікації",
       "year": "Рік",
-      "language": "Language",
       "isbn13": "ІСБН-13",
       "isbn10": "ІЗБН-10",
       "series": "Серія",
@@ -4361,9 +4187,7 @@
       "description": "Опис"
     },
     "upload": {
-      "nDone": "{count} завершено",
-      "nFailed": "{count} failed",
-      "nTotal": "{count} total"
+      "nDone": "{count} завершено"
     },
     "fileList": {
       "emptyTitle": "Немає файлів в панелі книги",
@@ -4501,7 +4325,6 @@
       "bookCount": "{count, plural, =0 {жодної книги} one {# книга} few {# книг} many {# книг} other {# книг}}",
       "fileCount": "{count, plural, =0 {Немає файлів} one {# файл} few {# файл} many {# файл} other {# файл}}",
       "uploadedToast": "Вивантажено {uploaded}",
-      "uploadFailedToast": "Upload failed for {failed}",
       "uploadPartialToast": "Вивантажено {uploaded}, {failed} не вдалося",
       "bookDock": "Книга док",
       "statistics": "Статистика",
@@ -4528,8 +4351,7 @@
         "body": "Якщо BookOrbit допомагає у вашій бібліотеці, будь ласка, розгляньте можливість розміщення проекту на GitHub. Це допоможе більшій кількості людей знайти застосунок і підтримує постійний розвиток.",
         "cta": "Зоряна книгарня на GitHub"
       },
-      "surfaceOpacity": "Непрозорість поверхні",
-      "surfaceOpacityValue": "{value}%"
+      "surfaceOpacity": "Непрозорість поверхні"
     },
     "sidebar": {
       "dashboard": "Приладна дошка",
@@ -4553,7 +4375,6 @@
         "showAll": "Показати всі",
         "showCount": "Показати {count}",
         "rowsShown": "Відображати рядки",
-        "menuAria": "Section options for {section}",
         "reorder": "Змінити порядок",
         "doneReordering": "Перегрупування закінчено"
       },
@@ -4575,9 +4396,7 @@
       },
       "reorder": {
         "gripAria": "Замовити {name}",
-        "lifted": "{name} lifted, position {position} of {total}. Use the arrow keys to move it.",
         "moved": "{name}, позиція {position} {total}",
-        "dropped": "{name} dropped at position {position} of {total}",
         "cancelled": "Замовлення скасовано. {name} повернувся до позиції {position} {total}.",
         "filteredHint": "Очистити фільтр для зміни порядку"
       }
@@ -4666,8 +4485,7 @@
       "system": "Система"
     },
     "userAvatar": {
-      "profilePicture": "Зображення профілю",
-      "profilePictureOf": "{name} profile picture"
+      "profilePicture": "Зображення профілю"
     },
     "ui": {
       "sidebar": {
@@ -4693,7 +4511,6 @@
       "resultCount": "{shown} {total}",
       "noMatches": "Збігів немає",
       "noMatchesHint": "Спробуйте інший пошуковий термін.",
-      "bookCount": "Books: {count}",
       "librariesEmptyHint": "Створіть бібліотеку, щоб почати додавати книги.",
       "smartScopesEmptyHint": "Розумні області зберігають набір фільтрів, які ви часто використовуєте.",
       "collectionsEmptyHint": "Колекції згрупованих книг, які ви обираєте вручну."
@@ -4704,7 +4521,6 @@
     "dialogDescription": "Перегляньте імена перед додаванням їх до вашої бібліотеки.",
     "readingFiles": "Зчитування файлів...",
     "dropPrompt": "Перетягніть файли SVG або натисніть, щоб переглянути",
-    "fileLimit": "Up to {max} files, 128 KB each",
     "namePlaceholder": "Ім'я",
     "nameRequired": "Потрібне ім'я",
     "invalidSvg": "Неприпустимий SVG",
@@ -4718,7 +4534,6 @@
     "upload": "Вивантажити",
     "uploadCount": "Вивантажити {count}",
     "onlySvgSupported": "Підтримуються лише файли SVG",
-    "maxStaged": "You can stage at most {max} icons at once",
     "onlyMoreCanStage": "{count, plural, =0 {Більше значків не може бути проіндексовано} one {Ще # значка може бути проіндексовано} few {Решта іконок можуть бути розміщені на сцені} many {Решта іконок можуть бути розміщені на сцені} other {Решта іконок можуть бути розміщені на сцені}}",
     "readFailed": "Не вдалося прочитати файли SVG",
     "uploadedCount": "{count, plural, =0 {Немає завантажених значків} one {Завантажено # значок} few {Завантажено # значків} many {Завантажено # значків} other {Завантажено # значків}}",
@@ -4775,14 +4590,6 @@
         "upNextInSeries": "Наступне завдання серії",
         "random": "Відкрийте щось нове",
         "smartScope": "Розумна область видимості"
-      },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
       },
       "reorderHintWidget": "Перетягніть щоб змінити порядок. Ввімкніть, щоб показати або приховати віджет.",
       "reorderHintShelf": "Перетягніть щоб змінити порядок. Ввімкніть, щоб показати або приховати полицю.",
@@ -4844,8 +4651,6 @@
       "neglectedGems": {
         "title": "Забуті коштовні камені",
         "empty": "Всі ваші рейтингові книги були прочитані!",
-        "rating": "{rating}/5",
-        "daysWaiting": "{count}d waiting",
         "queued": "Поставлено в чергу",
         "addToQueue": "Додати до черги",
         "shuffle": "Випадковий порядок"
@@ -4875,8 +4680,7 @@
         "title": "Читання Rhythm",
         "empty": "Почніть читати, щоб побачити форму ритму",
         "activeDays": "{count, plural, =0 {немає активних днів} one {# активний день} few {# активних днів} many {# активних днів} other {# активних днів}}",
-        "consistency": "{activeDays} · {percent}% послідовності",
-        "avgPerDay": "avg {time}/day"
+        "consistency": "{activeDays} · {percent}% послідовності"
       },
       "readingStreak": {
         "title": "Читання серії",
@@ -4893,8 +4697,7 @@
         "trendSteady": "Стійкий темп",
         "pages": "сторінок",
         "hours": "годин",
-        "readCount": "{count} прочитано",
-        "daysLeft": "{count}d left"
+        "readCount": "{count} прочитано"
       }
     }
   },
@@ -4935,7 +4738,6 @@
       "username": "Ім'я користувача",
       "password": "Пароль",
       "passwordEdit": "Пароль (залиште порожнім, щоб зберігати поточний)",
-      "fromName": "From Name",
       "fromNamePlaceholder": "Моя бібліотека",
       "fromAddress": "Домашня адреса",
       "authentication": "Автентифікація",
@@ -4984,7 +4786,6 @@
       "useAccountDefault": "Стандартні налаштування",
       "kindleNote": "Отримувачі Kindle автоматично отримувати електронні листи з темою \"convert\" в режимі перетворення формату.",
       "empty": "Одержувачів поки немає.",
-      "prefersFormat": "prefers {format}",
       "deleteTitle": "Видалити отримувача?",
       "nameEmailRequired": "Ім'я та пошта обов'язкові",
       "created": "Створено одержувачем",
@@ -5030,7 +4831,6 @@
       "editTemplate": "Редагувати шаблон",
       "empty": "Ще немає шаблонів.",
       "notesHeading": "Примітки шаблону",
-      "notesBody": "System templates cannot be deleted. Administrators can edit them. Use variables like {variable} in subjects and bodies - they are replaced with book details at send time.",
       "deleteTitle": "Видалити шаблон?",
       "nameSubjectRequired": "Ім'я та тема є обов'язковими",
       "created": "Шаблон створений",
@@ -5160,7 +4960,6 @@
         "eligible": "правомірні книги"
       },
       "checkingPending": "Перевірка очікуваних елементів...",
-      "pendingOf": "{pending} pending of {total} books.",
       "noBooksInScope": "Немає книг для синхронізації.",
       "allSynced": "Всі книги вже синхронізовані.",
       "lastSyncedLabel": "Остання синхронізація",
@@ -5178,7 +4977,6 @@
       },
       "lastSynced": {
         "justNow": "Щойно",
-        "minutesAgo": "{count} min ago",
         "hoursAgo": "{count, plural, =0 {# годину тому} one {# годину тому} few {# годин тому} many {# годин тому} other {# годин тому}}",
         "daysAgo": "{count, plural, =0 {# день тому} one {# день тому} few {# днів тому} many {# днів тому} other {# днів тому}}"
       }
@@ -5218,7 +5016,6 @@
     },
     "review": {
       "title": "Перегляд імпорту апаратних ковлин",
-      "subtitle": "{total} Hardcover books, {matched} matched.",
       "closeAriaLabel": "Закрити відгук про імпорт",
       "searchPlaceholder": "Пошук заголовку або автора",
       "importProgress": "Прогрес імпорту",
@@ -5274,7 +5071,6 @@
   "library": {
     "creator": {
       "createTitle": "Створити бібліотеку",
-      "editTitle": "Edit: {name}",
       "stepOf": "Крок {current} з {total}",
       "unsaved": "Не збережено",
       "required": "Обов'язково",
@@ -5295,7 +5091,6 @@
       "actions": {
         "saving": "Збереження…",
         "saveChanges": "Зберегти зміни",
-        "creating": "Creating…",
         "createLibrary": "Створити бібліотеку"
       },
       "details": {
@@ -5335,7 +5130,6 @@
         "overlapsWith": "Перекривається на \"{library}\"",
         "noneAdded": "Немає папок ще не додано",
         "runPrescanHint": "Запустити прес-сервер для перевірки шляхів перед збереженням.",
-        "scanning": "Scanning…",
         "prescan": "Прескан"
       },
       "scanner": {
@@ -5467,7 +5261,6 @@
         "title": "Контроль доступу",
         "description": "Суперкористувачі завжди мають повний доступ. Надайте доступ іншим користувачам нижче.",
         "notYetCreated": "Доступ можна налаштувати після створення бібліотеки.",
-        "selectUser": "Select a user…",
         "grant": "Грант",
         "empty": "Користувачів ще не надано доступ.",
         "loading": "Завантаження параметрів доступу...",
@@ -5497,7 +5290,6 @@
       "parentFolder": "Перейти до батьківської папки",
       "newFolder": "Нова папка",
       "goUp": "Догори",
-      "filterPlaceholder": "Filter folders…",
       "clearFilterAria": "Очистити фільтр тек",
       "newFolderNamePlaceholder": "Назва нової папки",
       "create": "Створити",
@@ -5635,7 +5427,6 @@
       },
       "snapshot": {
         "title": "Остання перевірка, знімок",
-        "sourceVersion": "Source version: {version}",
         "unknown": "Не вказано",
         "missingTables": "Відсутні необхідні таблиці: {tables}"
       }
@@ -5680,7 +5471,6 @@
       "sourceRecordId": "ID вихідного запису #{id}",
       "byAuthor": "від {author} (ID: {id})",
       "byFilePath": "{filePath} (ID: {id})",
-      "bookloreSourceId": "Booklore source ID: {id}",
       "libraryBookId": "Бібліотечна книга #{id}"
     },
     "preflight": {
@@ -5713,7 +5503,6 @@
       "refreshStatus": "Оновити статус",
       "pollingStopped": "Опитування стану зупинено через помилку.",
       "retry": "Повторити спробу",
-      "stage": "Stage: {stage}",
       "initializing": "ініціалізація",
       "ended": "Завершено {time}"
     },
@@ -5754,7 +5543,6 @@
       "unresolvedBooksExplanation": "Ці книги є у джерелі, але не можуть бути розміщені в будь-якій книзі у вашій бібліотеці.",
       "mappedUsers": "Згорнуті користувачі ({count})",
       "mappedUsersExplanation": "Сукупності користувачів беруться з багатоосновного попереднього перегляду сушного схованки з планом міграції.",
-      "coverFailures": "{count} cover import(s) failed. Detailed failure rows are not stored.",
       "userPreviewCounts": "{statuses} статуси, пункти поступу {progress} - {sessions} сесій, {bookmarks} закладки, {annotations} анотації, {collections} запис в колекції"
     },
     "unresolvedReason": {
@@ -5797,7 +5585,6 @@
       "loadSuggestionsFailed": "Не вдалося завантажити пропозиції зіставлень користувачів",
       "sourceFieldsRequired": "Потрібно вказати ім'я хоста, ім'я бази даних, бази даних і початкового тексту",
       "connectionPassedWithWarnings": "Тестування підключення пройшло з попередженнями",
-      "connectionPassedWithWarningCount": "Connection test passed with {count} warning(s). First: {warning}",
       "connectionPassed": "Тестування з'єднання пройдено",
       "connectionMissingTables": "Підключення до ok, але {count} обов'язкова таблиця (ів) відсутня",
       "cannotTestMediaWhileRunning": "Неможливо перевірити шлях до медіа, коли запускається",
@@ -5808,7 +5595,6 @@
       "mediaPathValidationFailed": "Помилка перевірки шляху медіа.",
       "connectionFailedBeforeMedia": "Помилка під час перевірки підключення до медіа-шляху.",
       "cannotModifySourceWhileRunning": "Не вдалося змінити джерело, поки запускається",
-      "sourceSavedWithWarnings": "Source saved and validated with {count} warning(s)",
       "sourceSaved": "Джерело збережено та перевірене",
       "saveSourceFailed": "Не вдалося зберегти або перевірити джерело",
       "cannotSaveMappingsWhileRunning": "Не вдалося зберегти зіставлення, коли запускається",
@@ -5922,7 +5708,6 @@
     },
     "loadingBook": "Завантаження книги…",
     "failedToLoadBook": "Не вдалося завантажити книгу",
-    "chapterNumber": "Chapter {number}",
     "peek": {
       "badge": "Пікінг",
       "startReading": "Почни читати"
@@ -5956,72 +5741,26 @@
     "settings": {
       "title": "Налаштування",
       "ariaLabel": "Параметри читання",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "Світла",
         "dark": "Темна"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "Вбудована тема",
-      "fontServer": "Server fonts",
       "fontYours": "Ваші шрифти",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "Потік читання",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "Розгортання сторінки",
       "pageSpreadsHint": "Виберіть, як відображаються сторінки пар на основі зображень.",
       "spread": {
         "bookDefault": "Книга за замовчуванням",
         "singlePage": "Одна сторінка"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "Розрив стовпчика",
       "justifyText": "По ширині тексту",
-      "hyphenation": "Дефікація",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "Дефікація"
     },
     "search": {
       "placeholder": "Пошук у книзі (min {min} символів)...",
       "searching": "Пошук…",
-      "tooShort": "Type at least {min} characters",
       "noResults": "Нічого не знайдено",
       "prompt": "Введіть для пошуку",
       "resultCount": "{count, plural, =0 {немає результатів} one {# результат} few {# результат} many {# результат} other {# результат}}"
@@ -6071,8 +5810,7 @@
       "apply": "Прийняти"
     },
     "note": {
-      "title": "Додати примітку",
-      "placeholder": "Write your note…"
+      "title": "Додати примітку"
     },
     "dictionary": {
       "noDefinition": "Не знайдено визначення",
@@ -6111,9 +5849,6 @@
       "scrollModeHint": "Використовуйте \"Немає прогалин для вебтонів та вертикальних смуг.",
       "readingDirection": "Напрямок читання",
       "pageView": "Перегляд сторінки",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "Поширення вирівнювання",
       "spreadGap": "Поширити розрив",
       "spreadGapValue": "{value}px",
@@ -6171,7 +5906,6 @@
       "endOfChapter": "Кінець розділу",
       "noChaptersAvailable": "Розділи відсутні",
       "extend15": "+ 15 хвилин",
-      "timeLeft": "({time} left)",
       "playbackSpeed": "Швидкість відтворення",
       "noChapters": "Розділи відсутні.",
       "noBookmarks": "Ще немає закладок.",
@@ -6188,10 +5922,6 @@
   "series": {
     "completion": {
       "readOfTotal": "{read} від {total} прочитано ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
     },
     "gaps": {
       "label": "Можливі прогалини:"
@@ -6420,34 +6150,27 @@
         "title": "Топ 50 Серії"
       },
       "booksCompleted": {
-        "title": "Книги завершені",
-        "notEnoughData": "Need at least {count} completed books for this chart."
+        "title": "Книги завершені"
       },
       "completionLatency": {
-        "title": "Затримка завершення",
-        "notEnoughData": "Need at least {count} completed books for this chart."
+        "title": "Затримка завершення"
       },
       "completionTimeline": {
-        "title": "Історія завершень",
-        "notEnoughData": "Need at least {count} completed books for this chart."
+        "title": "Історія завершень"
       },
       "favoriteReadingDays": {
-        "title": "Улюблені Дні Читання",
-        "notEnoughData": "Need at least {count} reading events for this chart."
+        "title": "Улюблені Дні Читання"
       },
       "genreReadingTime": {
-        "title": "Час читання жанрів",
-        "notEnoughData": "Need at least {count} genres with reading time for this chart."
+        "title": "Час читання жанрів"
       },
       "goalTrajectory": {
         "title": "Темп проти мети",
         "noCompletedTitle": "Ще немає завершених книг",
-        "noCompletedDescription": "Завершіть книгу за цей період, щоб порівняти темпи роботи з вашою річною метою.",
-        "notEnoughData": "Need at least {count} completed books for this chart."
+        "noCompletedDescription": "Завершіть книгу за цей період, щоб порівняти темпи роботи з вашою річною метою."
       },
       "peakReadingHours": {
-        "title": "Години піку для читання",
-        "notEnoughData": "Need at least {count} reading events for this chart."
+        "title": "Години піку для читання"
       },
       "progressFunnel": {
         "title": "Прогрес вонель",
@@ -6455,21 +6178,17 @@
         "modeCounts": "Лічильники",
         "modeDropoff": "Виключення",
         "started": "Запущено {count}",
-        "notEnoughData": "Need at least {count} started books for this chart.",
         "noDropOffTitle": "Жодних випадаючих списків",
         "noDropOffDescription": "Кожна початкова книга переросла через всі воронки в цей період."
       },
       "readingClock": {
-        "title": "Читання годинника",
-        "notEnoughData": "Need at least {count} reading sessions for this chart."
+        "title": "Читання годинника"
       },
       "readingHeatmap": {
-        "title": "Читання карти",
-        "notEnoughData": "Need activity on at least {count} days for this chart."
+        "title": "Читання карти"
       },
       "readingPace": {
-        "title": "Читаюча фігура",
-        "notEnoughData": "Need at least {count} sessions with progress data for this chart."
+        "title": "Читаюча фігура"
       },
       "readingSessionTimeline": {
         "title": "Читання часової шкали сесії",
@@ -6477,7 +6196,6 @@
         "dragOff": "Дракон: Вимкнено",
         "prev": "Попередня",
         "next": "Уперед",
-        "week": "Week {week}",
         "dragHint": "Перетягніть смужки для переміщення сесій. Тривалість заблокована і проєднуються сесії відхилено.",
         "noSessionsTitle": "Цього тижня немає сеансів",
         "noSessionsDescription": "Використовуйте попередній / Наступний або тижневий селектор для перегляду іншого тижня.",
@@ -6543,7 +6261,6 @@
       "summary": {
         "label": "Summary",
         "toRename": "{count} для перейменування",
-        "unchanged": "{count} unchanged",
         "collisions": "{count, plural, =0 {# зіткнення} one {# зіткнення} few {# зіткнень} many {# зіткнень} other {# зіткнень}}",
         "errors": "{count, plural, =0 {# помилка} one {# помилка} few {# помилок} many {# помилок} other {# помилок}}"
       },
@@ -6599,7 +6316,6 @@
       "showDetails": "Детальніше про твіт",
       "hideDetails": "Приховати подробиці",
       "deleteSelected": "Видалити вибране {count}",
-      "openBook": "Open details for {title}",
       "unknownAuthor": "Невідомий автор",
       "unknown": "Не вказано",
       "none": "Без ефекту",
@@ -6649,7 +6365,6 @@
     "entityManager": {
       "unknown": "Не вказано",
       "bookCount": "{count, plural, =0 {жодної книги} one {# книга} few {# книг} many {# книг} other {# книг}}",
-      "sortPrefix": "· sort: {sortName}",
       "selectTargetToKeep": "Виберіть ціль для утримання",
       "writeToFiles": "Запис до файлів",
       "writeChangesToFiles": "Записати зміни до файлів",
@@ -6697,8 +6412,6 @@
         "noEntities": "Сутності не знайдено",
         "mergeCount": "Об'єднати ({count})",
         "deleteCount": "Видалити ({count})",
-        "totalCount": "{count} total",
-        "sortLabel": "sort: {sortName}",
         "sort": {
           "nameAsc": "Ім'я А-Я",
           "nameDesc": "Назва Z-A",
@@ -6792,8 +6505,7 @@
         "editMetadata": "Редагувати метадані · {base}",
         "edit": "Редагувати · {base}",
         "files": "Файли · {base}",
-        "readingLog": "Журнал читання · {base}",
-        "highlights": "Highlights · {base}"
+        "readingLog": "Журнал читання · {base}"
       }
     },
     "bookDock": {
@@ -6805,7 +6517,6 @@
       "dropFiles": "Перетягніть файли до панелі книг",
       "supportedFormats": "Підтримка: {formats}",
       "empty": {
-        "noSearchMatch": "No files match \"{query}\"",
         "noStatusFiles": "Немає файлів {status}",
         "uploadPrompt": "Завантажити файли або кинути їх у папку Доку Книги"
       },
@@ -6817,7 +6528,6 @@
         "applied": "{count, plural, =0 {Застосовується до без файлів} one {Застосовується до одного файлу} few {Застосовується до # файлів} many {Застосовується до # файлів} other {Застосовується до # файлів}}",
         "skippedEdited": "{count, plural, =0 {Пропущено один файл, тому що вони мають ручні редагування} one {пропускається один файл, тому що він має ручні редагування} few {Пропущено # файли, тому що вони мають ручні редагування} many {Пропущено # файли, тому що вони мають ручні редагування} other {Пропущено # файли, тому що вони мають ручні редагування}}",
         "skippedNoMetadata": "{count, plural, =0 {Пропущено один файл, тому що вони не мають отриманих метаданих} one {пропускається один файл, тому що він не має метаданих} few {Пропущено # файлів, тому що вони не мають вивантажених метаданих} many {Пропущено # файлів, тому що вони не мають вивантажених метаданих} other {Пропущено # файлів, тому що вони не мають вивантажених метаданих}}",
-        "noneApplied": "No files applied; {reasons}",
         "noneSelected": "Не вибрано жодного файлу"
       }
     },
@@ -6887,8 +6597,7 @@
         "deleted": "\"{name}\" видалено",
         "deleteFailed": "Не вдалося вилучити \"{name}\"",
         "koboSyncEnabled": "\"{name}\" тепер синхронізується з вашим Кобо",
-        "koboSyncDisabled": "\"{name}\" більше не синхронізується з вашим Кобо",
-        "koboSyncFailed": "Failed to update Kobo sync for \"{name}\""
+        "koboSyncDisabled": "\"{name}\" більше не синхронізується з вашим Кобо"
       },
       "empty": {
         "noRules": "Немає налаштованих правил",
@@ -6913,7 +6622,6 @@
     "versions": "Версії",
     "currentVersion": "Поточна версія",
     "youreHere": "Ви знаходитесь тут",
-    "searchPlaceholder": "Search releases…",
     "noReleasesFound": "Не знайдено жодного релізу.",
     "noHighlights": "Немає відміток для цього релізу.",
     "showChangelog": "Показати весь журнал змін",
@@ -6997,8 +6705,7 @@
       "users": "Спільноти",
       "account-activity": "Активність облікового запису",
       "magic-links": "Магічні посилання",
-      "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "oidc": "OIDC / SSO"
     },
     "system": {
       "file-naming": "Назва файлу",

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -7,7 +7,7 @@
     "edit": "编辑",
     "close": "关闭",
     "confirm": "确认",
-    "loading": "Loading...",
+    "loading": "加载中…",
     "search": "搜索",
     "back": "后退",
     "next": "下一个",
@@ -48,7 +48,7 @@
         "narrators": "顶级用药器"
       },
       "confirm": {
-        "shareTitle": "Enable {level}?",
+        "shareTitle": "是否启用 {level}？",
         "shareDescription": "拥有权限的管理员可以看到以下信息。",
         "stopTitle": "停止分享阅读见解？",
         "stopDescription": "管理员的访问将立即被阻止。现有的访问记录仍在您的历史中。",
@@ -89,7 +89,7 @@
       },
       "pageTitle": "显示",
       "pageSubtitle": "控制主题、封面、布局以及您的知识库的显示方式。",
-      "mobileSummary": "Theme: {theme} • Accent: {accent} • Background: {background}",
+      "mobileSummary": "主题：{theme}・强调色：{accent}・背景：{background}",
       "themeMode": {
         "light": "亮色的",
         "dark": "深色",
@@ -168,8 +168,7 @@
           "blush": "Blush"
         },
         "accentColor": {
-          "label": "首选颜色",
-          "hint": "Controls highlights and interactive elements"
+          "label": "首选颜色"
         },
         "cornerRadius": {
           "label": "Corner radius",
@@ -259,7 +258,7 @@
           "hint": "网格、列表、表和仪表板缩略图下面的封面控制深度",
           "default": {
             "label": "默认设置",
-            "hint": "Current elevation and depth"
+            "hint": "当前层级与景深"
           },
           "strong": {
             "label": "强度",
@@ -352,7 +351,7 @@
             "label": "折叠系列封面",
             "hint": "选择当系列在书状网格中折叠时要显示的封面"
           },
-          "stack": "Stack",
+          "stack": "堆叠",
           "mosaic": "摩西文",
           "first": "第一页",
           "latest": "最新的",
@@ -410,14 +409,14 @@
         "selectedCount": "{count, plural, one {# 选择了} other {# 选择了}}",
         "clear": "清空",
         "deleteSelected": "删除选中的",
-        "loading": "Loading icons...",
+        "loading": "正在载入图标...",
         "emptySearch": "没有匹配您搜索的图标。",
         "emptyNoIcons": "尚未上传自定义图标。",
         "namePlaceholder": "名称",
-        "checkingUsage": "Checking usage...",
-        "usedBy": "Used by {count}",
+        "checkingUsage": "正在检查使用情况...",
+        "usedBy": "已有 {count} 处使用",
         "notUsedYet": "尚未使用",
-        "rename": "Rename",
+        "rename": "重命名",
         "replace": "替换",
         "usage": {
           "libraries": "{count, plural, =0 {没有库} one {# 库} other {# 库}}",
@@ -425,15 +424,15 @@
           "smartScopes": "{count, plural, =0 {没有智能范围} one {# 智能范围} other {# 智能范围}}"
         },
         "confirm": {
-          "deleteOne": "Delete \"{name}\"? Existing uses will fall back to their default icon.",
-          "deleteMany": "{count, plural, =0 {Delete no icons?} one {Delete # icon? Existing uses will fall back to their default icon.} other {Delete # icons? Existing uses will fall back to their default icon.}}"
+          "deleteOne": "删除 “{name}”？现有使用场景将回退为默认图标。",
+          "deleteMany": "{count, plural, =0 {不删除任何图标？} one {确定删除 # 个图标？现有使用场景将回退为默认图标。} other {确定删除 # 个图标？现有使用场景将回退为默认图标。}}"
         },
         "toasts": {
           "saved": "图标已保存",
           "updated": "图标已更新",
           "deleted": "图标已删除",
           "bulkDeleted": "{count, plural, =0 {删除没有图标} one {删除# 图标} other {删除# 图标}}",
-          "bulkDeletePartial": "Deleted {deleted}, {failed} failed"
+          "bulkDeletePartial": "已删除 {deleted} 项，{failed} 项失败"
         },
         "errors": {
           "load": "加载图标失败",
@@ -467,7 +466,7 @@
       },
       "feedback": {
         "unsavedChanges": "未保存的更改",
-        "discard": "Discard"
+        "discard": "放弃"
       },
       "profile": {
         "securityHeading": "个人资料与安全",
@@ -476,7 +475,7 @@
         "email": "电子邮件地址",
         "emailHint": "请联系管理员更改您的电子邮件地址。",
         "save": "保存配置文件",
-        "saving": "Saving...",
+        "saving": "正在保存…",
         "changePassword": "更改密码",
         "accountType": "帐户类型：",
         "accountTypeOidc": "OIDC / SSO",
@@ -508,12 +507,12 @@
       "avatar": {
         "title": "个人资料图片",
         "unknownUser": "未知用户",
-        "formatHint": "PNG/JPEG/WEBP up to {size} MB",
+        "formatHint": "PNG/JPEG/WEBP，最大 {size} MB",
         "upload": "上传图片",
         "replace": "替换图片",
-        "uploading": "Uploading...",
+        "uploading": "正在上传...",
         "remove": "移除图片",
-        "removing": "Removing...",
+        "removing": "正在删除...",
         "updated": "个人资料图片已更新",
         "uploadFailed": "上传个人资料图片失败",
         "removed": "个人资料图片已删除",
@@ -527,10 +526,10 @@
       "connectedAccounts": {
         "title": "已连接的账户",
         "unlink": "取消链接",
-        "unlinking": "Unlinking...",
+        "unlinking": "正在解绑...",
         "linkAdditional": "链接额外的提供商：",
-        "linkProvider": "Link {provider}",
-        "redirecting": "Redirecting...",
+        "linkProvider": "关联 {provider}",
+        "redirecting": "正在跳转授权…",
         "noneConfigured": "没有配置OIDC 提供商。请管理员设置SSO。",
         "linkStateFailed": "无法生成链接状态",
         "startLinkFailed": "启动 OIDC 链接失败",
@@ -538,12 +537,12 @@
         "unlinked": "身份未连接",
         "unlinkIdentityFailed": "取消链接身份失败",
         "unlinkDialog": {
-          "title": "Unlink {provider} identity?",
+          "title": "确定解绑 {provider} 账号？",
           "description": "输入您的密码以确认。您将无法使用此提供商登录。",
           "currentPassword": "当前密码"
         },
         "description": "使用关联到此帐户的外部身份提供商登录。",
-        "unlinkAria": "Unlink {provider}"
+        "unlinkAria": "解绑 {provider}"
       },
       "tour": {
         "title": "导游览",
@@ -584,7 +583,7 @@
       "subtitle": "为共享帐户创建可共享的登录链接。",
       "createLink": "创建链接",
       "noSharedAccounts": "未找到共享账户",
-      "noSharedAccountsHint": "Create a shared account from the {usersPage} first to generate magic links.",
+      "noSharedAccountsHint": "请先前往 {usersPage} 创建共享账号，方可生成免登录链接。",
       "activeLinks": "活动链接",
       "inactiveLinks": "非活动链接",
       "paused": "已暂停",
@@ -593,17 +592,17 @@
       "never": "没有记录的活动",
       "noExpiry": "无过期",
       "expired": "已过期",
-      "expiresOn": "Expires {date}",
-      "revokedOn": "Revoked {date}",
-      "expiredOn": "Expired {date}",
+      "expiresOn": "有效期至 {date}",
+      "revokedOn": "已于 {date} 撤销",
+      "expiredOn": "已于 {date} 过期",
       "usesCount": "{count, plural, =0 {没有使用} one {有人使用} other {# 使用}}",
       "copied": "已复制！",
       "copyLink": "复制链接",
       "pause": "暂停",
       "resume": "恢复",
       "revoke": "Revoke",
-      "revoking": "Revoking...",
-      "emptyState": "No magic links created yet. Click \"{action}\" to generate a shareable login URL.",
+      "revoking": "正在取消...",
+      "emptyState": "尚未创建任何免登录链接。点击 “{action}” 即可生成可分享的登录链接。",
       "columns": {
         "label": "标签",
         "account": "账户",
@@ -625,7 +624,7 @@
         "expiresAt": "过期时间",
         "optional": "(可选)",
         "create": "创建",
-        "creating": "Creating..."
+        "creating": "创建中..."
       },
       "revokeDialog": {
         "title": "撤销魔法链接？",
@@ -639,14 +638,14 @@
       },
       "usersPage": "用户页面",
       "emptyTitle": "尚未创建魔法链接",
-      "emptyHint": "Click \"{action}\" to generate a shareable login URL.",
+      "emptyHint": "点击 “{action}” 生成可分享的登录链接。",
       "noActiveTitle": "没有活动的魔法链接",
       "noActiveHint": "此页面生成的所有魔法链接都已过期或被撤销。",
-      "copyLinkAria": "Copy the link for {label}",
-      "pauseAria": "Pause {label}",
-      "resumeAria": "Resume {label}",
+      "copyLinkAria": "复制 {label} 的链接",
+      "pauseAria": "停用 {label}",
+      "resumeAria": "启用 {label}",
       "revokeAria": "Revoke {label}",
-      "lastUsedLabel": "Last used {date}"
+      "lastUsedLabel": "上次使用：{date}"
     },
     "oidc": {
       "title": "OIDC / SSO",
@@ -655,7 +654,7 @@
       "addProvider": "添加提供商",
       "editProvider": "编辑提供商",
       "configureNew": "配置一个新的 OIDC 提供程序。",
-      "editing": "Editing {slug}",
+      "editing": "正在编辑 {slug}",
       "enabled": "已启用",
       "disabled": "已禁用",
       "empty": {
@@ -678,14 +677,14 @@
         "issuerUri": "发行商URI",
         "issuerUriHint": "提供者的基础 URL。",
         "test": "测试",
-        "testing": "Testing...",
+        "testing": "测试中…",
         "clientId": "客户端ID",
         "clientSecret": "客户端密钥",
         "clientSecretPlaceholder": "留空以保持存在",
         "scopes": "范围",
         "claimMapping": "声明映射",
         "previewClaims": "预览求偿权",
-        "redirecting": "Redirecting...",
+        "redirecting": "正在跳转...",
         "mappedClaims": "3. 已冻结的索赔",
         "rawClaims": "原始索赔",
         "usernameClaim": "用户名请求",
@@ -701,12 +700,12 @@
         "defaultPermissionsHint": "授予第一个OIDC 登录的新用户的权限。",
         "createProvider": "创建提供商",
         "saveChanges": "保存更改",
-        "saving": "Saving...",
+        "saving": "保存中...",
         "deleteProvider": "删除提供商",
-        "deleting": "Deleting..."
+        "deleting": "删除中..."
       },
       "test": {
-        "connected": "Connected - {issuer}",
+        "connected": "已连接 - {issuer}",
         "connectionFailed": "连接失败",
         "hide": "隐藏",
         "details": "详细信息",
@@ -715,13 +714,12 @@
       },
       "groupMappings": {
         "title": "群组映射",
-        "description": "Map OIDC group claims to BookOrbit permissions. Synced on every login.",
         "noPermission": "无权限",
         "empty": "未配置组映射。",
         "addMapping": "添加映射",
         "claimPlaceholder": "OIDC 群组索赔 (例如，管理员)",
         "add": "添加",
-        "adding": "Adding..."
+        "adding": "正在添加..."
       },
       "toasts": {
         "providerCreated": "提供者已创建",
@@ -757,15 +755,14 @@
         "recommendationsGroup": "建议",
         "achievementsGroup": "1. 成就",
         "updatesGroup": "更新",
-        "importFromBooklore": "Import from Booklore",
         "bookloreImportConfigured": "已配置书签导入",
         "migrationRunning": "迁移正在运行",
         "migrationCompleted": "迁移完成",
         "migrationFailed": "迁移失败",
         "importDescription": "一次性导入书籍、元数据和从上一个书签安装中读取进度。",
-        "configuredDescription": "Source: {name}. No migration run yet - continue setup to run the import.",
-        "runningDescription": "Stage: {stage} - started {started}",
-        "completedDescription": "From {name} - completed {date}",
+        "configuredDescription": "数据源：{name}。尚未执行数据迁移，请完成剩余配置后再执行导入。",
+        "runningDescription": "环节：{stage}，已于 {started} 启动",
+        "completedDescription": "来自 {name}，已于 {date} 执行完成",
         "migrationErrorGeneric": "迁移过程中发生错误。",
         "stageInitializing": "初始化",
         "recently": "最近的",
@@ -776,24 +773,24 @@
         "refreshRecommendationHint": "使用您最新的库更改更新推荐引擎。此过程正在后台运行。",
         "booksQueuedForProcessing": "{count, plural, =0 {没有排队处理的书籍} one {# 处理中的书队列} other {# 排队处理中的书}}",
         "run": "运行",
-        "running": "Running...",
+        "running": "运行中...",
         "backfillAchievements": "倒退成就",
         "backfillAchievementsHint": "重新评估所有用户的成就。",
-        "backfillResult": "Processed {users} users; granted {awards} awards.",
+        "backfillResult": "已处理 {users} 位用户；已发放 {awards} 项奖励。",
         "runBackfill": "运行返回填充",
         "checkForUpdates": "检查更新",
         "checkForUpdatesHint": "启动时自动检查 GitHub 获取新版本，并在侧边栏显示一个指示器。",
         "updateChecksEnabled": "更新检查已启用",
         "updateChecksDisabled": "更新检查已禁用",
         "updateSettingFailed": "更新设置失败",
-        "booksQueuedForEmbedding": "{count, plural, =0 {no books queued for embedding} one {# book queued for embedding} other {# books queued for embedding}}",
+        "booksQueuedForEmbedding": "{count, plural, =0 {暂无待处理的图书向量化任务} one {# 本图书等待向量化处理} other {# 本图书等待向量化处理}}",
         "failed": "失败",
         "unknownError": "未知错误",
-        "rebuildEmbeddingsFailed": "Failed to rebuild embeddings: {error}",
+        "rebuildEmbeddingsFailed": "重建向量化数据失败：{error}",
         "achievementBackfillConfirm": "对所有用户的所有成就运行成绩回填？这可能需要一段时间。",
-        "achievementBackfillComplete": "Achievement backfill complete: {count} awards granted",
+        "achievementBackfillComplete": "成就数据补发完成：共发放 {count} 项奖励",
         "backfillRunFailed": "运行回填失败",
-        "achievementBackfillFailed": "Failed to run achievement backfill: {error}",
+        "achievementBackfillFailed": "执行成就数据补发失败：{error}",
         "uploadsGroup": "上传",
         "maxUploadSize": "上传文件大小限制",
         "maxUploadSizeHint": "配置全系统文件上传的最大尺寸限制。",
@@ -837,11 +834,11 @@
         "issueFreshDryRun": "运行新的干线",
         "issueResolveDuplicates": "解决干运行中重复的目标书匹配",
         "issueWaitActiveRun": "等待活动运行完成",
-        "sourceRecordId": "Source record ID #{id}",
-        "byAuthorWithId": "by {author} (ID: {id})",
+        "sourceRecordId": "源数据记录 ID：#{id}\t",
+        "byAuthorWithId": "创建人：{author}（ID：{id}）\t",
         "filePathWithId": "{path} (ID: {id})",
-        "bookloreSourceId": "Booklore source ID: {id}",
-        "libraryBookNum": "Library book #{id}",
+        "bookloreSourceId": "Booklore 源标识：{id}\t",
+        "libraryBookNum": "馆藏图书编号：#{id}",
         "errorInitialize": "初始化迁移设置失败",
         "errorLoadSourceTypes": "加载支持的迁移源类型失败",
         "errorLoadTargetUsers": "加载目标用户失败",
@@ -851,9 +848,9 @@
         "errorLoadSuggestions": "加载用户映射建议失败",
         "requiredFields": "主机、 用户、 数据库和源名称是必需的",
         "connectionTestPassedWithWarnings": "连接测试通过警告",
-        "connectionTestPassedWithCount": "Connection test passed with {count} warning(s). First: {first}",
+        "connectionTestPassedWithCount": "连接测试通过，存在 {count} 条警告；首条警告：{first}",
         "connectionTestPassed": "连接测试通过",
-        "connectionOkMissingTables": "Connection ok, but {count} required table(s) are missing",
+        "connectionOkMissingTables": "连接正常，但缺失 {count} 张必需数据表",
         "cannotTestMediaPathActiveRun": "在运行时无法测试媒体路径",
         "mediaRootPathRequiredCover": "导入封面需要媒体根路径。",
         "useAbsolutePath": "使用绝对路径(例如：/books)。",
@@ -862,7 +859,7 @@
         "mediaPathValidationFailed": "媒体路径验证失败。",
         "connectionFailedBeforeMediaPath": "在媒体路径验证完成之前，连接测试失败。",
         "cannotModifySourceActiveRun": "正在运行时无法修改源",
-        "sourceSavedValidatedWarnings": "Source saved and validated with {count} warning(s)",
+        "sourceSavedValidatedWarnings": "数据源已保存并校验完成，存在 {count} 条警告",
         "sourceSavedValidated": "源保存并验证",
         "errorSaveValidateSource": "保存或验证源失败",
         "cannotSaveMappingsActiveRun": "运行时无法保存映射",
@@ -874,9 +871,9 @@
         "errorSaveMappings": "保存映射失败",
         "cannotRunDryRunActiveRun": "正在运行时无法运行干运行",
         "saveMappingsFirst": "首先保存映射",
-        "dryRunCompleted": "Dry-run completed: {matched} matched, {unresolved} unresolved",
+        "dryRunCompleted": "试运行完成：匹配 {matched} 条、待处理 {unresolved} 条",
         "dryRunFailed": "Dry-运行失败",
-        "selectSourceForAllGroups": "Select a source book for all {count} duplicate groups",
+        "selectSourceForAllGroups": "请为全部 {count} 个重复分组选择对应源图书",
         "duplicatesResolved": "重复匹配已解决",
         "errorResolveDuplicates": "无法解析重复项",
         "preflightNotReady": "迁移前逃亡尚未准备好",
@@ -891,7 +888,7 @@
         "startMigrationFirst": "首先开始迁移",
         "reportRefreshed": "运行报告已刷新",
         "errorLoadReport": "加载运行报告失败",
-        "reportExported": "Report exported as {format}",
+        "reportExported": "报告已导出，格式：{format}",
         "errorExportReport": "导出迁移报告失败",
         "reasonNoTitleAuthorMatch": "未找到标题或作者匹配的书",
         "reasonNoFilePathMatch": "文件路径与此库中的任何书不匹配",
@@ -908,7 +905,7 @@
         "strategyPathMapping": "已映射文件路径匹配",
         "strategyTitleAuthor": "按标题和作者匹配",
         "strategyUnavailable": "比赛策略不可用",
-        "userPreviewCounts": "{statuses} statuses, {progress} progress entries, {bookmarks} bookmarks, {annotations} annotations, {collections} collection entries",
+        "userPreviewCounts": "状态数据：{statuses} 条、阅读进度：{progress} 条、书签：{bookmarks} 条、批注：{annotations} 条、收藏记录：{collections} 条",
         "connErrorUnreachable": "无法连接到数据库服务器。请检查主机和端口。",
         "connErrorAuth": "身份验证失败。请检查用户名和密码。",
         "connErrorUnknownDatabase": "找不到数据库。请检查数据库名称。",
@@ -920,7 +917,7 @@
         "port": "端口",
         "user": "用户",
         "password": "密码",
-        "passwordSavedPlaceholder": "Saved - leave unchanged",
+        "passwordSavedPlaceholder": "已保存，保持原有值不变",
         "passwordEmptyPlaceholder": "未设置密码",
         "database": "数据库",
         "mediaRootPath": "媒体根路径",
@@ -932,9 +929,9 @@
         "saveAndValidate": "保存并验证",
         "sourceValidatedWithWarnings": "经警告验证的源",
         "lastValidationSnapshot": "最后验证快照",
-        "sourceVersion": "Source version: {version}",
+        "sourceVersion": "数据源版本：{version}",
         "unknown": "未知的",
-        "missingRequiredTables": "Missing required tables: {tables}",
+        "missingRequiredTables": "缺失必需数据表：{tables}",
         "suggestionsAutoLoad": "源验证后自动加载用户建议。",
         "refresh": "刷新",
         "sourceUser": "源用户",
@@ -943,17 +940,17 @@
         "noActiveTargetUsers": "未找到活跃的目标用户。在映射前创建或重新启用书签。",
         "pathPrefixMappings": "路径前缀映射",
         "addMapping": "添加映射",
-        "pathMappingsHelp1": "Path mappings translate source file paths to target paths so books can be matched by file location. For example, if your Booklore library stored files under",
+        "pathMappingsHelp1": "路径映射会将源文件路径转换为目标路径，系统可依据文件位置匹配图书；例如：若你的 Booklore 书库文件存放于",
         "pathMappingsHelp2": "和同一文件已经存在",
         "pathMappingsHelp3": "，添加此映射。 书籍也被ISBN匹配，文件哈希。 和标题/作者，无论路径映射如何，路径映射只是四种策略中的一种，不限制在迁移中包含哪些源书籍。",
         "noPrefixesFound": "没有找到前缀 - 首先验证源代码",
-        "selectSourcePrefix": "Select source prefix...",
-        "selectTargetFolder": "Select target folder...",
+        "selectSourcePrefix": "选择源路径前缀…",
+        "selectTargetFolder": "选择目标文件夹…",
         "remove": "删除",
         "pathValidation": "路径验证",
-        "pathValidationMapped": "{mapped} of {total} source books have a mapped path",
-        "pathValidationUnmatched": "{count} mapped paths not found on disk - those books will fall back to ISBN / title matching",
-        "pathValidationAllMatched": "All {count} mapped paths found on disk",
+        "pathValidationMapped": "共 {total} 本源图书，已有 {mapped} 本完成路径映射",
+        "pathValidationUnmatched": "有 {count} 条映射路径在磁盘中未找到，这类图书将自动改用 ISBN / 书名匹配",
+        "pathValidationAllMatched": "全部 {count} 条映射路径均已在磁盘匹配成功",
         "saveMappings": "保存映射",
         "runDryRun": "运行 Dry-Run",
         "matched": "匹配：",
@@ -963,8 +960,8 @@
         "resolveDuplicateMatches": "解决重复的目标匹配",
         "resolveDuplicateHint": "对于每个目标书，选择一个源代码簿来保存。推荐选择将在有一个最强的比赛时预先选择。",
         "remainingGroups": "剩余群组：",
-        "ofCount": "of {count}",
-        "targetBookNum": "Target book #{id}",
+        "ofCount": "共 {count} 条",
+        "targetBookNum": "目标图书编号：#{id}",
         "recommended": "推荐的",
         "resolveDuplicatesButton": "{count, plural, =0 {解决# 重复} one {解决# 重复} other {解决# 重复}}",
         "preflightChecks": "飞行前检查",
@@ -985,16 +982,16 @@
         "refreshStatus": "刷新状态",
         "statusPollingStopped": "状态投票因错误而停止。",
         "retry": "重试",
-        "stageLabel": "Stage: {stage}",
+        "stageLabel": "环节：{stage}",
         "stageInitializing": "初始化",
-        "endedLabel": "Ended {date}",
+        "endedLabel": "结束时间：{date}",
         "stageCompleted": "已完成",
         "stageInit": "正在初始化",
         "stageSharedOverlays": "导入元数据",
         "stageBookCovers": "导入封面",
         "stageUserState": "正在导入用户数据",
         "noRunYet": "尚未运行迁移。完成上面的步骤以开始。",
-        "runNum": "Run #{id}",
+        "runNum": "任务批次编号：#{id}",
         "notStarted": "未启动",
         "reloadReport": "重新加载报告",
         "loadFullReport": "加载完整报告",
@@ -1002,7 +999,7 @@
         "exportCsv": "导出CSV",
         "migrationFailed": "迁移失败",
         "retryFromLastStage": "从上次完成的阶段重试",
-        "booksCard": "Books",
+        "booksCard": "图书统计",
         "metadataOverlaysApplied": "已应用元数据叠加层",
         "authorMappingsReplaced": "已替换作者映射",
         "narratorMappingsReplaced": "Narrator 映射已替换",
@@ -1020,22 +1017,22 @@
         "collectionEntries": "收藏条目",
         "loadFullReportHint": "单击“负载完整报告”以在导出的报告中包含干燥的比赛摘要。",
         "completedNoIssues": "迁移已完成，没有未解决的书籍或故障。",
-        "matchedBooksHeading": "Matched books ({count})",
+        "matchedBooksHeading": "匹配成功图书（{count} 本）",
         "matchedBooksHint": "这些干线比赛被用来决定哪些图书馆书籍收到了导入的数据。",
-        "sourceBookFallback": "Source book {id}",
-        "libraryBookFallback": "Library book {id}",
-        "unresolvedBooksHeading": "Unresolved books ({count})",
+        "sourceBookFallback": "源图书 {id}",
+        "libraryBookFallback": "馆藏图书 {id}",
+        "unresolvedBooksHeading": "待处理图书（{count} 本）",
         "unresolvedBooksHint": "这些书存在于源代码中，但无法与您的书库中的任何书匹配。",
-        "mappedUsersHeading": "Mapped users ({count})",
+        "mappedUsersHeading": "已匹配用户（{count} 人）",
         "mappedUsersHint": "每个用户的总数来自与迁移计划一起缓存的干动预览。",
-        "coverImportsFailed": "{count} cover import(s) failed. Detailed failure rows are not stored.",
+        "coverImportsFailed": "{count} 条封面导入失败，系统未保存失败明细数据",
         "backToSetup": "返回设置"
       },
       "libraries": {
         "title": "库",
         "subtitle": "管理您的媒体库并触发内容扫描。",
         "scanAll": "扫描全部",
-        "scanning": "Scanning...",
+        "scanning": "扫描中…",
         "addLibrary": "添加库",
         "scan": "扫描",
         "editLibrary": "编辑库",
@@ -1043,7 +1040,7 @@
         "syncMetadataToFiles": "同步元数据到文件",
         "deleteLibrary": "删除库",
         "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}",
-        "addedDate": "Added {date}",
+        "addedDate": "新增时间：{date}",
         "fileMode": "文件模式",
         "folderMode": "文件夹模式",
         "folderCount": "{count, plural, =0 {没有文件夹} one {# 文件夹} other {# 文件夹}}",
@@ -1053,39 +1050,39 @@
         "emptyTitle": "还没有库",
         "emptyHint": "添加一个库来开始组织您的书籍。",
         "addFirstLibrary": "添加您的第一个库",
-        "deleteConfirmTitle": "Delete \"{name}\"?",
+        "deleteConfirmTitle": "确定要删除 “{name}” 吗？",
         "deleteConfirmBody": "这将永久移除此库中的所有书籍、元数据、阅读进度、书签和批注。无法撤消。",
         "deleteConfirmTypeName": "输入要确认的库名称：",
-        "deleting": "Deleting...",
+        "deleting": "删除中...",
         "deleteLibraryButton": "删除库",
         "syncConfirmTitle": "同步元数据到文件？",
         "syncConfirmBodyPrefix": "这将覆盖每个支持的文件内的元数据",
         "syncConfirmBodySuffix": "直接在磁盘上。这不能撤消。",
         "syncFiles": "同步文件",
-        "metadataSynced": "Metadata synced to files for \"{name}\"",
+        "metadataSynced": "“{name}” 的元数据已同步至对应文件",
         "fileWriteNotEnabled": "此库未启用元数据文件写入。在库设置中启用它。",
-        "fileSyncFailed": "File sync failed for \"{name}\"",
-        "scanStarted": "Scan started for \"{name}\"",
-        "scanStartFailed": "Failed to start scan for \"{name}\"",
-        "refreshCoversFailed": "Failed to refresh covers for \"{name}\"",
+        "fileSyncFailed": "“{name}” 文件同步失败",
+        "scanStarted": "已启动 “{name}” 的扫描任务",
+        "scanStartFailed": "“{name}” 扫描任务启动失败",
+        "refreshCoversFailed": "“{name}” 封面刷新失败",
         "scanStartedAll": "开始扫描所有库",
         "librariesFailedToStart": "{count, plural, =0 {没有任何库未能启动} one {# 库未能启动} other {# 库未能启动}}",
         "scansStartFailed": "启动扫描失败",
-        "libraryCreated": "Library \"{name}\" created",
-        "libraryUpdated": "Library \"{name}\" updated",
-        "libraryDeleted": "\"{name}\" deleted",
+        "libraryCreated": "书库 “{name}” 创建成功",
+        "libraryUpdated": "书库 “{name}” 更新成功",
+        "libraryDeleted": "“{name}” 已删除",
         "deleteFailed": "删除库失败",
-        "scanningProgress": "Scanning {pct}% ({processed}/{total})",
-        "scanDone": "Done - {added} added, {updated} updated",
-        "scanFailedWithError": "Failed: {error}",
+        "scanningProgress": "扫描进度：{pct}%（已处理 {processed}/{total}）",
+        "scanDone": "扫描完成：新增 {added} 条、更新 {updated} 条",
+        "scanFailedWithError": "执行失败：{error}\t",
         "scanFailed": "扫描失败",
-        "refreshingCovers": "Refreshing covers {pct}% ({processed}/{total})",
-        "coversRefreshed": "Covers refreshed ({count} processed)"
+        "refreshingCovers": "封面刷新中 {pct}%（{processed}/{total}）",
+        "coversRefreshed": "封面刷新完成，已处理 {count} 条"
       },
       "authorEnrichment": {
         "configuration": "配置",
-        "saving": "Saving...",
-        "running": "Running...",
+        "saving": "保存中……",
+        "running": "运行中……",
         "runEligibleShort": "运行合格的",
         "runAllShort": "运行所有",
         "enableTitle": "启用自动丰富作者",
@@ -1105,7 +1102,7 @@
         "missingPhotoTitle": "缺少照片",
         "missingPhotoHint": "如果作者没有个人资料照片，请附上。",
         "runForEligibleAuthors": "为合格作者运行",
-        "eligibleCount": "~{count} eligible",
+        "eligibleCount": "~{count} 符合条件的",
         "runForAllAuthors": "为所有作者运行",
         "saved": "作者浓缩设置已保存",
         "saveFailed": "保存作者丰富设置失败",
@@ -1122,8 +1119,8 @@
         "confirmReset": "确认重置",
         "reset": "Reset",
         "recalculate": "重新计算",
-        "subtotal": "subtotal: {count}",
-        "savedRecalculating": "Score weights saved. Recalculating library scores...",
+        "subtotal": "小计：{count}",
+        "savedRecalculating": "权重分值已保存，正在重新计算书库评分…",
         "saveFailed": "保存得分权数失败",
         "recalcStarted": "从后台开始重新计算得分",
         "recalcFailed": "重新计算失败",
@@ -1134,14 +1131,14 @@
         "account-activity": "帐户活动",
         "magic-links": "魔法链接",
         "oidc": "OIDC / SSO",
-        "server-fonts": "Server Fonts"
+        "server-fonts": "服务端字体"
       },
       "serverFonts": {
-        "title": "Server Fonts",
-        "subtitle": "Upload fonts that every user can pick in the eBook reader, without uploading their own.",
-        "listLabel": "Server fonts",
-        "noFontsYet": "No server fonts yet",
-        "noFontsHint": "Fonts you add here appear in every user's reader."
+        "title": "服务端字体",
+        "subtitle": "上传字体后，所有用户均可在电子书阅读器内选用，无需自行上传字体",
+        "listLabel": "服务端字体",
+        "noFontsYet": "暂无服务端字体\t",
+        "noFontsHint": "在此处添加的字体将对全部用户的阅读器生效"
       }
     },
     "common": {
@@ -1198,8 +1195,8 @@
       "autoFetch": {
         "globalSettings": "全局设置",
         "perLibraryOverrides": "超媒体库覆盖",
-        "saving": "Saving...",
-        "running": "Running...",
+        "saving": "保存中...",
+        "running": "运行中...",
         "runNow": "立即运行",
         "runForEligible": "为合格的书籍运行",
         "enable": {
@@ -1208,12 +1205,12 @@
         },
         "triggerOnImport": {
           "label": "导入时触发",
-          "hint": "Queue eligible books when they are first added to a library."
+          "hint": "书籍首次接入书库时，将符合条件的书籍加入任务队列"
         },
         "status": {
-          "inQueuePaused": "{count} in queue - paused",
-          "remaining": "{count} remaining",
-          "eligible": "~{count} eligible"
+          "inQueuePaused": "队列内 {count} 项任务，已暂停",
+          "remaining": "剩余 {count} 项",
+          "eligible": "约 {count} 项符合条件"
         },
         "trigger": {
           "queued": "{count, plural, one {排队# 书} other {排队# 书}}",
@@ -1221,13 +1218,13 @@
         },
         "lastRun": {
           "justNow": "就在这里",
-          "minutesAgo": "{count}m ago",
-          "hoursAgo": "{count}h ago",
-          "yesterday": "yesterday",
+          "minutesAgo": "{count} 分钟前",
+          "hoursAgo": "{count} 小时前",
+          "yesterday": "昨天",
           "daysAgo": "{count, plural, one {#天前} other {#天前}}",
-          "label": "Last run: {when}",
-          "labelQueued": "Last run: {when} - queued {count} books",
-          "labelNoneEligible": "Last run: {when} - no eligible books"
+          "label": "上次执行：{when}",
+          "labelQueued": "上次执行：{when} - 已将 {count} 本书籍加入队列",
+          "labelNoneEligible": "上次执行：{when} - 无符合条件的书籍"
         },
         "conditions": {
           "title": "资格条件",
@@ -1242,7 +1239,7 @@
             "label": "低元数据分数",
             "hint": "获取元数据分数低于阈值。",
             "scoreBelow": "下方得分",
-            "summary": "Score < {threshold}"
+            "summary": "分值小于 {threshold}"
           },
           "missingFields": {
             "label": "缺少字段",
@@ -1261,9 +1258,9 @@
         "availableSources": "可用来源",
         "saveChanges": "保存更改",
         "test": "测试",
-        "testing": "Testing...",
+        "testing": "测试中…",
         "enabled": "已启用",
-        "retryIn": "Retry in {duration}",
+        "retryIn": "{duration} 后重试",
         "runTestBeforeEnabling": "启用前运行测试",
         "hardcoverEnableHint": "使用当前令牌运行测试以解锁启用开关。",
         "badge": {
@@ -1285,7 +1282,7 @@
         },
         "hints": {
           "google": "谷歌的书索引覆盖面更广。谷歌书现在需要一个 API 密钥才能启用该提供商。",
-          "amazon": "Session cookie is recommended. Paste cookie value only (no \"Cookie:\").",
+          "amazon": "推荐使用会话 Cookie，请仅粘贴 Cookie 取值（不要携带 “Cookie:” 前缀）",
           "goodreads": "网络上最大的阅读社区。无需安装。",
           "hardcover": "从硬cover.app/account/api获取的代币。\"持卡人\" 前缀是可选的。",
           "openLibrary": "Internet Archive免费书库。无需设置。",
@@ -1355,12 +1352,12 @@
           "unsavedSuffix": "(未保存)",
           "unsavedChanges": "未保存的更改",
           "globalDefaults": "全局默认值",
-          "overriding": "Overriding: {fields}",
+          "overriding": "已覆盖字段：{fields}",
           "inheritingAll": "继承所有全局元数据规则",
           "subHint": "未覆盖的字段继承全局默认值。",
           "resetTooltip": "删除所有覆盖并继承全局默认值",
-          "clearAllConfirm": "Remove all active providers from every field in \"{library}\"?",
-          "resetConfirm": "Reset \"{library}\" to global defaults? All library overrides will be removed."
+          "clearAllConfirm": "是否清除「{library}」内所有字段绑定的全部有效数据源？",
+          "resetConfirm": "是否将「{library}」恢复为全局默认配置？该书库所有自定义覆盖项将会被清除"
         },
         "groups": {
           "core": "核心文件",
@@ -1371,8 +1368,8 @@
           "audiobook": "音频簿"
         },
         "groupSummary": {
-          "base": "{fields} fields · {enabled} enabled",
-          "withOverrides": "{base} · {overrides} overrides"
+          "base": "共 {fields} 个字段，{enabled} 个已启用",
+          "withOverrides": "基础配置 {base}，含 {overrides} 条自定义覆盖规则"
         },
         "table": {
           "field": "字段",
@@ -1389,9 +1386,9 @@
           "resetToDefault": "重置为默认值"
         },
         "reservoir": {
-          "disabled": "{provider} - disabled",
-          "notConfigured": "{provider} - not configured",
-          "dragToAssign": "Drag to assign {provider} to a field"
+          "disabled": "{provider} - 已停用",
+          "notConfigured": "{provider} - 尚未配置",
+          "dragToAssign": "拖动即可将 {provider} 绑定至对应字段"
         },
         "sheet": {
           "subtitle": "点击提供商进行分配，使用箭头重新排序",
@@ -1403,7 +1400,7 @@
         }
       },
       "genreBlocklist": {
-        "heading": "Global Genre Exclusions",
+        "heading": "全局题材屏蔽列表",
         "hint": "此列表中的精确流派值在元数据写入之前从提供商的结果中删除。",
         "saving": "正在保存",
         "genreValueLabel": "流派值",
@@ -1412,11 +1409,11 @@
         "add": "添加",
         "filterPlaceholder": "过滤块列表",
         "entryCount": "{count, plural, one {# 条目} other {# 条目}}",
-        "filteredCount": "{shown} of {total}",
+        "filteredCount": "已展示：{shown} / 总计：{total}",
         "noFilterMatch": "没有与当前过滤器匹配的阻止的流派。",
         "emptyTitle": "没有屏蔽的类型",
         "emptyHint": "添加精确的值，如音频簿或成人，以使它们不再被获取的元数据。",
-        "removeLabel": "Remove {genre}"
+        "removeLabel": "移除 {genre}"
       },
       "customFields": {
         "label": "标签",
@@ -1438,7 +1435,7 @@
         "searchAriaLabel": "搜索自定义字段",
         "emptyTitle": "尚无自定义字段",
         "emptyHint": "使用上面的表单来定义您的第一个自定义元数据字段。",
-        "noMatchTitle": "No fields match \"{query}\"",
+        "noMatchTitle": "没有匹配 “{query}” 的字段",
         "noMatchHint": "尝试不同的标签、密钥或类型。",
         "clearSearchToReorder": "清除搜索以重新排序",
         "dragToReorder": "拖动以重新排序",
@@ -1447,7 +1444,7 @@
         "archive": "存档",
         "archivedFields": "存档的字段",
         "archivedSummary": "{count, plural, one {# 存档字段 - 还原或永久删除。} other {# 存档字段 - 还原或永久删除。}}",
-        "archivedAt": "Archived {when}",
+        "archivedAt": "归档时间：{when}",
         "restore": "恢复",
         "deleteForever": "永久删除",
         "deleteDialog": {
@@ -1462,7 +1459,7 @@
         "preview": "预览",
         "sampleValue": "示例值",
         "enabledLibraries": "已启用的库",
-        "countOf": "{selected} of {total}",
+        "countOf": "已选 {selected} / 总计 {total}",
         "selectAll": "选择所有",
         "clear": "清空",
         "noLibraries": "还没有可用的库。",
@@ -1474,7 +1471,7 @@
         "custom-fields": "自定义字段",
         "genre-blocklist": "Genre Blocklist",
         "score": "得分",
-        "auto-fetch": "Books",
+        "auto-fetch": "书籍",
         "authors": "作者"
       },
       "tabTitles": {
@@ -1643,13 +1640,13 @@
         "subtitle": "上传自定义字体以供eBook 阅读器使用。",
         "uploadFonts": "上传字体",
         "notAvailableDemo": "演示账户不可用",
-        "uploading": "Uploading...",
+        "uploading": "上传中…",
         "dropFilesHere": "将文件拖放到这里",
         "dragFontsPrefix": "拖动字体文件到此处或",
         "browse": "浏览",
         "fileTypesHint": "TTF, OTF, WOFFF, WOFF2 - 每最大10MB",
         "yourFonts": "您的字体",
-        "fontsUsed": "{count} / {max} used",
+        "fontsUsed": "已使用：{count}/{max}",
         "noFontsYet": "尚未上传字体",
         "noFontsHint": "拖动字体文件以开始操作。",
         "fileCount": "{count, plural, =0 {没有文件} one {# 文件} other {# 文件}}",
@@ -1670,18 +1667,18 @@
         "weightExtraBold": "Extra Bold",
         "weightBlack": "黑色",
         "renameFamilyFailed": "重命名字体组失败",
-        "renamedTo": "Renamed to \"{name}\"",
+        "renamedTo": "已重命名为 “{name}”",
         "updateVariantFailed": "更新字体变量失败",
         "deleteFontFailed": "删除字体失败",
         "deleteFamilyFailed": "删除字体组失败",
         "demoCannotManage": "受模拟限制的帐户无法管理字体",
-        "fileAdded": "\"{name}\" added",
+        "fileAdded": "已添加 “{name}”",
         "uploadFailed": "上传失败",
-        "serverFontsTitle": "Server fonts (shared by admin)",
-        "serverFontsHint": "These fonts come from your server administrator. Turn one off to keep it out of your reader.",
-        "serverFontsShown": "{count} of {total} shown",
-        "serverFontsAllHidden": "All server fonts are hidden. Your reader will only offer built-in and your own fonts.",
-        "serverFontVisibilityFailed": "Failed to update server font visibility"
+        "serverFontsTitle": "服务端字体（管理员共享）",
+        "serverFontsHint": "这些字体由服务器管理员提供；可关闭对应字体，使其不在阅读器内展示",
+        "serverFontsShown": "当前展示 {count} 项，共 {total} 项",
+        "serverFontsAllHidden": "所有服务端字体已隐藏，阅读器仅提供内置字体与您自行上传的字体",
+        "serverFontVisibilityFailed": "服务端字体显示状态更新失败"
       },
       "bookDock": {
         "title": "预约停靠栏",
@@ -1691,23 +1688,23 @@
         "containerPathHint": "复制或移动书卷文件到此文件夹，它们将被书签自动提取和处理。支持子目录。",
         "changePathPrefix": "要改变这条道路，请设置",
         "changePathMiddle": "在您的",
-        "changePathSuffix": "file.",
+        "changePathSuffix": "文件",
         "metadata": "元数据",
         "autoFetch": "从提供商自动获取元数据",
         "autoFetchHint": "在一个文件添加到书架后，自动从配置的提供商(Google Books, iTunes, Open Library等)获取元数据。",
         "autoFinalize": "自动完成",
         "enableAutoFinalize": "启用自动完成",
         "enableAutoFinalizeHint": "元数据信任分等于或高于阈值的文件将自动完成。",
-        "confidenceThreshold": "Confidence threshold: {value}%",
+        "confidenceThreshold": "置信度阈值：{value}%",
         "thresholdIgnored": "(在内嵌模式中忽略)",
         "destinationLibrary": "目标库",
-        "selectLibrary": "Select a library...",
+        "selectLibrary": "选择书库…",
         "metadataMode": "元数据模式",
         "metadataModeSafeMerge": "安全合并 (推荐)",
         "metadataModeFetchedOnly": "仅获取",
         "metadataModeEmbeddedOnly": "仅嵌入",
         "destinationFolder": "目标文件夹",
-        "selectFolder": "Select a folder...",
+        "selectFolder": "选择文件夹…",
         "saveSettingFailed": "保存设置失败",
         "updateSettingFailed": "更新设置失败",
         "autoFetchEnabled": "自动获取已启用",
@@ -1742,7 +1739,7 @@
         "resetToDefault": "重置为默认值",
         "tokens": "令牌",
         "clickTokenHint": "点击任意标记复制到剪贴板。",
-        "copyValue": "Copy {value}",
+        "copyValue": "复制 {value}",
         "modifiers": "修饰符",
         "modifiersExplain": "在令牌内附加一个修饰符来转换其值：",
         "modFirst": "仅第一个值",
@@ -1751,11 +1748,11 @@
         "modFixed2": "两个十进制位置",
         "folderOnlyPrefix": "结束图案以",
         "folderOnlySuffix": "只指定文件夹。原始文件名将保存在文件夹内。",
-        "conditionalLogic": "Conditional Logic",
+        "conditionalLogic": "条件逻辑",
         "conditionalPart1": "换行",
         "conditionalPart2": "当它的令牌为空时跳过一个分段。请使用",
         "conditionalPart3": "默认值。",
-        "examples": "Examples",
+        "examples": "示例",
         "exCalibre": "Calibre风格默认",
         "exSeriesReader": "系列阅读器",
         "exCleanDownload": "清除下载文件名",
@@ -1778,16 +1775,16 @@
         "caseWithPublisher": "与发布者",
         "caseNoPublisher": "没有发布者",
         "caseAllSet": "全部设置",
-        "copiedToClipboard": "{value} copied to clipboard",
+        "copiedToClipboard": "{value} 已复制到剪贴板",
         "copyTokenFailed": "复制令牌失败",
         "patternCopied": "模式已复制到剪贴板",
         "copyPatternFailed": "复制图案失败",
-        "labelCopied": "{label} copied to clipboard",
-        "copyLabelFailed": "Failed to copy {label}",
+        "labelCopied": "{label} 已复制到剪贴板",
+        "copyLabelFailed": "复制 {label} 失败",
         "patternHelp": "模式帮助",
         "patternHelpDescription": "您可以复制到任何字段的令牌、修改者和现成模式。",
-        "copyPreview": "Copy {label}",
-        "copyExample": "Copy the {label} pattern",
+        "copyPreview": "复制 {label}",
+        "copyExample": "复制 {label} 规则模板",
         "invalidCharacters": "模式包含无效字符",
         "fileAsBookSaved": "作为书卷默认保存的文件",
         "folderAsBookSaved": "文件夹默认已保存",
@@ -1797,13 +1794,13 @@
         "crossPlatformEnabled": "已启用跨平台路径净化",
         "crossPlatformDisabled": "已禁用跨平台路径净化",
         "crossPlatformSaveFailed": "保存跨平台路径净化失败",
-        "librarySaved": "Pattern saved for {name}",
+        "librarySaved": "已为 {name} 保存命名模板",
         "librarySaveFailed": "保存库图案失败",
-        "saveLibraryPattern": "Save pattern for {name}",
-        "resetLibraryPattern": "Reset {name} to the default pattern",
+        "saveLibraryPattern": "为 {name} 保存命名模板",
+        "resetLibraryPattern": "将 {name} 恢复为默认模板",
         "tokenTitle": "书籍标题",
         "tokenSubtitle": "书字幕",
-        "tokenAuthors": "Author(s), comma-separated",
+        "tokenAuthors": "作者，以逗号分隔",
         "tokenYear": "出版年份",
         "tokenSeries": "系列名称",
         "tokenSeriesIndex": "系列索引 (零页)",
@@ -1812,7 +1809,7 @@
         "tokenLanguage": "语言",
         "tokenOriginalFilename": "原始文件名 (无扩展名)",
         "tokenExtension": "文件扩展名 (无点)",
-        "patternHelpIntro": "Patterns use tokens like {titleToken} and {authorsToken}, plus modifiers and optional segments.",
+        "patternHelpIntro": "命名模板可使用 {titleToken}、{authorsToken} 这类占位标识，同时支持修饰符与可选片段",
         "browseTokensAndExamples": "浏览令牌和示例"
       },
       "kobo": {
@@ -1821,9 +1818,9 @@
         "copy": "复制",
         "never": "从不使用",
         "justNow": "马上开始",
-        "minutesAgo": "{count}m ago",
-        "hoursAgo": "{count}h ago",
-        "daysAgo": "{count}d ago",
+        "minutesAgo": "{count}分钟前",
+        "hoursAgo": "{count}小时前",
+        "daysAgo": "{count}天前",
         "loadFailed": "加载失败",
         "devicePaired": "设备配对成功",
         "devicePairedHint": "您已准备好设置您的 Kobo。请遵循下面的指示。",
@@ -1833,19 +1830,19 @@
         "addDevice": "添加设备",
         "deviceName": "设备名称",
         "deviceNamePlaceholder": "例如：我的 Kobo Libra",
-        "creating": "Creating...",
+        "creating": "创建中...",
         "createDevice": "创建设备",
         "createDeviceFailed": "创建设备失败",
-        "deviceRegistered": "Device \"{name}\" registered",
+        "deviceRegistered": "设备 \"{name}\" 已注册\t",
         "noDevicesYet": "尚无设备",
         "noDevicesHint": "添加一个设备来开始同步您的书籍到您的 Kobo。",
-        "lastSync": "Last sync: {time}",
+        "lastSync": "上次同步时间：{time}\t",
         "renameDevice": "重命名设备",
         "revokeAccess": "撤销访问",
         "deviceRenamed": "设备已重命名",
         "renameDeviceFailed": "重命名设备失败",
-        "revokeConfirm": "Revoke access for \"{name}\"? The device will not be able to sync until re-paired.",
-        "accessRevoked": "Access revoked for \"{name}\"",
+        "revokeConfirm": "确定要解除 \"{name}\" 的访问权限吗？设备需重新配对后才可恢复同步功能",
+        "accessRevoked": "已解除 \"{name}\" 的访问权限\t",
         "revokeFailed": "吊销访问失败",
         "syncUrlCopied": "同步URL已复制到剪贴板",
         "syncUrlCopyFailed": "复制同步URL失败",
@@ -1867,7 +1864,7 @@
         "kepubLimit": "KEPUB 转换限制",
         "kepubLimitHint": "超过此限制的书本将作为常规的 EPUBs发送，所以BookOrbit 将不会将其阅读器位置同步到 Kobo。",
         "changesMustBeSaved": "更改必须保存才能生效。",
-        "saving": "Saving...",
+        "saving": "正在保存…",
         "saveSyncSettings": "保存同步设置",
         "thresholdOrderError": "读取阈值必须小于完成阈值",
         "saveSettingsFailed": "保存设置失败",
@@ -1882,8 +1879,8 @@
           "unknown": "未知的",
           "failureCount": "{count, plural, one {# 失败} other {# 失败}}",
           "noActivityRecorded": "未记录 Kobo 同步活动。",
-          "lastSuccess": "Last success {time}",
-          "lastFailure": "Last failure {time}",
+          "lastSuccess": "上次成功时间：{time}\t",
+          "lastFailure": "上次失败时间：{time}\t",
           "noFailedActivity": "最近历史上没有失败的 Kobo 活动。",
           "noActivityYet": "尚无Kobo活动。",
           "event": {
@@ -1915,17 +1912,17 @@
             "morePending": "更多待处理",
             "noUpdatesPending": "没有未处理的更新",
             "bookCount": "{count, plural, one {# 书} other {# 书}}",
-            "deletedAnnotations": "{count} deleted annotations",
+            "deletedAnnotations": "已删除批注 {count} 条",
             "deviceAlreadyCurrent": "设备已经存在",
             "freshHighlightData": "新鲜高亮数据",
-            "created": "{count} created",
-            "updated": "{count} updated",
-            "deleted": "{count} deleted",
-            "unchanged": "{count} unchanged"
+            "created": "新增 {count} 条",
+            "updated": "更新 {count} 条",
+            "deleted": "删除 {count} 条",
+            "unchanged": "无变动 {count} 条"
           },
-          "readingPositionSyncedTitle": "Reading position synced: {title}",
+          "readingPositionSyncedTitle": "阅读进度已同步：{title}",
           "readingPositionSynced": "已同步阅读位置",
-          "labelWithTitle": "{label}: {title}",
+          "labelWithTitle": "{label}：{title}",
           "updateCount": "{count, plural, one {# 更新} other {# 更新}}",
           "directionToKobo": "BookOrbit -> Kobo",
           "directionToBookOrbit": "Kobo -> BookOrbit",
@@ -1934,22 +1931,22 @@
           "summary": {
             "noLibraryUpdatesPending": "此设备没有未处理的库更新",
             "libraryUpdatesPrepared": "{count, plural, one {# 为设备准备的库更新} other {# 为设备准备的库更新}}",
-            "bookDownloadedBy": "{title} was downloaded by {device}",
+            "bookDownloadedBy": "{title} 已由设备 {device} 下载",
             "booksDownloaded": "{count, plural, one {# 书已下载} other {# 书已下载}}",
             "progressUpdatesSyncedFor": "{count, plural, one {# 进度更新同步为 {title}} other {# 进度更新同步为 {title}}}",
             "progressUpdatesSynced": "{count, plural, one {# 进度更新同步} other {# 进度更新同步}}",
-            "newReadingPositionFor": "Kobo reported a new reading position for {title}",
+            "newReadingPositionFor": "Kobo 同步上报 {title} 最新阅读进度",
             "newReadingPosition": "Kobo报告了一个新的阅读位置",
-            "noHighlightChangesNeededFor": "No highlight changes needed for {title}",
+            "noHighlightChangesNeededFor": "{title} 的高亮内容无需调整",
             "noHighlightChangesNeeded": "无需高亮更改",
-            "highlightsSentToKoboFor": "{count, plural, one {# highlight sent to Kobo for {title}} other {# highlights sent to Kobo for {title}}}",
+            "highlightsSentToKoboFor": "{count, plural, one {# 条高亮已同步至Kobo：{title}} other {# 条高亮已同步至Kobo：{title}}}",
             "highlightsSentToKobo": "{count, plural, one {# 高亮发送到 Kobo} other {# 高亮发送到 Kobo}}",
-            "noKoboHighlightChangesFor": "No Kobo highlight changes for {title}",
+            "noKoboHighlightChangesFor": "{title} 的 Kobo 端无高亮内容变更",
             "noKoboHighlightChanges": "没有 Kobo 高亮更改",
-            "highlightsImportedFromKoboFor": "{count, plural, one {# highlight imported from Kobo for {title}} other {# highlights imported from Kobo for {title}}}",
+            "highlightsImportedFromKoboFor": "{count, plural, one {# 条高亮从Kobo导入：{title}} other {# 条高亮从Kobo导入：{title}}}",
             "highlightsImportedFromKobo": "{count, plural, one {# 高亮从 Kobo 导入} other {# 从Kobo 导入的高亮内容}}"
           },
-          "timeRange": "{from} to {to}",
+          "timeRange": "{from} 至 {to}",
           "eventsGrouped": "{count, plural, one {# 事件被分组} other {# 事件被分组}}",
           "removedDevice": "移除设备",
           "loadMoreFailed": "加载更多历史记录失败",
@@ -1959,20 +1956,20 @@
           "filterAll": "所有的",
           "filterFailures": "失败",
           "refresh": "刷新",
-          "loadingActivity": "Loading Kobo activity...",
+          "loadingActivity": "正在加载 Kobo 同步记录…",
           "noActivityHint": "最近的同步活动将在配对的 Kobo 联系人 BookOrbit 后出现。",
           "error": "错误",
-          "loading": "Loading...",
+          "loading": "加载中…",
           "loadMore": "加载更多活动"
         },
         "howBooksSynced": {
           "title": "书籍是如何同步的",
-          "body": "To send books to your Kobo device, you must enable {syncToKobo} on the collections containing those books. Open any collection from the sidebar, click the Edit icon, and toggle {syncToKobo}. Books that are not part of an enabled collection will not sync."
+          "body": "如需将书籍推送至 Kobo 设备，必须在对应合集开启{syncToKobo}开关：在侧边栏打开任意合集，点击编辑图标切换{syncToKobo}状态；未加入已开启同步合集的书籍不会执行同步"
         },
         "nextSteps": {
           "title": "以后的步骤",
           "step1": "1. 配置您的 Kobo 设备与上面的同步 URL。",
-          "step2": "2. In BookOrbit, go to any collection from the sidebar, click the Edit icon, and enable {syncToKobo}. Only books inside sync-enabled collections will download to your device."
+          "step2": "2. 在 BookOrbit 中，通过侧边栏进入任意合集、点击编辑图标并开启{syncToKobo}；仅已开启同步的合集内书籍可下载至设备"
         },
         "syncToKobo": "同步到 Kobo",
         "tabs": {
@@ -1997,7 +1994,7 @@
           "saveAccount": "保存账户默认",
           "deviceTitle": "覆盖 KOReader 设备",
           "deviceDescription": "自定义默认、序列和独立路径的任何组合。空设备特定行继承设备默认值，它本身可以继承账户默认的 KOReader 模式。",
-          "noDevices": "Devices appear here after they sync with BookOrbit.",
+          "noDevices": "设备与 BookOrbit 完成同步后，将在此处展示",
           "customOrganization": "自定义组织",
           "usingAccountDefault": "使用账户默认",
           "deviceDefaultHelp": "备份此设备。自动继承未来的更改将等于账户默认值。",
@@ -2017,18 +2014,18 @@
           "deviceSaveFailed": "无法保存设备覆盖",
           "deviceResetFailed": "重置设备覆盖失败"
         },
-        "loadingSettings": "Loading KOReader settings...",
+        "loadingSettings": "正在加载 KOReader 设置项…",
         "loadFailed": "加载 KOReader 设置失败",
         "never": "从不使用",
         "justNow": "马上开始",
-        "minutesAgo": "{count}m ago",
-        "hoursAgo": "{count}h ago",
-        "daysAgo": "{count}d ago",
+        "minutesAgo": "{count} 分钟前",
+        "hoursAgo": "{count} 小时前",
+        "daysAgo": "{count} 天前",
         "unknown": "未知的",
         "updateAvailable": "可用更新",
         "upToDate": "最新的",
         "versionUnknown": "版本未知",
-        "latestPlugin": "Latest plugin: v{version}",
+        "latestPlugin": "最新插件版本：v {version}",
         "latestPluginUnavailable": "最新插件不可用",
         "notConfigured": "未配置 KOReader 同步",
         "notConfiguredHint": "创建一组同步凭据，然后使用 BookOrbit KOReader 插件来浏览、下载、进度、阅读事件、高亮和删除。",
@@ -2039,14 +2036,14 @@
         "usernamePlaceholder": "例如：myreader",
         "password": "密码",
         "passwordPlaceholder": "最小6个字符",
-        "creating": "Creating...",
+        "creating": "创建中...",
         "create": "创建",
         "credentialsCreated": "创建了 KOReader 同步凭据",
         "createCredentialsFailed": "创建凭据失败",
         "status": "KO阅读器状态",
         "refresh": "刷新",
         "progressSync": "进度同步",
-        "progressSyncHint": "Allow KOReader devices to sync progress, reading activity, highlights, and annotation deletes with BookOrbit.",
+        "progressSyncHint": "允许 KOReader 设备与 BookOrbit 同步阅读进度、阅读动态、高亮内容以及批注删除记录",
         "lastSync": "上次同步",
         "syncedBooks": "同步的书",
         "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}",
@@ -2060,8 +2057,8 @@
         "preconfiguredPlugin": "预配置的 BookOrbit 插件",
         "preconfiguredPluginHintPrefix": "下载带有服务器URL的zip和您的同步登录已配置。插件包括目录浏览和同步。复制文件夹到",
         "preconfiguredPluginHintSuffix": "并重启 KOReader。",
-        "latestPluginNote": "{label}. Device updates run from the BookOrbit menu in KOReader.",
-        "preparing": "Preparing...",
+        "latestPluginNote": "{label}。设备更新请在 KOReader 内的 BookOrbit 菜单执行",
+        "preparing": "准备中...",
         "downloadPlugin": "下载插件",
         "noDevicesSynced": "尚未同步设备",
         "noDevicesSyncedHint": "安装完整同步的 BookOrbit 插件，或者配置 KOReader 的库存进度同步以便只进行进度更新。",
@@ -2070,8 +2067,8 @@
         "noneYet": "尚无",
         "pluginActivity": "插件活动",
         "noPluginActivity": "尚未报告插件活动。",
-        "lastFullSync": "Last full sync: {time}",
-        "latestPluginSuffix": "- latest plugin v{version}",
+        "lastFullSync": "上次全量同步时间：{time}\t",
+        "latestPluginSuffix": "- 最新插件版本 v {version}",
         "matchedBooks": "匹配的书",
         "readingEvents": "正在阅读事件",
         "highlights": "高光",
@@ -2126,17 +2123,17 @@
           "lastSeen": "上次查看：",
           "linked": "链接：",
           "updated": "已更新：",
-          "linkedTo": "Linked to {title}",
-          "loadingUnmatched": "Loading unmatched books...",
-          "loadingManual": "Loading manual hash links...",
+          "linkedTo": "已关联至 {title}",
+          "loadingUnmatched": "正在加载未匹配书籍…",
+          "loadingManual": "正在加载手动哈希链接...",
           "noUnmatched": "没有未匹配的 KOReader 书。",
           "noManual": "没有手动的 KOReader 链接。",
-          "pageOf": "Page {page} of {total}",
-          "showingRange": "Showing {start}-{end} of {total}",
-          "unknownFile": "Unknown KOReader file {hash}",
+          "pageOf": "第 {page} 页 / 共 {total} 页",
+          "showingRange": "正在显示第 {start}-{end} 条，共 {total} 条",
+          "unknownFile": "未知 KOReader 文件：{hash}",
           "unknownAuthor": "未知作者",
           "noTitleOrAuthor": "没有标题或作者报告",
-          "bookNumber": "BookOrbit book #{id}",
+          "bookNumber": "BookOrbit 书籍编号 #{id}",
           "toast": {
             "unmatchedRefreshed": "已刷新不匹配的书",
             "unmatchedRefreshFailed": "刷新不匹配的书籍失败",
@@ -2158,7 +2155,7 @@
             "bookOrbitBook": "书架环绕书",
             "searchPlaceholder": "搜索您的 BookOrbit 库",
             "minChars": "输入至少 2 个字符。",
-            "searching": "Searching...",
+            "searching": "搜索中...",
             "noBooksFound": "未找到书籍。",
             "untitledBook": "无标题书",
             "selected": "已选择",
@@ -2167,22 +2164,22 @@
             "confirmTitle": "确认 KOReader 链接",
             "koreader": "KOReader",
             "bookOrbit": "BookOrbit",
-            "bookId": "Book ID: {id}",
+            "bookId": "书籍 ID：{id}",
             "syncedStatsNote": "已经同步的统计数据将保留在他们当前的 BookOrbit 书中。",
             "chooseDifferent": "选择不同的",
-            "saving": "Saving...",
+            "saving": "保存中...",
             "confirmLink": "确认链接",
             "unlinkTitle": "取消链接 KOReader 簿？",
-            "unlinkBody": "Future syncs for this hash will stop resolving to {title} until it is linked again. Already synced stats will stay on their current BookOrbit book.",
-            "unlinking": "Unlinking..."
+            "unlinkBody": "解除关联后，该哈希后续同步将不再匹配 {title}；已同步完成的数据仍留存于当前 BookOrbit 书籍中",
+            "unlinking": "正在解绑..."
           },
           "dismiss": "关闭",
           "dismissAll": "关闭所有",
-          "dismissing": "Dismissing...",
-          "unlinking": "Unlinking...",
+          "dismissing": "正在丢弃...",
+          "unlinking": "正在解绑...",
           "unlinkConfirmTitle": "取消链接 KOReader 簿？",
-          "unlinkConfirmBody": "Future syncs for this hash will stop resolving to {title} until it is linked again. Already synced stats will stay on their current BookOrbit book.",
-          "dismissConfirmTitle": "Dismiss {title}?",
+          "unlinkConfirmBody": "解除关联后，该哈希值后续同步将不再匹配 {title}；已同步完成的数据仍留存于当前 BookOrbit 书籍中",
+          "dismissConfirmTitle": "是否关闭 {title}？",
           "dismissConfirmBody": "这将把它从您不匹配的书籍列表中移除。如果任何设备再次报告这个哈希，它将作为一个新条目重新出现。",
           "dismissAllConfirmTitle": "{count, plural, =0 {没有不匹配的书} one {丢弃所有# 不匹配的书？} other {丢弃所有# 不匹配的书？}}",
           "dismissAllConfirmBody": "这将清除您整个无匹配的书籍列表，而不仅仅是当前页面。 如果任何设备再次报告这些哈希之一，它将重新显示为一个新条目。",
@@ -2191,26 +2188,26 @@
           "bookOrbitBook": "书架环绕书",
           "searchLibraryPlaceholder": "搜索您的 BookOrbit 库",
           "enterMinChars": "输入至少 2 个字符。",
-          "searching": "Searching...",
+          "searching": "搜索中…",
           "noBooksFound": "未找到书籍。",
           "untitledBook": "无标题书",
           "selected": "已选择",
           "select": "选择",
           "loadMore": "加载更多",
-          "loadingMore": "Loading...",
+          "loadingMore": "加载中…",
           "confirmLinkTitle": "确认 KOReader 链接",
-          "bookId": "Book ID: {id}",
+          "bookId": "书籍 ID：{id}",
           "syncedStatsNote": "已经同步的统计数据将保留在他们当前的 BookOrbit 书中。",
           "chooseDifferent": "选择不同的",
-          "saving": "Saving...",
+          "saving": "保存中...",
           "confirmLink": "确认链接"
         },
         "remove": "删除",
-        "removing": "Removing...",
+        "removing": "正在删除...",
         "unmatchedBooks": "不匹配的书",
         "deviceRemoved": "设备已删除",
         "removeDeviceFailed": "移除设备失败",
-        "removeDeviceConfirmTitle": "Remove {device}?",
+        "removeDeviceConfirmTitle": "是否移除设备 {device}？",
         "removeDeviceConfirmBody": "这将永久删除此设备的同步进度、阅读活动和任何未匹配的书目不再由另一个设备报告。 如果设备稍后再次同步，它将重新显示为一个新条目。"
       },
       "opds": {
@@ -2232,7 +2229,7 @@
         "passwordPlaceholder": "最小8个字符",
         "defaultSort": "默认排序",
         "sortLabel": "排序",
-        "creating": "Creating...",
+        "creating": "创建中...",
         "create": "创建",
         "noAccounts": "暂无OPDS帐户。创建一个以开始使用OPDS客户端。",
         "hideDetails": "隐藏详细信息",
@@ -2241,7 +2238,7 @@
         "notes": "OPDS注释",
         "notesBody": "在阅读器应用中使用OPDS帐户。如果意外共享，请保持凭据私密并旋转密码。",
         "deleteConfirmTitle": "删除OPDS帐户吗？",
-        "deleteConfirmBody": "Delete \"{username}\". This action cannot be undone.",
+        "deleteConfirmBody": "删除用户 “{username}”，该操作不可撤销",
         "sortRecent": "最近添加",
         "sortTitleAsc": "标题 (A-Z)",
         "sortTitleDesc": "Title (Z-A)",
@@ -2255,13 +2252,13 @@
         "urlCopied": "OPDS URL已复制到剪贴板",
         "urlCopyFailed": "复制OPDS URL 失败",
         "createUserFailed": "创建 OPDS 用户失败",
-        "userCreated": "OPDS user \"{username}\" created",
-        "sortOrderUpdated": "Sort order updated for \"{username}\"",
+        "userCreated": "已创建 OPDS 用户 “{username}”",
+        "sortOrderUpdated": "已更新用户 “{username}” 的排序规则",
         "updateSortFailed": "更新排序失败",
-        "userDeleted": "OPDS user \"{username}\" deleted",
+        "userDeleted": "已删除 OPDS 用户 “{username}”",
         "deleteUserFailed": "删除OPDS用户失败",
-        "labelCopied": "{label} copied",
-        "copyLabelFailed": "Failed to copy {label}"
+        "labelCopied": "已复制 {label}",
+        "copyLabelFailed": "复制 {label} 失败"
       },
       "tabs": {
         "general": "A. 概况",
@@ -2283,15 +2280,15 @@
   },
   "achievements": {
     "title": "1. 成就",
-    "tiersCount": "{earned} / {total} tiers",
+    "tiersCount": "已达成等级：{earned}/{total}",
     "loadFailed": "加载成就失败",
     "tryAgain": "再试一次",
     "noMatchFilter": "没有匹配此过滤器的成就",
     "secretAchievement": "秘密成就",
-    "earnedOn": "Earned {date}",
-    "whileReading": "While reading “{title}”",
-    "tierProgress": "Tier {earned} of {total}",
-    "progressToNext": "{current} / {threshold} to {name}",
+    "earnedOn": "获得时间：{date}",
+    "whileReading": "阅读《{title}》期间",
+    "tierProgress": "等级进度：{earned}/{total}",
+    "progressToNext": "距离 {name}：{current}/{threshold}",
     "rarity": {
       "common": "常用的",
       "rare": "稀有的",
@@ -2300,9 +2297,9 @@
     },
     "filter": {
       "all": "所有的",
-      "earned": "Earned ({count})",
-      "inProgress": "In Progress ({count})",
-      "locked": "Locked ({count})"
+      "earned": "已获取（{count} 项）",
+      "inProgress": "进行中（{count} 项）",
+      "locked": "未解锁（{count} 项）"
     }
   },
   "adminFeature": {
@@ -2312,7 +2309,7 @@
       "privacyNotice": "这个页面只能报告登录和身份验证的刷新。它不使用阅读历史、书进度或库活动。",
       "privacyLabel": "关于账户活动隐私",
       "never": "从不使用",
-      "openInsightsFor": "Open shared reading insights for {name}",
+      "openInsightsFor": "查看 {name} 的公开阅读分析数据",
       "permissionLabel": "查看用户活动",
       "states": {
         "recent": "最近激活",
@@ -2362,7 +2359,7 @@
       },
       "pagination": {
         "label": "帐户活动页面",
-        "page": "Page {page} of {totalPages}"
+        "page": "第 {page} 页 / 共 {totalPages} 页"
       },
       "errors": {
         "load": "加载帐户活动失败。"
@@ -2373,7 +2370,7 @@
       "subtitle": "正在阅读该用户自愿选择分享的信息。",
       "auditNotice": "此配置文件的访问权已被录制并对用户可见。",
       "period": "报告期间",
-      "periodDays": "Last {count} days",
+      "periodDays": "近 {count} 天",
       "durationMinutes": "{count, plural, one {# 分钟} other {# 分钟}}",
       "durationHours": "{count, plural, one {# 小时} other {# 小时}}",
       "metrics": {
@@ -2486,9 +2483,9 @@
       "includeGenresHint": "(只显示带有这些基因的书籍)",
       "excludeGenres": "排除流体",
       "excludeGenresHint": "（带这些基因的书籍）",
-      "searchTagsPlaceholder": "Search tags...",
-      "searchGenresPlaceholder": "Search genres...",
-      "saving": "Saving...",
+      "searchTagsPlaceholder": "搜索标签…",
+      "searchGenresPlaceholder": "搜索题材…",
+      "saving": "保存中...",
       "errors": {
         "updateUser": "更新用户失败",
         "updatePermissions": "更新权限失败",
@@ -2524,8 +2521,8 @@
       "resetPasswordSharedHintFull": "共享账户没有密码。",
       "deleteUserAction": "删除用户",
       "deleteDialogTitle": "删除用户？",
-      "deleteDialogBody": "Delete user \"{username}\". This action cannot be undone.",
-      "deleting": "Deleting...",
+      "deleteDialogBody": "删除用户 “{username}”，该操作不可撤销。",
+      "deleting": "删除中...",
       "errors": {
         "load": "加载失败",
         "deleteUser": "删除用户失败",
@@ -2537,7 +2534,7 @@
         "description": "选择自动分配给新用户的库。",
         "noLibraries": "没有可用的库。",
         "save": "保存默认值",
-        "saving": "Saving...",
+        "saving": "保存中...",
         "saveError": "保存默认库访问失败"
       },
       "filters": {
@@ -2563,12 +2560,12 @@
       },
       "pagination": {
         "label": "用户分页",
-        "page": "Page {page} of {totalPages}"
+        "page": "第 {page} 页 / 共 {totalPages} 页"
       },
-      "editUserAria": "Edit {name}",
-      "resetPasswordAria": "Reset the password for {name}",
-      "deleteUserAria": "Delete {name}",
-      "moreActionsAria": "More actions for {name}"
+      "editUserAria": "编辑用户 {name}",
+      "resetPasswordAria": "重置 {name} 的密码",
+      "deleteUserAria": "删除 {name}",
+      "moreActionsAria": "{name} 更多操作"
     }
   },
   "annotations": {
@@ -2584,7 +2581,7 @@
       "filterByBook": "按书过滤",
       "allBooks": "所有书",
       "clearBookFilter": "清除书籍过滤器",
-      "searching": "Searching...",
+      "searching": "搜索中…",
       "noBooksFound": "未找到书"
     },
     "bulk": {
@@ -2592,12 +2589,12 @@
       "pageSelected": "选择页面",
       "selectPage": "选择页面",
       "clear": "清空",
-      "recolorTo": "Recolor to {color}",
-      "restyleTo": "Restyle to {style}"
+      "recolorTo": "批量改为颜色 {color}",
+      "restyleTo": "批量改为样式 {style}"
     },
     "chips": {
-      "active": "Active:",
-      "removeFilter": "Remove filter {label}",
+      "active": "生效：",
+      "removeFilter": "移除筛选条件 {label}",
       "clearAll": "全部清除"
     },
     "filters": {
@@ -2610,8 +2607,8 @@
       "clearAll": "全部清除"
     },
     "pagination": {
-      "showing": "Showing {start}-{end} of {total}",
-      "pageOf": "Page {page} of {totalPages}",
+      "showing": "展示 {start}–{end} 条，共 {total} 条",
+      "pageOf": "第 {page} 页 / 共 {totalPages} 页",
       "firstPage": "首页",
       "previousPage": "上一页",
       "nextPage": "下一页",
@@ -2625,8 +2622,8 @@
       "noStoredPositions": "没有存储的位置。",
       "notSynced": "尚未同步到任何设备。",
       "upToDate": "最新的",
-      "pendingVersion": "Pending v{version}",
-      "syncedAt": "synced {date}",
+      "pendingVersion": "待同步版本 v {version}",
+      "syncedAt": "同步：{date}",
       "format": {
         "webReader": "网页阅读器",
         "koreader": "KOReader",
@@ -2650,8 +2647,8 @@
       "comfortableView": "可视化视图"
     },
     "listItem": {
-      "pageNumber": "p. {page}",
-      "chapterNumber": "chapter {chapter}",
+      "pageNumber": "第 {page} 页",
+      "chapterNumber": "第 {chapter} 章",
       "selectAnnotation": "选择批注",
       "collapse": "收起",
       "expand": "扩展",
@@ -2673,7 +2670,7 @@
     },
     "hub": {
       "title": "说明",
-      "totalCount": "{count} total",
+      "totalCount": "共计 {count} 条",
       "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}",
       "noteCount": "{count, plural, =0 {没有便笺} one {# 笔记} other {# 笔记}}",
       "export": "导出",
@@ -2720,7 +2717,7 @@
     "hideDetails": "隐藏详细信息",
     "refresh": "刷新审核日志",
     "loadError": "无法加载审计事件。",
-    "removeFilter": "Remove filter: {value}",
+    "removeFilter": "移除筛选：{value}",
     "allActions": "所有操作",
     "allEventTypes": "所有事件类型",
     "allActors": "所有行为者",
@@ -2732,14 +2729,14 @@
     "allResources": "所有资源",
     "allTargetTypes": "所有目标类型",
     "quickDates": "快速日期",
-    "today": "Today",
+    "today": "今天",
     "sevenDays": "7 天",
     "thirtyDays": "30 天",
-    "userId": "User #{id}",
+    "userId": "用户 #{id}",
     "userIdCompact": "#{id}",
     "targetAdditional": "和 {count, plural, one {# 更多目标} other {# 更多目标}}",
     "bookImpact": "{count, plural, one {# 书} other {# 书}}",
-    "entryDetailsLabel": "Details for audit event #{id}",
+    "entryDetailsLabel": "审计事件 #{id} 详情",
     "detailEventId": "事件 ID",
     "detailOccurredAt": "发生了",
     "detailActor": "执行者",
@@ -2751,26 +2748,26 @@
     "detailResourceIdLabel": "资源 ID",
     "detailTargetTypeLabel": "Target type",
     "detailTargetIdLabel": "Target ID",
-    "detailAction": "Action: {value}",
-    "detailIp": "IP: {value}",
-    "detailResource": "Resource: {value}",
-    "detailResourceId": "Resource ID: {value}",
+    "detailAction": "操作：{value}",
+    "detailIp": "IP：{value}",
+    "detailResource": "资源：{value}",
+    "detailResourceId": "资源编号：{value}",
     "deletedBooks": "已删除的书",
-    "deletedBookDetail": "{title} (book #{id})",
+    "deletedBookDetail": "《{title}》（书籍编号 #{id}）",
     "untitledBook": "无标题",
     "deletedBooksOmitted": "{count, plural, one {# 额外的书被遗漏} other {# 额外的书被遗漏}}",
-    "showing": "Showing {from}-{to} of {total}",
+    "showing": "展示 {from}–{to} 条，共 {total} 条",
     "prev": "上一个",
     "chips": {
-      "search": "Search: {value}",
-      "action": "Action: {value}",
-      "eventType": "Event type: {value}",
-      "actor": "Actor: {value}",
-      "resource": "Resource: {value}",
+      "search": "搜索关键词：{value}",
+      "action": "操作：{value}",
+      "eventType": "事件类型：{value}",
+      "actor": "操作人：{value}",
+      "resource": "资源：{value}",
       "targetType": "Target type: {value}",
-      "user": "User: {value}",
-      "from": "From: {value}",
-      "to": "To: {value}"
+      "user": "用户：{value}",
+      "from": "起始时间：{value}",
+      "to": "结束时间：{value}"
     },
     "filterLabels": {
       "search": "搜索事件",
@@ -2802,7 +2799,7 @@
     },
     "categories": {
       "authentication": "认证",
-      "books": "Books",
+      "books": "书籍",
       "users": "用户",
       "libraries": "库",
       "collections": "A. 收款情况",
@@ -2886,7 +2883,7 @@
       "BookBulkUpdateTags": "更新书签标签",
       "BookBulkSetMetadataLock": "设置元数据锁",
       "BookBulkEditMetadata": "编辑书籍元数据",
-      "BookBulkMoveLibrary": "Move books to another library",
+      "BookBulkMoveLibrary": "批量将书籍转移至其他书库",
       "BookReadingStateReset": "重置阅读状态",
       "BookWriteAndRename": "写元数据并重命名文件",
       "CollectionCreate": "创建收藏",
@@ -2963,7 +2960,7 @@
     "login": {
       "subtitle": "登录到您的帐户",
       "signIn": "登录",
-      "signingIn": "Signing in...",
+      "signingIn": "登录中…",
       "orDivider": "或",
       "forgotPassword": "忘记密码？",
       "errors": {
@@ -2973,9 +2970,9 @@
     },
     "oidc": {
       "loginFailed": "OIDC 登录失败",
-      "redirecting": "Redirecting...",
-      "signInWith": "Sign in with {provider}",
-      "completingSignIn": "Completing sign in...",
+      "redirecting": "正在跳转授权…",
+      "signInWith": "使用 {provider} 账号登录",
+      "completingSignIn": "正在完成登录…",
       "tryAgain": "再试一次",
       "errors": {
         "stateExpired": "您的登录会话已过期。请尝试再次登录。",
@@ -2994,7 +2991,7 @@
     "forgotPassword": {
       "subtitle": "重置您的密码",
       "submitted": "如果存在该电子邮件的帐户，已发送重置链接。请检查您的收件箱。",
-      "sending": "Sending...",
+      "sending": "发送中...",
       "sendResetLink": "发送重置链接",
       "errors": {
         "emailUnavailable": "通过电子邮件重置密码不可用。请联系您的管理员。"
@@ -3002,7 +2999,7 @@
     },
     "resetPassword": {
       "subtitle": "设置新密码",
-      "saving": "Saving...",
+      "saving": "保存中…",
       "setNewPassword": "设置新密码",
       "errors": {
         "invalidLink": "无效的重置链接。请申请一个新链接。",
@@ -3014,7 +3011,7 @@
       "subtitle": "创建第一个管理员帐户。",
       "setupToken": "设置令牌",
       "setupTokenHint": "(生产所需)",
-      "creatingAccount": "Creating account...",
+      "creatingAccount": "账号创建中…",
       "createAccount": "创建管理员帐户",
       "errors": {
         "failed": "无法完成设置"
@@ -3022,14 +3019,14 @@
     },
     "changePassword": {
       "title": "更改密码",
-      "saving": "Saving…",
+      "saving": "保存中...",
       "forcedNotice": "您必须先设置一个新密码才能继续。",
       "errors": {
         "failed": "更改密码失败"
       }
     },
     "magicLink": {
-      "signingIn": "Signing you in...",
+      "signingIn": "正在登录...",
       "loginFailed": "登录失败",
       "goToLogin": "转到登录",
       "errors": {
@@ -3039,14 +3036,13 @@
   },
   "author": {
     "card": {
-      "portraitAlt": "{name} portrait",
+      "portraitAlt": "{name} 的肖像",
       "viewDetails": "查看作者详细信息",
       "refreshMetadata": "刷新元数据",
       "deleteAuthor": "删除作者"
     },
     "listRow": {
-      "noRecentAdditions": "没有最近的添加",
-      "portraitAlt": "{name} portrait"
+      "noRecentAdditions": "没有最近的添加"
     },
     "filters": {
       "title": "作者过滤器",
@@ -3060,19 +3056,14 @@
     },
     "header": {
       "never": "从不使用",
-      "portraitAlt": "{name} portrait",
       "actions": "行动",
       "editAuthor": "编辑作者",
       "mergeAuthors": "合并作者",
-      "refreshing": "Refreshing...",
       "refreshMetadata": "刷新元数据",
       "deleteAuthor": "删除作者",
       "showLess": "显示更少的",
       "showMore": "显示更多",
-      "lookingUpMetadata": "Looking up author metadata...",
       "noBiography": "没有可用的传记。使用菜单刷新元数据。",
-      "previewFrom": "Preview from {provider}. Save metadata to persist it.",
-      "booksLabel": "Books",
       "lastAdded": "最后添加"
     },
     "list": {
@@ -3087,7 +3078,6 @@
       "desc": "Desc",
       "filters": "筛选器",
       "clear": "清空",
-      "allLoaded": "All {total} authors loaded",
       "sort": {
         "name": "名称",
         "sortName": "排序名称",
@@ -3101,25 +3091,19 @@
       },
       "deleteDialog": {
         "titleOne": "删除作者？",
-        "titleMany": "Delete {count} authors?",
         "descriptionOne": "这会将作者从目录中移除，并从关联的书中取消链接。此操作不能撤消。",
         "descriptionMany": "此操作将从目录中删除所选作者，并从关联的书中取消链接。此操作不能撤消。"
       },
       "selection": {
         "selectVisible": "选择可见",
         "refreshMetadata": "刷新元数据",
-        "refreshingMetadata": "Refreshing metadata...",
         "deleteSelected": "删除选中的",
-        "deleting": "Deleting...",
-        "exitSelection": "退出选择",
-        "confirmDeleteCount": "{count, plural, =0 {Delete # author?} one {Delete # author?} other {Delete # authors?}}"
+        "exitSelection": "退出选择"
       },
       "toast": {
         "refreshed": "作者元数据已刷新",
         "refreshedNoImage": "元数据已刷新，但没有找到作者图像。",
         "refreshFailed": "刷新作者元数据失败",
-        "bulkRefreshPartial": "Refreshed {updated} author(s), {failed} failed",
-        "bulkRefreshSuccess": "Refreshed metadata for {updated} author(s)",
         "bulkRefreshFailed": "刷新选中作者失败",
         "deleteSuccess": "{count, plural, =0 {删除了# 作者; 影响了 {books} 书籍} one {删除了# 作者; 影响了 {books} 书籍} other {删除了# 作者; 影响了 {books} 书籍}}",
         "deleteFailed": "删除作者失败 (s)"
@@ -3127,35 +3111,24 @@
     },
     "detail": {
       "pageTitle": "作者",
-      "pageTitleNamed": "Author · {name}",
-      "pageTitleId": "Author #{id}",
       "entityName": "作者",
-      "loadingAuthor": "Loading author...",
       "previewError": "现在无法加载外部作者预览元数据。",
       "edit": {
         "name": "名称",
         "sortName": "排序名称",
         "description": "描述",
         "image": "图片",
-        "uploading": "Uploading...",
         "replaceImage": "替换图像",
         "uploadImage": "上传图片",
-        "removing": "Removing...",
-        "removeImage": "Remove image",
-        "imageHint": "PNG/JPEG/WEBP/GIF/BMP up to {size} MB",
-        "saving": "Saving..."
+        "removeImage": "Remove image"
       },
       "merge": {
         "searchPlaceholder": "搜索作者以合并到此作者",
-        "searching": "Searching...",
         "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}",
-        "selectedSummary": "Selected {count} author(s), approx. {books} books affected.",
-        "merging": "Merging...",
         "mergeSelected": "合并选中的",
         "confirmLabel": "合并"
       },
       "mergeDialog": {
-        "title": "Merge {count} author(s) into \"{name}\"?",
         "titleFallback": "合并选中的作者？",
         "description": "这将把选中的作者合并到当前作者并重新链接关联的书籍。此操作不能撤消。",
         "descriptionEmpty": "此操作不能撤消。"
@@ -3165,13 +3138,11 @@
         "description": "这会将作者从目录中移除，并从关联的书中取消链接。此操作不能撤消。"
       },
       "books": {
-        "heading": "Books",
         "allLibraries": "所有库",
         "asc": "Asc",
         "desc": "Desc",
         "ascending": "升序",
         "descending": "降序",
-        "allLoaded": "All {total} books loaded",
         "sort": {
           "recentlyAdded": "最近添加",
           "title": "标题",
@@ -3193,9 +3164,7 @@
         "imageUploadFailed": "上传作者图片失败",
         "imageRemoved": "已删除作者图像",
         "imageRemoveFailed": "删除作者图像失败",
-        "mergeSuccess": "Merged {count} author(s); affected {books} books",
         "mergeFailed": "合并作者失败",
-        "deleteSuccess": "Deleted author; affected {books} books",
         "deleteFailed": "删除作者失败"
       }
     }
@@ -3205,8 +3174,7 @@
     "unknownFormat": "未知",
     "collapsedSeries": {
       "label": "系列",
-      "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}",
-      "readCount": "{count} read"
+      "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}"
     },
     "card": {
       "missing": "丢失"
@@ -3229,9 +3197,7 @@
       "regenerateCover": "重新生成封面",
       "addToCollection": "添加到收藏",
       "setStatus": "设置状态",
-      "sendViaEmail": "通过电子邮件发送",
-      "rate": "Rate {star}",
-      "openAs": "Open as {format}"
+      "sendViaEmail": "通过电子邮件发送"
     },
     "readStatus": {
       "unread": "未读",
@@ -3345,18 +3311,11 @@
         "isFinished": "已完成",
         "isLocked": "已锁定",
         "isUnlocked": "已解锁",
-        "isUpNext": "是下一个",
-        "isTrue": "is yes",
-        "isFalse": "is no"
+        "isUpNext": "是下一个"
       },
-      "customFieldsGroup": "Custom fields",
-      "customFieldFallback": "Custom field",
       "anyProvider": "任何提供商",
       "communityRatingProvider": "社区评分提供商",
-      "loadingLibraries": "Loading libraries...",
       "noLibrariesAvailable": "没有可用的库",
-      "selectLibrary": "Select library...",
-      "selectStatus": "Select status...",
       "withinLastPlaceholder": "例如：7",
       "unit": {
         "days": "天",
@@ -3375,8 +3334,7 @@
       "to": "到",
       "group": "组别",
       "addRule": "添加规则",
-      "addGroup": "添加群组",
-      "typeToSearch": "Type to search..."
+      "addGroup": "添加群组"
     },
     "deleteDialog": {
       "title": "删除书？",
@@ -3386,12 +3344,8 @@
       "title": "{count, plural, =0 {编辑元数据-# 书} one {编辑元数据-# 书} other {编辑元数据-# 书}}",
       "instructions": "切换要编辑的字段，然后配置值。仅切换的字段将被更改。",
       "invalidYear": "输入一个有效的年份(仅限数字)",
-      "clearWarning": "This will remove all {field} from the selected books.",
-      "searchPlaceholder": "Search {field}...",
-      "enterPlaceholder": "Enter {field}",
       "yearPlaceholder": "例如：2024",
       "leaveEmptyHint": "留空以在所有选定的书中清除此字段。",
-      "applying": "Applying...",
       "apply": "应用",
       "mode": {
         "add": "添加",
@@ -3404,9 +3358,7 @@
       "title": "导出元数据",
       "scope": "范围",
       "selectedRows": "选定的行",
-      "currentlySelected": "{count} currently selected",
       "allMatchingRows": "所有匹配的行",
-      "rowsInResult": "{count} rows in current result",
       "format": "格式",
       "csvDescription": "快乐表、 UTF-8 BOM 包含",
       "jsonDescription": "按元数据上下文结构导出",
@@ -3418,15 +3370,11 @@
       "includeFilePaths": "包含文件路径(高级)",
       "includeContextMeta": "包含上下文元数据",
       "preflight": "预览",
-      "scopeLabel": "Scope: {summary}",
-      "calculatingSize": "Calculating export size...",
       "estimatedSize": "预计大小：",
-      "fileLabel": "File: {fileName}",
       "exportAction": "导出",
       "selectedRowsSummary": "{count, plural, =0 {# 选定行} one {# 选定行} other {# 选定行}}",
       "matchingRowsSummary": "{count, plural, =0 {# 匹配行} one {# 匹配行} other {# 匹配行}}",
       "prepareFailed": "准备导出失败",
-      "exportStarted": "Metadata export started: {fileName}",
       "exportFailed": "元数据导出失败"
     },
     "columnPanel": {
@@ -3441,7 +3389,6 @@
       "presets": "预设值",
       "exportBackup": "导出预设和保存的视图",
       "importBackup": "导入预设和保存的视图",
-      "rename": "Rename",
       "renamePrompt": "输入新名称",
       "builtIn": "内置于",
       "saveCurrentPreset": "保存当前预设",
@@ -3482,25 +3429,20 @@
     },
     "jumpRail": {
       "jumpToSection": "跳转到小组",
-      "jumpTo": "Jump to {label}",
       "unknownDate": "未知日期",
       "unknownValue": "未知值"
     },
     "quickView": {
       "title": "预订快速视图",
-      "titleFor": "Quick view for {title}",
       "description": "预览书详细信息并运行快速操作。",
-      "openIn": "Open in {provider}",
       "pages": "{count, plural, =0 {# 页面} one {# 页面} other {# 页面}}",
       "primaryFile": "主文件",
-      "fileNumber": "File #{id}",
       "showLess": "显示更少的",
       "showMore": "显示更多",
       "collections": "A. 收款情况",
       "noDescription": "无可用描述。",
       "openMetadataEditor": "打开元数据编辑器",
       "coverPreview": "书籍封面预览",
-      "coverPreviewFor": "{title} cover preview",
       "coverPreviewDescription": "扩大封面图像预览对话框。"
     },
     "tableView": {
@@ -3510,18 +3452,12 @@
       "booksSelected": "{count, plural, =0 {# 选择的书} one {# 选择的书} other {# 选择的书}}",
       "loadingMoreBooks": "正在加载更多书",
       "sort": "排序",
-      "refreshingMetadata": "Refreshing metadata {processed} / {total}",
-      "failedCount": "{count} failed",
-      "remainingCount": "{count} remaining",
       "readOnlyNotice": "表格编辑在较小的屏幕上被禁用。切换到列表或网格以更快的操作。",
-      "fetching": "Fetching...",
       "updated": "已更新",
       "failed": "失败",
       "noBooks": "没有要显示的书",
       "scrollToTop": "滚动到顶部",
-      "selectedStatus": "{count} selected",
       "filtered": "已过滤",
-      "loadedStatus": "{loaded} of {total} loaded",
       "bookCount": "{count, plural, =0 {# 书} one {# 书} other {# 书}}",
       "keyboardShortcutsTitle": "键盘快捷键 (?)",
       "showKeyboardShortcuts": "显示桌面快捷键",
@@ -3551,14 +3487,10 @@
       "recommended": {
         "moreLikeThis": "更多喜欢这个"
       },
-      "series": {
-        "moreInSeries": "More in the {series} series"
-      },
       "writeRename": {
         "written": "{count, plural, =0 {没有字段写入} one {写入(一个字段)} other {写入(# 字段)}}",
         "writeFailed": "写入失败",
         "skipped": "跳过",
-        "renamedTo": "Renamed to {name}",
         "fileRenamed": "文件已重命名",
         "renameFailed": "重命名失败",
         "autoWriteAndRenameDisabled": "自动写入和重命名在书库设置中被禁用。更改将不会自动同步到未来的存档。",
@@ -3568,12 +3500,10 @@
         "renameLabel": "重命名："
       },
       "addFile": {
-        "uploading": "Uploading...",
         "uploadComplete": "上传完成",
         "title": "添加文件",
         "dropzone": {
-          "title": "将文件拖放到此处，或单击以浏览",
-          "hint": "epub, pdf, mobi, cbz, m4b and more - up to {size} MB each"
+          "title": "将文件拖放到此处，或单击以浏览"
         },
         "addMore": "添加更多文件",
         "fileCount": "{count, plural, =0 {没有文件} one {一个文件} other {# 文件}}",
@@ -3581,10 +3511,7 @@
         "done": "完成",
         "retry": "重试",
         "filesAdded": "{count, plural, =0 {没有文件添加} one {一个文件添加} other {# 文件添加}}",
-        "uploadedFailed": "{done} uploaded, {failed} failed",
-        "uploadingProgress": "{done} of {total} uploading...",
         "renameAfter": "上传后重命名所有书文件",
-        "uploadCount": "Upload ({count})",
         "upload": "上传"
       },
       "addSession": {
@@ -3601,7 +3528,6 @@
         "optional": "可选的",
         "format": "格式",
         "noFormat": "没有特定格式",
-        "saving": "Saving...",
         "submit": "添加会话"
       },
       "coverEditor": {
@@ -3609,9 +3535,7 @@
         "lockCover": "锁定封面",
         "fileTab": "文件",
         "urlTab": "网址",
-        "chooseImage": "Choose image...",
         "findCoverOnline": "在线查找封面",
-        "saving": "Saving...",
         "saveCover": "保存封面",
         "revertToOriginal": "还原到原始的",
         "regenerateCover": "重新生成封面"
@@ -3625,7 +3549,6 @@
         "allSources": "所有来源",
         "audiobookCovers": "音频簿封面",
         "squareHint": "(平方)",
-        "searching": "Searching...",
         "findCovers": "查找封面",
         "selectCover": "选择封面",
         "noResultsTitle": "未找到结果",
@@ -3638,7 +3561,6 @@
         "by": "由",
         "narratedBy": "叙述者",
         "ratingLocked": "评分已锁定",
-        "rateStar": "Rate {star}",
         "listen": "监听",
         "read": "已读",
         "chooseFormat": "选择格式",
@@ -3657,13 +3579,9 @@
         "editCover": "编辑封面",
         "finished": "已完成",
         "resetFileProgress": "重置文件进度",
-        "resetting": "Resetting...",
-        "resetProgressConfirm": "Reset stored reading progress for {label}?",
-        "moreCount": "+{count} more",
         "untitled": "无标题",
         "metadataScore": "元数据分数",
         "primaryFormat": "主要格式",
-        "openIn": "Open in {provider}",
         "showLess": "显示更少的",
         "showMore": "显示更多",
         "publisher": "发布者",
@@ -3679,7 +3597,6 @@
         "library": "书库",
         "added": "已添加",
         "dateStarted": "开始日期",
-        "saving": "Saving...",
         "cancelDateStartedEdit": "取消日期开始编辑",
         "editDateStarted": "编辑开始日期",
         "dateFinished": "完成日期",
@@ -3688,8 +3605,6 @@
         "customMetadata": "自定义元数据",
         "synopsis": "简述",
         "noDescription": "无可用描述。",
-        "dateStartedFutureError": "Date Started cannot be in the future.",
-        "dateFinishedFutureError": "Date Finished cannot be in the future.",
         "dateFinishedBeforeStartedError": "完成日期必须是开始日期或之后。",
         "saveReadingDatesError": "无法保存阅读日期。",
         "koboPendingDelete": "等待从设备删除",
@@ -3704,28 +3619,19 @@
       "editMetadata": {
         "fieldCount": "{count, plural, =0 {没有字段} one {一个字段} other {# 字段}}",
         "bookFilesTarget": "书文件",
-        "formatFilesTarget": "{formats} files",
         "noPrimaryFile": "没有可用的主文件",
         "formatNotSupported": "此文件格式不支持回写",
         "formatDisabled": "此格式已禁用回写",
         "fileExceedsSizeLimit": "这个文件超过了回记大小限制",
-        "writing": "Writing...",
         "saveInProgress": "正在保存",
         "writeManualLibraryDisabled": "将元数据写入文件并在磁盘上重命名；此库的自动回写功能被禁用",
-        "writeManualTooltip": "Write {fields} to {target} and rename on disk",
-        "applyResult": "{skipped}, {updated}",
         "skippedLockedFields": "{count, plural, =0 {跳过没有锁定的字段} one {跳过了一个锁定的字段} other {跳过# 锁定的字段}}",
         "updatedFields": "{count, plural, =0 {未更新字段} one {更新一个字段} other {更新# 字段}}",
-        "wroteFieldsToFile": "Wrote {fields} to file",
-        "fileWriteFailedReason": "File write failed: {reason}",
         "fileWriteFailed": "文件写入失败",
-        "fileWriteSkippedReason": "File write skipped: {reason}",
         "fileWriteSkipped": "文件写入已跳过",
         "metadataSaved": "元数据已保存",
         "metadataWrittenToFile": "元数据已写入文件",
-        "savedButWriteFailedReason": "Metadata saved, but file write failed: {reason}",
         "savedButWriteFailed": "元数据已保存，但文件写入失败",
-        "savedWriteSkippedReason": "Metadata saved, file write skipped: {reason}",
         "savedWriteSkipped": "元数据已保存，文件写入跳过",
         "loadFromFileFailed": "从文件加载元数据失败",
         "loadedFieldsFromFile": "{count, plural, =0 {从文件中加载没有字段} one {从文件中加载一个字段} other {从文件中加载# 字段}}",
@@ -3734,18 +3640,15 @@
         "loadFromFileTooltip": "从主书文件加载元数据",
         "writeToFile": "写入文件",
         "autoFill": "自动填充",
-        "fetchingMetadata": "Fetching metadata...",
         "allFieldsLocked": "所有字段都被锁定",
         "autoFillTooltip": "使用您的元数据首选项自动填充字段",
         "lockAll": "锁定所有",
         "lockAllTooltip": "锁定所有字段",
         "unlockAll": "解锁所有",
         "unlockAllTooltip": "解锁所有字段",
-        "saving": "Saving...",
         "fileWriteBackDetails": "文件回写详细信息",
         "fileWriteBack": "文件回写",
         "enabled": "已启用",
-        "saveWritesMetadata": "'Save' writes metadata to {target}",
         "formats": "格式",
         "bookFiles": "预订文件",
         "supportedFields": "支持的字段",
@@ -3756,7 +3659,6 @@
         "genresLabel": "Genres",
         "tagsLabel": "标签",
         "ratingLabel": "评分",
-        "rateStar": "Rate {star}",
         "clear": "清空",
         "communityRatingsLabel": "社区评分",
         "noProviderRatings": "没有提供者评分",
@@ -3784,17 +3686,12 @@
         "comicLocationsLabel": "地点",
         "customMetadata": "自定义元数据",
         "descriptionLabel": "描述",
-        "unlockField": "Unlock {field}",
-        "lockField": "Lock {field}",
         "diffPanel": {
           "untitled": "无标题",
           "noFieldsSelected": "没有选定字段",
           "fieldsSelected": "{count, plural, =0 {没有选择字段} one {选择一个字段} other {# 字段选择}}",
           "results": "成果",
-          "providerMatches": "{provider} matches",
-          "selectedOf": "Selected {selected} of {total}",
           "yearUnknown": "年份未知",
-          "indexOf": "{index} of {total}",
           "switchedResult": "切换结果。先前从此提供商的选择已被清除。",
           "selectFieldsToApply": "选择要应用的字段",
           "copyMissing": "缺少复制",
@@ -3831,16 +3728,13 @@
           "titlePlaceholder": "标题",
           "authorPlaceholder": "作者",
           "isbnPlaceholder": "ISBN",
-          "searching": "Searching...",
           "activeQuery": "活动查询",
           "searchScope": "搜索范围",
           "allEnabled": "全部启用",
           "all": "所有的",
           "fieldRules": "字段规则",
           "custom": "自定义",
-          "providerNotInFieldRules": "{provider} is enabled but not in Field Rules",
           "notInFieldRulesLabel": "不在字段规则中：",
-          "notInFieldRulesText": "{providers}. Included in manual search with All enabled, but not used by automatic metadata fetch.",
           "noResults": "未找到结果",
           "noResultsHint": "尝试调整标题或作者",
           "searchPrompt": "在上方搜索，然后点击结果开始比较元数据。"
@@ -3851,20 +3745,12 @@
       "files": {
         "title": "预订文件",
         "fileCount": "{count, plural, =0 {没有文件} one {# 文件} other {# 文件}}",
-        "synced": "Synced {time}",
         "sortAria": "排序文件",
         "syncHistory": "同步历史记录",
         "metadataWriteBack": "元数据回写",
-        "relative": {
-          "seconds": "{value}s ago",
-          "minutes": "{value}m ago",
-          "hours": "{value}h ago",
-          "days": "{value}d ago"
-        },
         "renameFailed": "重命名文件失败",
         "deleteFailed": "删除文件失败",
         "addFile": "添加文件",
-        "lastSynced": "Last synced: {time}",
         "sort": {
           "label": "排序：",
           "name": "名称",
@@ -3878,14 +3764,12 @@
         "viewSyncLog": "查看同步日志",
         "noWriteHistory": "尚无写入历史记录。",
         "fieldsWritten": "{count, plural, =0 {没有字段} one {一个字段} other {# 字段}}",
-        "track": "Track {number}",
         "primary": "主要的",
         "read": "已读",
         "play": "播放",
         "peek": "佩克",
         "download": "下载",
         "moreActions": "更多操作",
-        "rename": "Rename",
         "empty": {
           "title": "没有附加文件",
           "description": "这本书没有相关文件。"
@@ -3895,16 +3779,12 @@
           "description": "重命名磁盘上的物理文件。",
           "placeholder": "新文件名"
         },
-        "saving": "Saving...",
         "deleteModal": {
-          "title": "删除文件？",
-          "description": "Are you sure you want to delete \"{filename}\"? This action cannot be undone."
-        },
-        "deleting": "Deleting..."
+          "title": "删除文件？"
+        }
       },
       "highlights": {
         "note": {
-          "placeholder": "Add a note...",
           "saving": "正在保存"
         },
         "export": {
@@ -3974,31 +3854,19 @@
           "summaryAria": "阅读摘要",
           "notSet": "未设置",
           "relative": {
-            "seconds": "{count}s ago",
-            "minutes": "{count}m ago",
-            "hours": "{count}h ago",
-            "days": "{count}d ago",
             "months": "{count, plural, =0 {# 月前} one {# 月前} other {# 月前}}",
             "years": "{count, plural, =0 {# 年前} one {# 年前} other {# 年前}}"
           },
           "noSessions": "没有会话",
           "dateErrors": {
-            "startFuture": "Start date cannot be in the future.",
-            "finishFuture": "Finish date cannot be in the future.",
-            "finishBeforeStart": "Finish date must be on or after the start date.",
             "saveFailed": "无法保存阅读日期。"
           },
           "eta": {
-            "max": "99h+完成",
-            "minutes": "~{m}m to finish",
-            "hours": "~{h}h to finish",
-            "hoursMinutes": "~{h}h {m}m to finish"
+            "max": "99h+完成"
           },
           "momentum": {
             "none": "过去两周内没有活动",
             "new": "本周新建活动",
-            "up": "+{pct}% vs previous 7 days",
-            "down": "{pct}% vs previous 7 days",
             "flat": "与前7天相比未更改"
           },
           "stats": {
@@ -4017,7 +3885,6 @@
           "tooltipProgress": "进展情况",
           "tooltipReading": "正在阅读",
           "minutesUnit": "分钟",
-          "title": "Progress journey",
           "empty": "此窗口中没有进度数据。",
           "emptyHint": "会话记录阅读位置后，进度将显示。"
         },
@@ -4033,7 +3900,6 @@
           "allTime": "全部时间",
           "last30": "过去 30 天",
           "last90": "最近90天",
-          "thisYear": "This year",
           "allFormats": "所有格式"
         },
         "table": {
@@ -4059,8 +3925,7 @@
           "confirmDeleteTitle": "再次单击以确认删除",
           "confirmDeleteAria": "确认删除会话",
           "deleteAria": "删除会话",
-          "loadMore": "加载更多",
-          "showing": "Showing {shown} of {total} sessions"
+          "loadMore": "加载更多"
         }
       },
       "richDescription": {
@@ -4095,11 +3960,7 @@
         "seriesPlaceholder": "系列",
         "moveUp": "上移",
         "moveDown": "向下移动",
-        "removeSeries": "删除系列",
-        "seriesIndexLabel": "Position in series",
-        "totalLabel": "Books in series",
-        "totalPlaceholder": "of",
-        "totalHint": "Total books in this series. Shared with everyone who has this series."
+        "removeSeries": "删除系列"
       }
     },
     "table": {
@@ -4115,9 +3976,6 @@
         "ariaNotSet": "未设置 - 点击设置 true",
         "ariaTrue": "True - 点击设置false",
         "ariaFalse": "False - 点击清除"
-      },
-      "chips": {
-        "addPlaceholder": "Add..."
       },
       "cover": {
         "previewDescription": "书籍封面预览",
@@ -4154,19 +4012,14 @@
         "clickToLock": "单击以锁定",
         "clickToUnlock": "点击解锁"
       },
-      "progress": {
-        "complete": "{percent} complete"
-      },
       "rating": {
         "label": "评分",
-        "remove": "删除评分",
-        "rate": "Rate {star} out of 5"
+        "remove": "删除评分"
       },
       "read": {
         "play": "播放",
         "read": "已读",
         "primary": "主要的",
-        "peekFormat": "Peek {format}",
         "chooseFormat": "选择要读取或播放的格式",
         "fileFallback": "文件"
       },
@@ -4174,8 +4027,7 @@
         "unread": "未读"
       },
       "series": {
-        "bookCount": "{count, plural, =0 {(无书)} one {(# 书)} other {(# 书)}}",
-        "readOfCount": "{read} of {total} read"
+        "bookCount": "{count, plural, =0 {(无书)} one {(# 书)} other {(# 书)}}"
       },
       "text": {
         "openDetails": "打开详情"
@@ -4183,65 +4035,10 @@
     },
     "move": {
       "title": "{count, plural, other {Move # books}}",
-      "subtitle": "Files move on disk into the destination library. This can change who can see these books.",
-      "searchPlaceholder": "Search libraries",
-      "currentLibrary": "Current",
       "folderCount": "{count, plural, other {# folders}}",
-      "continue": "Continue",
-      "back": "Back",
       "confirm": "{count, plural, other {Move # books}}",
-      "action": "Move to library",
       "review": {
-        "ready": "{count} ready",
-        "collisions": "{count, plural, other {# name conflicts}}",
-        "ineligible": "{count} cannot move",
-        "alreadyThere": "{count} already there",
-        "collisionsHeading": "Name conflicts",
-        "ineligibleHeading": "Cannot be moved",
-        "moreCollisions": "and {count} more"
-      },
-      "policy": {
-        "suggested": "Use suggested",
-        "keep_both": "Keep both",
-        "merge": "Merge",
-        "skip": "Skip"
-      },
-      "collision": {
-        "folder_path": "A book already uses this folder name",
-        "file_path": "A file already uses this path",
-        "hash_duplicate": "An identical copy is already in this library"
-      },
-      "ineligible": {
-        "book_not_present": "The files for this book are missing",
-        "no_content_file": "This book has no readable file",
-        "multi_file_target_per_file": "The destination stores one file per book, and this book has {detail} files",
-        "no_source_access": "You cannot edit the library this book is in",
-        "pattern_unresolved": "The destination library has no usable naming pattern",
-        "path_too_long": "The destination path would be too long",
-        "path_outside_target_root": "The destination path would fall outside the library folder"
-      },
-      "warning": {
-        "accessLoss": "{user} will stop seeing {count} of these books",
-        "koboImpact": "{count} books will leave {user}'s Kobo on the next sync",
-        "layout": {
-          "wrap_into_folder": "{count} books will each be placed in their own folder",
-          "dissolve_folder": "{count} book folders will be dissolved into single files"
-        },
-        "crossDevice": "Files move to another drive, so they are copied, verified, then removed."
-      },
-      "progress": {
-        "label": "Moving books to {library}",
-        "failed": "{count} failed"
-      },
-      "done": {
-        "summary": "Moved {count} books to {library}",
-        "merged": "{count} merged with copies already there",
-        "skipped": "{count} skipped",
-        "failed": "{count} failed"
-      },
-      "toast": {
-        "success": "Moved {count} books to {library}",
-        "partial": "Moved {moved} books, {failed} failed"
+        "collisions": "{count, plural, other {# name conflicts}}"
       }
     }
   },
@@ -4278,19 +4075,13 @@
       "authorEnrichmentFinished": "作者浓缩完成"
     },
     "label": {
-      "paused": "已暂停",
-      "remaining": "{count} remaining",
-      "processing": "{count} processing",
-      "failed": "{count} failed",
-      "rateLimited": "{count} rate limited"
+      "paused": "已暂停"
     },
     "report": {
       "bookTitle": "无法获取元数据",
       "authorTitle": "失败的作者积分数",
       "noFailedItems": "没有失败的项目。",
       "retryAllFailed": "重试所有失败",
-      "bookFallback": "Book #{id}",
-      "authorFallback": "Author #{id}",
       "columns": {
         "title": "标题",
         "library": "书库",
@@ -4304,22 +4095,15 @@
       "failedToResume": "恢复失败",
       "failedToCancel": "取消失败",
       "failedToRetry": "重试失败",
-      "failedItemsRequeued": "重新排队失败的项目",
-      "bookComplete": "Metadata fetch complete - {done} books updated",
-      "bookDoneWithFailures": "Metadata fetch done - {done} processed, {failed} failed",
-      "authorComplete": "Author enrichment complete - {done} authors updated",
-      "authorDoneWithFailures": "Author enrichment done - {done} processed, {failed} failed"
+      "failedItemsRequeued": "重新排队失败的项目"
     }
   },
   "bookDock": {
     "apply": "应用",
     "done": "完成",
-    "discard": "Discard",
     "finalize": "完成",
     "rescan": "重新扫描",
     "uploadAction": "上传",
-    "uploading": "Uploading...",
-    "searchPlaceholder": "Search files...",
     "setDestinationAction": "设定目标",
     "bulkEditAction": "批量编辑",
     "applyFetched": "应用已获取",
@@ -4327,9 +4111,6 @@
     "commaSeparated": "逗号分隔的",
     "destinationLibrary": "目标库",
     "destinationFolder": "目标文件夹",
-    "nFailed": "{count} failed",
-    "updatedOfFiles": "Updated {updated} of {total} files",
-    "errorStatus": "Error {status}",
     "tab": {
       "all": "所有的",
       "pending": "待定",
@@ -4360,11 +4141,6 @@
       "genresCommaSeparated": "流派(逗号分隔)",
       "description": "描述"
     },
-    "upload": {
-      "nDone": "{count} done",
-      "nFailed": "{count} failed",
-      "nTotal": "{count} total"
-    },
     "fileList": {
       "emptyTitle": "Book Dock 中没有文件",
       "emptyMessageDefault": "上传文件或将其拖放到书签文件夹",
@@ -4379,20 +4155,16 @@
       "applyFetchedMetadata": "应用获取的元数据",
       "coverPreview": "封面预览",
       "coverPreviewDescription": "扩大封面图像预览对话框。",
-      "currentCoverAlt": "{title} current cover",
-      "newCoverAlt": "{title} new cover",
       "unknownLibrary": "未知库",
       "unassigned": "未分配",
       "targetPath": "Target: {library} · {path}",
-      "targetUnassigned": "目标：未分配",
-      "targetUnknownPath": "Target: {library} · Unknown destination path"
+      "targetUnassigned": "目标：未分配"
     },
     "sheet": {
       "saved": "已保存",
       "providerMetadataFound": "找到提供商元数据",
       "providerMetadataFoundEdited": "找到提供商元数据 - 批量应用将跳过此文件 (您已经编辑)",
       "review": "审查",
-      "added": "Added {date}",
       "searchMetadata": "搜索元数据",
       "results": "成果"
     },
@@ -4416,16 +4188,12 @@
       "defaultDestinationLibrary": "默认目标库",
       "defaultDestinationFolder": "默认目标文件夹",
       "renamePreview": "重命名预览",
-      "moreFiles": "+{count} more files",
       "start": "开始",
-      "filesFinalized": "{succeeded} of {total} files finalized",
-      "checking": "Checking selected files...",
       "readyCount": "{count, plural, =0 {尚未准备好文件} one {# 文件已准备好} other {# 文件已准备好}}",
       "duplicateCount": "{count, plural, =0 {库里还没有存在} one {# 已经在库里} other {# 已经在库里}}",
       "conflictCount": "{count, plural, =0 {没有文件名冲突} one {# 文件名冲突} other {# 文件名冲突}}",
       "missingDestinationCount": "{count, plural, =0 {没有遗失的目的地} one {# 遗失目标} other {# 遗失目的地}}",
       "blockedCount": "{count, plural, =0 {没有文件已屏蔽} one {# 文件已屏蔽} other {# 文件已屏蔽}}",
-      "moreDuplicates": "+{count} more already in library",
       "discardDuplicates": "丢弃重复项",
       "failedCount": "{count, plural, =0 {没有文件失败} one {# 文件失败} other {# 文件失败}}",
       "failedWithDuplicates": "{count, plural, =0 {{failed} 失败 (# 重复)} one {{failed} 失败 (# 重复)} other {{failed} 失败 (# 重复)}}",
@@ -4434,7 +4202,6 @@
       "hide": "隐藏",
       "details": "详细信息",
       "alreadyExistsSaveAs": "已经存在 - 保存为：",
-      "renamePlaceholder": "e.g. {name} (2)",
       "import": "导入"
     }
   },
@@ -4442,10 +4209,8 @@
     "dialog": {
       "name": "名称",
       "icon": "图标",
-      "iconPlaceholder": "Choose an icon...",
       "nameRequired": "名称是必填项",
       "iconRequired": "选择一个图标",
-      "creating": "Creating...",
       "createFailed": "创建收藏失败"
     },
     "createDialog": {
@@ -4458,9 +4223,6 @@
       "syncToKoboHint": "此收藏中的书籍将出现在您的 Kobo 设备上",
       "deleteCollection": "删除收藏",
       "confirmDelete": "确认？",
-      "deleting": "Deleting...",
-      "saving": "Saving...",
-      "deleted": "\"{name}\" deleted",
       "updateFailed": "更新收藏失败",
       "deleteFailed": "删除收藏失败"
     },
@@ -4474,35 +4236,23 @@
       "empty": "还没有收藏。请在上面创建。",
       "done": "完成",
       "added": "已添加",
-      "allAdded": "All {total} added",
       "inCollection": "在此收藏中",
-      "allInCollection": "All {total} in this collection",
-      "partialInCollection": "{partial} of {total} in this collection",
       "bookCount": "{count, plural, =0 {没有书籍} one {一张书} other {# 书}}",
       "loadFailed": "加载收藏失败",
       "createdAndAdded": "{count, plural, =0 {创建了 \"{name}\" 且没有新增任何书籍} one {创建了 \"{name}”并添加了一本书} other {创建了“{name}”并添加了# 本书}}",
-      "createdButAddFailed": "Created \"{name}\" but failed to add books",
       "createFailed": "创建收藏失败",
       "addedNewWithExisting": "{count, plural, =0 {添加一本新书到 \"{name}\" ({alreadyHad} 已经存在)} one {添加一本新书到 \"{name}\" ({alreadyHad} 已经有)} other {添加# 新书到\"{name}\" ({alreadyHad} 已经有)}}",
       "addedToCollection": "{count, plural, =0 {添加没有书籍到 \"{name}\"} one {添加一本书到 \"{name}\"} other {添加# 书籍到 \"{name}\"}}",
       "addFailed": "添加到收藏失败",
-      "removedFromCollection": "{count, plural, =0 {Removed no books from \"{name}\"} one {Removed one book from \"{name}\"} other {Removed # books from \"{name}\"}}",
       "removeFailed": "从收藏中删除失败"
     }
   },
   "components": {
     "appHeader": {
-      "searchAllBooks": "Search all books...",
-      "searching": "Searching...",
       "noResults": "没有结果",
-      "loadingMore": "Loading more...",
-      "loadMore": "Load more ({loaded}/{total})",
       "allMatchesShown": "{count, plural, =0 {显示所有1场比赛} one {显示所有1场比赛} other {显示所有#场比赛}}",
       "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}",
       "fileCount": "{count, plural, =0 {没有文件} one {# 文件} other {# 文件}}",
-      "uploadedToast": "Uploaded {uploaded}",
-      "uploadFailedToast": "Upload failed for {failed}",
-      "uploadPartialToast": "Uploaded {uploaded}, {failed} failed",
       "bookDock": "预约停靠栏",
       "statistics": "统计",
       "achievements": "1. 成就",
@@ -4528,8 +4278,7 @@
         "body": "如果BookOrbit正在帮助您的库，请考虑启动GitHub上的项目。它帮助更多的人发现应用程序并支持正在进行的开发。",
         "cta": "GitHub 上的星座BookOrbit"
       },
-      "surfaceOpacity": "表面不透明度",
-      "surfaceOpacityValue": "{value}%"
+      "surfaceOpacity": "表面不透明度"
     },
     "sidebar": {
       "dashboard": "仪表板",
@@ -4538,7 +4287,6 @@
       "tools": "工具",
       "libraries": "库",
       "newLibrary": "新建库",
-      "scanProgress": "{processed} / {total} books",
       "smartScopes": "智能范围",
       "newSmartScope": "新建智能瞄准镜",
       "noSmartScopes": "尚无智能范围",
@@ -4551,34 +4299,19 @@
       "sectionHeader": {
         "add": "添加",
         "showAll": "显示所有",
-        "showCount": "Show {count}",
         "rowsShown": "显示行",
-        "menuAria": "Section options for {section}",
         "reorder": "重新排序",
         "doneReordering": "完成排序"
       },
       "noLibraries": "还没有库",
       "clearFilter": "清除过滤器",
-      "filterSummary": "{shown} of {total} shown",
       "filterLibraries": "过滤库",
-      "filterLibrariesPlaceholder": "Filter libraries...",
       "filterSmartScopes": "筛选智能范围",
-      "filterSmartScopesPlaceholder": "Filter smart scopes...",
       "filterCollections": "筛选收藏",
-      "filterCollectionsPlaceholder": "Filter collections...",
-      "seeAllLibraries": "See all libraries ({count})",
-      "seeAllSmartScopes": "See all smart scopes ({count})",
-      "seeAllCollections": "See all collections ({count})",
-      "updateAvailable": "Update {version}",
       "zones": {
         "browse": "浏览"
       },
       "reorder": {
-        "gripAria": "Reorder {name}",
-        "lifted": "{name} lifted, position {position} of {total}. Use the arrow keys to move it.",
-        "moved": "{name}, position {position} of {total}",
-        "dropped": "{name} dropped at position {position} of {total}",
-        "cancelled": "Reorder cancelled. {name} returned to position {position} of {total}.",
         "filteredHint": "清除过滤器以重新排序"
       }
     },
@@ -4607,11 +4340,9 @@
       "audioOnly": "仅音频",
       "setRatingLabel": "设置评分：",
       "clear": "清空",
-      "setFieldLabel": "Set field:",
       "apply": "应用",
       "fieldPlaceholder": "留空以清除",
       "fieldPlaceholderArray": "逗号分隔(留空以清除)",
-      "deleteConfirm": "{count, plural, =0 {Delete # book?} one {Delete # book?} other {Delete # books?}}",
       "typeDelete": "输入删除"
     },
     "viewHeader": {
@@ -4620,7 +4351,6 @@
       "displayDescription": "调整封面大小、网格间距和视图显示选项。",
       "columnVisibilityHint": "使用表头中的列可见面板来显示或隐藏列。",
       "columnVisibilityMobileHint": "列可见性可以从表头进行管理。",
-      "searchPlaceholder": "Search title, author, series, narrator...",
       "mobileSearch": {
         "description": "按标题、作者、序列号或语音搜索项目。",
         "done": "完成"
@@ -4644,20 +4374,13 @@
     },
     "iconPicker": {
       "clearSelectionAria": "清除选中的图标",
-      "searchLucide": "Search Lucide icons...",
-      "searchCustom": "Search custom icons...",
-      "chooseIcon": "Choose an icon...",
       "selectIcon": "选择图标",
       "customTab": "自定义",
-      "searching": "Searching...",
-      "noIconsMatch": "No icons match \"{query}\"",
       "typeToSearch": "输入搜索所有图标",
       "noCustomIcons": "没有自定义图标上传",
       "noIconsAvailable": "无可用图标"
     },
     "entityNotFound": {
-      "title": "{entity} not found",
-      "description": "This {entity} doesn't exist or has been deleted.",
       "goBack": "后退"
     },
     "themePicker": {
@@ -4666,8 +4389,7 @@
       "system": "系统"
     },
     "userAvatar": {
-      "profilePicture": "个人资料图片",
-      "profilePictureOf": "{name} profile picture"
+      "profilePicture": "个人资料图片"
     },
     "ui": {
       "sidebar": {
@@ -4690,10 +4412,8 @@
       "ascending": "升序",
       "descending": "降序",
       "clearSearch": "清除搜索",
-      "resultCount": "{shown} of {total}",
       "noMatches": "没有匹配",
       "noMatchesHint": "尝试一个不同的搜索词。",
-      "bookCount": "Books: {count}",
       "librariesEmptyHint": "创建一个库开始添加书籍。",
       "smartScopesEmptyHint": "智能范围保存您经常使用的一组过滤器。",
       "collectionsEmptyHint": "收藏群组你手上挑选的书籍。"
@@ -4702,27 +4422,19 @@
   "customIcons": {
     "dialogTitle": "上传自定义图标",
     "dialogDescription": "在将名字添加到您的书库之前审查这些名字。",
-    "readingFiles": "Reading files...",
     "dropPrompt": "拖放SVG文件或点击浏览",
-    "fileLimit": "Up to {max} files, 128 KB each",
     "namePlaceholder": "名称",
     "nameRequired": "名称是必填项",
     "invalidSvg": "无效的 SVG",
     "invalidSvgFile": "无效的 SVG 文件",
-    "identicalTo": "Identical to \"{name}\"",
     "uploadAnyway": "仍然上传",
     "skipThisOne": "跳过这一个",
-    "readyToUpload": "{count} ready to upload",
     "noIconsStaged": "尚未挂起图标",
-    "uploading": "Uploading...",
     "upload": "上传",
-    "uploadCount": "Upload {count}",
     "onlySvgSupported": "仅支持 SVG 文件",
-    "maxStaged": "You can stage at most {max} icons at once",
     "onlyMoreCanStage": "{count, plural, =0 {没有更多图标可以挂起} one {仅# 更多图标可以挂起} other {仅# 更多图标可以挂起}}",
     "readFailed": "无法读取 SVG 文件",
     "uploadedCount": "{count, plural, =0 {没有图标上传} one {上传# 图标} other {上传# 图标}}",
-    "uploadedPartial": "Uploaded {created}, {failed} failed",
     "noIconsUploaded": "没有上传图标",
     "uploadFailed": "上传图标失败",
     "uploadFailedEntry": "上传失败"
@@ -4776,14 +4488,6 @@
         "random": "发现新鲜事",
         "smartScope": "智能瞄准镜"
       },
-      "shelfLayout": {
-        "title": "Shelf layout",
-        "description": "Choose how shelves are arranged on larger screens.",
-        "wide": "Wide rows",
-        "wideDescription": "Show one shelf per row.",
-        "twoColumns": "Two columns",
-        "twoColumnsDescription": "Show two shelves per row."
-      },
       "reorderHintWidget": "拖动以重新排序。切换以显示或隐藏部件。",
       "reorderHintShelf": "拖动以重新排序。切换以显示或隐藏架。",
       "smartScope": "智能瞄准镜",
@@ -4822,9 +4526,7 @@
       "libraryOverview": {
         "title": "书库概览",
         "empty": "您的库是空的。添加一些书以开始操作。",
-        "addedThisYear": "+{count} added this year",
         "stats": {
-          "books": "Books",
           "authors": "作者",
           "series": "系列",
           "storage": "存储"
@@ -4838,14 +4540,11 @@
         "startReading": "开始阅读"
       },
       "monthlyChallenge": {
-        "title": "每月挑战",
-        "complete": "Complete!"
+        "title": "每月挑战"
       },
       "neglectedGems": {
         "title": "被忽略的 Gems",
         "empty": "您所有的评分最高的书籍都已读完！",
-        "rating": "{rating}/5",
-        "daysWaiting": "{count}d waiting",
         "queued": "队列中",
         "addToQueue": "添加到队列",
         "shuffle": "随机播放"
@@ -4863,20 +4562,15 @@
         }
       },
       "readingGoal": {
-        "title": "Reading Goal {year}",
         "setGoalPrompt": "设置一个读取目标来跟踪您的进度",
         "setGoal": "设置目标",
         "booksPerYear": "每年的书",
-        "ofGoal": "of {goal}",
         "percentComplete": "{percentage}% complete",
         "editGoal": "编辑目标"
       },
       "readingRhythm": {
         "title": "读取节日",
-        "empty": "Start reading to see your rhythm take shape",
-        "activeDays": "{count, plural, =0 {没有活动日} one {# 活动日} other {# 活动日}}",
-        "consistency": "{activeDays} · {percent}% consistency",
-        "avgPerDay": "avg {time}/day"
+        "activeDays": "{count, plural, =0 {没有活动日} one {# 活动日} other {# 活动日}}"
       },
       "readingStreak": {
         "title": "读取串流",
@@ -4887,14 +4581,11 @@
       },
       "yearProjection": {
         "title": "年预测",
-        "books": "books",
         "trendUp": "热门上移",
         "trendDown": "向下趋势",
         "trendSteady": "稳定速度",
         "pages": "页面",
-        "hours": "小时",
-        "readCount": "{count} read",
-        "daysLeft": "{count}d left"
+        "hours": "小时"
       }
     }
   },
@@ -4906,10 +4597,8 @@
     "deleteFailed": "删除失败",
     "setDefaultFailed": "设置默认值失败",
     "setAsDefault": "设置为默认",
-    "saving": "Saving...",
     "update": "更新",
     "create": "创建",
-    "deleteConfirm": "Delete \"{name}\". This action cannot be undone.",
     "badge": {
       "default": "默认设置",
       "shared": "共享的",
@@ -4950,18 +4639,13 @@
       "toggleSharing": "切换共享",
       "removeSystemBeforeDelete": "删除之前删除系统指定",
       "notesHeading": "提供者备注",
-      "notesBody": "The {system} provider (superuser only) is used for password reset emails. The {defaultProvider} provider is used when sending books with no explicit provider selected. Providers marked {shared} are available to all users.",
       "deleteTitle": "删除提供商？",
       "nameHostRequired": "名称和主机是必填项",
       "created": "提供者已创建",
       "updated": "提供者已更新",
-      "deleted": "\"{name}\" deleted",
-      "setDefaultSuccess": "\"{name}\" set as default",
       "unshared": "提供者未共享",
       "sharedWithAll": "所有用户共享的提供商",
       "updateSharingFailed": "更新共享失败",
-      "systemRemoved": "\"{name}\" removed as system mail provider",
-      "systemSet": "\"{name}\" set as system mail provider",
       "updateSystemFailed": "更新系统提供者失败",
       "connectionSuccess": "连接成功",
       "connectionFailed": "连接失败",
@@ -4984,13 +4668,10 @@
       "useAccountDefault": "使用账户默认",
       "kindleNote": "Kindle 收件人自动收到主题“转换”以触发格式转换的电子邮件。",
       "empty": "尚无收件人。",
-      "prefersFormat": "prefers {format}",
       "deleteTitle": "删除收件人？",
       "nameEmailRequired": "姓名和电子邮件是必填项",
       "created": "收件人已创建",
-      "updated": "收件人已更新",
-      "deleted": "\"{name}\" deleted",
-      "setDefaultSuccess": "\"{name}\" set as default"
+      "updated": "收件人已更新"
     },
     "groups": {
       "heading": "收件人组",
@@ -4998,20 +4679,17 @@
       "newTitle": "新建群组",
       "name": "群组名称",
       "namePlaceholder": "例如：Book Club",
-      "creating": "Creating...",
       "empty": "尚无群组。创建群组一次发送到多个收件人。",
       "memberCount": "{count, plural, =0 {没有成员} one {一个成员} other {# 成员}}",
       "deleteTooltip": "删除组",
       "noMembers": "尚无成员。",
       "removeMember": "删除",
-      "selectRecipient": "Select recipient...",
       "add": "添加",
       "addMember": "添加成员",
       "allRecipientsInGroup": "所有收件人已经在此组中。",
       "deleteTitle": "删除群组？",
       "created": "群组已创建",
       "createFailed": "创建群组失败",
-      "deleted": "\"{name}\" deleted",
       "memberAdded": "成员已添加",
       "addMemberFailed": "添加会员失败",
       "memberRemoved": "成员已删除",
@@ -5030,13 +4708,10 @@
       "editTemplate": "编辑模板",
       "empty": "尚无模板。",
       "notesHeading": "模板注释",
-      "notesBody": "System templates cannot be deleted. Administrators can edit them. Use variables like {variable} in subjects and bodies - they are replaced with book details at send time.",
       "deleteTitle": "删除模板？",
       "nameSubjectRequired": "名称和主题是必需的",
       "created": "模板已创建",
-      "updated": "模板已更新",
-      "deleted": "\"{name}\" deleted",
-      "setDefaultSuccess": "\"{name}\" set as default"
+      "updated": "模板已更新"
     },
     "preferences": {
       "heading": "电子邮件首选项",
@@ -5082,7 +4757,6 @@
       "template": "模板",
       "default": "默认设置",
       "send": "发送",
-      "sending": "Sending...",
       "queued": "{count, plural, =0 {没有邮件队列} one {有一封邮件队列} other {# 电子邮件队列}}",
       "failed": "发送失败"
     }
@@ -5126,8 +4800,7 @@
         "description": "暂停所有硬封面同步而不断开连接。"
       },
       "syncOnStatus": {
-        "title": "状态变化时同步",
-        "description": "Push updates when you mark a book as reading, read, etc."
+        "title": "状态变化时同步"
       },
       "syncOnProgress": {
         "title": "同步进度更新",
@@ -5154,31 +4827,24 @@
     },
     "sync": {
       "title": "手动同步",
-      "description": "Push your {scope} to Hardcover now.",
       "scope": {
         "selected": "选中的书",
         "eligible": "合格书"
       },
-      "checkingPending": "Checking pending items...",
-      "pendingOf": "{pending} pending of {total} books.",
       "noBooksInScope": "没有同步范围内的书籍。",
       "allSynced": "所有书籍已经同步。",
       "lastSyncedLabel": "上次同步",
       "lastSuccessfulSync": "最后一次成功同步",
-      "syncing": "Syncing...",
-      "progressCount": "{synced} / {total} books",
       "unavailable": {
         "permissionDenied": "您没有使用硬封面同步的权限。",
         "userDisabled": "同步已暂停在您的硬封面设置。"
       },
       "button": {
         "unavailable": "Sync unavailable",
-        "syncNow": "立即同步",
-        "syncNowCount": "Sync now ({count})"
+        "syncNow": "立即同步"
       },
       "lastSynced": {
         "justNow": "马上开始",
-        "minutesAgo": "{count} min ago",
         "hoursAgo": "{count, plural, =0 {# 小时前} one {# 小时前} other {# 小时前}}",
         "daysAgo": "{count, plural, =0 {#天前} one {#天前} other {#天前}}"
       }
@@ -5206,10 +4872,6 @@
         "unmatched": "未匹配",
         "skipped": "跳过"
       },
-      "result": {
-        "summary": "{applied} imported{progress}, {failed} failed",
-        "progressUpdated": "{count} progress updated"
-      },
       "toast": {
         "importFailed": "导入硬封面读取状态失败",
         "imported": "{count, plural, =0 {未读状态导入{progress}} one {# 读取状态已导入{progress}} other {# 读取状态已导入{progress}}}",
@@ -5218,15 +4880,12 @@
     },
     "review": {
       "title": "硬封面进口审查",
-      "subtitle": "{total} Hardcover books, {matched} matched.",
       "closeAriaLabel": "关闭导入审核",
       "searchPlaceholder": "搜索标题或作者",
       "importProgress": "导入进度",
       "untitled": "无标题",
       "blank": "空白",
       "noRows": "没有匹配当前筛选器的行。",
-      "selectRowAriaLabel": "Select {title}",
-      "selectionSummary": "{count} selected: {ready} ready, {reviewed} reviewed.",
       "selectedProgress": "{count, plural, =0 {没有进度更新} one {# 进度更新} other {# 进度更新}}",
       "selectReady": "选择已准备好",
       "selectPage": "选择页面",
@@ -5235,7 +4894,6 @@
       "importSelected": "导入选中的",
       "previousPage": "上一页",
       "nextPage": "下一页",
-      "pageRange": "{start}-{end} of {total}",
       "tabs": {
         "all": "所有的",
         "ready": "准备好",
@@ -5274,8 +4932,6 @@
   "library": {
     "creator": {
       "createTitle": "创建库",
-      "editTitle": "Edit: {name}",
-      "stepOf": "Step {current} of {total}",
       "unsaved": "未保存",
       "required": "必填",
       "closeAria": "关闭库创建者",
@@ -5293,7 +4949,6 @@
         "access": "访问权限"
       },
       "actions": {
-        "saving": "Saving…",
         "saveChanges": "保存更改",
         "creating": "正在创建…",
         "createLibrary": "创建库"
@@ -5309,7 +4964,6 @@
         },
         "icon": {
           "label": "图标",
-          "placeholder": "Choose an icon...",
           "selected": "已选择"
         }
       },
@@ -5324,7 +4978,6 @@
         "manualEntry": "手动输入路径",
         "absolutePath": "绝对服务器路径",
         "addFolder": "添加文件夹",
-        "removeFolder": "Remove {folder}",
         "manualCheckHint": "手动路径与所选文件夹的其余部分一起检查。",
         "pathPlaceholder": "/path/to/books",
         "test": "测试",
@@ -5332,7 +4985,6 @@
         "pathNotAccessible": "路径无法在服务器上访问。",
         "pathAccessible": "路径是可访问的。",
         "pathNotAccessibleShort": "路径不可访问",
-        "overlapsWith": "Overlaps with \"{library}\"",
         "noneAdded": "尚未添加文件夹",
         "runPrescanHint": "在保存前运行预览以验证路径。",
         "scanning": "正在扫描…",
@@ -5362,8 +5014,6 @@
         },
         "excludePatterns": {
           "title": "排除图案",
-          "hintBefore": "Glob patterns to skip during scanning (e.g. ",
-          "hintAfter": ").",
           "add": "添加",
           "empty": "没有添加图案。"
         }
@@ -5470,7 +5120,6 @@
         "selectUser": "选择一个用户…",
         "grant": "授权",
         "empty": "没有用户被授予访问权限。",
-        "loading": "Loading access settings...",
         "userSelectAria": "允许访问的用户",
         "levelSelectAria": "获得补助金的程度",
         "levels": {
@@ -5501,13 +5150,11 @@
       "clearFilterAria": "清除文件夹过滤器",
       "newFolderNamePlaceholder": "新文件夹名称",
       "create": "创建",
-      "loading": "Loading folders...",
       "selectCurrent": "选择当前文件夹",
       "noMatches": "没有匹配的文件夹",
       "noMatchesHint": "尝试不同的过滤器。",
       "empty": "此文件夹为空",
       "emptyHint": "您可以选择当前文件夹或创建一个新文件夹。",
-      "openFolderAria": "Open {name}",
       "selectedCount": "{count, plural, =0 {没有选择任何文件夹} one {# 文件夹选择} other {# 文件夹选择}}",
       "noFolders": "未找到文件夹",
       "selectFolder": "选择此文件夹",
@@ -5520,28 +5167,21 @@
     },
     "upload": {
       "library": "书库",
-      "selectLibrary": "Select a library...",
       "targetFolder": "目标文件夹",
       "addMoreFiles": "添加更多文件",
       "clearAll": "全部清除",
       "done": "完成",
       "retry": "重试",
       "upload": "上传",
-      "uploadWithCount": "Upload ({count})",
       "viewInLibrary": "在书库中查看",
       "fileCount": "{count, plural, =0 {没有文件} one {# 文件} other {# 文件}}",
       "booksAdded": "{count, plural, =0 {没有已添加的书} one {# 已添加的书} other {# 已添加的书}}",
-      "uploadedFailed": "{done} uploaded, {failed} failed",
-      "progress": "{done} of {total} uploading...",
       "header": {
-        "uploading": "Uploading...",
         "complete": "上传完成",
-        "uploadTo": "Upload to {library}",
         "uploadBooks": "上传书"
       },
       "dropzone": {
-        "title": "将文件拖放到此处，或单击以浏览",
-        "hint": "{formats} - up to {size} MB each"
+        "title": "将文件拖放到此处，或单击以浏览"
       }
     }
   },
@@ -5594,7 +5234,6 @@
       "continueToMigration": "继续迁移",
       "viewReport": "查看报告",
       "resetSetup": "Reset Setup",
-      "stepOf": "Step {current} of {total}",
       "backToSetup": "返回设置"
     },
     "stages": {
@@ -5614,7 +5253,6 @@
         "port": "端口",
         "user": "用户",
         "password": "密码",
-        "passwordSaved": "Saved - leave unchanged",
         "passwordNotSet": "未设置密码",
         "database": "数据库",
         "mediaRootPath": "媒体根路径",
@@ -5635,9 +5273,7 @@
       },
       "snapshot": {
         "title": "最后验证快照",
-        "sourceVersion": "Source version: {version}",
-        "unknown": "未知的",
-        "missingTables": "Missing required tables: {tables}"
+        "unknown": "未知的"
       }
     },
     "mappings": {
@@ -5651,15 +5287,10 @@
       "addMapping": "添加映射",
       "pathMappingsExplanation": "路径映射将源文件路径转换为目标路径，这样书本可以与文件位置匹配。 不论路径映射如何，都用ISBN、文件哈希和标题/作者匹配书籍。",
       "noPrefixesFound": "没有找到前缀 - 首先验证源代码",
-      "selectSourcePrefix": "Select source prefix...",
-      "selectTargetFolder": "Select target folder...",
       "remove": "删除",
       "saveMappings": "保存映射",
       "pathValidation": {
-        "title": "路径验证",
-        "mappedSummary": "{mapped} of {total} source books have a mapped path",
-        "unmatched": "{count} mapped paths not found on disk",
-        "allMatched": "All {count} mapped paths found on disk"
+        "title": "路径验证"
       }
     },
     "dryRun": {
@@ -5673,15 +5304,9 @@
       "title": "解决重复的目标匹配",
       "explanation": "对于每个目标书，选择一个源代码簿来保存。推荐选择将在有一个最强的比赛时预先选择。",
       "remainingGroups": "剩余群组：",
-      "ofCount": "of {total}",
-      "targetBookId": "Target book #{id}",
       "recommended": "推荐的",
       "resolveButton": "{count, plural, =0 {解决# 重复} one {解决# 重复} other {解决# 重复}}",
-      "sourceRecordId": "Source record ID #{id}",
-      "byAuthor": "by {author} (ID: {id})",
-      "byFilePath": "{filePath} (ID: {id})",
-      "bookloreSourceId": "Booklore source ID: {id}",
-      "libraryBookId": "Library book #{id}"
+      "byFilePath": "{filePath} (ID: {id})"
     },
     "preflight": {
       "title": "飞行前检查",
@@ -5713,13 +5338,10 @@
       "refreshStatus": "刷新状态",
       "pollingStopped": "状态投票因错误而停止。",
       "retry": "重试",
-      "stage": "Stage: {stage}",
-      "initializing": "初始化",
-      "ended": "Ended {time}"
+      "initializing": "初始化"
     },
     "report": {
       "noRunYet": "尚未运行迁移。完成上面的步骤以开始。",
-      "runNumber": "Run #{id}",
       "notStarted": "未启动",
       "reloadReport": "重新加载报告",
       "loadFullReport": "加载完整报告",
@@ -5727,7 +5349,6 @@
       "exportCsv": "导出CSV",
       "migrationFailed": "迁移失败",
       "retryFromLastStage": "从上次完成的阶段重试",
-      "booksSection": "Books",
       "metadataOverlays": "已应用元数据叠加层",
       "authorMappings": "已替换作者映射",
       "narratorMappings": "Narrator 映射已替换",
@@ -5746,16 +5367,9 @@
       "collectionEntries": "收藏条目",
       "loadFullReportHint": "单击“负载完整报告”以在导出的报告中包含干燥的比赛摘要。",
       "completedNoIssues": "迁移已完成，没有未解决的书籍或故障。",
-      "matchedBooks": "Matched books ({count})",
       "matchedBooksExplanation": "这些干线比赛被用来决定哪些图书馆书籍收到了导入的数据。",
-      "sourceBook": "Source book {id}",
-      "libraryBook": "Library book {id}",
-      "unresolvedBooks": "Unresolved books ({count})",
       "unresolvedBooksExplanation": "这些书存在于源代码中，但无法与您的书库中的任何书匹配。",
-      "mappedUsers": "Mapped users ({count})",
-      "mappedUsersExplanation": "每个用户的总数来自与迁移计划一起缓存的干动预览。",
-      "coverFailures": "{count} cover import(s) failed. Detailed failure rows are not stored.",
-      "userPreviewCounts": "{statuses} statuses, {progress} progress entries, {sessions} reading sessions, {bookmarks} bookmarks, {annotations} annotations, {collections} collection entries"
+      "mappedUsersExplanation": "每个用户的总数来自与迁移计划一起缓存的干动预览。"
     },
     "unresolvedReason": {
       "noTitleAuthorMatch": "未找到标题或作者匹配的书",
@@ -5797,9 +5411,7 @@
       "loadSuggestionsFailed": "加载用户映射建议失败",
       "sourceFieldsRequired": "主机、 用户、 数据库和源名称是必需的",
       "connectionPassedWithWarnings": "连接测试通过警告",
-      "connectionPassedWithWarningCount": "Connection test passed with {count} warning(s). First: {warning}",
       "connectionPassed": "连接测试通过",
-      "connectionMissingTables": "Connection ok, but {count} required table(s) are missing",
       "cannotTestMediaWhileRunning": "在运行时无法测试媒体路径",
       "mediaPathRequired": "导入封面需要媒体根路径。",
       "mediaPathAbsolute": "使用绝对路径(例如：/books)。",
@@ -5808,7 +5420,6 @@
       "mediaPathValidationFailed": "媒体路径验证失败。",
       "connectionFailedBeforeMedia": "在媒体路径验证完成之前，连接测试失败。",
       "cannotModifySourceWhileRunning": "正在运行时无法修改源",
-      "sourceSavedWithWarnings": "Source saved and validated with {count} warning(s)",
       "sourceSaved": "源保存并验证",
       "saveSourceFailed": "保存或验证源失败",
       "cannotSaveMappingsWhileRunning": "运行时无法保存映射",
@@ -5820,9 +5431,7 @@
       "saveMappingsFailed": "保存映射失败",
       "cannotDryRunWhileRunning": "正在运行时无法运行干运行",
       "saveMappingsFirst": "首先保存映射",
-      "dryRunCompleted": "Dry-run completed: {matched} matched, {unresolved} unresolved",
       "dryRunFailed": "Dry-运行失败",
-      "selectSourceForDuplicates": "Select a source book for all {count} duplicate groups",
       "duplicatesResolved": "重复匹配已解决",
       "resolveDuplicatesFailed": "无法解析重复项",
       "preflightNotReady": "迁移前逃亡尚未准备好",
@@ -5837,7 +5446,6 @@
       "startMigrationFirst": "首先开始迁移",
       "reportRefreshed": "运行报告已刷新",
       "loadReportFailed": "加载运行报告失败",
-      "reportExported": "Report exported as {format}",
       "exportFailed": "导出迁移报告失败"
     }
   },
@@ -5850,7 +5458,6 @@
     "preferences": {
       "title": "通知",
       "subtitle": "选择您想要收到的通知类别。",
-      "saving": "Saving...",
       "unsavedChanges": "未保存的更改",
       "saved": "通知首选项已保存",
       "saveFailed": "保存首选项失败",
@@ -5864,7 +5471,6 @@
         "personal": "个人资料",
         "app": "应用更新"
       },
-      "enabledCount": "{enabled} of {total} enabled",
       "categories": {
         "scanning": {
           "label": "书库扫描",
@@ -5922,14 +5528,12 @@
     },
     "loadingBook": "正在加载书…",
     "failedToLoadBook": "加载书失败",
-    "chapterNumber": "Chapter {number}",
     "peek": {
       "badge": "正在潮流",
       "startReading": "开始阅读"
     },
     "toast": {
-      "linkedHighlightError": "无法打开链接的高亮位置",
-      "resumed": "Resumed at {pct}% - {label}"
+      "linkedHighlightError": "无法打开链接的高亮位置"
     },
     "header": {
       "goBack": "后退",
@@ -5956,72 +5560,25 @@
     "settings": {
       "title": "设置",
       "ariaLabel": "阅读器设置",
-      "reset": "Reset to defaults",
-      "modeLabel": "Color mode",
       "mode": {
         "light": "亮色的",
         "dark": "深色"
       },
-      "textSize": "Text size",
-      "textSizeSmaller": "Smaller text",
-      "textSizeLarger": "Larger text",
-      "pixels": "{value} px",
-      "percent": "{value}%",
-      "pageColor": "Page color",
-      "font": "Font",
       "fontBuiltIn": "内置",
-      "fontServer": "Server fonts",
       "fontYours": "您的字体",
-      "lineSpacing": "Line spacing",
-      "pageWidth": "Page width",
-      "pageWidthNarrow": "Narrow",
-      "pageWidthMedium": "Medium",
-      "pageWidthWide": "Wide",
-      "pageWidthFull": "Full",
       "readingFlow": "读取流程",
-      "flow": {
-        "paginated": "Pages",
-        "scrolled": "Scroll"
-      },
       "pageSpreads": "页面扩展",
       "pageSpreadsHint": "选择这个基于图像的 EPUB 对应页面的方式。",
       "spread": {
         "bookDefault": "预约默认",
         "singlePage": "单页"
       },
-      "advanced": "Advanced layout",
-      "columns": "Columns",
-      "columnsFewer": "Fewer columns",
-      "columnsMore": "More columns",
       "columnGap": "列间距",
       "justifyText": "对齐文本",
-      "hyphenation": "低温化",
-      "themes": {
-        "default": "Default",
-        "gray": "Gray",
-        "sepia": "Sepia",
-        "crimson": "Crimson",
-        "meadow": "Meadow",
-        "rosewood": "Rosewood",
-        "azure": "Azure",
-        "dawnlight": "Dawnlight",
-        "ember": "Ember",
-        "aurora": "Aurora",
-        "ocean": "Ocean",
-        "mist": "Mist",
-        "amoled": "AMOLED"
-      },
-      "fonts": {
-        "bookDefault": "Book default",
-        "serif": "Serif",
-        "sansSerif": "Sans-serif",
-        "monospace": "Monospace"
-      }
+      "hyphenation": "低温化"
     },
     "search": {
-      "placeholder": "Search in book (min {min} chars)...",
       "searching": "正在搜索…",
-      "tooShort": "Type at least {min} characters",
       "noResults": "未找到结果",
       "prompt": "要搜索的类型",
       "resultCount": "{count, plural, =0 {没有结果} one {# 结果} other {# 结果}}"
@@ -6044,11 +5601,8 @@
       "noBookmarksMatch": "没有与您的筛选器匹配的书签",
       "noHighlights": "尚无高亮显示",
       "noHighlightsMatch": "没有高亮匹配您的过滤规则",
-      "searchBookmarks": "Search bookmarks...",
-      "searchHighlights": "Search highlights...",
       "bookmarkFallback": "书签",
       "locationUnavailable": "位置不可用",
-      "customColor": "Custom ({color})",
       "allColors": "所有颜色",
       "allChapters": "所有章节",
       "notesOnly": "仅备注",
@@ -6081,9 +5635,7 @@
     "translation": {
       "original": "原始文件",
       "translation": "翻译",
-      "translating": "Translating...",
       "noTranslation": "尚无翻译",
-      "viaProvider": "via {provider}",
       "copyTranslation": "复制翻译"
     },
     "shortcuts": {
@@ -6111,9 +5663,6 @@
       "scrollModeHint": "对网络玩具和垂直条纹使用“无差距”。",
       "readingDirection": "阅读方向",
       "pageView": "页面视图",
-      "twoPagePagedOnly": "Two pages are shown only in paged mode.",
-      "spreadSection": "Two-page spread",
-      "spreadFallbackHint": "This screen is too narrow for two pages, so single pages are shown.",
       "spreadAlignmentLabel": "扩展对齐",
       "spreadGap": "2. 扩大差距",
       "spreadGapValue": "{value}px",
@@ -6156,7 +5705,6 @@
     },
     "audiobook": {
       "untitled": "无标题",
-      "loading": "Loading audiobook...",
       "loadError": "加载音频簿失败",
       "noAudioFiles": "未找到该书的音频文件。",
       "speed": "速度",
@@ -6165,13 +5713,11 @@
       "volume": "音量",
       "muted": "静音",
       "sleep": "睡眠",
-      "chapterAbbrev": "Ch.",
       "sleepTimer": "睡眠计时器",
       "minutes": "{count, plural, one {# 分钟} other {# 分钟}}",
       "endOfChapter": "章节结尾",
       "noChaptersAvailable": "没有可用的章节",
       "extend15": "+ 15 分钟",
-      "timeLeft": "({time} left)",
       "playbackSpeed": "播放速度",
       "noChapters": "没有可用的章节。",
       "noBookmarks": "尚无书签。",
@@ -6182,17 +5728,9 @@
     }
   },
   "scanner": {
-    "filesProgress": "{processed}/{total} files",
     "booksFound": "{count, plural, =0 {没有找到书籍} one {# 找到书} other {# 找到书}}"
   },
   "series": {
-    "completion": {
-      "readOfTotal": "{read} of {total} read ({percentage}%)"
-    },
-    "ownership": {
-      "label": "In library",
-      "ownedOfExpected": "{owned} of {expected} in library"
-    },
     "gaps": {
       "label": "可能存在的差距："
     },
@@ -6228,31 +5766,20 @@
     },
     "detail": {
       "pageTitle": "系列",
-      "pageTitleNamed": "Series · {name}",
-      "pageTitleWithId": "Series #{id}",
       "entityName": "系列",
       "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}",
-      "byAuthors": "by {authors}",
-      "moreAuthors": "+{count} more",
-      "preparingEditor": "Preparing editor...",
       "editMetadata": "编辑元数据",
       "firstInSeries": "第一次在系列",
       "untitled": "无标题",
-      "loadingFirstBook": "Loading first book preview...",
       "showLess": "显示更少的",
       "showMore": "显示更多",
-      "moreGenres": "+{count} more",
       "synopsis": "简述",
       "noDescription": "无可用描述。",
-      "updatingPreview": "Updating preview...",
       "noBooksToPreview": "没有可以预览的书籍。",
-      "loadingSeries": "Loading series...",
-      "booksHeading": "Books",
       "allLibraries": "所有库",
       "groupByMedia": "按媒体分组",
       "noBooksFound": "此系列中未找到任何书",
       "trySelectingLibrary": "尝试选择另一个库。",
-      "allBooksLoaded": "All {count} books loaded",
       "leadBookLoadError": "加载领先书详细信息失败",
       "noBooksToEdit": "该系列没有要编辑的书籍。",
       "loadFullSeriesError": "加载完整系列编辑失败。",
@@ -6276,12 +5803,9 @@
       "name": "名称",
       "namePlaceholder": "例如：未读 Sci-Fi",
       "icon": "图标",
-      "iconPlaceholder": "Choose an icon...",
       "nameRequired": "名称是必填项",
       "iconRequired": "选择一个图标",
-      "create": "创建",
-      "creating": "Creating...",
-      "saving": "Saving..."
+      "create": "创建"
     },
     "createDialog": {
       "title": "新建智能瞄准镜",
@@ -6295,7 +5819,6 @@
     "editorPanel": {
       "untitled": "无标题的 SmartScope",
       "subtitle": "配置智能范围设置",
-      "counting": "counting...",
       "bookCount": "{count, plural, =0 {没有书籍} one {一张书} other {# 书}}",
       "identity": "身份",
       "filters": "筛选器",
@@ -6320,8 +5843,7 @@
       "user": "我的阅读"
     },
     "filter": {
-      "allLibraries": "所有库",
-      "librarySelection": "{count} of {total} Libraries"
+      "allLibraries": "所有库"
     },
     "config": {
       "button": "配置",
@@ -6330,7 +5852,6 @@
       "reset": "重置为默认值"
     },
     "summary": {
-      "books": "Books",
       "authors": "作者",
       "series": "系列",
       "publishers": "发布者",
@@ -6420,56 +5941,44 @@
         "title": "前 50 个系列"
       },
       "booksCompleted": {
-        "title": "已完成的书",
-        "notEnoughData": "Need at least {count} completed books for this chart."
+        "title": "已完成的书"
       },
       "completionLatency": {
-        "title": "完成延迟",
-        "notEnoughData": "Need at least {count} completed books for this chart."
+        "title": "完成延迟"
       },
       "completionTimeline": {
-        "title": "完成时间表",
-        "notEnoughData": "Need at least {count} completed books for this chart."
+        "title": "完成时间表"
       },
       "favoriteReadingDays": {
-        "title": "最喜欢的阅读日",
-        "notEnoughData": "Need at least {count} reading events for this chart."
+        "title": "最喜欢的阅读日"
       },
       "genreReadingTime": {
-        "title": "流派阅读时间",
-        "notEnoughData": "Need at least {count} genres with reading time for this chart."
+        "title": "流派阅读时间"
       },
       "goalTrajectory": {
         "title": "比赛目标与目标",
         "noCompletedTitle": "还没有完成的书",
-        "noCompletedDescription": "在此期间完成一本书，以比较您的速度和年度目标。",
-        "notEnoughData": "Need at least {count} completed books for this chart."
+        "noCompletedDescription": "在此期间完成一本书，以比较您的速度和年度目标。"
       },
       "peakReadingHours": {
-        "title": "最高阅读时间",
-        "notEnoughData": "Need at least {count} reading events for this chart."
+        "title": "最高阅读时间"
       },
       "progressFunnel": {
         "title": "进步通道线",
         "modePercent": "百分比",
         "modeCounts": "计数",
         "modeDropoff": "下拉列表",
-        "started": "Started {count}",
-        "notEnoughData": "Need at least {count} started books for this chart.",
         "noDropOffTitle": "没有观察到掉期事件",
         "noDropOffDescription": "在这段时间里，每一本已开始的书都在经过所有的通道阶段。"
       },
       "readingClock": {
-        "title": "读取时钟",
-        "notEnoughData": "Need at least {count} reading sessions for this chart."
+        "title": "读取时钟"
       },
       "readingHeatmap": {
-        "title": "读取热图",
-        "notEnoughData": "Need activity on at least {count} days for this chart."
+        "title": "读取热图"
       },
       "readingPace": {
-        "title": "阅读路径",
-        "notEnoughData": "Need at least {count} sessions with progress data for this chart."
+        "title": "阅读路径"
       },
       "readingSessionTimeline": {
         "title": "阅读会话时间表",
@@ -6477,11 +5986,9 @@
         "dragOff": "拖动：关闭",
         "prev": "上一个",
         "next": "下一个",
-        "week": "Week {week}",
         "dragHint": "拖动条移动会话。持续时间被锁定，重叠会话被拒绝。",
         "noSessionsTitle": "本周没有会话",
         "noSessionsDescription": "使用 Prev/Next 或 weeks 选择器查看不同的一个星期。",
-        "overlapError": "Session overlaps another session in this window",
         "moveError": "无法移动会话"
       },
       "sessionArchetypes": {
@@ -6513,7 +6020,6 @@
       "previewToolbar": "重命名预览",
       "renameSettings": "重命名设置",
       "library": "书库",
-      "selectLibraryPlaceholder": "Select a library...",
       "noEligibleLibraries": "没有启用文件重命名的库。请在书库设置中启用它。",
       "refresh": "刷新",
       "applyRename": "应用重命名",
@@ -6542,8 +6048,6 @@
       },
       "summary": {
         "label": "Summary",
-        "toRename": "{count} to rename",
-        "unchanged": "{count} unchanged",
         "collisions": "{count, plural, =0 {# 碰撞} one {# 碰撞} other {# 碰撞}}",
         "errors": "{count, plural, =0 {# 错误} one {# 错误} other {# 错误}}"
       },
@@ -6553,11 +6057,7 @@
         "chooseLibrary": "选择书库"
       },
       "completed": {
-        "title": "批量重命名完成",
-        "stats": "{succeeded} renamed, {failed} failed, {skipped} skipped ({processed} total)"
-      },
-      "pagination": {
-        "showing": "Showing {from}-{to} of {total}"
+        "title": "批量重命名完成"
       },
       "confirmDialog": {
         "title": "确认批量重命名",
@@ -6589,23 +6089,17 @@
         "exact_metadata": "确切的标题和作者",
         "fuzzy_metadata": "相似的头衔和作者"
       },
-      "similarityValue": "{percent}% title similarity",
       "notDuplicates": "不重复",
       "keepThis": "保留这本书",
       "discardThis": "丢弃这本书",
-      "selectKeeperFirst": "Select a keeper first",
       "noDirectMatch": "没有与管理员的直接匹配",
-      "moreFiles": "+{count} more",
       "showDetails": "显示详细信息",
       "hideDetails": "隐藏详细信息",
-      "deleteSelected": "Delete {count} selected",
-      "openBook": "Open details for {title}",
       "unknownAuthor": "未知作者",
       "unknown": "未知的",
       "none": "无",
       "accessDenied": "您没有权限使用重复的书籍工具。",
       "pairDetails": "比赛详情",
-      "pairLabel": "{first} and {second}",
       "fields": {
         "library": "书库",
         "isbn": "ISBN",
@@ -6629,7 +6123,6 @@
       },
       "deleteDialog": {
         "title": "永久删除重复的书？",
-        "description": "{count, plural, =0 {This will permanently delete # selected book and its files.} one {This will permanently delete # selected book and its files.} other {This will permanently delete # selected books and their files.}}",
         "warning": "元数据、采集、阅读数据和设备状态不会传输到保存的书。其他用户的相关数据也会被删除。",
         "confirm": "{count, plural, =0 {删除# 书} one {删除# 书} other {删除# 书}}",
         "success": "{count, plural, =0 {没有已删除的书} one {删除了一个重复的书} other {# 已删除的重复书}}"
@@ -6638,36 +6131,28 @@
         "start": "无法启动重复扫描。",
         "status": "无法加载扫描进度。",
         "scan": "重复扫描失败。请尝试重新运行。",
-        "results": "无法加载重复的组。",
-        "delete": "Could not delete the selected duplicate books."
+        "results": "无法加载重复的组。"
       },
       "pagination": {
-        "label": "复制组页面",
-        "page": "Page {page} of {total}"
+        "label": "复制组页面"
       }
     },
     "entityManager": {
       "unknown": "未知的",
       "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}",
-      "sortPrefix": "· sort: {sortName}",
       "selectTargetToKeep": "选择要保留的目标",
       "writeToFiles": "写入文件",
       "writeChangesToFiles": "将更改写入文件",
-      "mergeIntoTarget": "Merge {count} into target",
       "modes": {
         "browse": "浏览与管理",
         "duplicates": "查找重复项"
       },
       "actions": {
-        "rename": "Rename",
         "split": "拆分"
       },
       "duplicates": {
         "similarity": "相似度：",
         "scan": "扫描",
-        "scanning": "Scanning...",
-        "computing": "Computing candidates...",
-        "computedAt": "Candidates computed {date}",
         "recompute": "重新计算",
         "noneComputed": "尚未计算任何候选人。",
         "computeNow": "立即计算",
@@ -6677,13 +6162,11 @@
         "noneFoundDescription": "在当前设置中没有检测到潜在的重复。",
         "clustersFound": "{count, plural, =0 {没有找到集群} one {# 集群找到} other {# 集群找到}}",
         "plusOthers": "{count, plural, =0 {+ # 其它} one {+ # 其它} other {+ # 其它}}",
-        "percentSimilar": "{percent}% similar",
         "pairDetails": "配对详情",
         "dismissEntityTitle": "关闭此实体的所有对数",
         "dismissPairTitle": "取消这个配对"
       },
       "dismissed": {
-        "loading": "Loading dismissed pairs...",
         "empty": "没有被删除的对",
         "restore": "恢复",
         "restoreTitle": "还原此配对",
@@ -6691,14 +6174,9 @@
         "showPairs": "显示已删除对数"
       },
       "browse": {
-        "searchPlaceholder": "Search...",
         "emptyOnly": "仅为空",
         "clear": "清空",
         "noEntities": "未找到实体",
-        "mergeCount": "Merge ({count})",
-        "deleteCount": "Delete ({count})",
-        "totalCount": "{count} total",
-        "sortLabel": "sort: {sortName}",
         "sort": {
           "nameAsc": "名称 A-Z",
           "nameDesc": "名称 Z-A",
@@ -6721,20 +6199,15 @@
         "newName": "新名称"
       },
       "deleteModal": {
-        "title": "删除实体",
-        "confirm": "Are you sure you want to delete {name}?"
+        "title": "删除实体"
       },
       "splitModal": {
         "title": "分割实体",
         "splitting": "拆分",
-        "newNames": "New names (min 2)",
-        "namePlaceholder": "Enter name...",
         "addAnother": "添加另一个"
       },
       "bulkDeleteModal": {
-        "title": "批量删除",
-        "confirm": "{count, plural, =0 {Are you sure you want to delete # selected entity?} one {Are you sure you want to delete # selected entity?} other {Are you sure you want to delete # selected entities?}}",
-        "deleteButton": "Delete {count}"
+        "title": "批量删除"
       },
       "mergeModal": {
         "title": "合并实体",
@@ -6764,9 +6237,7 @@
       "expanded": "扩展",
       "exportMetadata": "导出元数据",
       "showControlsAria": "显示库控制",
-      "export": "导出",
-      "searchPlaceholder": "Search title, author, series, narrator...",
-      "allBooksLoaded": "All {count} books loaded"
+      "export": "导出"
     },
     "notFound": {
       "title": "找不到页面",
@@ -6785,28 +6256,15 @@
       }
     },
     "bookDetail": {
-      "title": "书",
-      "titleWithId": "Book #{id}",
-      "pageTitle": {
-        "book": "Book · {base}",
-        "editMetadata": "Edit Metadata · {base}",
-        "edit": "Edit · {base}",
-        "files": "Files · {base}",
-        "readingLog": "Reading Log · {base}",
-        "highlights": "Highlights · {base}"
-      }
+      "title": "书"
     },
     "bookDock": {
       "title": "预约停靠栏",
       "newFilesDetected": "检测到新文件",
       "reconnecting": "重新连接",
       "rescanFailed": "重新扫描失败",
-      "totalInDock": "{size} in Book Dock",
       "dropFiles": "将文件拖放到书架上",
-      "supportedFormats": "Supported: {formats}",
       "empty": {
-        "noSearchMatch": "No files match \"{query}\"",
-        "noStatusFiles": "No {status} files",
         "uploadPrompt": "上传文件或将其拖放到书签文件夹"
       },
       "retry": {
@@ -6817,14 +6275,11 @@
         "applied": "{count, plural, =0 {应用到没有文件} one {应用到一个文件} other {应用到# 文件}}",
         "skippedEdited": "{count, plural, =0 {因为他们手动编辑了一个文件} one {跳过了一个文件，因为它已经手动编辑了} other {跳过 # 文件，因为它们已经手动编辑了}}",
         "skippedNoMetadata": "{count, plural, =0 {因为没有获取元数据而跳过一个文件} one {跳过了一个文件，因为它没有获取元数据} other {跳过了# 文件，因为它们没有获取元数据}}",
-        "noneApplied": "No files applied; {reasons}",
         "noneSelected": "未选择文件"
       }
     },
     "collection": {
       "title": "收藏",
-      "pageTitle": "Collection · {name}",
-      "pageTitleWithId": "Collection #{id}",
       "editCollection": "编辑收藏",
       "showControlsAria": "显示收藏控制",
       "loadError": "无法加载此收藏",
@@ -6841,8 +6296,6 @@
     },
     "library": {
       "title": "书库",
-      "pageTitle": "Library · {name}",
-      "pageTitleWithId": "Library #{id}",
       "filterRules": "过滤规则",
       "saveAsSmartScope": "另存为 Smart Scope",
       "saveScope": "保存范围",
@@ -6856,20 +6309,14 @@
         "noFilterMatch": "没有符合筛选条件的书",
         "noFilterMatchHint": "尝试调整或清理筛选器以查看更多书籍。",
         "clearFilters": "清除过滤器",
-        "scanning": "Scanning your library...",
         "scanningHint": "一旦发现书，这些书就会在这里出现。",
         "emptyLibrary": "您的库为空",
         "emptyLibraryHint": "一旦您将书籍添加到这个库，它们就会出现在这里。"
-      },
-      "querySelection": {
-        "loadedSelected": "{selected} of {total} loaded books selected.",
-        "selectAllMatching": "Select all {total} matching books"
       }
     },
     "smartScope": {
       "title": "智能范围",
       "pageTitle": "SmartScope · {name}",
-      "pageTitleWithId": "SmartScope #{id}",
       "defaultName": "智能范围",
       "filter": "筛选器",
       "edit": "编辑智能瞄准镜",
@@ -6883,13 +6330,6 @@
       "showFilter": "显示过滤器",
       "confirmDelete": "确认？",
       "loadError": "无法加载此 SmartScope",
-      "toast": {
-        "deleted": "\"{name}\" deleted",
-        "deleteFailed": "Failed to delete \"{name}\"",
-        "koboSyncEnabled": "\"{name}\" now syncs to your Kobo",
-        "koboSyncDisabled": "\"{name}\" no longer syncs to your Kobo",
-        "koboSyncFailed": "Failed to update Kobo sync for \"{name}\""
-      },
       "empty": {
         "noRules": "未配置规则",
         "noRulesHint": "打开编辑器，使用过滤规则和排序规则来定义在这个智能范围中出现的书籍。",
@@ -6903,7 +6343,6 @@
   "whatsNew": {
     "title": "新功能",
     "subtitle": "所有最新发货。",
-    "versionPrefix": "Version {version}",
     "newUpdates": "{count, plural, =0 {没有新的更新} one {一个新的更新} other {# 新的更新}}",
     "remindLater": "稍后提醒我",
     "gotIt": "明白了",
@@ -6913,7 +6352,6 @@
     "versions": "版本",
     "currentVersion": "当前版本",
     "youreHere": "你在这里",
-    "searchPlaceholder": "Search releases…",
     "noReleasesFound": "未找到释放。",
     "noHighlights": "此发布没有高亮显示。",
     "showChangelog": "显示完整更新日志",
@@ -6939,7 +6377,7 @@
     "bookDock": "预约停靠栏",
     "whatsNew": "新功能",
     "annotations": "说明",
-    "achievements": "1. 成就",
+    "achievements": "成就",
     "statistics": "统计",
     "authors": "作者",
     "series": "系列",
@@ -6996,9 +6434,8 @@
     "admin": {
       "users": "用户",
       "account-activity": "帐户活动",
-      "magic-links": "魔法链接",
-      "oidc": "OIDC / SSO",
-      "server-fonts": "Server Fonts"
+      "magic-links": "免登录链接",
+      "oidc": "OIDC / SSO"
     },
     "system": {
       "file-naming": "文件名称",


### PR DESCRIPTION
Automated sparse translation export from Crowdin.

Untranslated entries are omitted so Vue I18n falls back to the English catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved translations across Czech, Danish, German, Spanish, Finnish, French, Italian, Dutch, Polish, Portuguese, Russian, Slovenian, Swedish, Ukrainian, and Chinese interfaces.
  * Added localized text for reader settings, administration, book movement, dashboard layouts, filtering, metadata, migration, and font management.
  * Replaced remaining English text in Chinese and Slovenian screens.
  * Removed obsolete, duplicate, and unsupported labels to keep translated interfaces consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->