### PR TITLE
i18n(client): sync translations from Crowdin

### DIFF
--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -782,10 +782,13 @@
         "updatesGroup": "Actualizaciones",
         "importFromBooklore": "Importar desde Booklore",
         "bookloreImportConfigured": "Importación de libros configurada",
+        "importLibraryData": "Importar datos de la biblioteca",
+        "migrationConfigured": "Fuente de migración configurada",
         "migrationRunning": "Migración en ejecución",
         "migrationCompleted": "Migración completada",
         "migrationFailed": "La migración falló",
         "importDescription": "Importación única de libros, metadatos y progreso de lectura de una instalación anterior de Booklore.",
+        "migrationDescription": "Importación única de libros, metadatos y progreso de lectura desde otra aplicación de biblioteca.",
         "configuredDescription": "Fuente: {name}. Aún no se ha ejecutado la migración; continúe con la configuración para ejecutar la importación.",
         "runningDescription": "Etapa: {stage} - iniciada {started}",
         "completedDescription": "De {name} - completado {date}",
@@ -827,6 +830,7 @@
       "migration": {
         "title": "Migración",
         "subtitle": "Importación única de Booklore: conecte la fuente, asigne usuarios, realice un ensayo, inicie la migración y exporte un informe.",
+        "genericSubtitle": "Importación única de biblioteca: conecta una fuente, asigna usuarios, realiza una prueba, inicia la migración y exporte un informe.",
         "progress": "Progreso",
         "stepSourceConnection": "Conexión de origen",
         "stepUserPathMapping": "Mapeo de usuarios y rutas",
@@ -836,6 +840,7 @@
         "stepReport": "Informe",
         "stepReportTitle": "Informe de migración",
         "subtitleSource": "Configure la conexión de la base de datos a su instancia de Booklore de origen.",
+        "genericSubtitleSource": "Configura la conexión a tu aplicación de biblioteca de origen.",
         "subtitleMappings": "Asigne usuarios de origen a usuarios de destino y traduzca rutas de archivos.",
         "subtitleDryRun": "Obtenga una vista previa de lo que se importará antes de ejecutar la migración en vivo.",
         "subtitleRun": "Inicie la importación en vivo y supervise su progreso.",
@@ -920,13 +925,16 @@
         "reasonNoFilePathMatch": "La ruta del archivo no coincide con ningún libro de esta biblioteca.",
         "reasonNoFileHashMatch": "El hash del archivo no coincide con ningún libro de esta biblioteca",
         "reasonNoIsbnMatch": "ISBN no coincide con ningún libro de esta biblioteca",
+        "reasonNoAsinMatch": "ISBN no coincide con ningún libro de esta biblioteca",
         "reasonInsufficientSourceData": "No hay suficientes metadatos para intentar hacer coincidir",
         "reasonAmbiguousIsbnMatch": "Varios libros coincidieron con el mismo ISBN",
+        "reasonAmbiguousAsinMatch": "Varios libros coinciden con el mismo ISBN",
         "reasonAmbiguousFileHashMatch": "Varios libros coincidieron con el mismo hash de archivo",
         "reasonAmbiguousFilePathMatch": "Varios libros coincidieron con la misma ruta de archivo",
         "reasonAmbiguousTitleAuthorMatch": "Varios libros coincidían con el mismo título y autor",
         "reasonUnknown": "No se pudo determinar el motivo",
         "strategyIsbn": "Emparejado por ISBN",
+        "strategyAsin": "Emparejado por ISBN",
         "strategyFileHash": "Coincidencia por hash de archivo",
         "strategyPathMapping": "Coincidencia por ruta de archivo asignada",
         "strategyTitleAuthor": "Emparejado por título y autor",
@@ -962,6 +970,7 @@
         "refresh": "Actualizar",
         "sourceUser": "Usuario fuente",
         "targetUser": "Usuario objetivo",
+        "doNotImport": "No importar este usuario",
         "noSourceUsersLoaded": "Aún no se han cargado usuarios de origen.",
         "noActiveTargetUsers": "No se encontraron usuarios objetivo activos. Cree o vuelva a habilitar un usuario BookOrbit antes de realizar la asignación.",
         "pathPrefixMappings": "Asignaciones de prefijos de ruta",
@@ -2364,6 +2373,54 @@
         "maintenance": "Mantenimiento",
         "audit-log": "Registro de auditoría"
       }
+    },
+    "nav": {
+      "title": "Configuración",
+      "ariaLabel": "Configuración de secciones",
+      "searchPlaceholder": "Ajustes de búsqueda",
+      "clearSearch": "Borrar búsqueda",
+      "noResults": "No hay ajustes que coincidan con {query}.",
+      "shortcutHint": "Presiona Cmd K para saltar a cualquier ajuste",
+      "groups": {
+        "you": "Tú",
+        "library": "Biblioteca",
+        "devices": "Dispositivos y sincronización",
+        "server": "Servidor"
+      },
+      "descriptions": {
+        "profile": "Tu nombre, correo electrónico, contraseña y sesiones activas.",
+        "appearanceTheme": "Tema, color de acento, fondo y radio de esquina.",
+        "appearanceBookCovers": "Cubrir sombras, efectos de columna y arte de marcadores de posición.",
+        "appearanceIcons": "Elige el estilo de icono usado en toda la aplicación.",
+        "appearanceLayout": "Vista predeterminada de la biblioteca, densidad y espacio.",
+        "appearanceBehavior": "Cómo reacciona la biblioteca mientras navegas y ordenas.",
+        "appearanceLanguage": "Idioma de interfaz y formatos regionales.",
+        "readerEbook": "Fuentes, espaciado y comportamiento de páginas para eBooks.",
+        "readerPdf": "Renderización, zoom y página ajustada para PDFs.",
+        "readerComics": "Sentido de lectura y disposición de páginas dobles para cómics.",
+        "readerAudio": "Velocidad de reproducción, intervalos de salto y temporizador de apagado.",
+        "readerFonts": "Fuentes disponibles durante la lectura.",
+        "readerGeneral": "Valores predeterminados compartidos por todos los modos de lectura.",
+        "notifications": "Lo que BookkOrbit te dice sobre y dónde.",
+        "privacy": "Estadísticas de lectura, enlaces compartidos y visibilidad de la actividad.",
+        "restrictions": "Calificaciones de edad y contenido oculto para esta cuenta.",
+        "libraries": "Escanea rutas, carpetas vistas y reglas de ingerencia.",
+        "fileNaming": "Patrones de carpetas y nombres de archivo para los archivos almacenados.",
+        "maintenance": "Reescaneos, duplicados, elementos huérfanos y reconstrucciones de caché.",
+        "kobo": "Endpoint de sincronización, proxy de almacenamiento y mapeo de estanterías",
+        "koreader": "Progreso de sincronización y coincidencia de documentos.",
+        "opds": "Fuentes de catálogo para aplicaciones de lectura de terceros.",
+        "email": "Envío SMTP y direcciones de envío a dispositivo.",
+        "hardcover": "Sincronizar estado de lectura y reseñas con Hardcover.",
+        "users": "Cuentas, roles, permisos e invitaciones.",
+        "accountActivity": "Actividad de lectura y de sesión por usuario.",
+        "magicLinks": "Compartir contraseñas y enlaces de inicio de sesión.",
+        "oidc": "Proveedor de inicio de sesión único, reclamos y aprovisionamiento.",
+        "serverFonts": "Fuentes instaladas para cada lector en este servidor.",
+        "bookDock": "Acciones rápidas que se muestran en las páginas de los libros.",
+        "auditLog": "¿Quién cambió qué, y cuándo."
+      },
+      "backToApp": "Volver a la biblioteca"
     }
   },
   "achievements": {
@@ -3860,6 +3917,8 @@
         "savedButWriteFailed": "Metadatos guardados, pero falla la escritura del archivo",
         "savedWriteSkippedReason": "Metadatos guardados, escritura de archivo omitida: {reason}",
         "savedWriteSkipped": "Metadatos guardados, escritura de archivo omitida",
+        "saveFailed": "No se han podido guardar los cambios",
+        "saveFailedWithStatus": "No se han podido guardar los cambios (HTTP {status})",
         "loadFromFileFailed": "No se pudieron cargar los metadatos del archivo",
         "loadedFieldsFromFile": "{count, plural, =0 {No se cargaron campos del archivo} one {Cargó un campo del archivo} other {cargado # campos del archivo} many {cargado # campos del archivo}}",
         "noMetadataInFile": "No se encontraron metadatos en el archivo",
@@ -4706,6 +4765,7 @@
       "annotations": "Anotaciones",
       "uploadBooks": "Subir libros",
       "appearance": "Apariencia",
+      "appearanceDescription": "Elegir las opciones de tema, acento, radio de esquina, superficie y fondo.",
       "theme": "Tema",
       "accent": "acento",
       "radius": "Radio",
@@ -4726,7 +4786,8 @@
         "cta": "Estrella BookOrbit en GitHub"
       },
       "surfaceOpacity": "Opacidad de la superficie",
-      "surfaceOpacityValue": "{value}%"
+      "surfaceOpacityValue": "{value}%",
+      "surfaceBrightnessValue": "{value}%"
     },
     "sidebar": {
       "dashboard": "Panel de control",
@@ -4767,6 +4828,8 @@
       "seeAllSmartScopes": "Ver todos los alcances inteligentes ({count})",
       "seeAllCollections": "Ver todas las colecciones ({count})",
       "updateAvailable": "Actualizar {version}",
+      "updateTooltip": "Actualización {version} disponible",
+      "openUpdateRelease": "Abrir la versión {version} en GitHub",
       "zones": {
         "browse": "Explorar"
       },
@@ -4861,6 +4924,12 @@
       "light": "Luz",
       "dark": "oscuro",
       "system": "Sistema"
+    },
+    "radiusPicker": {
+      "sharp": "Esquinas afiladas",
+      "default": "Esquinas por defecto",
+      "rounded": "Esquinas redondeadas",
+      "pill": "Esquinas en forma de aleta"
     },
     "languagePicker": {
       "searchPlaceholder": "Buscar idiomas",
@@ -5802,6 +5871,7 @@
   },
   "migration": {
     "sidebarTitle": "Importación de libros",
+    "importTitle": "Importar biblioteca",
     "status": {
       "done": "Hecho",
       "saved": "Guardado",
@@ -5817,7 +5887,8 @@
       "source": {
         "short": "Conexión de origen",
         "title": "Conexión de origen",
-        "subtitle": "Configure la conexión de la base de datos a su instancia de Booklore de origen."
+        "subtitle": "Configure la conexión de la base de datos a su instancia de Booklore de origen.",
+        "genericSubtitle": "Configura la conexión a tu aplicación de biblioteca de origen."
       },
       "mappings": {
         "short": "Mapeo de usuarios y rutas",
@@ -5859,18 +5930,61 @@
       "testConnection": "Conexión de prueba",
       "saveAndValidate": "Guardar y validar",
       "validatedWithWarnings": "Fuente validada con advertencias.",
+      "types": {
+        "booklore": "Librería",
+        "grimmory": "Grimmory",
+        "audiobookshelf": "Audiobookshelf",
+        "calibreWebAutomated": "Calibre-web automatizado"
+      },
       "fields": {
         "type": "Tipo de fuente",
         "name": "Nombre de fuente",
+        "namePlaceholder": "Importar biblioteca",
         "host": "Host",
         "port": "Puerto",
         "user": "Usuario",
         "password": "Contraseña",
         "passwordSaved": "Guardado - dejar sin cambios",
         "passwordNotSet": "No se ha establecido ninguna contraseña",
+        "showSecret": "Mostrar secreto",
+        "hideSecret": "Ocultar secreto",
         "database": "Base de datos",
         "mediaRootPath": "Ruta raíz de medios",
-        "ssl": "Usar TLS/SSL"
+        "ssl": "Usar TLS/SSL",
+        "connectionMode": "Modo de conexión",
+        "apiMode": "Live API",
+        "backupMode": "Archivo de copia de seguridad",
+        "baseUrl": "URL de Audiobookshelf",
+        "apiToken": "Token de API",
+        "apiTokenPlaceholder": "Introduzca un token de API de administrador",
+        "secretSaved": "Guardado - dejar sin cambios",
+        "allowPrivateNetwork": "Permitir acceso a red privada",
+        "allowPrivateNetworkHint": "Activar esto sólo cuando Audiobookshelf esté alojado en una red local o privada de confianza.",
+        "backupPath": "Ruta de la copia de seguridad",
+        "backupPathHint": "Introduzca una ruta absoluta del servidor dentro del directorio de importación de migración configurado.",
+        "cwaAppDatabasePath": "Instantánea automatizada de app.db para Calibre-Web",
+        "cwaAppDatabasePathPlaceholder": "/imports/calibre-web-automated/app.db",
+        "cwaMetadataDatabasePath": "Instantánea calibre metadata.db",
+        "cwaMetadataDatabasePathPlaceholder": "/imports/calibre-web-automated/metadata.db"
+      },
+      "validation": {
+        "nameRequired": "El nombre de origen es obligatorio",
+        "databaseFieldsRequired": "Se requieren host, usuario, base de datos y nombre de fuente",
+        "apiFieldsRequired": "URL de Audiobookshelf, token API y nombre de origen son requeridos",
+        "baseUrlInvalid": "La URL de Audiobookshelf debe ser un origen HTTP o HTTPS limpio sin una ruta",
+        "backupPathRequired": "Se requiere la ruta del archivo de copia de seguridad y el nombre de origen",
+        "backupPathAbsolute": "La ruta del archivo de copia de seguridad debe ser una ruta absoluta",
+        "cwaAppDatabasePathRequired": "Se requiere la ruta de la instantánea automática de app.db para Calibre-Web.",
+        "cwaAppDatabasePathAbsolute": "La ruta de la instantánea automática de app.db de Calibre-Web debe ser absoluta.",
+        "cwaMetadataDatabasePathRequired": "Se requiere la ruta de la instantánea de metadata.db de Calibre.",
+        "cwaMetadataDatabasePathAbsolute": "La ruta de instantánea de Calibre metadata.db debe ser absoluta"
+      },
+      "cwa": {
+        "snapshotTitle": "Modo de instantánea detenido",
+        "stoppedWarning": "Detén el proceso automatizado de Calibre-Web antes de copiar ambas bases de datos. BookOrbit no puede verificar que las dos instantáneas se hayan copiado exactamente en el mismo instante.",
+        "importRootGuidance": "Ambos archivos snapshot deben ser rutas de servidor legibles debajo del directorio MIGRATION_IMPORT_ROOT.",
+        "logicalRootGuidance": "El mapeo de rutas de libros utiliza la raíz lógica de librería Calibre almacenada en app.db, no la carpeta host que contiene estas instantáneas de base de datos.",
+        "compatibilityNote": "El comportamiento del esquema se ha verificado con Calibre-Web Automated v4.0.6. Sus bases de datos no exponen una versión de lanzamiento de la aplicación que sea fiable."
       },
       "mediaPath": {
         "hintRequired": "Requerido para migrar portadas de libros.",
@@ -5897,6 +6011,7 @@
       "refresh": "Actualizar",
       "sourceUser": "Usuario fuente",
       "targetUser": "Usuario objetivo",
+      "doNotImport": "No importar este usuario",
       "noSourceUsersLoaded": "Aún no se han cargado usuarios de origen.",
       "noActiveTargetUsers": "No se encontraron usuarios objetivo activos. Cree o vuelva a habilitar un usuario BookOrbit antes de realizar la asignación.",
       "pathPrefixMappings": "Asignaciones de prefijos de ruta",
@@ -6014,8 +6129,10 @@
       "noFilePathMatch": "La ruta del archivo no coincide con ningún libro de esta biblioteca.",
       "noFileHashMatch": "El hash del archivo no coincide con ningún libro de esta biblioteca",
       "noIsbnMatch": "ISBN no coincide con ningún libro de esta biblioteca",
+      "noAsinMatch": "ISBN no coincide con ningún libro de esta biblioteca",
       "insufficientSourceData": "No hay suficientes metadatos para intentar hacer coincidir",
       "ambiguousIsbnMatch": "Varios libros coincidieron con el mismo ISBN",
+      "ambiguousAsinMatch": "Varios libros coinciden con el mismo ISBN",
       "ambiguousFileHashMatch": "Varios libros coincidieron con el mismo hash de archivo",
       "ambiguousFilePathMatch": "Varios libros coincidieron con la misma ruta de archivo",
       "ambiguousTitleAuthorMatch": "Varios libros coincidían con el mismo título y autor",
@@ -6023,6 +6140,7 @@
     },
     "matchStrategy": {
       "isbn": "Emparejado por ISBN",
+      "asin": "Emparejado por ISBN",
       "fileHash": "Coincidencia por hash de archivo",
       "pathMapping": "Coincidencia por ruta de archivo asignada",
       "titleAuthor": "Emparejado por título y autor",
@@ -6095,6 +6213,7 @@
   },
   "notifications": {
     "title": "Notificaciones",
+    "description": "Revisar y administrar tus notificaciones.",
     "markAllRead": "Marcar todo como leído",
     "clear": "Borrar",
     "empty": "Aún no hay notificaciones",
@@ -6208,6 +6327,7 @@
     "settings": {
       "title": "Configuración",
       "ariaLabel": "Configuración del lector",
+      "close": "Cerrar ajustes",
       "reset": "Restablecer valores predeterminados",
       "modeLabel": "Modo color",
       "mode": {

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -29,7 +29,7 @@
         },
         "summary": {
           "title": "分享摘要",
-          "description": "分享合计习惯而不使用书名、作者、系列片或写词。"
+          "description": "分享汇总后的使用习惯，但不包含书名、作者、系列或叙述者。"
         },
         "detailed": {
           "title": "分享详细的看法",
@@ -91,7 +91,7 @@
       "pageSubtitle": "控制主题、封面、布局以及书库的呈现方式。",
       "mobileSummary": "主题：{theme}・强调色：{accent}・背景：{background}",
       "themeMode": {
-        "light": "亮色的",
+        "light": "浅色",
         "dark": "深色",
         "system": "系统"
       },
@@ -635,7 +635,7 @@
         "created": "已创建",
         "status": "状态",
         "totalUses": "总使用量",
-        "actions": "行动"
+        "actions": "操作"
       },
       "createDialog": {
         "title": "创建魔法链接",
@@ -1213,8 +1213,8 @@
         "seriesName": "系列名称",
         "seriesIndex": "系列索引",
         "genres": "体裁",
-        "narrators": "神秘者",
-        "duration": "期限",
+        "narrators": "叙述者",
+        "duration": "阅读时长",
         "abridged": "桥接的"
       },
       "mergeStrategy": {
@@ -1346,7 +1346,7 @@
         "clearAllProviders": "清除所有提供商",
         "clearAll": "全部清除",
         "resetToDefault": "重置为默认值",
-        "reset": "Reset",
+        "reset": "重置",
         "dragProvidersHint": "将提供商从这里拖动到任何字段以添加它",
         "dragProviderHere": "将一个提供商拖到这里",
         "howItWorks": {
@@ -1704,7 +1704,7 @@
         "styleItalic": "斜体",
         "weightThin": "最小值",
         "weightExtraLight": "额外的光线",
-        "weightLight": "亮色的",
+        "weightLight": "浅色",
         "weightRegular": "常规的",
         "weightMedium": "中",
         "weightSemiBold": "半粗体",
@@ -1954,7 +1954,7 @@
             "bookDownload": "下载未完成",
             "progressUpdate": "读取位置未更新",
             "annotationsPull": "摘录未发送",
-            "annotationsPush": "未导入摘录"
+            "annotationsPush": "未导入高亮"
           },
           "chip": {
             "morePending": "更多待处理",
@@ -2140,7 +2140,7 @@
         "latestPluginSuffix": "- 最新插件版本 v {version}",
         "matchedBooks": "匹配的书",
         "readingEvents": "正在阅读事件",
-        "highlights": "高光",
+        "highlights": "高亮",
         "syncedTotals": "已同步总计",
         "trashedHighlights": "回收站突出显示",
         "pendingDeletes": "{count, plural, =0 {没有删除等待KOReader 插件确认的摘录内容。} one {# 删除了等待KOReader 插件确认的摘录内容。} other {# 删除了等待KOReader 插件确认的高亮内容。}}",
@@ -2591,7 +2591,7 @@
         "email": "电子邮件地址",
         "access": "访问权限",
         "status": "状态",
-        "actions": "行动"
+        "actions": "操作"
       },
       "adminBadge": "管理员",
       "permissionCount": "{count, plural, =0 {没有权限} one {一个权限} other {# 权限}}",
@@ -2782,7 +2782,7 @@
       "bulkTrash": "回收站",
       "bulkRestore": "恢复",
       "tabs": {
-        "highlights": "摘录",
+        "highlights": "高亮",
         "trash": "回收站"
       },
       "empty": {
@@ -3185,7 +3185,7 @@
     "header": {
       "never": "从不使用",
       "portraitAlt": "{name} 的头像",
-      "actions": "行动",
+      "actions": "操作",
       "editAuthor": "编辑作者",
       "mergeAuthors": "合并作者",
       "refreshing": "刷新中……",
@@ -3341,7 +3341,7 @@
     },
     "actions": {
       "read": "阅读",
-      "listen": "监听",
+      "listen": "听书",
       "peek": "快速预览",
       "quickView": "快速视图",
       "details": "详细信息",
@@ -3359,13 +3359,13 @@
     },
     "readStatus": {
       "unread": "未读",
-      "wantToRead": "想要阅读",
+      "wantToRead": "想读",
       "reading": "正在阅读",
-      "onHold": "按住时",
-      "rereading": "重新读取",
+      "onHold": "搁置",
+      "rereading": "重读",
       "read": "已读",
-      "skimmed": "Skimed",
-      "abandoned": "废弃的"
+      "skimmed": "略读",
+      "abandoned": "弃读"
     },
     "download": {
       "action": "下载",
@@ -3392,7 +3392,7 @@
         "publisher": "出版社",
         "fileSize": "文件大小",
         "readProgress": "读取进度",
-        "readStatus": "读取状态",
+        "readStatus": "阅读状态",
         "format": "格式",
         "lastReadAt": "最后读",
         "startedAt": "开始日期",
@@ -3435,7 +3435,7 @@
         "rating": "评分",
         "communityRating": "社区评分",
         "readProgress": "阅读进度",
-        "readStatus": "读取状态",
+        "readStatus": "阅读状态",
         "description": "描述",
         "isbn": "ISBN",
         "metadataScore": "元数据分数",
@@ -3578,7 +3578,7 @@
       "columns": {
         "cover": "封面",
         "read": "阅读",
-        "actions": "行动"
+        "actions": "操作"
       }
     },
     "shortcuts": {
@@ -3593,7 +3593,7 @@
         "jumpLastRow": "跳转到最后一行"
       },
       "actions": {
-        "title": "行动",
+        "title": "操作",
         "editCell": "编辑焦点单元",
         "cancelEditing": "取消编辑/关闭叠加",
         "toggleRowSelection": "切换行选择",
@@ -3666,7 +3666,7 @@
         "editMetadata": "编辑元数据",
         "files": "文件",
         "readingLog": "阅读日志",
-        "highlights": "摘录"
+        "highlights": "高亮"
       },
       "discover": {
         "moreInSeries": "更多在系列中",
@@ -3764,10 +3764,10 @@
         "narratedBy": "叙述者",
         "ratingLocked": "评分已锁定",
         "rateStar": "评分 {star} 星",
-        "listen": "监听",
+        "listen": "听书",
         "read": "阅读",
         "chooseFormat": "选择格式",
-        "audiobook": "音频簿",
+        "audiobook": "有声书",
         "primary": "主要的",
         "peek": "快速预览",
         "sendViaEmail": "通过电子邮件发送",
@@ -3789,16 +3789,16 @@
         "metadataScore": "元数据分数",
         "primaryFormat": "主要格式",
         "openIn": "使用 {provider} 打开",
-        "showLess": "显示更少的",
+        "showLess": "显示更少",
         "showMore": "显示更多",
         "publisher": "出版社",
         "published": "已发布",
         "language": "语言",
         "pages": "页 次",
-        "duration": "期限",
-        "edition": "编辑",
-        "abridged": "桥接的",
-        "unabridged": "未缩写",
+        "duration": "阅读时长",
+        "edition": "版本",
+        "abridged": "节选版",
+        "unabridged": "未删节版",
         "isbn": "ISBN",
         "fileSize": "文件大小",
         "library": "书库",
@@ -4172,8 +4172,8 @@
           "sourceManual": "手动模式",
           "colDate": "日期",
           "colDateMobile": "日期",
-          "colDuration": "期限",
-          "colDurationMobile": "期限",
+          "colDuration": "阅读时长",
+          "colDurationMobile": "阅读时长",
           "colProgressChange": "进度变化",
           "colProgressChangeMobile": "德尔塔",
           "colEndProgress": "结束进度",
@@ -4704,9 +4704,9 @@
       "uploadBooks": "上传书",
       "appearance": "外观",
       "theme": "主题",
-      "accent": "刻度",
-      "radius": "Radius",
-      "background": "二. 背景",
+      "accent": "强调色",
+      "radius": "圆角",
+      "background": "背景",
       "settings": "设置",
       "whatsNew": "新功能",
       "documentation": "文件",
@@ -4962,10 +4962,10 @@
         "readingStreak": "阅读连续记录",
         "currentlyReading": "正在阅读",
         "readingGoal": "正在阅读目标",
-        "readingDna": "正在读取 DNA",
+        "readingDna": "阅读 DNA",
         "monthlyChallenge": "每月挑战",
         "highlightOfTheDay": "每日摘录",
-        "neglectedGems": "被忽略的 Gems",
+        "neglectedGems": "被埋没的佳作",
         "readingRhythm": "阅读节奏",
         "diversityScore": "多样性得分",
         "libraryOverview": "书库概览",
@@ -4976,7 +4976,7 @@
         "recentlyAdded": "最近添加",
         "continueReading": "继续阅读",
         "continueListening": "继续收听中",
-        "wantToRead": "想要阅读",
+        "wantToRead": "想读",
         "upNextInSeries": "上一系列中的下一个",
         "random": "发现新鲜事",
         "smartScope": "智能瞄准镜"
@@ -5052,23 +5052,23 @@
         "complete": "已完成！"
       },
       "neglectedGems": {
-        "title": "被忽略的 Gems",
+        "title": "被埋没的佳作",
         "empty": "您所有的评分最高的书籍都已读完！",
         "rating": "{rating}/5 分",
         "daysWaiting": "已等待 {count} 天",
         "queued": "队列中",
         "addToQueue": "添加到队列",
-        "shuffle": "随机播放"
+        "shuffle": "随机"
       },
       "readingDna": {
-        "title": "正在读取 DNA",
+        "title": "阅读 DNA",
         "notEnoughData": "阅读至少5本书解锁你的阅读DNA",
         "basedOn": "{count, plural, =0 {基于没有书籍} one {基于# 本} other {基于# 本}}",
         "traits": {
-          "length": "长度",
-          "variety": "变量",
-          "rhythm": "节日",
-          "time": "时间",
+          "length": "时长",
+          "variety": "多样性",
+          "rhythm": "节奏",
+          "time": "时段",
           "speed": "速度"
         }
       },
@@ -6092,6 +6092,7 @@
   },
   "notifications": {
     "title": "通知",
+    "description": "查看和管理您的通知。",
     "markAllRead": "全部标记为已读",
     "clear": "清空",
     "empty": "还没有通知",
@@ -6205,6 +6206,7 @@
     "settings": {
       "title": "设置",
       "ariaLabel": "阅读器设置",
+      "close": "关闭设置",
       "reset": "恢复默认设置",
       "modeLabel": "配色模式",
       "mode": {
@@ -6279,7 +6281,7 @@
       "tabs": {
         "chapters": "章 次",
         "bookmarks": "书签",
-        "highlights": "高光",
+        "highlights": "高亮",
         "toc": "目录",
         "tocShort": "排行",
         "marksShort": "Marks",
@@ -6340,7 +6342,7 @@
       "groups": {
         "panels": "专家小组",
         "reading": "正在阅读",
-        "actions": "行动"
+        "actions": "操作"
       },
       "toggleToc": "切换内容表",
       "toggleSearch": "切换搜索",
@@ -6355,7 +6357,7 @@
     },
     "cbz": {
       "fitMode": "适合模式",
-      "background": "二. 背景",
+      "background": "背景",
       "scrollMode": "滚动模式",
       "scrollModeHint": "对网络玩具和垂直条纹使用“无差距”。",
       "readingDirection": "阅读方向",
@@ -6470,7 +6472,7 @@
       "filters": "筛选器",
       "clear": "清空",
       "noMatch": "没有匹配筛选器的系列文件。",
-      "empty": "您的资料库中没有找到系列片。",
+      "empty": "您的资料库中没有找到系列。",
       "sort": {
         "name": "名称",
         "bookCount": "书计数",


### PR DESCRIPTION
Automated sparse translation export from Crowdin.

Untranslated entries are omitted so Vue I18n falls back to the English catalog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved Spanish and Chinese translations across settings, metadata, reader, dashboard, notifications, books, and series interfaces.
  * Added Spanish migration guidance and terminology for supported library sources.
  * Corrected labels for ASINs, audiobooks, reading statuses, highlights, dashboard widgets, and user-mapping options.
  * Added missing settings, notification, metadata, and reader interface labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->