### PR TITLE
Fix: Recompute fileHash when scanner detects modified file

### DIFF
--- a/server/src/modules/scanner/scanner.repository.ts
+++ b/server/src/modules/scanner/scanner.repository.ts
@@ -7,6 +7,7 @@ import * as schema from '../../db/schema';
 import {
   authors,
   bookAuthors,
+  bookFileHashHistory,
   bookFiles,
   bookGenres,
   bookMetadata,
@@ -235,6 +236,10 @@ export class ScannerRepository {
       .where(eq(bookFiles.id, id))
       .returning();
     return file;
+  }
+
+  async recordFileHashHistory(bookFileId: number, fileHash: string, reason: 'rescan' | 'external_change' | 'file_write') {
+    await this.db.insert(bookFileHashHistory).values({ bookFileId, fileHash, reason }).onConflictDoNothing();
   }
 
   async findBookFileByAbsolutePath(absolutePath: string, libraryId?: number) {

--- a/server/src/modules/scanner/scanner.service.test.ts
+++ b/server/src/modules/scanner/scanner.service.test.ts
@@ -121,6 +121,7 @@ function makeRepo(overrides: Record<string, unknown> = {}) {
     upsertDirScanState: vi.fn().mockResolvedValue(undefined),
     deleteStaleDirScanState: vi.fn().mockResolvedValue(undefined),
     clearDirScanState: vi.fn().mockResolvedValue(undefined),
+    recordFileHashHistory: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/server/src/modules/scanner/scanner.service.ts
+++ b/server/src/modules/scanner/scanner.service.ts
@@ -2053,12 +2053,21 @@ export class ScannerService implements OnApplicationBootstrap {
     await waitForStability(fileStat.absolutePath, fileStat.mtime.getTime());
 
     if (!sizeUnchanged || !mtimeUnchanged || !inoUnchanged || reassigned) {
+      let fileHash = byPath.fileHash;
+      if (!sizeUnchanged || !mtimeUnchanged) {
+        fileHash = await computeFileHash(fileStat.absolutePath);
+        if (fileHash !== byPath.fileHash && byPath.fileHash) {
+          await this.scannerRepo.recordFileHashHistory(byPath.id, byPath.fileHash, 'rescan');
+        }
+      }
+
       await this.scannerRepo.updateBookFile(byPath.id, {
         ...(reassigned && { bookId }),
         libraryFolderId,
         ino: fileStat.ino,
         sizeBytes: fileStat.sizeBytes,
         mtime: fileStat.mtime,
+        fileHash,
         format,
         role,
         sortOrder,
@@ -2112,6 +2121,17 @@ export class ScannerService implements OnApplicationBootstrap {
     if (await this.pathExists(oldAbsolutePath)) return null;
     const sizeUnchanged = fileStat.sizeBytes === byIno.sizeBytes;
     const mtimeUnchanged = fileStat.mtime.getTime() === byIno.mtime?.getTime();
+    
+    const oldPathEntry = fileByPath.get(oldAbsolutePath);
+    let fileHash = oldPathEntry?.fileHash ?? null;
+    
+    if (!sizeUnchanged || !mtimeUnchanged) {
+      fileHash = await computeFileHash(fileStat.absolutePath);
+      if (oldPathEntry?.fileHash && fileHash !== oldPathEntry.fileHash) {
+        await this.scannerRepo.recordFileHashHistory(byIno.id, oldPathEntry.fileHash, 'rescan');
+      }
+    }
+
     await this.scannerRepo.updateBookFile(byIno.id, {
       bookId,
       libraryFolderId,
@@ -2119,12 +2139,12 @@ export class ScannerService implements OnApplicationBootstrap {
       relPath: fileStat.relPath,
       sizeBytes: fileStat.sizeBytes,
       mtime: fileStat.mtime,
+      fileHash,
       format,
       role,
       sortOrder,
     });
     counts.updatedCount++;
-    const oldPathEntry = fileByPath.get(oldAbsolutePath);
     if (oldPathEntry?.id === byIno.id) {
       fileByPath.delete(oldAbsolutePath);
     }
@@ -2134,7 +2154,7 @@ export class ScannerService implements OnApplicationBootstrap {
       ino: fileStat.ino,
       sizeBytes: fileStat.sizeBytes,
       mtime: fileStat.mtime,
-      fileHash: oldPathEntry?.fileHash ?? null,
+      fileHash,
       sortOrder,
     });
     fileByIno.set(fileStat.ino, { id: byIno.id, bookId, absolutePath: fileStat.absolutePath, sizeBytes: fileStat.sizeBytes, mtime: fileStat.mtime });
@@ -2173,6 +2193,15 @@ export class ScannerService implements OnApplicationBootstrap {
     const oldAbsolutePath = globalByIno.file.absolutePath;
     const sizeUnchanged = fileStat.sizeBytes === globalByIno.file.sizeBytes;
     const mtimeUnchanged = fileStat.mtime.getTime() === globalByIno.file.mtime?.getTime();
+    
+    let fileHash = globalByIno.file.fileHash;
+    if (!sizeUnchanged || !mtimeUnchanged) {
+      fileHash = await computeFileHash(fileStat.absolutePath);
+      if (globalByIno.file.fileHash && fileHash !== globalByIno.file.fileHash) {
+        await this.scannerRepo.recordFileHashHistory(globalByIno.file.id, globalByIno.file.fileHash, 'rescan');
+      }
+    }
+
     await this.scannerRepo.updateBookFile(globalByIno.file.id, {
       bookId,
       libraryFolderId,
@@ -2181,6 +2210,7 @@ export class ScannerService implements OnApplicationBootstrap {
       ino: fileStat.ino,
       sizeBytes: fileStat.sizeBytes,
       mtime: fileStat.mtime,
+      fileHash,
       format,
       role,
       sortOrder,
@@ -2200,7 +2230,7 @@ export class ScannerService implements OnApplicationBootstrap {
       ino: fileStat.ino,
       sizeBytes: fileStat.sizeBytes,
       mtime: fileStat.mtime,
-      fileHash: globalByIno.file.fileHash,
+      fileHash,
       sortOrder,
     });
     fileByIno.set(fileStat.ino, {


### PR DESCRIPTION
### Fix KOReader sync bug caused by outdated file hashes during rescans

**Description:**
This PR fixes a bug where KOReader devices fail to sync books with BookOrbit (throwing a "This book is not in your BookOrbit library" error) after a book file is modified externally (e.g. embedding new metadata or covers in Calibre) and rescanned.

**Root Cause:**
When a file's `sizeBytes` or `mtime` changed, BookOrbit's scanner service properly detected the change and updated the `sizeBytes` and `mtime` fields in the database. However, it skipped recalculating and updating the `fileHash`. 

This created a desync:
1. BookOrbit's database retained the **old** file hash.
2. A newly downloaded version of the book on a KOReader device would compute the **new** file hash locally via its `partialMD5` logic.
3. When KOReader attempted to sync using the new hash, the server rejected it as an unmatched book.

**Changes:**
* Updated `resolveExistingFilePath`, `resolveByLocalIno`, and `resolveByGlobalIno` in `scanner.service.ts` to properly explicitly compute and save the new `fileHash` if a file's size or mtime has changed.
* Added `recordFileHashHistory` to `scanner.repository.ts` and invoked it in the scanner to store the old hash into `bookFileHashHistory` before overwriting it. This guarantees that devices with the older, unmodified copy of the book downloaded can still sync flawlessly with the server.

**Testing:**
* Verified that modified files correctly receive updated hashes in the database.
* Confirmed that `bookFileHashHistory` securely retains the previous hashes using the `rescan` reason code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file rescanning when files change size or modification time.
  * Updated file records consistently across path and inode-based file moves.
  * Preserved file-change history to improve tracking of rescans, external changes, and file updates.
  * Refreshed file lookup information after inode-based moves for more reliable subsequent scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->