### PR TITLE
i18n(client): sync translations from Crowdin

### DIFF
--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -254,6 +254,22 @@
           "label": "Mostrar lomo en cómics",
           "hint": "Aplicar el efecto de lomo y brillo a las portadas de cómics (cbz, cbr, cb7)"
         },
+        "detailCoverTint": {
+          "title": "Color de la portada en la ficha del libro",
+          "hint": "Difumina el color extraído de la portada detrás de la imagen y del título en la página de detalles del libro.",
+          "off": {
+            "label": "Desactivado",
+            "hint": "Fondo liso de la tarjeta"
+          },
+          "single": {
+            "label": "Un color",
+            "hint": "Solo el color predominante de la portada."
+          },
+          "duotone": {
+            "label": "Dos colores",
+            "hint": "Añade el color de acento de la portada cuando tiene uno bien definido."
+          }
+        },
         "shadow": {
           "title": "Intensidad de la sombra de portada",
           "hint": "Controla la profundidad bajo las portadas en las miniaturas de cuadrícula, lista, tabla y panel",
@@ -2026,6 +2042,8 @@
         "daysAgo": "Hace {count}d",
         "unknown": "Desconocido",
         "updateAvailable": "Actualización disponible",
+        "manualUpdateRequired": "Actualización manual necesaria",
+        "manualUpdateExplanation": "Esta versión de plugin no puede instalar sus propias actualizaciones. Descarga el plugin y copia bookorbit.koplugin a koreader/plugins/ en este dispositivo.",
         "upToDate": "actualizado",
         "versionUnknown": "Versión desconocida",
         "latestPlugin": "Complemento más reciente: v{version}",
@@ -2094,6 +2112,7 @@
         "stockStep1Prefix": "En su dispositivo KOReader, vaya a",
         "stockStep1Suffix": ".",
         "stockStep2": "Configure el servidor de sincronización personalizado en el URL que se muestra arriba.",
+        "stockStep2InlineUrl": "Configure el servidor de sincronización personalizado en la siguiente URL:",
         "stockStep3": "Ingrese el nombre de usuario y la contraseña que creó, luego toque Iniciar sesión.",
         "locationNote": "BookOrbit guarda ubicaciones EPUB compatibles con KOReader del lector web. La restauración debe aterrizar cerca de la misma posición, aunque la ubicación exacta de la línea puede variar según el lector y el diseño de EPUB.",
         "dangerZone": "Zona de peligro",
@@ -3678,6 +3697,8 @@
         "fileSize": "Tamaño de archivo",
         "library": "Biblioteca",
         "added": "Añadido",
+        "cancelDateAddedEdit": "Cancelar fecha de edición añadida",
+        "editDateAdded": "Editar fecha añadida",
         "dateStarted": "Fecha de inicio",
         "saving": "Guardando...",
         "cancelDateStartedEdit": "Cancelar fecha de inicio editar",
@@ -3689,9 +3710,12 @@
         "synopsis": "Sinopsis",
         "noDescription": "No hay descripción disponible.",
         "dateStartedFutureError": "La fecha de inicio no puede ser futura.",
+        "dateAddedRequiredError": "Se requiere la fecha añadida.",
+        "dateAddedFutureError": "La fecha añadida no puede ser futura.",
         "dateFinishedFutureError": "La fecha de finalización no puede ser futura.",
         "dateFinishedBeforeStartedError": "La fecha de finalización debe ser igual o posterior a la fecha de inicio.",
         "saveReadingDatesError": "No se pudieron guardar las fechas de lectura.",
+        "saveAddedDateError": "Error al guardar la fecha añadida.",
         "koboPendingDelete": "Pendiente de eliminar del dispositivo",
         "koboPendingDeleteTooltip": "Kobo lo eliminará en la próxima sincronización.",
         "koboRemovedByDevice": "Eliminado por dispositivo",
@@ -4734,6 +4758,10 @@
       "untitled": "Sin título",
       "cover": "Portada",
       "bookCover": "portada del libro"
+    },
+    "libraryLoad": {
+      "errorTitle": "No se pueden cargar tus bibliotecas",
+      "errorDescription": "BookOrbit no ha podido recuperar tus bibliotecas. Los datos de tu biblioteca no se han eliminado."
     },
     "scroller": {
       "failedToLoad": "No se pudo cargar.",
@@ -6111,6 +6139,9 @@
       "scrollModeHint": "Utilice \"Sin espacios\" para webtoons y tiras verticales.",
       "readingDirection": "dirección de lectura",
       "pageView": "Vista de página",
+      "twoPagePagedOnly": "Dos páginas se muestran sólo en modo paginado.",
+      "spreadSection": "Distribución de dos páginas",
+      "spreadFallbackHint": "Esta pantalla es demasiado estrecha para dos páginas, por lo que se muestran páginas individuales.",
       "spreadAlignmentLabel": "Alineación extendida",
       "spreadGap": "Brecha de propagación",
       "spreadGapValue": "{value}px",
@@ -6118,6 +6149,9 @@
       "widePages": "Páginas anchas",
       "firstPage": "Primera página",
       "lastPage": "Última página",
+      "zoomControls": "Controles de zoom",
+      "zoomOut": "Alejar",
+      "zoomIn": "Acercar",
       "fit": {
         "page": "Ajuste de página",
         "width": "Ancho de página",

--- a/client/src/locales/sl.json
+++ b/client/src/locales/sl.json
@@ -254,6 +254,22 @@
           "label": "Prikaži hrbet na stripih",
           "hint": "Uporabi učinek hrbta in sijaja na naslovnicah stripov (cbz, cbr, cb7)"
         },
+        "detailCoverTint": {
+          "title": "Barva platnice podrobnosti knjige",
+          "hint": "Barva bledenja, vzorčena z naslovnice za umetniškim delom in naslovom na strani s podrobnostmi o knjigi",
+          "off": {
+            "label": "Izklopljeno",
+            "hint": "Ozadje navadne kartice"
+          },
+          "single": {
+            "label": "Ena barva",
+            "hint": "Samo prevladujoča barva naslovnice"
+          },
+          "duotone": {
+            "label": "Dve barvi",
+            "hint": "Doda poudarjeno barvo naslovnice, če ima izrazito barvo"
+          }
+        },
         "shadow": {
           "title": "Jakost sence naslovnice",
           "hint": "Nadzoruje globino pod naslovnicami v mreži, seznamu, tabeli in sličicah nadzorne plošče",
@@ -587,7 +603,7 @@
       "noSharedAccountsHint": "Za ustvarjanje čarobnih povezav najprej ustvarite skupni račun na {usersPage}.",
       "activeLinks": "Aktivne povezave",
       "inactiveLinks": "Neaktivne povezave",
-      "paused": "Ustavljeno",
+      "paused": "Zaustavljeno",
       "deletedUser": "Izbrisan uporabnik",
       "expiredPrefix": "Poteklo ",
       "never": "Ni zabeležene dejavnosti",
@@ -599,7 +615,7 @@
       "usesCount": "{count, plural, =0 {brez uporab} one {ena uporaba} two {# uporab} few {# uporab} other {# uporab}}",
       "copied": "Kopirano!",
       "copyLink": "Kopiraj povezavo",
-      "pause": "Ustavi",
+      "pause": "Premor",
       "resume": "Nadaljuj",
       "revoke": "Prekliči",
       "revoking": "Preklicevanje ...",
@@ -2026,6 +2042,8 @@
         "daysAgo": "pred {count} dnevi",
         "unknown": "Neznano",
         "updateAvailable": "Na voljo je posodobitev",
+        "manualUpdateRequired": "Potrebna je ročna posodobitev",
+        "manualUpdateExplanation": "Ta različica vtičnika ne more namestiti lastnih posodobitev. Prenesite vtičnik in kopirajte datoteko bookorbit.koplugin v datoteko koreader/plugins/ v tej napravi.",
         "upToDate": "Posodobljeno",
         "versionUnknown": "Različica neznana",
         "latestPlugin": "Najnovejši vtičnik: v{version}",
@@ -2094,6 +2112,7 @@
         "stockStep1Prefix": "Na vaši napravi KOReader pojdite na",
         "stockStep1Suffix": ".",
         "stockStep2": "Nastavite strežnik za sinhronizacijo po meri na zgoraj prikazani URL.",
+        "stockStep2InlineUrl": "Nastavite strežnik za sinhronizacijo po meri na naslednji URL:",
         "stockStep3": "Vnesite uporabniško ime in geslo, ki ste ju ustvarili, nato tapnite Prijava.",
         "locationNote": "BookOrbit shrani lokacije EPUB, združljive s KOReader, iz spletnega bralnika. Obnovitev naj bi pristala blizu enakega položaja, čeprav se natančna postavitev vrstice lahko razlikuje glede na bralnik in postavitev EPUB.",
         "dangerZone": "Nevarno območje",
@@ -3678,6 +3697,8 @@
         "fileSize": "Velikost datoteke",
         "library": "Knjižnica",
         "added": "Dodano",
+        "cancelDateAddedEdit": "Prekliči datum dodajanja urejanja",
+        "editDateAdded": "Uredi datum dodajanja",
         "dateStarted": "Datum začetka",
         "saving": "Shranjevanje...",
         "cancelDateStartedEdit": "Prekliči urejanje datuma začetka",
@@ -3689,9 +3710,12 @@
         "synopsis": "Vsebina",
         "noDescription": "Opis ni na voljo.",
         "dateStartedFutureError": "Datum začetka ne more biti v prihodnosti.",
+        "dateAddedRequiredError": "Datum dodajanja je obvezen.",
+        "dateAddedFutureError": "Datum dodajanja ne sme biti v prihodnosti.",
         "dateFinishedFutureError": "Datum zaključka ne more biti v prihodnosti.",
         "dateFinishedBeforeStartedError": "Datum zaključka mora biti enak ali za datumom začetka.",
         "saveReadingDatesError": "Shranjevanje bralnih datumov ni uspelo.",
+        "saveAddedDateError": "Shranjevanje datuma dodajanja ni uspelo.",
         "koboPendingDelete": "Čaka na izbris iz naprave",
         "koboPendingDeleteTooltip": "Kobo jo bo odstranil ob naslednji sinhronizaciji.",
         "koboRemovedByDevice": "Odstranjeno z naprave",
@@ -4734,6 +4758,10 @@
       "untitled": "Brez naslova",
       "cover": "Naslovnica",
       "bookCover": "Naslovnica knjige"
+    },
+    "libraryLoad": {
+      "errorTitle": "Vaših knjižnic ni mogoče naložiti",
+      "errorDescription": "BookOrbit ni mogel pridobiti vaših knjižnic. Vsebina v vaši knjižnici ni bila odstranjena."
     },
     "scroller": {
       "failedToLoad": "Nalaganje ni uspelo.",
@@ -6111,6 +6139,9 @@
       "scrollModeHint": "Uporabite \"Brez vrzeli\" za webtoone in navpične trakove.",
       "readingDirection": "Smer branja",
       "pageView": "Pogled strani",
+      "twoPagePagedOnly": "Dve strani sta prikazani samo v načinu po strani.",
+      "spreadSection": "Dvostranska razporeditev",
+      "spreadFallbackHint": "Ta zaslon je preozek za dve strani, zato so prikazane posamezne strani.",
       "spreadAlignmentLabel": "Poravnava razpona",
       "spreadGap": "Razmik",
       "spreadGapValue": "{value}px",
@@ -6118,6 +6149,9 @@
       "widePages": "Široke strani",
       "firstPage": "Prva stran",
       "lastPage": "Zadnja stran",
+      "zoomControls": "Kontrolniki za povečavo",
+      "zoomOut": "Pomanjšaj",
+      "zoomIn": "Povečaj",
       "fit": {
         "page": "Prilagoditev strani",
         "width": "Širina strani",

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -491,8 +491,8 @@
       },
       "readingPreferences": {
         "title": "阅读首选项",
-        "timezoneHint": "时区用于时间敏感的成就，如早期鸟类和全夜。",
-        "timezone": "Timezone",
+        "timezoneHint": "时区用于处理对时间敏感的成就，例如“早鸟”和“通宵达人”。",
+        "timezone": "时区",
         "save": "保存首选项",
         "enableAchievements": "启用成就",
         "enableAchievementsHint": "跟踪成就进度，显示与成就相关的接口。在通知中单独管理成就通知。",
@@ -1013,7 +1013,7 @@
         "readingProgressEntries": "读取进度条目",
         "audiobookProgressEntries": "音频簿进度条目",
         "bookmarksLabel": "书签",
-        "annotationsLabel": "说明",
+        "annotationsLabel": "批注",
         "collectionEntries": "收藏条目",
         "loadFullReportHint": "单击“负载完整报告”以在导出的报告中包含干燥的比赛摘要。",
         "completedNoIssues": "迁移已完成，没有未解决的书籍或故障。",
@@ -1681,7 +1681,7 @@
         "serverFontVisibilityFailed": "服务端字体显示状态更新失败"
       },
       "bookDock": {
-        "title": "预约停靠栏",
+        "title": "Book Dock",
         "subtitle": "配置文件进入书签时的处理方式。",
         "dropFolder": "丢弃文件夹",
         "containerPath": "容器路径",
@@ -2272,7 +2272,7 @@
     "system": {
       "tabs": {
         "file-naming": "文件名称",
-        "book-dock": "预约停靠栏",
+        "book-dock": "Book Dock",
         "maintenance": "维护费",
         "audit-log": "审核日志"
       }
@@ -4253,7 +4253,7 @@
       "allMatchesShown": "{count, plural, =0 {显示所有1场比赛} one {显示所有1场比赛} other {显示所有#场比赛}}",
       "bookCount": "{count, plural, =0 {没有书籍} one {# 书} other {# 书}}",
       "fileCount": "{count, plural, =0 {没有文件} one {# 文件} other {# 文件}}",
-      "bookDock": "预约停靠栏",
+      "bookDock": "Book Dock",
       "statistics": "统计",
       "achievements": "1. 成就",
       "annotations": "说明",
@@ -5501,7 +5501,7 @@
           "description": "从另一个库工具导入完成或失败。"
         },
         "bookDock": {
-          "label": "预约停靠栏",
+          "label": "Book Dock",
           "description": "当存入码头的文件准备好审查或最后定稿。"
         },
         "koboSync": {
@@ -6259,7 +6259,7 @@
       "title": "书"
     },
     "bookDock": {
-      "title": "预约停靠栏",
+      "title": "Book Dock",
       "newFilesDetected": "检测到新文件",
       "reconnecting": "重新连接",
       "rescanFailed": "重新扫描失败",
@@ -6374,7 +6374,7 @@
     "opds": "OPDS",
     "koboSync": "Kobo Sync",
     "koreaderSync": "KOReader 同步",
-    "bookDock": "预约停靠栏",
+    "bookDock": "Book Dock",
     "whatsNew": "新功能",
     "annotations": "说明",
     "achievements": "成就",
@@ -6439,7 +6439,7 @@
     },
     "system": {
       "file-naming": "文件名称",
-      "book-dock": "预约停靠栏",
+      "book-dock": "Book Dock",
       "maintenance": "维护费",
       "audit-log": "审核日志"
     },


### PR DESCRIPTION
Automated sparse translation export from Crowdin.

Untranslated entries are omitted so Vue I18n falls back to the English catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spanish and Slovenian translations for cover tint settings, KOReader update guidance, book date editing, validation messages, dashboard errors, and comic reader controls.
  * Added related labels for book details and magic-link pause settings in Slovenian.
* **Localization**
  * Updated Chinese translations for timezone and annotation labels.
  * Improved the Chinese translation of “Book Dock” across settings, navigation, notifications, and views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->