### PR TITLE
fix(client): normalise validate-styles paths so the allowlist matches on Windows

### DIFF
--- a/client/scripts/validate-styles.mjs
+++ b/client/scripts/validate-styles.mjs
@@ -58,7 +58,8 @@ const errors = []
 const unusedAllowances = new Set(ALLOWED.keys())
 
 for (const file of await sourceFiles(sourceDirectory)) {
-  const relativePath = path.relative(sourceDirectory, file)
+  // normalise separators so the ALLOWED keys (POSIX-style) also match on Windows
+  const relativePath = path.relative(sourceDirectory, file).split(path.sep).join('/')
   const source = await readFile(file, 'utf8')
   const lines = source.split('\n')
 


### PR DESCRIPTION
## What does this PR do?

Closes #824

`validate-styles.mjs` compares `path.relative()` output against POSIX-style keys in the `ALLOWED` map. On Windows, `path.relative()` returns paths with backslashes, so the lookup never matches: the allowlisted `views/NotFoundView.vue` gets reported as a violation, and its own allowlist entry gets simultaneously reported as unused (since the lookup key never matched to consume it).

That makes `validate:styles` (part of `lint:check`) fail on a clean checkout on Windows, which in turn fails `verify:fast` and the husky pre-push hook.

The fix normalises the separators after `path.relative()` so the comparison key is always POSIX-style, matching how `ALLOWED` is authored.

## How did you test this?

Reproduced the failure on a clean Windows checkout of `main` first:

```
Error: Style validation failed:
views\NotFoundView.vue:17: text-foreground/10 - fade-free text only. ...
views/NotFoundView.vue: listed in the validate-styles allowlist but no longer has faded text. Remove the entry.
```

With the fix applied, `node client/scripts/validate-styles.mjs` exits 0 and prints `Validated text colour tokens: no alpha-faded text`. This is a two-line change to a single script with no test suite of its own, so I verified by toggling the fix on/off against the same checkout rather than a unit test.

## Screenshots

Nothing visual in this one.

## Anything non-obvious in the diff?

None - single-line normalisation, no behavior change on POSIX where `path.sep` is already `/`.

## Checklist

- [x] I've read through my own diff
- [x] Lint and tests pass locally
- [x] No unintended files included (build artifacts, `.env`, personal configs)
- [x] Discussed in an issue and has maintainer approval (for new features). This is a bug fix, and #824 is filed and linked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved style validation consistency across operating systems by standardizing path formats before allowlist checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->