### PR TITLE
i18n(client): sync translations from Crowdin

### DIFF
--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -2674,7 +2674,19 @@
         "deviceRemoved": "Gerät entfernt",
         "removeDeviceFailed": "Entfernen des Geräts fehlgeschlagen",
         "removeDeviceConfirmTitle": "{device} entfernen?",
-        "removeDeviceConfirmBody": "Dies löscht dauerhaft den synchronisierten Fortschritt, die Leseaktivität und alle nicht zugeordneten Bucheinträge dieses Geräts, die von keinem anderen Gerät mehr gemeldet werden. Wenn das Gerät später erneut synchronisiert, erscheint es wieder als neuer Eintrag."
+        "removeDeviceConfirmBody": "Dies löscht dauerhaft den synchronisierten Fortschritt, die Leseaktivität und alle nicht zugeordneten Bucheinträge dieses Geräts, die von keinem anderen Gerät mehr gemeldet werden. Wenn das Gerät später erneut synchronisiert, erscheint es wieder als neuer Eintrag.",
+        "retire": "Archivieren",
+        "retiring": "Archiviert...",
+        "restore": "Wiederherstellen",
+        "restoring": "Wiederherstellen...",
+        "deleteSyncedData": "Daten löschen",
+        "deletingSyncedData": "Lösche...",
+        "deviceRetired": "Gerät Archiviert",
+        "deviceRestored": "Gerät wiederhergestellt",
+        "retireDeviceFailed": "Gerät kann nicht archiviert werden",
+        "restoreDeviceFailed": "Gerät konnte nicht wiederhergestellt werden",
+        "retiredDevices": "{count, plural, one {# Gerät Archiviert} other {# Geräte Archiviert}}",
+        "retiredOnLabel": "Archiviert"
       },
       "opds": {
         "title": "OPDS",
@@ -2741,6 +2753,14 @@
         "book-dock": "Book Dock",
         "maintenance": "Wartung",
         "audit-log": "Prüfprotokoll"
+      }
+    },
+    "nav": {
+      "title": "Einstellungen",
+      "descriptions": {
+        "appearanceLayout": "Standard Bibliotheksansicht, Dichte und Abstand.",
+        "appearanceBehavior": "Wie die Bibliothek reagiert, wie Sie suchen und sortieren.",
+        "appearanceLanguage": "Interface-Sprache und regionale Formate."
       }
     }
   },
@@ -3025,7 +3045,45 @@
       },
       "pagination": {
         "label": "Benutzer-Seitennavigation",
-        "page": "Seite {page} von {totalPages}"
+        "page": "Seite {page} von {totalPages}",
+        "showing": "{shown} von {total} Konten anzeigen"
+      },
+      "editUserAria": "{name} bearbeiten",
+      "resetPasswordAria": "Passwort für {name} zurücksetzen",
+      "deleteUserAria": "{name} löschen",
+      "moreActionsAria": "Weitere Aktionen für {name}",
+      "headerSummary": "{count, plural, =0 {Keine Konten} one {# Konto} other {# Konten}} · {admins} mit Administratorzugriff",
+      "noEmail": "Keine Adresse",
+      "editAccount": "Account bearbeiten",
+      "cardMeta": "{access} · {libraries} · {lastActive}",
+      "accessTier": {
+        "superuser": "Superuser",
+        "admin": "Administrator",
+        "standard": "Standard",
+        "custom": "Benutzerdefiniert",
+        "none": "Kein Zugriff"
+      },
+      "libraries": {
+        "all": "Alle {total}",
+        "some": "{granted} von {total}"
+      },
+      "statusLocked": "Gesperrt",
+      "status": {
+        "never": "Nie",
+        "neverSignedIn": "Nie angemeldet",
+        "defaultPassword": "Standardpasswort",
+        "contentFiltered": "Inhalt gefiltert",
+        "unlocksIn": "Freigeschaltet {when}"
+      },
+      "attention": {
+        "title": "Erfordert Aufmerksamkeit",
+        "count": "{count, plural, one {# Konto} other {# Konten}}",
+        "filter": "{count, plural, one {# benötigt Aufmerksamkeit} other {# benötigen Aufmerksamkeit}}",
+        "more": "{count} weitere nicht hier angezeigt",
+        "reason": {
+          "locked": "{name} ist nach zu vielen fehlgeschlagenen Anmeldungen gesperrt",
+          "neverSignedIn": "{name} hat sich noch nie angemeldet"
+        }
       }
     }
   },
@@ -3162,7 +3220,15 @@
         "bulkRestored": "{count, plural, =0 {Keine Markierungen wiederhergestellt} one {# Markierung wiederhergestellt} other {# Markierungen wiederhergestellt}}",
         "bulkRecolored": "{count, plural, =0 {Farbe für keine Markierung geändert} one {Farbe für # Markierung geändert} other {Farbe für # Markierungen geändert}}",
         "bulkRestyled": "{count, plural, =0 {Stil für keine Markierung geändert} one {Stil für # Markierung geändert} other {Stil für # Markierungen geändert}}"
-      }
+      },
+      "views": {
+        "color": "Nach Farbe",
+        "source": "Nach Quelle"
+      },
+      "matchCount": "{shown} von {total}",
+      "moreActions": "Weitere Aktionen",
+      "loadMore": "{count, plural, one {Lade 1 mehr} other {Lade # mehr}}",
+      "openBook": "Buch öffnen"
     }
   },
   "audit": {

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -3323,7 +3323,16 @@
         "noMatch": "Aucun passage surligné ne correspond à vos filtres.",
         "resetFilters": "Réinitialiser les filtres",
         "trashEmpty": "La corbeille est vide",
-        "noAnnotations": "Aucun passage surligné pour l'instant. Vos futurs passages surlignés et notes apparaîtront ici."
+        "noAnnotations": "Aucun passage surligné pour l'instant. Vos futurs passages surlignés et notes apparaîtront ici.",
+        "noMatchHint": "Essayez une expression plus courte, ou effacez les filtres de couleur et de livre.",
+        "noAnnotationsBody": "Tout ce que vous marquez, dans n'importe quel livre et sur n'importe quel appareil, se retrouve ici.",
+        "readHere": "Lisez ici",
+        "readHereBody": "Sélectionnez du texte dans le lecteur et choisissez une couleur.",
+        "syncKobo": "Synchroniser une Kobo",
+        "syncKoboBody": "Les marques faites sur l'appareil arrivent à la synchronisation suivante.",
+        "syncKoreader": "Synchroniser KOReader",
+        "syncKoreaderBody": "Le plugin envoie les annotations avec leur position.",
+        "goToLibrary": "Aller à la bibliothèque"
       },
       "toast": {
         "movedToTrash": "Déplacé vers la corbeille",
@@ -3333,8 +3342,70 @@
         "bulkTrashed": "{count, plural, =0 {Aucune annotation déplacée vers la corbeille} one {Déplacé # annotation à la corbeille} other {Déplacé # annotations à la corbeille} many {Déplacé # annotations à la corbeille}}",
         "bulkRestored": "{count, plural, =0 {Restauré sans annotations} one {Restauré # annotation} other {Restauré # annotations} many {Restauré # annotations}}",
         "bulkRecolored": "{count, plural, =0 {Recoloré sans annotations} one {Recoloré # annotation} other {Recoloré # annotations} many {Recoloré # annotations}}",
-        "bulkRestyled": "{count, plural, =0 {Aucune annotation restylée} one {# annotation restylée} other {# annotations restylées} many {# annotations restylées}}"
-      }
+        "bulkRestyled": "{count, plural, =0 {Aucune annotation restylée} one {# annotation restylée} other {# annotations restylées} many {# annotations restylées}}",
+        "noteSaved": "Remarque enregistrée"
+      },
+      "railTitle": "{marks} marques · {books} livres",
+      "lastTwelveMonths": "12 derniers mois",
+      "colour": "Couleur",
+      "whereFrom": "Provenance",
+      "theShelf": "L'étagère",
+      "devices": "Appareils",
+      "allBooks": "Les {count} livres",
+      "behindCount": "{count, plural, one {# en retard} other {# en retard} many {# en retard}}",
+      "busiestWeek": "Semaine la plus chargée",
+      "longestQuiet": "Plus longue période creuse",
+      "mostMarked": "Le plus marqué",
+      "weekCount": "{count, plural, one {# semaine} other {# semaines} many {# semaines}}",
+      "anchorsUnplaced": "{count, plural, one {# ancre n'a pas pu être placée} other {# ancres n'ont pas pu être placées} many {# ancres n'ont pas pu être placées}}",
+      "reviewThem": "Les vérifier",
+      "anchorLost": "Ancre perdue",
+      "anchorRepaired": "Réparée",
+      "notes": "Remarques",
+      "review": "À vérifier",
+      "viewLabel": "Grouper et trier",
+      "views": {
+        "newest": "Plus récents d'abord",
+        "oldest": "Plus anciens d'abord",
+        "book": "Par livre",
+        "color": "Par couleur",
+        "source": "Par provenance"
+      },
+      "matchCount": "{shown} sur {total}",
+      "moreActions": "Plus d'actions",
+      "loadMore": "{count, plural, one {En charger 1 de plus} other {En charger # de plus} many {En charger # de plus}}",
+      "openBook": "Ouvrir le livre",
+      "noteLabel": "Remarque",
+      "yourNote": "Votre remarque",
+      "notePlaceholder": "Dites pourquoi cela comptait.",
+      "openAtThisPage": "Ouvrir à cette page",
+      "positionAndSync": "Position et synchronisation",
+      "loadFailed": "Impossible de charger vos passages surlignés. Réessayez dans un instant.",
+      "chips": {
+        "dateBetween": "de {from} à {to}",
+        "dateFrom": "À partir de {from}",
+        "dateUntil": "Jusqu'à {to}"
+      },
+      "activitySummary": "{count, plural, one {# passage surligné entre {from} et {to}} other {# passages surlignés entre {from} et {to}} many {# passages surlignés entre {from} et {to}}}",
+      "book": "Livre",
+      "needsReview": "À vérifier"
+    },
+    "sources": {
+      "web": "Web",
+      "koreader": "KOReader",
+      "kobo": "Kobo"
+    },
+    "colors": {
+      "yellow": "Jaune",
+      "green": "Vert",
+      "blue": "Bleu",
+      "pink": "Rose",
+      "orange": "Orange",
+      "red": "Rouge",
+      "olive": "Olive",
+      "cyan": "Cyan",
+      "purple": "Violet",
+      "gray": "Gris"
     }
   },
   "audit": {
@@ -3706,7 +3777,15 @@
       "deleteAuthor": "Supprimer l'auteur"
     },
     "filters": {
-      "allLibraries": "Toutes les bibliothèques"
+      "allLibraries": "Toutes les bibliothèques",
+      "chips": {
+        "groupLabel": "Filtrer les auteurs",
+        "all": "Tous",
+        "noPortrait": "Sans portrait",
+        "multipleBooks": "2 livres et plus",
+        "recentlyAdded": "Ajoutés cette semaine",
+        "noSortName": "Sans nom de tri"
+      }
     },
     "header": {
       "never": "Jamais",
@@ -3853,6 +3932,16 @@
         "deleteSuccess": "Auteur supprimé ; {books} livres concernés",
         "deleteFailed": "Échec de la suppression de l'auteur"
       }
+    },
+    "portrait": {
+      "fromTheirBook": "Couverture d'un de ses livres ; aucun portrait disponible"
+    },
+    "index": {
+      "bookCount": "{count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+      "rowLabel": "{name}, {count, plural, =0 {pas de livres} one {# livre} other {# livres} many {# livres}}",
+      "actionsFor": "Actions pour {name}",
+      "refreshing": "Actualisation des métadonnées de {name}",
+      "deleting": "Suppression de {name}"
     }
   },
   "book": {
@@ -4090,7 +4179,7 @@
       "reset": "Réinitialiser",
       "tableDensity": "Densité du tableau",
       "density": {
-        "compact": "Compacte",
+        "compact": "Compact",
         "comfortable": "Confortable",
         "roomy": "Spacieux"
       },
@@ -4598,10 +4687,10 @@
         "viewSyncLog": "Afficher le journal de synchronisation",
         "noWriteHistory": "Pas encore d'écriture d'historique.",
         "fieldsWritten": "{count, plural, =0 {pas de champs} one {un champ} other {# champs} many {# champs}}",
-        "track": "Suivre {number}",
+        "track": "Piste {number}",
         "primary": "Principal",
         "read": "Lire",
-        "play": "Jouer",
+        "play": "Écouter",
         "peek": "Aperçu",
         "download": "Télécharger",
         "moreActions": "Plus de propositions",
@@ -4630,6 +4719,66 @@
         "backToFolder": "Revenir au dossier",
         "copyPath": "Copier le chemin complet",
         "pathCopied": "Chemin copié dans le presse-papiers",
+        "resume": "Reprendre",
+        "audiobook": "Livre audio",
+        "writeTarget": "Cible d'écriture",
+        "enabled": "Activée",
+        "disabled": "Désactivée",
+        "notSet": "non défini",
+        "sortAdded": "Ajout",
+        "formatCount": "{count, plural, one {# format} other {# formats} many {# formats}}",
+        "trackCount": "{count, plural, one {# piste} other {# pistes} many {# pistes}}",
+        "formatsInFolder": "{count, plural, one {# format ici} other {# formats ici} many {# formats ici}}",
+        "compositionAria": "Répartition de la taille du dossier par format",
+        "percentRead": "{percent} lu",
+        "trackOf": "Piste {track} sur {total}",
+        "groups": {
+          "ebook": "Ebook",
+          "document": "Document",
+          "comic": "Bande dessinée",
+          "audio": "Audio",
+          "extras": "Suppléments"
+        },
+        "roles": {
+          "primary": "Principal",
+          "content": "Autre version",
+          "supplement": "Complément",
+          "cover": "Couverture"
+        },
+        "reader": {
+          "none": "Aucun lecteur",
+          "ebook": "Lecteur d'ebooks",
+          "document": "Lecteur PDF",
+          "comic": "Lecteur de bandes dessinées",
+          "audio": "Lecteur audio"
+        },
+        "spec": {
+          "format": "Format",
+          "role": "Rôle",
+          "size": "Taille",
+          "length": "Durée",
+          "added": "Ajouté le",
+          "indexed": "Indexé",
+          "opensIn": "S'ouvre dans",
+          "writeBack": "Réécriture",
+          "track": "Piste",
+          "targetFile": "Fichier cible",
+          "notWritten": "Non réécrit"
+        },
+        "duration": {
+          "hoursMinutes": "{hours} h {minutes} min",
+          "minutes": "{minutes} min",
+          "minutesSeconds": "{minutes} min {seconds} s",
+          "seconds": "{seconds} s"
+        },
+        "positionHeading": "Votre position dans cet exemplaire",
+        "copiesStarted": "{started} exemplaires commencés sur {total}",
+        "nothingStarted": "Rien de commencé",
+        "throughFile": "{percent} de ce fichier lu",
+        "notOpened": "Jamais ouvert",
+        "lastRead": "Dernière lecture {time}",
+        "noPosition": "Aucune position de lecture enregistrée",
+        "trackPositionHeading": "Position de cette piste",
         "totalRuntime": "{duration} totale",
         "startsAt": "Commence à {time}",
         "trackLength": "{duration} totale",
@@ -4680,7 +4829,133 @@
           "hint": "Sélectionnez du texte pendant la lecture pour créer des passages surlignés"
         },
         "uncategorized": "Non classé",
-        "paginationUnit": "passages surlignés"
+        "paginationUnit": "passages surlignés",
+        "rail": {
+          "title": "Marques",
+          "unit": "{count, plural, one {passage surligné} other {passages surlignés} many {passages surlignés}}",
+          "withNotes": "portent une remarque",
+          "chaptersMarked": "chapitres marqués",
+          "ofChaptersMarked": "sur {total} chapitres marqués",
+          "colour": "Couleur",
+          "showOnly": "Afficher seulement {colour}",
+          "source": "Provenance",
+          "health": "État des positions",
+          "needsAttention": "{count, plural, one {# à vérifier} other {# à vérifier} many {# à vérifier}}",
+          "anchorLost": "{count, plural, one {une a perdu son ancre quand le fichier a changé} other {# ont perdu leur ancre quand le fichier a changé} many {# ont perdu leur ancre quand le fichier a changé}}",
+          "reAnchored": "{count, plural, one {une a été réancrée automatiquement} other {# ont été réancrées automatiquement} many {# ont été réancrées automatiquement}}",
+          "reviewPositions": "Vérifier les positions",
+          "span": "Étendue",
+          "firstMark": "Première marque",
+          "lastMark": "Dernière marque",
+          "markingDays": "Jours de marquage",
+          "exportCount": "Exporter {count}"
+        },
+        "row": {
+          "select": "Sélectionner ce passage surligné",
+          "showMore": "Afficher plus",
+          "showLess": "Afficher moins",
+          "note": "Remarque",
+          "addNote": "Ajouter une remarque",
+          "page": "p. {page}",
+          "anchorLost": "Ancre perdue",
+          "reAnchored": "Réancrée"
+        },
+        "stream": {
+          "title": "Le flux",
+          "searchPlaceholder": "Rechercher parmi {count} passages surlignés et remarques",
+          "all": "Tout",
+          "notes": "Remarques",
+          "review": "À vérifier",
+          "density": "Basculer entre lignes confortables et compactes",
+          "matchCount": "{shown} sur {total} correspondent",
+          "textChip": "texte « {query} »",
+          "marks": "{count, plural, one {# marque} other {# marques} many {# marques}}",
+          "loadingMore": "Chargement en cours"
+        },
+        "bulk": {
+          "selected": "{count} sélectionnés",
+          "selectAll": "Sélectionner les {count}",
+          "recolour": "Recolorer la sélection",
+          "recolourTo": "Recolorer en {colour}",
+          "clear": "Effacer la sélection"
+        },
+        "index": {
+          "title": "Index",
+          "groupBy": "Grouper le flux par",
+          "byChapter": "Chapitres",
+          "byColour": "Couleurs",
+          "byDay": "Jours"
+        },
+        "activity": {
+          "title": "Activité de marquage",
+          "days": "{count, plural, one {# jour} other {# jours} many {# jours}}",
+          "showAll": "Afficher les {count} jours",
+          "showFewer": "Afficher moins"
+        },
+        "inspector": {
+          "title": "Détail du passage surligné",
+          "back": "Retour à l'index",
+          "counter": "Marque {position} sur {total}",
+          "previous": "Marque précédente",
+          "next": "Marque suivante",
+          "notePrompt": "Pourquoi celui-ci comptait-il ? Les remarques sont consultables et suivent l'export.",
+          "style": "Style",
+          "position": "Position et synchronisation",
+          "openHere": "Ouvrir ici"
+        },
+        "band": {
+          "title": "Où sont les marques",
+          "subtitle": "chaque chapitre marqué dans l'ordre de lecture, avec la couleur que vous avez choisie",
+          "barTitle": "{chapter}, {count} marques",
+          "start": "Début",
+          "densest": "Le plus dense",
+          "marks": "{count, plural, one {# marque} other {# marques} many {# marques}}",
+          "longestGap": "Plus longue portion sans marque",
+          "chapters": "{count, plural, one {# chapitre} other {# chapitres} many {# chapitres}}",
+          "end": "Fin"
+        },
+        "emptyStage": {
+          "title": "Aucun passage surligné dans {title}",
+          "body": "Les passages surlignés arrivent de trois endroits, et cette page les rassemble tous sur une seule colonne.",
+          "openReader": "Ouvrir le lecteur",
+          "web": {
+            "title": "Lisez ici",
+            "body": "Sélectionnez du texte dans le lecteur intégré et choisissez une couleur."
+          },
+          "kobo": {
+            "title": "Synchroniser une Kobo",
+            "body": "Les passages surlignés faits sur l'appareil arrivent à la synchronisation suivante."
+          },
+          "koreader": {
+            "title": "Synchroniser KOReader",
+            "body": "Le plugin envoie les annotations avec leur position exacte."
+          }
+        },
+        "shortcuts": {
+          "title": "Clavier",
+          "description": "Raccourcis clavier de la liste des passages surlignés.",
+          "move": "Marque suivante / précédente",
+          "open": "Ouvrir l'inspecteur",
+          "back": "Retour à l'index",
+          "search": "Rechercher",
+          "note": "Écrire une remarque",
+          "recolour": "Recolorer",
+          "select": "Sélectionner cette marque",
+          "regroup": "Regrouper le flux",
+          "copy": "Copier la citation",
+          "reader": "Ouvrir dans le lecteur"
+        },
+        "railTitle": "{marks} marques · {chapters} chapitres",
+        "whenMarked": "Quand elles ont été marquées",
+        "chapters": "Chapitres",
+        "noChapter": "Sans chapitre",
+        "views": {
+          "position": "Dans l'ordre de lecture",
+          "newest": "Plus récents d'abord",
+          "oldest": "Plus anciens d'abord",
+          "colour": "Par couleur",
+          "source": "Par provenance"
+        }
       },
       "readingLog": {
         "resetReadingState": "Réinitialiser le statut de lecture",
@@ -4716,7 +4991,84 @@
           "colReached": "Atteint",
           "colSource": "Source",
           "colFormat": "Format",
-          "gapDays": "{count, plural, one {# jour sans lire} other {# jours sans lire}}"
+          "gapDays": "{count, plural, one {# jour sans lire} other {# jours sans lire}}",
+          "attemptBegan": "Début de la tentative {index}",
+          "attemptOutsideAny": "Hors de toute tentative",
+          "empty": "Aucune session enregistrée",
+          "emptyHint": "Ouvrez le livre dans le lecteur, synchronisez un appareil ou ajoutez une session à la main."
+        },
+        "attempts": {
+          "title": "Tentatives",
+          "none": "aucune",
+          "ordinal": "Tentative {index}",
+          "addPast": "Ajouter une tentative passée",
+          "reread": "Relire",
+          "rereadPrompt": "Démarrer une nouvelle tentative de lecture ?",
+          "rereadResetProgress": "Remet la position de lecture au début. Les appareils synchronisés peuvent recevoir cette remise à zéro.",
+          "rereadConfirm": "Démarrer la relecture",
+          "fieldStarted": "Début",
+          "fieldEnded": "Fin",
+          "fieldOutcome": "Issue",
+          "outcome": {
+            "completed": "Terminée",
+            "skimmed": "Parcourue",
+            "abandoned": "Abandonnée",
+            "inProgress": "En cours"
+          },
+          "spanRange": "de {from} à {to}",
+          "spanSince": "depuis {from}",
+          "spanEnded": "terminée {to}",
+          "spanUnknown": "Aucune date enregistrée",
+          "sessionCount": "{count, plural, one {# session} other {# sessions} many {# sessions}}",
+          "endBeforeStart": "La date de fin doit être égale ou postérieure à la date de début.",
+          "editAria": "Modifier cette tentative",
+          "deleteAria": "Supprimer cette tentative",
+          "cancelDeleteAria": "Annuler la suppression de cette tentative",
+          "confirmDeleteAria": "Confirmer la suppression de cette tentative",
+          "empty": "Aucune tentative enregistrée",
+          "emptyHint": "Démarrez une relecture, ou ajoutez une tentative terminée avant l'existence de cette bibliothèque."
+        },
+        "records": {
+          "title": "Records",
+          "longestSession": "Session la plus longue",
+          "bestDay": "Meilleure journée",
+          "longestStreak": "Plus longue série",
+          "streakDays": "{count, plural, one {# jour} other {# jours} many {# jours}}",
+          "pace": "Rythme de lecture",
+          "jumpedBack": "Retours en arrière",
+          "jumpedBackTimes": "{count, plural, one {# fois} other {# fois} many {# fois}}",
+          "firstOpened": "Première ouverture",
+          "empty": "Les records apparaîtront dès que ce livre aura des sessions."
+        },
+        "band": {
+          "curve": "Courbe",
+          "trace": "Tracé",
+          "switchAria": "Type de graphique",
+          "curveTitle": "Progression dans le temps",
+          "traceTitle": "Où vous en étiez dans le livre",
+          "curveSubDays": "{active} jours actifs sur {total}",
+          "curveSubSitting": "d'une traite, session par session",
+          "traceSub": "chaque barre est le passage couvert par une session",
+          "traceSubWithBacktracks": "{count, plural, one {chaque barre est une session, # retour en arrière} other {chaque barre est une session, # retours en arrière} many {chaque barre est une session, # retours en arrière}}",
+          "legendPosition": "Position atteinte",
+          "legendMinutes": "Minutes lues",
+          "legendBacktrack": "Retours en arrière",
+          "traceEmpty": "Aucun tracé",
+          "traceEmptyHint": "Dès qu'il y aura des sessions, ceci montrera le passage du livre couvert par chacune, et les endroits où vous êtes revenu en arrière.",
+          "tooltipCovered": "De {from} % à {to} %",
+          "tooltipMinutes": "{minutes} min"
+        },
+        "emptyStage": {
+          "title": "Rien d'enregistré pour ce livre",
+          "description": "Un journal de lecture se construit à partir des sessions. BookOrbit en enregistre une chaque fois que vous lisez dans le lecteur web, et récupère le reste depuis les appareils que vous synchronisez.",
+          "readerTitle": "Lisez ici",
+          "readerBody": "Chaque minute passée dans le lecteur BookOrbit est enregistrée automatiquement.",
+          "koreaderTitle": "Synchroniser KOReader",
+          "koreaderBody": "Le plugin renvoie chaque séance, avec la page que vous avez atteinte.",
+          "koboTitle": "Synchroniser une Kobo",
+          "koboBody": "Branchez l'appareil et BookOrbit lit son propre compteur de temps de lecture.",
+          "addSession": "Ajouter une session à la main",
+          "recordPast": "Enregistrer une lecture passée"
         },
         "moreActionsAria": "Plus d'actions de journal de lecture",
         "export": {
@@ -4820,7 +5172,7 @@
         },
         "table": {
           "title": "Séances",
-          "sourceWeb": "Internet",
+          "sourceWeb": "Web",
           "sourceManual": "Manuel",
           "colDate": "Date",
           "colDateMobile": "Date",
@@ -5499,7 +5851,16 @@
         "columnsHint": "Utilisez le panneau de visibilité des colonnes dans l'en-tête du tableau pour afficher ou masquer les colonnes.",
         "coverShape": "Forme de la couverture",
         "circle": "Rond",
-        "square": "Carré"
+        "square": "Carré",
+        "rowDensity": "Hauteur des lignes",
+        "densityCompact": "Compact",
+        "densityComfortable": "Confortable",
+        "densityRoomy": "Spacieux",
+        "coverFallback": "Utiliser les couvertures de livres à défaut de portrait"
+      },
+      "viewModes": {
+        "grid": "Vue en grille",
+        "list": "Vue en liste"
       }
     },
     "iconPicker": {
@@ -7841,6 +8202,9 @@
       "sort": "Trier",
       "sortOn": "Sur",
       "resetSort": "Réinitialiser le tri par défaut",
+      "shuffle": "Mélanger",
+      "shuffleAria": "Mélanger l'ordre des livres",
+      "shuffleHint": "Tirer un nouvel ordre aléatoire",
       "filters": "Filtres",
       "clear": "Effacer",
       "clearAllFilters": "Supprimer tous les filtres",

--- a/client/src/locales/ja.json
+++ b/client/src/locales/ja.json
@@ -1050,6 +1050,7 @@
         "scanStartFailed": "\"{name}\" のスキャンを開始できませんでした",
         "refreshCoversFailed": "\"{name}\" のカバーを更新できませんでした",
         "scanStartedAll": "すべてのライブラリのスキャンが開始されました",
+        "librariesFailedToStart": "{count, plural, =0 {開始に失敗したライブラリはありません} one {# ライブラリの開始に失敗しました} other {# ライブラリの開始に失敗しました}}",
         "scansStartFailed": "スキャンの開始に失敗しました",
         "libraryCreated": "ライブラリ \"{name}\" を作成しました",
         "libraryUpdated": "ライブラリ \"{name}\" が更新されました",
@@ -2723,7 +2724,8 @@
         "failedToDelete": "削除に失敗",
         "bulkTrashed": "{count, plural, =0 {アノテーションをゴミ箱に移動しました} one {アノテーションをゴミ箱に移動しました} other {アノテーションをゴミ箱に移動しました}}",
         "bulkRestored": "{count, plural, =0 {ノーアノテーション} one {リストアされた#アノテーション} other {リストアされた#アノテーション}}",
-        "bulkRecolored": "{count, plural, =0 {ノーアノテーションを再着色しました} one {recolored # annotation} other {recolored # annotations}}"
+        "bulkRecolored": "{count, plural, =0 {ノーアノテーションを再着色しました} one {recolored # annotation} other {recolored # annotations}}",
+        "bulkRestyled": "{count, plural, =0 {リセットされたアノテーションはありません} one {リセットされた # アノテーション} other {リセットされた # アノテーション}}"
       }
     }
   },
@@ -5087,6 +5089,7 @@
       "template": "テンプレート",
       "default": "デフォルト",
       "send": "送信",
+      "queued": "{count, plural, =0 {キューに入れられたメールはありません} one {1 つのメールがキューに入れられました} other {# 件のメールがキューに入れられました}}",
       "failed": "送信に失敗しました"
     }
   },
@@ -6585,6 +6588,7 @@
       },
       "confirmDialog": {
         "title": "一括リネームを確認",
+        "body": "{count, plural, =0 {ディスク上の # 本の名前を変更します。衝突やエラーのあるファイルはスキップされます。この操作は元に戻せません。} one {ディスク上の # 本の名前を変更します。衝突やエラーのあるファイルはスキップされます。この操作は元に戻せません。} other {ディスク上の # 冊のブックの名前が変更されます。衝突またはエラーのあるファイルはスキップされます。この操作は元に戻せません。}}",
         "renameButton": "{count, plural, =0 {リネーム # 本} one {リネーム # 本} other {リネーム # 本}}"
       }
     },

--- a/client/src/locales/ko.json
+++ b/client/src/locales/ko.json
@@ -4376,6 +4376,7 @@
         "saveInProgress": "진행도 저장",
         "writeManualLibraryDisabled": "파일에 메타데이터를 기록하고 디스크에서 이름을 변경합니다. 이 라이브러리에서는 자동 다시 쓰기 기능이 비활성화되어 있습니다.",
         "writeManualTooltip": "{fields}을(를) {target} 내부에 작성하고 디스크에서 이름을 변경합니다.",
+        "applyResult": "{skipped}, {updated}",
         "skippedLockedFields": "{count, plural, =0 {잠긴 필드 0개 건너뜀} one {잠긴 필드 #개 건너뜀} other {잠긴 필드 #개 건너뜀}}",
         "updatedFields": "{count, plural, =0 {0개 필드 업데이트됨} one {1개 필드 업데이트됨} other {#개 필드 업데이트됨}}",
         "wroteFieldsToFile": "{fields}을(를) 파일에 작성했습니다.",
@@ -6542,6 +6543,7 @@
       "title": "중복 타겟 매칭 해결",
       "explanation": "각 타겟 도서별로 보존할 소스 도서 하나를 선택하세요. 가장 유력한 매칭이 하나일 경우, 추천 선택지는 미리 선택되어 있습니다.",
       "remainingGroups": "남은 그룹:",
+      "ofCount": "(전체 {total}개)",
       "targetBookId": "타겟 도서 #{id}",
       "recommended": "추천",
       "resolveButton": "{count, plural, =0 {#개 중복 해결} one {#개 중복 해결} other {#개 중복 해결}}",
@@ -6622,7 +6624,8 @@
       "unresolvedBooksExplanation": "이 책들은 소스에는 존재하지만, 사용자의 라이브러리에 있는 어떤 책과도 일치하는 항목을 찾을 수 없었습니다.",
       "mappedUsers": "매핑된 사용자 ({count})",
       "mappedUsersExplanation": "사용자별 총계는 마이그레이션 계획과 함께 캐시된 모의 테스트 미리보기에서 가져옵니다.",
-      "coverFailures": "{count}개의 표지를 가져오지 못했습니다. 상세 실패 내역은 저장되지 않습니다."
+      "coverFailures": "{count}개의 표지를 가져오지 못했습니다. 상세 실패 내역은 저장되지 않습니다.",
+      "userPreviewCounts": "{statuses}개 상태, {progress}개 진행 항목, {sessions}개 독서 세션, {bookmarks}개 북마크, {annotations}개 메모, {collections}개 컬렉션 항목"
     },
     "unresolvedReason": {
       "noTitleAuthorMatch": "제목이나 저자가 일치하는 책을 찾을 수 없음",
@@ -7535,6 +7538,7 @@
       },
       "deleteDialog": {
         "title": "중복 도서를 영구적으로 삭제하시겠습니까?",
+        "description": "{count, plural, =0 {선택된 책 #권과 파일이 영구적으로 삭제됩니다.} one {선택된 책 #권과 파일이 영구적으로 삭제됩니다.} other {선택된 책 #권과 파일이 영구적으로 삭제됩니다.}}",
         "warning": "메타데이터, 컬렉션, 독서 데이터 및 기기 상태는 유지되는 책으로 전송되지 않습니다. 다른 사용자의 관련 데이터도 제거됩니다.",
         "confirm": "{count, plural, =0 {책 #권 삭제} one {책 #권 삭제} other {책 #권 삭제}}",
         "success": "{count, plural, =0 {삭제된 책이 없습니다.} one {중복 도서 #권이 삭제되었습니다.} other {중복 도서 #권이 삭제되었습니다.}}"

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -3323,7 +3323,16 @@
         "noMatch": "Nenhum destaque corresponde aos seus filtros.",
         "resetFilters": "Restaurar filtros",
         "trashEmpty": "A lixeira está vazia",
-        "noAnnotations": "Nenhuma anotação ainda. Os destaques criados na web ou em seu e-reader aparecerão aqui."
+        "noAnnotations": "Nenhuma anotação ainda. Os destaques criados na web ou em seu e-reader aparecerão aqui.",
+        "noMatchHint": "Tente uma frase mais curta, ou limpe os filtros de cores e livros.",
+        "noAnnotationsBody": "Tudo o que você marca, em qualquer livro e em qualquer dispositivo, coleciona aqui.",
+        "readHere": "Leia aqui",
+        "readHereBody": "Selecione o texto no leitor e selecione uma cor.",
+        "syncKobo": "Sincronizar com o Kobo",
+        "syncKoboBody": "Marcas feitas no dispositivo chegarão com a próxima sincronização.",
+        "syncKoreader": "Sincronizar com o KOReader",
+        "syncKoreaderBody": "O plugin faz upload de anotações com suas posições exatas.",
+        "goToLibrary": "Ir para a biblioteca"
       },
       "toast": {
         "movedToTrash": "Movido para a lixeira",
@@ -3333,8 +3342,70 @@
         "bulkTrashed": "{count, plural, =0 {Nenhuma anotação movida para a lixeira} one {Movida # anotação para a lixeira} many {Movidas # anotações para a lixeira} other {Movidas # anotações para a lixeira}}",
         "bulkRestored": "{count, plural, =0 {Nenhuma anotação restaurada} one {Restaurada # anotação} many {Restauradas # anotações} other {Restauradas # anotações}}",
         "bulkRecolored": "{count, plural, =0 {Nenhuma anotação recolorida} one {Recolorida # anotação} many {Recoloridas # anotações} other {Recoloridas # anotações}}",
-        "bulkRestyled": "{count, plural, =0 {Estilo não alterado} one {Alterado o estilo de # anotação} many {Alterado o estilo de # anotações} other {Alterado o estilo de # anotações}}"
-      }
+        "bulkRestyled": "{count, plural, =0 {Estilo não alterado} one {Alterado o estilo de # anotação} many {Alterado o estilo de # anotações} other {Alterado o estilo de # anotações}}",
+        "noteSaved": "Nota salva"
+      },
+      "railTitle": "{marks} marcas · {books} livros",
+      "lastTwelveMonths": "Últimos 12 meses",
+      "colour": "Colorido",
+      "whereFrom": "De onde eles vieram",
+      "theShelf": "A prateleira",
+      "devices": "Dispositivos",
+      "allBooks": "Todos os {count} livros",
+      "behindCount": "{count, plural, one {# missing} other {# missing}}",
+      "busiestWeek": "Semana de compra",
+      "longestQuiet": "Escopo de silêncio mais longo",
+      "mostMarked": "Mais marcados",
+      "weekCount": "{count, plural, one {# semana} other {# semanas}}",
+      "anchorsUnplaced": "{count, plural, one {# âncora não pôde ser colocado} other {# âncoras não puderam ser colocados}}",
+      "reviewThem": "Revisar",
+      "anchorLost": "Âncora perdida",
+      "anchorRepaired": "Reparado",
+      "notes": "Anotações",
+      "review": "Revisão",
+      "viewLabel": "Grupo e ordenação",
+      "views": {
+        "newest": "Mais recente primeiro",
+        "oldest": "Mais antigos primeiro",
+        "book": "Por Livro",
+        "color": "Por cor",
+        "source": "Por fonte"
+      },
+      "matchCount": "{shown} de {total}",
+      "moreActions": "Mais ações",
+      "loadMore": "{count, plural, one {Move # book} many {Move # books} other {Move # books}}",
+      "openBook": "Abrir o livro",
+      "noteLabel": "Nota",
+      "yourNote": "Sua nota",
+      "notePlaceholder": "Diga por que isso importa.",
+      "openAtThisPage": "Abrir nesta página",
+      "positionAndSync": "Posição e sincronização",
+      "loadFailed": "Não foi possível carregar seus destaques. Tente novamente daqui a pouco.",
+      "chips": {
+        "dateBetween": "{from} até {to}",
+        "dateFrom": "De {from}",
+        "dateUntil": "Até {to}"
+      },
+      "activitySummary": "{count, plural, one {# destaque entre {from} e {to}} other {# destaques entre {from} e {to}}}",
+      "book": "Livro",
+      "needsReview": "Requer revisão"
+    },
+    "sources": {
+      "web": "Web",
+      "koreader": "KOReader",
+      "kobo": "Kobo"
+    },
+    "colors": {
+      "yellow": "Amarelo",
+      "green": "Verde",
+      "blue": "Azul",
+      "pink": "Rosa",
+      "orange": "Laranja",
+      "red": "Vermelho",
+      "olive": "Oliva",
+      "cyan": "Ciano",
+      "purple": "Roxo",
+      "gray": "Cinza"
     }
   },
   "audit": {
@@ -3706,7 +3777,15 @@
       "deleteAuthor": "Excluir Autor"
     },
     "filters": {
-      "allLibraries": "Todas as Bibliotecas"
+      "allLibraries": "Todas as Bibliotecas",
+      "chips": {
+        "groupLabel": "Filtrar autores",
+        "all": "Tudo",
+        "noPortrait": "Sem retratos",
+        "multipleBooks": "2+ livros",
+        "recentlyAdded": "Adicionado esta semana",
+        "noSortName": "Sem nome da ordenação"
+      }
     },
     "header": {
       "never": "Nunca",
@@ -3853,6 +3932,16 @@
         "deleteSuccess": "Autor excluído; {books} livros afetados",
         "deleteFailed": "Falha ao excluir o autor"
       }
+    },
+    "portrait": {
+      "fromTheirBook": "Capa de um de seus livros; nenhum retrato no arquivo"
+    },
+    "index": {
+      "bookCount": "{count, plural, =0 {sem livros} one {# livro} other {# livros}}",
+      "rowLabel": "{name}, {count, plural, =0 {sem livros} one {# livro} other {# livros}}",
+      "actionsFor": "Ações para {name}",
+      "refreshing": "Atualizando metadados do {name}",
+      "deleting": "Excluindo {name}"
     }
   },
   "book": {
@@ -3902,7 +3991,13 @@
       "action": "Baixar",
       "audiobookZip": "Audiolivro (ZIP)",
       "allFormatsZip": "Todos os formatos (ZIP)",
-      "primaryOnlyZip": "Apenas primário (ZIP)"
+      "primaryOnlyZip": "Apenas primário (ZIP)",
+      "preparing": "Preparando o download...",
+      "preparingExport": "Preparando {count, plural, one {# livro} other {# livros}} para baixar...",
+      "progressPercent": "Baixando {percent} do {total}",
+      "progressBytes": "Baixando {transferred}",
+      "failed": "Falha no download",
+      "exportFailed": "Falha na exportação"
     },
     "sort": {
       "moveUp": "Mover para cima",
@@ -4855,6 +4950,17 @@
           "regroup": "Reagrupar a transmissão",
           "copy": "Copiar orçamento",
           "reader": "Abrir no leitor"
+        },
+        "railTitle": "{marks} marcas · {chapters} capítulos",
+        "whenMarked": "Quando eles foram marcados",
+        "chapters": "Capítulos",
+        "noChapter": "Sem Capítulo",
+        "views": {
+          "position": "Ordem de leitura",
+          "newest": "Mais recente primeiro",
+          "oldest": "Mais antigos primeiro",
+          "colour": "Por cor",
+          "source": "Por fonte"
         }
       },
       "readingLog": {
@@ -5751,7 +5857,17 @@
         "columnsHint": "Use o painel de visibilidade de colunas no cabeçalho da tabela para mostrar ou ocultar colunas.",
         "coverShape": "Formato da capa",
         "circle": "Círculo",
-        "square": "Quadrado"
+        "square": "Quadrado",
+        "rowDensity": "Altura da linha",
+        "densityCompact": "Compacta",
+        "densityComfortable": "Cosy",
+        "densityRoomy": "Espaçosa",
+        "coverFallback": "Usar capas de livros para retratos ausentes"
+      },
+      "viewModes": {
+        "grid": "Exibição em grade",
+        "list": "Exibição em lista",
+        "table": "Visualização em tabela"
       }
     },
     "iconPicker": {
@@ -7459,7 +7575,10 @@
       "ownedOfExpected": "{owned} da {expected} na biblioteca"
     },
     "gaps": {
-      "label": "Possíveis lacunas:"
+      "label": "Possíveis lacunas:",
+      "missingCount": "{count, plural, one {# missing} other {# missing}}",
+      "missingList": "{list} Faltando",
+      "previewMore": "{shown} {count}"
     },
     "filters": {
       "title": "Filtros de Séries",
@@ -7489,7 +7608,10 @@
         "bookCount": "Contagem de Livros",
         "recentAdditions": "Adições Recentes",
         "readingProgress": "Progresso de Leitura"
-      }
+      },
+      "clearSearch": "Limpar busca",
+      "noMatchHint": "Tente outra biblioteca ou limpe o que é definido.",
+      "emptyHint": "As séries aparecem quando seus livros carregam metadados da série."
     },
     "detail": {
       "pageTitle": "Série",
@@ -7530,6 +7652,66 @@
         "ascending": "Crescente",
         "descending": "Decrescente"
       }
+    },
+    "authorsPlus": "{authors} +{count}",
+    "track": {
+      "readCount": "{count, plural, one {# field} other {# fields}}",
+      "readingCount": "{count, plural, one {# livro} many {# livros} other {# livros}}",
+      "unreadCount": "{count, plural, one {# field} other {# fields}}",
+      "missingCount": "{count, plural, one {# missing} other {# missing}}",
+      "slotMissing": "{number} não está na biblioteca",
+      "untitled": "Sem título"
+    },
+    "legend": {
+      "read": "Lido",
+      "reading": "Lendo",
+      "unread": "Na biblioteca",
+      "missing": "Ausente"
+    },
+    "status": {
+      "label": "Filtrar séries por status de leitura",
+      "all": "Tudo",
+      "reading": "Lendo",
+      "unread": "Não Lido",
+      "complete": "Concluído",
+      "gaps": "Lacunas",
+      "read": "Lido",
+      "inProgress": "Em progresso",
+      "hasGaps": "Possui lacunas",
+      "notStarted": "Não iniciado"
+    },
+    "index": {
+      "columnSeries": "Séries",
+      "columnVolumes": "Volumes",
+      "columnRead": "Lido",
+      "columnNext": "A seguir",
+      "columnAdded": "Adicionado",
+      "percent": "{value} %",
+      "captionReading": "{base} · {count, plural, one {# in progress} other {# in progress}}",
+      "finished": "Leia o fim para o fim",
+      "reading": "Lendo",
+      "next": "Próximo",
+      "start": "Iniciar"
+    },
+    "grouping": {
+      "label": "Agrupar por",
+      "none": "Sem agrupamento",
+      "letter": "Por letra",
+      "library": "Por biblioteca",
+      "status": "Por estado"
+    },
+    "libraries": {
+      "more": "+{count}"
+    },
+    "card": {
+      "oneVolume": "Volume único",
+      "oneVolumeShort": "1 vol",
+      "volumeCount": "{count, plural, one {# arquivo} other {# arquivos}}",
+      "readSummary": "{base} · {read} lido",
+      "publishedOf": "{owned} de {total} publicado",
+      "complete": "Concluído",
+      "moreVolumes": "{count, plural, one {# arquivo} other {# arquivos}}",
+      "label": "{name}, {read} de {total} volumes lidos"
     }
   },
   "smartScope": {

--- a/client/src/locales/ro.json
+++ b/client/src/locales/ro.json
@@ -70,6 +70,8 @@
         "empty": "Niciun administrator nu a vizualizat profilul de lectură partajat.",
         "paginationLabel": "Pagini istoric acces la profil"
       },
+      "durationMinutes": "{count, plural, one {# minut} few {# minute} other {# de minute}}",
+      "durationHours": "{count, plural, one {# oră} few {# ore} other {# de ore}}",
       "unknownTitle": "Carte fără titlu",
       "errors": {
         "load": "Încărcarea setărilor de partajare a eșuat.",
@@ -420,11 +422,13 @@
       "icons": {
         "title": "Pictograme personalizate",
         "uploadIcons": "Încărcare pictograme",
+        "uploadedCount": "{count, plural, =0 {nici o pictogramă încărcată} one {# pictogramă încărcată} few {# pictograme încărcate} other {# de pictograme încărcate}}",
         "searchPlaceholder": "Caută pictograme",
         "sort": {
           "newest": "Cele mai noi",
           "name": "Nume"
         },
+        "selectedCount": "{count, plural, one {# a selectat} few {# a selectat} other {# de a selectat}}",
         "clear": "Curăță",
         "deleteSelected": "Ştergeţi selecţia",
         "loading": "Se încarcă pictogramele...",
@@ -436,13 +440,20 @@
         "notUsedYet": "Nu este folosit încă",
         "rename": "Redenumire",
         "replace": "Înlocuiește",
+        "usage": {
+          "libraries": "{count, plural, =0 {Nici o bibliotecă} one {# bibliotecă} few {# biblioteci} other {# de biblioteci}}",
+          "collections": "{count, plural, =0 {nicio colecţie} one {# colecţie} few {# colecţii} other {# de colecţii}}",
+          "smartScopes": "{count, plural, =0 {Nici un scop inteligent} one {# scop inteligent} few {# scopuri inteligente} other {# de scopuri inteligente}}"
+        },
         "confirm": {
-          "deleteOne": "Ștergeți \"{name}\"? Utilizările existente vor reveni la pictograma lor implicită."
+          "deleteOne": "Ștergeți \"{name}\"? Utilizările existente vor reveni la pictograma lor implicită.",
+          "deleteMany": "{count, plural, =0 {Nu ștergeți nicio pictogramă?} one {Ștergeți # pictogramă? Utilizările existente vor reveni la pictograma lor implicită.} few {Ştergeţi # pictograme? Utilizările existente vor reveni la pictograma lor implicită.} other {Ştergeţi # de pictograme? Utilizările existente vor reveni la pictograma lor implicită.}}"
         },
         "toasts": {
           "saved": "Pictogramă salvată",
           "updated": "Pictogramă actualizată",
           "deleted": "Iconiță ștearsă",
+          "bulkDeleted": "{count, plural, =0 {Nu s-au șters iconițe} one {S-a șters # iconiță} few {# iconițe} other {# de iconițe}}",
           "bulkDeletePartial": "S-a șters {deleted}, {failed} a eșuat"
         },
         "errors": {
@@ -607,6 +618,7 @@
       "expiresOn": "Expiră {date}",
       "revokedOn": "{date} revocat",
       "expiredOn": "A expirat {date}",
+      "usesCount": "{count, plural, =0 {nu folosește} one {una folosește} few {# folosește} other {# de folosește}}",
       "copied": "Copiat!",
       "copyLink": "Copiază link-ul",
       "pause": "Întrerupeți",
@@ -783,6 +795,7 @@
         "viewDetails": "Vezi detalii",
         "refreshRecommendationIndex": "Reîmprospătează indicele recomandării",
         "refreshRecommendationHint": "Actualizați motorul de recomandări cu ultimele modificări ale bibliotecii. Acest proces se derulează în fundal.",
+        "booksQueuedForProcessing": "{count, plural, =0 {nu există cărţi în coada de aşteptare pentru procesare} one {# carte în aşteptare pentru procesare} few {# cărţi în aşteptare pentru procesare} other {# de cărţi în aşteptare pentru procesare}}",
         "run": "Rulează",
         "running": "Rulează...",
         "backfillAchievements": "Realizări de rezervă",
@@ -794,6 +807,7 @@
         "updateChecksEnabled": "Verificări actualizări activate",
         "updateChecksDisabled": "Verificarea actualizărilor dezactivată",
         "updateSettingFailed": "Actualizarea setărilor a eșuat",
+        "booksQueuedForEmbedding": "{count, plural, =0 {nu există cărţi în coada de aşteptare pentru a fi încorporate} one {# carte în aşteptare pentru a fi încorporată} few {# cărţi în aşteptare pentru a fi încorporate} other {# de cărţi în aşteptare pentru a fi încorporate}}",
         "failed": "Eșuat",
         "unknownError": "Eroare necunoscută",
         "rebuildEmbeddingsFailed": "Nu s-a reușit reconstruirea încorporărilor: {error}",
@@ -976,6 +990,7 @@
         "ofCount": "de {count}",
         "targetBookNum": "Agendă țintă #{id}",
         "recommended": "Recomandat",
+        "resolveDuplicatesButton": "{count, plural, =0 {Rezolvă # duplicat} one {Rezolvă # duplicat} few {Rezolvă # duplicate} other {Rezolvă # de duplicate}}",
         "preflightChecks": "Verificări înainte de zbor",
         "allChecksPassed": "Toate verificările au trecut - sunt gata să migreze",
         "checkSourceValidated": "Sursă validată",
@@ -1051,6 +1066,8 @@
         "refreshCovers": "Reîmprospătare coperte",
         "syncMetadataToFiles": "Sincronizare metadate în fișiere",
         "deleteLibrary": "Șterge biblioteca",
+        "bookCount": "{count, plural, =0 {Nici o carte} one {# carte} few {# cărţi} other {# de cărţi}}",
+        "folderCount": "{count, plural, =0 {nici un folder} one {# folder} few {# foldere} other {# de foldere}}",
         "fileMode": "Mod fișier",
         "folderMode": "Mod dosar",
         "emptyTitle": "Încă nu există biblioteci",
@@ -1239,12 +1256,14 @@
           "eligible": "~{count} eligibile"
         },
         "trigger": {
+          "queued": "{count, plural, one {În aşteptare # carte} few {# cărţi în aşteptare} other {# de cărţi în aşteptare}}",
           "noneFound": "Nu au fost găsite cărți eligibile"
         },
         "lastRun": {
           "justNow": "chiar acum",
           "minutesAgo": "{count}m în urmă",
           "yesterday": "ieri",
+          "daysAgo": "{count, plural, one {# zile în urmă} few {# zile în urmă} other {# de zile în urmă}}",
           "label": "Ultima rulare: {when}",
           "labelQueued": "Ultima rulare: {when} - {count} cărți",
           "labelNoneEligible": "Ultima rulare: {when} - nu există cărți eligibile"
@@ -1266,7 +1285,8 @@
           },
           "missingFields": {
             "label": "Câmpuri lipsă",
-            "hint": "Preia daca oricare dintre campurile selectate este goala."
+            "hint": "Preia daca oricare dintre campurile selectate este goala.",
+            "summary": "{count, plural, one {Lipsește câmpul #} few {Lipsește # câmpuri} other {Lipsește # de câmpuri}}"
           }
         },
         "library": {
@@ -1374,6 +1394,7 @@
         },
         "library": {
           "primary": "Primar:",
+          "overrideCount": "{count, plural, one {# Suprascrie} few {# Suprascrie} other {# de Suprascrie}}",
           "unsavedSuffix": "(nesalvat)",
           "unsavedChanges": "Modificări nesalvate",
           "globalDefaults": "Implicite globale",
@@ -1433,6 +1454,7 @@
         "duplicate": "Acest gen este deja blocat.",
         "add": "Adăugare",
         "filterPlaceholder": "Lista de filtre",
+        "entryCount": "{count, plural, one {# intrare} few {# intrări} other {# de intrări}}",
         "filteredCount": "{shown} {total}",
         "noFilterMatch": "Niciun gen blocat nu se potrivește cu filtrul curent.",
         "emptyTitle": "Niciun gen blocat",
@@ -1445,6 +1467,7 @@
         "labelTooLong": "Eticheta trebuie să aibă cel mult 255 de caractere",
         "labelDuplicate": "Un câmp cu această etichetă există deja",
         "type": "Tip",
+        "usage": "{count, plural, one {Folosit de # carte} few {Folosit de # cărţi} other {Folosit de # de cărţi}}",
         "newField": {
           "title": "Câmp nou",
           "hint": "Definiți un câmp personalizat pentru metadate și alegeți bibliotecile care îl folosesc."
@@ -1466,6 +1489,7 @@
         "unsaved": "nesalvate",
         "archive": "Arhivează",
         "archivedFields": "Câmpuri arhivate",
+        "archivedSummary": "{count, plural, one {# câmp arhivat - restaurează sau șterge definitiv.} few {# câmpuri arhivate - restaurează sau șterge definitiv.} other {# de câmpuri arhivate - restaurează sau șterge definitiv.}}",
         "archivedAt": "{when} arhivat",
         "restore": "Restaurează",
         "deleteForever": "Șterge pentru totdeauna",
@@ -1671,6 +1695,7 @@
         "fontsUsed": "{count} / {max} utilizat",
         "noFontsYet": "Nici un font încărcat încă",
         "noFontsHint": "Trageți un fișier font de mai sus pentru a începe.",
+        "fileCount": "{count, plural, =0 {nici un fişier} one {# fişier} few {# fişiere} other {# de fişiere}}",
         "pangram": "Rapida vulpe maro sare peste câinele leneş",
         "renameFamily": "Redenumire familie",
         "deleteFamily": "Şterge familie",
@@ -1895,6 +1920,7 @@
           "never": "Niciodată",
           "none": "Niciunul",
           "unknown": "Necunoscut",
+          "failureCount": "{count, plural, one {# eșec} few {# eșec} other {# de eșec}}",
           "noActivityRecorded": "Nu a fost înregistrată nici o activitate de sincronizare Kobo.",
           "lastSuccess": "Ultimul succes {time}",
           "lastFailure": "Ultimul eșec {time}",
@@ -1928,6 +1954,7 @@
           "chip": {
             "morePending": "Mai multe în așteptare",
             "noUpdatesPending": "Nicio actualizare în așteptare",
+            "bookCount": "{count, plural, one {# carte} few {# cărţi} other {# de cărţi}}",
             "deletedAnnotations": "{count} adnotări șterse",
             "deviceAlreadyCurrent": "Dispozitivul este deja curent",
             "freshHighlightData": "Date evidențiere noi",
@@ -1939,21 +1966,31 @@
           "readingPositionSyncedTitle": "Poziție de lectură sincronizată: {title}",
           "readingPositionSynced": "Poziție de lectură sincronizată",
           "labelWithTitle": "{label}: {title}",
+          "updateCount": "{count, plural, one {# actualizează} few {# actualizări} other {# de actualizări}}",
           "directionToKobo": "BookOrbit -> Kobo",
           "directionToBookOrbit": "Kobo -> BookOrbit",
           "twoWaySyncEnabled": "Sincronizare în două direcții activată",
           "deviceProgressSaved": "Progresul dispozitivului salvat",
           "summary": {
             "noLibraryUpdatesPending": "Nu sunt în așteptare actualizări ale bibliotecii pentru acest dispozitiv",
+            "libraryUpdatesPrepared": "{count, plural, one {# actualizare bibliotecă pregătită pentru dispozitiv} few {# actualizări ale bibliotecii pregătite pentru dispozitiv} other {# de actualizări ale bibliotecii pregătite pentru dispozitiv}}",
             "bookDownloadedBy": "{title} a fost descărcat de {device}",
+            "booksDownloaded": "{count, plural, one {# carte descărcată} few {# cărţi descărcate} other {# de cărţi descărcate}}",
+            "progressUpdatesSyncedFor": "{count, plural, one {# actualizare de progres sincronizată pentru {title}} few {# actualizări de progres sincronizate pentru {title}} other {# de actualizări de progres sincronizate pentru {title}}}",
+            "progressUpdatesSynced": "{count, plural, one {# actualizare de progres sincronizată} few {# actualizări de progres sincronizate} other {# de actualizări de progres sincronizate}}",
             "newReadingPositionFor": "Kobo a raportat o nouă poziție în lectură pentru {title}",
             "newReadingPosition": "Kobo a raportat o nouă poziție în lectură",
             "noHighlightChangesNeededFor": "Nu sunt necesare modificări evidențiate pentru {title}",
             "noHighlightChangesNeeded": "Nu sunt necesare modificări evidențiate",
+            "highlightsSentToKoboFor": "{count, plural, one {# de evidențiere trimise către Kobo pentru {title}} few {# atracții trimise către Kobo pentru {title}} other {# de atracții trimise către Kobo pentru {title}}}",
+            "highlightsSentToKobo": "{count, plural, one {# de evidențiere trimise către Kobo} few {# repere trimise către Kobo} other {# de repere trimise către Kobo}}",
             "noKoboHighlightChangesFor": "Niciun Kobo nu evidențiază modificări pentru {title}",
-            "noKoboHighlightChanges": "Niciun Kobo nu evidențiază modificări"
+            "noKoboHighlightChanges": "Niciun Kobo nu evidențiază modificări",
+            "highlightsImportedFromKoboFor": "{count, plural, one {# evidenţiază importul din Kobo pentru {title}} few {# repere importate din Kobo pentru {title}} other {# de repere importate din Kobo pentru {title}}}",
+            "highlightsImportedFromKobo": "{count, plural, one {# subliniază importul din Kobo} few {# repere importate din Kobo} other {# de repere importate din Kobo}}"
           },
           "timeRange": "{from} la {to}",
+          "eventsGrouped": "{count, plural, one {# eveniment grupat} few {# evenimente grupate} other {# de evenimente grupate}}",
           "removedDevice": "Dispozitiv eliminat",
           "loadMoreFailed": "Nu s-a putut încărca mai mult istoric",
           "historyRefreshed": "Istoricul sincronizării Kobo reîmprospătat",
@@ -2070,7 +2107,9 @@
         "progressSyncHint": "Permite dispozitivelor KOReader să sincronizeze progresul, citirea activităţii, sublinierilor şi adnotării şterg cu BookOrbit.",
         "lastSync": "Ultima sincronizare",
         "syncedBooks": "Cărți sincronizate",
+        "bookCount": "{count, plural, =0 {Nici o carte} one {# carte} few {# cărţi} other {# de cărţi}}",
         "devices": "Dispozitive",
+        "deviceCount": "{count, plural, =0 {Nu există dispozitive} one {# dispozitiv} few {# dispozitive} other {# de dispozitive}}",
         "credentialsCreatedLabel": "Acreditări create",
         "setup": "Configurare",
         "pluginServerUrl": "URL server plugin",
@@ -2098,6 +2137,7 @@
         "highlights": "Evidențieri",
         "syncedTotals": "Totaluri sincronizate",
         "trashedHighlights": "Evidențe șterse",
+        "pendingDeletes": "{count, plural, =0 {Nu s-au şters momente principale în aşteptarea acceptării plugin-ului KOReader.} one {# Evidenţiere ştearsă în aşteptarea acceptării plugin-ului KOReader.} few {# au şters repere în aşteptarea acceptării plugin-ului KOReader.} other {# de au şters repere în aşteptarea acceptării plugin-ului KOReader.}}",
         "setupGuide": "Ghid de configurare",
         "setupSteps": "Etapele configurării KOReader",
         "setupStepsHint": "Utilizați plugin-ul BookOrbit pentru navigarea catalogului, descărcări, progres, citire evenimente și evidențieri. Utilizați plugin-ul stoc doar pentru progres.",
@@ -2169,6 +2209,7 @@
             "unlinkFailed": "Deconectarea cărții a eșuat",
             "unmatchedDismissed": "Carte neegalată respinsă",
             "dismissFailed": "Nu a reuşit să respingă cartea neegalată",
+            "allDismissed": "{count, plural, =0 {Nu ai găsit cărţi de neegalat} one {Respingeţi # o carte de neegalat} few {Respingeţi # cărţi nepotrivite} other {Respingeţi # de cărţi nepotrivite}}",
             "dismissAllFailed": "Nu s-a reușit respingerea tuturor cărților care nu se potrivesc"
           },
           "modal": {
@@ -2243,6 +2284,7 @@
         "deviceRestored": "Dispozitiv restaurat",
         "retireDeviceFailed": "Dispozitivul nu a reușit să se retragă",
         "restoreDeviceFailed": "Restaurarea dispozitivului a eșuat",
+        "retiredDevices": "{count, plural, one {# dispozitiv retras} few {# dispozitive retrase} other {# de dispozitive retrase}}",
         "retiredOnLabel": "Ocupat"
       },
       "opds": {
@@ -2453,6 +2495,8 @@
       "auditNotice": "Accesul la acest profil este înregistrat și vizibil pentru utilizator.",
       "period": "Perioada de raportare",
       "periodDays": "Ultimul {count} zile",
+      "durationMinutes": "{count, plural, one {# minut} few {# minute} other {# de minute}}",
+      "durationHours": "{count, plural, one {# oră} few {# ore} other {# de ore}}",
       "metrics": {
         "sessions": "Sesiuni",
         "readingTime": "Timp de lectură",
@@ -2589,6 +2633,7 @@
         "actions": "Acțiuni"
       },
       "adminBadge": "Admin",
+      "permissionCount": "{count, plural, =0 {nu există permisiuni} one {o permisiune} few {# permisiuni} other {# de permisiuni}}",
       "filteredBadge": "Filtrate",
       "contentRestrictionsActive": "Restricții de conținut active",
       "statusActive": "Activ",
@@ -2673,6 +2718,7 @@
       "noBooksFound": "Nicio carte găsită"
     },
     "bulk": {
+      "countSelected": "{count, plural, one {# a selectat} few {# a selectat} other {# de a selectat}}",
       "pageSelected": "Pagină selectată",
       "selectPage": "Selectați pagina",
       "clear": "Curăță",
@@ -2758,6 +2804,8 @@
     "hub": {
       "title": "Adnotări",
       "totalCount": "{count} total",
+      "bookCount": "{count, plural, =0 {Nici o carte} one {# carte} few {# cărţi} other {# de cărţi}}",
+      "noteCount": "{count, plural, =0 {nici o notiță} one {# notă} few {# note} other {# de note}}",
       "export": "Exportă",
       "exportMarkdown": "Markdown",
       "exportCsv": "CSV",
@@ -2781,7 +2829,11 @@
         "movedToTrash": "Mutat la gunoi",
         "annotationRestored": "Annotare restaurată",
         "annotationDeletedForever": "Adnotare ștearsă pentru totdeauna",
-        "failedToDelete": "Ștergerea a eșuat"
+        "failedToDelete": "Ștergerea a eșuat",
+        "bulkTrashed": "{count, plural, =0 {Nu s-a mutat nicio adnotare la gunoi} one {A mutat # adnotare la gunoi} few {Ai mutat # adnotări la gunoi} other {Ai mutat # de adnotări la gunoi}}",
+        "bulkRestored": "{count, plural, =0 {Nu a fost restaurat nicio adnotare} one {Restaurat # adnotare} few {Restaurat # adnotări} other {Restaurat # de adnotări}}",
+        "bulkRecolored": "{count, plural, =0 {Nu ai primit nici o adnotare} one {A fost ocupat cu # adnotare} few {A primit # adnotări} other {A primit # de adnotări}}",
+        "bulkRestyled": "{count, plural, =0 {Restabilire nici o adnotare} one {Restabilit # adnotare} few {Restabilit # adnotări} other {Restabilit # de adnotări}}"
       }
     }
   },
@@ -2814,6 +2866,8 @@
     "sevenDays": "7 zile",
     "thirtyDays": "30 de zile",
     "userId": "Utilizator #{id}",
+    "targetAdditional": "și {count, plural, one {# mai ținta} few {# mai multe ținte} other {# de mai multe ținte}}",
+    "bookImpact": "{count, plural, one {# carte} few {# cărţi} other {# de cărţi}}",
     "entryDetailsLabel": "Detalii pentru evenimentul de audit #{id}",
     "detailEventId": "ID eveniment",
     "detailOccurredAt": "A apărut",
@@ -2832,6 +2886,7 @@
     "deletedBooks": "Cărți șterse",
     "deletedBookDetail": "{title} (carte #{id})",
     "untitledBook": "Fără titlu",
+    "deletedBooksOmitted": "{count, plural, one {# carte adiţională omisă} few {# cărţi adiţionale omise} other {# de cărţi adiţionale omise}}",
     "showing": "Afișare {from}-{to} {total}",
     "prev": "Anterior",
     "chips": {
@@ -3045,7 +3100,8 @@
       "registeredNotice": "Cont creat. Conectați-vă pentru a continua. Un administrator trebuie să acorde permisiuni înainte de a putea accesa biblioteca.",
       "errors": {
         "invalidCredentials": "Nume de utilizator sau parolă nevalide",
-        "tooManyAttempts": "Prea multe încercări de autentificare. Vă rugăm să aşteptaţi un minut şi să încercaţi din nou."
+        "tooManyAttempts": "Prea multe încercări de autentificare. Vă rugăm să aşteptaţi un minut şi să încercaţi din nou.",
+        "accountLocked": "Parola dvs. este corectă, dar acest cont este blocat temporar după prea multe încercări de conectare eșuate. Încearcă din nou în {minutes, plural, one {# minut} few {# minute} other {# de minute}}sau resetează-ți parola pentru a o debloca acum."
       }
     },
     "oidc": {
@@ -3201,7 +3257,8 @@
         "refreshingMetadata": "Reîmprospătare metadate...",
         "deleteSelected": "Ştergeţi selecţia",
         "deleting": "Ștergere...",
-        "exitSelection": "Ieșiți din selecție"
+        "exitSelection": "Ieșiți din selecție",
+        "confirmDeleteCount": "{count, plural, =0 {Ștergeți # autor?} one {Ștergeți # autor?} few {Ștergeți # autori?} other {Ștergeți # de autori?}}"
       },
       "toast": {
         "refreshed": "Rescrierea metadatelor autorului",
@@ -3209,6 +3266,7 @@
         "refreshFailed": "Reîmprospătarea metadatelor autorului a eșuat",
         "bulkRefreshSuccess": "Actualizați metadatele pentru {updated} autor(i)",
         "bulkRefreshFailed": "Reîmprospătarea autorilor selectați a eșuat",
+        "deleteSuccess": "{count, plural, =0 {Şters # autor; afectate {books} cărţi} one {Şters # autor; afectate {books} cărţi} few {Şters # autori; afectate {books} cărţi} other {Şters # de autori; afectate {books} cărţi}}",
         "deleteFailed": "Ștergerea autorului (autorilor) a eșuat"
       }
     },
@@ -3234,6 +3292,7 @@
       "merge": {
         "searchPlaceholder": "Caută autori pentru a fuziona în acest autor",
         "searching": "Căutare...",
+        "bookCount": "{count, plural, =0 {Nici o carte} one {# carte} few {# cărţi} other {# de cărţi}}",
         "merging": "Fuzionare...",
         "mergeSelected": "Îmbinare selectată",
         "confirmLabel": "Îmbinare"
@@ -3288,6 +3347,7 @@
     "unknownFormat": "necunoscut",
     "collapsedSeries": {
       "label": "Serii",
+      "bookCount": "{count, plural, =0 {Nici o carte} one {# carte} few {# cărţi} other {# de cărţi}}",
       "readCount": "{count} citite"
     },
     "card": {
@@ -3465,6 +3525,7 @@
       "description": "Acest lucru va şterge definitiv cartea şi toate metadatele sale, fişierele, progresul citirii şi semnele de carte. Acest lucru nu poate fi anulat."
     },
     "bulkEdit": {
+      "title": "{count, plural, =0 {Editare metadate - # carte} one {Editare metadate - # carte} few {Editare metadate - # cărţi} other {Editare metadate - # de cărţi}}",
       "instructions": "Comutați câmpurile pentru a edita, apoi configurați valorile. Numai câmpurile togled vor fi modificate.",
       "invalidYear": "Introduceți un an valid (doar numere)",
       "clearWarning": "Acest lucru va elimina toate {field} din cărțile selectate.",
@@ -3504,6 +3565,8 @@
       "estimatedSize": "Dimensiune estimată:",
       "fileLabel": "Fișier: {fileName}",
       "exportAction": "Exportă",
+      "selectedRowsSummary": "{count, plural, =0 {# rând selectat} one {# rând selectat} few {# rânduri selectate} other {# de rânduri selectate}}",
+      "matchingRowsSummary": "{count, plural, =0 {# rândul potrivit} one {# rândul potrivit} few {# se potrivesc cu rândurile} other {# de se potrivesc cu rândurile}}",
       "prepareFailed": "Nu s-a putut pregăti exportul",
       "exportStarted": "Exportul metadatelor a început: {fileName}",
       "exportFailed": "Exportarea metadatelor a eșuat"
@@ -3570,6 +3633,7 @@
       "titleFor": "Vizualizare rapidă pentru {title}",
       "description": "Previzualizați detaliile cărții și executați acțiuni rapide.",
       "openIn": "Deschide în {provider}",
+      "pages": "{count, plural, =0 {# pagină} one {# pagină} few {# pagini} other {# de pagini}}",
       "primaryFile": "Fişier principal",
       "fileNumber": "Fișier #{id}",
       "showLess": "Arată mai puțin",
@@ -3584,6 +3648,7 @@
       "openBookDetails": "Detalii carte deschisă",
       "openSeries": "Serie deschisă",
       "metadataRefreshFailed": "Reîmprospătarea metadatelor a eșuat",
+      "booksSelected": "{count, plural, =0 {# carte selectată} one {# carte selectată} few {# cărţi selectate} other {# de cărţi selectate}}",
       "loadingMoreBooks": "Se încarcă mai multe cărți",
       "sort": "Sortează",
       "failedCount": "{count} a eșuat",
@@ -3596,6 +3661,7 @@
       "selectedStatus": "{count} selectate",
       "filtered": "Filtrate",
       "loadedStatus": "{loaded} {total} încărcat",
+      "bookCount": "{count, plural, =0 {# carte} one {# carte} few {# cărţi} other {# de cărţi}}",
       "keyboardShortcutsTitle": "Scurtături tastatură (?)",
       "showKeyboardShortcuts": "Arată scurtăturile pentru tastatură",
       "copyHint": "Copiere celulă: Ctrl/Cmd+C · rând de copiere: Ctrl/Cmd+Shift+C"
@@ -3628,6 +3694,7 @@
         "moreInSeries": "Mai multe în seria {series}"
       },
       "writeRename": {
+        "written": "{count, plural, =0 {niciun câmp scris} one {Scris (un câmp)} few {Scris (# câmpuri)} other {Scris (# de câmpuri)}}",
         "writeFailed": "Scriere eșuată",
         "skipped": "Sărit",
         "renamedTo": "Redenumit în {name}",
@@ -3648,9 +3715,11 @@
           "hint": "epub, pdf, mobi, cbz, m4b și multe altele - până la {size} MB în fiecare"
         },
         "addMore": "Adăugați mai multe fișiere",
+        "fileCount": "{count, plural, =0 {nici un fişier} one {un fişier} few {# fişiere} other {# de fişiere}}",
         "clearAll": "Șterge tot",
         "done": "Terminat",
         "retry": "Reîncercați",
+        "filesAdded": "{count, plural, =0 {nici un fişier adăugat} one {Un fişier adăugat} few {# fişiere adăugate} other {# de fişiere adăugate}}",
         "uploadedFailed": "{done} încărcat, {failed} a eșuat",
         "uploadingProgress": "{done} de {total} încărcare...",
         "renameAfter": "Redenumiţi toate fişierele de carte după încărcare",
@@ -3779,6 +3848,7 @@
         "resetHoldReleaseFailed": "Nu s-a putut folosi această poziție. Încercați din nou."
       },
       "editMetadata": {
+        "fieldCount": "{count, plural, =0 {nici un câmp} one {un câmp} few {# câmpuri} other {# de câmpuri}}",
         "bookFilesTarget": "fişiere de carte",
         "formatFilesTarget": "{formats} fișiere",
         "noPrimaryFile": "Nici un fişier primar disponibil",
@@ -3790,6 +3860,8 @@
         "writeManualLibraryDisabled": "Scrie metadate în fișier și redenumesc pe disc; scrierea automată este dezactivată pentru această bibliotecă",
         "writeManualTooltip": "Scrie {fields} la {target} și redenumește pe disc",
         "applyResult": "{skipped}, {updated}",
+        "skippedLockedFields": "{count, plural, =0 {Nu a trecut nici un câmp blocat} one {A sărit peste un câmp blocat} few {Au sărit # câmpuri blocate} other {Au sărit # de câmpuri blocate}}",
+        "updatedFields": "{count, plural, =0 {Nici un câmp nu a fost actualizat} one {a actualizat un câmp} few {# câmpuri actualizate} other {# de câmpuri actualizate}}",
         "wroteFieldsToFile": "{fields} la fișier",
         "fileWriteFailed": "Scrierea fișierului a eșuat",
         "fileWriteSkippedReason": "Fişier de scris omis: {reason}",
@@ -3803,6 +3875,7 @@
         "saveFailed": "Modificările nu au putut fi salvate",
         "saveFailedWithStatus": "Nu s-au putut salva modificările (HTTP {status})",
         "loadFromFileFailed": "Încărcarea metadatelor din fișier a eșuat",
+        "loadedFieldsFromFile": "{count, plural, =0 {Nu s-au încărcat câmpuri din fişierul} one {Încărcat un câmp din fişierul} few {Încărcat # câmpuri din fişierul} other {Încărcat # de câmpuri din fişierul}}",
         "noMetadataInFile": "Nu s-au găsit metadate în fișier",
         "loadFromFile": "Incarca din fisier",
         "loadFromFileTooltip": "Încarcă metadate din fișierul principal al cărții",
@@ -3862,6 +3935,7 @@
         "diffPanel": {
           "untitled": "Fără titlu",
           "noFieldsSelected": "Niciun câmp selectat",
+          "fieldsSelected": "{count, plural, =0 {nici un câmp selectat} one {un câmp selectat} few {# câmpuri selectate} other {# de câmpuri selectate}}",
           "results": "Rezultate",
           "providerMatches": "{provider} meciuri",
           "selectedOf": "{selected} {total} selectat",
@@ -3922,6 +3996,7 @@
       },
       "files": {
         "title": "Fişiere de carte",
+        "fileCount": "{count, plural, =0 {nici un fişier} one {# fişier} few {# fişiere} other {# de fişiere}}",
         "synced": "Sincronizat {time}",
         "sortAria": "Sortează fișierele",
         "syncHistory": "Istoricul sincronizării",
@@ -3947,6 +4022,7 @@
         "hideLog": "Ascundere jurnal",
         "viewSyncLog": "Vezi jurnalul de sincronizare",
         "noWriteHistory": "Nici un istoric de scriere încă.",
+        "fieldsWritten": "{count, plural, =0 {nici un câmp} one {un câmp} few {# câmpuri} other {# de câmpuri}}",
         "track": "Urmărire {number}",
         "primary": "Primară",
         "read": "Citește",
@@ -3986,6 +4062,11 @@
           "position": "Poziție",
           "newest": "Cele mai noi",
           "oldest": "Cel mai vechi primul"
+        },
+        "summary": {
+          "highlights": "{count, plural, =0 {Nu ai evidenţiat} one {o subliniere} few {# evidenţiază} other {# de evidenţiază}}",
+          "notes": "{count, plural, =0 {nici o notiță} one {o notiță} few {# notițe} other {# de notițe}}",
+          "chapters": "{count, plural, =0 {Nici un capitol} one {Un capitol} few {# capitole} other {# de capitole}}"
         },
         "filterByChapter": "Filtrare după capitol",
         "allChapters": "Toate capitolele",
@@ -4039,7 +4120,9 @@
           "relative": {
             "seconds": "{count}s acum",
             "minutes": "{count}m în urmă",
-            "days": "{count}d acum"
+            "days": "{count}d acum",
+            "months": "{count, plural, =0 {# lună în urmă} one {# lună în urmă} few {# luni în urmă} other {# de luni în urmă}}",
+            "years": "{count, plural, =0 {# an în urmă} one {# în urmă cu} few {# ani în urmă} other {# de ani în urmă}}"
           },
           "noSessions": "Nici o sesiune",
           "dateErrors": {
@@ -4233,6 +4316,7 @@
         "unread": "Necitit"
       },
       "series": {
+        "bookCount": "{count, plural, =0 {(fără cărți)} one {(# carte)} few {(# cărți)} other {(# de cărți)}}",
         "readOfCount": "{read} of {total} read"
       },
       "text": {
@@ -4240,14 +4324,18 @@
       }
     },
     "move": {
+      "title": "{count, plural, one {Mută # carte} few {Mută # cărţi} other {Mută # de cărţi}}",
       "subtitle": "Fișierele se mută pe disc în biblioteca de destinație. Acest lucru se poate schimba și cine poate vedea aceste cărți.",
       "searchPlaceholder": "Caută biblioteci",
       "currentLibrary": "Actuală",
+      "folderCount": "{count, plural, one {# dosar} few {# dosare} other {# de dosare}}",
       "continue": "Continuă",
       "back": "Înapoi",
+      "confirm": "{count, plural, one {Mută # carte} few {Mută # cărţi} other {Mută # de cărţi}}",
       "action": "Mutare în bibliotecă",
       "review": {
         "ready": "{count} gata",
+        "collisions": "{count, plural, one {# conflict de nume} few {# conflicte de nume} other {# de conflicte de nume}}",
         "ineligible": "{count} nu se poate muta",
         "alreadyThere": "{count} există deja",
         "collisionsHeading": "Conflicte de nume",
@@ -4322,6 +4410,7 @@
       "confirm": "Confirmă anularea",
       "keepRunning": "Continuă să rulezi"
     },
+    "viewFailed": "{count, plural, one {Vizualizarea uneia a eșuat} few {Vizualizarea # a eșuat} other {Vizualizarea # de a eșuat}}",
     "card": {
       "fetchingMetadata": "Preluare metadate",
       "enrichingAuthors": "Autori de îmbogățire",
@@ -4446,17 +4535,21 @@
       "results": "Rezultate"
     },
     "bulkEdit": {
+      "title": "{count, plural, =0 {Editare în bloc nici un fişier} one {Editează # fişierul} few {Editează în bloc # fişiere} other {Editează în bloc # de fişiere}}",
       "resultTitle": "Rezultate editare în bloc",
       "instructions": "Comutați câmpurile pe care doriți să le actualizați. Numai câmpurile activate vor fi aplicate.",
       "mergeArrays": "Îmbinați array-uri (adăugați la valorile existente în loc să înlocuiți)",
       "failed": "Editarea în bloc a eșuat"
     },
     "setDestination": {
+      "title": "{count, plural, =0 {Setează destinaţia pentru niciun fişier} one {Setează destinaţia pentru # fişier} few {Setează destinaţia pentru # fişiere} other {Setează destinaţia pentru # de fişiere}}",
       "resultTitle": "Destinație actualizată",
       "failed": "Setarea destinației a eșuat"
     },
     "finalizeDialog": {
+      "title": "{count, plural, =0 {Finalizează nici un fişier} one {Finalizează fişierul #} few {Finalizează # fişiere} other {Finalizează # de fişiere}}",
       "resultTitle": "Finalizează rezultatele",
+      "needDestination": "{count, plural, =0 {{without} din # fişiere selectate au nevoie de o destinaţie} one {{without} din # fişierul selectat are nevoie de o destinaţie} few {{without} din # fişiere selectate au nevoie de o destinaţie} other {{without} din # de fişiere selectate au nevoie de o destinaţie}}",
       "allHaveDestination": "Toate fișierele selectate au deja o destinație setată",
       "defaultDestinationLibrary": "Biblioteca implicită de destinație",
       "defaultDestinationFolder": "Dosar destinație implicit",
@@ -4465,8 +4558,14 @@
       "start": "Pornire",
       "filesFinalized": "{succeeded} de {total} fișiere finalizate",
       "checking": "Se verifică fișierele selectate...",
+      "readyCount": "{count, plural, =0 {nici un fişier gata} one {# fişier gata} few {# fişiere gata} other {# de fişiere gata}}",
+      "duplicateCount": "{count, plural, =0 {Nici unul din bibliotecile deja} one {# este deja în bibliotecă} few {# este deja în bibliotecă} other {# de este deja în bibliotecă}}",
+      "conflictCount": "{count, plural, =0 {nici un fişier de conflict} one {# Numele de fișier} few {# nume de fișier} other {# de nume de fișier}}",
+      "missingDestinationCount": "{count, plural, =0 {Nu lipsesc destinaţiile} one {# destinaţie lipsă} few {# destinaţii lipsă} other {# de destinaţii lipsă}}",
+      "blockedCount": "{count, plural, =0 {nici un fişier nu este blocat} one {# fişierul a fost blocat} few {# fişiere blocate} other {# de fişiere blocate}}",
       "moreDuplicates": "+{count} mai mult în bibliotecă",
       "discardDuplicates": "Renunțați la duplicate",
+      "failedCount": "{count, plural, =0 {nici un fişier nu a reuşit} one {# fişier a eşuat} few {# fişiere au eşuat} other {# de fişiere au eşuat}}",
       "view": "Vizualizare",
       "viewExisting": "Vizualizare existentă",
       "hide": "Ascunde",
@@ -4503,9 +4602,11 @@
         "applied": "Aplicat",
         "refetch": "Re-accesare metadate",
         "clickToZoom": "Faceți clic pe o copertă pentru a mări",
+        "changedFields": "{count, plural, one {Câmp #} few {# câmpuri} other {# de câmpuri}}",
         "needMore": "Ai nevoie să cauți furnizori sau să editezi alte câmpuri?"
       },
       "selection": {
+        "fileToLibrary": "{count, plural, =0 {Fişier în bibliotecă} one {Fişierul # până la bibliotecă} few {Fişierul # până la bibliotecă} other {Fişierul # de până la bibliotecă}}",
         "nSelected": "{count} selectate",
         "nReadyToFile": "{count} gata pentru fișier"
       },
@@ -4566,6 +4667,7 @@
     },
     "addToSheet": {
       "title": "Gestionează colecțiile",
+      "selectedCount": "{count, plural, =0 {nici o carte selectată} one {o carte selectată} few {# cărţi selectate} other {# de cărţi selectate}}",
       "newCollection": "Colecție nouă",
       "namePlaceholder": "Numele colecției",
       "create": "Crează",
@@ -4577,9 +4679,14 @@
       "inCollection": "În această colecție",
       "allInCollection": "Toate {total} în această colecție",
       "partialInCollection": "{partial} {total} în această colecție",
+      "bookCount": "{count, plural, =0 {Nu există cărţi} one {o carte} few {# cărţi} other {# de cărţi}}",
       "loadFailed": "Încărcarea colecțiilor a eșuat",
+      "createdAndAdded": "{count, plural, =0 {A creat \"{name}\" şi nu a adăugat nici o carte} one {A creat{name}\" şi a adăugat o carte} few {A creat \"{name}\" şi a adăugat # cărţi} other {A creat \"{name}\" şi a adăugat # de cărţi}}",
       "createFailed": "Crearea colecției a eșuat",
+      "addedNewWithExisting": "{count, plural, =0 {A adăugat o carte nouă la \"{name}({alreadyHad} deja acolo)} one {A adăugat o carte nouă la \"{name}\" ({alreadyHad} deja acolo)} few {A adăugat # cărţi noi la \"{name}({alreadyHad} deja acolo)} other {A adăugat # de cărţi noi la \"{name}({alreadyHad} deja acolo)}}",
+      "addedToCollection": "{count, plural, =0 {Nu au fost adăugate cărţi la \"{name}\"} one {A fost adăugată o carte la \"{name}} few {A fost adăugată # cărţi la \"{name}} other {A fost adăugată # de cărţi la \"{name}}}",
       "addFailed": "Adăugarea la colecție a eșuat",
+      "removedFromCollection": "{count, plural, =0 {Nu a fost eliminată nicio carte din \"{name}\"} one {A fost eliminată o carte din \"{name}} few {A fost eliminată # cărţi din \"{name}} other {A fost eliminată # de cărţi din \"{name}}}",
       "removeFailed": "Ștergerea din colecție a eșuat"
     }
   },
@@ -4590,6 +4697,9 @@
       "noResults": "Niciun rezultat",
       "loadingMore": "Se încarcă mai mult...",
       "loadMore": "Încarcă mai multe ({loaded}/{total})",
+      "allMatchesShown": "{count, plural, =0 {Toate cele 1 meciuri afișate} one {Toate meciurile 1 sunt afișate} few {Toate cele # meciuri afișate} other {Toate cele # de meciuri afișate}}",
+      "bookCount": "{count, plural, =0 {Nici o carte} one {# carte} few {# cărţi} other {# de cărţi}}",
+      "fileCount": "{count, plural, =0 {nici un fişier} one {# fişier} few {# fişiere} other {# de fişiere}}",
       "uploadedToast": "{uploaded} încărcate",
       "uploadFailedToast": "Încărcarea a eșuat pentru {failed}",
       "uploadPartialToast": "{uploaded}, {failed} a eșuat",
@@ -4704,6 +4814,7 @@
       "apply": "Aplică",
       "fieldPlaceholder": "Lăsați necompletat pentru a curăța",
       "fieldPlaceholderArray": "Separat prin virgulă (lăsaţi necompletat pentru a şterge)",
+      "deleteConfirm": "{count, plural, =0 {Ştergeţi # carte?} one {Ştergeţi # carte?} few {Ştergeţi # cărţi?} other {Ştergeţi # de cărţi?}}",
       "typeDelete": "Tip DELETE"
     },
     "viewHeader": {
@@ -4823,7 +4934,9 @@
     "uploadCount": "Încărcaţi {count}",
     "onlySvgSupported": "Doar fișierele SVG sunt acceptate",
     "maxStaged": "Puteți să prezentați cel mult iconița {max} o dată",
+    "onlyMoreCanStage": "{count, plural, =0 {Nu mai pot fi puse în scenă nici o pictogramă} one {Doar # în plus pot fi puse în scenă} few {Numai # alte pictograme pot fi puse în scenă} other {Numai # de alte pictograme pot fi puse în scenă}}",
     "readFailed": "Nu s-a putut citi fișierele SVG",
+    "uploadedCount": "{count, plural, =0 {Nici o pictogramă încărcată} one {Încărcat # pictogramă} few {Încărcat # pictograme} other {Încărcat # de pictograme}}",
     "uploadedPartial": "{created}, {failed} a eșuat",
     "noIconsUploaded": "Nicio pictogramă încărcată",
     "uploadFailed": "Încărcarea pictogramelor a eșuat",
@@ -4892,6 +5005,7 @@
       },
       "shelfRows": {
         "label": "Rânduri de cărți",
+        "option": "{count, plural, one {Un rând de cărţi} few {# rânduri de cărţi} other {# de rânduri de cărţi}}",
         "hint": "Setaţi câte rânduri de cărţi fiecare raft. Ecranele cu săgeată sunt afişate cel mult două."
       },
       "reorderHintWidget": "Trageți pentru a reordona. Comutați pentru a afișa sau ascunde un widget.",
@@ -4917,6 +5031,7 @@
       "diversityScore": {
         "title": "Scor Diversitate",
         "notEnoughData": "Citește cel puțin 3 cărți pentru a-ți vedea scorul diversității",
+        "booksAnalyzed": "{count, plural, =0 {nici o carte analizată} one {# carte analizată} few {# de cărţi analizate} other {# de cărţi analizate}}",
         "subScores": {
           "genre": "Gen",
           "author": "Autor",
@@ -4943,6 +5058,7 @@
         "title": "Așteptare lungă",
         "empty": "Nicio carte în așteptare. Ai pornit totul!",
         "daysWaiting": "zile în aşteptare",
+        "pages": "{count, plural, =0 {nici o pagină} one {# pagină} few {# pagini} other {# de pagini}}",
         "startReading": "Începe să citești"
       },
       "monthlyChallenge": {
@@ -4961,6 +5077,7 @@
       "readingDna": {
         "title": "ADN de lectură",
         "notEnoughData": "Citește cel puțin 5 cărți pentru a-ți debloca ADN-ul de lectură",
+        "basedOn": "{count, plural, =0 {Bazat pe nicio carte} one {Bazat pe # carte} few {Bazat pe # cărţi} other {Bazat pe # de cărţi}}",
         "traits": {
           "length": "Lungime",
           "variety": "Varietate",
@@ -4981,11 +5098,14 @@
       "readingRhythm": {
         "title": "Ritm de citire",
         "empty": "Începe să citești pentru a vedea ritmul tău prinde formă",
+        "activeDays": "{count, plural, =0 {nu sunt zile active} one {# zi activă} few {# zile active} other {# de zile active}}",
         "consistency": "{activeDays} · {percent}% consistență"
       },
       "readingStreak": {
         "title": "Lectură de lectură",
         "empty": "Citește astăzi pentru a porni streak",
+        "streakLabel": "{count, plural, =0 {Zi stradală} one {Zi stradală} few {zile stradale} other {zile stradale}}",
+        "best": "{count, plural, =0 {Cel mai bun: # ziua} one {Best: # ziua} few {Cel mai bun: # zile} other {Cel mai bun: # de zile}}",
         "lastSevenDays": "Ultimele 7 zile"
       },
       "yearProjection": {
@@ -5103,6 +5223,7 @@
       "namePlaceholder": "ex. Book Club",
       "creating": "Creare...",
       "empty": "Niciun grup încă. Creați un grup pentru a trimite mai mulți destinatari simultan.",
+      "memberCount": "{count, plural, =0 {niciun membru} one {un membru} few {# membri} other {# de membri}}",
       "deleteTooltip": "Șterge grup",
       "noMembers": "Nici un membru încă.",
       "removeMember": "Elimină",
@@ -5170,6 +5291,7 @@
     },
     "send": {
       "title": "Trimite prin e-mail",
+      "bookCount": "{count, plural, =0 {Nu există cărţi} one {o carte} few {# cărţi} other {# de cărţi}}",
       "recipients": "Destinatari",
       "noRecipients": "Niciun destinatar configurat. Adăugați unul în setările de e-mail.",
       "groups": "Grupuri",
@@ -5183,6 +5305,7 @@
       "default": "Implicit",
       "send": "Trimite",
       "sending": "Trimitere...",
+      "queued": "{count, plural, =0 {nu există e-mailuri în coada de aşteptare} one {un e-mail în aşteptare} few {# e-mailuri în aşteptare} other {# de e-mailuri în aşteptare}}",
       "failed": "Trimitere eșuată"
     }
   },
@@ -5275,7 +5398,9 @@
       },
       "lastSynced": {
         "justNow": "Chiar acum",
-        "minutesAgo": "{count} min acum"
+        "minutesAgo": "{count} min acum",
+        "hoursAgo": "{count, plural, =0 {# oră în urmă} one {# oră în urmă} few {# ore în urmă} other {# de ore în urmă}}",
+        "daysAgo": "{count, plural, =0 {# zile în urmă} one {# acum} few {# zile în urmă} other {# de zile în urmă}}"
       }
     },
     "import": {
@@ -5286,6 +5411,9 @@
       "importProgress": "Progresul importului",
       "reviewMatches": "Revizuiește meciurile",
       "importReady": "Importă gata",
+      "exactMatches": "{count, plural, =0 {nici o potrivire exactă nu poate fi importată fără revizuire} one {# Potrivire exactă poate fi importată fără recenzie} few {# potriviri exacte pot fi importate fără a revizui} other {# de potriviri exacte pot fi importate fără a revizui}}",
+      "progressAvailable": "{count, plural, =0 {nici o actualizare de progres disponibilă} one {# actualizare de progres disponibilă} few {# actualizări de progres disponibile} other {# de actualizări de progres disponibile}}",
+      "progressConflicts": "{count, plural, =0 {nu există conflicte} one {# conflict} few {# conflicte} other {# de conflicte}}",
       "unavailable": {
         "missingToken": "Conectează Hardcover înainte de import.",
         "userDisabled": "Sincronizarea este întreruptă în setările hardcos."
@@ -5302,7 +5430,9 @@
         "progressUpdated": "{count} progres actualizat"
       },
       "toast": {
-        "importFailed": "Importarea stării de citire Hardcover a eșuat"
+        "importFailed": "Importarea stării de citire Hardcover a eșuat",
+        "imported": "{count, plural, =0 {nu sunt statusuri de citire importate{progress}} one {# statutul de citire importate{progress}} few {# de a citi statusuri importate{progress}} other {# de a citi statusuri importate{progress}}}",
+        "progressUpdates": "{count, plural, =0 {nici o actualizare de progres} one {# actualizare de progres} few {# actualizări de progres} other {# de actualizări de progres}}"
       }
     },
     "review": {
@@ -5316,6 +5446,7 @@
       "noRows": "Niciun rând nu corespunde filtrelor curente.",
       "selectRowAriaLabel": "Selectați {title}",
       "selectionSummary": "{count} selectat: {ready} gata, {reviewed} revizuit.",
+      "selectedProgress": "{count, plural, =0 {nici o actualizare de progres} one {# actualizare de progres} few {# actualizări de progres} other {# de actualizări de progres}}",
       "selectReady": "Selectează gata",
       "selectPage": "Selectați pagina",
       "clearPage": "Ștergeți pagina",
@@ -5386,6 +5517,7 @@
       "noEditionsFound": "Nici o ediţie găsită.",
       "booksTruncated": "Arată primele cărți {count} pe care le citești.",
       "editionsTruncated": "Se afișează primele ediții {count}.",
+      "pages": "{count, plural, one {# pagină} few {# pagini} other {# de pagini}}",
       "isbn": "ISBN {isbn}",
       "current": "Actuală",
       "useThis": "Utilizează asta",
@@ -5634,6 +5766,7 @@
       "empty": "Acest dosar este gol",
       "emptyHint": "Puteți selecta dosarul curent sau crea unul nou.",
       "openFolderAria": "Deschide {name}",
+      "selectedCount": "{count, plural, =0 {nici un folder selectat} one {# folder selectat} few {# foldere selectate} other {# de foldere selectate}}",
       "noFolders": "Nu s-au găsit dosare",
       "selectFolder": "Selectați acest dosar",
       "errors": {
@@ -5654,6 +5787,8 @@
       "upload": "Incarca",
       "uploadWithCount": "Încărcare ({count})",
       "viewInLibrary": "Vezi în bibliotecă",
+      "fileCount": "{count, plural, =0 {nici un fişier} one {# fişier} few {# fişiere} other {# de fişiere}}",
+      "booksAdded": "{count, plural, =0 {nici o carte adăugată} one {# adăugată} few {# cărţi adăugate} other {# de cărţi adăugate}}",
       "uploadedFailed": "{done} încărcat, {failed} a eșuat",
       "progress": "{done} de {total} încărcare...",
       "header": {
@@ -5667,6 +5802,9 @@
         "hint": "{formats} - până la {size} MB în fiecare"
       }
     }
+  },
+  "metadataScore": {
+    "missingFields": "{count, plural, =0 {niciun câmp lipsește - editează metadatele} one {# câmp lipsă - editează metadatele} few {# câmpuri lipsă - editează metadate} other {# de câmpuri lipsă - editează metadate}}"
   },
   "migration": {
     "sidebarTitle": "Import Booklore",
@@ -5841,6 +5979,7 @@
       "ofCount": "de {total}",
       "targetBookId": "Agendă țintă #{id}",
       "recommended": "Recomandat",
+      "resolveButton": "{count, plural, =0 {Rezolvă # duplicat} one {Rezolvă # duplicat} few {Rezolvă # duplicate} other {Rezolvă # de duplicate}}",
       "byAuthor": "de {author} (ID: {id})",
       "byFilePath": "{filePath} (ID: {id})",
       "bookloreSourceId": "ID sursa: {id}",
@@ -6188,7 +6327,8 @@
       "searching": "Se caută…",
       "tooShort": "Introduceți cel puțin {min} caractere",
       "noResults": "Nici un rezultat găsit",
-      "prompt": "Scrie pentru a căuta"
+      "prompt": "Scrie pentru a căuta",
+      "resultCount": "{count, plural, =0 {nu există rezultate} one {# rezultat} few {# rezultate} other {# de rezultate}}"
     },
     "sidebar": {
       "tabs": {
@@ -6334,6 +6474,7 @@
       "sleep": "Somn",
       "chapterAbbrev": "Ch.",
       "sleepTimer": "Cronometru somn",
+      "minutes": "{count, plural, one {# minut} few {# minute} other {# de minute}}",
       "endOfChapter": "Sfârșitul capitolului",
       "noChaptersAvailable": "Nici un capitol disponibil",
       "extend15": "+ 15 minute",
@@ -6348,7 +6489,8 @@
     }
   },
   "scanner": {
-    "filesProgress": "{processed}/{total} fișiere"
+    "filesProgress": "{processed}/{total} fișiere",
+    "booksFound": "{count, plural, =0 {nu au fost găsite cărţi} one {# carte găsită} few {# cărţi găsite} other {# de cărţi găsite}}"
   },
   "series": {
     "completion": {
@@ -6396,6 +6538,7 @@
       "pageTitleNamed": "Seria · {name}",
       "pageTitleWithId": "Serii #{id}",
       "entityName": "Serii",
+      "bookCount": "{count, plural, =0 {Nici o carte} one {# carte} few {# cărţi} other {# de cărţi}}",
       "byAuthors": "de {authors}",
       "moreAuthors": "+{count} mai mult",
       "preparingEditor": "Se pregătește editorul...",
@@ -6460,6 +6603,7 @@
       "untitled": "SmartScope fără titlu",
       "subtitle": "Configurați setările inteligente de domeniu",
       "counting": "numărare...",
+      "bookCount": "{count, plural, =0 {Nu există cărţi} one {o carte} few {# cărţi} other {# de cărţi}}",
       "identity": "Identitate",
       "filters": "Filtre",
       "noFilters": "Niciun filtru setat. Toate cărțile accesibile vor fi incluse în această sferă inteligentă.",
@@ -6510,7 +6654,8 @@
     "card": {
       "loadError": "Încărcarea datelor a eșuat",
       "emptyTitle": "Încă nu există date",
-      "emptyDescription": "Nu există date disponibile pentru această diagramă"
+      "emptyDescription": "Nu există date disponibile pentru această diagramă",
+      "unknownField": "{count, plural, =0 {nu există date pentru acest domeniu} one {# carte nu are date pentru acest domeniu} few {# cărţi nu au nici o informaţie pentru acest domeniu} other {# de cărţi nu au nici o informaţie pentru acest domeniu}}"
     },
     "breakdown": {
       "ariaLabel": "Defalcare după sursă sau format"
@@ -6705,7 +6850,9 @@
       "summary": {
         "label": "Summary",
         "toRename": "{count} pentru redenumire",
-        "unchanged": "{count} neschimbat"
+        "unchanged": "{count} neschimbat",
+        "collisions": "{count, plural, =0 {# coliziune} one {# coliziune} few {# coliziuni} other {# de coliziuni}}",
+        "errors": "{count, plural, =0 {# eroare} one {# eroare} few {# erori} other {# de erori}}"
       },
       "empty": {
         "title": "Alege o bibliotecă pentru a începe",
@@ -6720,7 +6867,9 @@
         "showing": "Afișare {from}-{to} {total}"
       },
       "confirmDialog": {
-        "title": "Confirmare Redenumire în bloc"
+        "title": "Confirmare Redenumire în bloc",
+        "body": "{count, plural, =0 {Aceasta va redenumi # carte pe disc. Fişierele cu coliziuni sau erori vor fi sărite. Această acţiune nu poate fi anulată.} one {Aceasta va redenumi # carte pe disc. Fișierele cu coliziuni sau erori vor fi sărite. Această acțiune nu poate fi anulată.} few {Aceasta va redenumi # cărți pe disc. Fișierele cu coliziuni sau erori vor fi sărite. Această acțiune nu poate fi anulată.} other {Aceasta va redenumi # de cărți pe disc. Fișierele cu coliziuni sau erori vor fi sărite. Această acțiune nu poate fi anulată.}}",
+        "renameButton": "{count, plural, =0 {Redenumiţi # carte} one {Redenumiţi # carte} few {Redenumiţi # cărţi} other {Redenumiţi # de cărţi}}"
       }
     },
     "bookDuplicates": {
@@ -6738,6 +6887,7 @@
         "queued": "Scanare în așteptare",
         "running": "Scanare cărți"
       },
+      "groupsFound": "{count, plural, =0 {Niciun grup duplicat} one {Un grup duplicat} few {# grupuri duplicate} other {# de grupuri duplicate}}",
       "filter": "Potrivire tip",
       "allReasons": "Toate tipurile de meciuri",
       "reasons": {
@@ -6785,7 +6935,10 @@
       },
       "deleteDialog": {
         "title": "Ștergeți definitiv cărțile duplicate?",
-        "warning": "Metadata, colectările, datele de citire și starea dispozitivului nu sunt transferate în cartea păstrată. Datele asociate pentru alți utilizatori sunt, de asemenea, eliminate."
+        "description": "{count, plural, =0 {Acest lucru va şterge definitiv # de carte şi fişierele selectate.} one {Aceasta va şterge definitiv # şi fişierele selectate.} few {Aceasta va şterge definitiv # cărţi şi fişierele selectate.} other {Aceasta va şterge definitiv # de cărţi şi fişierele selectate.}}",
+        "warning": "Metadata, colectările, datele de citire și starea dispozitivului nu sunt transferate în cartea păstrată. Datele asociate pentru alți utilizatori sunt, de asemenea, eliminate.",
+        "confirm": "{count, plural, =0 {Ştergeţi # carte} one {Ştergeţi # carte} few {Ştergeţi # cărţi} other {Ştergeţi # de cărţi}}",
+        "success": "{count, plural, =0 {Nicio carte nu a fost ștearsă} one {O carte duplicat a fost ștearsă} few {# cărți duplicat șterse} other {# de cărți duplicat șterse}}"
       },
       "errors": {
         "start": "Nu s-a putut începe scanarea duplicat.",
@@ -6801,6 +6954,7 @@
     },
     "entityManager": {
       "unknown": "Necunoscut",
+      "bookCount": "{count, plural, =0 {Nici o carte} one {# carte} few {# cărţi} other {# de cărţi}}",
       "sortPrefix": "· sortare: {sortName}",
       "selectTargetToKeep": "Selectați ținta pentru a păstra",
       "writeToFiles": "Scrie în fişiere",
@@ -6827,6 +6981,8 @@
         "emptyDescription": "Reglaţi pragul de similaritate şi faceţi clic pe Scanare pentru a detecta dublurile potenţiale.",
         "noneFoundTitle": "Nici o dublură găsită",
         "noneFoundDescription": "Nu au fost detectate dubluri potențiale cu setările curente.",
+        "clustersFound": "{count, plural, =0 {niciun cluster nu a fost găsit} one {# cluster găsit} few {# clustere găsite} other {# de clustere găsite}}",
+        "plusOthers": "{count, plural, =0 {+ # altceva} one {+ # altele} few {+ # alții} other {+ # de alții}}",
         "percentSimilar": "{percent}% similar",
         "pairDetails": "Detalii pereche",
         "dismissEntityTitle": "Renunță la toate perechile pentru această entitate",
@@ -6959,9 +7115,13 @@
         "uploadPrompt": "Încărcaţi fişiere sau plasaţi-le în folderul Book Dock"
       },
       "retry": {
-        "noneToRetry": "Nu există fișiere de eroare pentru a reîncerca"
+        "noneToRetry": "Nu există fișiere de eroare pentru a reîncerca",
+        "retrying": "{count, plural, =0 {Reîncearcă un fișier} one {Reîncearcă un fișier} few {Reîncearcă # fișiere} other {Reîncearcă # de fișiere}}"
       },
       "applyFetched": {
+        "applied": "{count, plural, =0 {A fost aplicat niciunui fișier} one {S-a aplicat la un fișier} few {S-a aplicat la # fișiere} other {S-a aplicat la # de fișiere}}",
+        "skippedEdited": "{count, plural, =0 {a omis un fișier deoarece au editat manual} one {a omis un fișier deoarece a editat manual} few {au omis # fișiere, deoarece au editat manual} other {au omis # de fișiere, deoarece au editat manual}}",
+        "skippedNoMetadata": "{count, plural, =0 {a omis un fișier pentru că nu au găsit metadate} one {a sărit un fișier deoarece nu are metadate preluate} few {au omis # fișiere, pentru că nu au găsit metadate} other {au omis # de fișiere, pentru că nu au găsit metadate}}",
         "noneApplied": "Nu se aplică fișiere; {reasons}",
         "noneSelected": "Niciun fișier selectat"
       }
@@ -6974,6 +7134,7 @@
       "showControlsAria": "Arată controalele colecției",
       "loadError": "Nu s-a putut încărca această colecție",
       "toast": {
+        "removed": "{count, plural, =0 {Nici o carte nu a fost eliminată din colecţie} one {A fost eliminată o carte din colecţie} few {A fost eliminată # cărţi din colecţie} other {A fost eliminată # de cărţi din colecţie}}",
         "removeFailed": "Ștergerea cărților din colecție a eșuat"
       },
       "empty": {
@@ -7048,6 +7209,7 @@
     "title": "Ce este nou",
     "subtitle": "Tot ceea ce este transportat, cel mai nou început.",
     "versionPrefix": "{version} versiune",
+    "newUpdates": "{count, plural, =0 {nu sunt actualizări noi} one {o actualizare nouă} few {# actualizări noi} other {# de actualizări noi}}",
     "remindLater": "Amintește-mi mai târziu",
     "gotIt": "Am înțeles",
     "latest": "Ultimele",


### PR DESCRIPTION
Automated sparse translation export from Crowdin.

Untranslated entries are omitted so Vue I18n falls back to the English catalog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Expanded German, French, Japanese, Korean, Portuguese, and Romanian translations across device management, settings, users, annotations, books, authors, reading activity, migration, sharing, and administration.
  * Added clearer empty states, progress messages, bulk-action confirmations, status labels, accessibility text, and pluralized item counts.
  * Corrected several French labels and added new viewing, filtering, grouping, and download options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->