### PR TITLE
fix(server): stop late-delivered sessions from duplicating a completed reading attempt

### DIFF
--- a/server/src/modules/user-book-status/reading-attempt.repository.ts
+++ b/server/src/modules/user-book-status/reading-attempt.repository.ts
@@ -82,6 +82,11 @@ export class ReadingAttemptRepository {
       .where(and(...boundaries));
   }
 
+  async findUserSettings(tx: Tx, userId: number): Promise<unknown> {
+    const [row] = await tx.select({ settings: users.settings }).from(users).where(eq(users.id, userId)).limit(1);
+    return row?.settings ?? null;
+  }
+
   async findActive(tx: Tx, userId: number, bookId: number) {
     const [row] = await tx
       .select()

--- a/server/src/modules/user-book-status/reading-attempt.service.test.ts
+++ b/server/src/modules/user-book-status/reading-attempt.service.test.ts
@@ -111,6 +111,8 @@ function makeFakeRepo() {
       return Promise.resolve();
     }),
     findStatus: vi.fn(() => Promise.resolve(null)),
+    findUserSettings: vi.fn(() => Promise.resolve({ timezone: 'Europe/Paris' })),
+    attachBackfilledSessions: vi.fn(() => Promise.resolve()),
     findByExternal: vi.fn((_tx: object, userId: number, provider: string, externalId: string) =>
       Promise.resolve(rows.find((row) => row.userId === userId && row.externalProvider === provider && row.externalId === externalId)),
     ),
@@ -511,6 +513,143 @@ describe('ReadingAttemptService', () => {
     });
 
     expect(row.endedOn).toBe('2025-01-10');
+  });
+
+  describe('sessions delivered after the device already closed the attempt', () => {
+    async function completeAttempt() {
+      return fake.repo.create(
+        {},
+        {
+          userId: 1,
+          bookId: 10,
+          startedOn: '2026-08-27',
+          endedOn: '2026-08-31',
+          outcome: 'completed',
+          origin: 'kobo',
+        },
+      );
+    }
+
+    it('adopts a late meaningful session into the completed attempt instead of opening a duplicate', async () => {
+      const attempt = await completeAttempt();
+
+      const result = await service.recordActivity({
+        userId: 1,
+        bookId: 10,
+        occurredOn: '2026-08-30',
+        origin: 'bookorbit',
+        progress: 94,
+        finishThreshold: 98,
+        strongRereadEvidence: false,
+        meaningfulActivity: true,
+      });
+
+      expect(result).toBeNull();
+      expect(fake.rows).toHaveLength(1);
+      expect(fake.repo.attachBackfilledSessions).toHaveBeenCalledWith(
+        fake.transactionContext,
+        1,
+        10,
+        attempt.id,
+        'Europe/Paris',
+        '2026-08-27',
+        '2026-08-31',
+      );
+    });
+
+    it('adopts the finishing session that trails the reading-state close', async () => {
+      const attempt = await completeAttempt();
+
+      const result = await service.recordActivity({
+        userId: 1,
+        bookId: 10,
+        occurredOn: '2026-08-31',
+        origin: 'bookorbit',
+        progress: 100,
+        finishThreshold: 98,
+        strongRereadEvidence: false,
+        meaningfulActivity: true,
+      });
+
+      expect(result).toBeNull();
+      expect(fake.rows).toHaveLength(1);
+      expect(fake.repo.attachBackfilledSessions).toHaveBeenCalledWith(
+        fake.transactionContext,
+        1,
+        10,
+        attempt.id,
+        'Europe/Paris',
+        '2026-08-27',
+        '2026-08-31',
+      );
+    });
+
+    it('still opens a same-day reread when the strong signal says so', async () => {
+      await completeAttempt();
+
+      const result = await service.recordActivity({
+        userId: 1,
+        bookId: 10,
+        occurredOn: '2026-08-31',
+        origin: 'kobo',
+        progress: 5,
+        finishThreshold: 98,
+        strongRereadEvidence: true,
+        meaningfulActivity: false,
+      });
+
+      expect(result?.status).toBe('rereading');
+      expect(fake.rows).toHaveLength(2);
+      expect(fake.repo.attachBackfilledSessions).not.toHaveBeenCalled();
+    });
+
+    it('still opens a reread from meaningful activity after the attempt ended', async () => {
+      await completeAttempt();
+
+      const result = await service.recordActivity({
+        userId: 1,
+        bookId: 10,
+        occurredOn: '2026-09-05',
+        origin: 'bookorbit',
+        progress: 12,
+        finishThreshold: 98,
+        strongRereadEvidence: false,
+        meaningfulActivity: true,
+      });
+
+      expect(result?.status).toBe('rereading');
+      expect(fake.rows).toHaveLength(2);
+      expect(fake.repo.attachBackfilledSessions).not.toHaveBeenCalled();
+    });
+
+    it('leaves a completion without an end date out of the retroactivity guard', async () => {
+      await fake.repo.create(
+        {},
+        {
+          userId: 1,
+          bookId: 10,
+          startedOn: null,
+          endedOn: null,
+          outcome: 'completed',
+          origin: 'migration',
+        },
+      );
+
+      const result = await service.recordActivity({
+        userId: 1,
+        bookId: 10,
+        occurredOn: '2026-08-30',
+        origin: 'bookorbit',
+        progress: 94,
+        finishThreshold: 98,
+        strongRereadEvidence: false,
+        meaningfulActivity: true,
+      });
+
+      expect(result?.status).toBe('rereading');
+      expect(fake.rows).toHaveLength(2);
+      expect(fake.repo.attachBackfilledSessions).not.toHaveBeenCalled();
+    });
   });
 
   describe('closing an attempt that a skewed device clock started in the future', () => {

--- a/server/src/modules/user-book-status/reading-attempt.service.ts
+++ b/server/src/modules/user-book-status/reading-attempt.service.ts
@@ -9,6 +9,7 @@ import type {
   UserBookStatus,
 } from '@bookorbit/types';
 
+import { resolveTimeZone } from '../../common/utils/timezone.utils';
 import { ReadingAttemptRepository } from './reading-attempt.repository';
 import { READING_DATE_ERROR_CODES } from './user-book-status.constants';
 
@@ -261,6 +262,23 @@ export class ReadingAttemptService {
       const hasCompleted = await this.repo.hasCompleted(tx, input.userId, input.bookId);
       const isFinished = input.progress >= input.finishThreshold;
 
+      // A device that skips a sync delivers the closing sessions of a read only after the
+      // finished state itself has already closed the attempt (the analytics batch trails the
+      // reading-state PUT). Activity dated on or before that attempt's end is late-arriving
+      // backlog of it, not evidence of a new read: adopt whatever sessions the close left
+      // unassigned into the attempt they belong to instead of fabricating a duplicate.
+      if (
+        !active &&
+        !input.strongRereadEvidence &&
+        latest?.outcome === 'completed' &&
+        latest.endedOn !== null &&
+        input.occurredOn <= latest.endedOn
+      ) {
+        const settings = await this.repo.findUserSettings(tx, input.userId);
+        const timezone = resolveTimeZone((settings as { timezone?: unknown } | null)?.timezone, 'UTC');
+        await this.repo.attachBackfilledSessions(tx, input.userId, input.bookId, latest.id, timezone, latest.startedOn, latest.endedOn);
+        return null;
+      }
       if (!active && hasCompleted && !input.strongRereadEvidence && !input.meaningfulActivity) return null;
       if (!active && isFinished && !hasCompleted) {
         latest = await this.repo.create(tx, {


### PR DESCRIPTION
Closes #1224

## What went wrong

When a Kobo device skips a sync and then syncs right after the reader finishes a book, the reading-state PUT (`Status: Finished`) closes the active reading attempt first, and the analytics batch carrying the final reading sessions lands a few seconds later. `ReadingAttemptService.recordActivity()` then finds no active attempt, a meaningful session (≥ 300 s or ≥ 1 % delta) passes the weak-activity guard, and the `!active && !isFinished` branch fabricates a second active attempt — which the batch's 100 % session immediately completes. The book shows as read twice, and with Hardcover sync enabled the duplicate is pushed there too. Full trace in #1224.

## The fix

- `recordActivity()` gains a retroactivity guard: with no active attempt, no strong reread evidence, and the latest attempt completed with an end date on or after the activity date, the activity is treated as late-delivered backlog of that attempt. Nothing new is created; the sessions the close left unassigned (`attempt_id IS NULL`) are adopted into the completed attempt through the existing `attachBackfilledSessions()` boundary logic, and the projection is left untouched.
- New `ReadingAttemptRepository.findUserSettings()` (one indexed select, only on the guard path) provides the user's timezone for those date boundaries, resolved with the same `resolveTimeZone(..., 'UTC')` convention as the backfill service.

Genuine rereads keep working: a same-day restart carries `strongRereadEvidence` (≥ 10-point progress drop) and bypasses the guard; activity dated after the completed attempt's end never enters the guard and opens a reread exactly as before; completions without an end date (`migration` origin) are excluded.

## Tests

Five new Vitest cases in `reading-attempt.service.test.ts`, in the file's existing fake-repo style: the two race orderings (late 94 % session, trailing 100 % session) no longer create a second attempt and adopt the orphaned sessions; a same-day strong reread still opens an attempt; later meaningful activity still opens a reread; a dateless completion stays out of the guard. The first two fail on `main` and pass with this patch.

`pnpm --filter server type-check`, `eslint` on the touched files, and `vitest run src/modules/user-book-status` (137 tests) all pass.

## AI disclosure

```
AI tools used: Claude (Claude Code)
Extent: root-cause analysis, the patch and the test cases were produced with Claude Code, driven and reviewed line by line by me; the fix implements the approach proposed and discussed in #1224 before any code was written.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Late-arriving reading activity is now correctly attached to completed reading attempts when it falls within the attempt’s end date.
  - User timezone settings are used to process backfilled sessions accurately.
  - Activities indicating a reread or occurring after the relevant period continue to create a new reading attempt.
  - Completed attempts without an end date are excluded from retroactive activity attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->