### PR TITLE
perf(cover): stop the loading shimmer once the cover has loaded

### DIFF
--- a/client/src/features/book/components/BookCoverArtwork.vue
+++ b/client/src/features/book/components/BookCoverArtwork.vue
@@ -144,9 +144,10 @@ function handleImageError() {
   <template v-if="canRenderImage">
     <span
       :class="[
-        'absolute inset-0 z-0 animate-pulse bg-foreground/5 transition-opacity duration-200 ease-out',
-        loaded ? 'opacity-0 pointer-events-none' : 'opacity-100',
+        'absolute inset-0 z-0 bg-foreground/5 transition-opacity duration-200 ease-out',
+        loaded ? 'opacity-0 pointer-events-none' : 'animate-pulse opacity-100',
       ]"
+      data-testid="cover-skeleton"
       aria-hidden="true"
     />
     <img

--- a/client/src/features/book/components/__tests__/BookCoverArtwork.spec.ts
+++ b/client/src/features/book/components/__tests__/BookCoverArtwork.spec.ts
@@ -164,8 +164,11 @@ describe('BookCoverArtwork', () => {
     await triggerMainImageLoad(wrapper, 600, 900)
 
     expect(wrapper.find('[data-testid="placeholder"]').exists()).toBe(false)
-    const skeleton = wrapper.find('.animate-pulse')
+    const skeleton = wrapper.find('[data-testid="cover-skeleton"]')
     expect(skeleton.classes()).toContain('opacity-0')
+    // The shimmer is an infinite animation, so leaving it on a loaded cover keeps the
+    // refresh driver ticking for the life of the page. See issue #626.
+    expect(skeleton.classes()).not.toContain('animate-pulse')
   })
 
   it('does not render the fitted spine layer when spine is disabled', async () => {
@@ -242,7 +245,7 @@ describe('BookCoverArtwork', () => {
 
       expect(image.classes()).toContain('opacity-100')
       expect(image.classes()).not.toContain('transition-opacity')
-      expect(second.find('.animate-pulse').classes()).toContain('opacity-0')
+      expect(second.find('[data-testid="cover-skeleton"]').classes()).toContain('opacity-0')
     })
 
     it('restores instantly when src changes to an already-loaded cover', async () => {
@@ -255,7 +258,7 @@ describe('BookCoverArtwork', () => {
       await wrapper.setProps({ src: '/warm.jpg' })
       const image = wrapper.find('img[alt="Dune cover"]')
       expect(image.classes()).toContain('opacity-100')
-      expect(wrapper.find('.animate-pulse').classes()).toContain('opacity-0')
+      expect(wrapper.find('[data-testid="cover-skeleton"]').classes()).toContain('opacity-0')
     })
 
     it('still shows the skeleton when src changes to an unseen cover', async () => {


### PR DESCRIPTION
The cover skeleton kept `animate-pulse` after the image loaded. It only got `opacity-0`, which does
nothing here, because a CSS animation overrides the specified value. So every rendered cover ran an
infinite opacity animation, forever, behind an opaque image where nobody could see it.

Measured in Firefox 153 on an idle library view with 54 covers, window visible and focused:

| | idle CPU |
|---|---|
| as shipped | 109% |
| cancel only the pulse animations, nothing else | 0.5% |
| with this fix | 0.0% |

Not the blur, which was the first suspect on the issue. All four `backdrop-filter` surfaces are
still on in that 0.5% run.

Three tests were finding the skeleton by `.animate-pulse` in the loaded state, so they were
asserting the bug. They use a `data-testid` now, plus one assertion that the animation class is gone
once the cover has loaded.

Off-screen covers in the dashboard carousels use `loading="lazy"`, never load, and so still shimmer.
That is worth about 1 point of CPU because an off-screen animation restyles but never paints. Left
alone.

Closes #626


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated book cover loading states so the skeleton animation stops once the cover image loads.
  * Loaded covers now display a plain background with a smooth opacity transition, preventing lingering loading visuals.

* **Tests**
  * Added coverage to verify the loading animation is removed for loaded, cached, and reassigned covers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->