### PR TITLE
feat(client): make genre and tag pills open a pre-filtered library view

### DIFF
--- a/client/src/features/book/components/detail/tabs/DetailsTab.vue
+++ b/client/src/features/book/components/detail/tabs/DetailsTab.vue
@@ -946,6 +946,27 @@ function providerLinkStyle(provider: string) {
   }
 }
 
+// Genre/tag pills jump to this book's library pre-filtered to that value, mirroring the
+// genre/tag quick-filter already available from the library table's column chips
+// (see VirtualBookTable.vue's getChipsActionFn). The filter itself is applied by
+// HomeView reading these query params on mount, since filter state there is otherwise
+// local/localStorage-only, not route-driven.
+function navigateWithQuickFilter(field: 'genre' | 'tag', value: string) {
+  router.push({
+    name: 'library',
+    params: { id: props.book.libraryId },
+    query: { quickFilterField: field, quickFilterValue: value },
+  })
+}
+
+function handleGenreClick(genre: string) {
+  navigateWithQuickFilter('genre', genre)
+}
+
+function handleTagClick(tag: string) {
+  navigateWithQuickFilter('tag', tag)
+}
+
 function handleEditMetadataFromScore() {
   scoreBreakdownOpen.value = false
   router.push({ name: 'book-detail', params: { bookId: props.book.id }, query: { tab: 'edit' } })
@@ -1665,14 +1686,16 @@ watch(
       <div v-if="book.genres.length || book.tags.length" class="space-y-1">
         <div v-if="book.genres.length" class="relative">
           <div data-test="genre-row" class="flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap">
-            <span
+            <button
               v-for="(genre, index) in displayedGenres"
               :key="`${genre}-${index}`"
+              type="button"
               data-test="visible-genre"
-              class="shrink-0 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground"
+              class="shrink-0 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+              @click="() => handleGenreClick(genre)"
             >
               {{ genre }}
-            </span>
+            </button>
             <Popover v-if="genreHiddenCount > 0">
               <PopoverTrigger as-child>
                 <button
@@ -1686,13 +1709,15 @@ watch(
               </PopoverTrigger>
               <PopoverContent align="start" class="w-80 max-w-[calc(100vw-2rem)] p-3">
                 <div data-test="hidden-genres" class="flex flex-wrap gap-1.5">
-                  <span
+                  <button
                     v-for="(genre, index) in hiddenGenres"
                     :key="`hidden-${genre}-${index}`"
-                    class="rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground"
+                    type="button"
+                    class="rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                    @click="() => handleGenreClick(genre)"
                   >
                     {{ genre }}
-                  </span>
+                  </button>
                 </div>
               </PopoverContent>
             </Popover>
@@ -1722,13 +1747,15 @@ watch(
         </div>
 
         <div v-if="book.tags.length" class="flex flex-wrap gap-1.5">
-          <span
+          <button
             v-for="tag in book.tags"
             :key="tag"
-            class="rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-600 dark:text-amber-400"
+            type="button"
+            class="rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-600 transition-colors hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring dark:text-amber-400"
+            @click="() => handleTagClick(tag)"
           >
             #{{ tag }}
-          </span>
+          </button>
         </div>
       </div>
 

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -273,6 +273,25 @@ function dismissQuerySelectionBanner() {
   showQuerySelectionBanner.value = false
 }
 
+// Lets a genre/tag pill on the book detail page (or anywhere else) deep-link into this
+// library pre-filtered, by reusing the same quick-filter rule shape the table's genre/tag
+// column chips already produce (see VirtualBookTable.vue's getChipsActionFn). Filter state
+// here is otherwise local/localStorage-only, not route-driven, so this is read once on
+// arrival and then stripped from the URL rather than kept live in sync with it.
+function applyQuickFilterFromRoute() {
+  const field = route.query.quickFilterField
+  const value = route.query.quickFilterValue
+  if (typeof field !== 'string' || typeof value !== 'string') return
+  if (field !== 'genre' && field !== 'tag') return
+
+  handleQuickFilter({ type: 'rule', field, operator: 'includesAny', value: [value] })
+
+  const nextQuery = { ...route.query }
+  delete nextQuery.quickFilterField
+  delete nextQuery.quickFilterValue
+  void router.replace({ query: nextQuery })
+}
+
 watch(
   libraryId,
   (id) => {
@@ -286,6 +305,7 @@ watch(
         savedFilter.value = undefined
         filter.value = undefined
       }
+      applyQuickFilterFromRoute()
     } else {
       savedFilter.value = undefined
       filter.value = undefined


### PR DESCRIPTION
Closes #1077.

Genres and tags on the book detail page were static, non-interactive badges - authors already linked out to a filtered author page, this brings genres/tags to parity.

Rather than inventing new plumbing, this reuses the exact quick-filter rule shape the library table's genre/tag column chips already produce (`VirtualBookTable.vue`'s `getChipsActionFn`, emitting `{ type: 'rule', field: 'genre'|'tag', operator: 'includesAny', value: [name] }`), which `HomeView`'s `handleQuickFilter` already knows how to merge into the active filter. Since the detail page is a separate route from the library view and filter state there is local/localStorage-only (not URL-driven), the rule is passed through as a one-time `quickFilterField`/`quickFilterValue` query param that `HomeView` applies once on arrival and then strips from the URL.

Verified: typecheck and lint clean on both workspaces, all 50 existing `DetailsTab` component tests pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Genre and tag pills in book details are now clickable.
  - Selecting a genre or tag opens the library with results filtered to that value.
  - Filter links work for both visible and overflowed genres.
  - Library filter links are applied automatically when opened from a deep link, while keeping the URL clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->