### PR TITLE
fix(requests): honour the source private-address opt-in on direct downloads

### DIFF
--- a/docs/BOOK_REQUESTS.md
+++ b/docs/BOOK_REQUESTS.md
@@ -67,7 +67,8 @@ when the request has one, and a colour that marks its releases in the release pi
 
 Private network addresses are refused unless you opt the row in with **Allow private address**. A
 self-hosted Prowlarr on the LAN is the common reason to; a public tracker resolving to a private
-address is not.
+address is not. The opt-in covers the whole of that row's work: searching it, and fetching a file
+from it when the source serves its own files rather than handing over a torrent.
 
 Two health facts are shown per row, and they answer different questions:
 

--- a/server/src/modules/book-request/fulfillment/direct-download.service.test.ts
+++ b/server/src/modules/book-request/fulfillment/direct-download.service.test.ts
@@ -27,11 +27,13 @@ describe('DirectDownloadService', () => {
   let service: DirectDownloadService;
   let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
   let downloads: { update: ReturnType<typeof vi.fn> };
+  let indexers: { findById: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
     appDataPath = await mkdtemp(join(tmpdir(), 'bookorbit-http-'));
     downloads = { update: vi.fn().mockResolvedValue(undefined) };
-    service = new DirectDownloadService({ appDataPath } as never, downloads as never);
+    indexers = { findById: vi.fn().mockResolvedValue({ allowPrivateAddress: false }) };
+    service = new DirectDownloadService({ appDataPath } as never, downloads as never, indexers as never);
     fetchMock = vi.fn<typeof fetch>();
     vi.stubGlobal('fetch', fetchMock);
   });
@@ -57,7 +59,7 @@ describe('DirectDownloadService', () => {
   it('writes the file into its staging directory and reports where it landed', async () => {
     fetchMock.mockResolvedValue(fileResponse('a real epub would go here'));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
     const status = await settle();
 
     expect(status.state).toBe('completed');
@@ -200,7 +202,7 @@ describe('DirectDownloadService', () => {
   it('stages a nameless file under the format the source declared', async () => {
     fetchMock.mockResolvedValue(fileResponse('a real epub would go here'));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/get', fileName: 'download', format: 'epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/get', fileName: 'download', format: 'epub', infoHash: HASH });
 
     expect((await settle()).contentPath).toBe(join(appDataPath, 'request-downloads', HASH, 'download.epub'));
   });
@@ -213,7 +215,7 @@ describe('DirectDownloadService', () => {
   it('accepts a content-length that does not divide evenly', async () => {
     fetchMock.mockResolvedValue(fileResponse('x'.repeat(187712), { 'content-length': '187712' }));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
 
     expect((await settle()).state).toBe('completed');
   });
@@ -306,7 +308,7 @@ describe('DirectDownloadService', () => {
         return Promise.resolve(fileResponse('a real epub would go here'));
       });
 
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       await until(() => handed !== undefined);
       // Well past the connect deadline, which by then has nothing left to say about the transfer.
       vi.advanceTimersByTime(90_000);
@@ -327,7 +329,7 @@ describe('DirectDownloadService', () => {
         });
       });
 
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       await until(() => asked);
       vi.advanceTimersByTime(31_000);
 
@@ -346,7 +348,7 @@ describe('DirectDownloadService', () => {
       const trickle = trickleResponse();
       fetchMock.mockResolvedValue(trickle.response);
 
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       // Ten minutes of transfer, for a file the old size-scaled budget allowed two.
       const chunk = 'another chunk of the audiobook';
       for (let minute = 0; minute < 10; minute++) {
@@ -366,7 +368,7 @@ describe('DirectDownloadService', () => {
       const trickle = trickleResponse();
       fetchMock.mockResolvedValue(trickle.response);
 
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       const chunk = 'the only chunk that ever arrives';
       trickle.push(chunk);
       await untilDownloaded(chunk.length);
@@ -380,7 +382,7 @@ describe('DirectDownloadService', () => {
   it('fails a response that is a web page rather than a file', async () => {
     fetchMock.mockResolvedValue(new Response('<html>not found</html>', { headers: { 'content-type': 'text/html; charset=utf-8' } }));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
     const status = await settle();
 
     expect(status.state).toBe('failed');
@@ -394,7 +396,7 @@ describe('DirectDownloadService', () => {
   it('names itself rather than letting Node announce the request as node', async () => {
     fetchMock.mockResolvedValue(fileResponse('a real epub would go here'));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
     await settle();
 
     const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
@@ -404,7 +406,7 @@ describe('DirectDownloadService', () => {
   it('fails a file that declares itself past the size cap', async () => {
     fetchMock.mockResolvedValue(fileResponse('x', { 'content-length': String(64 * 1024 * 1024 * 1024) }));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/huge.m4b', fileName: 'huge.m4b', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/huge.m4b', fileName: 'huge.m4b', infoHash: HASH });
 
     expect((await settle()).state).toBe('failed');
   });
@@ -412,7 +414,7 @@ describe('DirectDownloadService', () => {
   it('fails an empty file rather than importing nothing', async () => {
     fetchMock.mockResolvedValue(fileResponse(''));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
 
     expect((await settle()).state).toBe('failed');
   });
@@ -424,7 +426,7 @@ describe('DirectDownloadService', () => {
   it('refuses a redirect to a private address', async () => {
     fetchMock.mockResolvedValueOnce(new Response('', { status: 302, headers: { location: 'http://127.0.0.1:8080/secret' } }));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
 
     expect((await settle()).state).toBe('failed');
   });
@@ -432,7 +434,7 @@ describe('DirectDownloadService', () => {
   it('gives up rather than following redirects forever', async () => {
     fetchMock.mockResolvedValue(new Response('', { status: 302, headers: { location: 'https://archive.org/again' } }));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
     const status = await settle();
 
     expect(status.state).toBe('failed');
@@ -443,7 +445,7 @@ describe('DirectDownloadService', () => {
   it('keeps a traversing filename inside the download directory', async () => {
     fetchMock.mockResolvedValue(fileResponse('payload'));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/b', fileName: '../../escaped.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/b', fileName: '../../escaped.epub', infoHash: HASH });
     const status = await settle();
 
     expect(status.state).toBe('completed');
@@ -458,7 +460,7 @@ describe('DirectDownloadService', () => {
   it('connects only to the address that passed policy', async () => {
     fetchMock.mockResolvedValue(fileResponse('a real epub would go here'));
 
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
     await settle();
 
     expect(fetchMock.mock.calls[0][1]).toMatchObject({ dispatcher: expect.any(Agent) });
@@ -475,7 +477,7 @@ describe('DirectDownloadService', () => {
 
   it('deletes only the staged copy, the library hardlink being a separate one', async () => {
     fetchMock.mockResolvedValue(fileResponse('payload'));
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
     await settle();
 
     await service.remove(HASH, { deleteFiles: true });
@@ -502,7 +504,7 @@ describe('DirectDownloadService', () => {
     it('leaves nothing behind when the server answers with a page rather than a file', async () => {
       fetchMock.mockResolvedValue(new Response('<html>not found</html>', { headers: { 'content-type': 'text/html' } }));
 
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       await settle();
 
       expect(await stagingExists()).toBe(false);
@@ -511,7 +513,7 @@ describe('DirectDownloadService', () => {
     it('leaves nothing behind when the file declares itself past the size cap', async () => {
       fetchMock.mockResolvedValue(fileResponse('x', { 'content-length': String(64 * 1024 * 1024 * 1024) }));
 
-      await service.add({ fileUrl: 'https://archive.org/download/x/huge.m4b', fileName: 'huge.m4b', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/huge.m4b', fileName: 'huge.m4b', infoHash: HASH });
       await settle();
 
       expect(await stagingExists()).toBe(false);
@@ -520,7 +522,7 @@ describe('DirectDownloadService', () => {
     it('leaves nothing behind when the connection fails outright', async () => {
       fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
 
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       await settle();
 
       expect(await stagingExists()).toBe(false);
@@ -535,7 +537,7 @@ describe('DirectDownloadService', () => {
       });
       fetchMock.mockResolvedValue(new Response(body, { headers: { 'content-type': 'application/epub+zip' } }));
 
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       await settle();
 
       expect(await stagingExists()).toBe(false);
@@ -544,7 +546,7 @@ describe('DirectDownloadService', () => {
     /** Read once by the poll loop and then never again, so the entry must not outlive the process. */
     it('drops a terminal entry once nothing could still be reading it', async () => {
       fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       expect((await settle()).state).toBe('failed');
 
       const reported = await atLaterTime(11 * 60 * 1000, () => service.status([HASH]));
@@ -555,7 +557,7 @@ describe('DirectDownloadService', () => {
     /** Dropping it too early would replace the reason it failed with "the client has never heard of it". */
     it('keeps a terminal entry readable while the poll loop could still want it', async () => {
       fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       await settle();
 
       const state = await atLaterTime(60 * 1000, async () => (await service.status([HASH]))[0].state);
@@ -587,7 +589,7 @@ describe('DirectDownloadService', () => {
     it('never reaps a directory this process is downloading into', async () => {
       const trickle = trickleResponse();
       fetchMock.mockResolvedValue(trickle.response);
-      await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+      await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
       await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
 
       expect(await service.reapStaging(new Set())).toBe(0);
@@ -610,7 +612,7 @@ describe('DirectDownloadService', () => {
       },
     });
     fetchMock.mockResolvedValue(new Response(body, { headers: { 'content-type': 'application/epub+zip', 'content-length': '1000' } }));
-    await service.add({ fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
+    await service.add({ allowPrivate: false, fileUrl: 'https://archive.org/download/x/book.epub', fileName: 'book.epub', infoHash: HASH });
     await vi.waitFor(async () => {
       expect((await service.status([HASH]))[0].downloadedBytes).toBeGreaterThan(0);
     });
@@ -619,6 +621,76 @@ describe('DirectDownloadService', () => {
 
     await expect(service.status([HASH])).resolves.toEqual([]);
     await expect(stat(join(appDataPath, 'request-downloads', HASH))).rejects.toThrow();
+  });
+
+  /**
+   * The row's opt-in, not this service's opinion. A source an operator has already marked as
+   * living on their own network is reachable here for the same reason a torrent client on the LAN
+   * is: they said so about the row, and which of the row's two grab paths is taken is not a second
+   * question they were asked.
+   */
+  describe('private addresses', () => {
+    const PRIVATE_URL = 'http://192.168.1.10:8080/book.epub';
+
+    it('refuses a private address when the source has no opt-in', async () => {
+      await expect(service.add({ allowPrivate: false, fileUrl: PRIVATE_URL, fileName: 'book.epub', infoHash: HASH })).rejects.toThrow(
+        /private or local address/i,
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fetches a private address when the source has one', async () => {
+      fetchMock.mockResolvedValue(fileResponse('a real epub would go here'));
+
+      await service.add({ allowPrivate: true, fileUrl: PRIVATE_URL, fileName: 'book.epub', infoHash: HASH });
+
+      expect((await settle()).state).toBe('completed');
+      expect(fetchMock.mock.calls[0][0]).toBe(PRIVATE_URL);
+    });
+
+    /**
+     * Read off the source rather than remembered on the attempt: a row that has since been told to
+     * stop reaching private addresses must not go on doing it because a transfer outlived the
+     * change.
+     */
+    it('reads the policy off the source when resuming, and refuses a row that has lost it', async () => {
+      indexers.findById.mockResolvedValue({ allowPrivateAddress: false });
+
+      await expect(
+        service.resume({
+          id: 46,
+          indexerId: 7,
+          source: 'direct_url',
+          clientHash: HASH,
+          directUrl: PRIVATE_URL,
+          directFileName: 'book.epub',
+          directEtag: null,
+          directLastModified: null,
+          totalBytes: null,
+          status: 'downloading',
+        } as BookRequestDownloadRow),
+      ).rejects.toThrow(/private or local address/i);
+      expect(indexers.findById).toHaveBeenCalledWith(7);
+    });
+
+    /** A deleted source leaves `indexerId` null, and null is not permission. */
+    it('refuses a private address for an attempt whose source is gone', async () => {
+      await expect(
+        service.resume({
+          id: 47,
+          indexerId: null,
+          source: 'direct_url',
+          clientHash: HASH,
+          directUrl: PRIVATE_URL,
+          directFileName: 'book.epub',
+          directEtag: null,
+          directLastModified: null,
+          totalBytes: null,
+          status: 'downloading',
+        } as BookRequestDownloadRow),
+      ).rejects.toThrow(/private or local address/i);
+      expect(indexers.findById).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/server/src/modules/book-request/fulfillment/direct-download.service.ts
+++ b/server/src/modules/book-request/fulfillment/direct-download.service.ts
@@ -14,6 +14,7 @@ import { safeFetch } from '../../../common/utils/safe-fetch';
 import { ensureSafeUrl } from '../../../common/utils/ssrf.utils';
 import type { BookRequestDownloadRow } from '../../../db/schema';
 import type { DownloadStatus } from '../download-clients/download-client-adapter';
+import { IndexerRepository } from '../indexers/indexer.repository';
 import { BookRequestDownloadRepository } from './book-request-download.repository';
 
 /**
@@ -92,11 +93,17 @@ const HTML_CONTENT_TYPE = /^text\/html\b/i;
 const USER_AGENT = 'BookOrbit';
 
 /**
- * A release URL comes from an indexer, which is the one thing on this path that is never trusted,
- * so a direct fetch never reaches the private network. Torrent clients get a per-row opt-in
- * because they live on the LAN; there is no equivalent reason for a file to.
+ * Whether a fetch may reach a private address is the indexer row's own `allowPrivateAddress`, the
+ * same opt-in a torrent client gets, and it is passed in rather than assumed here.
+ *
+ * A release URL still comes from an indexer and is still the one thing on this path that is never
+ * trusted, so the default remains no. But a self-hosted source on the LAN is the same situation
+ * that put the opt-in on the torrent clients: an operator who has already said "this row may
+ * resolve to a private address" has said it about the row, not about which of its two grab paths
+ * happens to be taken. Refusing here regardless made a plugin that serves its own files unusable
+ * on a Docker network, and failed it at grab time, after the picker had shown the release as
+ * available.
  */
-const ALLOW_PRIVATE = false;
 
 interface Progress {
   state: DownloadStatus['state'];
@@ -119,6 +126,12 @@ export interface DirectDownloadRequest {
    * derives a stable digest of the URL, which keeps the duplicate-grab index meaningful.
    */
   infoHash: string;
+  /**
+   * The indexer row's `allowPrivateAddress`. Stated rather than defaulted, because "this source
+   * is on the LAN" and "nobody has said where this source is" are different facts and only one of
+   * them may reach a private address.
+   */
+  allowPrivate: boolean;
 }
 
 /**
@@ -151,6 +164,7 @@ export class DirectDownloadService {
   constructor(
     @Inject(storageConfig.KEY) private readonly storage: ConfigType<typeof storageConfig>,
     private readonly downloads: BookRequestDownloadRepository,
+    private readonly indexers: IndexerRepository,
   ) {}
 
   private get root(): string {
@@ -158,13 +172,13 @@ export class DirectDownloadService {
   }
 
   async add(release: DirectDownloadRequest): Promise<{ clientHash: string }> {
-    const url = await ensureSafeUrl(release.fileUrl, { allowPrivate: ALLOW_PRIVATE });
+    const url = await ensureSafeUrl(release.fileUrl, { allowPrivate: release.allowPrivate });
 
     const directory = join(this.root, release.infoHash);
     const target = safeJoin(directory, stagedDirectFileName(release.fileName, release.format));
 
     await mkdir(directory, { recursive: true });
-    this.start(release.downloadId, release.infoHash, url, target, directory, 0, null, null);
+    this.start(release.downloadId, release.infoHash, url, target, directory, 0, null, null, release.allowPrivate);
 
     return { clientHash: release.infoHash };
   }
@@ -181,7 +195,11 @@ export class DirectDownloadService {
       return false;
     }
 
-    const url = await ensureSafeUrl(download.directUrl, { allowPrivate: ALLOW_PRIVATE });
+    // Re-read rather than remembered on the attempt: a row that has since been told to stop
+    // reaching private addresses must not go on doing it because a transfer outlived the change.
+    // A source that has been deleted leaves `indexerId` null, and null is not permission.
+    const allowPrivate = await this.allowPrivateFor(download.indexerId);
+    const url = await ensureSafeUrl(download.directUrl, { allowPrivate });
     const directory = join(this.root, download.clientHash);
     const target = safeJoin(directory, download.directFileName);
     const existingBytes = await stat(target)
@@ -192,11 +210,21 @@ export class DirectDownloadService {
     if (existingBytes > MAX_FILE_BYTES) return false;
 
     await mkdir(directory, { recursive: true });
-    this.start(download.id, download.clientHash, url, target, directory, existingBytes, validator, download.totalBytes);
+    this.start(download.id, download.clientHash, url, target, directory, existingBytes, validator, download.totalBytes, allowPrivate);
     this.logger.log(
       `[direct_download.resume] [start] downloadId=${download.id} hash=${download.clientHash} bytes=${existingBytes} - resuming an interrupted direct download`,
     );
     return true;
+  }
+
+  /**
+   * The private-address policy of the source a transfer came from, for a caller that holds an
+   * attempt row rather than a release.
+   */
+  private async allowPrivateFor(indexerId: number | null): Promise<boolean> {
+    if (indexerId === null) return false;
+    const indexer = await this.indexers.findById(indexerId);
+    return indexer?.allowPrivateAddress ?? false;
   }
 
   private start(
@@ -208,6 +236,7 @@ export class DirectDownloadService {
     offset: number,
     validator: string | null,
     expectedBytes: number | null,
+    allowPrivate: boolean,
   ): void {
     this.progress.set(infoHash, {
       state: 'downloading',
@@ -220,7 +249,7 @@ export class DirectDownloadService {
 
     // Deliberately not awaited: `add` hands the work over the way a torrent client does, and the
     // poll loop is what reports on it from here.
-    const task = this.run(downloadId, infoHash, url, target, controller.signal, offset, validator, expectedBytes)
+    const task = this.run(downloadId, infoHash, url, target, controller.signal, offset, validator, expectedBytes, allowPrivate)
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;
         const message = error instanceof Error ? error.message : String(error);
@@ -347,8 +376,9 @@ export class DirectDownloadService {
     offset: number,
     validator: string | null,
     expectedBytes: number | null,
+    allowPrivate: boolean,
   ): Promise<void> {
-    const response = await this.open(url, signal, offset > 0 ? { Range: `bytes=${offset}-`, 'If-Range': validator as string } : {});
+    const response = await this.open(url, signal, allowPrivate, offset > 0 ? { Range: `bytes=${offset}-`, 'If-Range': validator as string } : {});
     const responseMeta = validateDownloadResponse(response, offset, expectedBytes, validator);
     const totalBytes = responseMeta.totalBytes;
     if (totalBytes !== null && totalBytes > MAX_FILE_BYTES) {
@@ -471,16 +501,16 @@ export class DirectDownloadService {
    * socket open until the agent times it out: five hops through a chain of mirrors would otherwise
    * leave five sockets and five buffers behind per grab.
    */
-  private async open(url: URL, signal: AbortSignal, headers: Record<string, string> = {}): Promise<Response> {
+  private async open(url: URL, signal: AbortSignal, allowPrivate: boolean, headers: Record<string, string> = {}): Promise<Response> {
     let current = url;
     for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-      const response = await this.openHop(current, signal, headers);
+      const response = await this.openHop(current, signal, headers, allowPrivate);
 
       if (response.status >= 300 && response.status < 400) {
         const location = response.headers.get('location');
         await response.body?.cancel().catch(() => {});
         if (!location) throw new Error(`That URL answered ${response.status} without saying where to go`);
-        current = await ensureSafeUrl(new URL(location, current).href, { allowPrivate: ALLOW_PRIVATE });
+        current = await ensureSafeUrl(new URL(location, current).href, { allowPrivate });
 
         continue;
       }
@@ -506,7 +536,7 @@ export class DirectDownloadService {
    *
    * The body is not left unbounded: `run` holds it to an idle timeout and a total ceiling.
    */
-  private async openHop(url: URL, signal: AbortSignal, headers: Record<string, string>): Promise<Response> {
+  private async openHop(url: URL, signal: AbortSignal, headers: Record<string, string>, allowPrivate: boolean): Promise<Response> {
     const connect = new AbortController();
     const deadline = setTimeout(() => connect.abort(new Error(`That URL did not answer within ${CONNECT_TIMEOUT_MS}ms`)), CONNECT_TIMEOUT_MS);
     try {
@@ -520,7 +550,7 @@ export class DirectDownloadService {
         // Pinned, because the URL came from an indexer or a plugin rather than from an operator:
         // this is exactly the caller the resolve-twice window in `safeFetch` is not acceptable
         // for, so the address that passed policy is the address the socket opens to.
-        { allowPrivate: ALLOW_PRIVATE, profile: null, pinResolvedAddress: true },
+        { allowPrivate, profile: null, pinResolvedAddress: true },
       );
     } finally {
       clearTimeout(deadline);

--- a/server/src/modules/book-request/fulfillment/request-fulfillment.service.test.ts
+++ b/server/src/modules/book-request/fulfillment/request-fulfillment.service.test.ts
@@ -554,6 +554,34 @@ describe('RequestFulfillmentService.grab from a picked release', () => {
   });
 
   /**
+   * The fetch happens later and elsewhere, so the row that resolved the release is the only thing
+   * that ever knows whether this source is allowed to live on a private address. Dropping it here
+   * is what made a self-hosted source pass Test and search, and then fail every grab.
+   */
+  it('carries the source private-address opt-in to the downloader', async () => {
+    const directRelease = { ...RELEASE, downloadUrl: 'https://curator.example/proxy/t', format: 'epub' };
+    const { service, direct } = makeService({
+      indexers: {
+        resolveConfig: vi.fn().mockResolvedValue({
+          id: 9,
+          name: 'Curator',
+          adapterType: 'curator',
+          allowPrivateAddress: true,
+          seedRatioGoal: null,
+        }),
+      },
+      releases: { find: vi.fn().mockReturnValue(directRelease) },
+      indexerAdapter: {
+        resolveFile: vi.fn().mockResolvedValue({ url: directRelease.downloadUrl, fileName: 'book.epub', sizeBytes: 1234, format: 'epub' }),
+      },
+    });
+
+    await service.grab(7, { indexerId: 9, releaseGuid: 'r-1' }, user());
+
+    expect(direct.add).toHaveBeenCalledWith(expect.objectContaining({ allowPrivate: true }));
+  });
+
+  /**
    * A direct source states its format out of band, and its URL often ends in something that is not
    * a filename at all. Staging that answer unchanged is how a release was reported ready, fetched
    * in full, and only then refused by an importer that classifies by extension alone.

--- a/server/src/modules/book-request/fulfillment/request-fulfillment.service.ts
+++ b/server/src/modules/book-request/fulfillment/request-fulfillment.service.ts
@@ -285,6 +285,9 @@ export class RequestFulfillmentService {
           fileUrl: directUrl as string,
           fileName: directFileName as string,
           infoHash: grab.infoHash,
+          // The source's own opt-in. A hand-pasted link has no indexer behind it and so no row
+          // that could have said yes, which is the same answer as a row that never did.
+          allowPrivate: grab.allowPrivate === true,
         });
       } else {
         const config = await this.clients.resolveConfig(client.id);
@@ -622,6 +625,9 @@ export class RequestFulfillmentService {
         source: 'direct_url',
         fileUrl: file.url,
         fileName,
+        // Carried from the row that resolved it, because the fetch happens later and elsewhere:
+        // by then the only thing that knows where this source lives is this field.
+        allowPrivate: indexer.allowPrivateAddress,
         // A digest of the URL, because there is no infohash and the poll loop still needs a key.
         infoHash: createHash('sha1').update(file.url).digest('hex'),
         releaseFormat: file.format.slice(0, 20),
@@ -846,6 +852,8 @@ interface ParsedGrab {
   torrentFileName?: string;
   fileUrl?: string;
   fileName?: string;
+  /** The resolving indexer's `allowPrivateAddress`, for the fetch this grab turns into. */
+  allowPrivate?: boolean;
   releaseTitle: string;
   /** The size of what the release carries, which a magnet does not state. */
   releaseSizeBytes: number | null;


### PR DESCRIPTION
> Draft. No linked issue or maintainer approval yet, and no video evidence. Not ready for review.

Closes #

- **Maintainer approval:** none yet
- **Assigned contributor:** @babariviere
- **UI changed:** no
- **Evidence commit:** 69ff6b7

## What changed

The indexer row's **Allow private address** toggle did not reach the fetch that pulls the bytes on a
direct download. It covers the search and the `resolveFile` URL check in the plugin host, while
`direct-download.service.ts` held a module-level `ALLOW_PRIVATE = false` used for the fetch itself,
for every redirect hop, and for a resume.

A self-hosted source that serves its own files therefore passes Test, answers searches, and has
every grab refused, after the picker has already shown the release as available.

The policy is now passed in from the row that resolved the release. On resume it is read back off
that row rather than remembered on the attempt, so a source since told to stop reaching private
addresses does not go on doing it because a transfer outlived the change. A deleted source leaves
`indexerId` null, and null is not permission. A hand-pasted link has no row behind it and gets the
same answer.

`DirectDownloadService` takes `IndexerRepository`, which is already a provider in the same module.

## Impact

- **Filesystem/external input:** this is the SSRF boundary for direct downloads. The default is
  unchanged (refuse); the only way to reach a private address is a row an operator explicitly opted
  in, which is the same gate the torrent clients already have.
- **Configuration/deployment:** a self-hosted indexer plugin on a LAN or Docker network becomes
  grabbable. No migration, no new setting, no new dependency.
- **API/shared types:** `DirectDownloadRequest.allowPrivate` is required rather than optional, so a
  caller cannot forget to state it. Internal to the server.

## Verification

**Commands run.**

```text
$ npx vitest run src/modules/book-request/fulfillment/direct-download.service.test.ts src/modules/book-request/fulfillment/request-fulfillment.service.test.ts

 ✓ src/modules/book-request/fulfillment/request-fulfillment.service.test.ts (56 tests) 34ms
 ✓ src/modules/book-request/fulfillment/direct-download.service.test.ts (39 tests) 1509ms

 Test Files  2 passed (2)
      Tests  95 passed (95)
   Duration  2.09s

$ pnpm typecheck:server
$ pnpm --filter @bookorbit/types build && pnpm --filter @bookorbit/plugin-api build
$ tsc
$ tsc
$ tsc --noEmit -p tsconfig.build.json
(clean)

$ npx eslint src/modules/book-request/fulfillment/{direct-download,request-fulfillment}.service{,.test}.ts
(clean)
```

**Personal verification**

1. **What did you personally test, and what did you observe?**

   To be completed by me before this leaves draft.

2. **What is most likely to regress, and how did you check it?**

   To be completed by me before this leaves draft.

**Anything you could not test or verify:**

No end-to-end run against a live instance yet, and `pnpm verify` has not been run in full. Only the
two affected unit suites, the server typecheck, and eslint on the changed files.

## Evidence

Not attached yet. This stays a draft until it is.

## Authorship and review

- **AI tools used:** Claude
- **Extent (what they wrote, and what you wrote):** Claude wrote the diff and this description. I
  found the bug, chose the approach, and am reviewing the change.
- **How you verified their output yourself:** to be completed before this leaves draft.

<details open>
<summary><b>Contributor checklist</b></summary>

- [ ] This is one focused change approved and assigned before implementation.
- [ ] I personally authored this submission, reviewed the diff, and can explain every change.
- [x] I disclosed all AI assistance, limitations, and unverified behavior.
- [ ] The required tests and `pnpm verify` pass against the evidence commit.
- [x] No unintended files, secrets, personal configuration, or unapproved dependencies are included.
- [ ] I followed the contribution guidelines and commit guidelines.

</details>
