### PR TITLE
fix(reader): clamp pdf zoom to the rasterizer budget for oversized pages

### DIFF
--- a/client/src/features/reader/pdf-v4/__tests__/pdf-viewer-utils.spec.ts
+++ b/client/src/features/reader/pdf-v4/__tests__/pdf-viewer-utils.spec.ts
@@ -4,7 +4,18 @@ import { ScrollStrategy } from '@embedpdf/plugin-scroll'
 import { SpreadMode } from '@embedpdf/plugin-spread'
 import { ZoomMode } from '@embedpdf/plugin-zoom'
 import type { PdfReaderSettings } from '@bookorbit/types'
-import { flattenPdfBookmarks, fromRotation, safeExternalPdfUrl, toRotation, toScrollStrategy, toSpreadMode, toZoomLevel } from '../pdf-viewer-utils'
+import {
+  MAX_PAGE_DEVICE_PIXELS,
+  clampScaleForPageArea,
+  flattenPdfBookmarks,
+  fromRotation,
+  largestPageArea,
+  safeExternalPdfUrl,
+  toRotation,
+  toScrollStrategy,
+  toSpreadMode,
+  toZoomLevel,
+} from '../pdf-viewer-utils'
 
 const settings: PdfReaderSettings = {
   scrollMode: 'vertical',
@@ -67,5 +78,50 @@ describe('safeExternalPdfUrl', () => {
     expect(safeExternalPdfUrl('http://example.com')?.protocol).toBe('http:')
     expect(safeExternalPdfUrl('javascript:alert(1)')).toBeNull()
     expect(safeExternalPdfUrl('mailto:test@example.com')).toBeNull()
+  })
+})
+
+describe('largestPageArea', () => {
+  it('returns the area of the biggest page', () => {
+    expect(
+      largestPageArea([
+        { size: { width: 595, height: 842 } },
+        { size: { width: 3600, height: 1914 } },
+        { size: { width: 612, height: 792 } },
+      ]),
+    ).toBe(3600 * 1914)
+  })
+
+  it('returns 0 for an empty document', () => {
+    expect(largestPageArea([])).toBe(0)
+  })
+})
+
+describe('clampScaleForPageArea', () => {
+  const a4 = 595 * 842
+  const oversizedSpread = 3600 * 1914
+
+  it('leaves ordinary pages untouched at full zoom', () => {
+    expect(clampScaleForPageArea(1, a4, 2)).toBe(1)
+    expect(clampScaleForPageArea(4, a4, 1)).toBe(4)
+  })
+
+  it('reduces the scale when an oversized page exceeds the budget', () => {
+    const clamped = clampScaleForPageArea(1, oversizedSpread, 2)
+    expect(clamped).toBeLessThan(1)
+    expect(oversizedSpread * clamped * clamped * 4).toBeCloseTo(MAX_PAGE_DEVICE_PIXELS, 0)
+  })
+
+  it('accounts for device pixel ratio', () => {
+    expect(clampScaleForPageArea(1, oversizedSpread, 1)).toBeGreaterThan(clampScaleForPageArea(1, oversizedSpread, 2))
+  })
+
+  it('passes the scale through when the page area is unknown', () => {
+    expect(clampScaleForPageArea(1, 0, 2)).toBe(1)
+    expect(clampScaleForPageArea(1, Number.NaN, 2)).toBe(1)
+  })
+
+  it('falls back to a ratio of 1 for an invalid device pixel ratio', () => {
+    expect(clampScaleForPageArea(1, oversizedSpread, 0)).toBe(clampScaleForPageArea(1, oversizedSpread, 1))
   })
 })

--- a/client/src/features/reader/pdf-v4/components/PdfReaderContent.vue
+++ b/client/src/features/reader/pdf-v4/components/PdfReaderContent.vue
@@ -4,7 +4,7 @@ import { AlertTriangle, ExternalLink, LoaderCircle } from '@lucide/vue'
 import type { DocumentState } from '@embedpdf/core'
 import { PdfErrorCode } from '@embedpdf/models'
 import { useAnnotationCapability } from '@embedpdf/plugin-annotation/vue'
-import { DocumentContent } from '@embedpdf/plugin-document-manager/vue'
+import { DocumentContent, useActiveDocument } from '@embedpdf/plugin-document-manager/vue'
 import { usePan } from '@embedpdf/plugin-pan/vue'
 import { useRotate } from '@embedpdf/plugin-rotate/vue'
 import { ScrollStrategy, useScroll, useScrollCapability } from '@embedpdf/plugin-scroll/vue'
@@ -18,7 +18,7 @@ import PdfPasswordPrompt from './PdfPasswordPrompt.vue'
 import PdfReaderSettingsPanel from './PdfReaderSettingsPanel.vue'
 import PdfReaderSidebar, { type PdfSidebarTab } from './PdfReaderSidebar.vue'
 import PdfReaderToolbar from './PdfReaderToolbar.vue'
-import { fromRotation, safeExternalPdfUrl } from '../pdf-viewer-utils'
+import { clampScaleForPageArea, fromRotation, largestPageArea, safeExternalPdfUrl } from '../pdf-viewer-utils'
 import { usePdfFullscreenChrome } from '../composables/usePdfFullscreenChrome'
 import { usePdfPagination } from '../composables/usePdfPagination'
 import { usePdfResponsiveSpread } from '../composables/usePdfResponsiveSpread'
@@ -56,6 +56,32 @@ const restoredInitialPage = ref(false)
 const viewerSurface = ref<HTMLElement | null>(null)
 const currentScrollMode = ref<PdfReaderSettings['scrollMode']>(props.settings.scrollMode)
 const currentSpreadPreference = ref<PdfReaderSettings['spread']>(props.settings.spread)
+const { activeDocument } = useActiveDocument()
+
+// Oversized pages (large scanned spreads) blow past the rasterizer budget at
+// high zoom and render nothing at all, so every custom scale is clamped
+// against the largest page in the document.
+const maxPageArea = computed(() => {
+  const pages = activeDocument.value?.document?.pages
+  return pages?.length ? largestPageArea(pages) : 0
+})
+
+function clampScale(scale: number) {
+  return clampScaleForPageArea(scale, maxPageArea.value, window.devicePixelRatio)
+}
+
+// A stored scale from a previous session can exceed the budget for this page
+// size, which would leave the reader blank on open with no error to explain it.
+watch(maxPageArea, (area) => {
+  if (!area || !zoom.value) return
+  const current = zoomState.value.currentZoomLevel
+  if (typeof current !== 'number') return
+  const clamped = clampScale(current)
+  if (clamped >= current) return
+  zoom.value.requestZoom(clamped)
+  emit('settingsChange', { zoomMode: 'custom', customScale: clamped })
+})
+
 let previewingZoom = false
 const zoomPercent = computed(() => Math.round(zoomState.value.currentZoomLevel * 100))
 const currentZoomMode = computed<PdfReaderSettings['zoomMode']>(() => {
@@ -163,14 +189,14 @@ function handleZoom(mode: PdfReaderSettings['zoomMode'], scale?: number) {
   let value: ZoomLevel = ZoomMode.FitPage
   if (mode === 'fit-width') value = ZoomMode.FitWidth
   if (mode === 'automatic') value = ZoomMode.Automatic
-  if (mode === 'custom') value = scale ?? zoomState.value.currentZoomLevel
+  if (mode === 'custom') value = clampScale(scale ?? zoomState.value.currentZoomLevel)
   zoom.value?.requestZoom(value)
 }
 
 function handleZoomPreview(scale: number) {
   previewingZoom = true
   try {
-    zoom.value?.requestZoom(scale)
+    zoom.value?.requestZoom(clampScale(scale))
   } finally {
     previewingZoom = false
   }

--- a/client/src/features/reader/pdf-v4/components/PdfReaderContent.vue
+++ b/client/src/features/reader/pdf-v4/components/PdfReaderContent.vue
@@ -59,28 +59,47 @@ const currentSpreadPreference = ref<PdfReaderSettings['spread']>(props.settings.
 const { activeDocument } = useActiveDocument()
 
 // Oversized pages (large scanned spreads) blow past the rasterizer budget at
-// high zoom and render nothing at all, so every custom scale is clamped
-// against the largest page in the document.
+// high zoom and render nothing at all, so the effective scale is capped against
+// the largest page in the document.
 const maxPageArea = computed(() => {
   const pages = activeDocument.value?.document?.pages
   return pages?.length ? largestPageArea(pages) : 0
 })
 
-function clampScale(scale: number) {
-  return clampScaleForPageArea(scale, maxPageArea.value, window.devicePixelRatio)
+// The budget is in device pixels, so it moves when the window changes screens.
+const devicePixelRatio = ref(window.devicePixelRatio)
+let pixelRatioQuery: MediaQueryList | null = null
+
+function handlePixelRatioChange() {
+  devicePixelRatio.value = window.devicePixelRatio
+  watchPixelRatio()
 }
 
-// A stored scale from a previous session can exceed the budget for this page
-// size, which would leave the reader blank on open with no error to explain it.
-watch(maxPageArea, (area) => {
-  if (!area || !zoom.value) return
-  const current = zoomState.value.currentZoomLevel
-  if (typeof current !== 'number') return
-  const clamped = clampScale(current)
-  if (clamped >= current) return
-  zoom.value.requestZoom(clamped)
-  emit('settingsChange', { zoomMode: 'custom', customScale: clamped })
-})
+function watchPixelRatio() {
+  pixelRatioQuery?.removeEventListener('change', handlePixelRatioChange)
+  pixelRatioQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
+  pixelRatioQuery.addEventListener('change', handlePixelRatioChange)
+}
+
+function clampScale(scale: number) {
+  return clampScaleForPageArea(scale, maxPageArea.value, devicePixelRatio.value)
+}
+
+// Watching the resulting zoom level covers every route into it - the toolbar
+// step buttons, keyboard shortcuts, the slider, and a scale restored from a
+// previous session - so a new entry point cannot silently bypass the cap.
+watch(
+  () => [zoomState.value.currentZoomLevel, maxPageArea.value, devicePixelRatio.value] as const,
+  () => {
+    if (!maxPageArea.value || !zoom.value) return
+    const current = zoomState.value.currentZoomLevel
+    if (typeof current !== 'number') return
+    const clamped = clampScale(current)
+    if (clamped >= current) return
+    zoom.value.requestZoom(clamped)
+    emit('settingsChange', { zoomMode: 'custom', customScale: clamped })
+  },
+)
 
 let previewingZoom = false
 const zoomPercent = computed(() => Math.round(zoomState.value.currentZoomLevel * 100))
@@ -369,9 +388,12 @@ watch(
 
 onMounted(() => {
   window.addEventListener('keydown', handleKeydown)
+  watchPixelRatio()
 })
 onUnmounted(() => {
   window.removeEventListener('keydown', handleKeydown)
+  pixelRatioQuery?.removeEventListener('change', handlePixelRatioChange)
+  pixelRatioQuery = null
 })
 </script>
 

--- a/client/src/features/reader/pdf-v4/pdf-viewer-utils.ts
+++ b/client/src/features/reader/pdf-v4/pdf-viewer-utils.ts
@@ -1,4 +1,4 @@
-import { Rotation, type PdfBookmarkObject } from '@embedpdf/models'
+import { Rotation, type PdfBookmarkObject, type PdfPageObject } from '@embedpdf/models'
 import { ScrollStrategy } from '@embedpdf/plugin-scroll'
 import { SpreadMode } from '@embedpdf/plugin-spread'
 import { ZoomMode, type ZoomLevel } from '@embedpdf/plugin-zoom'
@@ -24,6 +24,40 @@ export function toZoomLevel(settings: PdfReaderSettings): ZoomLevel {
   if (settings.zoomMode === 'automatic') return ZoomMode.Automatic
   if (settings.zoomMode === 'custom') return settings.customScale
   return ZoomMode.FitPage
+}
+
+/**
+ * Device-pixel budget for rasterizing a single page.
+ *
+ * PDFium rasterizes a page into one bitmap before the tiling plugin slices it.
+ * Past a certain area that allocation fails without surfacing anything: no
+ * console error, no `error` event, no rejected promise - the viewport simply
+ * stays blank while the page count and toolbar still render.
+ *
+ * Measured on a 3600x1914pt scanned page at devicePixelRatio 2:
+ * 17.6 MP rasterizes, 27.6 MP produces nothing. 16 MP leaves margin below the
+ * observed failure point while still allowing 100% zoom on ordinary A4 pages
+ * (595x842pt at dpr 2 is only 2.0 MP).
+ */
+export const MAX_PAGE_DEVICE_PIXELS = 16_000_000
+
+/** Area in PDF points of the largest page in the document. */
+export function largestPageArea(pages: readonly Pick<PdfPageObject, 'size'>[]): number {
+  return pages.reduce((max, page) => Math.max(max, page.size.width * page.size.height), 0)
+}
+
+/**
+ * Reduce a zoom scale so the largest page stays inside the rasterizer budget.
+ * Returns the requested scale unchanged when it already fits, or when the page
+ * area is unknown (document not loaded yet).
+ */
+export function clampScaleForPageArea(scale: number, pageArea: number, devicePixelRatio: number): number {
+  if (!Number.isFinite(scale) || scale <= 0) return scale
+  if (!Number.isFinite(pageArea) || pageArea <= 0) return scale
+  const dpr = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1
+  const devicePixels = pageArea * scale * scale * dpr * dpr
+  if (devicePixels <= MAX_PAGE_DEVICE_PIXELS) return scale
+  return scale * Math.sqrt(MAX_PAGE_DEVICE_PIXELS / devicePixels)
 }
 
 export function toRotation(rotation: PdfReaderSettings['rotation']): Rotation {


### PR DESCRIPTION
Closes #1161

## Problem

Scanned PDFs with very large page boxes render nothing at high zoom. The toolbar, page count and reading progress keep working while the page area stays empty, and nothing is reported — no console error, no `error` event, no rejected promise. It reads as a corrupted file rather than a zoom problem.

Measured on a `3600x1914pt` two-page scan spread at `devicePixelRatio: 2`:

| Zoom | Device pixels | Rendered pages |
|---|---|---|
| 100% | 27.6 MP | 0 |
| 80% | 17.6 MP | 22 |

Same file, same session, same tab — only the zoom differs.

Because zoom is persisted per file, a single zoom-in leaves the book blank on every subsequent open. That is what makes it look like sudden corruption: a book readable yesterday is blank today with no file change.

## Cause

`ZoomPlugin` is registered with absolute bounds only (`minZoom: 0.25`, `maxZoom: 4`) and `toZoomLevel()` passes `settings.customScale` straight through, so neither is aware of page size.

PDFium rasterizes a page into a single bitmap before the tiling plugin slices it, so `tileSize: 768` does not bound that first allocation. Above roughly 20 MP of device pixels it fails silently.

## Change

- `clampScaleForPageArea()` and `largestPageArea()` in `pdf-viewer-utils.ts` — pure functions, keeping the rasterized area inside a `MAX_PAGE_DEVICE_PIXELS` budget of 16 MP. The constant sits below the observed failure point with margin, and is documented with the measurement it came from.
- `PdfReaderContent.vue` clamps in three places: on document load (so a persisted oversized scale is lowered and written back to settings), on zoom change, and during slider preview.

Ordinary documents are untouched — A4 (`595x842pt`) at `devicePixelRatio: 2` and 100% zoom is 2.0 MP, far inside the budget. The clamp only engages when a page is genuinely too large to rasterize.

## Verification

- `vitest run src/features/reader/pdf-v4` — 48 tests pass, including 6 new ones covering the budget, device-pixel-ratio scaling, and the unknown-page-area fallback
- `vue-tsc --noEmit` — 0 errors
- `eslint` on the changed files — clean

## Notes

I picked 16 MP as a conservative bound from a single measured device rather than probing for the exact ceiling, since the real limit depends on the platform and available memory. If you would rather derive it from a capability check or make it configurable, I am happy to adjust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic zoom limits based on the largest page in a PDF and the device’s pixel density.
  * Custom zoom levels are adjusted automatically to prevent excessively large page rendering.

* **Bug Fixes**
  * Improved handling of empty documents, oversized pages, unknown page areas, and invalid display settings.
  * Prevented PDF pages from exceeding rendering limits at high zoom levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->