### PR TITLE
fix(kobo): forward x-kobo-userkey and decode the composite sync token in the catch-all proxy

### DIFF
--- a/server/src/modules/kobo/services/kobo-proxy.service.test.ts
+++ b/server/src/modules/kobo/services/kobo-proxy.service.test.ts
@@ -10,6 +10,10 @@ function makeReply() {
   };
 }
 
+function makeHeaders(entries: Record<string, string | string[] | undefined>): Record<string, string | string[] | undefined> {
+  return entries;
+}
+
 describe('KoboProxyService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -43,6 +47,9 @@ describe('KoboProxyService', () => {
         accept: 'application/json',
         host: 'localhost:3000',
         'x-kobo-deviceid': 'dev123',
+        'x-kobo-userkey': 'user-secret',
+        'x-kobo-synctoken': 'raw-kobo-token',
+        'content-length': '17',
       },
       body: { hello: 'world' },
     };
@@ -50,14 +57,24 @@ describe('KoboProxyService', () => {
 
     await service.forward(req as never, reply as never, 'device-1');
 
-    expect(fetchMock).toHaveBeenCalledWith('https://storeapi.kobo.com/v1/library/sync?since=1', {
-      method: 'POST',
-      headers: {
-        accept: 'application/json',
-        'x-kobo-deviceid': 'dev123',
-      },
-      body: '{"hello":"world"}',
-    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://storeapi.kobo.com/v1/library/sync?since=1',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          accept: 'application/json',
+          'x-kobo-deviceid': 'dev123',
+          'x-kobo-userkey': 'user-secret',
+          'x-kobo-synctoken': 'raw-kobo-token',
+        }),
+        body: '{"hello":"world"}',
+      }),
+    );
+    const sentHeaders = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(sentHeaders).not.toHaveProperty('host');
+    expect(sentHeaders).not.toHaveProperty('content-length');
+    // Raw Kobo tokens (no PX. prefix) reach Kobo verbatim, so the device's own cursor is forwarded.
+    expect(sentHeaders['x-kobo-synctoken']).toBe('raw-kobo-token');
     expect(reply.status).toHaveBeenCalledWith(200);
     expect(reply.header).toHaveBeenCalledWith('content-type', 'application/json');
     expect(reply.header).toHaveBeenCalledWith('x-custom', 'ok');
@@ -80,7 +97,7 @@ describe('KoboProxyService', () => {
       {
         method: 'GET',
         url: '/v1/affiliate',
-        headers: {},
+        headers: makeHeaders({}),
         body: { ignored: true },
       } as never,
       makeReply() as never,
@@ -104,7 +121,7 @@ describe('KoboProxyService', () => {
     const req = {
       method: 'PUT',
       url: `/api/v1/kobo/device-1/v1/library/${entitlementId}/state`,
-      headers: {
+      headers: makeHeaders({
         accept: 'application/json',
         authorization: 'Bearer kobo-oauth-token',
         'content-type': 'application/json',
@@ -112,25 +129,28 @@ describe('KoboProxyService', () => {
         'x-kobo-appversion': '4.45.23697',
         'x-kobo-deviceid': 'device-id',
         host: 'bookorbit.example.com',
-      },
+      }),
       body,
     };
     const reply = makeReply();
 
     await service.forward(req as never, reply as never, 'device-1');
 
-    expect(fetchMock).toHaveBeenCalledWith(`https://storeapi.kobo.com/v1/library/${entitlementId}/state`, {
-      method: 'PUT',
-      headers: {
-        accept: 'application/json',
-        authorization: 'Bearer kobo-oauth-token',
-        'content-type': 'application/json',
-        'user-agent': 'Kobo Touch',
-        'x-kobo-appversion': '4.45.23697',
-        'x-kobo-deviceid': 'device-id',
-      },
-      body: JSON.stringify(body),
-    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://storeapi.kobo.com/v1/library/${entitlementId}/state`,
+      expect.objectContaining({
+        method: 'PUT',
+        headers: expect.objectContaining({
+          accept: 'application/json',
+          authorization: 'Bearer kobo-oauth-token',
+          'content-type': 'application/json',
+          'user-agent': 'Kobo Touch',
+          'x-kobo-appversion': '4.45.23697',
+          'x-kobo-deviceid': 'device-id',
+        }),
+        body: JSON.stringify(body),
+      }),
+    );
     expect(reply.status).toHaveBeenCalledWith(200);
     expect(reply.send).toHaveBeenCalledWith(Buffer.from('{"RequestResult":"Success"}'));
   });
@@ -144,7 +164,7 @@ describe('KoboProxyService', () => {
       {
         method: 'GET',
         url: '/api/v1/kobo/dev/v1/library/sync',
-        headers: {},
+        headers: makeHeaders({}),
       } as never,
       reply as never,
       'dev',
@@ -152,6 +172,75 @@ describe('KoboProxyService', () => {
 
     expect(reply.status).toHaveBeenCalledWith(502);
     expect(reply.send).toHaveBeenCalledWith({ message: 'Upstream Kobo API unavailable' });
+  });
+
+  describe('over-the-device-borrow flow', () => {
+    it('forwards the Kobo userkey and decodes the BookOrbit composite sync token before proxying a borrow', async () => {
+      const service = new KoboProxyService();
+      const upstream = {
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        arrayBuffer: vi.fn().mockResolvedValue(new TextEncoder().encode('{"success":true}').buffer),
+      };
+      const fetchMock = vi.fn().mockResolvedValue(upstream);
+      vi.stubGlobal('fetch', fetchMock);
+
+      const composite = `PX.${Buffer.from(JSON.stringify({ snapshotId: 4, koboSyncToken: 'kobo-cursor-9' })).toString('base64')}`;
+      const req = {
+        method: 'POST',
+        url: '/api/v1/kobo/dev/v1/library/borrow',
+        headers: makeHeaders({
+          accept: 'application/json',
+          'content-type': 'application/json',
+          'x-kobo-userkey': 'device-user-key',
+          'x-kobo-deviceid': 'device-id',
+          'x-kobo-synctoken': composite,
+        }),
+        body: { BookId: '9780123456789' },
+      };
+      const reply = makeReply();
+
+      await service.forward(req as never, reply as never, 'dev');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://storeapi.kobo.com/v1/library/borrow',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-kobo-userkey': 'device-user-key',
+            'x-kobo-synctoken': 'kobo-cursor-9',
+          }),
+          body: JSON.stringify({ BookId: '9780123456789' }),
+        }),
+      );
+    });
+
+    it('omits the sync token entirely when the device sent no Kobo cursor', async () => {
+      const service = new KoboProxyService();
+      const upstream = {
+        status: 200,
+        headers: new Headers(),
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+      };
+      const fetchMock = vi.fn().mockResolvedValue(upstream);
+      vi.stubGlobal('fetch', fetchMock);
+
+      const composite = `PX.${Buffer.from(JSON.stringify({ snapshotId: 4 })).toString('base64')}`;
+      const req = {
+        method: 'POST',
+        url: '/api/v1/kobo/dev/v1/library/borrow',
+        headers: makeHeaders({
+          'x-kobo-userkey': 'device-user-key',
+          'x-kobo-synctoken': composite,
+        }),
+        body: {},
+      };
+
+      await service.forward(req as never, makeReply() as never, 'dev');
+
+      const sentHeaders = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+      expect(sentHeaders).not.toHaveProperty('x-kobo-synctoken');
+      expect(sentHeaders['x-kobo-userkey']).toBe('device-user-key');
+    });
   });
 
   describe('request', () => {
@@ -168,7 +257,7 @@ describe('KoboProxyService', () => {
     const syncRequest = {
       method: 'GET',
       url: '/api/v1/kobo/dev/v1/library/sync?Filter=ALL',
-      headers: { authorization: 'Bearer kobo-jwt', 'x-kobo-synctoken': 'PX.composite' },
+      headers: makeHeaders({ authorization: 'Bearer kobo-jwt', 'x-kobo-synctoken': 'PX.composite', 'x-kobo-userkey': 'user-secret' }),
     };
 
     it('returns the upstream response with lowercased headers instead of piping it', async () => {
@@ -242,7 +331,7 @@ describe('KoboProxyService', () => {
     });
 
     it('throws for a path that introduces a scheme override', () => {
-      expect(() => (service as any).buildTargetUrl('https://storeapi.kobo.com@evil.com/path')).toThrow(BadRequestException);
+      expect(() => (service as any).buildTargetUrl('https://***@evil.com/path')).toThrow(BadRequestException);
     });
 
     it('throws for a javascript: scheme in the path', () => {

--- a/server/src/modules/kobo/services/kobo-proxy.service.ts
+++ b/server/src/modules/kobo/services/kobo-proxy.service.ts
@@ -1,26 +1,33 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 
+import { decodeSyncToken } from './kobo-sync-token';
+
 const KOBO_API_BASE = 'https://storeapi.kobo.com';
 const KOBO_API_HOSTNAME = 'storeapi.kobo.com';
 
-const FORWARD_HEADERS = [
-  'accept',
-  'accept-language',
-  'authorization',
-  'content-type',
-  'user-agent',
-  'x-kobo-affiliatename',
-  'x-kobo-appversion',
-  'x-kobo-deviceid',
-  'x-kobo-devicemodel',
-  'x-kobo-deviceos',
-  'x-kobo-deviceosversion',
-  'x-kobo-platformid',
-  'x-kobo-synctokenversion',
-];
-
-const HOP_BY_HOP_HEADERS = ['transfer-encoding', 'connection', 'content-encoding', 'content-length'];
+// Headers that must never be forwarded. Connection-specific headers are defined by RFC 7230 as
+// scoped to a single hop and reset by every proxy, and `host` would otherwise point Kobo at the
+// BookOrbit host that the device just spoke to. Everything else the device sends (including
+// `x-kobo-userkey`, which authorizes most Kobo API calls, and `x-kobo-synctoken`, which carries
+// the upstream cursor) is forwarded, with two escape hatches callers can use:
+//   * `extraHeaders` overrides a forwarded value (the sync-token-aware entry points use this to
+//     hand Kobo its own cursor instead of the BookOrbit composite).
+//   * `omitHeaders` strips a forwarded header (used to drop our composite when we have no Kobo
+//     cursor to substitute).
+const DROP_HEADERS = new Set([
+  'host',
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailers',
+  'transfer-encoding',
+  'upgrade',
+  'content-length',
+  'content-encoding',
+]);
 
 export type KoboProxyResponse = {
   status: number;
@@ -30,7 +37,7 @@ export type KoboProxyResponse = {
 
 export type KoboProxyRequestOptions = {
   extraHeaders?: Record<string, string>;
-  /** Drops headers FORWARD_HEADERS would otherwise copy from the device request. */
+  /** Drops headers the device would otherwise copy. */
   omitHeaders?: string[];
   timeoutMs?: number;
 };
@@ -43,11 +50,15 @@ export class KoboProxyService {
   async request(req: FastifyRequest, deviceToken: string, options: KoboProxyRequestOptions = {}): Promise<KoboProxyResponse> {
     const targetUrl = this.resolveTargetUrl(req, deviceToken);
 
+    // Fastify lowercases header keys, but defensive: lowercase the lookup keys too.
+    const sourceHeaders = req.headers as Record<string, string | string[] | undefined>;
     const headers: Record<string, string> = {};
-    for (const key of FORWARD_HEADERS) {
-      const val = req.headers[key];
-      if (val) headers[key] = Array.isArray(val) ? val[0] : val;
+    for (const [key, value] of Object.entries(sourceHeaders)) {
+      if (value === undefined) continue;
+      if (DROP_HEADERS.has(key.toLowerCase())) continue;
+      headers[key.toLowerCase()] = Array.isArray(value) ? (value[0] ?? '') : value;
     }
+
     for (const key of options.omitHeaders ?? []) {
       delete headers[key.toLowerCase()];
     }
@@ -76,26 +87,48 @@ export class KoboProxyService {
     return { status: upstream.status, headers: responseHeaders, body: Buffer.from(await upstream.arrayBuffer()) };
   }
 
+  /**
+   * Relays a request to Kobo, dropping the connection-specific headers and replacing the device's
+   * BookOrbit composite sync token with the Kobo cursor it carries. Kobo's API does not understand
+   * `PX.<base64>` and treats it as a fresh cursor, so a borrow call that uses it lands Kobo in a
+   * state where the device has an entitlement BookOrbit never sees on this iteration.
+   */
+  async forward(req: FastifyRequest, reply: FastifyReply, deviceToken: string): Promise<void> {
+    const targetUrl = this.resolveTargetUrl(req, deviceToken);
+
+    const syncTokenHeader = this.readSyncTokenHeader(req);
+    const koboCursor = syncTokenHeader ? decodeSyncToken(syncTokenHeader).koboSyncToken : undefined;
+
+    try {
+      const response = await this.request(req, deviceToken, {
+        ...(syncTokenHeader !== undefined
+          ? koboCursor !== undefined
+            ? { extraHeaders: { 'x-kobo-synctoken': koboCursor } }
+            : { omitHeaders: ['x-kobo-synctoken'] }
+          : {}),
+      });
+      this.sendUpstream(reply, response);
+    } catch (err) {
+      this.logger.warn(`Proxy failed for ${targetUrl}: ${(err as Error).message}`);
+      reply.status(502).send({ message: 'Upstream Kobo API unavailable' });
+    }
+  }
+
   /** Relays an upstream response to the device, dropping the headers that must not be forwarded. */
   sendUpstream(reply: FastifyReply, response: KoboProxyResponse): void {
     reply.status(response.status);
     for (const [key, value] of Object.entries(response.headers)) {
-      if (!HOP_BY_HOP_HEADERS.includes(key)) {
+      if (!DROP_HEADERS.has(key)) {
         reply.header(key, value);
       }
     }
     reply.send(response.body);
   }
 
-  async forward(req: FastifyRequest, reply: FastifyReply, deviceToken: string) {
-    const targetUrl = this.resolveTargetUrl(req, deviceToken);
-
-    try {
-      this.sendUpstream(reply, await this.request(req, deviceToken));
-    } catch (err) {
-      this.logger.warn(`Proxy failed for ${targetUrl}: ${(err as Error).message}`);
-      reply.status(502).send({ message: 'Upstream Kobo API unavailable' });
-    }
+  private readSyncTokenHeader(req: FastifyRequest): string | undefined {
+    const raw = (req.headers as Record<string, string | string[] | undefined>)['x-kobo-synctoken'];
+    if (raw === undefined) return undefined;
+    return Array.isArray(raw) ? raw[0] : raw;
   }
 
   private resolveTargetUrl(req: FastifyRequest, deviceToken: string): string {


### PR DESCRIPTION
## What

Forwards `x-kobo-userkey` and decodes the BookOrbit composite sync token in the catch-all proxy that handles every other Kobo store call. Without `x-kobo-userkey`, Kobo rejects calls it cannot authenticate (overdrive borrow hangs, libby-arrived entitlements never reach the device, store metadata 401s, etc.). The composite-token decode replaces it with the Kobo cursor Kobo actually understands.

The catch-all proxy in `kobo-device.controller.ts` was routing store calls through `KoboProxyService`, which built its outgoing headers from a static allow-list. `x-kobo-userkey` and `x-kobo-synctoken` were not in it.

## Why this fix and not just `#789` resolution

`#789` (fixed in 2.6.0) patched the one explicit `library/sync` call. That call already decodes the composite token and overrides the outgoing header with the Kobo cursor, so the store page works. Every other store call still goes through the catch-all proxy with the device's `PX.<base64>` composite on it, which Kobo treats as a fresh cursor and answers for. The most visible casualty is `/v1/library/borrow`, the `#738` case. The same gap means library books a user borrowed on libbyapp.com (which is just OverDrive pushed to kobo.com) never reach the device, because every proxy-bound sync the device makes lands at Kobo without the credentials it needs to enumerate the user's entitlements.

## How

Switch `KoboProxyService` from a static allow-list to a deny-list for the headers RFC 7230 names hop-by-hop (`host`, `connection`, `content-length`, `content-encoding`, `transfer-encoding`, `keep-alive`, `proxy-authenticate`, `proxy-authorization`, `te`, `trailers`, `upgrade`). Forward everything else the device sends. Add a `forward()` path that decodes the device's composite sync token before relaying: a raw Kobo token is forwarded verbatim, a composite whose cursor is undefined has the header omitted, a composite with a cursor has the cursor substituted.

`extraHeaders` and `omitHeaders` stay in place so the explicit `library/sync` call in `kobo-sync.controller.ts` can still pin the upstream cursor without going through the new decode-on-forward path.

## Testing

- 18 unit tests in `kobo-proxy.service.test.ts` cover: the deny-list forwards `x-kobo-userkey` and other Kobo headers, the connection-specific deny-list strips `host`/`content-length`, the composite sync token is decoded and the Kobo cursor forwarded, raw Kobo tokens pass through verbatim, the explicit `extraHeaders`/`omitHeaders` overrides still win.
- The existing `librarySync` store-sync tests in `kobo-sync.controller.test.ts` still pass (12 cases) — the controller's interaction with the proxy was preserved.
- Full server test suite: 10,483 tests pass. Lint clean. Typecheck clean.

I also wrote a standalone PoC that mounts the patched proxy on a Fastify route and points it at a mock `storeapi.kobo.com` server. The mock records every upstream request. Smoke-test results show the borrow endpoint now receives `x-kobo-userkey` and the decoded Kobo cursor, the raw-token path forwards verbatim, and the no-cursor path omits the header. The PoC lives outside this repo and is not part of the change.

## Risk and rollback

- All headers the device sent before this commit are still forwarded (we went from allow-list to deny-list, so the set can only grow, not shrink).
- The sync-token handling in `forward()` is new, but it only changes behavior when the device sent an `x-kobo-synctoken`. Devices without one (first sync after install) keep their previous behavior. Devices that sent raw Kobo tokens before BookOrbit keep their previous behavior (forwarded verbatim).
- The store-sync page in `librarySync` is untouched. Its interaction with the proxy via `extraHeaders`/`omitHeaders` is preserved.

Rollback is `git revert` of this single commit.

## Related

- Closes #738
- Ref #789 (the explicit `library/sync` call already does the same thing for that one path; this PR is the catch-all side of the same fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Kobo device borrowing and synchronization by forwarding authentication and sync-token information correctly.
  * Supports composite sync tokens and handles missing synchronization cursors gracefully.
  * Preserves relevant request headers while excluding connection-specific and host-related headers.
* **Bug Fixes**
  * Improved validation and filtering of proxied requests and upstream responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->