### PR TITLE
fix(scanner): treat symlinked files as valid scan candidates

### DIFF
--- a/server/src/modules/scanner/lib/walk.ts
+++ b/server/src/modules/scanner/lib/walk.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from 'fs';
 import { readdir, stat } from 'fs/promises';
 import { basename, dirname, join, relative } from 'path';
 
@@ -41,6 +42,19 @@ export function isDiscDirectory(name: string): boolean {
 export function stemOf(name: string): string {
   const i = name.lastIndexOf('.');
   return i > 0 ? name.slice(0, i) : name;
+}
+
+// A symlinked *file* is a valid content/sidecar candidate once resolved to a
+// regular file - this is how debrid/rclone-backed libraries (Shelfarr's
+// reference import mode, decypharr, Zurg, blackhole-style setups) publish
+// content without a full local copy. Symlinked *directories* are still never
+// followed here, to avoid introducing traversal loops or letting a scan
+// escape the library root through a redirected subfolder.
+async function resolveFileEntry(fullPath: string, entry: Dirent): Promise<boolean> {
+  if (entry.isFile() && !entry.isSymbolicLink()) return true;
+  if (!entry.isSymbolicLink()) return false;
+  const resolved = await stat(fullPath).catch(() => null);
+  return resolved?.isFile() ?? false;
 }
 
 function buildExcludeMatcher(patterns: string[]): (name: string) => boolean {
@@ -141,7 +155,7 @@ async function collectByDir(
 
     if (entry.isDirectory() && !entry.isSymbolicLink()) {
       subdirs.push(full);
-    } else if (entry.isFile() && !entry.isSymbolicLink()) {
+    } else if (await resolveFileEntry(full, entry)) {
       if (full.length > MAX_PATH_LENGTH) {
         logger?.(`Path exceeds ${MAX_PATH_LENGTH} characters, skipping: ${full}`);
         continue;
@@ -384,7 +398,7 @@ export async function buildSingleBookCandidate(
       } else {
         nonDiscDirs.push({ name: entry.name, path: full });
       }
-    } else if (entry.isFile() && !entry.isSymbolicLink() && full.length <= MAX_PATH_LENGTH) {
+    } else if (full.length <= MAX_PATH_LENGTH && (await resolveFileEntry(full, entry))) {
       filePaths.push(full);
     }
   }
@@ -392,10 +406,10 @@ export async function buildSingleBookCandidate(
   for (const discDir of discDirs) {
     const discEntries = await readdir(discDir, { withFileTypes: true }).catch(() => []);
     for (const entry of discEntries) {
-      if (!entry.isFile() || entry.isSymbolicLink() || entry.name.startsWith('.')) continue;
+      if (entry.name.startsWith('.')) continue;
       if (shouldExclude(entry.name)) continue;
       const full = join(discDir, entry.name);
-      if (full.length <= MAX_PATH_LENGTH) filePaths.push(full);
+      if (full.length <= MAX_PATH_LENGTH && (await resolveFileEntry(full, entry))) filePaths.push(full);
     }
   }
 

--- a/server/test/e2e/scanner/scanner-fixture-builder.ts
+++ b/server/test/e2e/scanner/scanner-fixture-builder.ts
@@ -1,8 +1,12 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, rm, symlink as symlinkFs, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 
-export type FixtureEntry = { kind: 'file'; path: string; content?: string } | { kind: 'dir'; path: string };
+export type FixtureEntry =
+  | { kind: 'file'; path: string; content?: string }
+  | { kind: 'dir'; path: string }
+  | { kind: 'symlink'; path: string; content?: string }
+  | { kind: 'symlinkDir'; path: string; entries: FixtureEntry[] };
 
 export interface FixtureTree {
   rootPath: string;
@@ -25,24 +29,63 @@ export function dir(path: string): FixtureEntry {
   return { kind: 'dir', path };
 }
 
-export async function createFixtureTree(entries: FixtureEntry[], prefix = 'scanner-e2e-'): Promise<FixtureTree> {
-  const rootPath = await mkdtemp(join(tmpdir(), prefix));
+// Creates a symlink pointing at a real file kept outside the fixture root,
+// mirroring how debrid/rclone-backed libraries publish content.
+export function symlink(path: string, content?: string): FixtureEntry {
+  assertRelativePath(path);
+  return { kind: 'symlink', path, content: content ?? `${path}\n`.repeat(600) };
+}
 
+// Creates a symlink pointing at a real directory (containing `entries`) kept
+// outside the fixture root, to verify symlinked directories are still excluded.
+export function symlinkDir(path: string, entries: FixtureEntry[]): FixtureEntry {
+  assertRelativePath(path);
+  return { kind: 'symlinkDir', path, entries };
+}
+
+async function materialize(rootPath: string, targetsPath: string, entries: FixtureEntry[]): Promise<void> {
   for (const entry of entries) {
     const fullPath = join(rootPath, entry.path);
+
     if (entry.kind === 'dir') {
       await mkdir(fullPath, { recursive: true });
       continue;
     }
 
+    if (entry.kind === 'file') {
+      await mkdir(dirname(fullPath), { recursive: true });
+      await writeFile(fullPath, entry.content);
+      continue;
+    }
+
+    if (entry.kind === 'symlink') {
+      const targetPath = join(targetsPath, entry.path);
+      await mkdir(dirname(targetPath), { recursive: true });
+      await writeFile(targetPath, entry.content);
+      await mkdir(dirname(fullPath), { recursive: true });
+      await symlinkFs(targetPath, fullPath);
+      continue;
+    }
+
+    const targetDirPath = join(targetsPath, entry.path);
+    await mkdir(targetDirPath, { recursive: true });
+    await materialize(targetDirPath, targetsPath, entry.entries);
     await mkdir(dirname(fullPath), { recursive: true });
-    await writeFile(fullPath, entry.content);
+    await symlinkFs(targetDirPath, fullPath);
   }
+}
+
+export async function createFixtureTree(entries: FixtureEntry[], prefix = 'scanner-e2e-'): Promise<FixtureTree> {
+  const rootPath = await mkdtemp(join(tmpdir(), prefix));
+  const targetsPath = await mkdtemp(join(tmpdir(), `${prefix}targets-`));
+
+  await materialize(rootPath, targetsPath, entries);
 
   return {
     rootPath,
     cleanup: async () => {
       await rm(rootPath, { recursive: true, force: true });
+      await rm(targetsPath, { recursive: true, force: true });
     },
   };
 }

--- a/server/test/scanner-scenarios.e2e-spec.ts
+++ b/server/test/scanner-scenarios.e2e-spec.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 
 import type { FixtureEntry } from './e2e/scanner/scanner-fixture-builder';
-import { createFixtureTree, file } from './e2e/scanner/scanner-fixture-builder';
+import { createFixtureTree, file, symlink, symlinkDir } from './e2e/scanner/scanner-fixture-builder';
 import {
   assertNoIntegrityViolations,
   closeScannerE2EContext,
@@ -237,6 +237,30 @@ const bookPerFolderScenarios: ScannerScenario[] = [
     mode: 'book_per_folder',
     entries: [file('AudioBook/Discography/01.mp3'), file('AudioBook/cover.jpg')],
     expected: [{ folderPath: 'AudioBook/Discography', filePaths: ['AudioBook/Discography/01.mp3'], primaryPath: 'AudioBook/Discography/01.mp3' }],
+  },
+  {
+    id: 'book-per-folder-symlinked-audio-file-included',
+    mode: 'book_per_folder',
+    entries: [symlink('Audio/track-1.mp3'), file('Audio/track-2.mp3'), file('Audio/cover.jpg')],
+    expected: [
+      {
+        folderPath: 'Audio',
+        filePaths: ['Audio/cover.jpg', 'Audio/track-1.mp3', 'Audio/track-2.mp3'],
+        primaryPath: 'Audio/track-1.mp3',
+      },
+    ],
+  },
+  {
+    id: 'book-per-folder-symlinked-directory-excluded',
+    mode: 'book_per_folder',
+    entries: [file('AudioSymlinked/track-1.mp3'), file('AudioSymlinked/cover.jpg'), symlinkDir('AudioSymlinked/Extras', [file('bonus.mp3')])],
+    expected: [
+      {
+        folderPath: 'AudioSymlinked',
+        filePaths: ['AudioSymlinked/cover.jpg', 'AudioSymlinked/track-1.mp3'],
+        primaryPath: 'AudioSymlinked/track-1.mp3',
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
## Summary
- The library scanner unconditionally excluded every symlink — including symlinked *files* — from scan candidates, in `collectByDir`, `buildSingleBookCandidate`'s main loop, and its disc-subdirectory loop.
- This breaks any library backed by debrid/rclone-style content (e.g. Shelfarr's `reference` import mode, decypharr, Zurg, blackhole-style setups), since those publish books as symlinks to files that live elsewhere.
- Added a shared `resolveFileEntry` helper that `stat()`s a symlinked entry and accepts it once confirmed to resolve to a regular file. Symlinked *directories* are still never followed, to avoid traversal loops or a scan escaping the library root through a redirected subfolder.

## Test plan
- [x] Added `symlink`/`symlinkDir` fixture helpers to `scanner-fixture-builder.ts` (symlink targets live outside the fixture root, mirroring real debrid setups)
- [x] Added `book-per-folder-symlinked-audio-file-included` e2e scenario — proves a symlinked audio file is now picked up as book content
- [x] Added `book-per-folder-symlinked-directory-excluded` e2e scenario — proves symlinked directories are still excluded from traversal
- [x] `pnpm run e2e:run -- scanner-scenarios` — all 37 scenarios pass
- [x] `pnpm run typecheck:server` and `pnpm run lint:check` pass
- [x] Full `pnpm run verify:fast` (pre-push hook) passes for both server and client

Fixes #999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scanner now includes symlinks that resolve to regular files, including audio files within book folders.
  * Symlinked directories remain excluded from scanning to prevent unintended content discovery.

* **Tests**
  * Added end-to-end coverage for included symlinked files and excluded symlinked directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->